### PR TITLE
eth,rpc: make RPCBlock,RPCTransaction,RPCReceipt as public struct

### DIFF
--- a/eth/api.go
+++ b/eth/api.go
@@ -19,6 +19,7 @@ package eth
 import (
 	"compress/gzip"
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -306,7 +307,6 @@ type BadBlockArgs struct {
 // and returns them as a JSON list of block hashes.
 func (api *DebugAPI) GetBadBlocks(ctx context.Context) ([]*BadBlockArgs, error) {
 	var (
-		err     error
 		blocks  = rawdb.ReadAllBadBlocks(api.eth.chainDb)
 		results = make([]*BadBlockArgs, 0, len(blocks))
 	)
@@ -320,8 +320,11 @@ func (api *DebugAPI) GetBadBlocks(ctx context.Context) ([]*BadBlockArgs, error) 
 		} else {
 			blockRlp = fmt.Sprintf("%#x", rlpBytes)
 		}
-		if blockJSON, err = ethapi.RPCMarshalBlock(block, true, true, api.eth.APIBackend.ChainConfig()); err != nil {
+		if rpcBlock, err := ethapi.RPCMarshalBlock(block, true, true, api.eth.APIBackend.ChainConfig()); err != nil {
 			blockJSON = map[string]interface{}{"error": err.Error()}
+		} else {
+			out, _ := json.Marshal(rpcBlock)
+			json.Unmarshal(out, &blockJSON)
 		}
 		results = append(results, &BadBlockArgs{
 			Hash:  block.Hash(),

--- a/eth/api.go
+++ b/eth/api.go
@@ -34,7 +34,6 @@ import (
 	"github.com/ethereum/go-ethereum/core/rawdb"
 	"github.com/ethereum/go-ethereum/core/state"
 	"github.com/ethereum/go-ethereum/core/types"
-	"github.com/ethereum/go-ethereum/internal/ethapi"
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/rlp"
 	"github.com/ethereum/go-ethereum/rpc"
@@ -320,7 +319,7 @@ func (api *DebugAPI) GetBadBlocks(ctx context.Context) ([]*BadBlockArgs, error) 
 		} else {
 			blockRlp = fmt.Sprintf("%#x", rlpBytes)
 		}
-		if rpcBlock, err := ethapi.RPCMarshalBlock(block, true, true, api.eth.APIBackend.ChainConfig()); err != nil {
+		if rpcBlock, err := rpc.RPCMarshalBlock(block, true, true, api.eth.APIBackend.ChainConfig()); err != nil {
 			blockJSON = map[string]interface{}{"error": err.Error()}
 		} else {
 			out, _ := json.Marshal(rpcBlock)

--- a/eth/filters/api.go
+++ b/eth/filters/api.go
@@ -29,7 +29,6 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/core/types"
-	"github.com/ethereum/go-ethereum/internal/ethapi"
 	"github.com/ethereum/go-ethereum/rpc"
 )
 
@@ -159,7 +158,7 @@ func (api *FilterAPI) NewPendingTransactions(ctx context.Context, fullTx *bool) 
 				latest := api.sys.backend.CurrentHeader()
 				for _, tx := range txs {
 					if fullTx != nil && *fullTx {
-						rpcTx := ethapi.NewRPCPendingTransaction(tx, latest, chainConfig)
+						rpcTx := rpc.NewRPCPendingTransaction(tx, latest, chainConfig)
 						notifier.Notify(rpcSub.ID, rpcTx)
 					} else {
 						notifier.Notify(rpcSub.ID, tx.Hash())
@@ -431,9 +430,9 @@ func (api *FilterAPI) GetFilterChanges(id rpc.ID) (interface{}, error) {
 			return returnHashes(hashes), nil
 		case PendingTransactionsSubscription:
 			if f.fullTx {
-				txs := make([]*ethapi.RPCTransaction, 0, len(f.txs))
+				txs := make([]*rpc.RPCTransaction, 0, len(f.txs))
 				for _, tx := range f.txs {
-					txs = append(txs, ethapi.NewRPCPendingTransaction(tx, latest, chainConfig))
+					txs = append(txs, rpc.NewRPCPendingTransaction(tx, latest, chainConfig))
 				}
 				f.txs = nil
 				return txs, nil

--- a/eth/filters/filter_system_test.go
+++ b/eth/filters/filter_system_test.go
@@ -37,7 +37,6 @@ import (
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/ethdb"
 	"github.com/ethereum/go-ethereum/event"
-	"github.com/ethereum/go-ethereum/internal/ethapi"
 	"github.com/ethereum/go-ethereum/params"
 	"github.com/ethereum/go-ethereum/rpc"
 )
@@ -316,7 +315,7 @@ func TestPendingTxFilterFullTx(t *testing.T) {
 			types.NewTransaction(4, common.HexToAddress("0xb794f5ea0ba39494ce83a213fffba74279579268"), new(big.Int), 0, new(big.Int), nil),
 		}
 
-		txs []*ethapi.RPCTransaction
+		txs []*rpc.RPCTransaction
 	)
 
 	fullTx := true
@@ -332,7 +331,7 @@ func TestPendingTxFilterFullTx(t *testing.T) {
 			t.Fatalf("Unable to retrieve logs: %v", err)
 		}
 
-		tx := results.([]*ethapi.RPCTransaction)
+		tx := results.([]*rpc.RPCTransaction)
 		txs = append(txs, tx...)
 		if len(txs) >= len(transactions) {
 			break

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -1222,6 +1222,29 @@ func (s *BlockChainAPI) EstimateGas(ctx context.Context, args TransactionArgs, b
 	return DoEstimateGas(ctx, s.b, args, bNrOrHash, s.b.RPCGasCap())
 }
 
+// RPCBlock represents a block with header that will serialize to the RPC representation of a block
+type RPCBlock struct {
+	Hash            common.Hash      `json:"hash"`
+	ParentHash      common.Hash      `json:"parentHash"`
+	UncleHash       common.Hash      `json:"sha3Uncles"`
+	Coinbase        common.Address   `json:"miner"`
+	Root            common.Hash      `json:"stateRoot"`
+	TxHash          common.Hash      `json:"transactionsRoot"`
+	ReceiptHash     common.Hash      `json:"receiptsRoot"`
+	Bloom           types.Bloom      `json:"logsBloom"`
+	Difficulty      *big.Int         `json:"difficulty"`
+	Number          *hexutil.Big     `json:"number"`
+	GasLimit        uint64           `json:"gasLimit"`
+	GasUsed         uint64           `json:"gasUsed"`
+	Time            uint64           `json:"timestamp"`
+	Extra           []byte           `json:"extraData"`
+	MixDigest       common.Hash      `json:"mixHash"`
+	Nonce           types.BlockNonce `json:"nonce"`
+	BaseFee         *big.Int         `json:"baseFeePerGas,omitempty"`
+	WithdrawalsHash *common.Hash     `json:"withdrawalsRoot,omitempty"`
+	Size            uint64           `json:"size,omitempty"`
+}
+
 // RPCMarshalHeader converts the given header to the RPC output .
 func RPCMarshalHeader(head *types.Header) map[string]interface{} {
 	result := map[string]interface{}{

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -19,6 +19,7 @@ package ethapi
 import (
 	"context"
 	"encoding/hex"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"math/big"
@@ -732,15 +733,15 @@ func decodeHash(s string) (common.Hash, error) {
 // GetHeaderByNumber returns the requested canonical block header.
 // * When blockNr is -1 the chain head is returned.
 // * When blockNr is -2 the pending chain head is returned.
-func (s *BlockChainAPI) GetHeaderByNumber(ctx context.Context, number rpc.BlockNumber) (map[string]interface{}, error) {
+func (s *BlockChainAPI) GetHeaderByNumber(ctx context.Context, number rpc.BlockNumber) (*RPCBlock, error) {
 	header, err := s.b.HeaderByNumber(ctx, number)
 	if header != nil && err == nil {
 		response := s.rpcMarshalHeader(ctx, header)
 		if number == rpc.PendingBlockNumber {
 			// Pending header need to nil out a few fields
-			for _, field := range []string{"hash", "nonce", "miner"} {
-				response[field] = nil
-			}
+			response.Hash = nil
+			response.Nonce = nil
+			response.Coinbase = nil
 		}
 		return response, err
 	}
@@ -748,7 +749,7 @@ func (s *BlockChainAPI) GetHeaderByNumber(ctx context.Context, number rpc.BlockN
 }
 
 // GetHeaderByHash returns the requested header by hash.
-func (s *BlockChainAPI) GetHeaderByHash(ctx context.Context, hash common.Hash) map[string]interface{} {
+func (s *BlockChainAPI) GetHeaderByHash(ctx context.Context, hash common.Hash) *RPCBlock {
 	header, _ := s.b.HeaderByHash(ctx, hash)
 	if header != nil {
 		return s.rpcMarshalHeader(ctx, header)
@@ -761,15 +762,15 @@ func (s *BlockChainAPI) GetHeaderByHash(ctx context.Context, hash common.Hash) m
 //   - When blockNr is -2 the pending chain head is returned.
 //   - When fullTx is true all transactions in the block are returned, otherwise
 //     only the transaction hash is returned.
-func (s *BlockChainAPI) GetBlockByNumber(ctx context.Context, number rpc.BlockNumber, fullTx bool) (map[string]interface{}, error) {
+func (s *BlockChainAPI) GetBlockByNumber(ctx context.Context, number rpc.BlockNumber, fullTx bool) (*RPCBlock, error) {
 	block, err := s.b.BlockByNumber(ctx, number)
 	if block != nil && err == nil {
 		response, err := s.rpcMarshalBlock(ctx, block, true, fullTx)
 		if err == nil && number == rpc.PendingBlockNumber {
 			// Pending blocks need to nil out a few fields
-			for _, field := range []string{"hash", "nonce", "miner"} {
-				response[field] = nil
-			}
+			response.Hash = nil
+			response.Nonce = nil
+			response.Coinbase = nil
 		}
 		return response, err
 	}
@@ -778,7 +779,7 @@ func (s *BlockChainAPI) GetBlockByNumber(ctx context.Context, number rpc.BlockNu
 
 // GetBlockByHash returns the requested block. When fullTx is true all transactions in the block are returned in full
 // detail, otherwise only the transaction hash is returned.
-func (s *BlockChainAPI) GetBlockByHash(ctx context.Context, hash common.Hash, fullTx bool) (map[string]interface{}, error) {
+func (s *BlockChainAPI) GetBlockByHash(ctx context.Context, hash common.Hash, fullTx bool) (*RPCBlock, error) {
 	block, err := s.b.BlockByHash(ctx, hash)
 	if block != nil {
 		return s.rpcMarshalBlock(ctx, block, true, fullTx)
@@ -787,7 +788,7 @@ func (s *BlockChainAPI) GetBlockByHash(ctx context.Context, hash common.Hash, fu
 }
 
 // GetUncleByBlockNumberAndIndex returns the uncle block for the given block hash and index.
-func (s *BlockChainAPI) GetUncleByBlockNumberAndIndex(ctx context.Context, blockNr rpc.BlockNumber, index hexutil.Uint) (map[string]interface{}, error) {
+func (s *BlockChainAPI) GetUncleByBlockNumberAndIndex(ctx context.Context, blockNr rpc.BlockNumber, index hexutil.Uint) (*RPCBlock, error) {
 	block, err := s.b.BlockByNumber(ctx, blockNr)
 	if block != nil {
 		uncles := block.Uncles()
@@ -802,7 +803,7 @@ func (s *BlockChainAPI) GetUncleByBlockNumberAndIndex(ctx context.Context, block
 }
 
 // GetUncleByBlockHashAndIndex returns the uncle block for the given block hash and index.
-func (s *BlockChainAPI) GetUncleByBlockHashAndIndex(ctx context.Context, blockHash common.Hash, index hexutil.Uint) (map[string]interface{}, error) {
+func (s *BlockChainAPI) GetUncleByBlockHashAndIndex(ctx context.Context, blockHash common.Hash, index hexutil.Uint) (*RPCBlock, error) {
 	block, err := s.b.BlockByHash(ctx, blockHash)
 	if block != nil {
 		uncles := block.Uncles()
@@ -1224,115 +1225,120 @@ func (s *BlockChainAPI) EstimateGas(ctx context.Context, args TransactionArgs, b
 
 // RPCBlock represents a block with header that will serialize to the RPC representation of a block
 type RPCBlock struct {
-	Hash            common.Hash      `json:"hash"`
-	ParentHash      common.Hash      `json:"parentHash"`
-	UncleHash       common.Hash      `json:"sha3Uncles"`
-	Coinbase        common.Address   `json:"miner"`
-	Root            common.Hash      `json:"stateRoot"`
-	TxHash          common.Hash      `json:"transactionsRoot"`
-	ReceiptHash     common.Hash      `json:"receiptsRoot"`
-	Bloom           types.Bloom      `json:"logsBloom"`
-	Difficulty      *big.Int         `json:"difficulty"`
-	Number          *hexutil.Big     `json:"number"`
-	GasLimit        uint64           `json:"gasLimit"`
-	GasUsed         uint64           `json:"gasUsed"`
-	Time            uint64           `json:"timestamp"`
-	Extra           []byte           `json:"extraData"`
-	MixDigest       common.Hash      `json:"mixHash"`
-	Nonce           types.BlockNonce `json:"nonce"`
-	BaseFee         *big.Int         `json:"baseFeePerGas,omitempty"`
-	WithdrawalsHash *common.Hash     `json:"withdrawalsRoot,omitempty"`
-	Size            uint64           `json:"size,omitempty"`
+	Number          *hexutil.Big      `json:"number,omitempty"`
+	Hash            *common.Hash      `json:"hash,omitempty"`
+	ParentHash      common.Hash       `json:"parentHash"`
+	Nonce           *types.BlockNonce `json:"nonce,omitempty"`
+	MixDigest       common.Hash       `json:"mixHash"`
+	UncleHash       common.Hash       `json:"sha3Uncles"`
+	Bloom           types.Bloom       `json:"logsBloom"`
+	Root            common.Hash       `json:"stateRoot"`
+	Coinbase        *common.Address   `json:"miner,omitempty"`
+	Difficulty      *hexutil.Big      `json:"difficulty"`
+	Extra           hexutil.Bytes     `json:"extraData"`
+	Size            hexutil.Uint64    `json:"size,omitempty"`
+	GasLimit        hexutil.Uint64    `json:"gasLimit"`
+	GasUsed         hexutil.Uint64    `json:"gasUsed"`
+	Time            hexutil.Uint64    `json:"timestamp"`
+	TxHash          common.Hash       `json:"transactionsRoot"`
+	ReceiptHash     common.Hash       `json:"receiptsRoot"`
+	BaseFee         *hexutil.Big      `json:"baseFeePerGas,omitempty"`
+	WithdrawalsHash *common.Hash      `json:"withdrawalsRoot,omitempty"`
+	Transactions    []json.RawMessage `json:"transactions,omitempty"`
+	TotalDifficulty *hexutil.Big      `json:"totalDifficulty,omitempty"`
+	Uncles          []common.Hash     `json:"uncles,omitempty"`
+	Withdrawals     types.Withdrawals `json:"withdrawls,omitempty"`
 }
 
 // RPCMarshalHeader converts the given header to the RPC output .
-func RPCMarshalHeader(head *types.Header) map[string]interface{} {
-	result := map[string]interface{}{
-		"number":           (*hexutil.Big)(head.Number),
-		"hash":             head.Hash(),
-		"parentHash":       head.ParentHash,
-		"nonce":            head.Nonce,
-		"mixHash":          head.MixDigest,
-		"sha3Uncles":       head.UncleHash,
-		"logsBloom":        head.Bloom,
-		"stateRoot":        head.Root,
-		"miner":            head.Coinbase,
-		"difficulty":       (*hexutil.Big)(head.Difficulty),
-		"extraData":        hexutil.Bytes(head.Extra),
-		"size":             hexutil.Uint64(head.Size()),
-		"gasLimit":         hexutil.Uint64(head.GasLimit),
-		"gasUsed":          hexutil.Uint64(head.GasUsed),
-		"timestamp":        hexutil.Uint64(head.Time),
-		"transactionsRoot": head.TxHash,
-		"receiptsRoot":     head.ReceiptHash,
+func RPCMarshalHeader(head *types.Header) *RPCBlock {
+	headHash := head.Hash()
+	block := &RPCBlock{
+		Number:      (*hexutil.Big)(head.Number),
+		Hash:        &headHash,
+		ParentHash:  head.ParentHash,
+		Nonce:       &head.Nonce,
+		MixDigest:   head.MixDigest,
+		UncleHash:   head.UncleHash,
+		Bloom:       head.Bloom,
+		Root:        head.Root,
+		Coinbase:    &head.Coinbase,
+		Difficulty:  (*hexutil.Big)(head.Difficulty),
+		Extra:       hexutil.Bytes(head.Extra),
+		Size:        hexutil.Uint64(head.Size()),
+		GasLimit:    hexutil.Uint64(head.GasLimit),
+		GasUsed:     hexutil.Uint64(head.GasUsed),
+		Time:        hexutil.Uint64(head.Time),
+		TxHash:      head.TxHash,
+		ReceiptHash: head.ReceiptHash,
 	}
 
 	if head.BaseFee != nil {
-		result["baseFeePerGas"] = (*hexutil.Big)(head.BaseFee)
+		block.BaseFee = (*hexutil.Big)(head.BaseFee)
 	}
 
 	if head.WithdrawalsHash != nil {
-		result["withdrawalsRoot"] = head.WithdrawalsHash
+		block.WithdrawalsHash = head.WithdrawalsHash
 	}
 
-	return result
+	return block
 }
 
 // RPCMarshalBlock converts the given block to the RPC output which depends on fullTx. If inclTx is true transactions are
 // returned. When fullTx is true the returned block contains full transaction details, otherwise it will only contain
 // transaction hashes.
-func RPCMarshalBlock(block *types.Block, inclTx bool, fullTx bool, config *params.ChainConfig) (map[string]interface{}, error) {
+func RPCMarshalBlock(block *types.Block, inclTx bool, fullTx bool, config *params.ChainConfig) (*RPCBlock, error) {
 	fields := RPCMarshalHeader(block.Header())
-	fields["size"] = hexutil.Uint64(block.Size())
+	fields.Size = hexutil.Uint64(block.Size())
 
 	if inclTx {
-		formatTx := func(tx *types.Transaction) (interface{}, error) {
-			return tx.Hash(), nil
+		formatTx := func(tx *types.Transaction) (json.RawMessage, error) {
+			return tx.Hash().Bytes(), nil
 		}
 		if fullTx {
-			formatTx = func(tx *types.Transaction) (interface{}, error) {
-				return newRPCTransactionFromBlockHash(block, tx.Hash(), config), nil
+			formatTx = func(tx *types.Transaction) (json.RawMessage, error) {
+				return json.Marshal(newRPCTransactionFromBlockHash(block, tx.Hash(), config))
 			}
 		}
 		txs := block.Transactions()
-		transactions := make([]interface{}, len(txs))
+		transactions := make([]json.RawMessage, len(txs))
 		var err error
 		for i, tx := range txs {
 			if transactions[i], err = formatTx(tx); err != nil {
 				return nil, err
 			}
 		}
-		fields["transactions"] = transactions
+		fields.Transactions = transactions
 	}
 	uncles := block.Uncles()
 	uncleHashes := make([]common.Hash, len(uncles))
 	for i, uncle := range uncles {
 		uncleHashes[i] = uncle.Hash()
 	}
-	fields["uncles"] = uncleHashes
+	fields.Uncles = uncleHashes
 	if block.Header().WithdrawalsHash != nil {
-		fields["withdrawals"] = block.Withdrawals()
+		fields.Withdrawals = block.Withdrawals()
 	}
 	return fields, nil
 }
 
 // rpcMarshalHeader uses the generalized output filler, then adds the total difficulty field, which requires
 // a `BlockchainAPI`.
-func (s *BlockChainAPI) rpcMarshalHeader(ctx context.Context, header *types.Header) map[string]interface{} {
+func (s *BlockChainAPI) rpcMarshalHeader(ctx context.Context, header *types.Header) *RPCBlock {
 	fields := RPCMarshalHeader(header)
-	fields["totalDifficulty"] = (*hexutil.Big)(s.b.GetTd(ctx, header.Hash()))
+	fields.TotalDifficulty = (*hexutil.Big)(s.b.GetTd(ctx, header.Hash()))
 	return fields
 }
 
 // rpcMarshalBlock uses the generalized output filler, then adds the total difficulty field, which requires
 // a `BlockchainAPI`.
-func (s *BlockChainAPI) rpcMarshalBlock(ctx context.Context, b *types.Block, inclTx bool, fullTx bool) (map[string]interface{}, error) {
+func (s *BlockChainAPI) rpcMarshalBlock(ctx context.Context, b *types.Block, inclTx bool, fullTx bool) (*RPCBlock, error) {
 	fields, err := RPCMarshalBlock(b, inclTx, fullTx, s.b.ChainConfig())
 	if err != nil {
 		return nil, err
 	}
 	if inclTx {
-		fields["totalDifficulty"] = (*hexutil.Big)(s.b.GetTd(ctx, b.Hash()))
+		fields.TotalDifficulty = (*hexutil.Big)(s.b.GetTd(ctx, b.Hash()))
 	}
 	return fields, err
 }

--- a/internal/ethapi/api_test.go
+++ b/internal/ethapi/api_test.go
@@ -71,7 +71,7 @@ func TestTransaction_RoundTripRpcJSON(t *testing.T) {
 		}
 
 		//  rpcTransaction
-		rpcTx := newRPCTransaction(tx, common.Hash{}, 0, 0, 0, nil, config)
+		rpcTx := rpc.NewRPCTransaction(tx, common.Hash{}, 0, 0, 0, nil, config)
 		if data, err := json.Marshal(rpcTx); err != nil {
 			t.Fatalf("test %d: marshalling failed; %v", i, err)
 		} else if err = tx2.UnmarshalJSON(data); err != nil {
@@ -549,7 +549,7 @@ func TestCall(t *testing.T) {
 			overrides: StateOverride{
 				randomAccounts[2].addr: OverrideAccount{
 					Code:      hex2Bytes("6080604052348015600f57600080fd5b506004361060285760003560e01c80638381f58a14602d575b600080fd5b60336049565b6040518082815260200191505060405180910390f35b6000548156fea2646970667358221220eab35ffa6ab2adfe380772a48b8ba78e82a1b820a18fcb6f59aa4efb20a5f60064736f6c63430007040033"),
-					StateDiff: &map[common.Hash]common.Hash{common.Hash{}: common.BigToHash(big.NewInt(123))},
+					StateDiff: &map[common.Hash]common.Hash{{}: common.BigToHash(big.NewInt(123))},
 				},
 			},
 			want: "0x000000000000000000000000000000000000000000000000000000000000007b",

--- a/rpc/types.go
+++ b/rpc/types.go
@@ -248,7 +248,7 @@ func BlockNumberOrHashWithHash(hash common.Hash, canonical bool) BlockNumberOrHa
 	}
 }
 
-// RPCBlock represents a block with header that will serialize to the RPC representation of a block
+// RPCBlock represents a serializable block of RPC response
 type RPCBlock struct {
 	Number          *hexutil.Big      `json:"number,omitempty"`
 	Hash            *common.Hash      `json:"hash,omitempty"`
@@ -357,7 +357,7 @@ func newRPCTransactionFromBlockHash(b *types.Block, hash common.Hash, config *pa
 	return nil
 }
 
-// RPCTransaction represents a transaction that will serialize to the RPC representation of a transaction
+// RPCTransaction represents a serializable transaction of RPC response
 type RPCTransaction struct {
 	BlockHash        *common.Hash      `json:"blockHash"`
 	BlockNumber      *hexutil.Big      `json:"blockNumber"`
@@ -465,4 +465,23 @@ func NewRPCRawTransactionFromBlockIndex(b *types.Block, index uint64) hexutil.By
 	}
 	blob, _ := txs[index].MarshalBinary()
 	return blob
+}
+
+// RPCReceipt represents a serializable transaction receipt of RPC response
+type RPCReceipt struct {
+	BlockHash         common.Hash     `json:"blockHash"`
+	BlockNumber       hexutil.Uint64  `json:"blockNumber"`
+	TxHash            common.Hash     `json:"transactionHash"`
+	TxIndex           hexutil.Uint64  `json:"transactionIndex"`
+	From              common.Address  `json:"from"`
+	To                *common.Address `json:"to"`
+	GasUsed           hexutil.Uint64  `json:"gasUsed"`
+	CumulativeGasUsed hexutil.Uint64  `json:"cumulativeGasUsed"`
+	ContractAddress   *common.Address `json:"contractAddress"`
+	Logs              []*types.Log    `json:"logs"`
+	LogsBloom         types.Bloom     `json:"logsBloom"`
+	Type              hexutil.Uint    `json:"type"`
+	EffectiveGasPrice *hexutil.Big    `json:"effectiveGasPrice"`
+	Root              hexutil.Bytes   `json:"root,omitempty"`
+	Status            hexutil.Uint    `json:"status,omitempty"`
 }


### PR DESCRIPTION
This PR moves the RPC Response-related structures, which were originally in the [internal/ethapi package](./internal/ethapi), to the [rpc package](./rpc). 
This allows third-party clients to access more raw data based on these structures. For example, `ethclient.BlockByNumber` can only return the `types.Block` structure:

https://github.com/ethereum/go-ethereum/blob/9e8575ce8896acd543123ff83df01fe80d15dcc4/ethclient/ethclient.go#L84-L86

But on RPC server's side, we do return more data (such as `totalDifficulty`) in `rpcMarshalBlock`.

https://github.com/ethereum/go-ethereum/blob/9e8575ce8896acd543123ff83df01fe80d15dcc4/internal/ethapi/api.go#L1234-L1243
