### PR TITLE
node: create authrpc jwtsecret path if non-existent

### DIFF
--- a/node/node.go
+++ b/node/node.go
@@ -357,7 +357,10 @@ func (n *Node) obtainJWTSecret(cliParam string) ([]byte, error) {
 		log.Error("Invalid JWT secret", "path", fileName, "length", len(jwtSecret))
 		return nil, errors.New("invalid JWT secret")
 	}
-	// Need to generate one
+	// Need to generate one, make sure custom destination folder exists
+	if err := os.MkdirAll(filepath.Dir(fileName), 0700); err != nil {
+		return nil, err
+	}
 	jwtSecret := make([]byte, 32)
 	crand.Read(jwtSecret)
 	// if we're in --dev mode, don't bother saving, just show it


### PR DESCRIPTION
I'm unsure if this was deliberately not implemented or just forgotten. If the `authrpc.jwtsecret` points to a non-existent path, Geth fails to start up. This is a tad annoying in a docker setting:

I'd like to share the jwtsecret outside of Geth's container, and the simplest way was to map the folder containing the secret into another container to consume. For that however, I'd rather map a custom folder containing only this file and not the entire geth data directory.

This cannot be done with a stock Geth container, because there's no way to create this JWT secret folder to place the file into. The PR fixes it by allowing non-existing folders to be created instead of errored out.

Unsure if this has any security implications we might want to take into account? 