### PR TITLE
[wip] UX: make website sticky header

### DIFF
--- a/src/components/UI/Header.tsx
+++ b/src/components/UI/Header.tsx
@@ -12,78 +12,79 @@ export const Header: FC = () => {
   const isDark = colorMode === 'dark';
 
   return (
-    <Flex
-      mb={{ base: 4, lg: 8 }}
-      border='2px'
-      borderColor='primary'
-      justifyContent='space-between'
-      position='relative'
-    >
+    <Box bg='bg'>
       <Flex
-        p={4}
-        justifyContent='flex-start'
-        alignItems='center'
-        borderRight='2px'
+        border='2px'
         borderColor='primary'
-        flex={1}
-        gap={6}
+        justifyContent='space-between'
+        mb={{ base: 4, lg: 8 }}
       >
-        <NextLink href={'/'} passHref legacyBehavior>
-          <Link _hover={{ textDecoration: 'none' }}>
-            <Text textStyle='header-font' whiteSpace='nowrap'>
-              go-ethereum
-            </Text>
-          </Link>
-        </NextLink>
-        <Box
-          as='a'
-          href='#main-content'
-          pointerEvents='none'
-          w='0px'
-          opacity={0}
-          transition='opacity 200ms ease-in-out'
-          _focus={{
-            opacity: 1,
-            w: 'auto',
-            transition: 'opacity 200ms ease-in-out'
-          }}
-        >
-          <Text textStyle='header-font' whiteSpace='nowrap' fontSize='xs'>
-            skip to content
-          </Text>
-        </Box>
-      </Flex>
-
-      <Flex>
-        {/* HEADER BUTTONS */}
-        <Stack display={{ base: 'none', md: 'block' }}>
-          <HeaderButtons />
-        </Stack>
-
-        {/* SEARCH */}
-        <Stack display={{ base: 'none', md: 'block' }} borderRight='2px' borderColor='primary'>
-          <Search />
-        </Stack>
-
-        {/* DARK MODE SWITCH */}
-        <Box
-          as='button'
+        <Flex
           p={4}
-          borderRight={{ base: '2px', md: 'none' }}
+          justifyContent='flex-start'
+          alignItems='center'
+          borderRight='2px'
           borderColor='primary'
-          onClick={toggleColorMode}
-          _hover={{
-            bg: 'primary',
-            svg: { color: 'bg' }
-          }}
-          aria-label={`Toggle ${isDark ? 'light' : 'dark'} mode`}
+          flex={1}
+          gap={6}
         >
-          {isDark ? <SunIcon color='primary' /> : <MoonIcon color='primary' />}
-        </Box>
-      </Flex>
+          <NextLink href={'/'} passHref legacyBehavior>
+            <Link _hover={{ textDecoration: 'none' }}>
+              <Text textStyle='header-font' whiteSpace='nowrap'>
+                go-ethereum
+              </Text>
+            </Link>
+          </NextLink>
+          <Box
+            as='a'
+            href='#main-content'
+            pointerEvents='none'
+            w='0px'
+            opacity={0}
+            transition='opacity 200ms ease-in-out'
+            _focus={{
+              opacity: 1,
+              w: 'auto',
+              transition: 'opacity 200ms ease-in-out'
+            }}
+          >
+            <Text textStyle='header-font' whiteSpace='nowrap' fontSize='xs'>
+              skip to content
+            </Text>
+          </Box>
+        </Flex>
 
-      {/* MOBILE MENU */}
-      <MobileMenu />
-    </Flex>
+        <Flex>
+          {/* HEADER BUTTONS */}
+          <Stack display={{ base: 'none', md: 'block' }}>
+            <HeaderButtons />
+          </Stack>
+
+          {/* SEARCH */}
+          <Stack display={{ base: 'none', md: 'block' }} borderRight='2px' borderColor='primary'>
+            <Search />
+          </Stack>
+
+          {/* DARK MODE SWITCH */}
+          <Box
+            as='button'
+            p={4}
+            borderRight={{ base: '2px', md: 'none' }}
+            borderColor='primary'
+            onClick={toggleColorMode}
+            _hover={{
+              bg: 'primary',
+              svg: { color: 'bg' }
+            }}
+            aria-label={`Toggle ${isDark ? 'light' : 'dark'} mode`}
+          >
+            {isDark ? <SunIcon color='primary' /> : <MoonIcon color='primary' />}
+          </Box>
+        </Flex>
+
+        {/* MOBILE MENU */}
+        <MobileMenu />
+      </Flex>
+    </Box>
   );
 };

--- a/src/components/UI/docs/Code.tsx
+++ b/src/components/UI/docs/Code.tsx
@@ -1,10 +1,9 @@
-// Libraries
 import { Code as ChakraCode, Stack, Text, useColorMode } from '@chakra-ui/react';
 import { nightOwl, prism } from 'react-syntax-highlighter/dist/cjs/styles/prism';
 import { PrismLight as SyntaxHighlighter } from 'react-syntax-highlighter';
 
-// Constants, utilities
 import { CLASSNAME_PREFIX } from '../../../constants';
+
 import { getProgrammingLanguageName } from '../../../utils';
 
 // Programming lang syntax highlighters

--- a/src/components/UI/docs/DocsLinks.tsx
+++ b/src/components/UI/docs/DocsLinks.tsx
@@ -15,12 +15,13 @@ import { useRouter } from 'next/router';
 
 import { LinksList } from './';
 
-import { NavLink } from '../../../types';
 import { checkNavLinks } from '../../../utils';
+
+import { NavLink } from '../../../types';
 
 interface Props {
   navLinks: NavLink[];
-  toggleMobileAccordion: () => void;
+  toggleMobileAccordion?: () => void;
 }
 
 export const DocsLinks: FC<Props> = ({ navLinks, toggleMobileAccordion }) => {
@@ -79,7 +80,10 @@ export const DocsLinks: FC<Props> = ({ navLinks, toggleMobileAccordion }) => {
                     >
                       {to ? (
                         <NextLink href={to} passHref legacyBehavior>
-                          <Link textDecoration='none !important' onClick={toggleMobileAccordion}>
+                          <Link
+                            textDecoration='none !important'
+                            onClick={toggleMobileAccordion ? toggleMobileAccordion : () => {}}
+                          >
                             <Text
                               textStyle='docs-nav-dropdown'
                               color={isActive ? 'primary' : 'unset'}
@@ -115,7 +119,12 @@ export const DocsLinks: FC<Props> = ({ navLinks, toggleMobileAccordion }) => {
                   </AccordionButton>
                   {items && (
                     <AccordionPanel borderBottom='2px solid' borderColor='primary' px={0} py={4}>
-                      <LinksList links={items} toggleMobileAccordion={toggleMobileAccordion} />
+                      <LinksList
+                        links={items}
+                        toggleMobileAccordion={
+                          toggleMobileAccordion ? toggleMobileAccordion : () => {}
+                        }
+                      />
                     </AccordionPanel>
                   )}
                 </>

--- a/src/components/UI/docs/DocsLinks.tsx
+++ b/src/components/UI/docs/DocsLinks.tsx
@@ -89,7 +89,6 @@ export const DocsLinks: FC<Props> = ({ navLinks, toggleMobileAccordion }) => {
                               color={isActive ? 'primary' : 'unset'}
                               _before={{
                                 content: '"■"',
-                                verticalAlign: '-1.25px',
                                 marginInlineEnd: 2,
                                 fontSize: 'lg',
                                 display: isActive ? 'unset' : 'none'

--- a/src/components/UI/docs/DocsNav.tsx
+++ b/src/components/UI/docs/DocsNav.tsx
@@ -1,13 +1,6 @@
-import { FC, useState } from 'react';
-import {
-  Accordion,
-  AccordionButton,
-  AccordionIcon,
-  AccordionItem,
-  AccordionPanel,
-  Stack,
-  Text
-} from '@chakra-ui/react';
+import { FC } from 'react';
+import { Stack } from '@chakra-ui/react';
+
 import { DocsLinks } from './DocsLinks';
 
 import { NavLink } from '../../../types';
@@ -17,51 +10,9 @@ interface Props {
 }
 
 export const DocsNav: FC<Props> = ({ navLinks }) => {
-  const [isMobileAccordionOpen, setMobileAccordionState] = useState(false);
-
-  const toggleMobileAccordion = () => {
-    setMobileAccordionState(prev => !prev);
-  };
-
   return (
-    <Stack w={{ base: '100%', lg: 72 }} as='aside'>
-      <Stack display={{ base: 'none', lg: 'block' }}>
-        <DocsLinks navLinks={navLinks} toggleMobileAccordion={toggleMobileAccordion} />
-      </Stack>
-
-      <Stack display={{ base: 'block', lg: 'none' }}>
-        <Accordion
-          allowToggle
-          index={isMobileAccordionOpen ? 0 : -1}
-          onChange={toggleMobileAccordion}
-        >
-          <AccordionItem border='none'>
-            <AccordionButton
-              display='flex'
-              py={4}
-              px={8}
-              border='2px'
-              borderColor='primary'
-              placeContent='space-between'
-              bg='button-bg'
-              _hover={{
-                bg: 'primary',
-                color: 'bg'
-              }}
-              _expanded={{
-                bg: 'primary',
-                color: 'bg'
-              }}
-            >
-              <Text textStyle='docs-nav-dropdown'>Documentation</Text>
-              <AccordionIcon />
-            </AccordionButton>
-            <AccordionPanel p={0}>
-              <DocsLinks navLinks={navLinks} toggleMobileAccordion={toggleMobileAccordion} />
-            </AccordionPanel>
-          </AccordionItem>
-        </Accordion>
-      </Stack>
+    <Stack w={{ base: '100%', lg: 72 }} as='aside' display={{ base: 'none', lg: 'block' }}>
+      <DocsLinks navLinks={navLinks} />
     </Stack>
   );
 };

--- a/src/components/UI/docs/MobileDocsNav.tsx
+++ b/src/components/UI/docs/MobileDocsNav.tsx
@@ -1,0 +1,56 @@
+import { FC, useState } from 'react';
+import {
+  Accordion,
+  AccordionButton,
+  AccordionIcon,
+  AccordionItem,
+  AccordionPanel,
+  Text
+} from '@chakra-ui/react';
+
+import { DocsLinks } from './DocsLinks';
+
+import { NavLink } from '../../../types';
+
+interface Props {
+  navLinks: NavLink[];
+}
+
+export const MobileDocsNav: FC<Props> = ({ navLinks }) => {
+  const [isMobileAccordionOpen, setMobileAccordionState] = useState(false);
+
+  const toggleMobileAccordion = () => {
+    setMobileAccordionState(prev => !prev);
+  };
+
+  return (
+    <Accordion allowToggle index={isMobileAccordionOpen ? 0 : -1} onChange={toggleMobileAccordion}>
+      <AccordionItem border='none'>
+        <AccordionButton
+          display='flex'
+          py={4}
+          px={8}
+          border='2px'
+          borderColor='primary'
+          placeContent='space-between'
+          bg='button-bg'
+          _hover={{
+            bg: 'primary',
+            color: 'bg'
+          }}
+          _expanded={{
+            bg: 'primary',
+            color: 'bg'
+          }}
+        >
+          <Text textStyle='docs-nav-dropdown'>Documentation</Text>
+          <AccordionIcon />
+        </AccordionButton>
+
+        <AccordionPanel p={0}>
+          <DocsLinks navLinks={navLinks} toggleMobileAccordion={toggleMobileAccordion} />
+        </AccordionPanel>
+      </AccordionItem>
+    </Accordion>
+  );
+};

--- a/src/components/UI/docs/index.ts
+++ b/src/components/UI/docs/index.ts
@@ -3,6 +3,7 @@ export * from './Code';
 export * from './DocsLinks';
 export * from './DocsNav';
 export * from './DocumentNav';
+export * from './MobileDocsNav';
 export * from './LinksList';
 export * from './Note';
 export { default } from './MDComponents';

--- a/src/components/layouts/Layout.tsx
+++ b/src/components/layouts/Layout.tsx
@@ -1,22 +1,49 @@
-// Libraries
-import { Container, Flex, Stack } from '@chakra-ui/react';
-import { FC } from 'react';
+import { Box, Container, Flex, Stack } from '@chakra-ui/react';
+import { FC, useContext } from 'react';
+import { useRouter } from 'next/router';
 
-// Components
 import { Header } from '../UI';
 import { Footer } from './Footer';
+import { MobileDocsNav } from '../UI/docs';
+
+// Context
+import { NavLinksContext } from '../../context';
 
 interface Props {
   children?: React.ReactNode;
 }
 
 export const Layout: FC<Props> = ({ children }) => {
+  const router = useRouter();
+
+  const { mobileNavLinks } = useContext(NavLinksContext);
+  // console.log({ mobileNavLinks });
+
   return (
-    <Container maxW={{ base: 'full', md: 'container.2xl' }} my={{ base: 4, md: 7 }}>
-      {/* adding min-height & top margin to keep footer at the bottom of the page */}
-      <Flex direction='column' minH='calc(100vh - 3.5rem)'>
+    <Container
+      maxW={{ base: 'full', md: 'container.2xl' }}
+      my={{ base: 4, md: 7 }}
+      overflow='visible'
+    >
+      <Box
+        position='sticky'
+        top={{ base: 3, md: 7 }}
+        backdropFilter='blur(10px)'
+        opacity={0.9}
+        zIndex={9}
+      >
         <Header />
 
+        {/* `MobileDocsNav` should be rendered under `/docs` pages only */}
+        {router.asPath.startsWith('/docs') && (
+          <Stack display={{ base: 'block', lg: 'none' }} my={6}>
+            <MobileDocsNav navLinks={mobileNavLinks} />
+          </Stack>
+        )}
+      </Box>
+
+      {/* adding min-height & top margin to keep footer at the bottom of the page */}
+      <Flex direction='column' minH='calc(100vh - 3.5rem)' height='auto' overflow='auto'>
         {children}
 
         <Stack mt='auto'>

--- a/src/components/layouts/Layout.tsx
+++ b/src/components/layouts/Layout.tsx
@@ -4,7 +4,7 @@ import { useRouter } from 'next/router';
 
 import { Header } from '../UI';
 import { Footer } from './Footer';
-import { MobileDocsNav } from '../UI/docs';
+import { DocsNav, MobileDocsNav } from '../UI/docs';
 
 // Context
 import { NavLinksContext } from '../../context';
@@ -15,9 +15,7 @@ interface Props {
 
 export const Layout: FC<Props> = ({ children }) => {
   const router = useRouter();
-
-  const { mobileNavLinks } = useContext(NavLinksContext);
-  // console.log({ mobileNavLinks });
+  const { _navLinks } = useContext(NavLinksContext);
 
   return (
     <Container
@@ -25,19 +23,21 @@ export const Layout: FC<Props> = ({ children }) => {
       my={{ base: 4, md: 7 }}
       overflow='visible'
     >
-      <Box
-        position='sticky'
-        top={{ base: 3, md: 7 }}
-        backdropFilter='blur(10px)'
-        opacity={0.9}
-        zIndex={9}
-      >
-        <Header />
+      <Box position='sticky' top={{ base: 3, md: 7 }} zIndex={9}>
+        <Box backdropFilter='blur(10px)' opacity={0.9}>
+          <Header />
 
-        {/* `MobileDocsNav` should be rendered under `/docs` pages only */}
+          {/* `MobileDocsNav` should be rendered under `/docs` pages only */}
+          {router.asPath.startsWith('/docs') && (
+            <Stack display={{ base: 'block', lg: 'none' }} my={6}>
+              <MobileDocsNav navLinks={_navLinks} />
+            </Stack>
+          )}
+        </Box>
+
         {router.asPath.startsWith('/docs') && (
-          <Stack display={{ base: 'block', lg: 'none' }} my={6}>
-            <MobileDocsNav navLinks={mobileNavLinks} />
+          <Stack display={{ base: 'none', lg: 'block' }} position='absolute'>
+            <DocsNav navLinks={_navLinks} />
           </Stack>
         )}
       </Box>

--- a/src/context/NavLinksContext.tsx
+++ b/src/context/NavLinksContext.tsx
@@ -1,0 +1,30 @@
+import { ReactNode, createContext, useState } from 'react';
+
+import { NavLink } from '../types';
+
+export interface NavLinksContextInterface {
+  mobileNavLinks: NavLink[];
+  setMobileNavLinks: (navLinks: NavLink[]) => void;
+}
+
+const defaultState = {
+  mobileNavLinks: [],
+  setMobileNavLinks: (mobileNavLinks: NavLink[]) => {}
+};
+
+// initialize Context with default state
+export const NavLinksContext = createContext<NavLinksContextInterface>(defaultState);
+
+interface Props {
+  children: ReactNode;
+}
+
+export const NavLinksContextProvider = ({ children }: Props) => {
+  const [mobileNavLinks, setMobileNavLinks] = useState<NavLink[]>([]);
+
+  return (
+    <NavLinksContext.Provider value={{ mobileNavLinks, setMobileNavLinks }}>
+      {children}
+    </NavLinksContext.Provider>
+  );
+};

--- a/src/context/NavLinksContext.tsx
+++ b/src/context/NavLinksContext.tsx
@@ -3,13 +3,13 @@ import { ReactNode, createContext, useState } from 'react';
 import { NavLink } from '../types';
 
 export interface NavLinksContextInterface {
-  mobileNavLinks: NavLink[];
-  setMobileNavLinks: (navLinks: NavLink[]) => void;
+  _navLinks: NavLink[];
+  setNavLinks: (navLinks: NavLink[]) => void;
 }
 
 const defaultState = {
-  mobileNavLinks: [],
-  setMobileNavLinks: (mobileNavLinks: NavLink[]) => {}
+  _navLinks: [],
+  setNavLinks: (mobileNavLinks: NavLink[]) => {}
 };
 
 // initialize Context with default state
@@ -20,10 +20,10 @@ interface Props {
 }
 
 export const NavLinksContextProvider = ({ children }: Props) => {
-  const [mobileNavLinks, setMobileNavLinks] = useState<NavLink[]>([]);
+  const [_navLinks, setNavLinks] = useState<NavLink[]>([]);
 
   return (
-    <NavLinksContext.Provider value={{ mobileNavLinks, setMobileNavLinks }}>
+    <NavLinksContext.Provider value={{ _navLinks, setNavLinks }}>
       {children}
     </NavLinksContext.Provider>
   );

--- a/src/context/index.ts
+++ b/src/context/index.ts
@@ -1,0 +1,1 @@
+export * from './NavLinksContext';

--- a/src/pages/[...slug].tsx
+++ b/src/pages/[...slug].tsx
@@ -1,15 +1,15 @@
 import fs from 'fs';
 import matter from 'gray-matter';
 import yaml from 'js-yaml';
+import { useContext, useEffect } from 'react';
 import { Box, Grid, Stack, Heading, Text } from '@chakra-ui/react';
 import ChakraUIRenderer from 'chakra-ui-markdown-renderer';
 import ReactMarkdown from 'react-markdown';
+import type { GetStaticPaths, GetStaticProps, NextPage } from 'next';
 import { useRouter } from 'next/router';
-import { useEffect } from 'react';
 import gfm from 'remark-gfm';
 import rehypeRaw from 'rehype-raw';
 import { ParsedUrlQuery } from 'querystring';
-import type { GetStaticPaths, GetStaticProps, NextPage } from 'next';
 
 import MDComponents, { Breadcrumbs, DocsNav, DocumentNav } from '../components/UI/docs';
 import { PageMetadata } from '../components/UI';
@@ -20,6 +20,9 @@ import { getLastModifiedDate, getParsedDate } from '../utils';
 import { NavLink } from '../types';
 
 import { textStyles } from '../theme/foundations';
+
+// Context
+import { NavLinksContext } from '../context';
 
 const MATTER_OPTIONS = {
   engines: {
@@ -80,6 +83,14 @@ interface Props {
 
 const DocPage: NextPage<Props> = ({ frontmatter, content, navLinks, lastModified }) => {
   const router = useRouter();
+  const { mobileNavLinks, setMobileNavLinks } = useContext(NavLinksContext);
+
+  useEffect(() => {
+    // set context value for `MobileDocsNav` component
+    console.log({ navLinks });
+    setMobileNavLinks(navLinks);
+    console.log({ mobileNavLinks });
+  }, []);
 
   useEffect(() => {
     const id = router.asPath.split('#')[1];
@@ -101,13 +112,17 @@ const DocPage: NextPage<Props> = ({ frontmatter, content, navLinks, lastModified
           gap={{ base: 4, lg: 8 }}
           templateColumns={{ base: 'repeat(1, 1fr)', lg: '288px 1fr' }}
         >
-          <Stack>
+          <Stack display={{ base: 'none', lg: 'block' }}>
             <DocsNav navLinks={navLinks} />
           </Stack>
 
           <Stack pb={4} width='100%' id='main-content'>
             <Stack mb={16}>
-              <Breadcrumbs />
+              {/* hide breadcrumbs on mobile */}
+              <Box display={{ base: 'none', lg: 'block' }}>
+                <Breadcrumbs />
+              </Box>
+
               <Heading as='h1' mt='4 !important' mb={0} {...textStyles.h1}>
                 {frontmatter.title}
               </Heading>

--- a/src/pages/[...slug].tsx
+++ b/src/pages/[...slug].tsx
@@ -2,7 +2,7 @@ import fs from 'fs';
 import matter from 'gray-matter';
 import yaml from 'js-yaml';
 import { useContext, useEffect } from 'react';
-import { Box, Grid, Stack, Heading, Text } from '@chakra-ui/react';
+import { Box, Grid, Stack, Heading, Text, Flex } from '@chakra-ui/react';
 import ChakraUIRenderer from 'chakra-ui-markdown-renderer';
 import ReactMarkdown from 'react-markdown';
 import type { GetStaticPaths, GetStaticProps, NextPage } from 'next';
@@ -11,7 +11,7 @@ import gfm from 'remark-gfm';
 import rehypeRaw from 'rehype-raw';
 import { ParsedUrlQuery } from 'querystring';
 
-import MDComponents, { Breadcrumbs, DocsNav, DocumentNav } from '../components/UI/docs';
+import MDComponents, { Breadcrumbs, DocumentNav } from '../components/UI/docs';
 import { PageMetadata } from '../components/UI';
 
 import { getFileList } from '../utils/getFileList';
@@ -83,14 +83,11 @@ interface Props {
 
 const DocPage: NextPage<Props> = ({ frontmatter, content, navLinks, lastModified }) => {
   const router = useRouter();
-  const { mobileNavLinks, setMobileNavLinks } = useContext(NavLinksContext);
+  const { setNavLinks } = useContext(NavLinksContext);
 
   useEffect(() => {
-    // set context value for `MobileDocsNav` component
-    console.log({ navLinks });
-    setMobileNavLinks(navLinks);
-    console.log({ mobileNavLinks });
-  }, []);
+    setNavLinks(navLinks);
+  }, [navLinks, setNavLinks]);
 
   useEffect(() => {
     const id = router.asPath.split('#')[1];
@@ -108,53 +105,44 @@ const DocPage: NextPage<Props> = ({ frontmatter, content, navLinks, lastModified
       <PageMetadata title={frontmatter.title} description={frontmatter.description} />
 
       <main>
-        <Grid
-          gap={{ base: 4, lg: 8 }}
-          templateColumns={{ base: 'repeat(1, 1fr)', lg: '288px 1fr' }}
-        >
-          <Stack display={{ base: 'none', lg: 'block' }}>
-            <DocsNav navLinks={navLinks} />
+        <Stack pl={{ base: 0, lg: 80 }} pb={4} width='100%' id='main-content'>
+          <Stack mb={16}>
+            {/* hide breadcrumbs on mobile */}
+            <Box display={{ base: 'none', lg: 'block' }}>
+              <Breadcrumbs />
+            </Box>
+
+            <Heading as='h1' mt='4 !important' mb={0} {...textStyles.h1}>
+              {frontmatter.title}
+            </Heading>
+            <Text as='span' mt='0 !important'>
+              Last edited on {lastModified}
+            </Text>
           </Stack>
 
-          <Stack pb={4} width='100%' id='main-content'>
-            <Stack mb={16}>
-              {/* hide breadcrumbs on mobile */}
-              <Box display={{ base: 'none', lg: 'block' }}>
-                <Breadcrumbs />
-              </Box>
-
-              <Heading as='h1' mt='4 !important' mb={0} {...textStyles.h1}>
-                {frontmatter.title}
-              </Heading>
-              <Text as='span' mt='0 !important'>
-                Last edited on {lastModified}
-              </Text>
-            </Stack>
-
-            <Grid
-              gap={{ base: 4, lg: 8 }}
-              templateColumns={{ base: 'repeat(1, 1fr)', xl: '1fr 192px' }}
+          <Grid
+            gap={{ base: 4, lg: 8 }}
+            templateColumns={{ base: 'repeat(1, 1fr)', xl: '1fr 192px' }}
+          >
+            <Box
+              w='min(100%, 768px)'
+              sx={{ '*:first-of-type': { marginTop: '0 !important' } }}
+              overflow='auto'
             >
-              <Box
-                w='min(100%, 768px)'
-                sx={{ '*:first-of-type': { marginTop: '0 !important' } }}
-                overflow='auto'
+              <ReactMarkdown
+                remarkPlugins={[gfm]}
+                rehypePlugins={[rehypeRaw]}
+                components={ChakraUIRenderer(MDComponents)}
               >
-                <ReactMarkdown
-                  remarkPlugins={[gfm]}
-                  rehypePlugins={[rehypeRaw]}
-                  components={ChakraUIRenderer(MDComponents)}
-                >
-                  {content}
-                </ReactMarkdown>
-              </Box>
+                {content}
+              </ReactMarkdown>
+            </Box>
 
-              <Stack display={{ base: 'none', xl: 'block' }}>
-                <DocumentNav content={content} />
-              </Stack>
-            </Grid>
-          </Stack>
-        </Grid>
+            <Stack display={{ base: 'none', xl: 'block' }}>
+              <DocumentNav content={content} />
+            </Stack>
+          </Grid>
+        </Stack>
       </main>
     </>
   );

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -11,6 +11,9 @@ import theme from '../theme';
 // Algolia search css styling
 import '../theme/search.css';
 
+// Context
+import { NavLinksContextProvider } from '../context';
+
 export default function App({ Component, pageProps }: AppProps) {
   useEffect(() => {
     init({
@@ -23,9 +26,11 @@ export default function App({ Component, pageProps }: AppProps) {
     // `colorModeManager` added to fix flashing issue
     // See: https://chakra-ui.com/docs/styled-system/color-mode#add-colormodemanager-optional-for-ssr
     <ChakraProvider theme={theme} colorModeManager={localStorageManager}>
-      <Layout>
-        <Component {...pageProps} />
-      </Layout>
+      <NavLinksContextProvider>
+        <Layout>
+          <Component {...pageProps} />
+        </Layout>
+      </NavLinksContextProvider>
     </ChakraProvider>
   );
 }


### PR DESCRIPTION
This PR makes the header & docs nav components sticky

**Preview:** https://deploy-preview-27057--geth-website.netlify.app/

## Description

- Refactors `DocsNav`, splitting into 2 simpler & smaller components:
  - `DocsNav` for desktop
  - `MobileDocsNav` for mobile 
- Moves `Header` component inside `Layout`, to be able to make it sticky
- Moves `MobileDocsNav` component inside `Layout`, to be able to make it sticky
- Moves `DocsNav` component inside `Layout`, to be able to make it sticky
- Updates `/docs` pages layout
- Hide `Breadcrumbs` in mobile
- Creates `NavLinksContext` (Context API) to be able to share state between `/docs` pages and `Layout` component, required to be able to pass `navLinks` data as props to `MobileDocsNav`

## Issues to be solved

- In `/docs` pages:
  - Right menu (`DocumentNav`) scrolls under header in desktop
  - Footer scrolls under left menu (`DocsNav`) in desktop
  
 ## Related issue

#26424