### PR TITLE
core/state: move slot RLP encoding into the MPT implementation

### DIFF
--- a/core/state/state_object.go
+++ b/core/state/state_object.go
@@ -293,7 +293,8 @@ func (s *stateObject) updateTrie(db Database) (Trie, error) {
 		}
 		s.originStorage[key] = value
 
-		var v []byte
+		// rlp-encoded value to be used by the snapshot
+		var snapshotVal []byte
 		if (value == common.Hash{}) {
 			if err := tr.DeleteStorage(s.address, key[:]); err != nil {
 				s.db.setError(err)
@@ -303,7 +304,7 @@ func (s *stateObject) updateTrie(db Database) (Trie, error) {
 		} else {
 			trimmedVal := common.TrimLeftZeroes(value[:])
 			// Encoding []byte cannot fail, ok to ignore the error.
-			v, _ = rlp.EncodeToBytes(trimmedVal)
+			snapshotVal, _ = rlp.EncodeToBytes(trimmedVal)
 			if err := tr.UpdateStorage(s.address, key[:], trimmedVal); err != nil {
 				s.db.setError(err)
 				return nil, err
@@ -319,7 +320,7 @@ func (s *stateObject) updateTrie(db Database) (Trie, error) {
 					s.db.snapStorage[s.addrHash] = storage
 				}
 			}
-			storage[crypto.HashData(hasher, key[:])] = v // v will be nil if it's deleted
+			storage[crypto.HashData(hasher, key[:])] = snapshotVal // will be nil if it's deleted
 		}
 		usedStorage = append(usedStorage, common.CopyBytes(key[:])) // Copy needed for closure
 	}

--- a/core/state/state_object.go
+++ b/core/state/state_object.go
@@ -183,14 +183,22 @@ func (s *stateObject) GetCommittedState(db Database, key common.Hash) common.Has
 	}
 	// If no live objects are available, attempt to use snapshots
 	var (
-		enc []byte
-		err error
+		enc   []byte
+		err   error
+		value common.Hash
 	)
 	if s.db.snap != nil {
 		start := time.Now()
 		enc, err = s.db.snap.Storage(s.addrHash, crypto.Keccak256Hash(key.Bytes()))
 		if metrics.EnabledExpensive {
 			s.db.SnapshotStorageReads += time.Since(start)
+		}
+		if len(enc) > 0 {
+			_, content, _, err := rlp.Split(enc)
+			if err != nil {
+				s.db.setError(err)
+			}
+			value.SetBytes(content)
 		}
 	}
 	// If the snapshot is unavailable or reading from it fails, load from the database.
@@ -201,7 +209,7 @@ func (s *stateObject) GetCommittedState(db Database, key common.Hash) common.Has
 			s.db.setError(err)
 			return common.Hash{}
 		}
-		enc, err = tr.GetStorage(s.address, key.Bytes())
+		val, err := tr.GetStorage(s.address, key.Bytes())
 		if metrics.EnabledExpensive {
 			s.db.StorageReads += time.Since(start)
 		}
@@ -209,14 +217,7 @@ func (s *stateObject) GetCommittedState(db Database, key common.Hash) common.Has
 			s.db.setError(err)
 			return common.Hash{}
 		}
-	}
-	var value common.Hash
-	if len(enc) > 0 {
-		_, content, _, err := rlp.Split(enc)
-		if err != nil {
-			s.db.setError(err)
-		}
-		value.SetBytes(content)
+		value.SetBytes(val)
 	}
 	s.originStorage[key] = value
 	return value
@@ -300,9 +301,10 @@ func (s *stateObject) updateTrie(db Database) (Trie, error) {
 			}
 			s.db.StorageDeleted += 1
 		} else {
+			trimmedVal := common.TrimLeftZeroes(value[:])
 			// Encoding []byte cannot fail, ok to ignore the error.
-			v, _ = rlp.EncodeToBytes(common.TrimLeftZeroes(value[:]))
-			if err := tr.UpdateStorage(s.address, key[:], v); err != nil {
+			v, _ = rlp.EncodeToBytes(trimmedVal)
+			if err := tr.UpdateStorage(s.address, key[:], trimmedVal); err != nil {
 				s.db.setError(err)
 				return nil, err
 			}

--- a/light/trie.go
+++ b/light/trie.go
@@ -107,12 +107,16 @@ type odrTrie struct {
 
 func (t *odrTrie) GetStorage(_ common.Address, key []byte) ([]byte, error) {
 	key = crypto.Keccak256(key)
-	var res []byte
+	var enc []byte
 	err := t.do(key, func() (err error) {
-		res, err = t.trie.Get(key)
+		enc, err = t.trie.Get(key)
 		return err
 	})
-	return res, err
+	if err != nil {
+		return nil, err
+	}
+	_, content, _, err := rlp.Split(enc)
+	return content, err
 }
 
 func (t *odrTrie) GetAccount(address common.Address) (*types.StateAccount, error) {
@@ -144,8 +148,9 @@ func (t *odrTrie) UpdateAccount(address common.Address, acc *types.StateAccount)
 
 func (t *odrTrie) UpdateStorage(_ common.Address, key, value []byte) error {
 	key = crypto.Keccak256(key)
+	v, _ := rlp.EncodeToBytes(value)
 	return t.do(key, func() error {
-		return t.trie.Update(key, value)
+		return t.trie.Update(key, v)
 	})
 }
 

--- a/light/trie.go
+++ b/light/trie.go
@@ -112,7 +112,7 @@ func (t *odrTrie) GetStorage(_ common.Address, key []byte) ([]byte, error) {
 		enc, err = t.trie.Get(key)
 		return err
 	})
-	if err != nil {
+	if err != nil || len(enc) == 0 {
 		return nil, err
 	}
 	_, content, _, err := rlp.Split(enc)

--- a/trie/secure_trie.go
+++ b/trie/secure_trie.go
@@ -86,7 +86,7 @@ func (t *StateTrie) MustGet(key []byte) []byte {
 // If a trie node is not found in the database, a MissingNodeError is returned.
 func (t *StateTrie) GetStorage(_ common.Address, key []byte) ([]byte, error) {
 	enc, err := t.trie.Get(t.hashKey(key))
-	if err != nil {
+	if err != nil || len(enc) == 0 {
 		return nil, err
 	}
 	_, content, _, err := rlp.Split(enc)

--- a/trie/secure_trie.go
+++ b/trie/secure_trie.go
@@ -19,6 +19,7 @@ package trie
 import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/rlp"
 )
 
@@ -85,7 +86,12 @@ func (t *StateTrie) MustGet(key []byte) []byte {
 // If the specified storage slot is not in the trie, nil will be returned.
 // If a trie node is not found in the database, a MissingNodeError is returned.
 func (t *StateTrie) GetStorage(_ common.Address, key []byte) ([]byte, error) {
-	return t.trie.Get(t.hashKey(key))
+	enc, err := t.trie.Get(t.hashKey(key))
+	if err != nil {
+		return nil, err
+	}
+	_, content, _, err := rlp.Split(enc)
+	return content, err
 }
 
 // GetAccount attempts to retrieve an account with provided account address.
@@ -147,7 +153,8 @@ func (t *StateTrie) MustUpdate(key, value []byte) {
 // If a node is not found in the database, a MissingNodeError is returned.
 func (t *StateTrie) UpdateStorage(_ common.Address, key, value []byte) error {
 	hk := t.hashKey(key)
-	err := t.trie.Update(hk, value)
+	v, _ := rlp.EncodeToBytes(value)
+	err := t.trie.Update(hk, v)
 	if err != nil {
 		return err
 	}

--- a/trie/secure_trie.go
+++ b/trie/secure_trie.go
@@ -19,7 +19,6 @@ package trie
 import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
-	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/rlp"
 )
 


### PR DESCRIPTION
Continuing with a series of PRs to make the `Trie` interface more generic, this PR moves the RLP encoding of storage slots inside the `secure_trie` and `light.Trie` implementations, as other types of tries don't use this.

This PR is still in draft, as the snapshot still uses RLP. While I think the snapshot should also get rid of RLP, this would cause a bunch of issues:

 * rlp encoding would have to be added to the snapsync code
 * an upgrade path needs to be devised

Until a solution has been found, this means the RLP decoding happens twice for a snapshot-enabled MPT client.