### PR TITLE
event: secondary send method

### DIFF
--- a/event/feed.go
+++ b/event/feed.go
@@ -17,6 +17,7 @@
 package event
 
 import (
+	"context"
 	"errors"
 	"reflect"
 	"sync"
@@ -46,7 +47,11 @@ type Feed struct {
 
 // This is the index of the first actual subscription channel in sendCases.
 // sendCases[0] is a SelectRecv case for the removeSub channel.
+// sendCases[1] is a Ctx case.
 const firstSubSendCase = 1
+const secondSubSendCase = 2
+
+var cachedNullCtx = reflect.SelectCase{Dir: reflect.SelectRecv, Chan: reflect.ValueOf(context.Background().Done())}
 
 type feedTypeError struct {
 	got, want reflect.Type
@@ -221,6 +226,9 @@ func (cs caseList) find(channel interface{}) int {
 
 // delete removes the given case from cs.
 func (cs caseList) delete(index int) caseList {
+	if index == -1 {
+		return cs
+	}
 	return append(cs[:index], cs[index+1:]...)
 }
 

--- a/event/feedof.go
+++ b/event/feedof.go
@@ -153,7 +153,7 @@ func (f *FeedOf[T]) Send(value T) (nsent int) {
 
 // If ctx passes deadline, the send is being aborted.
 // Slow consumers can be dropped by setting drop to true.
-// It returns number of subscribers that the value was sent to and number of dropped subsribers.
+// It returns number of subscribers that the value was sent to and number of dropped subscribers.
 func (f *FeedOf[T]) SendWithCtx(ctx context.Context, drop bool, value T) (nsent int, ndropped int) {
 	rvalue := reflect.ValueOf(value)
 

--- a/event/feedof_test.go
+++ b/event/feedof_test.go
@@ -160,6 +160,7 @@ func TestFeedOfSubscribeBlockedCanceled(t *testing.T) {
 	defer wg.Wait()
 	wg.Add(nsends / 2)
 	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel() // prevent automatic checks from reporting "leak"
 	feed.Subscribe(ch1)
 	for i := 0; i < (nsends / 2); i++ {
 		go func(i int) {


### PR DESCRIPTION
This pr adds a secondary method for notifying subscribers. This method allows notifications to be sent within a deadline and optionally allows for slow consumers to be dropped. 