### PR TITLE
p2p/discover: add traffic metrics

### DIFF
--- a/p2p/discover/metrics.go
+++ b/p2p/discover/metrics.go
@@ -1,0 +1,50 @@
+package discover
+
+import (
+	"net"
+
+	"github.com/ethereum/go-ethereum/metrics"
+)
+
+const (
+	moduleName = "discover"
+	// ingressMeterName is the prefix of the per-packet inbound metrics.
+	ingressMeterName = moduleName + "/ingress"
+
+	// egressMeterName is the prefix of the per-packet outbound metrics.
+	egressMeterName = moduleName + "/egress"
+)
+
+var (
+	ingressTrafficMeter = metrics.NewRegisteredMeter(ingressMeterName, nil)
+	egressTrafficMeter  = metrics.NewRegisteredMeter(egressMeterName, nil)
+)
+
+// meteredConn is a wrapper around a net.UDPConn that meters both the
+// inbound and outbound network traffic.
+type meteredUdpConn struct {
+	UDPConn
+}
+
+func newMeteredConn(conn UDPConn) UDPConn {
+	// Short circuit if metrics are disabled
+	if !metrics.Enabled {
+		return conn
+	}
+
+	return &meteredUdpConn{UDPConn: conn}
+}
+
+// Read delegates a network read to the underlying connection, bumping the udp ingress traffic meter along the way.
+func (c *meteredUdpConn) ReadFromUDP(b []byte) (n int, addr *net.UDPAddr, err error) {
+	n, addr, err = c.UDPConn.ReadFromUDP(b)
+	ingressTrafficMeter.Mark(int64(n))
+	return n, addr, err
+}
+
+// Write delegates a network write to the underlying connection, bumping the udp egress traffic meter along the way.
+func (c *meteredUdpConn) WriteToUDP(b []byte, addr *net.UDPAddr) (n int, err error) {
+	n, err = c.UDPConn.WriteToUDP(b, addr)
+	egressTrafficMeter.Mark(int64(n))
+	return n, err
+}

--- a/p2p/discover/metrics.go
+++ b/p2p/discover/metrics.go
@@ -1,3 +1,19 @@
+// Copyright 2023 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+
 package discover
 
 import (

--- a/p2p/discover/metrics.go
+++ b/p2p/discover/metrics.go
@@ -47,7 +47,6 @@ func newMeteredConn(conn UDPConn) UDPConn {
 	if !metrics.Enabled {
 		return conn
 	}
-
 	return &meteredUdpConn{UDPConn: conn}
 }
 

--- a/p2p/discover/v4_udp.go
+++ b/p2p/discover/v4_udp.go
@@ -130,7 +130,7 @@ func ListenV4(c UDPConn, ln *enode.LocalNode, cfg Config) (*UDPv4, error) {
 	cfg = cfg.withDefaults()
 	closeCtx, cancel := context.WithCancel(context.Background())
 	t := &UDPv4{
-		conn:            c,
+		conn:            newMeteredConn(c),
 		priv:            cfg.PrivateKey,
 		netrestrict:     cfg.NetRestrict,
 		localNode:       ln,

--- a/p2p/discover/v5_udp.go
+++ b/p2p/discover/v5_udp.go
@@ -142,7 +142,7 @@ func newUDPv5(conn UDPConn, ln *enode.LocalNode, cfg Config) (*UDPv5, error) {
 	cfg = cfg.withDefaults()
 	t := &UDPv5{
 		// static fields
-		conn:         conn,
+		conn:         newMeteredConn(conn),
 		localNode:    ln,
 		db:           ln.Database(),
 		netrestrict:  cfg.NetRestrict,


### PR DESCRIPTION
This PR adds similar to p2p/metrics metered connection for discovery module. The aim is to have more detailed information about network usage which currently isn't tracked for discV4 and discV5.