### PR TITLE
fix blocking

### DIFF
--- a/p2p/peer_test.go
+++ b/p2p/peer_test.go
@@ -129,7 +129,8 @@ func TestPeerProtoReadMsg(t *testing.T) {
 		},
 	}
 
-	closer, rw, _, errc := testPeer([]Protocol{proto})
+	closer, rw, peer, errc := testPeer([]Protocol{proto})
+	defer peer.Disconnect(DiscQuitting)
 	defer closer()
 
 	Send(rw, baseProtocolLength+2, []uint{1})
@@ -160,7 +161,8 @@ func TestPeerProtoEncodeMsg(t *testing.T) {
 			return nil
 		},
 	}
-	closer, rw, _, _ := testPeer([]Protocol{proto})
+	closer, rw, peer, _ := testPeer([]Protocol{proto})
+	defer peer.Disconnect(DiscQuitting)
 	defer closer()
 
 	if err := ExpectMsg(rw, 17, []string{"foo", "bar"}); err != nil {
@@ -172,7 +174,7 @@ func TestPeerPing(t *testing.T) {
 	closer, rw, _, _ := testPeer(nil)
 	defer closer()
 	if err := SendItems(rw, pingMsg); err != nil {
-		t.Fatal(err)
+		t.Error(err)
 	}
 	if err := ExpectMsg(rw, pongMsg, nil); err != nil {
 		t.Error(err)


### PR DESCRIPTION
These tests has a leak goroutine at `Peer.run()` because the peer is not closed and `p.disc` will never come.
https://github.com/ethereum/go-ethereum/blob/2d1492821d058a3488b4da2c1f62906eaf6d7c95/p2p/peer.go#L262-L287
1. Add disconnect can avoid such goroutine leak.
2. Fatal will skip the defer functions,  but I don't know if it is ok to change `t.Fatal` to `t.Error`