### PR TITLE
internal/ethapi: prevent unnecessary resource usage in eth_getProof implementation

### DIFF
--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -692,8 +692,8 @@ func (s *BlockChainAPI) GetProof(ctx context.Context, address common.Address, st
 	if storageTrie, err = state.StorageTrie(address); err != nil {
 		return nil, err
 	}
-	// if we have a storageTrie, the account exists). and we we must update
-	// the storage root hash and the code hash
+	// if we have a storageTrie, the account exists and we must update
+	// the storage root hash and the code hash.
 	if storageTrie != nil {
 		storageHash = storageTrie.Hash()
 		codeHash = state.GetCodeHash(address)


### PR DESCRIPTION
closes #27308

- deserializes hex keys early to shortcut on invalid input
- re-use the account `storageTrie` for each proof for each proof in the account, preventing repeated deep-copying of the trie

Code smell: 
I duplicated the `proofList` type rather than making it public. Making it public seemed like the wrong choice, as it would result in panics on misuse. There is probably a better way to do this but I'm not sufficiently familiar with the codebase