### PR TITLE
core/state: Remove unused returned error

### DIFF
--- a/core/state/pruner/bloom.go
+++ b/core/state/pruner/bloom.go
@@ -127,6 +127,6 @@ func (bloom *stateBloom) Delete(key []byte) error { panic("not supported") }
 // reports whether the key is contained.
 // - If it says yes, the key may be contained
 // - If it says no, the key is definitely not contained.
-func (bloom *stateBloom) Contain(key []byte) (bool, error) {
-	return bloom.bloom.Contains(stateBloomHasher(key)), nil
+func (bloom *stateBloom) Contain(key []byte) bool {
+	return bloom.bloom.Contains(stateBloomHasher(key))
 }

--- a/core/state/pruner/pruner.go
+++ b/core/state/pruner/pruner.go
@@ -146,9 +146,7 @@ func prune(snaptree *snapshot.Tree, root common.Hash, maindb ethdb.Database, sta
 			if _, exist := middleStateRoots[common.BytesToHash(checkKey)]; exist {
 				log.Debug("Forcibly delete the middle state roots", "hash", common.BytesToHash(checkKey))
 			} else {
-				if ok, err := stateBloom.Contain(checkKey); err != nil {
-					return err
-				} else if ok {
+				if stateBloom.Contain(checkKey) {
 					continue
 				}
 			}


### PR DESCRIPTION
BTW, Do we need to create a 'summary PR' to modify all similar definitions of nil error? If so, please modify the title of this PR. 