### PR TITLE
tests/fuzzers/bn256: add PairingCheck fuzzer

### DIFF
--- a/tests/fuzzers/bn256/bn256_fuzz.go
+++ b/tests/fuzzers/bn256/bn256_fuzz.go
@@ -151,12 +151,12 @@ func FuzzPair(data []byte) int {
 	}
 
 	// Pair the two points and ensure they result in the same output
-	clPair := cloudflare.Pair(pc, tc).Marshal() // e_cloudflare(P, Q)
+	clPair := cloudflare.Pair(pc, tc).Marshal()
 	gPair := google.Pair(pg, tg).Marshal()
 	if !bytes.Equal(clPair, gPair) {
 		panic("pairing mismatch: cloudflare/google")
 	}
-	cPair, err := bn254.Pair([]bn254.G1Affine{*ps}, []bn254.G2Affine{*ts}) // e_gnark(-P, Q)
+	cPair, err := bn254.Pair([]bn254.G1Affine{*ps}, []bn254.G2Affine{*ts})
 	if err != nil {
 		panic(fmt.Sprintf("gnark/bn254 encountered error: %v", err))
 	}

--- a/tests/fuzzers/bn256/bn256_fuzz.go
+++ b/tests/fuzzers/bn256/bn256_fuzz.go
@@ -151,17 +151,34 @@ func FuzzPair(data []byte) int {
 	}
 
 	// Pair the two points and ensure they result in the same output
-	clPair := cloudflare.Pair(pc, tc).Marshal()
+	clPair := cloudflare.Pair(pc, tc).Marshal() // e_cloudflare(P, Q)
 	gPair := google.Pair(pg, tg).Marshal()
 	if !bytes.Equal(clPair, gPair) {
 		panic("pairing mismatch: cloudflare/google")
 	}
-
-	cPair, err := bn254.Pair([]bn254.G1Affine{*ps}, []bn254.G2Affine{*ts})
+	cPair, err := bn254.Pair([]bn254.G1Affine{*ps}, []bn254.G2Affine{*ts}) // e_gnark(-P, Q)
 	if err != nil {
 		panic(fmt.Sprintf("gnark/bn254 encountered error: %v", err))
 	}
-	if !bytes.Equal(clPair, cPair.Marshal()) {
+
+	// gnark uses a different pairing algorithm which might produce
+	// different but also correct outputs, we need to scale the output by s
+
+	u, _ := new(big.Int).SetString("0x44e992b44a6909f1", 0)
+	u_exp2 := new(big.Int).Exp(u, big.NewInt(2), nil)   // u^2
+	u_6_exp2 := new(big.Int).Mul(big.NewInt(6), u_exp2) // 6*u^2
+	u_3 := new(big.Int).Mul(big.NewInt(3), u)           // 3*u
+	inner := u_6_exp2.Add(u_6_exp2, u_3)                // 6*u^2 + 3*u
+	inner.Add(inner, big.NewInt(1))                     // 6*u^2 + 3*u + 1
+	u_2 := new(big.Int).Mul(big.NewInt(2), u)           // 2*u
+	s := u_2.Mul(u_2, inner)                            // 2*u(6*u^2 + 3*u + 1)
+
+	gRes := new(bn254.GT)
+	if err := gRes.SetBytes(clPair); err != nil {
+		panic(err)
+	}
+	gRes = gRes.Exp(*gRes, s)
+	if !bytes.Equal(cPair.Marshal(), gRes.Marshal()) {
 		panic("pairing mismatch: cloudflare/gnark")
 	}
 


### PR DESCRIPTION
This PR removes Gnark from the Pair fuzzer. Because gnark uses a different pairing algorithm, it might produce a different result than the other implementations. However this is not an issue, since the bilinearity of a pairing means both results are correct. 
In order to preserve some fuzzing of the gnark pairing, I added a fuzzer that fuzzes the pairingCheck function, which does a pairing and verifies that the result is not equal to one. This is the function we use in ethereum, the pairing algorithm is not under consensus, only the pairing check algorithm.