### PR TITLE
common, core, eth: add remaining time estimate to log msgs

### DIFF
--- a/common/math/integer.go
+++ b/common/math/integer.go
@@ -107,3 +107,19 @@ func SafeMul(x, y uint64) (uint64, bool) {
 	hi, lo := bits.Mul64(x, y)
 	return lo, hi != 0
 }
+
+// Max is a helper function which returns the larger of the two given integers.
+func Max(a, b int) int {
+	if a > b {
+		return a
+	}
+	return b
+}
+
+// Max64 is a helper function which returns the larger of the two int64s
+func Max64(a, b int64) int64 {
+	if a > b {
+		return a
+	}
+	return b
+}

--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -1814,7 +1814,7 @@ func (bc *BlockChain) insertChain(chain types.Blocks, verifySeals, setHead bool)
 		stats.usedGas += usedGas
 
 		dirty, _ := bc.triedb.Size()
-		stats.report(chain, it.index, dirty, setHead)
+		stats.report(chain, it.index, dirty, setHead, bc)
 
 		if !setHead {
 			// After merge we expect few side chains. Simply count

--- a/core/blockchain_insert.go
+++ b/core/blockchain_insert.go
@@ -17,7 +17,6 @@
 package core
 
 import (
-	"github.com/ethereum/go-ethereum/common/math"
 	"time"
 
 	"github.com/ethereum/go-ethereum/common"
@@ -38,13 +37,9 @@ type insertStats struct {
 // always print out progress. This avoids the user wondering what's going on.
 const statsReportLimit = 8 * time.Second
 
-// blocksPerSecondCheckLength is the number of blocks to look back when estimating
-// remaining time to sync
-const blocksPerSecondCheckLength = 128
-
 // report prints statistics if some number of blocks have been processed
 // or more than a few seconds have passed since the last message.
-func (st *insertStats) report(chain []*types.Block, index int, dirty common.StorageSize, setHead bool, bc *BlockChain) {
+func (st *insertStats) report(chain []*types.Block, index int, dirty common.StorageSize, setHead bool, secondsPerBlock float64) {
 	// Fetch the timings for the batch
 	var (
 		now     = mclock.Now()
@@ -69,18 +64,10 @@ func (st *insertStats) report(chain []*types.Block, index int, dirty common.Stor
 			context = append(context, []interface{}{"age", common.PrettyAge(timestamp)}...)
 			// estimate remaining time by comparing age to the rate at which recent blocks were processed
 			// this is approximate but seems to work adequately for rough tracking
-			curBlockNum := bc.CurrentHeader().Number.Int64()
-			prevBlockNum := math.Max64(0, curBlockNum-blocksPerSecondCheckLength)
-			prevHeader := bc.GetHeaderByNumber(uint64(prevBlockNum))
-			if prevHeader != nil {
-				chainSecondsPerBlock := float64(bc.CurrentHeader().Time-prevHeader.Time) / float64(curBlockNum-prevBlockNum)
-				blocksToDo := float64(time.Since(timestamp).Seconds()) / chainSecondsPerBlock
-				ingestSecondsPerBlock := float64(elapsed.Seconds()) / float64(st.processed)
-				secondsToGo := blocksToDo * ingestSecondsPerBlock
-				expectedTime := time.Unix(time.Now().Unix()+int64(secondsToGo), 0)
-				expectedDuration := expectedTime.Sub(time.Now())
-				context = append(context, []interface{}{"remaining", common.PrettyDuration(expectedDuration)}...)
-			}
+			blocksToDo := time.Since(timestamp).Seconds() / secondsPerBlock
+			ingestSecondsPerBlock := elapsed.Seconds() / float64(st.processed)
+			expectedDuration := time.Duration(blocksToDo * ingestSecondsPerBlock * float64(time.Second))
+			context = append(context, []interface{}{"remaining", common.PrettyDuration(expectedDuration)}...)
 		}
 		context = append(context, []interface{}{"dirty", dirty}...)
 

--- a/core/error.go
+++ b/core/error.go
@@ -33,6 +33,9 @@ var (
 	ErrNoGenesis = errors.New("genesis not found in chain")
 
 	errSideChainReceipts = errors.New("side blocks can't be accepted as ancient chain data")
+
+	// ErrNoBlockHeader is returned when we cannot find requested block header
+	ErrNoBlockHeader = errors.New("could not find requested block header")
 )
 
 // List of evm-call-message pre-checking errors. All state transition messages will

--- a/eth/protocols/eth/peer.go
+++ b/eth/protocols/eth/peer.go
@@ -17,6 +17,7 @@
 package eth
 
 import (
+	"github.com/ethereum/go-ethereum/common/math"
 	"math/big"
 	"math/rand"
 	"sync"
@@ -55,14 +56,6 @@ const (
 	// above some healthy uncle limit, so use that.
 	maxQueuedBlockAnns = 4
 )
-
-// max is a helper function which returns the larger of the two given integers.
-func max(a, b int) int {
-	if a > b {
-		return a
-	}
-	return b
-}
 
 // Peer is a collection of relevant information we have about a `eth` peer.
 type Peer struct {
@@ -516,7 +509,7 @@ func newKnownCache(max int) *knownCache {
 
 // Add adds a list of elements to the set.
 func (k *knownCache) Add(hashes ...common.Hash) {
-	for k.hashes.Cardinality() > max(0, k.max-len(hashes)) {
+	for k.hashes.Cardinality() > math.Max(0, k.max-len(hashes)) {
 		k.hashes.Pop()
 	}
 	for _, hash := range hashes {


### PR DESCRIPTION
add a remaining= field to report() to show an estimate of remaining time to sync for a node
also move the max(int,int) helper function from eth to common as it is needed to implement this

this passes a pointer to the BlockChain struct into report() which is not great. but there does not seem to be another robust way to work out the recent seconds-per-block quantity and surely that logic does not belong in insertChain().

should the calc be moved to a separate function or method on bc? not terribly familiar with the style here.