### PR TITLE
vmConfig check for invalid tracer.

### DIFF
--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -87,6 +87,7 @@ var (
 
 	errInsertionInterrupted = errors.New("insertion is interrupted")
 	errChainStopped         = errors.New("blockchain is stopped")
+	errInvalidVmConfig      = errors.New("vmConfig debug enabled without tracer")
 )
 
 const (
@@ -233,7 +234,12 @@ func NewBlockChain(db ethdb.Database, cacheConfig *CacheConfig, genesis *Genesis
 	if cacheConfig == nil {
 		cacheConfig = defaultCacheConfig
 	}
-
+	// Ensure a Trace is provided if we are running in debug mode
+	if vmConfig.Debug {
+		if vmConfig.Tracer == nil {
+			return nil, errInvalidVmConfig
+		}
+	}
 	// Open trie database with provided config
 	triedb := trie.NewDatabaseWithConfig(db, &trie.Config{
 		Cache:     cacheConfig.TrieCleanLimit,


### PR DESCRIPTION
When we create a new blockchain we supply a vmConfig object. If we set debug mode to true without supplying aTracer we have the following nil pointer deref.

https://github.com/ethereum/go-ethereum/blob/7ca4f60a1abd2a8c9df2ed9ae35a891b0ac9e464/core/state_transition.go#L328

If we specify debug without adding a tracer we will get the nil pointer deref here. To mitigate this the constructor for blockchain checks that if the vmConfig has debug mode enabled it also checks to make sure the tracer is non-nil.