### PR TITLE
p2p: access embedded fields directly

### DIFF
--- a/p2p/server.go
+++ b/p2p/server.go
@@ -443,7 +443,7 @@ func (srv *Server) Start() (err error) {
 		return errors.New("server already running")
 	}
 	srv.running = true
-	srv.log = srv.Config.Logger
+	srv.log = srv.Logger
 	if srv.log == nil {
 		srv.log = log.Root()
 	}
@@ -501,7 +501,7 @@ func (srv *Server) setupLocalNode() error {
 	sort.Sort(capsByNameAndVersion(srv.ourHandshake.Caps))
 
 	// Create the local node.
-	db, err := enode.OpenDB(srv.Config.NodeDatabase)
+	db, err := enode.OpenDB(srv.NodeDatabase)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
In this file, for the internal anonymous Config structure calls within the Server struct, some calls were made using 'srv.Config.xx', while others were made using 'srv.xx'. In order to unify the coding style, I have removed the calls to 'srv.Config.xx'.