### PR TITLE
cmd/utils: report the correct invalid block number in block import

### DIFF
--- a/cmd/utils/cmd.go
+++ b/cmd/utils/cmd.go
@@ -211,8 +211,8 @@ func ImportChain(chain *core.BlockChain, fn string) error {
 			log.Info("Skipping batch as all blocks present", "batch", batch, "first", blocks[0].Hash(), "last", blocks[i-1].Hash())
 			continue
 		}
-		if _, err := chain.InsertChain(missing); err != nil {
-			return fmt.Errorf("invalid block %d: %v", n, err)
+		if failindex, err := chain.InsertChain(missing); err != nil {
+			return fmt.Errorf("invalid block %d: %v", blocks[failindex].NumberU64(), err)
 		}
 	}
 	return nil


### PR DESCRIPTION
When the block import fails, the error displays the number of the first block past the import batch, not the number of the failing block. This PR fixes this problem by identifying which blocks fails and reporting its number.