### PR TITLE
core: fix comment to reflect function name

### DIFF
--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -908,7 +908,7 @@ func (bc *BlockChain) writeHeadBlock(block *types.Block) {
 	headBlockGauge.Update(int64(block.NumberU64()))
 }
 
-// stop stops the blockchain service. If any imports are currently in progress
+// stopWithoutSaving stops the blockchain service. If any imports are currently in progress
 // it will abort them using the procInterrupt. This method stops all running
 // goroutines, but does not do all the post-stop work of persisting data.
 // OBS! It is generally recommended to use the Stop method!

--- a/core/state/snapshot/snapshot_test.go
+++ b/core/state/snapshot/snapshot_test.go
@@ -118,7 +118,7 @@ func TestDiskLayerExternalInvalidationFullFlatten(t *testing.T) {
 	if err := snaps.Cap(common.HexToHash("0x02"), 0); err != nil {
 		t.Fatalf("failed to merge diff layer onto disk: %v", err)
 	}
-	// Since the base layer was modified, ensure that data retrieval on the external reference fail
+	// Since the base layer was modified, ensure that data retrievals on the external reference fail
 	if acc, err := ref.Account(common.HexToHash("0x01")); err != ErrSnapshotStale {
 		t.Errorf("stale reference returned account: %#x (err: %v)", acc, err)
 	}


### PR DESCRIPTION
Fix comment to reflect function name. 

Currently, geth uses `stop` instead of `stopWithoutSaving` in the comment description, which is incorrect.

Also pluralized the subject of the sentence in another comment to match the correct one. 

Correct: https://github.com/ethereum/go-ethereum/blob/master/core/state/snapshot/snapshot_test.go#L229
Incorrect: https://github.com/ethereum/go-ethereum/blob/master/core/state/snapshot/snapshot_test.go#L121
