### PR TITLE
core/txpool: remove queue, implement temporary buffer (limbo)

### DIFF
--- a/core/txpool/limbo.go
+++ b/core/txpool/limbo.go
@@ -1,0 +1,119 @@
+// Copyright 2023 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+
+package txpool
+
+import (
+	"fmt"
+	"sort"
+	"sync"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+)
+
+// limboArea is a struct for maintaining 'not quite ready' transactions; it may be
+// that transactions are broadcast out of order, making them arrive with
+// nonce-gaps. In that case, they arrive in 'limboArea', and after a brief time,
+// they are accepted as executable (the gaps have been resolved) or are discarded.
+type limboArea struct {
+	signer   types.Signer
+	mu       sync.RWMutex
+	txs      map[string]*types.Transaction
+	txHashes map[common.Hash]string
+	count    uint64
+
+	wg      sync.WaitGroup
+	closeCh chan any
+}
+
+func newLimbo(signer types.Signer) *limboArea {
+	return &limboArea{
+		signer:   signer,
+		txs:      make(map[string]*types.Transaction),
+		txHashes: make(map[common.Hash]string),
+		closeCh:  make(chan any),
+	}
+}
+
+// Add adds a transaction to limboArea. If the transaction already is present, this is
+// a no-op.
+// returns true if the transaction was added, false if already known
+func (l *limboArea) Add(tx *types.Transaction) bool {
+	from, _ := types.Sender(l.signer, tx)
+	key := fmt.Sprintf("%x-%d", from[:10], tx.Nonce())
+	hash := tx.Hash()
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	if _, ok := l.txHashes[hash]; ok {
+		return false
+	}
+	l.count++
+	l.txs[key] = tx
+	l.txHashes[hash] = key
+	return true
+}
+
+// Has returns true iff the tx with hash is in limboArea.
+func (l *limboArea) Has(hash common.Hash) bool {
+	l.mu.RLock()
+	defer l.mu.RUnlock()
+	_, present := l.txHashes[hash]
+	return present
+
+}
+
+func (l *limboArea) flush(fn func(*types.Transaction)) {
+	// Copy-and-replace the txs
+	l.mu.Lock()
+	txs := l.txs
+	//count := l.count
+	l.txs = make(map[string]*types.Transaction)
+	l.count = 0
+	l.mu.Unlock()
+	// Now flush them out
+	var keys = make(sort.StringSlice, 0, len(txs))
+	for k, _ := range l.txs {
+		keys = append(keys, k)
+	}
+	sort.Sort(keys)
+	for _, k := range keys {
+		fn(txs[k])
+	}
+}
+
+//func (l *limboArea) Start(pool TxPool) {
+//	l.wg.Add(1)
+//	go func() {
+//		t := time.NewTimer(1 * time.Second)
+//		defer l.wg.Done()
+//		defer t.Stop()
+//		for {
+//			select {
+//			case <-l.closeCh:
+//				return
+//			case <-t.C:
+//				l.flush(pool.tryAddPending)
+//				t.Reset(1 * time.Second)
+//			}
+//		}
+//	}()
+//}
+//
+//func (l *limboArea) Stop() {
+//	close(l.closeCh)
+//	l.wg.Wait()
+//}

--- a/core/txpool/limbo.go
+++ b/core/txpool/limbo.go
@@ -86,7 +86,7 @@ func (l *limboArea) flush(fn func(*types.Transaction)) {
 	l.mu.Unlock()
 	// Now flush them out
 	var keys = make(sort.StringSlice, 0, len(txs))
-	for k, _ := range l.txs {
+	for k, _ := range txs {
 		keys = append(keys, k)
 	}
 	sort.Sort(keys)

--- a/core/txpool/txpool.go
+++ b/core/txpool/txpool.go
@@ -953,13 +953,6 @@ func (pool *TxPool) addTxs(txs []*types.Transaction, local, sync bool) []error {
 		// Exclude transactions with invalid signatures as soon as
 		// possible and cache senders in transactions before
 		// obtaining lock
-		_, err := types.Sender(pool.signer, tx)
-		if err != nil {
-			errs[i] = ErrInvalidSender
-			invalidTxMeter.Mark(1)
-			continue
-		}
-
 		if err := pool.validateTxBasics(tx); err != nil {
 			errs[i] = err
 			invalidTxMeter.Mark(1)

--- a/core/txpool/txpool.go
+++ b/core/txpool/txpool.go
@@ -975,7 +975,7 @@ func (pool *TxPool) addTxs(txs []*types.Transaction, local, sync bool) []error {
 
 	// Process all the new transaction and merge any errors into the original slice
 	pool.mu.Lock()
-	newErrs, dirtyAddrs := pool.addTxsLocked(news, local)
+	newErrs, _ := pool.addTxsLocked(news, local)
 	pool.mu.Unlock()
 
 	var nilSlot = 0
@@ -987,7 +987,7 @@ func (pool *TxPool) addTxs(txs []*types.Transaction, local, sync bool) []error {
 		nilSlot++
 	}
 	// Reorg the pool internals if needed and return
-	done := pool.requestPromoteExecutables(dirtyAddrs)
+	done := pool.requestPromoteExecutables( /* dirtyAddrs */)
 	if sync {
 		<-done
 	}
@@ -997,17 +997,19 @@ func (pool *TxPool) addTxs(txs []*types.Transaction, local, sync bool) []error {
 // addTxsLocked attempts to queue a batch of transactions if they are valid.
 // The transaction pool lock must be held.
 func (pool *TxPool) addTxsLocked(txs []*types.Transaction, local bool) ([]error, *accountSet) {
-	dirty := newAccountSet(pool.signer)
+	//dirty := newAccountSet(pool.signer)
 	errs := make([]error, len(txs))
+	valid := int64(0)
 	for i, tx := range txs {
 		replaced, err := pool.add(tx, local)
 		errs[i] = err
 		if err == nil && !replaced {
-			dirty.addTx(tx)
+			//dirty.addTx(tx)
+			valid++
 		}
 	}
-	validTxMeter.Mark(int64(len(dirty.accounts)))
-	return errs, dirty
+	validTxMeter.Mark(valid)
+	return errs, nil
 }
 
 // Status returns the status (unknown/pending/queued) of a batch of transactions
@@ -1109,9 +1111,9 @@ func (pool *TxPool) requestReset(oldHead *types.Header, newHead *types.Header) c
 
 // requestPromoteExecutables requests transaction promotion checks for the given addresses.
 // The returned channel is closed when the promotion checks have occurred.
-func (pool *TxPool) requestPromoteExecutables(set *accountSet) chan struct{} {
+func (pool *TxPool) requestPromoteExecutables( /* set *accountSet */) chan struct{} {
 	select {
-	case pool.reqPromoteCh <- set:
+	case pool.reqPromoteCh <- nil: //set:
 		return <-pool.reorgDoneCh
 	case <-pool.reorgShutdownCh:
 		return pool.reorgShutdownCh
@@ -1137,15 +1139,15 @@ func (pool *TxPool) scheduleReorgLoop() {
 		nextDone      = make(chan struct{})
 		launchNextRun bool
 		reset         *txpoolResetRequest
-		dirtyAccounts *accountSet
-		queuedEvents  = make(map[common.Address]*sortedMap)
+		//dirtyAccounts *accountSet
+		queuedEvents = make(map[common.Address]*sortedMap)
 	)
 	for {
 		// Launch next background reorg if needed
 		if curDone == nil && launchNextRun {
 			// Run the background reorg and announcements
 			go func(done chan struct{}) {
-				pool.runReorg(reset, dirtyAccounts, queuedEvents)
+				pool.runReorg(reset /* dirtyAccounts ,*/, queuedEvents)
 				close(done)
 			}(nextDone)
 
@@ -1153,7 +1155,7 @@ func (pool *TxPool) scheduleReorgLoop() {
 			curDone, nextDone = nextDone, make(chan struct{})
 			launchNextRun = false
 
-			reset, dirtyAccounts = nil, nil
+			reset = nil
 			queuedEvents = make(map[common.Address]*sortedMap)
 		}
 
@@ -1168,13 +1170,13 @@ func (pool *TxPool) scheduleReorgLoop() {
 			launchNextRun = true
 			pool.reorgDoneCh <- nextDone
 
-		case req := <-pool.reqPromoteCh:
+		case <-pool.reqPromoteCh:
 			// Promote request: update address set if request is already pending.
-			if dirtyAccounts == nil {
-				dirtyAccounts = req
-			} else {
-				dirtyAccounts.merge(req)
-			}
+			//if dirtyAccounts == nil {
+			//	dirtyAccounts = req
+			//} else {
+			//	dirtyAccounts.merge(req)
+			//}
 			launchNextRun = true
 			pool.reorgDoneCh <- nextDone
 
@@ -1202,7 +1204,7 @@ func (pool *TxPool) scheduleReorgLoop() {
 }
 
 // runReorg runs reset and promoteExecutables on behalf of scheduleReorgLoop.
-func (pool *TxPool) runReorg(reset *txpoolResetRequest, dirtyAccounts *accountSet, events map[common.Address]*sortedMap) {
+func (pool *TxPool) runReorg(reset *txpoolResetRequest, events map[common.Address]*sortedMap) {
 	defer func(t0 time.Time) {
 		reorgDurationTimer.Update(time.Since(t0))
 	}(time.Now())

--- a/core/txpool/txpool.go
+++ b/core/txpool/txpool.go
@@ -304,8 +304,8 @@ func NewTxPool(config Config, chainconfig *params.ChainConfig, chain blockChain)
 		signer:      signer,
 		pending:     make(map[common.Address]*list),
 		//queue:           make(map[common.Address]*list),
-		limbo:           newLimbo(signer),
-		beats:           make(map[common.Address]time.Time),
+		limbo: newLimbo(signer),
+		//beats:           make(map[common.Address]time.Time),
 		all:             newLookup(),
 		chainHeadCh:     make(chan core.ChainHeadEvent, chainHeadChanSize),
 		reqResetCh:      make(chan *txpoolResetRequest),
@@ -789,7 +789,7 @@ func (pool *TxPool) addPending(tx *types.Transaction, local bool) (added, replac
 		log.Trace("Pooled new executable transaction", "hash", hash, "from", from, "to", tx.To())
 
 		// Successful promotion, bump the heartbeat
-		pool.beats[from] = time.Now()
+		//pool.beats[from] = time.Now()
 		return true, old != nil, nil
 	}
 	// Mark local addresses and journal local transactions
@@ -871,7 +871,7 @@ func (pool *TxPool) promoteTx(addr common.Address, hash common.Hash, tx *types.T
 	pool.pendingNonces.set(addr, tx.Nonce()+1)
 
 	// Successful promotion, bump the heartbeat
-	pool.beats[addr] = time.Now()
+	//pool.beats[addr] = time.Now()
 	return true
 }
 

--- a/core/txpool/txpool_test.go
+++ b/core/txpool/txpool_test.go
@@ -499,6 +499,11 @@ func TestDoubleNonce(t *testing.T) {
 	}
 }
 
+func pendingSize(pool *TxPool) int {
+	p, _ := pool.Stats()
+	return p
+}
+
 func TestMissingNonce(t *testing.T) {
 	t.Parallel()
 
@@ -513,7 +518,7 @@ func TestMissingNonce(t *testing.T) {
 		if _, err := pool.add(tx, false); err != nil {
 			t.Error("didn't expect error", err)
 		}
-		if have, want := len(pool.pending), 0; have != want {
+		if have, want := pendingSize(pool), 0; have != want {
 			t.Errorf("expected %d pending transactions, got %d", want, have)
 		}
 		if have, want := pool.all.Count(), 0; have != want {
@@ -530,7 +535,7 @@ func TestMissingNonce(t *testing.T) {
 		if _, err := pool.add(tx, false); err != nil {
 			t.Error("didn't expect error", err)
 		}
-		if have, want := pool.pending[addr].Len(), 1; have != want {
+		if have, want := pendingSize(pool), 1; have != want {
 			t.Errorf("expected %d pending transactions, got %d", want, have)
 		}
 		if have, want := pool.all.Count(), 1; have != want {
@@ -540,7 +545,7 @@ func TestMissingNonce(t *testing.T) {
 	<-pool.requestReset(nil, nil)
 	// both should now be pending
 	{
-		if have, want := pool.pending[addr].Len(), 2; have != want {
+		if have, want := pendingSize(pool), 2; have != want {
 			t.Errorf("expected %d pending transactions, got %d", want, have)
 		}
 		if have, want := pool.all.Count(), 2; have != want {


### PR DESCRIPTION
This PR implements the "Limbo" idea. 

--- 
"Future" transactions are problematic, in that it can be used to push pending transactions out. The reason for even having future transactions is that we cannot guarantee stable delivery: a node has `[tx1, tx2]`, and announces it to a peer. During delivery, the peer may receive them in the order `[tx2, tx1]`, and not necessarily within the same network packet/batch. When this occurs, it would be bad UX if we dropped `tx2`.

To mitigate this, what we can do is have a 'limbo'. A transaction entering the node can take two paths:

1. fast-path: this tx is executable, and can thus enter the 
2. slow-path: this tx is not executable, and is put into 'limbo'.

Every `N` seconds, we

1. Sort transactions in limbo by nonce.
 2. For each transaction
       - If is executable, add to pool,
       - Else: discard

At the end of this loop, the limbo is empty again

In this system, the transaction pool itself is only ever aware of executable transactions. A user submitting multiple transactions may notice a degradation in propagation speeds of the "later" transactions, but should not experience them being dropped by the network.

--- 

This PR is a work in progress, which implements most of this. The removal of the `queue` makes a **lot** of code redundant. For now, I have chosen to leave the code mostly in place, but commenting it out. This is to make it easier for a reviewer to check and see that the removed code indeed was not useful any more. 

I also split up the validation in two phases:
- "generic" or "basic" validation, which is more or less static. Is the transaction essentially valid? 
- "stateful" validation, which is more temporal: is the transaction valid __at this time__? This check is stateful, and needs to be re-performed from time to time. 


---

A lot more work needs to be done on the PR itself, and also the tests are failing en masse. 