### PR TITLE
cmd/utils, core/{rawdb, state}, trie, eth: change preimage format follow snapshot order

### DIFF
--- a/cmd/utils/cmd.go
+++ b/cmd/utils/cmd.go
@@ -287,8 +287,8 @@ func ExportAppendChain(blockchain *core.BlockChain, fn string, first uint64, las
 }
 
 type exportPreimage struct {
-	key []byte
-	val []byte
+	Key []byte
+	Val []byte
 }
 
 // ImportPreimages imports a batch of exported hash preimages into the database.
@@ -325,7 +325,7 @@ func ImportPreimages(db ethdb.Database, fn string) error {
 			return err
 		}
 		// Accumulate the preimages and flush when enough ws gathered
-		preimages[string(blob.key)] = common.CopyBytes(blob.val)
+		preimages[string(blob.Key)] = common.CopyBytes(blob.Val)
 		if len(preimages) > 1024 {
 			rawdb.WritePreimages(db, preimages)
 			preimages = make(map[string][]byte)

--- a/core/rawdb/accessors_state.go
+++ b/core/rawdb/accessors_state.go
@@ -23,15 +23,15 @@ import (
 )
 
 // ReadPreimage retrieves a single preimage of the provided hash.
-func ReadPreimage(db ethdb.KeyValueReader, hash common.Hash) []byte {
+func ReadPreimage(db ethdb.KeyValueReader, hash []byte) []byte {
 	data, _ := db.Get(preimageKey(hash))
 	return data
 }
 
 // WritePreimages writes the provided set of preimages to the database.
-func WritePreimages(db ethdb.KeyValueWriter, preimages map[common.Hash][]byte) {
-	for hash, preimage := range preimages {
-		if err := db.Put(preimageKey(hash), preimage); err != nil {
+func WritePreimages(db ethdb.KeyValueWriter, preimages map[string][]byte) {
+	for hashstr, preimage := range preimages {
+		if err := db.Put(preimageKey([]byte(hashstr)), preimage); err != nil {
 			log.Crit("Failed to store trie preimage", "err", err)
 		}
 	}

--- a/core/rawdb/schema.go
+++ b/core/rawdb/schema.go
@@ -211,8 +211,8 @@ func skeletonHeaderKey(number uint64) []byte {
 }
 
 // preimageKey = PreimagePrefix + hash
-func preimageKey(hash common.Hash) []byte {
-	return append(PreimagePrefix, hash.Bytes()...)
+func preimageKey(hash []byte) []byte {
+	return append(PreimagePrefix, hash...)
 }
 
 // codeKey = CodePrefix + hash

--- a/core/state/journal.go
+++ b/core/state/journal.go
@@ -249,7 +249,7 @@ func (ch addLogChange) dirtied() *common.Address {
 }
 
 func (ch addPreimageChange) revert(s *StateDB) {
-	delete(s.preimages, ch.hash)
+	delete(s.preimages, string(ch.hash[:]))
 }
 
 func (ch addPreimageChange) dirtied() *common.Address {

--- a/core/state/statedb.go
+++ b/core/state/statedb.go
@@ -95,7 +95,7 @@ type StateDB struct {
 	logs    map[common.Hash][]*types.Log
 	logSize uint
 
-	preimages map[common.Hash][]byte
+	preimages map[string][]byte
 
 	// Per-transaction access list
 	accessList *accessList
@@ -145,7 +145,7 @@ func New(root common.Hash, db Database, snaps *snapshot.Tree) (*StateDB, error) 
 		stateObjectsDirty:    make(map[common.Address]struct{}),
 		stateObjectsDestruct: make(map[common.Address]struct{}),
 		logs:                 make(map[common.Hash][]*types.Log),
-		preimages:            make(map[common.Hash][]byte),
+		preimages:            make(map[string][]byte),
 		journal:              newJournal(),
 		accessList:           newAccessList(),
 		transientStorage:     newTransientStorage(),
@@ -225,16 +225,16 @@ func (s *StateDB) Logs() []*types.Log {
 
 // AddPreimage records a SHA3 preimage seen by the VM.
 func (s *StateDB) AddPreimage(hash common.Hash, preimage []byte) {
-	if _, ok := s.preimages[hash]; !ok {
+	if _, ok := s.preimages[string(hash[:])]; !ok {
 		s.journal.append(addPreimageChange{hash: hash})
 		pi := make([]byte, len(preimage))
 		copy(pi, preimage)
-		s.preimages[hash] = pi
+		s.preimages[string(hash[:])] = pi
 	}
 }
 
 // Preimages returns a list of SHA3 preimages that have been submitted.
-func (s *StateDB) Preimages() map[common.Hash][]byte {
+func (s *StateDB) Preimages() map[string][]byte {
 	return s.preimages
 }
 
@@ -708,7 +708,7 @@ func (s *StateDB) Copy() *StateDB {
 		refund:               s.refund,
 		logs:                 make(map[common.Hash][]*types.Log, len(s.logs)),
 		logSize:              s.logSize,
-		preimages:            make(map[common.Hash][]byte, len(s.preimages)),
+		preimages:            make(map[string][]byte, len(s.preimages)),
 		journal:              newJournal(),
 		hasher:               crypto.NewKeccakState(),
 	}

--- a/eth/api.go
+++ b/eth/api.go
@@ -292,7 +292,7 @@ func (api *DebugAPI) DumpBlock(blockNr rpc.BlockNumber) (state.Dump, error) {
 }
 
 // Preimage is a debug API function that returns the preimage for a sha3 hash, if known.
-func (api *DebugAPI) Preimage(ctx context.Context, hash common.Hash) (hexutil.Bytes, error) {
+func (api *DebugAPI) Preimage(ctx context.Context, hash []byte) (hexutil.Bytes, error) {
 	if preimage := rawdb.ReadPreimage(api.eth.ChainDb(), hash); preimage != nil {
 		return preimage, nil
 	}


### PR DESCRIPTION
This PR changes the format of

Overview of changes:

 * In `preimageStore`, preimages are no longer indexed by the hash, but by the string representation of either:
   *  `<address hash> + <slot hash>` if this is a slot
   * `<address hash>` if this is an address
 * If non-zero, the trie owner is used to prefix the slot hash in the preimage key
 * preimage export/import is modified to also export the hashes. This will make for larger files, unfortunately.

Note that for slots, the RPC API now expects the `<address hash> + <slot hash>` format. This could break e.g. preimages.bordel.wtf if that's the interface that they use.