### PR TITLE
eth/filters: retrieve logs in async

### DIFF
--- a/eth/filters/filter.go
+++ b/eth/filters/filter.go
@@ -99,7 +99,7 @@ func (f *Filter) Logs(ctx context.Context) ([]*types.Log, error) {
 		logs []*types.Log
 		err  error
 	)
-	logChan, errChan := f.LogsAsync(ctx)
+	logChan, errChan := f.logsAsync(ctx)
 LOOP:
 	for {
 		select {
@@ -114,9 +114,9 @@ LOOP:
 	return logs, err
 }
 
-// LogsAsync retrieves logs that match the filter criteria asynchronously,
+// logsAsync retrieves logs that match the filter criteria asynchronously,
 // it creates and returns two channels: one for delivering log data, and one for reporting errors.
-func (f *Filter) LogsAsync(ctx context.Context) (chan *types.Log, chan error) {
+func (f *Filter) logsAsync(ctx context.Context) (chan *types.Log, chan error) {
 	var (
 		logChan = make(chan *types.Log)
 		errChan = make(chan error)

--- a/eth/filters/filter.go
+++ b/eth/filters/filter.go
@@ -200,11 +200,9 @@ func (f *Filter) rangeLogsAsync(ctx context.Context) (chan *types.Log, chan erro
 		)
 		if indexed := sections * size; indexed > uint64(f.begin) {
 			if indexed > end {
-				err = f.indexedLogs(ctx, end, logChan)
-			} else {
-				err = f.indexedLogs(ctx, indexed-1, logChan)
+			        indexed = end+1
 			}
-			if err != nil {
+			if err = f.indexedLogs(ctx, indexed-1, logChan); err != nil {
 				errChan <- err
 				return
 			}

--- a/eth/filters/filter.go
+++ b/eth/filters/filter.go
@@ -173,7 +173,7 @@ LOOP:
 	}
 
 	// Append the pending ones
-	if endPending {
+	if endPending && err == nil {
 		pendingLogs := f.pendingLogs()
 		logs = append(logs, pendingLogs...)
 	}

--- a/eth/filters/filter.go
+++ b/eth/filters/filter.go
@@ -157,9 +157,7 @@ func (f *Filter) Logs(ctx context.Context) ([]*types.Log, error) {
 		return nil, err
 	}
 
-	// Else fetch blcok-range logs
 	logChan, errChan := f.rangeLogsAsync(ctx)
-
 	var logs []*types.Log
 LOOP:
 	for {

--- a/eth/filters/filter.go
+++ b/eth/filters/filter.go
@@ -111,7 +111,7 @@ func (f *Filter) Logs(ctx context.Context) ([]*types.Log, error) {
 		if f.end != rpc.PendingBlockNumber.Int64() {
 			return nil, errors.New("invalid block range")
 		}
-		return f.pendingLogs()
+		return f.pendingLogs(), nil
 	}
 	// Figure out the limits of the filter range
 	header, _ := f.sys.backend.HeaderByNumber(ctx, rpc.LatestBlockNumber)
@@ -172,10 +172,7 @@ func (f *Filter) Logs(ctx context.Context) ([]*types.Log, error) {
 	rest, err := f.unindexedLogs(ctx, end)
 	logs = append(logs, rest...)
 	if pending {
-		pendingLogs, err := f.pendingLogs()
-		if err != nil {
-			return nil, err
-		}
+		pendingLogs := f.pendingLogs()
 		logs = append(logs, pendingLogs...)
 	}
 	return logs, err
@@ -294,7 +291,7 @@ func (f *Filter) checkMatches(ctx context.Context, header *types.Header) ([]*typ
 }
 
 // pendingLogs returns the logs matching the filter criteria within the pending block.
-func (f *Filter) pendingLogs() ([]*types.Log, error) {
+func (f *Filter) pendingLogs() []*types.Log {
 	block, receipts := f.sys.backend.PendingBlockAndReceipts()
 	if block == nil {
 		return nil, errors.New("pending state not available")
@@ -304,9 +301,9 @@ func (f *Filter) pendingLogs() ([]*types.Log, error) {
 		for _, r := range receipts {
 			unfiltered = append(unfiltered, r.Logs...)
 		}
-		return filterLogs(unfiltered, nil, nil, f.addresses, f.topics), nil
+		return filterLogs(unfiltered, nil, nil, f.addresses, f.topics)
 	}
-	return nil, nil
+	return nil
 }
 
 func includes(addresses []common.Address, a common.Address) bool {

--- a/eth/filters/filter.go
+++ b/eth/filters/filter.go
@@ -200,7 +200,7 @@ func (f *Filter) rangeLogsAsync(ctx context.Context) (chan *types.Log, chan erro
 		)
 		if indexed := sections * size; indexed > uint64(f.begin) {
 			if indexed > end {
-			        indexed = end+1
+				indexed = end + 1
 			}
 			if err = f.indexedLogs(ctx, indexed-1, logChan); err != nil {
 				errChan <- err
@@ -208,7 +208,6 @@ func (f *Filter) rangeLogsAsync(ctx context.Context) (chan *types.Log, chan erro
 			}
 		}
 
-		
 		if err := f.unindexedLogs(ctx, end, logChan); err != nil {
 			errChan <- err
 			return
@@ -283,9 +282,10 @@ func (f *Filter) unindexedLogs(ctx context.Context, end uint64, logChan chan *ty
 		}
 		for _, log := range found {
 			select {
-				case logChan <- log:
-				case <- ctx.Done():
-			        	return ctx.Err()
+			case logChan <- log:
+			case <-ctx.Done():
+				return ctx.Err()
+			}
 		}
 	}
 	return nil

--- a/eth/filters/filter.go
+++ b/eth/filters/filter.go
@@ -269,9 +269,6 @@ func (f *Filter) indexedLogs(ctx context.Context, end uint64, logChan chan *type
 // iteration and bloom matching.
 func (f *Filter) unindexedLogs(ctx context.Context, end uint64, logChan chan *types.Log) error {
 	for ; f.begin <= int64(end); f.begin++ {
-		if f.begin%10 == 0 && ctx.Err() != nil {
-			return ctx.Err()
-		}
 		header, err := f.sys.backend.HeaderByNumber(ctx, rpc.BlockNumber(f.begin))
 		if header == nil || err != nil {
 			return err

--- a/eth/filters/filter.go
+++ b/eth/filters/filter.go
@@ -282,7 +282,10 @@ func (f *Filter) unindexedLogs(ctx context.Context, end uint64, logChan chan *ty
 			return err
 		}
 		for _, log := range found {
-			logChan <- log
+			select {
+				case logChan <- log:
+				case <- ctx.Done():
+			        	return ctx.Err()
 		}
 	}
 	return nil

--- a/eth/filters/filter.go
+++ b/eth/filters/filter.go
@@ -335,7 +335,7 @@ func (f *Filter) checkMatches(ctx context.Context, header *types.Header) ([]*typ
 func (f *Filter) pendingLogs() []*types.Log {
 	block, receipts := f.sys.backend.PendingBlockAndReceipts()
 	if block == nil {
-		return nil, errors.New("pending state not available")
+		return nil
 	}
 	if bloomFilter(block.Bloom(), f.addresses, f.topics) {
 		var unfiltered []*types.Log

--- a/eth/filters/filter.go
+++ b/eth/filters/filter.go
@@ -208,8 +208,8 @@ func (f *Filter) rangeLogsAsync(ctx context.Context) (chan *types.Log, chan erro
 			}
 		}
 
-		err = f.unindexedLogs(ctx, end, logChan)
-		if err != nil {
+		
+		if err := f.unindexedLogs(ctx, end, logChan); err != nil {
 			errChan <- err
 			return
 		}

--- a/eth/filters/filter_system.go
+++ b/eth/filters/filter_system.go
@@ -187,41 +187,6 @@ type subscription struct {
 	headers   chan *types.Header
 	installed chan struct{} // closed when the filter is installed
 	err       chan error    // closed when the filter is uninstalled
-	backfill  atomic.Bool   // weather we are in the backfilling state, if so no need to handle the new logs
-}
-
-// backfilling runs in a separate goroutine and is responsible for retrieving historical data.
-// After the backfilling process is complete, the flow for new log subscription is resumed.
-func (sub *subscription) backfilling(ev *EventSystem, crit ethereum.FilterQuery) {
-	defer sub.backfill.Store(false)
-
-	ctx := context.Background()
-	begin := crit.FromBlock.Int64()
-	for {
-		header := ev.backend.CurrentHeader()
-		end := header.Number.Int64()
-		if begin > end {
-			break
-		}
-		filter := ev.sys.NewRangeFilter(begin, end, crit.Addresses, crit.Topics)
-
-		logChan, errChan := filter.logsAsync(ctx)
-	LOOP:
-		for {
-			select {
-			case log := <-logChan:
-				sub.logs <- []*types.Log{log}
-			case err := <-errChan:
-				if err != nil {
-					sub.err <- err
-				}
-				close(logChan)
-				break LOOP
-			}
-		}
-
-		begin = end + 1
-	}
 }
 
 // EventSystem creates subscriptions, processes events and broadcasts them to the
@@ -383,10 +348,6 @@ func (es *EventSystem) subscribeMinedPendingLogs(crit ethereum.FilterQuery, logs
 		installed: make(chan struct{}),
 		err:       make(chan error),
 	}
-	if crit.FromBlock != nil {
-		sub.backfill.Store(true)
-		go sub.backfilling(es, crit)
-	}
 	return es.subscribe(sub)
 }
 
@@ -403,10 +364,6 @@ func (es *EventSystem) subscribeLogs(crit ethereum.FilterQuery, logs chan []*typ
 		headers:   make(chan *types.Header),
 		installed: make(chan struct{}),
 		err:       make(chan error),
-	}
-	if crit.FromBlock != nil {
-		sub.backfill.Store(true)
-		go sub.backfilling(es, crit)
 	}
 	return es.subscribe(sub)
 }
@@ -467,9 +424,6 @@ func (es *EventSystem) handleLogs(filters filterIndex, ev []*types.Log) {
 		return
 	}
 	for _, f := range filters[LogsSubscription] {
-		if backfill := f.backfill.Load(); backfill {
-			continue
-		}
 		matchedLogs := filterLogs(ev, f.logsCrit.FromBlock, f.logsCrit.ToBlock, f.logsCrit.Addresses, f.logsCrit.Topics)
 		if len(matchedLogs) > 0 {
 			f.logs <- matchedLogs
@@ -491,9 +445,6 @@ func (es *EventSystem) handlePendingLogs(filters filterIndex, ev []*types.Log) {
 
 func (es *EventSystem) handleRemovedLogs(filters filterIndex, ev core.RemovedLogsEvent) {
 	for _, f := range filters[LogsSubscription] {
-		if backfill := f.backfill.Load(); backfill {
-			continue
-		}
 		matchedLogs := filterLogs(ev.Logs, f.logsCrit.FromBlock, f.logsCrit.ToBlock, f.logsCrit.Addresses, f.logsCrit.Topics)
 		if len(matchedLogs) > 0 {
 			f.logs <- matchedLogs

--- a/eth/filters/filter_system.go
+++ b/eth/filters/filter_system.go
@@ -205,7 +205,7 @@ func (sub *subscription) backfilling(ev *EventSystem, crit ethereum.FilterQuery)
 		}
 		filter := ev.sys.NewRangeFilter(begin, end, crit.Addresses, crit.Topics)
 
-		logChan, errChan := filter.LogsAsync(ctx)
+		logChan, errChan := filter.logsAsync(ctx)
 	LOOP:
 		for {
 			select {

--- a/eth/filters/filter_system_test.go
+++ b/eth/filters/filter_system_test.go
@@ -50,6 +50,8 @@ type testBackend struct {
 	rmLogsFeed      event.Feed
 	pendingLogsFeed event.Feed
 	chainFeed       event.Feed
+	pendingBlock    *types.Block
+	pendingReceipts types.Receipts
 }
 
 func (b *testBackend) ChainConfig() *params.ChainConfig {
@@ -124,7 +126,7 @@ func (b *testBackend) GetLogs(ctx context.Context, hash common.Hash, number uint
 }
 
 func (b *testBackend) PendingBlockAndReceipts() (*types.Block, types.Receipts) {
-	return nil, nil
+	return b.pendingBlock, b.pendingReceipts
 }
 
 func (b *testBackend) SubscribeNewTxsEvent(ch chan<- core.NewTxsEvent) event.Subscription {

--- a/eth/filters/filter_test.go
+++ b/eth/filters/filter_test.go
@@ -358,7 +358,7 @@ func TestFilters(t *testing.T) {
 
 	t.Run("timeout", func(t *testing.T) {
 		f := sys.NewRangeFilter(0, -1, nil, nil)
-		ctx, cancel := context.WithTimeout(context.Background(), 100*time.Microsecond)
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Microsecond)
 		defer cancel()
 		_, err := f.Logs(ctx)
 		if err == nil {

--- a/eth/filters/filter_test.go
+++ b/eth/filters/filter_test.go
@@ -198,13 +198,21 @@ func TestFilters(t *testing.T) {
 				Data:     data,
 			}), signer, key1)
 			gen.AddTx(tx)
+			tx2, _ := types.SignTx(types.NewTx(&types.LegacyTx{
+				Nonce:    1,
+				GasPrice: gen.BaseFee(),
+				Gas:      30000,
+				To:       &contract2,
+				Data:     data,
+			}), signer, key1)
+			gen.AddTx(tx2)
 		case 2:
-			data, err := contractABI.Pack("log1", hash2.Big())
+			data, err := contractABI.Pack("log2", hash2.Big(), hash1.Big())
 			if err != nil {
 				t.Fatal(err)
 			}
 			tx, _ := types.SignTx(types.NewTx(&types.LegacyTx{
-				Nonce:    1,
+				Nonce:    2,
 				GasPrice: gen.BaseFee(),
 				Gas:      30000,
 				To:       &contract,
@@ -217,10 +225,10 @@ func TestFilters(t *testing.T) {
 				t.Fatal(err)
 			}
 			tx, _ := types.SignTx(types.NewTx(&types.LegacyTx{
-				Nonce:    2,
+				Nonce:    3,
 				GasPrice: gen.BaseFee(),
 				Gas:      30000,
-				To:       &contract,
+				To:       &contract2,
 				Data:     data,
 			}), signer, key1)
 			gen.AddTx(tx)
@@ -230,7 +238,7 @@ func TestFilters(t *testing.T) {
 				t.Fatal(err)
 			}
 			tx, _ := types.SignTx(types.NewTx(&types.LegacyTx{
-				Nonce:    3,
+				Nonce:    4,
 				GasPrice: gen.BaseFee(),
 				Gas:      30000,
 				To:       &contract,
@@ -259,7 +267,7 @@ func TestFilters(t *testing.T) {
 			t.Fatal(err)
 		}
 		tx, _ := types.SignTx(types.NewTx(&types.LegacyTx{
-			Nonce:    4,
+			Nonce:    5,
 			GasPrice: gen.BaseFee(),
 			Gas:      30000,
 			To:       &contract,
@@ -270,12 +278,6 @@ func TestFilters(t *testing.T) {
 	sys.backend.(*testBackend).pendingBlock = pchain[0]
 	sys.backend.(*testBackend).pendingReceipts = preceipts[0]
 
-	filter := sys.NewRangeFilter(0, -1, []common.Address{contract}, [][]common.Hash{{hash1, hash2, hash3, hash4}})
-	logs, _ := filter.Logs(context.Background())
-	if len(logs) != 4 {
-		t.Error("expected 4 log, got", len(logs))
-	}
-
 	for i, tc := range []struct {
 		f    *Filter
 		want string
@@ -283,17 +285,21 @@ func TestFilters(t *testing.T) {
 	}{
 		{
 			f:    sys.NewBlockFilter(chain[2].Hash(), []common.Address{contract}, nil),
-			want: `[{"address":"0xfe00000000000000000000000000000000000000","topics":["0x0000000000000000000000000000000000000000000000000000746f70696332"],"data":"0x","blockNumber":"0x3","transactionHash":"0x233e6a1b0715a700cef51bf4014b4a424ea3e2bd5a444a341bfc971e700d090d","transactionIndex":"0x0","blockHash":"0x8534d82e05b9f7da31e056ec2416c2e35d79c1bada1e9df99dea80a3d6bfaaeb","logIndex":"0x0","removed":false}]`,
-		},
-		{
-			f:    sys.NewRangeFilter(900, 999, []common.Address{contract}, [][]common.Hash{{hash3}}),
-			want: `[{"address":"0xfe00000000000000000000000000000000000000","topics":["0x0000000000000000000000000000000000000000000000000000746f70696333"],"data":"0x","blockNumber":"0x3e7","transactionHash":"0x3f3f143916f57e0d4081b4de395b7f861e03322bc0ebbf5d5f9238ede754f366","transactionIndex":"0x0","blockHash":"0x3fd3e9f6064f2128f95b5443a5b9f29f9d90c0bbf8efa46e17bd8081680c4241","logIndex":"0x0","removed":false}]`,
+			want: `[{"address":"0xfe00000000000000000000000000000000000000","topics":["0x0000000000000000000000000000000000000000000000000000746f70696332","0x0000000000000000000000000000000000000000000000000000746f70696331"],"data":"0x","blockNumber":"0x3","transactionHash":"0xdefe471992a07a02acdfbe33edaae22fbb86d7d3cec3f1b8e4e77702fb3acc1d","transactionIndex":"0x0","blockHash":"0x7a7556792ca7d37882882e2b001fe14833eaf81c2c7f865c9c771ec37a024f6b","logIndex":"0x0","removed":false}]`,
 		}, {
-			f:    sys.NewRangeFilter(990, int64(rpc.LatestBlockNumber), []common.Address{contract}, [][]common.Hash{{hash3}}),
-			want: `[{"address":"0xfe00000000000000000000000000000000000000","topics":["0x0000000000000000000000000000000000000000000000000000746f70696333"],"data":"0x","blockNumber":"0x3e7","transactionHash":"0x3f3f143916f57e0d4081b4de395b7f861e03322bc0ebbf5d5f9238ede754f366","transactionIndex":"0x0","blockHash":"0x3fd3e9f6064f2128f95b5443a5b9f29f9d90c0bbf8efa46e17bd8081680c4241","logIndex":"0x0","removed":false}]`,
+			f:    sys.NewRangeFilter(0, int64(rpc.LatestBlockNumber), []common.Address{contract}, [][]common.Hash{{hash1, hash2, hash3, hash4}}),
+			want: `[{"address":"0xfe00000000000000000000000000000000000000","topics":["0x0000000000000000000000000000000000000000000000000000746f70696331"],"data":"0x","blockNumber":"0x2","transactionHash":"0xa8028c655b6423204c8edfbc339f57b042d6bec2b6a61145d76b7c08b4cccd42","transactionIndex":"0x0","blockHash":"0x24417bb49ce44cfad65da68f33b510bf2a129c0d89ccf06acb6958b8585ccf34","logIndex":"0x0","removed":false},{"address":"0xfe00000000000000000000000000000000000000","topics":["0x0000000000000000000000000000000000000000000000000000746f70696332","0x0000000000000000000000000000000000000000000000000000746f70696331"],"data":"0x","blockNumber":"0x3","transactionHash":"0xdefe471992a07a02acdfbe33edaae22fbb86d7d3cec3f1b8e4e77702fb3acc1d","transactionIndex":"0x0","blockHash":"0x7a7556792ca7d37882882e2b001fe14833eaf81c2c7f865c9c771ec37a024f6b","logIndex":"0x0","removed":false},{"address":"0xfe00000000000000000000000000000000000000","topics":["0x0000000000000000000000000000000000000000000000000000746f70696334"],"data":"0x","blockNumber":"0x3e8","transactionHash":"0x9a87842100a638dfa5da8842b4beda691d2fd77b0c84b57f24ecfa9fb208f747","transactionIndex":"0x0","blockHash":"0xb360bad5265261c075ece02d3bf0e39498a6a76310482cdfd90588748e6c5ee0","logIndex":"0x0","removed":false}]`,
+		}, {
+			f: sys.NewRangeFilter(900, 999, []common.Address{contract}, [][]common.Hash{{hash3}}),
+		}, {
+			f:    sys.NewRangeFilter(990, int64(rpc.LatestBlockNumber), []common.Address{contract2}, [][]common.Hash{{hash3}}),
+			want: `[{"address":"0xff00000000000000000000000000000000000000","topics":["0x0000000000000000000000000000000000000000000000000000746f70696333"],"data":"0x","blockNumber":"0x3e7","transactionHash":"0x53e3675800c6908424b61b35a44e51ca4c73ca603e58a65b32c67968b4f42200","transactionIndex":"0x0","blockHash":"0x2e4620a2b426b0612ec6cad9603f466723edaed87f98c9137405dd4f7a2409ff","logIndex":"0x0","removed":false}]`,
+		}, {
+			f:    sys.NewRangeFilter(1, 10, []common.Address{contract}, [][]common.Hash{{hash2}, {hash1}}),
+			want: `[{"address":"0xfe00000000000000000000000000000000000000","topics":["0x0000000000000000000000000000000000000000000000000000746f70696332","0x0000000000000000000000000000000000000000000000000000746f70696331"],"data":"0x","blockNumber":"0x3","transactionHash":"0xdefe471992a07a02acdfbe33edaae22fbb86d7d3cec3f1b8e4e77702fb3acc1d","transactionIndex":"0x0","blockHash":"0x7a7556792ca7d37882882e2b001fe14833eaf81c2c7f865c9c771ec37a024f6b","logIndex":"0x0","removed":false}]`,
 		}, {
 			f:    sys.NewRangeFilter(1, 10, nil, [][]common.Hash{{hash1, hash2}}),
-			want: `[{"address":"0xfe00000000000000000000000000000000000000","topics":["0x0000000000000000000000000000000000000000000000000000746f70696331"],"data":"0x","blockNumber":"0x2","transactionHash":"0xa8028c655b6423204c8edfbc339f57b042d6bec2b6a61145d76b7c08b4cccd42","transactionIndex":"0x0","blockHash":"0xfc2aae62df9aa3da8e1bf37a540145b14b34fe5a0848460ef7b80be2b37a8430","logIndex":"0x0","removed":false},{"address":"0xfe00000000000000000000000000000000000000","topics":["0x0000000000000000000000000000000000000000000000000000746f70696332"],"data":"0x","blockNumber":"0x3","transactionHash":"0x233e6a1b0715a700cef51bf4014b4a424ea3e2bd5a444a341bfc971e700d090d","transactionIndex":"0x0","blockHash":"0x8534d82e05b9f7da31e056ec2416c2e35d79c1bada1e9df99dea80a3d6bfaaeb","logIndex":"0x0","removed":false}]`,
+			want: `[{"address":"0xfe00000000000000000000000000000000000000","topics":["0x0000000000000000000000000000000000000000000000000000746f70696331"],"data":"0x","blockNumber":"0x2","transactionHash":"0xa8028c655b6423204c8edfbc339f57b042d6bec2b6a61145d76b7c08b4cccd42","transactionIndex":"0x0","blockHash":"0x24417bb49ce44cfad65da68f33b510bf2a129c0d89ccf06acb6958b8585ccf34","logIndex":"0x0","removed":false},{"address":"0xff00000000000000000000000000000000000000","topics":["0x0000000000000000000000000000000000000000000000000000746f70696331"],"data":"0x","blockNumber":"0x2","transactionHash":"0xdba3e2ea9a7d690b722d70ee605fd67ba4c00d1d3aecd5cf187a7b92ad8eb3df","transactionIndex":"0x1","blockHash":"0x24417bb49ce44cfad65da68f33b510bf2a129c0d89ccf06acb6958b8585ccf34","logIndex":"0x1","removed":false},{"address":"0xfe00000000000000000000000000000000000000","topics":["0x0000000000000000000000000000000000000000000000000000746f70696332","0x0000000000000000000000000000000000000000000000000000746f70696331"],"data":"0x","blockNumber":"0x3","transactionHash":"0xdefe471992a07a02acdfbe33edaae22fbb86d7d3cec3f1b8e4e77702fb3acc1d","transactionIndex":"0x0","blockHash":"0x7a7556792ca7d37882882e2b001fe14833eaf81c2c7f865c9c771ec37a024f6b","logIndex":"0x0","removed":false}]`,
 		}, {
 			f: sys.NewRangeFilter(0, int64(rpc.LatestBlockNumber), nil, [][]common.Hash{{common.BytesToHash([]byte("fail"))}}),
 		}, {
@@ -302,13 +308,13 @@ func TestFilters(t *testing.T) {
 			f: sys.NewRangeFilter(0, int64(rpc.LatestBlockNumber), nil, [][]common.Hash{{common.BytesToHash([]byte("fail"))}, {hash1}}),
 		}, {
 			f:    sys.NewRangeFilter(int64(rpc.LatestBlockNumber), int64(rpc.LatestBlockNumber), nil, nil),
-			want: `[{"address":"0xfe00000000000000000000000000000000000000","topics":["0x0000000000000000000000000000000000000000000000000000746f70696334"],"data":"0x","blockNumber":"0x3e8","transactionHash":"0x1058ecf1c5da9a8eae907e97ac772e562de583dbac280840b1b35d71c9954eb4","transactionIndex":"0x0","blockHash":"0xbca1cc04078a0c594243b1dae659575b2422fceeff523f0d754654289d2afbb3","logIndex":"0x0","removed":false}]`,
+			want: `[{"address":"0xfe00000000000000000000000000000000000000","topics":["0x0000000000000000000000000000000000000000000000000000746f70696334"],"data":"0x","blockNumber":"0x3e8","transactionHash":"0x9a87842100a638dfa5da8842b4beda691d2fd77b0c84b57f24ecfa9fb208f747","transactionIndex":"0x0","blockHash":"0xb360bad5265261c075ece02d3bf0e39498a6a76310482cdfd90588748e6c5ee0","logIndex":"0x0","removed":false}]`,
 		}, {
 			f:    sys.NewRangeFilter(int64(rpc.FinalizedBlockNumber), int64(rpc.LatestBlockNumber), nil, nil),
-			want: `[{"address":"0xfe00000000000000000000000000000000000000","topics":["0x0000000000000000000000000000000000000000000000000000746f70696333"],"data":"0x","blockNumber":"0x3e7","transactionHash":"0x3f3f143916f57e0d4081b4de395b7f861e03322bc0ebbf5d5f9238ede754f366","transactionIndex":"0x0","blockHash":"0x3fd3e9f6064f2128f95b5443a5b9f29f9d90c0bbf8efa46e17bd8081680c4241","logIndex":"0x0","removed":false},{"address":"0xfe00000000000000000000000000000000000000","topics":["0x0000000000000000000000000000000000000000000000000000746f70696334"],"data":"0x","blockNumber":"0x3e8","transactionHash":"0x1058ecf1c5da9a8eae907e97ac772e562de583dbac280840b1b35d71c9954eb4","transactionIndex":"0x0","blockHash":"0xbca1cc04078a0c594243b1dae659575b2422fceeff523f0d754654289d2afbb3","logIndex":"0x0","removed":false}]`,
+			want: `[{"address":"0xff00000000000000000000000000000000000000","topics":["0x0000000000000000000000000000000000000000000000000000746f70696333"],"data":"0x","blockNumber":"0x3e7","transactionHash":"0x53e3675800c6908424b61b35a44e51ca4c73ca603e58a65b32c67968b4f42200","transactionIndex":"0x0","blockHash":"0x2e4620a2b426b0612ec6cad9603f466723edaed87f98c9137405dd4f7a2409ff","logIndex":"0x0","removed":false},{"address":"0xfe00000000000000000000000000000000000000","topics":["0x0000000000000000000000000000000000000000000000000000746f70696334"],"data":"0x","blockNumber":"0x3e8","transactionHash":"0x9a87842100a638dfa5da8842b4beda691d2fd77b0c84b57f24ecfa9fb208f747","transactionIndex":"0x0","blockHash":"0xb360bad5265261c075ece02d3bf0e39498a6a76310482cdfd90588748e6c5ee0","logIndex":"0x0","removed":false}]`,
 		}, {
 			f:    sys.NewRangeFilter(int64(rpc.FinalizedBlockNumber), int64(rpc.FinalizedBlockNumber), nil, nil),
-			want: `[{"address":"0xfe00000000000000000000000000000000000000","topics":["0x0000000000000000000000000000000000000000000000000000746f70696333"],"data":"0x","blockNumber":"0x3e7","transactionHash":"0x3f3f143916f57e0d4081b4de395b7f861e03322bc0ebbf5d5f9238ede754f366","transactionIndex":"0x0","blockHash":"0x3fd3e9f6064f2128f95b5443a5b9f29f9d90c0bbf8efa46e17bd8081680c4241","logIndex":"0x0","removed":false}]`,
+			want: `[{"address":"0xff00000000000000000000000000000000000000","topics":["0x0000000000000000000000000000000000000000000000000000746f70696333"],"data":"0x","blockNumber":"0x3e7","transactionHash":"0x53e3675800c6908424b61b35a44e51ca4c73ca603e58a65b32c67968b4f42200","transactionIndex":"0x0","blockHash":"0x2e4620a2b426b0612ec6cad9603f466723edaed87f98c9137405dd4f7a2409ff","logIndex":"0x0","removed":false}]`,
 		}, {
 			f: sys.NewRangeFilter(int64(rpc.LatestBlockNumber), int64(rpc.FinalizedBlockNumber), nil, nil),
 		}, {
@@ -322,10 +328,10 @@ func TestFilters(t *testing.T) {
 			err: "safe header not found",
 		}, {
 			f:    sys.NewRangeFilter(int64(rpc.PendingBlockNumber), int64(rpc.PendingBlockNumber), nil, nil),
-			want: `[{"address":"0xfe00000000000000000000000000000000000000","topics":["0x0000000000000000000000000000000000000000000000000000746f70696335"],"data":"0x","blockNumber":"0x3e9","transactionHash":"0x39c3b25137e8778d35f443593b3187751d0780cc887dd4bfe775a2d7ebe5491e","transactionIndex":"0x0","blockHash":"0x018655ebb21c0e229a297eb0bf16abc1c5aaf23ec2b6a402a483ce982889f7e9","logIndex":"0x0","removed":false}]`,
+			want: `[{"address":"0xfe00000000000000000000000000000000000000","topics":["0x0000000000000000000000000000000000000000000000000000746f70696335"],"data":"0x","blockNumber":"0x3e9","transactionHash":"0x4110587c1b8d86edc85dce929a34127f1cb8809515a9f177c91c866de3eb0638","transactionIndex":"0x0","blockHash":"0xc7245899e5817f16fa99cf5ad2d9c1e4b98443a565a673ec9c764640443ef037","logIndex":"0x0","removed":false}]`,
 		}, {
 			f:    sys.NewRangeFilter(int64(rpc.LatestBlockNumber), int64(rpc.PendingBlockNumber), nil, nil),
-			want: `[{"address":"0xfe00000000000000000000000000000000000000","topics":["0x0000000000000000000000000000000000000000000000000000746f70696334"],"data":"0x","blockNumber":"0x3e8","transactionHash":"0x1058ecf1c5da9a8eae907e97ac772e562de583dbac280840b1b35d71c9954eb4","transactionIndex":"0x0","blockHash":"0xbca1cc04078a0c594243b1dae659575b2422fceeff523f0d754654289d2afbb3","logIndex":"0x0","removed":false},{"address":"0xfe00000000000000000000000000000000000000","topics":["0x0000000000000000000000000000000000000000000000000000746f70696335"],"data":"0x","blockNumber":"0x3e9","transactionHash":"0x39c3b25137e8778d35f443593b3187751d0780cc887dd4bfe775a2d7ebe5491e","transactionIndex":"0x0","blockHash":"0x018655ebb21c0e229a297eb0bf16abc1c5aaf23ec2b6a402a483ce982889f7e9","logIndex":"0x0","removed":false}]`,
+			want: `[{"address":"0xfe00000000000000000000000000000000000000","topics":["0x0000000000000000000000000000000000000000000000000000746f70696334"],"data":"0x","blockNumber":"0x3e8","transactionHash":"0x9a87842100a638dfa5da8842b4beda691d2fd77b0c84b57f24ecfa9fb208f747","transactionIndex":"0x0","blockHash":"0xb360bad5265261c075ece02d3bf0e39498a6a76310482cdfd90588748e6c5ee0","logIndex":"0x0","removed":false},{"address":"0xfe00000000000000000000000000000000000000","topics":["0x0000000000000000000000000000000000000000000000000000746f70696335"],"data":"0x","blockNumber":"0x3e9","transactionHash":"0x4110587c1b8d86edc85dce929a34127f1cb8809515a9f177c91c866de3eb0638","transactionIndex":"0x0","blockHash":"0xc7245899e5817f16fa99cf5ad2d9c1e4b98443a565a673ec9c764640443ef037","logIndex":"0x0","removed":false}]`,
 		}, {
 			f:   sys.NewRangeFilter(int64(rpc.PendingBlockNumber), int64(rpc.LatestBlockNumber), nil, nil),
 			err: "invalid block range",

--- a/eth/filters/filter_test.go
+++ b/eth/filters/filter_test.go
@@ -358,7 +358,7 @@ func TestFilters(t *testing.T) {
 
 	t.Run("timeout", func(t *testing.T) {
 		f := sys.NewRangeFilter(0, -1, nil, nil)
-		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Microsecond)
+		ctx, cancel := context.WithDeadline(context.Background(), time.Now().Add(-time.Hour))
 		defer cancel()
 		_, err := f.Logs(ctx)
 		if err == nil {

--- a/eth/filters/filter_test.go
+++ b/eth/filters/filter_test.go
@@ -22,6 +22,7 @@ import (
 	"math/big"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/ethereum/go-ethereum/accounts/abi"
 	"github.com/ethereum/go-ethereum/common"
@@ -354,4 +355,17 @@ func TestFilters(t *testing.T) {
 			t.Fatalf("test %d, have:\n%s\nwant:\n%s", i, have, tc.want)
 		}
 	}
+
+	t.Run("timeout", func(t *testing.T) {
+		f := sys.NewRangeFilter(0, -1, nil, nil)
+		ctx, cancel := context.WithTimeout(context.Background(), 100*time.Microsecond)
+		defer cancel()
+		_, err := f.Logs(ctx)
+		if err == nil {
+			t.Fatal("expected error")
+		}
+		if err != context.DeadlineExceeded {
+			t.Fatalf("expected context.DeadlineExceeded, got %v", err)
+		}
+	})
 }


### PR DESCRIPTION
Try to implement https://github.com/ethereum/go-ethereum/issues/15063 and discussed with @s1na, 
In the first phase, we want to make the `filter.Logs()` function returns a channel instead of a large array