### PR TITLE
remove @gballet as a GraphQL codeowner

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -10,7 +10,7 @@ core/                           @karalabe @holiman @rjl493456442
 eth/                            @karalabe @holiman @rjl493456442
 eth/catalyst/                   @gballet
 eth/tracers/                    @s1na
-graphql/                        @gballet @s1na
+graphql/                        @s1na
 les/                            @zsfelfoldi @rjl493456442
 light/                          @zsfelfoldi @rjl493456442
 node/                           @fjl


### PR DESCRIPTION
I haven't touched this part of the codebase in years, never really used GraphQL in the meantime and @s1na is now the GraphQL man.