### PR TITLE
p2p: logs peer statistics in seperate goroutine

### DIFF
--- a/p2p/dial.go
+++ b/p2p/dial.go
@@ -121,6 +121,7 @@ type dialScheduler struct {
 	historyTimer *mclock.Alarm
 
 	// for logStats
+	lastStatsLog     mclock.AbsTime
 	doneSinceLastLog int
 }
 
@@ -173,6 +174,7 @@ func newDialScheduler(config dialConfig, it enode.Iterator, setupFunc dialSetupF
 		addPeerCh:    make(chan *conn),
 		remPeerCh:    make(chan *conn),
 	}
+	d.lastStatsLog = d.clock.Now()
 	d.ctx, d.cancel = context.WithCancel(context.Background())
 	d.wg.Add(3)
 	go d.readNodes(it)
@@ -328,25 +330,27 @@ func (d *dialScheduler) readNodes(it enode.Iterator) {
 // peers are connected because users should only see it while their client is starting up
 // or comes back online.
 func (d *dialScheduler) logStats() {
+	now := d.clock.Now()
+	if d.lastStatsLog.Add(dialStatsLogInterval) > now {
+		return
+	}
 	if d.dialPeers < dialStatsPeerLimit && d.dialPeers < d.maxDialPeers {
 		d.log.Info("Looking for peers", "peercount", len(d.peers), "tried", d.doneSinceLastLog, "static", len(d.static))
 	}
 	d.doneSinceLastLog = 0
+	d.lastStatsLog = now
 }
 
 // logloop logs statistics in separate goroutine
 func (d *dialScheduler) logloop() {
 	defer d.wg.Done()
 
-	timer := time.NewTimer(dialStatsLogInterval)
-
 	for {
 		select {
 		case <-d.ctx.Done():
 			return
-		case <-timer.C:
+		default:
 			d.logStats()
-			timer = time.NewTimer(dialStatsLogInterval)
 		}
 	}
 }

--- a/p2p/dial.go
+++ b/p2p/dial.go
@@ -176,10 +176,9 @@ func newDialScheduler(config dialConfig, it enode.Iterator, setupFunc dialSetupF
 	}
 	d.lastStatsLog = d.clock.Now()
 	d.ctx, d.cancel = context.WithCancel(context.Background())
-	d.wg.Add(3)
+	d.wg.Add(2)
 	go d.readNodes(it)
 	go d.loop(it)
-	go d.logloop()
 	return d
 }
 
@@ -238,6 +237,7 @@ loop:
 			nodesCh = nil
 		}
 		d.rearmHistoryTimer()
+		d.logStats()
 
 		select {
 		case node := <-nodesCh:
@@ -339,20 +339,6 @@ func (d *dialScheduler) logStats() {
 	}
 	d.doneSinceLastLog = 0
 	d.lastStatsLog = now
-}
-
-// logloop logs statistics in separate goroutine
-func (d *dialScheduler) logloop() {
-	defer d.wg.Done()
-
-	for {
-		select {
-		case <-d.ctx.Done():
-			return
-		default:
-			d.logStats()
-		}
-	}
 }
 
 // rearmHistoryTimer configures d.historyTimer to fire when the

--- a/p2p/dial.go
+++ b/p2p/dial.go
@@ -176,9 +176,10 @@ func newDialScheduler(config dialConfig, it enode.Iterator, setupFunc dialSetupF
 	}
 	d.lastStatsLog = d.clock.Now()
 	d.ctx, d.cancel = context.WithCancel(context.Background())
-	d.wg.Add(2)
+	d.wg.Add(3)
 	go d.readNodes(it)
 	go d.loop(it)
+	go d.logloop()
 	return d
 }
 
@@ -237,7 +238,6 @@ loop:
 			nodesCh = nil
 		}
 		d.rearmHistoryTimer()
-		d.logStats()
 
 		select {
 		case node := <-nodesCh:
@@ -339,6 +339,20 @@ func (d *dialScheduler) logStats() {
 	}
 	d.doneSinceLastLog = 0
 	d.lastStatsLog = now
+}
+
+// logloop logs statistics in separate goroutine
+func (d *dialScheduler) logloop() {
+	defer d.wg.Done()
+
+	for {
+		select {
+		case <-d.ctx.Done():
+			return
+		default:
+			d.logStats()
+		}
+	}
 }
 
 // rearmHistoryTimer configures d.historyTimer to fire when the


### PR DESCRIPTION
## Reason

The dialer main loop blocks this line of code: https://github.com/ethereum/go-ethereum/blob/a14301823ea4da3004f05584ca1093d1d626819d/p2p/dial.go#L240

When no bootnode and staticnode are configured, logStat will not execute.

The code may not be written very well, looking forward to improvement.

## Reproduce

```
geth --datadir data --bootnodes "" --netrestrict "10.0.0.0/8"
```

`netrestrict` can be any fake CIDR masks.