### PR TITLE
consensus, core:  set PoS transition status in db if it is configured to be activated at genesis

### DIFF
--- a/consensus/merger.go
+++ b/consensus/merger.go
@@ -97,6 +97,8 @@ func (m *Merger) FinalizePoS() {
 	log.Info("Entered PoS stage")
 }
 
+// WriteGenesisTransitionStatusToDB sets the proof-of-stake transition status in the db if PoS is configured to
+// be activated at the genesis block
 func WriteGenesisTransitionStatusToDB(db ethdb.Database, config *params.ChainConfig, genesisHash common.Hash) error {
 	if config.TerminalTotalDifficulty != nil && config.TerminalTotalDifficulty.Cmp(big.NewInt(0)) == 0 {
 		if !config.TerminalTotalDifficultyPassed {

--- a/consensus/merger.go
+++ b/consensus/merger.go
@@ -97,8 +97,8 @@ func (m *Merger) FinalizePoS() {
 	log.Info("Entered PoS stage")
 }
 
-// WriteGenesisTransitionStatusToDB sets the proof-of-stake transition status in the db if PoS is configured to
-// be activated at the genesis block
+// WriteGenesisTransitionStatusToDB sets the PoS transition status in the db if PoS is configured to
+// be activated at the genesis block.
 func WriteGenesisTransitionStatusToDB(db ethdb.Database, config *params.ChainConfig, genesisHash common.Hash) error {
 	if config.TerminalTotalDifficulty != nil && config.TerminalTotalDifficulty.Cmp(big.NewInt(0)) == 0 {
 		if !config.TerminalTotalDifficultyPassed {

--- a/core/genesis.go
+++ b/core/genesis.go
@@ -28,6 +28,7 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/common/math"
+	"github.com/ethereum/go-ethereum/consensus"
 	"github.com/ethereum/go-ethereum/core/rawdb"
 	"github.com/ethereum/go-ethereum/core/state"
 	"github.com/ethereum/go-ethereum/core/types"
@@ -493,6 +494,10 @@ func (g *Genesis) Commit(db ethdb.Database, triedb *trie.Database) (*types.Block
 	if err := g.Alloc.flush(db, triedb, block.Hash()); err != nil {
 		return nil, err
 	}
+	if err := consensus.WriteGenesisTransitionStatusToDB(db, config, block.Hash()); err != nil {
+		return nil, err
+	}
+
 	rawdb.WriteTd(db, block.Hash(), block.NumberU64(), block.Difficulty())
 	rawdb.WriteBlock(db, block)
 	rawdb.WriteReceipts(db, block.Hash(), block.NumberU64(), nil)


### PR DESCRIPTION
When PoS is configured to be active at genesis (ttd = 0), PoS should be activated.