### PR TITLE
metrics: use sync.map in registry

### DIFF
--- a/metrics/registry_test.go
+++ b/metrics/registry_test.go
@@ -1,6 +1,7 @@
 package metrics
 
 import (
+	"sync"
 	"testing"
 )
 
@@ -11,6 +12,30 @@ func BenchmarkRegistry(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		r.Each(func(string, interface{}) {})
 	}
+}
+
+func BenchmarkRegistryGetOrRegisterParallel_8(b *testing.B) {
+	benchmarkRegistryGetOrRegisterParallel(b, 8)
+}
+
+func BenchmarkRegistryGetOrRegisterParallel_32(b *testing.B) {
+	benchmarkRegistryGetOrRegisterParallel(b, 32)
+}
+
+func benchmarkRegistryGetOrRegisterParallel(b *testing.B, amount int) {
+	r := NewRegistry()
+	b.ResetTimer()
+	var wg sync.WaitGroup
+	for i := 0; i < amount; i++ {
+		wg.Add(1)
+		go func() {
+			for i := 0; i < b.N; i++ {
+				r.GetOrRegister("foo", NewMeter)
+			}
+			wg.Done()
+		}()
+	}
+	wg.Wait()
 }
 
 func TestRegistry(t *testing.T) {


### PR DESCRIPTION
This PR changes the registry from mutex protected map to sync.map implementation. 
The registry is mostly read-heavy due to GetOrRegister method being used for tracking packets and rpc. Besides that most of the primitives are created at initialization and never unregistered. It sounds like a good place for sync.map.

Some stats:
name                                                       old time/op     new time/op   delta
RegistryGetOrRegisterParallel_8-16      222.50n  ± 2%   21.93n ± 7%  -90.14% (p=0.000 n=10)
RegistryGetOrRegisterParallel_32-16   1608.50n ± 0%   50.35n ± 2%  -96.87% (p=0.000 n=10)