### PR TITLE
accounts/abi: add ErrorById

### DIFF
--- a/accounts/abi/abi.go
+++ b/accounts/abi/abi.go
@@ -222,15 +222,15 @@ func (abi *ABI) EventByID(topic common.Hash) (*Event, error) {
 	return nil, fmt.Errorf("no event with id: %#x", topic.Hex())
 }
 
-// ErrorById looks up an error by the 4-byte id,
+// ErrorByID looks up an error by the 4-byte id,
 // returns nil if none found.
-func (abi *ABI) ErrorById(sigdata [4]byte) (*Error, error) {
+func (abi *ABI) ErrorByID(sigdata [4]byte) (*Error, error) {
 	for _, errABI := range abi.Errors {
-		if errABI.ID == sigdata {
+		if bytes.Equal(errABI.ID[:4], sigdata[:]) {
 			return &errABI, nil
 		}
 	}
-	return nil, fmt.Errorf("no error with id: %#x", sigdata[:4])
+	return nil, fmt.Errorf("no error with id: %#x", sigdata[:])
 }
 
 // HasFallback returns an indicator whether a fallback function is included.

--- a/accounts/abi/abi.go
+++ b/accounts/abi/abi.go
@@ -222,6 +222,20 @@ func (abi *ABI) EventByID(topic common.Hash) (*Event, error) {
 	return nil, fmt.Errorf("no event with id: %#x", topic.Hex())
 }
 
+// ErrorById looks up an error by the 4-byte id,
+// returns nil if none found.
+func (abi *ABI) ErrorById(sigdata []byte) (*Error, error) {
+	if len(sigdata) < 4 {
+		return nil, fmt.Errorf("data too short (%d bytes) for abi error lookup", len(sigdata))
+	}
+	for _, errABI := range abi.Errors {
+		if bytes.Equal(errABI.ID, sigdata[:4]) {
+			return &errABI, nil
+		}
+	}
+	return nil, fmt.Errorf("no error with id: %#x", sigdata[:4])
+}
+
 // HasFallback returns an indicator whether a fallback function is included.
 func (abi *ABI) HasFallback() bool {
 	return abi.Fallback.Type == Fallback

--- a/accounts/abi/abi.go
+++ b/accounts/abi/abi.go
@@ -224,12 +224,9 @@ func (abi *ABI) EventByID(topic common.Hash) (*Event, error) {
 
 // ErrorById looks up an error by the 4-byte id,
 // returns nil if none found.
-func (abi *ABI) ErrorById(sigdata []byte) (*Error, error) {
-	if len(sigdata) < 4 {
-		return nil, fmt.Errorf("data too short (%d bytes) for abi error lookup", len(sigdata))
-	}
+func (abi *ABI) ErrorById(sigdata [4]byte) (*Error, error) {
 	for _, errABI := range abi.Errors {
-		if bytes.Equal(errABI.ID, sigdata[:4]) {
+		if errABI.ID == sigdata {
 			return &errABI, nil
 		}
 	}

--- a/accounts/abi/abi_test.go
+++ b/accounts/abi/abi_test.go
@@ -1057,7 +1057,7 @@ func TestABI_EventById(t *testing.T) {
 	}
 }
 
-func TestABI_ErrorById(t *testing.T) {
+func TestABI_ErrorByID(t *testing.T) {
 	abi, err := JSON(strings.NewReader(`[
 		{"inputs":[{"internalType":"uint256","name":"x","type":"uint256"}],"name":"MyError1","type":"error"},
 		{"inputs":[{"components":[{"internalType":"uint256","name":"a","type":"uint256"},{"internalType":"string","name":"b","type":"string"},{"internalType":"address","name":"c","type":"address"}],"internalType":"struct MyError.MyStruct","name":"x","type":"tuple"},{"internalType":"address","name":"y","type":"address"},{"components":[{"internalType":"uint256","name":"a","type":"uint256"},{"internalType":"string","name":"b","type":"string"},{"internalType":"address","name":"c","type":"address"}],"internalType":"struct MyError.MyStruct","name":"z","type":"tuple"}],"name":"MyError2","type":"error"},
@@ -1068,17 +1068,18 @@ func TestABI_ErrorById(t *testing.T) {
 	}
 	for name, m := range abi.Errors {
 		a := fmt.Sprintf("%v", &m)
-		m2, err := abi.ErrorById(m.ID)
+		id := *(*[4]byte)(m.ID[:4])
+		m2, err := abi.ErrorByID(id)
 		if err != nil {
 			t.Fatalf("Failed to look up ABI error: %v", err)
 		}
 		b := fmt.Sprintf("%v", m2)
 		if a != b {
-			t.Errorf("Error %v (id %x) not 'findable' by id in ABI", name, m.ID)
+			t.Errorf("Error %v (id %x) not 'findable' by id in ABI", name, id)
 		}
 	}
 	// test unsuccessful lookups
-	if _, err = abi.ErrorById([4]byte{}); err == nil {
+	if _, err = abi.ErrorByID([4]byte{}); err == nil {
 		t.Error("Expected error: no error with this id")
 	}
 }

--- a/accounts/abi/abi_test.go
+++ b/accounts/abi/abi_test.go
@@ -1078,18 +1078,8 @@ func TestABI_ErrorById(t *testing.T) {
 		}
 	}
 	// test unsuccessful lookups
-	if _, err = abi.ErrorById(crypto.Keccak256()); err == nil {
+	if _, err = abi.ErrorById([4]byte{}); err == nil {
 		t.Error("Expected error: no error with this id")
-	}
-	// Also test empty
-	if _, err := abi.ErrorById([]byte{0x00}); err == nil {
-		t.Errorf("Expected error, too short to decode data")
-	}
-	if _, err := abi.ErrorById([]byte{}); err == nil {
-		t.Errorf("Expected error, too short to decode data")
-	}
-	if _, err := abi.ErrorById(nil); err == nil {
-		t.Errorf("Expected error, nil is short to decode data")
 	}
 }
 

--- a/accounts/abi/abi_test.go
+++ b/accounts/abi/abi_test.go
@@ -1068,7 +1068,8 @@ func TestABI_ErrorByID(t *testing.T) {
 	}
 	for name, m := range abi.Errors {
 		a := fmt.Sprintf("%v", &m)
-		id := *(*[4]byte)(m.ID[:4])
+		var id [4]byte
+		copy(id[:], m.ID[:4])
 		m2, err := abi.ErrorByID(id)
 		if err != nil {
 			t.Fatalf("Failed to look up ABI error: %v", err)

--- a/accounts/abi/error.go
+++ b/accounts/abi/error.go
@@ -22,7 +22,6 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/crypto"
 )
 
@@ -38,7 +37,7 @@ type Error struct {
 
 	// ID returns the canonical representation of the error's signature used by the
 	// abi definition to identify event names and types.
-	ID common.Hash
+	ID []byte
 }
 
 func NewError(name string, inputs Arguments) Error {
@@ -67,7 +66,7 @@ func NewError(name string, inputs Arguments) Error {
 
 	str := fmt.Sprintf("error %v(%v)", name, strings.Join(names, ", "))
 	sig := fmt.Sprintf("%v(%v)", name, strings.Join(types, ","))
-	id := common.BytesToHash(crypto.Keccak256([]byte(sig)))
+	id := crypto.Keccak256([]byte(sig))[:4]
 
 	return Error{
 		Name:   name,
@@ -78,7 +77,7 @@ func NewError(name string, inputs Arguments) Error {
 	}
 }
 
-func (e *Error) String() string {
+func (e Error) String() string {
 	return e.str
 }
 

--- a/accounts/abi/error.go
+++ b/accounts/abi/error.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/crypto"
 )
 
@@ -37,7 +38,7 @@ type Error struct {
 
 	// ID returns the canonical representation of the error's signature used by the
 	// abi definition to identify event names and types.
-	ID [4]byte
+	ID common.Hash
 }
 
 func NewError(name string, inputs Arguments) Error {
@@ -66,7 +67,7 @@ func NewError(name string, inputs Arguments) Error {
 
 	str := fmt.Sprintf("error %v(%v)", name, strings.Join(names, ", "))
 	sig := fmt.Sprintf("%v(%v)", name, strings.Join(types, ","))
-	id := *(*[4]byte)(crypto.Keccak256([]byte(sig))[:4])
+	id := common.BytesToHash(crypto.Keccak256([]byte(sig)))
 
 	return Error{
 		Name:   name,

--- a/accounts/abi/error.go
+++ b/accounts/abi/error.go
@@ -37,7 +37,7 @@ type Error struct {
 
 	// ID returns the canonical representation of the error's signature used by the
 	// abi definition to identify event names and types.
-	ID []byte
+	ID [4]byte
 }
 
 func NewError(name string, inputs Arguments) Error {
@@ -66,7 +66,7 @@ func NewError(name string, inputs Arguments) Error {
 
 	str := fmt.Sprintf("error %v(%v)", name, strings.Join(names, ", "))
 	sig := fmt.Sprintf("%v(%v)", name, strings.Join(types, ","))
-	id := crypto.Keccak256([]byte(sig))[:4]
+	id := *(*[4]byte)(crypto.Keccak256([]byte(sig))[:4])
 
 	return Error{
 		Name:   name,


### PR DESCRIPTION
### Changes
- Modify ID type from `common.Hash` to `[]byte` in Error struct
- Add ErrorById