### PR TITLE
eth/downloader: fix data overflow

### DIFF
--- a/eth/downloader/downloader.go
+++ b/eth/downloader/downloader.go
@@ -554,7 +554,7 @@ func (d *Downloader) syncWithPeer(p *peerConnection, hash common.Hash, td, ttd *
 			origin = 0
 		} else {
 			pivotNumber := pivot.Number.Uint64()
-			if pivotNumber <= origin {
+			if pivotNumber > 0 && pivotNumber <= origin {
 				origin = pivotNumber - 1
 			}
 			// Write out the pivot into the database so a rollback beyond it will


### PR DESCRIPTION
I found that in some cases the value of the pivotNumber here may be 0. 
Just add a `>0` judgment to avoid overflow