### PR TITLE
core: remove unused ContractCode method from BlockChain

### DIFF
--- a/core/blockchain_reader.go
+++ b/core/blockchain_reader.go
@@ -299,12 +299,6 @@ func (bc *BlockChain) TrieNode(hash common.Hash) ([]byte, error) {
 	return bc.stateCache.TrieDB().Node(hash)
 }
 
-// ContractCode retrieves a blob of data associated with a contract hash
-// either from ephemeral in-memory cache, or from persistent storage.
-func (bc *BlockChain) ContractCode(hash common.Hash) ([]byte, error) {
-	return bc.stateCache.ContractCode(common.Hash{}, hash)
-}
-
 // ContractCodeWithPrefix retrieves a blob of data associated with a contract
 // hash either from ephemeral in-memory cache, or from persistent storage.
 //


### PR DESCRIPTION
**Context** : I'm looking into implementing stateless block execution in geth. One of the problems I see is that `(*state.Database).ContractCode expects the hash of the address instead of the address itself. This interface should be changed altogether in a different PR when I have figured all the details out.

While investigating the call tree for `(*state.Database).ContractCode`, I noticed that `(*BlockChain).ContractCode` isn't used anywhere, and it makes sense to remove it from the interface, lest someone starts using it in the future, and make the interface redesign more difficult.

So this PR simply removes that method.