### PR TITLE
p2p/discover: concurrent TALKREQ handling

### DIFF
--- a/p2p/discover/table_util_test.go
+++ b/p2p/discover/table_util_test.go
@@ -52,6 +52,7 @@ func newTestTable(t transport) (*Table, *enode.DB) {
 func nodeAtDistance(base enode.ID, ld int, ip net.IP) *node {
 	var r enr.Record
 	r.Set(enr.IP(ip))
+	r.Set(enr.UDP(30303))
 	return wrapNode(enode.SignNull(&r, idAtDistance(base, ld)))
 }
 

--- a/p2p/discover/v5_talk.go
+++ b/p2p/discover/v5_talk.go
@@ -1,0 +1,104 @@
+// Copyright 2023 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+
+package discover
+
+import (
+	"net"
+	"sync"
+	"time"
+
+	"github.com/ethereum/go-ethereum/p2p/discover/v5wire"
+	"github.com/ethereum/go-ethereum/p2p/enode"
+)
+
+// This is a limit for the number of concurrent talk requests.
+const maxActiveTalkRequests = 1024
+
+// This is the timeout for acquiring a handler execution slot for a talk request.
+// The timeout should be short enough to fit within the request timeout.
+const talkHandlerLaunchTimeout = 400 * time.Millisecond
+
+// TalkRequestHandler callback processes a talk request and returns a response.
+//
+// Note that talk handlers are expected to come up with a response very quickly, within at
+// most 200ms or so. If the handler takes longer than that, the remote end may time out
+// and wont receive the response.
+type TalkRequestHandler func(enode.ID, *net.UDPAddr, []byte) []byte
+
+type talkSystem struct {
+	transport *UDPv5
+
+	mutex    sync.Mutex
+	handlers map[string]TalkRequestHandler
+	slots    chan struct{}
+}
+
+func newTalkSystem(transport *UDPv5) *talkSystem {
+	t := &talkSystem{
+		transport: transport,
+		handlers:  make(map[string]TalkRequestHandler),
+		slots:     make(chan struct{}, maxActiveTalkRequests),
+	}
+	for i := 0; i < cap(t.slots); i++ {
+		t.slots <- struct{}{}
+	}
+	return t
+}
+
+// register adds a protocol handler.
+func (t *talkSystem) register(protocol string, handler TalkRequestHandler) {
+	t.mutex.Lock()
+	t.handlers[protocol] = handler
+	t.mutex.Unlock()
+}
+
+// handleRequest handles a talk request.
+func (t *talkSystem) handleRequest(id enode.ID, addr *net.UDPAddr, req *v5wire.TalkRequest) {
+	t.mutex.Lock()
+	handler, ok := t.handlers[req.Protocol]
+	t.mutex.Unlock()
+
+	if !ok {
+		resp := &v5wire.TalkResponse{ReqID: req.ReqID}
+		t.transport.sendResponse(id, addr, resp)
+		return
+	}
+
+	// Wait for a slot to become available, then run the handler.
+	timeout := time.NewTimer(talkHandlerLaunchTimeout)
+	defer timeout.Stop()
+	select {
+	case <-t.slots:
+		go func() {
+			defer func() { t.slots <- struct{}{} }()
+			respMessage := handler(id, addr, req.Message)
+			resp := &v5wire.TalkResponse{ReqID: req.ReqID, Message: respMessage}
+			t.transport.sendFromAnotherThread(id, addr, resp)
+		}()
+	case <-t.transport.closeCtx.Done():
+		// Transport closed, drop the request.
+	case <-timeout.C:
+		// Couldn't get it in time, drop the request.
+	}
+}
+
+// wait blocks until all active requests have finished.
+func (t *talkSystem) wait() {
+	for i := 0; i < cap(t.slots); i++ {
+		<-t.slots
+	}
+}

--- a/p2p/discover/v5_talk.go
+++ b/p2p/discover/v5_talk.go
@@ -104,7 +104,8 @@ func (t *talkSystem) handleRequest(id enode.ID, addr *net.UDPAddr, req *v5wire.T
 	}
 }
 
-// wait blocks until all active requests have finished.
+// wait blocks until all active requests have finished, and prevents new request
+// handlers from being launched.
 func (t *talkSystem) wait() {
 	for i := 0; i < cap(t.slots); i++ {
 		<-t.slots

--- a/p2p/discover/v5_udp.go
+++ b/p2p/discover/v5_udp.go
@@ -106,7 +106,10 @@ type sendRequest struct {
 
 // callV5 represents a remote procedure call against another node.
 type callV5 struct {
-	node         *enode.Node
+	id   enode.ID
+	addr *net.UDPAddr
+	node *enode.Node // This is required to perform handshakes.
+
 	packet       v5wire.Packet
 	responseType byte // expected packet type of response
 	reqid        []byte
@@ -251,7 +254,20 @@ func (t *UDPv5) RegisterTalkHandler(protocol string, handler TalkRequestHandler)
 // TalkRequest sends a talk request to a node and waits for a response.
 func (t *UDPv5) TalkRequest(n *enode.Node, protocol string, request []byte) ([]byte, error) {
 	req := &v5wire.TalkRequest{Protocol: protocol, Message: request}
-	resp := t.call(n, v5wire.TalkResponseMsg, req)
+	resp := t.callToNode(n, v5wire.TalkResponseMsg, req)
+	defer t.callDone(resp)
+	select {
+	case respMsg := <-resp.ch:
+		return respMsg.(*v5wire.TalkResponse).Message, nil
+	case err := <-resp.err:
+		return nil, err
+	}
+}
+
+// TalkRequest sends a talk request to a node and waits for a response.
+func (t *UDPv5) TalkRequestToID(id enode.ID, addr *net.UDPAddr, protocol string, request []byte) ([]byte, error) {
+	req := &v5wire.TalkRequest{Protocol: protocol, Message: request}
+	resp := t.callToID(id, addr, v5wire.TalkResponseMsg, req)
 	defer t.callDone(resp)
 	select {
 	case respMsg := <-resp.ch:
@@ -342,7 +358,7 @@ func lookupDistances(target, dest enode.ID) (dists []uint) {
 // ping calls PING on a node and waits for a PONG response.
 func (t *UDPv5) ping(n *enode.Node) (uint64, error) {
 	req := &v5wire.Ping{ENRSeq: t.localNode.Node().Seq()}
-	resp := t.call(n, v5wire.PongMsg, req)
+	resp := t.callToNode(n, v5wire.PongMsg, req)
 	defer t.callDone(resp)
 
 	select {
@@ -367,7 +383,7 @@ func (t *UDPv5) RequestENR(n *enode.Node) (*enode.Node, error) {
 
 // findnode calls FINDNODE on a node and waits for responses.
 func (t *UDPv5) findnode(n *enode.Node, distances []uint) ([]*enode.Node, error) {
-	resp := t.call(n, v5wire.NodesMsg, &v5wire.Findnode{Distances: distances})
+	resp := t.callToNode(n, v5wire.NodesMsg, &v5wire.Findnode{Distances: distances})
 	return t.waitForNodes(resp, distances)
 }
 
@@ -410,17 +426,17 @@ func (t *UDPv5) verifyResponseNode(c *callV5, r *enr.Record, distances []uint, s
 	if err != nil {
 		return nil, err
 	}
-	if err := netutil.CheckRelayIP(c.node.IP(), node.IP()); err != nil {
+	if err := netutil.CheckRelayIP(c.addr.IP, node.IP()); err != nil {
 		return nil, err
 	}
 	if t.netrestrict != nil && !t.netrestrict.Contains(node.IP()) {
 		return nil, errors.New("not contained in netrestrict list")
 	}
-	if c.node.UDP() <= 1024 {
+	if node.UDP() <= 1024 {
 		return nil, errLowPort
 	}
 	if distances != nil {
-		nd := enode.LogDist(c.node.ID(), node.ID())
+		nd := enode.LogDist(c.id, node.ID())
 		if !containsUint(uint(nd), distances) {
 			return nil, errors.New("does not match any requested distance")
 		}
@@ -441,17 +457,28 @@ func containsUint(x uint, xs []uint) bool {
 	return false
 }
 
-// call sends the given call and sets up a handler for response packets (of message type
-// responseType). Responses are dispatched to the call's response channel.
-func (t *UDPv5) call(node *enode.Node, responseType byte, packet v5wire.Packet) *callV5 {
-	c := &callV5{
-		node:         node,
-		packet:       packet,
-		responseType: responseType,
-		reqid:        make([]byte, 8),
-		ch:           make(chan v5wire.Packet, 1),
-		err:          make(chan error, 1),
-	}
+// callToNode sends the given call and sets up a handler for response packets (of message
+// type responseType). Responses are dispatched to the call's response channel.
+func (t *UDPv5) callToNode(n *enode.Node, responseType byte, req v5wire.Packet) *callV5 {
+	addr := &net.UDPAddr{IP: n.IP(), Port: int(n.UDP())}
+	c := &callV5{id: n.ID(), addr: addr, node: n}
+	t.initCall(c, responseType, req)
+	return c
+}
+
+// callToID is like callToNode, but for cases where the node record is not available.
+func (t *UDPv5) callToID(id enode.ID, addr *net.UDPAddr, responseType byte, req v5wire.Packet) *callV5 {
+	c := &callV5{id: id, addr: addr}
+	t.initCall(c, responseType, req)
+	return c
+}
+
+func (t *UDPv5) initCall(c *callV5, responseType byte, packet v5wire.Packet) {
+	c.packet = packet
+	c.responseType = responseType
+	c.reqid = make([]byte, 8)
+	c.ch = make(chan v5wire.Packet, 1)
+	c.err = make(chan error, 1)
 	// Assign request ID.
 	crand.Read(c.reqid)
 	packet.SetRequestID(c.reqid)
@@ -461,7 +488,6 @@ func (t *UDPv5) call(node *enode.Node, responseType byte, packet v5wire.Packet) 
 	case <-t.closeCtx.Done():
 		c.err <- errClosed
 	}
-	return c
 }
 
 // callDone tells dispatch that the active call is done.
@@ -503,26 +529,24 @@ func (t *UDPv5) dispatch() {
 	for {
 		select {
 		case c := <-t.callCh:
-			id := c.node.ID()
-			t.callQueue[id] = append(t.callQueue[id], c)
-			t.sendNextCall(id)
+			t.callQueue[c.id] = append(t.callQueue[c.id], c)
+			t.sendNextCall(c.id)
 
 		case ct := <-t.respTimeoutCh:
-			active := t.activeCallByNode[ct.c.node.ID()]
+			active := t.activeCallByNode[ct.c.id]
 			if ct.c == active && ct.timer == active.timeout {
 				ct.c.err <- errTimeout
 			}
 
 		case c := <-t.callDoneCh:
-			id := c.node.ID()
-			active := t.activeCallByNode[id]
+			active := t.activeCallByNode[c.id]
 			if active != c {
 				panic("BUG: callDone for inactive call")
 			}
 			c.timeout.Stop()
 			delete(t.activeCallByAuth, c.nonce)
-			delete(t.activeCallByNode, id)
-			t.sendNextCall(id)
+			delete(t.activeCallByNode, c.id)
+			t.sendNextCall(c.id)
 
 		case r := <-t.sendCh:
 			t.send(r.destID, r.destAddr, r.msg, nil)
@@ -595,8 +619,7 @@ func (t *UDPv5) sendCall(c *callV5) {
 		delete(t.activeCallByAuth, c.nonce)
 	}
 
-	addr := &net.UDPAddr{IP: c.node.IP(), Port: c.node.UDP()}
-	newNonce, _ := t.send(c.node.ID(), addr, c.packet, c.challenge)
+	newNonce, _ := t.send(c.id, c.addr, c.packet, c.challenge)
 	c.nonce = newNonce
 	t.activeCallByAuth[newNonce] = c
 	t.startResponseTimeout(c)
@@ -775,6 +798,12 @@ func (t *UDPv5) handleWhoareyou(p *v5wire.Whoareyou, fromID enode.ID, fromAddr *
 		return
 	}
 
+	if c.node == nil {
+		// Can't perform handshake because we don't have the ENR.
+		t.log.Debug("Can't handle "+p.Name(), "addr", fromAddr, "err", "call has no ENR")
+		c.err <- errors.New("remote wants handshake, but call has no ENR")
+		return
+	}
 	// Resend the call that was answered by WHOAREYOU.
 	t.log.Trace("<< "+p.Name(), "id", c.node.ID(), "addr", fromAddr)
 	c.handshakeCount++

--- a/p2p/discover/v5_udp.go
+++ b/p2p/discover/v5_udp.go
@@ -726,7 +726,7 @@ func (t *UDPv5) handleCallResponse(fromID enode.ID, fromAddr *net.UDPAddr, p v5w
 		t.log.Debug(fmt.Sprintf("Unsolicited/late %s response", p.Name()), "id", fromID, "addr", fromAddr)
 		return false
 	}
-	if !fromAddr.IP.Equal(ac.node.IP()) || fromAddr.Port != ac.node.UDP() {
+	if !fromAddr.IP.Equal(ac.addr.IP) || fromAddr.Port != ac.addr.Port {
 		t.log.Debug(fmt.Sprintf("%s from wrong endpoint", p.Name()), "id", fromID, "addr", fromAddr)
 		return false
 	}

--- a/p2p/discover/v5_udp_test.go
+++ b/p2p/discover/v5_udp_test.go
@@ -186,7 +186,7 @@ func TestUDPv5_findnodeHandling(t *testing.T) {
 
 	// This request gets all the distance-253 nodes.
 	test.packetIn(&v5wire.Findnode{ReqID: []byte{4}, Distances: []uint{253}})
-	test.expectNodes([]byte{4}, 1, nodes253)
+	test.expectNodes([]byte{4}, 2, nodes253)
 
 	// This request gets all the distance-249 nodes and some more at 248 because
 	// the bucket at 249 is not full.

--- a/p2p/discover/v5wire/msg.go
+++ b/p2p/discover/v5wire/msg.go
@@ -216,7 +216,7 @@ func (p *TalkRequest) RequestID() []byte      { return p.ReqID }
 func (p *TalkRequest) SetRequestID(id []byte) { p.ReqID = id }
 
 func (p *TalkRequest) AppendLogInfo(ctx []interface{}) []interface{} {
-	return append(ctx, "proto", p.Protocol, "reqid", hexutil.Bytes(p.ReqID), "len", len(p.Message))
+	return append(ctx, "proto", p.Protocol, "req", hexutil.Bytes(p.ReqID), "len", len(p.Message))
 }
 
 func (*TalkResponse) Name() string             { return "TALKRESP/v5" }
@@ -225,5 +225,5 @@ func (p *TalkResponse) RequestID() []byte      { return p.ReqID }
 func (p *TalkResponse) SetRequestID(id []byte) { p.ReqID = id }
 
 func (p *TalkResponse) AppendLogInfo(ctx []interface{}) []interface{} {
-	return append(ctx, "req", p.ReqID, "len", len(p.Message))
+	return append(ctx, "req", hexutil.Bytes(p.ReqID), "len", len(p.Message))
 }


### PR DESCRIPTION
This changes TALKREQ message processing to run the handler on separate goroutine,
instead of running on the main discv5 dispatcher goroutine. It's better this way because
it allows the handler to perform blocking actions.

I'm also adding a new method `TalkRequestToID` here. This is needed for my work on
data transfers over discv5 in the [discv5-streams repo](https://github.com/fjl/discv5-streams).
The new method allows implementing a request flow where one node `A` sends TALKREQ to
another node `B`, and node `B` later sends a TALKREQ back. With `TalkRequestToID`, node `B`
does not need the ENR of `A` to send its request.
