### PR TITLE
cmd/geth: Rename --vmodule to --log.vmodule

### DIFF
--- a/internal/debug/flags.go
+++ b/internal/debug/flags.go
@@ -45,10 +45,17 @@ var (
 		Value:    3,
 		Category: flags.LoggingCategory,
 	}
+	logVmoduleFlag = &cli.StringFlag{
+		Name:     "log.vmodule",
+		Usage:    "Per-module verbosity: comma-separated list of <pattern>=<level> (e.g. eth/*=5,p2p=4)",
+		Value:    "",
+		Category: flags.LoggingCategory,
+	}
 	vmoduleFlag = &cli.StringFlag{
 		Name:     "vmodule",
 		Usage:    "Per-module verbosity: comma-separated list of <pattern>=<level> (e.g. eth/*=5,p2p=4)",
 		Value:    "",
+		Hidden:   true,
 		Category: flags.LoggingCategory,
 	}
 	logjsonFlag = &cli.BoolFlag{
@@ -149,6 +156,7 @@ var (
 // Flags holds all command-line flags required for debugging.
 var Flags = []cli.Flag{
 	verbosityFlag,
+	logVmoduleFlag,
 	vmoduleFlag,
 	backtraceAtFlag,
 	debugFlag,
@@ -252,7 +260,14 @@ func Setup(ctx *cli.Context) error {
 	// logging
 	verbosity := ctx.Int(verbosityFlag.Name)
 	glogger.Verbosity(log.Lvl(verbosity))
-	vmodule := ctx.String(vmoduleFlag.Name)
+	vmodule := ctx.String(logVmoduleFlag.Name)
+	if vmodule == "" {
+		// Retain backwards compatibility with `--vmodule` flag if `--log.vmodule` not set
+		vmodule = ctx.String(vmoduleFlag.Name)
+		if vmodule != "" {
+			defer log.Warn("The flag '--vmodule' is deprecated, please use '--log.vmodule' instead")
+		}
+	}
 	glogger.Vmodule(vmodule)
 
 	debug := ctx.Bool(debugFlag.Name)


### PR DESCRIPTION
Backwards compatibility for --vmodule is preserved if --log.vmodule isn't specified with a warning logged.

Follows up on a suggestion in #26970 so log related CLI args all start with `--log.`