### PR TITLE
rpc: websocket should respect the "HTTP_PROXY" by default

### DIFF
--- a/rpc/websocket.go
+++ b/rpc/websocket.go
@@ -224,6 +224,7 @@ func newClientTransportWS(endpoint string, cfg *clientConfig) (reconnectFunc, er
 			ReadBufferSize:  wsReadBuffer,
 			WriteBufferSize: wsWriteBuffer,
 			WriteBufferPool: wsBufferPool,
+			Proxy:           http.ProxyFromEnvironment,
 		}
 	}
 


### PR DESCRIPTION
rpc: the default dialer for websocket should respect the proxy environment variables like "HTTP_PROXY"

By default `gorilla/websocket` did respect the `http_proxy` setting, but the `newClientTransportWS` function explicitly provide a `websocket.Dialer` without a Proxy which overwrites the default one.

# Related code:
- https://github.com/gorilla/websocket/blob/76ecc29eff79f0cedf70c530605e486fc32131d1/client.go#L140-L144
- https://github.com/ethereum/go-ethereum/blob/9ca84e6b0b8302a0834534f262d4d2dd232640c5/rpc/websocket.go#L221-L228