### PR TITLE
cmd/evm: use correct parent number for t8n base fee calculation

### DIFF
--- a/cmd/evm/internal/t8ntool/transition.go
+++ b/cmd/evm/internal/t8ntool/transition.go
@@ -250,9 +250,9 @@ func Transition(ctx *cli.Context) error {
 	if chainConfig.IsLondon(big.NewInt(int64(prestate.Env.Number))) {
 		if prestate.Env.BaseFee != nil {
 			// Already set, base fee has precedent over parent base fee.
-		} else if prestate.Env.ParentBaseFee != nil {
+		} else if prestate.Env.ParentBaseFee != nil && prestate.Env.Number != 0 {
 			parent := &types.Header{
-				Number:   new(big.Int).SetUint64(prestate.Env.Number),
+				Number:   new(big.Int).SetUint64(prestate.Env.Number - 1),
 				BaseFee:  prestate.Env.ParentBaseFee,
 				GasUsed:  prestate.Env.ParentGasUsed,
 				GasLimit: prestate.Env.ParentGasLimit,


### PR DESCRIPTION
Currently the t8n tool uses the same block number for the current block and its parent while calculating the base fee. This causes incorrect base fee calculation for the London fork block.

This commit sets the parent block number to be one less than the current block number