### PR TITLE
eth/downloader: fix error aggregator

### DIFF
--- a/eth/downloader/downloader.go
+++ b/eth/downloader/downloader.go
@@ -663,8 +663,11 @@ func (d *Downloader) spawnSync(fetchers []func() error) error {
 			// it has processed the queue.
 			d.queue.Close()
 		}
-		if err = <-errc; err != nil && err != errCanceled {
-			break
+		if got := <-errc; got != nil {
+			err = got
+			if got != errCanceled {
+				break // receive a meaningful error, bubble it up
+			}
 		}
 	}
 	d.queue.Close()


### PR DESCRIPTION
This PR fixes an incorrect error aggregation in downloader.

Downloader has a few components used to sync up chain. Whenever an error occurs in any of
these components, the sync procedure needs to be aborted and the error is expected to be 
bubbled up. This error is an important marker, one use case is as an indicator if transactions
from network should be accepted or not.

However this error aggregation is wrong. Previously the aggregated error is always overwritten
by the returned value from components, but the fact is some components(e.g. processFullSyncContent)
won't return error in some cases.

This PR fixes this error, and I believe it can prevent accepting transactions when syncing.