### PR TITLE
rpc,internal/cmdtest: increase timeout in tests

### DIFF
--- a/cmd/geth/consolecmd_test.go
+++ b/cmd/geth/consolecmd_test.go
@@ -116,7 +116,7 @@ func TestAttachWelcome(t *testing.T) {
 		waitForEndpoint(t, endpoint, 3*time.Second)
 		testAttachWelcome(t, geth, endpoint, httpAPIs)
 	})
-	geth.ExpectExit()
+	geth.Kill()
 }
 
 func testAttachWelcome(t *testing.T, geth *testgeth, endpoint, apis string) {

--- a/internal/cmdtest/test_cmd.go
+++ b/internal/cmdtest/test_cmd.go
@@ -237,7 +237,7 @@ func (tt *TestCmd) Kill() {
 }
 
 func (tt *TestCmd) withKillTimeout(fn func()) {
-	timeout := time.AfterFunc(5*time.Second, func() {
+	timeout := time.AfterFunc(30*time.Second, func() {
 		tt.Log("killing the child process (timeout)")
 		tt.Kill()
 	})

--- a/rpc/client.go
+++ b/rpc/client.go
@@ -43,7 +43,7 @@ var (
 const (
 	// Timeouts
 	defaultDialTimeout = 10 * time.Second // used if context has no deadline
-	subscribeTimeout   = 5 * time.Second  // overall timeout eth_subscribe, rpc_modules calls
+	subscribeTimeout   = 10 * time.Second // overall timeout eth_subscribe, rpc_modules calls
 )
 
 const (


### PR DESCRIPTION
I'm running the tests in my dev machine(m1 mac air), and some test case failed

I ran the test cases on my local machine (macOS M1 Air) and found that some test cases could not be passed. 

> run with command:

```bash
go test ./cmd/geth/... -v 
```


> test case 1

```bash
    test_cmd.go:241: killing the child process (timeout)
    test_cmd.go:115: not enough output, got until ◊:
        ---------------- (stdout text)
        
        ---------------- (expected text)
        ◊undefined
        
--- FAIL: TestUnlockFlagPasswordFile (5.03s)
=== RUN   TestUnlockFlagPasswordFileWrongPassword
```

> test case 2

```basg
=== NAME  TestAttachWithHeaders
    test_cmd.go:261: (stderr:42) Fatal: Failed to start the JavaScript console: Post "http://localhost:58843": context deadline exceeded
--- PASS: TestRemoteDbWithHeaders (10.14s)
=== NAME  TestAttachWithHeaders
    attach_test.go:81: Test fail, expected invocation to succeed
--- FAIL: TestAttachWithHeaders (10.14s)
FAIL
```

> test case ...


After checking, I discovered that this was due to the timeout being set too short.