### PR TITLE
common: delete MakeName

### DIFF
--- a/common/path.go
+++ b/common/path.go
@@ -17,18 +17,9 @@
 package common
 
 import (
-	"fmt"
 	"os"
 	"path/filepath"
-	"runtime"
 )
-
-// MakeName creates a node name that follows the ethereum convention
-// for such names. It adds the operation system name and Go runtime version
-// the name.
-func MakeName(name, version string) string {
-	return fmt.Sprintf("%s/v%s/%s/%s", name, version, runtime.GOOS, runtime.Version())
-}
 
 // FileExist checks if a file exists at filePath.
 func FileExist(filePath string) bool {

--- a/p2p/server.go
+++ b/p2p/server.go
@@ -94,7 +94,6 @@ type Config struct {
 	DiscoveryV5 bool `toml:",omitempty"`
 
 	// Name sets the node name of this server.
-	// Use common.MakeName to create a name that follows existing conventions.
 	Name string `toml:"-"`
 
 	// BootstrapNodes are used to establish connectivity


### PR DESCRIPTION
Although the comment in `p2p` says it uses `common.MakeName` to create the p2p name of the node, the function is actually not used anywhere in the codebase. Instead, the name is set in `node/node.go`: https://github.com/ethereum/go-ethereum/blob/00a73fbcce3250b87fc4160f3deddc44390848f4/node/node.go#L134

where `NodeName()`is this function: https://github.com/ethereum/go-ethereum/blob/00a73fbcce3250b87fc4160f3deddc44390848f4/node/config.go#L290-L306