### PR TITLE
cmd/utils: don't check free disk space in dev mode

### DIFF
--- a/cmd/utils/cmd.go
+++ b/cmd/utils/cmd.go
@@ -118,6 +118,9 @@ func StartNode(ctx *cli.Context, stack *node.Node, isConsole bool) {
 }
 
 func monitorFreeDiskSpace(sigc chan os.Signal, path string, freeDiskSpaceCritical uint64) {
+	if path == "" {
+		return
+	}
 	for {
 		freeSpace, err := getFreeDiskSpace(path)
 		if err != nil {


### PR DESCRIPTION
data dir is empty when using dev mode.

```console
$ ./build/bin/geth --dev
WARN [05-16|21:41:40.685] Failed to get free disk space            path= err="failed to call Statfs: no such file or directory"
```
