### PR TITLE
accounts/keystore: refactor function name

### DIFF
--- a/accounts/keystore/key.go
+++ b/accounts/keystore/key.go
@@ -171,7 +171,7 @@ func newKey(rand io.Reader) (*Key, error) {
 	return newKeyFromECDSA(privateKeyECDSA), nil
 }
 
-func storeNewKey(ks keyStore, rand io.Reader, auth string) (*Key, accounts.Account, error) {
+func StoreNewKey(ks keyStore, rand io.Reader, auth string) (*Key, accounts.Account, error) {
 	key, err := newKey(rand)
 	if err != nil {
 		return nil, accounts.Account{}, err

--- a/accounts/keystore/keystore.go
+++ b/accounts/keystore/keystore.go
@@ -407,7 +407,7 @@ func (ks *KeyStore) expire(addr common.Address, u *unlocked, timeout time.Durati
 // NewAccount generates a new key and stores it into the key directory,
 // encrypting it with the passphrase.
 func (ks *KeyStore) NewAccount(passphrase string) (accounts.Account, error) {
-	_, account, err := storeNewKey(ks.storage, crand.Reader, passphrase)
+	_, account, err := StoreNewKey(ks.storage, crand.Reader, passphrase)
 	if err != nil {
 		return accounts.Account{}, err
 	}

--- a/accounts/keystore/passphrase.go
+++ b/accounts/keystore/passphrase.go
@@ -98,7 +98,7 @@ func (ks keyStorePassphrase) GetKey(addr common.Address, filename, auth string) 
 
 // StoreKey generates a key, encrypts with 'auth' and stores in the given directory
 func StoreKey(dir, auth string, scryptN, scryptP int) (accounts.Account, error) {
-	_, a, err := storeNewKey(&keyStorePassphrase{dir, scryptN, scryptP, false}, rand.Reader, auth)
+	_, a, err := StoreNewKey(&keyStorePassphrase{dir, scryptN, scryptP, false}, rand.Reader, auth)
 	return a, err
 }
 

--- a/accounts/keystore/plain_test.go
+++ b/accounts/keystore/plain_test.go
@@ -43,7 +43,7 @@ func TestKeyStorePlain(t *testing.T) {
 	_, ks := tmpKeyStoreIface(t, false)
 
 	pass := "" // not used but required by API
-	k1, account, err := storeNewKey(ks, rand.Reader, pass)
+	k1, account, err := StoreNewKey(ks, rand.Reader, pass)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -63,7 +63,7 @@ func TestKeyStorePassphrase(t *testing.T) {
 	_, ks := tmpKeyStoreIface(t, true)
 
 	pass := "foo"
-	k1, account, err := storeNewKey(ks, rand.Reader, pass)
+	k1, account, err := StoreNewKey(ks, rand.Reader, pass)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -83,7 +83,7 @@ func TestKeyStorePassphraseDecryptionFail(t *testing.T) {
 	_, ks := tmpKeyStoreIface(t, true)
 
 	pass := "foo"
-	k1, account, err := storeNewKey(ks, rand.Reader, pass)
+	k1, account, err := StoreNewKey(ks, rand.Reader, pass)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
This pull request proposes changes to the function name `storeNewKey()` in the **keystore** package, as it is designed for external use rather than internal use. 

### Changes Made:

Renamed the function storeNewKey to StoreNewKey to reflect its intended use as a public function.
### Questions:

In the keystore.go file, there is a private function called `newKeyFromECDSA()` that was initially designed for internal use. However, it is referenced in other files within the package. Should we consider changing the naming convention for such private functions to better reflect their usage?