### PR TITLE
rpc: 1st param of a Pub/Sub function should not be a pointer of context.Context

### DIFF
--- a/rpc/service.go
+++ b/rpc/service.go
@@ -214,14 +214,6 @@ func (c *callback) call(ctx context.Context, method string, args []reflect.Value
 	return results[0].Interface(), nil
 }
 
-// Is t context.Context or *context.Context?
-func isContextType(t reflect.Type) bool {
-	for t.Kind() == reflect.Ptr {
-		t = t.Elem()
-	}
-	return t == contextType
-}
-
 // Does t satisfy the error interface?
 func isErrorType(t reflect.Type) bool {
 	for t.Kind() == reflect.Ptr {
@@ -245,7 +237,7 @@ func isPubSub(methodType reflect.Type) bool {
 	if methodType.NumIn() < 2 || methodType.NumOut() != 2 {
 		return false
 	}
-	return isContextType(methodType.In(1)) &&
+	return methodType.In(1) == contextType &&
 		isSubscriptionType(methodType.Out(0)) &&
 		isErrorType(methodType.Out(1))
 }


### PR DESCRIPTION
the first argument of a Pub/Sub function should not be a pointer to context.Context, otherwise it will be registered as a subscription and its corresponding callback.hasCtx==false. This results in the parameter not having the correct value when called.