### PR TITLE
cmd/geth, les/vflux/client, les, rpc: use atomic types

### DIFF
--- a/cmd/geth/les_test.go
+++ b/cmd/geth/les_test.go
@@ -107,10 +107,10 @@ func ipcEndpoint(ipcPath, datadir string) string {
 // but windows require pipes to sit in "\\.\pipe\". Therefore, to run several
 // nodes simultaneously, we need to distinguish between them, which we do by
 // the pipe filename instead of folder.
-var nextIPC = uint32(0)
+var nextIPC atomic.Uint32
 
 func startGethWithIpc(t *testing.T, name string, args ...string) *gethrpc {
-	ipcName := fmt.Sprintf("geth-%d.ipc", atomic.AddUint32(&nextIPC, 1))
+	ipcName := fmt.Sprintf("geth-%d.ipc", nextIPC.Add(1))
 	args = append([]string{"--networkid=42", "--port=0", "--authrpc.port", "0", "--ipcpath", ipcName}, args...)
 	t.Logf("Starting %v with rpc: %v", name, args)
 

--- a/les/servingqueue.go
+++ b/les/servingqueue.go
@@ -28,10 +28,11 @@ import (
 // servingQueue allows running tasks in a limited number of threads and puts the
 // waiting tasks in a priority queue
 type servingQueue struct {
-	recentTime, queuedTime, servingTimeDiff uint64
-	burstLimit, burstDropLimit              uint64
-	burstDecRate                            float64
-	lastUpdate                              mclock.AbsTime
+	recentTime, queuedTime     uint64
+	servingTimeDiff            atomic.Uint64
+	burstLimit, burstDropLimit uint64
+	burstDecRate               float64
+	lastUpdate                 mclock.AbsTime
 
 	queueAddCh, queueBestCh chan *servingTask
 	stopThreadCh, quit      chan struct{}
@@ -100,7 +101,7 @@ func (t *servingTask) done() uint64 {
 	t.timeAdded = t.servingTime
 	if t.expTime > diff {
 		t.expTime -= diff
-		atomic.AddUint64(&t.sq.servingTimeDiff, t.expTime)
+		t.sq.servingTimeDiff.Add(t.expTime)
 	} else {
 		t.expTime = 0
 	}
@@ -257,7 +258,7 @@ func (sq *servingQueue) freezePeers() {
 
 // updateRecentTime recalculates the recent serving time value
 func (sq *servingQueue) updateRecentTime() {
-	subTime := atomic.SwapUint64(&sq.servingTimeDiff, 0)
+	subTime := sq.servingTimeDiff.Swap(0)
 	now := mclock.Now()
 	dt := now - sq.lastUpdate
 	sq.lastUpdate = now

--- a/rpc/client.go
+++ b/rpc/client.go
@@ -79,7 +79,7 @@ type Client struct {
 	isHTTP   bool      // connection type: http, ws or ipc
 	services *serviceRegistry
 
-	idCounter uint32
+	idCounter atomic.Uint32
 
 	// This function, if non-nil, is called when the connection is lost.
 	reconnectFunc reconnectFunc
@@ -263,7 +263,7 @@ func (c *Client) RegisterName(name string, receiver interface{}) error {
 }
 
 func (c *Client) nextID() json.RawMessage {
-	id := atomic.AddUint32(&c.idCounter, 1)
+	id := c.idCounter.Add(1)
 	return strconv.AppendUint(nil, uint64(id), 10)
 }
 


### PR DESCRIPTION
non-local variables use atomic types