### PR TITLE
eth/filters: subscribe ChainReorg events

### DIFF
--- a/accounts/abi/bind/backends/simulated.go
+++ b/accounts/abi/bind/backends/simulated.go
@@ -904,6 +904,10 @@ func (fb *filterBackend) SubscribeChainEvent(ch chan<- core.ChainEvent) event.Su
 	return fb.bc.SubscribeChainEvent(ch)
 }
 
+func (fb *filterBackend) SubscribeChainSideEvent(ch chan<- core.ChainSideEvent) event.Subscription {
+	return fb.bc.SubscribeChainSideEvent(ch)
+}
+
 func (fb *filterBackend) SubscribeRemovedLogsEvent(ch chan<- core.RemovedLogsEvent) event.Subscription {
 	return fb.bc.SubscribeRemovedLogsEvent(ch)
 }

--- a/eth/filters/api.go
+++ b/eth/filters/api.go
@@ -28,7 +28,6 @@ import (
 	"github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
-	"github.com/ethereum/go-ethereum/core"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/internal/ethapi"
 	"github.com/ethereum/go-ethereum/rpc"
@@ -257,7 +256,7 @@ func (api *FilterAPI) ChainReorgs(ctx context.Context) (*rpc.Subscription, error
 	rpcSub := notifier.CreateSubscription()
 
 	go func() {
-		reorgs := make(chan *core.ChainSideEvent)
+		reorgs := make(chan *types.Header)
 		headersSub := api.events.SubscribeChainReorgs(reorgs)
 
 		for {

--- a/eth/filters/filter_system.go
+++ b/eth/filters/filter_system.go
@@ -189,7 +189,7 @@ type subscription struct {
 	logs      chan []*types.Log
 	txs       chan []*types.Transaction
 	headers   chan *types.Header
-	reorgs    chan *core.ChainSideEvent
+	reorgs    chan *types.Header
 	installed chan struct{} // closed when the filter is installed
 	err       chan error    // closed when the filter is uninstalled
 }
@@ -355,7 +355,7 @@ func (es *EventSystem) subscribeMinedPendingLogs(crit ethereum.FilterQuery, logs
 		logs:      logs,
 		txs:       make(chan []*types.Transaction),
 		headers:   make(chan *types.Header),
-		reorgs:    make(chan *core.ChainSideEvent),
+		reorgs:    make(chan *types.Header),
 		installed: make(chan struct{}),
 		err:       make(chan error),
 	}
@@ -373,7 +373,7 @@ func (es *EventSystem) subscribeLogs(crit ethereum.FilterQuery, logs chan []*typ
 		logs:      logs,
 		txs:       make(chan []*types.Transaction),
 		headers:   make(chan *types.Header),
-		reorgs:    make(chan *core.ChainSideEvent),
+		reorgs:    make(chan *types.Header),
 		installed: make(chan struct{}),
 		err:       make(chan error),
 	}
@@ -391,7 +391,7 @@ func (es *EventSystem) subscribePendingLogs(crit ethereum.FilterQuery, logs chan
 		logs:      logs,
 		txs:       make(chan []*types.Transaction),
 		headers:   make(chan *types.Header),
-		reorgs:    make(chan *core.ChainSideEvent),
+		reorgs:    make(chan *types.Header),
 		installed: make(chan struct{}),
 		err:       make(chan error),
 	}
@@ -408,7 +408,7 @@ func (es *EventSystem) SubscribeNewHeads(headers chan *types.Header) *Subscripti
 		logs:      make(chan []*types.Log),
 		txs:       make(chan []*types.Transaction),
 		headers:   headers,
-		reorgs:    make(chan *core.ChainSideEvent),
+		reorgs:    make(chan *types.Header),
 		installed: make(chan struct{}),
 		err:       make(chan error),
 	}
@@ -425,7 +425,7 @@ func (es *EventSystem) SubscribePendingTxs(txs chan []*types.Transaction) *Subsc
 		logs:      make(chan []*types.Log),
 		txs:       txs,
 		headers:   make(chan *types.Header),
-		reorgs:    make(chan *core.ChainSideEvent),
+		reorgs:    make(chan *types.Header),
 		installed: make(chan struct{}),
 		err:       make(chan error),
 	}
@@ -434,7 +434,7 @@ func (es *EventSystem) SubscribePendingTxs(txs chan []*types.Transaction) *Subsc
 
 // SubscribeNewHeads creates a subscription that writes the header of a block that is
 // imported in the chain.
-func (es *EventSystem) SubscribeChainReorgs(reorgs chan *core.ChainSideEvent) *Subscription {
+func (es *EventSystem) SubscribeChainReorgs(reorgs chan *types.Header) *Subscription {
 	sub := &subscription{
 		id:        rpc.NewID(),
 		typ:       ReorgsSubscription,
@@ -513,7 +513,7 @@ func (es *EventSystem) handleChainEvent(filters filterIndex, ev core.ChainEvent)
 
 func (es *EventSystem) handleReorgEvent(filters filterIndex, ev core.ChainSideEvent) {
 	for _, f := range filters[ReorgsSubscription] {
-		f.reorgs <- &ev
+		f.reorgs <- ev.Block.Header()
 	}
 }
 

--- a/eth/filters/filter_system.go
+++ b/eth/filters/filter_system.go
@@ -432,8 +432,8 @@ func (es *EventSystem) SubscribePendingTxs(txs chan []*types.Transaction) *Subsc
 	return es.subscribe(sub)
 }
 
-// SubscribeNewHeads creates a subscription that writes the header of a block that is
-// imported in the chain.
+// SubscribeChainReorgs creates a subscription that writes the header of a block that was
+// reorged in the chain.
 func (es *EventSystem) SubscribeChainReorgs(reorgs chan *types.Header) *Subscription {
 	sub := &subscription{
 		id:        rpc.NewID(),

--- a/eth/filters/filter_system.go
+++ b/eth/filters/filter_system.go
@@ -163,7 +163,7 @@ const (
 	PendingTransactionsSubscription
 	// BlocksSubscription queries hashes for blocks that are imported
 	BlocksSubscription
-	// ReorgsSubscription queries hashes for blocks that are imported
+	// ReorgsSubscription queries hashes for blocks that are reorged
 	ReorgsSubscription
 	// LastIndexSubscription keeps track of the last index
 	LastIndexSubscription

--- a/eth/filters/filter_system_test.go
+++ b/eth/filters/filter_system_test.go
@@ -52,6 +52,7 @@ type testBackend struct {
 	chainFeed       event.Feed
 	pendingBlock    *types.Block
 	pendingReceipts types.Receipts
+	reorgFeed       event.Feed
 }
 
 func (b *testBackend) ChainConfig() *params.ChainConfig {
@@ -147,6 +148,10 @@ func (b *testBackend) SubscribePendingLogsEvent(ch chan<- []*types.Log) event.Su
 
 func (b *testBackend) SubscribeChainEvent(ch chan<- core.ChainEvent) event.Subscription {
 	return b.chainFeed.Subscribe(ch)
+}
+
+func (b *testBackend) SubscribeChainSideEvent(ch chan<- core.ChainSideEvent) event.Subscription {
+	return b.reorgFeed.Subscribe(ch)
 }
 
 func (b *testBackend) BloomStatus() (uint64, uint64) {

--- a/ethclient/ethclient.go
+++ b/ethclient/ethclient.go
@@ -27,6 +27,7 @@ import (
 	"github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/ethereum/go-ethereum/core"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/rpc"
 )
@@ -328,6 +329,19 @@ func (ec *Client) SyncProgress(ctx context.Context) (*ethereum.SyncProgress, err
 // on the given channel.
 func (ec *Client) SubscribeNewHead(ctx context.Context, ch chan<- *types.Header) (ethereum.Subscription, error) {
 	sub, err := ec.c.EthSubscribe(ctx, ch, "newHeads")
+	if err != nil {
+		// Defensively prefer returning nil interface explicitly on error-path, instead
+		// of letting default golang behavior wrap it with non-nil interface that stores
+		// nil concrete type value.
+		return nil, err
+	}
+	return sub, nil
+}
+
+// SubscribeChainReorg subscribes to notifications about the chain reorg events
+// on the given channel.
+func (ec *Client) SubscribeChainReorg(ctx context.Context, ch chan<- core.ChainSideEvent) (ethereum.Subscription, error) {
+	sub, err := ec.c.EthSubscribe(ctx, ch, "chainReorgs")
 	if err != nil {
 		// Defensively prefer returning nil interface explicitly on error-path, instead
 		// of letting default golang behavior wrap it with non-nil interface that stores

--- a/ethclient/ethclient.go
+++ b/ethclient/ethclient.go
@@ -27,7 +27,6 @@ import (
 	"github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
-	"github.com/ethereum/go-ethereum/core"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/rpc"
 )
@@ -340,7 +339,7 @@ func (ec *Client) SubscribeNewHead(ctx context.Context, ch chan<- *types.Header)
 
 // SubscribeChainReorg subscribes to notifications about the chain reorg events
 // on the given channel.
-func (ec *Client) SubscribeChainReorg(ctx context.Context, ch chan<- core.ChainSideEvent) (ethereum.Subscription, error) {
+func (ec *Client) SubscribeChainReorg(ctx context.Context, ch chan<- *types.Header) (ethereum.Subscription, error) {
 	sub, err := ec.c.EthSubscribe(ctx, ch, "chainReorgs")
 	if err != nil {
 		// Defensively prefer returning nil interface explicitly on error-path, instead


### PR DESCRIPTION
A simple implementation of https://github.com/ethereum/go-ethereum/issues/26953

And here is a simple client example:

```go
package main

import (
	"context"
	"encoding/json"
	"flag"
	"fmt"
	"os"

	"github.com/ethereum/go-ethereum/core/types"
	"github.com/ethereum/go-ethereum/ethclient"
	"github.com/ethereum/go-ethereum/log"
)

var (
	provider = flag.String("rpc", "ws://127.0.0.1:8546", "rpc provider")
)

func main() {
	flag.Parse()
	log.Root().SetHandler(log.LvlFilterHandler(log.LvlInfo, log.StreamHandler(os.Stdout, log.TerminalFormat(true))))

	client, err := ethclient.Dial(*provider)
	if err != nil {
		log.Crit("error creating client", "err", err)
	}
	defer client.Close()

	ctx := context.Background()
	ch := make(chan *types.Header)
	sub, err := client.SubscribeChainReorg(ctx, ch)
	if err != nil {
		log.Crit("failed to subscribe chainside event", "err", err)
	}
	defer sub.Unsubscribe()

	log.Info("Success subscribe ChainReorg")
LOOP:
	for {
		select {
		case err := <-sub.Err():
			log.Error("subscribe error", "err", err)
			break LOOP

		case e := <-ch:
			ef, _ := json.MarshalIndent(e, "", "  ")
			log.Info("reorg -->")
			fmt.Println(string(ef))
		case err := <-ctx.Done():
			log.Error("context error", "err", err)
			break LOOP
		}
	}
	close(ch)
}
```

> Subscribe with 

```bash
go run reorg.go -rpc xxx
```

> Some example output:

```bash
INFO [05-16|23:35:54.737] Success subscribe ChainReorg


INFO [05-17|00:35:02.198] reorg -->
{
  "parentHash": "0xf4a6cf72480f4f84a0be2db64b1480ec1022172f652ffafdabdc8482eec1821e",
  "sha3Uncles": "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
  "miner": "0x690b9a9e9aa1c9db991c7721a92d351db4fac990",
  "stateRoot": "0x43c89b7a6b65328c56fc47911dde4ff00705f668d7745f9dbe00712ef6c9eeab",
  "transactionsRoot": "0x6162b6db65a3e60bb00a9f550f0c14d7b5644fc9a2dae5ecb393f0abd2ba5399",
  "receiptsRoot": "0xb846ad0702fdf2b74c9569fa49bfed05bf64c53acaedc858fc525fef7e0a582d",
  "logsBloom": "0x1ba10482081c10d87918571a8f08894b9027230138921052020163555dc4754241365de0c136207084205a3a0b10a11532070003da0138c85064e00c152d980b800aba9a20711c282b0660cbc014677f29428046bc475ce04e901c7088682c217f21092d0340a90381c41680832098830010e0a0a9c16e68c884c4f48b78be72c020425144888b5a81cf01305f53040620080281cb4c0b8a4d25006ec01003d1ffcc51ca1a0ef1632a0900c0dc89448e05c0a282e5a34b695d48a68835302a414b2c02b20a479053a04210980041265bc17d038282122c74f452518a08006200a535e80eb9110868166428e1a6551a04845a02d03000147445a9125287287f44",
  "difficulty": "0x0",
  "number": "0x1079bc4",
  "gasLimit": "0x1c9c380",
  "gasUsed": "0xa24b5a",
  "timestamp": "0x64642127",
  "extraData": "0x627920406275696c64657230783639",
  "mixHash": "0x7c6a7a16af8749719f5bfdee24a1f91efa2386fb923e29aaa14a80c21fb3a374",
  "nonce": "0x0000000000000000",
  "baseFeePerGas": "0x931606255",
  "withdrawalsRoot": "0xfc8557f98bcd013b833c686683cf0780c193379feb29d27e064e3c732d4a0c8a",
  "excessDataGas": null,
  "hash": "0xafdf26616fe59929b1ac85733b525eaaceb7b94822d9058b922a64a691ee909c"
}
INFO [05-17|00:42:21.005] reorg -->
{
  "parentHash": "0x3d58851135b811edfbc26c82b8343f6919a76709fc1c077499e2499884da0290",
  "sha3Uncles": "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
  "miner": "0xebec795c9c8bbd61ffc14a6662944748f299cacf",
  "stateRoot": "0xfced68db87020b4f510c55a0963266b0201ee74b3a176f6610fde41aae6a15f5",
  "transactionsRoot": "0x2770e1899b04ebaa05ce366fd99e2de89e24edd3fb404d51dff21c674c9c604c",
  "receiptsRoot": "0xfe41971da8a78646254d0ee53f8437ca8818a6a5a438e300e7e297202462630c",
  "logsBloom": "0x2f250248482e40c90248122080411a61322ec58202028c414003a041b0a001565808a240e4619161c21203063120a5840a89ca5ca880a8c0261c8e6712a931b0118a8a1804182cadec2443ca8a5008a0101a0602005d2c051090f57f984a5803a2022230120210cfa148540419c4186da0129080481b04b0020164f20439680ca911a04e16404222164e004ca26a01422caa2c09a908401ca411024344107003ba09e1d6091a6802d10a42e59014054854402841c000494a4444860211b1000742b26842401014d45400e425042a146c5740bd07432e20141826d5a3a0052463041a200c898008847f844da0ab2849c0845487ba510800ee90c81817d4190c9c",
  "difficulty": "0x0",
  "number": "0x1079be6",
  "gasLimit": "0x1c9c380",
  "gasUsed": "0xfd1b5e",
  "timestamp": "0x646422d7",
  "extraData": "0xd883010b06846765746888676f312e31392e38856c696e7578",
  "mixHash": "0xf48ad139fde09d2b9bec8bec4d33bbbe8e5058c0e8c56bf91a9284b18a498888",
  "nonce": "0x0000000000000000",
  "baseFeePerGas": "0x94f0dd366",
  "withdrawalsRoot": "0x3c3ea92e5fd9732b648d319f59d97cbc2c8cc959d3b5650c47b4e686bf0459f3",
  "excessDataGas": null,
  "hash": "0xa3526448bdbb58f8f3ebc69a2020e41861e21a93a20f079d8bc53cfd6e751881"
}

```