### PR TITLE
graphql: revert storage access regression

### DIFF
--- a/graphql/graphql.go
+++ b/graphql/graphql.go
@@ -81,26 +81,12 @@ type Account struct {
 	r             *Resolver
 	address       common.Address
 	blockNrOrHash rpc.BlockNumberOrHash
-	state         *state.StateDB
-	mu            sync.Mutex
 }
 
 // getState fetches the StateDB object for an account.
 func (a *Account) getState(ctx context.Context) (*state.StateDB, error) {
-	a.mu.Lock()
-	defer a.mu.Unlock()
-	if a.state != nil {
-		return a.state, nil
-	}
 	state, _, err := a.r.backend.StateAndHeaderByNumberOrHash(ctx, a.blockNrOrHash)
-	if err != nil {
-		return nil, err
-	}
-	a.state = state
-	// Cache the state object. This is done so that concurrent resolvers
-	// don't have to fetch the object from DB individually.
-	a.state.GetOrNewStateObject(a.address)
-	return a.state, nil
+	return state, err
 }
 
 func (a *Account) Address(ctx context.Context) (common.Address, error) {


### PR DESCRIPTION
Ironic that https://github.com/ethereum/go-ethereum/pull/26965 introduced a data race. Problem is it caches the `stateObject` for each account. However stateObject is not thread-safe, even when used in read-only mode. The race specifically happens when multiple storage slots are queried. They will both will try to write to the stateObject's `originStorage` cache.

I temporarily reverted the change. But I'd still like the ability to cache a state object. It doesn't make sense IMO to hit the db/snapshot multiple times for the same account during one query. But not sure how to achieve that yet.

TODO: add test case.