### PR TITLE
params: new sepolia bootnodes

### DIFF
--- a/params/bootnodes.go
+++ b/params/bootnodes.go
@@ -31,10 +31,12 @@ var MainnetBootnodes = []string{
 // SepoliaBootnodes are the enode URLs of the P2P bootstrap nodes running on the
 // Sepolia test network.
 var SepoliaBootnodes = []string{
-	// geth
-	"enode://9246d00bc8fd1742e5ad2428b80fc4dc45d786283e05ef6edbd9002cbc335d40998444732fbe921cb88e1d2c73d1b1de53bae6a2237996e9bfe14f871baf7066@18.168.182.86:30303",
-	// besu
-	"enode://ec66ddcf1a974950bd4c782789a7e04f8aa7110a72569b6e65fcd51e937e74eed303b1ea734e4d19cfaec9fbff9b6ee65bf31dcb50ba79acce9dd63a6aca61c7@52.14.151.177:30303",
+	// EF DevOps
+	"enode://4e5e92199ee224a01932a377160aa432f31d0b351f84ab413a8e0a42f4f36476f8fb1cbe914af0d9aef0d51665c214cf653c651c4bbd9d5550a934f241f1682b@138.197.51.181:30303", // sepolia-bootnode-1-nyc3
+	"enode://143e11fb766781d22d92a2e33f8f104cddae4411a122295ed1fdb6638de96a6ce65f5b7c964ba3763bba27961738fef7d3ecc739268f3e5e771fb4c87b6234ba@146.190.1.103:30303",  // sepolia-bootnode-1-sfo3
+	"enode://8b61dc2d06c3f96fddcbebb0efb29d60d3598650275dc469c22229d3e5620369b0d3dedafd929835fe7f489618f19f456fe7c0df572bf2d914a9f4e006f783a9@170.64.250.88:30303",  // sepolia-bootnode-1-syd1
+	"enode://10d62eff032205fcef19497f35ca8477bea0eadfff6d769a147e895d8b2b8f8ae6341630c645c30f5df6e67547c03494ced3d9c5764e8622a26587b083b028e8@139.59.49.206:30303",  // sepolia-bootnode-1-blr1
+	"enode://9e9492e2e8836114cc75f5b929784f4f46c324ad01daf87d956f98b3b6c5fcba95524d6e5cf9861dc96a2c8a171ea7105bb554a197455058de185fa870970c7c@138.68.123.152:30303", // sepolia-bootnode-1-ams3
 }
 
 // RinkebyBootnodes are the enode URLs of the P2P bootstrap nodes running on the


### PR DESCRIPTION
Sepolia has had some peering troubles in the past, seems like running `./devp2p rlpx ping enode` against the existing sepolia bootnodes doesn't return a response (thanks @lightclient for bring that up and introducing me to the tool!). It seems like the old bootnodes weren't created properly or not added to the IaC stack we usually have our configs in, so I went ahead and setup new bootnodes on DigitalOcean. These have more liberal bandwidth limits and cost far lesser to run, they should be able to help with peering and sync performance on Sepolia. 

The bootnode configs have been commited to the private devops repo along with a reserved IP and the nodekey has been backed up. The bootnode has additionally been added to the DevOps monitoring and updating stack. We should be able to maintain these bootnodes far better in the future. 