### PR TITLE
metrics: make gauge_float64 and counter_float64 lock free

### DIFF
--- a/metrics/counter_float64.go
+++ b/metrics/counter_float64.go
@@ -121,12 +121,12 @@ type StandardCounterFloat64 struct {
 
 // Clear sets the counter to zero.
 func (c *StandardCounterFloat64) Clear() {
-	atomicClearFloat(&c.floatBits)
+	c.floatBits.Store(0)
 }
 
 // Count returns the current value.
 func (c *StandardCounterFloat64) Count() float64 {
-	return atomicGetFloat(&c.floatBits)
+	return math.Float64frombits(c.floatBits.Load())
 }
 
 // Dec decrements the counter by the given amount.
@@ -152,16 +152,4 @@ func atomicAddFloat(fbits *atomic.Uint64, v float64) {
 			break
 		}
 	}
-}
-
-func atomicGetFloat(addr *atomic.Uint64) float64 {
-	return math.Float64frombits(addr.Load())
-}
-
-func atomicClearFloat(addr *atomic.Uint64) {
-	addr.Store(0)
-}
-
-func atomicStoreFloat(addr *atomic.Uint64, v float64) {
-	addr.Store(math.Float64bits(v))
 }

--- a/metrics/counter_float64.go
+++ b/metrics/counter_float64.go
@@ -114,7 +114,7 @@ func (NilCounterFloat64) Inc(i float64) {}
 func (NilCounterFloat64) Snapshot() CounterFloat64 { return NilCounterFloat64{} }
 
 // StandardCounterFloat64 is the standard implementation of a CounterFloat64 and uses the
-// sync.Mutex package to manage a single float64 value.
+// atomic to manage a single float64 value.
 type StandardCounterFloat64 struct {
 	floatBits uint64
 }

--- a/metrics/counter_float64.go
+++ b/metrics/counter_float64.go
@@ -116,7 +116,7 @@ func (NilCounterFloat64) Snapshot() CounterFloat64 { return NilCounterFloat64{} 
 // StandardCounterFloat64 is the standard implementation of a CounterFloat64 and uses the
 // atomic to manage a single float64 value.
 type StandardCounterFloat64 struct {
-	floatBits uint64
+	floatBits atomic.Uint64
 }
 
 // Clear sets the counter to zero.
@@ -144,24 +144,24 @@ func (c *StandardCounterFloat64) Snapshot() CounterFloat64 {
 	return CounterFloat64Snapshot(c.Count())
 }
 
-func atomicAddFloat(fbits *uint64, v float64) {
+func atomicAddFloat(fbits *atomic.Uint64, v float64) {
 	for {
-		loadedBits := atomic.LoadUint64(fbits)
+		loadedBits := fbits.Load()
 		newBits := math.Float64bits(math.Float64frombits(loadedBits) + v)
-		if atomic.CompareAndSwapUint64(fbits, loadedBits, newBits) {
+		if fbits.CompareAndSwap(loadedBits, newBits) {
 			break
 		}
 	}
 }
 
-func atomicGetFloat(addr *uint64) float64 {
-	return math.Float64frombits(atomic.LoadUint64(addr))
+func atomicGetFloat(addr *atomic.Uint64) float64 {
+	return math.Float64frombits(addr.Load())
 }
 
-func atomicClearFloat(addr *uint64) {
-	atomic.StoreUint64(addr, 0)
+func atomicClearFloat(addr *atomic.Uint64) {
+	addr.Store(0)
 }
 
-func atomicStoreFloat(addr *uint64, v float64) {
-	atomic.StoreUint64(addr, math.Float64bits(v))
+func atomicStoreFloat(addr *atomic.Uint64, v float64) {
+	addr.Store(math.Float64bits(v))
 }

--- a/metrics/counter_float_64_test.go
+++ b/metrics/counter_float_64_test.go
@@ -13,7 +13,7 @@ func BenchmarkCounterFloat64(b *testing.B) {
 	}
 }
 
-func BenchmarkCounterFloat64Pararel(b *testing.B) {
+func BenchmarkCounterFloat64Parallel(b *testing.B) {
 	c := NewCounterFloat64()
 	b.ResetTimer()
 	var wg sync.WaitGroup

--- a/metrics/counter_float_64_test.go
+++ b/metrics/counter_float_64_test.go
@@ -1,7 +1,6 @@
 package metrics
 
 import (
-	"sync"
 	"testing"
 )
 
@@ -16,15 +15,11 @@ func BenchmarkCounterFloat64(b *testing.B) {
 func BenchmarkCounterFloat64Parallel(b *testing.B) {
 	c := NewCounterFloat64()
 	b.ResetTimer()
-	var wg sync.WaitGroup
-	for i := 0; i < b.N; i++ {
-		wg.Add(1)
-		go func(i float64) {
-			c.Inc(i)
-			wg.Done()
-		}(float64(i))
-	}
-	wg.Wait()
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			c.Inc(1.0)
+		}
+	})
 }
 
 func TestCounterFloat64Clear(t *testing.T) {

--- a/metrics/counter_float_64_test.go
+++ b/metrics/counter_float_64_test.go
@@ -1,6 +1,9 @@
 package metrics
 
-import "testing"
+import (
+	"sync"
+	"testing"
+)
 
 func BenchmarkCounterFloat64(b *testing.B) {
 	c := NewCounterFloat64()
@@ -8,6 +11,20 @@ func BenchmarkCounterFloat64(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		c.Inc(1.0)
 	}
+}
+
+func BenchmarkCounterFloat64Pararel(b *testing.B) {
+	c := NewCounterFloat64()
+	b.ResetTimer()
+	var wg sync.WaitGroup
+	for i := 0; i < b.N; i++ {
+		wg.Add(1)
+		go func(i float64) {
+			c.Inc(i)
+			wg.Done()
+		}(float64(i))
+	}
+	wg.Wait()
 }
 
 func TestCounterFloat64Clear(t *testing.T) {

--- a/metrics/gauge_float64.go
+++ b/metrics/gauge_float64.go
@@ -1,5 +1,7 @@
 package metrics
 
+import "sync/atomic"
+
 // GaugeFloat64s hold a float64 value that can be set arbitrarily.
 type GaugeFloat64 interface {
 	Snapshot() GaugeFloat64
@@ -81,7 +83,7 @@ func (NilGaugeFloat64) Value() float64 { return 0.0 }
 // StandardGaugeFloat64 is the standard implementation of a GaugeFloat64 and uses
 // atomic to manage a single float64 value.
 type StandardGaugeFloat64 struct {
-	floatBits uint64
+	floatBits atomic.Uint64
 }
 
 // Snapshot returns a read-only copy of the gauge.

--- a/metrics/gauge_float64.go
+++ b/metrics/gauge_float64.go
@@ -79,7 +79,7 @@ func (NilGaugeFloat64) Update(v float64) {}
 func (NilGaugeFloat64) Value() float64 { return 0.0 }
 
 // StandardGaugeFloat64 is the standard implementation of a GaugeFloat64 and uses
-// sync.Mutex to manage a single float64 value.
+// atomic to manage a single float64 value.
 type StandardGaugeFloat64 struct {
 	floatBits uint64
 }

--- a/metrics/gauge_float64.go
+++ b/metrics/gauge_float64.go
@@ -1,6 +1,9 @@
 package metrics
 
-import "sync/atomic"
+import (
+	"math"
+	"sync/atomic"
+)
 
 // GaugeFloat64s hold a float64 value that can be set arbitrarily.
 type GaugeFloat64 interface {
@@ -93,12 +96,12 @@ func (g *StandardGaugeFloat64) Snapshot() GaugeFloat64 {
 
 // Update updates the gauge's value.
 func (g *StandardGaugeFloat64) Update(v float64) {
-	atomicStoreFloat(&g.floatBits, v)
+	g.floatBits.Store(math.Float64bits(v))
 }
 
 // Value returns the gauge's current value.
 func (g *StandardGaugeFloat64) Value() float64 {
-	return atomicGetFloat(&g.floatBits)
+	return math.Float64frombits(g.floatBits.Load())
 }
 
 // FunctionalGaugeFloat64 returns value from given function

--- a/metrics/gauge_float64_test.go
+++ b/metrics/gauge_float64_test.go
@@ -1,7 +1,6 @@
 package metrics
 
 import (
-	"sync"
 	"testing"
 )
 
@@ -16,15 +15,13 @@ func BenchmarkGaugeFloat64(b *testing.B) {
 func BenchmarkGaugeFloat64Parallel(b *testing.B) {
 	c := NewGaugeFloat64()
 	b.ResetTimer()
-	var wg sync.WaitGroup
-	for i := 0; i < b.N; i++ {
-		wg.Add(1)
-		go func(i float64) {
-			c.Update(i)
-			wg.Done()
-		}(float64(i))
-	}
-	wg.Wait()
+	b.RunParallel(func(pb *testing.PB) {
+		count := 1.0
+		for pb.Next() {
+			c.Update(count)
+			count += 1.0
+		}
+	})
 }
 
 func TestGaugeFloat64(t *testing.T) {

--- a/metrics/gauge_float64_test.go
+++ b/metrics/gauge_float64_test.go
@@ -1,6 +1,9 @@
 package metrics
 
-import "testing"
+import (
+	"sync"
+	"testing"
+)
 
 func BenchmarkGaugeFloat64(b *testing.B) {
 	g := NewGaugeFloat64()
@@ -8,6 +11,20 @@ func BenchmarkGaugeFloat64(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		g.Update(float64(i))
 	}
+}
+
+func BenchmarkGaugeFloat64Pararel(b *testing.B) {
+	c := NewGaugeFloat64()
+	b.ResetTimer()
+	var wg sync.WaitGroup
+	for i := 0; i < b.N; i++ {
+		wg.Add(1)
+		go func(i float64) {
+			c.Update(i)
+			wg.Done()
+		}(float64(i))
+	}
+	wg.Wait()
 }
 
 func TestGaugeFloat64(t *testing.T) {

--- a/metrics/gauge_float64_test.go
+++ b/metrics/gauge_float64_test.go
@@ -13,7 +13,7 @@ func BenchmarkGaugeFloat64(b *testing.B) {
 	}
 }
 
-func BenchmarkGaugeFloat64Pararel(b *testing.B) {
+func BenchmarkGaugeFloat64Parallel(b *testing.B) {
 	c := NewGaugeFloat64()
 	b.ResetTimer()
 	var wg sync.WaitGroup


### PR DESCRIPTION
This PR changes the gauge and counter of type f64 to use atomic instead of mutex.

BenchmarkCounterFloat64Pararel-32       186.0 ns/op
BenchmarkCounterFloat64Pararel-32       169.3 ns/op

BenchmarkGaugeFloat64Pararel-32         180.7 ns/op
BenchmarkGaugeFloat64Pararel-32         170.2 ns/op