### PR TITLE
rpc: more accurate checking of callback/subpub method signatures

### DIFF
--- a/rpc/service.go
+++ b/rpc/service.go
@@ -216,9 +216,6 @@ func (c *callback) call(ctx context.Context, method string, args []reflect.Value
 
 // Does t satisfy the error interface?
 func isErrorType(t reflect.Type) bool {
-	for t.Kind() == reflect.Ptr {
-		t = t.Elem()
-	}
 	return t.Implements(errorType)
 }
 

--- a/rpc/service.go
+++ b/rpc/service.go
@@ -214,14 +214,6 @@ func (c *callback) call(ctx context.Context, method string, args []reflect.Value
 	return results[0].Interface(), nil
 }
 
-// Is t context.Context or *context.Context?
-func isContextType(t reflect.Type) bool {
-	for t.Kind() == reflect.Ptr {
-		t = t.Elem()
-	}
-	return t == contextType
-}
-
 // Does t satisfy the error interface?
 func isErrorType(t reflect.Type) bool {
 	for t.Kind() == reflect.Ptr {
@@ -245,7 +237,7 @@ func isPubSub(methodType reflect.Type) bool {
 	if methodType.NumIn() < 2 || methodType.NumOut() != 2 {
 		return false
 	}
-	return isContextType(methodType.In(1)) &&
+	return methodType.In(1) == contextType &&
 		isSubscriptionType(methodType.Out(0)) &&
 		isErrorType(methodType.Out(1))
 }


### PR DESCRIPTION
The first argument of a Pub/Sub function should not be a pointer to context.Context, otherwise it will be registered as a subscription and its corresponding callback.hasCtx==false. This results in the parameter not having the correct value when called.

The problem description of the old code is as follows:

1. Suppose we define a subscription method, the first parameter is *context.Context.
2. When executing serviceRegistry.registerName for service registration, the isContextType method returns true, and isPubSub returns true, making callback.isSubscribe==true.
3. In the makeArgTypes method, because the first parameter Type!=contextType, the previously created callback.hasCtx==false.
4. In the callback.Call method, because callback.hasCtx==false, the correct context.Context cannot be passed into the corresponding method.