### PR TITLE
website: add 'jsonrpc:2.0' in jsonrpc request

### DIFF
--- a/docs/developers/evm-tracing/basic-traces.md
+++ b/docs/developers/evm-tracing/basic-traces.md
@@ -54,7 +54,7 @@ debug.traceTransaction('0xfc9359e49278b7ba99f59edac0e3de49956e46e530a53c15aa7122
 The same call can also be invoked from outside the node too via HTTP RPC (e.g. using Curl). In this case, the HTTP endpoint must be enabled in Geth using the `--http` command and the `debug` API namespace must be exposed using `--http.api=debug`.
 
 ```sh
-$ curl -H "Content-Type: application/json" -d '{"id": 1, "method": "debug_traceTransaction", "params": ["0xfc9359e49278b7ba99f59edac0e3de49956e46e530a53c15aa71226b7aa92c6f"]}' localhost:8545
+$ curl -H "Content-Type: application/json" -d '{"id": 1, "jsonrpc": "2.0", "method": "debug_traceTransaction", "params": ["0xfc9359e49278b7ba99f59edac0e3de49956e46e530a53c15aa71226b7aa92c6f"]}' localhost:8545
 ```
 
 To follow along with this tutorial, transaction hashes can be found from a local Geth node (e.g. by attaching a [Javascript console](/docs/interacting-with-geth/javascript-console) and running `eth.getBlock('latest')` then passing a transaction hash from the returned block to `debug.traceTransaction()`) or from a block explorer (for [Mainnet](https://etherscan.io/) or a [testnet](https://goerli.etherscan.io/)).
@@ -84,7 +84,7 @@ The above operation was run on the (now-deprecated) Rinkeby network (with a node
 Alternatively, disabling _EVM Stack_, _EVM Memory_, _Storage_ and _Return data_ (as demonstrated in the Curl request below) results in the following, much shorter, [trace dump](https://gist.github.com/karalabe/d74a7cb33a70f2af75e7824fc772c5b4).
 
 ```sh
-$ curl -H "Content-Type: application/json" -d '{"id": 1, "method": "debug_traceTransaction", "params": ["0xfc9359e49278b7ba99f59edac0e3de49956e46e530a53c15aa71226b7aa92c6f", {"disableStack": true, "disableStorage": true}]}' localhost:8545
+$ curl -H "Content-Type: application/json" -d '{"id": 1, "jsonrpc": "2.0", "method": "debug_traceTransaction", "params": ["0xfc9359e49278b7ba99f59edac0e3de49956e46e530a53c15aa71226b7aa92c6f", {"disableStack": true, "disableStorage": true}]}' localhost:8545
 ```
 
 ### Limits of basic traces {#list-of-basic-traces}

--- a/docs/interacting-with-geth/rpc/ns-personal.md
+++ b/docs/interacting-with-geth/rpc/ns-personal.md
@@ -100,7 +100,7 @@ eth.sendTransaction(tx);
 Example call (terminal)
 
 ```sh
-curl --data '{"id":1,"jsonrpc":"2.0", "method":"eth_sendTransaction","params":[{"from": "0xE70CAD05D0D54Ae3C9Fe5442f901E0433f9bd14B", "to":"0x4FDc03d09Ffca5Bba3138149E29D85C8A9E2Ac42", "gas":"21000","gasPrice":"20000000000", "nonce":"94"}]}' -H "Content-Type: application/json" -X POST localhost:8545
+curl --data '{"id":1, "jsonrpc":"2.0", "method":"eth_sendTransaction", "params":[{"from": "0xE70CAD05D0D54Ae3C9Fe5442f901E0433f9bd14B", "to":"0x4FDc03d09Ffca5Bba3138149E29D85C8A9E2Ac42", "gas":"21000","gasPrice":"20000000000", "nonce":"94"}]}' -H "Content-Type: application/json" -X POST localhost:8545
 ```
 
 ### personal_sign

--- a/docs/interacting-with-geth/rpc/pubsub.md
+++ b/docs/interacting-with-geth/rpc/pubsub.md
@@ -11,7 +11,7 @@ Example:
 
 ```sh
 // create subscription
-{"id": 1, "method": "eth_subscribe", "params": ["newHeads"]}
+{"id": 1, "jsonrpc": "2.0", "method": "eth_subscribe", "params": ["newHeads"]}
 ```
 
 returns
@@ -27,7 +27,7 @@ to cancel the subscription:
 
 ```sh
 // cancel subscription
-{"id": 1, "method": "eth_unsubscribe", "params": ["0xcd0c3e8af590364c09d0fa6a1210faf5"]}
+{"id": 1, "jsonrpc": "2.0", "method": "eth_unsubscribe", "params": ["0xcd0c3e8af590364c09d0fa6a1210faf5"]}
 {"jsonrpc":"2.0","id":1,"result":true}
 ```
 
@@ -50,7 +50,7 @@ Subscriptions are created with a regular RPC call with `eth_subscribe` as method
 ### Example
 
 ```sh
-{"id": 1, "method": "eth_subscribe", "params": ["newHeads"]}
+{"id": 1, "jsonrpc": "2.0", "method": "eth_subscribe", "params": ["newHeads"]}
 {"id": 1, "jsonrpc": "2.0", "result": "0x9cef478923ff08bf67fde6c64013158d"}
 ```
 
@@ -65,7 +65,7 @@ Subscriptions are cancelled with a regular RPC call with `eth_unsubscribe` as me
 ### Example
 
 ```json
-{"id": 1, "method": "eth_unsubscribe", "params": ["0x9cef478923ff08bf67fde6c64013158d"]}
+{"id": 1, "jsonrpc": "2.0", "method": "eth_unsubscribe", "params": ["0x9cef478923ff08bf67fde6c64013158d"]}
 {"jsonrpc":"2.0","id":1,"result":true}
 ```
 
@@ -80,7 +80,7 @@ In case of a chain reorganization the subscription will emit the last header in 
 #### Example
 
 ```json
-{ "id": 1, "method": "eth_subscribe", "params": ["newHeads"] }
+{"id": 1, "jsonrpc": "2.0", "method": "eth_subscribe", "params": ["newHeads"]}
 ```
 
 returns
@@ -130,6 +130,7 @@ In case of a chain reorganization previous sent logs that are on the old chain w
 ```json
 {
   "id": 1,
+  "jsonrpc": "2.0",
   "method": "eth_subscribe",
   "params": [
     "logs",
@@ -162,7 +163,7 @@ none
 #### Example
 
 ```json
-{ "id": 1, "method": "eth_subscribe", "params": ["newPendingTransactions"] }
+{"id": 1, "jsonrpc": "2.0", "method": "eth_subscribe", "params": ["newPendingTransactions"]}
 ```
 
 returns
@@ -190,7 +191,7 @@ none
 #### Example
 
 ```json
-{"id": 1, "method": "eth_subscribe", "params": ["syncing"]}
+{"id": 1, "jsonrpc": "2.0", "method": "eth_subscribe", "params": ["syncing"]}
 
 {"jsonrpc":"2.0","id":2,"result":"0xe2ffeb2703bcf602d42922385829ce96"}
 {"subscription":"0xe2ffeb2703bcf602d42922385829ce96","result":{"syncing":true,"status":{"startingBlock":674427,"currentBlock":67400,"highestBlock":674432,"pulledStates":0,"knownStates":0}}}}


### PR DESCRIPTION
If `jsonrpc` is not given, JSONRPC will raise the error as below:

```bash
> {"id": 1, "method": "eth_subscribe", "params": ["newHeads"]}
< {"jsonrpc":"2.0","id":1,"error":{"code":-32600,"message":"invalid request"}}
```