### PR TITLE
node/rpcstack, node: Rename function  'RegisterAPIs' & 'RegisterApis'

### DIFF
--- a/cmd/clef/main.go
+++ b/cmd/clef/main.go
@@ -732,7 +732,7 @@ func signer(c *cli.Context) error {
 		cors := utils.SplitAndTrim(c.String(utils.HTTPCORSDomainFlag.Name))
 
 		srv := rpc.NewServer()
-		err := node.RegisterApis(rpcAPI, []string{"account"}, srv)
+		err := node.RegisterAPIsToServer(rpcAPI, []string{"account"}, srv)
 		if err != nil {
 			utils.Fatalf("Could not register API: %w", err)
 		}

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -1884,7 +1884,7 @@ func RegisterEthService(stack *node.Node, cfg *ethconfig.Config) (ethapi.Backend
 		if err != nil {
 			Fatalf("Failed to register the Ethereum service: %v", err)
 		}
-		stack.RegisterAPIs(tracers.APIs(backend.ApiBackend))
+		stack.RegisterAPIsToNode(tracers.APIs(backend.ApiBackend))
 		if err := lescatalyst.Register(stack, backend); err != nil {
 			Fatalf("Failed to register the Engine API service: %v", err)
 		}
@@ -1903,7 +1903,7 @@ func RegisterEthService(stack *node.Node, cfg *ethconfig.Config) (ethapi.Backend
 	if err := ethcatalyst.Register(stack, backend); err != nil {
 		Fatalf("Failed to register the Engine API service: %v", err)
 	}
-	stack.RegisterAPIs(tracers.APIs(backend.APIBackend))
+	stack.RegisterAPIsToNode(tracers.APIs(backend.APIBackend))
 	return backend.APIBackend, backend
 }
 
@@ -1928,7 +1928,7 @@ func RegisterFilterAPI(stack *node.Node, backend ethapi.Backend, ethcfg *ethconf
 	filterSystem := filters.NewFilterSystem(backend, filters.Config{
 		LogCacheSize: ethcfg.FilterLogCacheSize,
 	})
-	stack.RegisterAPIs([]rpc.API{{
+	stack.RegisterAPIsToNode([]rpc.API{{
 		Namespace: "eth",
 		Service:   filters.NewFilterAPI(filterSystem, isLightClient),
 	}})

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -252,7 +252,7 @@ func New(stack *node.Node, config *ethconfig.Config) (*Ethereum, error) {
 	eth.netRPCService = ethapi.NewNetAPI(eth.p2pServer, config.NetworkId)
 
 	// Register the backend on the node
-	stack.RegisterAPIs(eth.APIs())
+	stack.RegisterAPIsToNode(eth.APIs())
 	stack.RegisterProtocols(eth.Protocols())
 	stack.RegisterLifecycle(eth)
 

--- a/eth/catalyst/api.go
+++ b/eth/catalyst/api.go
@@ -39,7 +39,7 @@ import (
 // Register adds the engine API to the full node.
 func Register(stack *node.Node, backend *eth.Ethereum) error {
 	log.Warn("Engine API enabled", "protocol", "eth")
-	stack.RegisterAPIs([]rpc.API{
+	stack.RegisterAPIsToNode([]rpc.API{
 		{
 			Namespace:     "engine",
 			Service:       NewConsensusAPI(backend),

--- a/ethclient/gethclient/gethclient_test.go
+++ b/ethclient/gethclient/gethclient_test.go
@@ -61,7 +61,7 @@ func newTestBackend(t *testing.T) (*node.Node, []*types.Block) {
 		t.Fatalf("can't create new ethereum service: %v", err)
 	}
 	filterSystem := filters.NewFilterSystem(ethservice.APIBackend, filters.Config{})
-	n.RegisterAPIs([]rpc.API{{
+	n.RegisterAPIsToNode([]rpc.API{{
 		Namespace: "eth",
 		Service:   filters.NewFilterAPI(filterSystem, false),
 	}})

--- a/les/catalyst/api.go
+++ b/les/catalyst/api.go
@@ -33,7 +33,7 @@ import (
 // Register adds catalyst APIs to the light client.
 func Register(stack *node.Node, backend *les.LightEthereum) error {
 	log.Warn("Catalyst mode enabled", "protocol", "les")
-	stack.RegisterAPIs([]rpc.API{
+	stack.RegisterAPIsToNode([]rpc.API{
 		{
 			Namespace:     "engine",
 			Service:       NewConsensusAPI(backend),

--- a/les/client.go
+++ b/les/client.go
@@ -192,7 +192,7 @@ func New(stack *node.Node, config *ethconfig.Config) (*LightEthereum, error) {
 	leth.netRPCService = ethapi.NewNetAPI(leth.p2pServer, leth.config.NetworkId)
 
 	// Register the backend on the node
-	stack.RegisterAPIs(leth.APIs())
+	stack.RegisterAPIsToNode(leth.APIs())
 	stack.RegisterProtocols(leth.Protocols())
 	stack.RegisterLifecycle(leth)
 

--- a/les/server.go
+++ b/les/server.go
@@ -144,7 +144,7 @@ func NewLesServer(node *node.Node, e ethBackend, config *ethconfig.Config) (*Les
 	srv.chtIndexer.Start(e.BlockChain())
 
 	node.RegisterProtocols(srv.Protocols())
-	node.RegisterAPIs(srv.APIs())
+	node.RegisterAPIsToNode(srv.APIs())
 	node.RegisterLifecycle(srv)
 	return srv, nil
 }

--- a/node/node.go
+++ b/node/node.go
@@ -566,8 +566,8 @@ func (n *Node) RegisterProtocols(protocols []p2p.Protocol) {
 	n.server.Protocols = append(n.server.Protocols, protocols...)
 }
 
-// RegisterAPIs registers the APIs a service provides on the node.
-func (n *Node) RegisterAPIs(apis []rpc.API) {
+// RegisterAPIsToNode registers the APIs a service provides on the node.
+func (n *Node) RegisterAPIsToNode(apis []rpc.API) {
 	n.lock.Lock()
 	defer n.lock.Unlock()
 

--- a/node/node_auth_test.go
+++ b/node/node_auth_test.go
@@ -120,7 +120,7 @@ func TestAuthEndpoints(t *testing.T) {
 		t.Fatalf("could not create a new node: %v", err)
 	}
 	// register dummy apis so we can test the modules are available and reachable with authentication
-	node.RegisterAPIs([]rpc.API{
+	node.RegisterAPIsToNode([]rpc.API{
 		{
 			Namespace:     "engine",
 			Version:       "1.0",

--- a/node/rpcstack.go
+++ b/node/rpcstack.go
@@ -297,7 +297,7 @@ func (h *httpServer) enableRPC(apis []rpc.API, config httpConfig) error {
 
 	// Create RPC server and handler.
 	srv := rpc.NewServer()
-	if err := RegisterApis(apis, config.Modules, srv); err != nil {
+	if err := RegisterAPIsToServer(apis, config.Modules, srv); err != nil {
 		return err
 	}
 	h.httpConfig = config
@@ -328,7 +328,7 @@ func (h *httpServer) enableWS(apis []rpc.API, config wsConfig) error {
 	}
 	// Create RPC server and handler.
 	srv := rpc.NewServer()
-	if err := RegisterApis(apis, config.Modules, srv); err != nil {
+	if err := RegisterAPIsToServer(apis, config.Modules, srv); err != nil {
 		return err
 	}
 	h.wsConfig = config
@@ -613,9 +613,9 @@ func (is *ipcServer) stop() error {
 	return err
 }
 
-// RegisterApis checks the given modules' availability, generates an allowlist based on the allowed modules,
+// RegisterAPIsToServer checks the given modules' availability, generates an allowlist based on the allowed modules,
 // and then registers all of the APIs exposed by the services.
-func RegisterApis(apis []rpc.API, modules []string, srv *rpc.Server) error {
+func RegisterAPIsToServer(apis []rpc.API, modules []string, srv *rpc.Server) error {
 	if bad, available := checkModuleAvailability(modules, apis); len(bad) > 0 {
 		log.Error("Unavailable modules in HTTP API list", "unavailable", bad, "available", available)
 	}

--- a/node/utils_test.go
+++ b/node/utils_test.go
@@ -69,7 +69,7 @@ func NewFullService(stack *Node) (*FullService, error) {
 	fs := new(FullService)
 
 	stack.RegisterProtocols(fs.Protocols())
-	stack.RegisterAPIs(fs.APIs())
+	stack.RegisterAPIsToNode(fs.APIs())
 	stack.RegisterLifecycle(fs)
 	return fs, nil
 }

--- a/p2p/simulations/adapters/exec.go
+++ b/p2p/simulations/adapters/exec.go
@@ -501,7 +501,7 @@ func startExecNodeStack() (*node.Node, error) {
 	}
 
 	// Add the snapshot API.
-	stack.RegisterAPIs([]rpc.API{{
+	stack.RegisterAPIsToNode([]rpc.API{{
 		Namespace: "simulation",
 		Service:   SnapshotAPI{services},
 	}})

--- a/p2p/simulations/http_test.go
+++ b/p2p/simulations/http_test.go
@@ -72,7 +72,7 @@ func newTestService(ctx *adapters.ServiceContext, stack *node.Node) (node.Lifecy
 	svc.state.Store(ctx.Snapshot)
 
 	stack.RegisterProtocols(svc.Protocols())
-	stack.RegisterAPIs(svc.APIs())
+	stack.RegisterAPIsToNode(svc.APIs())
 	return svc, nil
 }
 


### PR DESCRIPTION
The RegisterAPIs function is a method of the Node struct, defined in the node/node.go file. Its purpose is to add a set of APIs to the node's rpcAPIs slice, which will later be used during the startup process to initialize the different RPC communication methods (HTTP, WebSocket, and IPC).

The RegisterApis function is defined in the node/rpcstack.go file. Its purpose is to register APIs to an rpc.Server instance during the node startup, based on a list of allowed modules. It generates an allowlist by checking the module availability and registers the qualifying APIs onto the RPC server.

To avoid confusion, it might be a good idea to provide more descriptive names for these two functions, so that they better reflect their purposes.