### PR TITLE
core/types: fix discrepancy in receipt.EffectiveGasPrice json encoding tags

### DIFF
--- a/cmd/evm/t8n_test.go
+++ b/cmd/evm/t8n_test.go
@@ -286,7 +286,7 @@ func TestT8n(t *testing.T) {
 			case err != nil:
 				t.Fatalf("test %d, file %v: json parsing failed: %v", i, file, err)
 			case !ok:
-				t.Fatalf("test %d file %v: output wrong, have \n%v\nwant\n%v\n", i, file, string(have), string(want))
+				t.Fatalf("test %d, file %v: output wrong, have \n%v\nwant\n%v\n", i, file, string(have), string(want))
 			}
 		}
 		tt.WaitExit()

--- a/cmd/evm/t8n_test.go
+++ b/cmd/evm/t8n_test.go
@@ -284,7 +284,7 @@ func TestT8n(t *testing.T) {
 			ok, err := cmpJson(have, want)
 			switch {
 			case err != nil:
-				t.Fatalf("test %d file %v:, json parsing failed: %v", i, file, err)
+				t.Fatalf("test %d, file %v: json parsing failed: %v", i, file, err)
 			case !ok:
 				t.Fatalf("test %d file %v: output wrong, have \n%v\nwant\n%v\n", i, file, string(have), string(want))
 			}

--- a/cmd/evm/t8n_test.go
+++ b/cmd/evm/t8n_test.go
@@ -275,7 +275,8 @@ func TestT8n(t *testing.T) {
 		tt.Run("evm-test", args...)
 		// Compare the expected output, if provided
 		if tc.expOut != "" {
-			want, err := os.ReadFile(fmt.Sprintf("%v/%v", tc.base, tc.expOut))
+			file := fmt.Sprintf("%v/%v", tc.base, tc.expOut)
+			want, err := os.ReadFile(file)
 			if err != nil {
 				t.Fatalf("test %d: could not read expected output: %v", i, err)
 			}
@@ -283,9 +284,9 @@ func TestT8n(t *testing.T) {
 			ok, err := cmpJson(have, want)
 			switch {
 			case err != nil:
-				t.Fatalf("test %d, json parsing failed: %v", i, err)
+				t.Fatalf("test %d file %v:, json parsing failed: %v", i, file, err)
 			case !ok:
-				t.Fatalf("test %d: output wrong, have \n%v\nwant\n%v\n", i, string(have), string(want))
+				t.Fatalf("test %d file %v: output wrong, have \n%v\nwant\n%v\n", i, file, string(have), string(want))
 			}
 		}
 		tt.WaitExit()

--- a/cmd/evm/testdata/1/exp.json
+++ b/cmd/evm/testdata/1/exp.json
@@ -28,6 +28,7 @@
         "transactionHash": "0x0557bacce3375c98d806609b8d5043072f0b6a8bae45ae5a67a00d3a1a18d673",
         "contractAddress": "0x0000000000000000000000000000000000000000",
         "gasUsed": "0x5208",
+        "effectiveGasPrice": null,
         "blockHash": "0x0000000000000000000000000000000000000000000000000000000000000000",
         "transactionIndex": "0x0"
       }

--- a/cmd/evm/testdata/13/exp2.json
+++ b/cmd/evm/testdata/13/exp2.json
@@ -16,6 +16,7 @@
         "transactionHash": "0xa98a24882ea90916c6a86da650fbc6b14238e46f0af04a131ce92be897507476",
         "contractAddress": "0x0000000000000000000000000000000000000000",
         "gasUsed": "0x84d0",
+        "effectiveGasPrice": null,
         "blockHash": "0x0000000000000000000000000000000000000000000000000000000000000000",
         "transactionIndex": "0x0"
       },
@@ -29,6 +30,7 @@
         "transactionHash": "0x36bad80acce7040c45fd32764b5c2b2d2e6f778669fb41791f73f546d56e739a",
         "contractAddress": "0x0000000000000000000000000000000000000000",
         "gasUsed": "0x84d0",
+        "effectiveGasPrice": null,
         "blockHash": "0x0000000000000000000000000000000000000000000000000000000000000000",
         "transactionIndex": "0x1"
       }

--- a/cmd/evm/testdata/23/exp.json
+++ b/cmd/evm/testdata/23/exp.json
@@ -15,6 +15,7 @@
         "transactionHash": "0x72fadbef39cd251a437eea619cfeda752271a5faaaa2147df012e112159ffb81",
         "contractAddress": "0x0000000000000000000000000000000000000000",
         "gasUsed": "0x520b",
+        "effectiveGasPrice": null,
         "blockHash": "0x0000000000000000000000000000000000000000000000000000000000000000",
         "transactionIndex": "0x0"
       }

--- a/cmd/evm/testdata/24/exp.json
+++ b/cmd/evm/testdata/24/exp.json
@@ -31,6 +31,7 @@
         "transactionHash": "0x92ea4a28224d033afb20e0cc2b290d4c7c2d61f6a4800a680e4e19ac962ee941",
         "contractAddress": "0x0000000000000000000000000000000000000000",
         "gasUsed": "0xa861",
+        "effectiveGasPrice": null,
         "blockHash": "0x0000000000000000000000000000000000000000000000000000000000000000",
         "transactionIndex": "0x0"
       },
@@ -43,6 +44,7 @@
         "transactionHash": "0x16b1d912f1d664f3f60f4e1b5f296f3c82a64a1a253117b4851d18bc03c4f1da",
         "contractAddress": "0x0000000000000000000000000000000000000000",
         "gasUsed": "0x5aa5",
+        "effectiveGasPrice": null,
         "blockHash": "0x0000000000000000000000000000000000000000000000000000000000000000",
         "transactionIndex": "0x1"
       }

--- a/cmd/evm/testdata/25/exp.json
+++ b/cmd/evm/testdata/25/exp.json
@@ -27,6 +27,7 @@
         "transactionHash": "0x92ea4a28224d033afb20e0cc2b290d4c7c2d61f6a4800a680e4e19ac962ee941",
         "contractAddress": "0x0000000000000000000000000000000000000000",
         "gasUsed": "0x5208",
+        "effectiveGasPrice": null,
         "blockHash": "0x0000000000000000000000000000000000000000000000000000000000000000",
         "transactionIndex": "0x0"
       }

--- a/cmd/evm/testdata/3/exp.json
+++ b/cmd/evm/testdata/3/exp.json
@@ -28,6 +28,7 @@
         "transactionHash": "0x72fadbef39cd251a437eea619cfeda752271a5faaaa2147df012e112159ffb81",
         "contractAddress": "0x0000000000000000000000000000000000000000",
         "gasUsed": "0x521f",
+        "effectiveGasPrice": null,
         "blockHash": "0x0000000000000000000000000000000000000000000000000000000000000000",
         "transactionIndex": "0x0"
       }

--- a/core/types/gen_receipt_json.go
+++ b/core/types/gen_receipt_json.go
@@ -25,7 +25,7 @@ func (r Receipt) MarshalJSON() ([]byte, error) {
 		TxHash            common.Hash    `json:"transactionHash" gencodec:"required"`
 		ContractAddress   common.Address `json:"contractAddress"`
 		GasUsed           hexutil.Uint64 `json:"gasUsed" gencodec:"required"`
-		EffectiveGasPrice *big.Int       `json:"effectiveGasPrice"`
+		EffectiveGasPrice *hexutil.Big   `json:"effectiveGasPrice"`
 		BlockHash         common.Hash    `json:"blockHash,omitempty"`
 		BlockNumber       *hexutil.Big   `json:"blockNumber,omitempty"`
 		TransactionIndex  hexutil.Uint   `json:"transactionIndex"`
@@ -40,7 +40,7 @@ func (r Receipt) MarshalJSON() ([]byte, error) {
 	enc.TxHash = r.TxHash
 	enc.ContractAddress = r.ContractAddress
 	enc.GasUsed = hexutil.Uint64(r.GasUsed)
-	enc.EffectiveGasPrice = r.EffectiveGasPrice
+	enc.EffectiveGasPrice = (*hexutil.Big)(r.EffectiveGasPrice)
 	enc.BlockHash = r.BlockHash
 	enc.BlockNumber = (*hexutil.Big)(r.BlockNumber)
 	enc.TransactionIndex = hexutil.Uint(r.TransactionIndex)
@@ -59,7 +59,7 @@ func (r *Receipt) UnmarshalJSON(input []byte) error {
 		TxHash            *common.Hash    `json:"transactionHash" gencodec:"required"`
 		ContractAddress   *common.Address `json:"contractAddress"`
 		GasUsed           *hexutil.Uint64 `json:"gasUsed" gencodec:"required"`
-		EffectiveGasPrice *big.Int        `json:"effectiveGasPrice"`
+		EffectiveGasPrice *hexutil.Big    `json:"effectiveGasPrice"`
 		BlockHash         *common.Hash    `json:"blockHash,omitempty"`
 		BlockNumber       *hexutil.Big    `json:"blockNumber,omitempty"`
 		TransactionIndex  *hexutil.Uint   `json:"transactionIndex"`
@@ -101,7 +101,7 @@ func (r *Receipt) UnmarshalJSON(input []byte) error {
 	}
 	r.GasUsed = uint64(*dec.GasUsed)
 	if dec.EffectiveGasPrice != nil {
-		r.EffectiveGasPrice = dec.EffectiveGasPrice
+		r.EffectiveGasPrice = (*big.Int)(dec.EffectiveGasPrice)
 	}
 	if dec.BlockHash != nil {
 		r.BlockHash = *dec.BlockHash

--- a/core/types/gen_receipt_json.go
+++ b/core/types/gen_receipt_json.go
@@ -25,7 +25,7 @@ func (r Receipt) MarshalJSON() ([]byte, error) {
 		TxHash            common.Hash    `json:"transactionHash" gencodec:"required"`
 		ContractAddress   common.Address `json:"contractAddress"`
 		GasUsed           hexutil.Uint64 `json:"gasUsed" gencodec:"required"`
-		EffectiveGasPrice *hexutil.Big   `json:"effectiveGasPrice,omitempty"`
+		EffectiveGasPrice *big.Int       `json:"effectiveGasPrice"`
 		BlockHash         common.Hash    `json:"blockHash,omitempty"`
 		BlockNumber       *hexutil.Big   `json:"blockNumber,omitempty"`
 		TransactionIndex  hexutil.Uint   `json:"transactionIndex"`
@@ -40,7 +40,7 @@ func (r Receipt) MarshalJSON() ([]byte, error) {
 	enc.TxHash = r.TxHash
 	enc.ContractAddress = r.ContractAddress
 	enc.GasUsed = hexutil.Uint64(r.GasUsed)
-	enc.EffectiveGasPrice = (*hexutil.Big)(r.EffectiveGasPrice)
+	enc.EffectiveGasPrice = r.EffectiveGasPrice
 	enc.BlockHash = r.BlockHash
 	enc.BlockNumber = (*hexutil.Big)(r.BlockNumber)
 	enc.TransactionIndex = hexutil.Uint(r.TransactionIndex)
@@ -59,7 +59,7 @@ func (r *Receipt) UnmarshalJSON(input []byte) error {
 		TxHash            *common.Hash    `json:"transactionHash" gencodec:"required"`
 		ContractAddress   *common.Address `json:"contractAddress"`
 		GasUsed           *hexutil.Uint64 `json:"gasUsed" gencodec:"required"`
-		EffectiveGasPrice *hexutil.Big    `json:"effectiveGasPrice,omitempty"`
+		EffectiveGasPrice *big.Int        `json:"effectiveGasPrice"`
 		BlockHash         *common.Hash    `json:"blockHash,omitempty"`
 		BlockNumber       *hexutil.Big    `json:"blockNumber,omitempty"`
 		TransactionIndex  *hexutil.Uint   `json:"transactionIndex"`
@@ -101,7 +101,7 @@ func (r *Receipt) UnmarshalJSON(input []byte) error {
 	}
 	r.GasUsed = uint64(*dec.GasUsed)
 	if dec.EffectiveGasPrice != nil {
-		r.EffectiveGasPrice = (*big.Int)(dec.EffectiveGasPrice)
+		r.EffectiveGasPrice = dec.EffectiveGasPrice
 	}
 	if dec.BlockHash != nil {
 		r.BlockHash = *dec.BlockHash

--- a/core/types/receipt.go
+++ b/core/types/receipt.go
@@ -77,6 +77,7 @@ type receiptMarshaling struct {
 	Status            hexutil.Uint64
 	CumulativeGasUsed hexutil.Uint64
 	GasUsed           hexutil.Uint64
+	EffectiveGasPrice *hexutil.Big
 	BlockNumber       *hexutil.Big
 	TransactionIndex  hexutil.Uint
 }

--- a/core/types/receipt.go
+++ b/core/types/receipt.go
@@ -62,7 +62,7 @@ type Receipt struct {
 	TxHash            common.Hash    `json:"transactionHash" gencodec:"required"`
 	ContractAddress   common.Address `json:"contractAddress"`
 	GasUsed           uint64         `json:"gasUsed" gencodec:"required"`
-	EffectiveGasPrice *big.Int       `json:"effectiveGasPrice"`
+	EffectiveGasPrice *big.Int       `json:"effectiveGasPrice"` // required, but tag omitted for backwards compatibility
 
 	// Inclusion information: These fields provide information about the inclusion of the
 	// transaction corresponding to this receipt.

--- a/core/types/receipt_test.go
+++ b/core/types/receipt_test.go
@@ -84,13 +84,13 @@ var (
 	}
 
 	// Create a few transactions to have receipts for
-	to2     = common.HexToAddress("0x2")
-	to3     = common.HexToAddress("0x3")
-	to4     = common.HexToAddress("0x4")
-	to5     = common.HexToAddress("0x5")
-	to6     = common.HexToAddress("0x6")
-	to7     = common.HexToAddress("0x7")
-	testTxs = Transactions{
+	to2 = common.HexToAddress("0x2")
+	to3 = common.HexToAddress("0x3")
+	to4 = common.HexToAddress("0x4")
+	to5 = common.HexToAddress("0x5")
+	to6 = common.HexToAddress("0x6")
+	to7 = common.HexToAddress("0x7")
+	txs = Transactions{
 		NewTx(&LegacyTx{
 			Nonce:    1,
 			Value:    big.NewInt(1),
@@ -149,11 +149,12 @@ var (
 		}),
 	}
 
-	// Create corresponding receipts for the testTxs
-	blockNumber  = big.NewInt(1)
-	blockTime    = uint64(2)
-	blockHash    = common.BytesToHash([]byte{0x03, 0x14})
-	testReceipts = Receipts{
+	blockNumber = big.NewInt(1)
+	blockTime   = uint64(2)
+	blockHash   = common.BytesToHash([]byte{0x03, 0x14})
+
+	// Create the corresponding receipts
+	receipts = Receipts{
 		&Receipt{
 			Status:            ReceiptStatusFailed,
 			CumulativeGasUsed: 1,
@@ -163,7 +164,7 @@ var (
 					Topics:  []common.Hash{common.HexToHash("dead"), common.HexToHash("beef")},
 					// derived fields:
 					BlockNumber: blockNumber.Uint64(),
-					TxHash:      testTxs[0].Hash(),
+					TxHash:      txs[0].Hash(),
 					TxIndex:     0,
 					BlockHash:   blockHash,
 					Index:       0,
@@ -173,14 +174,14 @@ var (
 					Topics:  []common.Hash{common.HexToHash("dead"), common.HexToHash("beef")},
 					// derived fields:
 					BlockNumber: blockNumber.Uint64(),
-					TxHash:      testTxs[0].Hash(),
+					TxHash:      txs[0].Hash(),
 					TxIndex:     0,
 					BlockHash:   blockHash,
 					Index:       1,
 				},
 			},
 			// derived fields:
-			TxHash:            testTxs[0].Hash(),
+			TxHash:            txs[0].Hash(),
 			ContractAddress:   common.HexToAddress("0x5a443704dd4b594b382c22a083e2bd3090a6fef3"),
 			GasUsed:           1,
 			EffectiveGasPrice: big.NewInt(11),
@@ -197,7 +198,7 @@ var (
 					Topics:  []common.Hash{common.HexToHash("dead"), common.HexToHash("beef")},
 					// derived fields:
 					BlockNumber: blockNumber.Uint64(),
-					TxHash:      testTxs[1].Hash(),
+					TxHash:      txs[1].Hash(),
 					TxIndex:     1,
 					BlockHash:   blockHash,
 					Index:       2,
@@ -207,14 +208,14 @@ var (
 					Topics:  []common.Hash{common.HexToHash("dead"), common.HexToHash("beef")},
 					// derived fields:
 					BlockNumber: blockNumber.Uint64(),
-					TxHash:      testTxs[1].Hash(),
+					TxHash:      txs[1].Hash(),
 					TxIndex:     1,
 					BlockHash:   blockHash,
 					Index:       3,
 				},
 			},
 			// derived fields:
-			TxHash:            testTxs[1].Hash(),
+			TxHash:            txs[1].Hash(),
 			GasUsed:           2,
 			EffectiveGasPrice: big.NewInt(22),
 			BlockHash:         blockHash,
@@ -227,7 +228,7 @@ var (
 			CumulativeGasUsed: 6,
 			Logs:              []*Log{},
 			// derived fields:
-			TxHash:            testTxs[2].Hash(),
+			TxHash:            txs[2].Hash(),
 			GasUsed:           3,
 			EffectiveGasPrice: big.NewInt(33),
 			BlockHash:         blockHash,
@@ -240,7 +241,7 @@ var (
 			CumulativeGasUsed: 10,
 			Logs:              []*Log{},
 			// derived fields:
-			TxHash:            testTxs[3].Hash(),
+			TxHash:            txs[3].Hash(),
 			GasUsed:           4,
 			EffectiveGasPrice: big.NewInt(1044),
 			BlockHash:         blockHash,
@@ -253,7 +254,7 @@ var (
 			CumulativeGasUsed: 15,
 			Logs:              []*Log{},
 			// derived fields:
-			TxHash:            testTxs[4].Hash(),
+			TxHash:            txs[4].Hash(),
 			GasUsed:           5,
 			EffectiveGasPrice: big.NewInt(1055),
 			BlockHash:         blockHash,
@@ -266,7 +267,7 @@ var (
 			CumulativeGasUsed: 21,
 			Logs:              []*Log{},
 			// derived fields:
-			TxHash:            testTxs[5].Hash(),
+			TxHash:            txs[5].Hash(),
 			GasUsed:           6,
 			EffectiveGasPrice: big.NewInt(1066),
 			BlockHash:         blockHash,
@@ -279,7 +280,7 @@ var (
 			CumulativeGasUsed: 28,
 			Logs:              []*Log{},
 			// derived fields:
-			TxHash:            testTxs[6].Hash(),
+			TxHash:            txs[6].Hash(),
 			GasUsed:           7,
 			EffectiveGasPrice: big.NewInt(1077),
 			BlockHash:         blockHash,
@@ -302,14 +303,14 @@ func TestDecodeEmptyTypedReceipt(t *testing.T) {
 func TestDeriveFields(t *testing.T) {
 	// Re-derive receipts.
 	basefee := big.NewInt(1000)
-	derivedReceipts := clearComputedFieldsOnReceipts(testReceipts)
-	err := Receipts(derivedReceipts).DeriveFields(params.TestChainConfig, blockHash, blockNumber.Uint64(), blockTime, basefee, testTxs)
+	derivedReceipts := clearComputedFieldsOnReceipts(receipts)
+	err := Receipts(derivedReceipts).DeriveFields(params.TestChainConfig, blockHash, blockNumber.Uint64(), blockTime, basefee, txs)
 	if err != nil {
 		t.Fatalf("DeriveFields(...) = %v, want <nil>", err)
 	}
 
 	// Check diff of receipts against derivedReceipts.
-	r1, err := json.MarshalIndent(testReceipts, "", "  ")
+	r1, err := json.MarshalIndent(receipts, "", "  ")
 	if err != nil {
 		t.Fatal("error marshaling input receipts:", err)
 	}
@@ -327,8 +328,8 @@ func TestDeriveFields(t *testing.T) {
 // Test that we can marshal/unmarshal receipts to/from json without errors.
 // This also confirms that our test receipts contain all the required fields.
 func TestReceiptJSON(t *testing.T) {
-	for i := range testReceipts {
-		b, err := testReceipts[i].MarshalJSON()
+	for i := range receipts {
+		b, err := receipts[i].MarshalJSON()
 		if err != nil {
 			t.Fatal("error marshaling receipt to json:", err)
 		}
@@ -343,7 +344,7 @@ func TestReceiptJSON(t *testing.T) {
 // Test we can still parse receipt without EffectiveGasPrice for backwards compatibility, even
 // though it is required per the spec.
 func TestEffectiveGasPriceNotRequired(t *testing.T) {
-	r := *testReceipts[0]
+	r := *receipts[0]
 	r.EffectiveGasPrice = nil
 	b, err := r.MarshalJSON()
 	if err != nil {

--- a/core/types/receipt_test.go
+++ b/core/types/receipt_test.go
@@ -82,27 +82,15 @@ var (
 		},
 		Type: DynamicFeeTxType,
 	}
-)
 
-func TestDecodeEmptyTypedReceipt(t *testing.T) {
-	input := []byte{0x80}
-	var r Receipt
-	err := rlp.DecodeBytes(input, &r)
-	if err != errShortTypedReceipt {
-		t.Fatal("wrong error:", err)
-	}
-}
-
-// Tests that receipt data can be correctly derived from the contextual infos
-func TestDeriveFields(t *testing.T) {
 	// Create a few transactions to have receipts for
-	to2 := common.HexToAddress("0x2")
-	to3 := common.HexToAddress("0x3")
-	to4 := common.HexToAddress("0x4")
-	to5 := common.HexToAddress("0x5")
-	to6 := common.HexToAddress("0x6")
-	to7 := common.HexToAddress("0x7")
-	txs := Transactions{
+	to2     = common.HexToAddress("0x2")
+	to3     = common.HexToAddress("0x3")
+	to4     = common.HexToAddress("0x4")
+	to5     = common.HexToAddress("0x5")
+	to6     = common.HexToAddress("0x6")
+	to7     = common.HexToAddress("0x7")
+	testTxs = Transactions{
 		NewTx(&LegacyTx{
 			Nonce:    1,
 			Value:    big.NewInt(1),
@@ -161,37 +149,38 @@ func TestDeriveFields(t *testing.T) {
 		}),
 	}
 
-	blockNumber := big.NewInt(1)
-	blockTime := uint64(2)
-	blockHash := common.BytesToHash([]byte{0x03, 0x14})
-
-	// Create the corresponding receipts
-	receipts := Receipts{
+	// Create corresponding receipts for the testTxs
+	blockNumber  = big.NewInt(1)
+	blockTime    = uint64(2)
+	blockHash    = common.BytesToHash([]byte{0x03, 0x14})
+	testReceipts = Receipts{
 		&Receipt{
 			Status:            ReceiptStatusFailed,
 			CumulativeGasUsed: 1,
 			Logs: []*Log{
 				{
 					Address: common.BytesToAddress([]byte{0x11}),
+					Topics:  []common.Hash{common.HexToHash("dead"), common.HexToHash("beef")},
 					// derived fields:
 					BlockNumber: blockNumber.Uint64(),
-					TxHash:      txs[0].Hash(),
+					TxHash:      testTxs[0].Hash(),
 					TxIndex:     0,
 					BlockHash:   blockHash,
 					Index:       0,
 				},
 				{
 					Address: common.BytesToAddress([]byte{0x01, 0x11}),
+					Topics:  []common.Hash{common.HexToHash("dead"), common.HexToHash("beef")},
 					// derived fields:
 					BlockNumber: blockNumber.Uint64(),
-					TxHash:      txs[0].Hash(),
+					TxHash:      testTxs[0].Hash(),
 					TxIndex:     0,
 					BlockHash:   blockHash,
 					Index:       1,
 				},
 			},
 			// derived fields:
-			TxHash:            txs[0].Hash(),
+			TxHash:            testTxs[0].Hash(),
 			ContractAddress:   common.HexToAddress("0x5a443704dd4b594b382c22a083e2bd3090a6fef3"),
 			GasUsed:           1,
 			EffectiveGasPrice: big.NewInt(11),
@@ -205,25 +194,27 @@ func TestDeriveFields(t *testing.T) {
 			Logs: []*Log{
 				{
 					Address: common.BytesToAddress([]byte{0x22}),
+					Topics:  []common.Hash{common.HexToHash("dead"), common.HexToHash("beef")},
 					// derived fields:
 					BlockNumber: blockNumber.Uint64(),
-					TxHash:      txs[1].Hash(),
+					TxHash:      testTxs[1].Hash(),
 					TxIndex:     1,
 					BlockHash:   blockHash,
 					Index:       2,
 				},
 				{
 					Address: common.BytesToAddress([]byte{0x02, 0x22}),
+					Topics:  []common.Hash{common.HexToHash("dead"), common.HexToHash("beef")},
 					// derived fields:
 					BlockNumber: blockNumber.Uint64(),
-					TxHash:      txs[1].Hash(),
+					TxHash:      testTxs[1].Hash(),
 					TxIndex:     1,
 					BlockHash:   blockHash,
 					Index:       3,
 				},
 			},
 			// derived fields:
-			TxHash:            txs[1].Hash(),
+			TxHash:            testTxs[1].Hash(),
 			GasUsed:           2,
 			EffectiveGasPrice: big.NewInt(22),
 			BlockHash:         blockHash,
@@ -236,7 +227,7 @@ func TestDeriveFields(t *testing.T) {
 			CumulativeGasUsed: 6,
 			Logs:              []*Log{},
 			// derived fields:
-			TxHash:            txs[2].Hash(),
+			TxHash:            testTxs[2].Hash(),
 			GasUsed:           3,
 			EffectiveGasPrice: big.NewInt(33),
 			BlockHash:         blockHash,
@@ -249,7 +240,7 @@ func TestDeriveFields(t *testing.T) {
 			CumulativeGasUsed: 10,
 			Logs:              []*Log{},
 			// derived fields:
-			TxHash:            txs[3].Hash(),
+			TxHash:            testTxs[3].Hash(),
 			GasUsed:           4,
 			EffectiveGasPrice: big.NewInt(1044),
 			BlockHash:         blockHash,
@@ -262,7 +253,7 @@ func TestDeriveFields(t *testing.T) {
 			CumulativeGasUsed: 15,
 			Logs:              []*Log{},
 			// derived fields:
-			TxHash:            txs[4].Hash(),
+			TxHash:            testTxs[4].Hash(),
 			GasUsed:           5,
 			EffectiveGasPrice: big.NewInt(1055),
 			BlockHash:         blockHash,
@@ -275,7 +266,7 @@ func TestDeriveFields(t *testing.T) {
 			CumulativeGasUsed: 21,
 			Logs:              []*Log{},
 			// derived fields:
-			TxHash:            txs[5].Hash(),
+			TxHash:            testTxs[5].Hash(),
 			GasUsed:           6,
 			EffectiveGasPrice: big.NewInt(1066),
 			BlockHash:         blockHash,
@@ -288,7 +279,7 @@ func TestDeriveFields(t *testing.T) {
 			CumulativeGasUsed: 28,
 			Logs:              []*Log{},
 			// derived fields:
-			TxHash:            txs[6].Hash(),
+			TxHash:            testTxs[6].Hash(),
 			GasUsed:           7,
 			EffectiveGasPrice: big.NewInt(1077),
 			BlockHash:         blockHash,
@@ -296,20 +287,33 @@ func TestDeriveFields(t *testing.T) {
 			TransactionIndex:  6,
 		},
 	}
+)
 
+func TestDecodeEmptyTypedReceipt(t *testing.T) {
+	input := []byte{0x80}
+	var r Receipt
+	err := rlp.DecodeBytes(input, &r)
+	if err != errShortTypedReceipt {
+		t.Fatal("wrong error:", err)
+	}
+}
+
+// Tests that receipt data can be correctly derived from the contextual infos
+func TestDeriveFields(t *testing.T) {
 	// Re-derive receipts.
 	basefee := big.NewInt(1000)
-	derivedReceipts := clearComputedFieldsOnReceipts(receipts)
-	err := Receipts(derivedReceipts).DeriveFields(params.TestChainConfig, blockHash, blockNumber.Uint64(), blockTime, basefee, txs)
+	derivedReceipts := clearComputedFieldsOnReceipts(testReceipts)
+	err := Receipts(derivedReceipts).DeriveFields(params.TestChainConfig, blockHash, blockNumber.Uint64(), blockTime, basefee, testTxs)
 	if err != nil {
 		t.Fatalf("DeriveFields(...) = %v, want <nil>", err)
 	}
 
 	// Check diff of receipts against derivedReceipts.
-	r1, err := json.MarshalIndent(receipts, "", "  ")
+	r1, err := json.MarshalIndent(testReceipts, "", "  ")
 	if err != nil {
 		t.Fatal("error marshaling input receipts:", err)
 	}
+
 	r2, err := json.MarshalIndent(derivedReceipts, "", "  ")
 	if err != nil {
 		t.Fatal("error marshaling derived receipts:", err)
@@ -317,6 +321,38 @@ func TestDeriveFields(t *testing.T) {
 	d := diff.Diff(string(r1), string(r2))
 	if d != "" {
 		t.Fatal("receipts differ:", d)
+	}
+}
+
+// Test that we can marshal/unmarshal receipts to/from json without errors.
+// This also confirms that our test receipts contain all the required fields.
+func TestReceiptJSON(t *testing.T) {
+	for i := range testReceipts {
+		b, err := testReceipts[i].MarshalJSON()
+		if err != nil {
+			t.Fatal("error marshaling receipt to json:", err)
+		}
+		r := Receipt{}
+		err = r.UnmarshalJSON(b)
+		if err != nil {
+			t.Fatal("error unmarshaling receipt from json:", err)
+		}
+	}
+}
+
+// Test we can still parse receipt without EffectiveGasPrice for backwards compatibility, even
+// though it is required per the spec.
+func TestEffectiveGasPriceNotRequired(t *testing.T) {
+	r := *testReceipts[0]
+	r.EffectiveGasPrice = nil
+	b, err := r.MarshalJSON()
+	if err != nil {
+		t.Fatal("error marshaling receipt to json:", err)
+	}
+	r2 := Receipt{}
+	err = r2.UnmarshalJSON(b)
+	if err != nil {
+		t.Fatal("error unmarshaling receipt from json:", err)
 	}
 }
 


### PR DESCRIPTION
the execution api [spec](https://github.com/ethereum/execution-apis/blob/af82a989bead35e2325ecc49a9023df39c548756/src/schemas/receipt.yaml#L49) suggests receipt.EffectiveGasPrice should be required, but it's currently not tagged as required in its receipt.go schema. Further, the field is tagged as 'omitempty' in the generated code even though it's not tagged as such in the schema.

This PR leaves the field as untagged in the receipt.go schema for backwards compatibility, adds a comment clarifying it's still technically required, removes the omitempty discrepancy in the generated code, and adds/updates test cases to codify the untagged behavior of the field. 

Alternatives considered:

- tag as required in schema + generated code. Dismissed due to backwards compatilbity concerns as it could break interop w/ older servers that do not require the field.

- tag as omitempty in both schema + generated code.  I don't have a strong reason yet to exclude this alternative, though I don't have a reason to prefer it either.
