### PR TITLE
core/state: unexport NodeIterator

### DIFF
--- a/core/state/iterator.go
+++ b/core/state/iterator.go
@@ -26,9 +26,9 @@ import (
 	"github.com/ethereum/go-ethereum/trie"
 )
 
-// NodeIterator is an iterator to traverse the entire state trie post-order,
+// nodeIterator is an iterator to traverse the entire state trie post-order,
 // including all of the contract code and contract state tries.
-type NodeIterator struct {
+type nodeIterator struct {
 	state *StateDB // State being iterated
 
 	stateIt trie.NodeIterator // Primary iterator for the global state trie
@@ -44,9 +44,9 @@ type NodeIterator struct {
 	Error error // Failure set in case of an internal error in the iterator
 }
 
-// NewNodeIterator creates an post-order state node iterator.
-func NewNodeIterator(state *StateDB) *NodeIterator {
-	return &NodeIterator{
+// newNodeIterator creates an post-order state node iterator.
+func newNodeIterator(state *StateDB) *nodeIterator {
+	return &nodeIterator{
 		state: state,
 	}
 }
@@ -54,7 +54,7 @@ func NewNodeIterator(state *StateDB) *NodeIterator {
 // Next moves the iterator to the next node, returning whether there are any
 // further nodes. In case of an internal error this method returns false and
 // sets the Error field to the encountered failure.
-func (it *NodeIterator) Next() bool {
+func (it *nodeIterator) Next() bool {
 	// If the iterator failed previously, don't do anything
 	if it.Error != nil {
 		return false
@@ -68,7 +68,7 @@ func (it *NodeIterator) Next() bool {
 }
 
 // step moves the iterator to the next entry of the state trie.
-func (it *NodeIterator) step() error {
+func (it *nodeIterator) step() error {
 	// Abort if we reached the end of the iteration
 	if it.state == nil {
 		return nil
@@ -131,7 +131,7 @@ func (it *NodeIterator) step() error {
 
 // retrieve pulls and caches the current state entry the iterator is traversing.
 // The method returns whether there are any more data left for inspection.
-func (it *NodeIterator) retrieve() bool {
+func (it *nodeIterator) retrieve() bool {
 	// Clear out any previously set values
 	it.Hash = common.Hash{}
 

--- a/core/state/iterator_test.go
+++ b/core/state/iterator_test.go
@@ -36,7 +36,7 @@ func TestNodeIteratorCoverage(t *testing.T) {
 	}
 	// Gather all the node hashes found by the iterator
 	hashes := make(map[common.Hash]struct{})
-	for it := NewNodeIterator(state); it.Next(); {
+	for it := newNodeIterator(state); it.Next(); {
 		if it.Hash != (common.Hash{}) {
 			hashes[it.Hash] = struct{}{}
 		}

--- a/core/state/sync_test.go
+++ b/core/state/sync_test.go
@@ -125,7 +125,7 @@ func checkStateConsistency(db ethdb.Database, root common.Hash) error {
 	if err != nil {
 		return err
 	}
-	it := NewNodeIterator(state)
+	it := newNodeIterator(state)
 	for it.Next() {
 	}
 	return it.Error


### PR DESCRIPTION
This is a prerequisite for #27209 : changing the interface in `OpenStorageTrie` to accept an address instead of an address hash. This interface change is needed for verkle trees, as the hashing algorithm used to find storage is not keccak.

The problem this PR addresses, is that the node iterator would require preimage usage to conform to this new interface. Luckily, the node iterator is only used in tests, so this preimage requirement can easily be enforced. For this to happen, though, the node iterator interface should be unexported, lest someone else starts using it in the meantime.