### PR TITLE
cmd: use errrors.New instead of empty fmt.Errorf

### DIFF
--- a/cmd/clef/main.go
+++ b/cmd/clef/main.go
@@ -326,7 +326,7 @@ func initializeSecrets(c *cli.Context) error {
 		return err
 	}
 	if num != len(masterSeed) {
-		return fmt.Errorf("failed to read enough random")
+		return errors.New("failed to read enough random")
 	}
 	n, p := keystore.StandardScryptN, keystore.StandardScryptP
 	if c.Bool(utils.LightKDFFlag.Name) {
@@ -482,7 +482,7 @@ func initialize(c *cli.Context) error {
 		}
 	} else if !c.Bool(acceptFlag.Name) {
 		if !confirm(legalWarning) {
-			return fmt.Errorf("aborted by user")
+			return errors.New("aborted by user")
 		}
 		fmt.Println()
 	}
@@ -590,7 +590,7 @@ func accountImport(c *cli.Context) error {
   Address %v
   Keystore file: %v
 
-The key is now encrypted; losing the password will result in permanently losing 
+The key is now encrypted; losing the password will result in permanently losing
 access to the key and all associated funds!
 
 Make sure to backup keystore and passwords in a safe location.`,
@@ -844,7 +844,7 @@ func readMasterKey(ctx *cli.Context, ui core.UIClientAPI) ([]byte, error) {
 	}
 	masterSeed, err := decryptSeed(cipherKey, password)
 	if err != nil {
-		return nil, fmt.Errorf("failed to decrypt the master seed of clef")
+		return nil, errors.New("failed to decrypt the master seed of clef")
 	}
 	if len(masterSeed) < 256 {
 		return nil, fmt.Errorf("master seed of insufficient length, expected >255 bytes, got %d", len(masterSeed))

--- a/cmd/devp2p/discv4cmd.go
+++ b/cmd/devp2p/discv4cmd.go
@@ -17,6 +17,7 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 	"net"
 	"strconv"
@@ -177,7 +178,7 @@ func discv4Resolve(ctx *cli.Context) error {
 
 func discv4ResolveJSON(ctx *cli.Context) error {
 	if ctx.NArg() < 1 {
-		return fmt.Errorf("need nodes file as argument")
+		return errors.New("need nodes file as argument")
 	}
 	nodesFile := ctx.Args().Get(0)
 	inputSet := make(nodeSet)
@@ -207,7 +208,7 @@ func discv4ResolveJSON(ctx *cli.Context) error {
 
 func discv4Crawl(ctx *cli.Context) error {
 	if ctx.NArg() < 1 {
-		return fmt.Errorf("need nodes file as argument")
+		return errors.New("need nodes file as argument")
 	}
 	nodesFile := ctx.Args().First()
 	var inputSet nodeSet

--- a/cmd/devp2p/discv5cmd.go
+++ b/cmd/devp2p/discv5cmd.go
@@ -17,6 +17,7 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 	"time"
 
@@ -98,7 +99,7 @@ func discv5Resolve(ctx *cli.Context) error {
 
 func discv5Crawl(ctx *cli.Context) error {
 	if ctx.NArg() < 1 {
-		return fmt.Errorf("need nodes file as argument")
+		return errors.New("need nodes file as argument")
 	}
 	nodesFile := ctx.Args().First()
 	var inputSet nodeSet

--- a/cmd/devp2p/dns_cloudflare.go
+++ b/cmd/devp2p/dns_cloudflare.go
@@ -18,6 +18,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 
@@ -48,7 +49,7 @@ type cloudflareClient struct {
 func newCloudflareClient(ctx *cli.Context) *cloudflareClient {
 	token := ctx.String(cloudflareTokenFlag.Name)
 	if token == "" {
-		exit(fmt.Errorf("need cloudflare API token to proceed"))
+		exit(errors.New("need cloudflare API token to proceed"))
 	}
 	api, err := cloudflare.NewWithAPIToken(token)
 	if err != nil {

--- a/cmd/devp2p/dns_route53.go
+++ b/cmd/devp2p/dns_route53.go
@@ -81,7 +81,7 @@ func newRoute53Client(ctx *cli.Context) *route53Client {
 	akey := ctx.String(route53AccessKeyFlag.Name)
 	asec := ctx.String(route53AccessSecretFlag.Name)
 	if akey == "" || asec == "" {
-		exit(fmt.Errorf("need Route53 Access Key ID and secret to proceed"))
+		exit(errors.New("need Route53 Access Key ID and secret to proceed"))
 	}
 	creds := aws.NewCredentialsCache(credentials.NewStaticCredentialsProvider(akey, asec, ""))
 	cfg, err := config.LoadDefaultConfig(context.Background(), config.WithCredentialsProvider(creds))

--- a/cmd/devp2p/dnscmd.go
+++ b/cmd/devp2p/dnscmd.go
@@ -19,6 +19,7 @@ package main
 import (
 	"crypto/ecdsa"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -147,7 +148,7 @@ func dnsSync(ctx *cli.Context) error {
 
 func dnsSign(ctx *cli.Context) error {
 	if ctx.NArg() < 2 {
-		return fmt.Errorf("need tree definition directory and key file as arguments")
+		return errors.New("need tree definition directory and key file as arguments")
 	}
 	var (
 		defdir  = ctx.Args().Get(0)
@@ -201,7 +202,7 @@ func directoryName(dir string) string {
 // dnsToTXT performs dnsTXTCommand.
 func dnsToTXT(ctx *cli.Context) error {
 	if ctx.NArg() < 1 {
-		return fmt.Errorf("need tree definition directory as argument")
+		return errors.New("need tree definition directory as argument")
 	}
 	output := ctx.Args().Get(1)
 	if output == "" {
@@ -218,7 +219,7 @@ func dnsToTXT(ctx *cli.Context) error {
 // dnsToCloudflare performs dnsCloudflareCommand.
 func dnsToCloudflare(ctx *cli.Context) error {
 	if ctx.NArg() != 1 {
-		return fmt.Errorf("need tree definition directory as argument")
+		return errors.New("need tree definition directory as argument")
 	}
 	domain, t, err := loadTreeDefinitionForExport(ctx.Args().Get(0))
 	if err != nil {
@@ -231,7 +232,7 @@ func dnsToCloudflare(ctx *cli.Context) error {
 // dnsToRoute53 performs dnsRoute53Command.
 func dnsToRoute53(ctx *cli.Context) error {
 	if ctx.NArg() != 1 {
-		return fmt.Errorf("need tree definition directory as argument")
+		return errors.New("need tree definition directory as argument")
 	}
 	domain, t, err := loadTreeDefinitionForExport(ctx.Args().Get(0))
 	if err != nil {
@@ -244,7 +245,7 @@ func dnsToRoute53(ctx *cli.Context) error {
 // dnsNukeRoute53 performs dnsRoute53NukeCommand.
 func dnsNukeRoute53(ctx *cli.Context) error {
 	if ctx.NArg() != 1 {
-		return fmt.Errorf("need domain name as argument")
+		return errors.New("need domain name as argument")
 	}
 	client := newRoute53Client(ctx)
 	return client.deleteDomain(ctx.Args().First())
@@ -363,10 +364,10 @@ func loadTreeDefinitionForExport(dir string) (domain string, t *dnsdisc.Tree, er
 // tree's signature if valid.
 func ensureValidTreeSignature(t *dnsdisc.Tree, pubkey *ecdsa.PublicKey, sig string) error {
 	if sig == "" {
-		return fmt.Errorf("missing signature, run 'devp2p dns sign' first")
+		return errors.New("missing signature, run 'devp2p dns sign' first")
 	}
 	if err := t.SetSignature(pubkey, sig); err != nil {
-		return fmt.Errorf("invalid signature on tree, run 'devp2p dns sign' to update it")
+		return errors.New("invalid signature on tree, run 'devp2p dns sign' to update it")
 	}
 	return nil
 }

--- a/cmd/devp2p/enrcmd.go
+++ b/cmd/devp2p/enrcmd.go
@@ -20,6 +20,7 @@ import (
 	"bytes"
 	"encoding/base64"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"io"
 	"net"
@@ -48,7 +49,7 @@ func enrdump(ctx *cli.Context) error {
 	var source string
 	if file := ctx.String(fileFlag.Name); file != "" {
 		if ctx.NArg() != 0 {
-			return fmt.Errorf("can't dump record from command-line argument in -file mode")
+			return errors.New("can't dump record from command-line argument in -file mode")
 		}
 		var b []byte
 		var err error
@@ -64,7 +65,7 @@ func enrdump(ctx *cli.Context) error {
 	} else if ctx.NArg() == 1 {
 		source = ctx.Args().First()
 	} else {
-		return fmt.Errorf("need record as argument")
+		return errors.New("need record as argument")
 	}
 
 	r, err := parseRecord(source)

--- a/cmd/devp2p/internal/ethtest/chain.go
+++ b/cmd/devp2p/internal/ethtest/chain.go
@@ -19,6 +19,7 @@ package ethtest
 import (
 	"compress/gzip"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"math/big"
@@ -98,7 +99,7 @@ func (c *Chain) Head() *types.Block {
 
 func (c *Chain) GetHeaders(req *GetBlockHeaders) ([]*types.Header, error) {
 	if req.Amount < 1 {
-		return nil, fmt.Errorf("no block headers requested")
+		return nil, errors.New("no block headers requested")
 	}
 
 	headers := make([]*types.Header, req.Amount)

--- a/cmd/devp2p/internal/ethtest/helpers.go
+++ b/cmd/devp2p/internal/ethtest/helpers.go
@@ -17,6 +17,7 @@
 package ethtest
 
 import (
+	"errors"
 	"fmt"
 	"net"
 	"reflect"
@@ -185,7 +186,7 @@ loop:
 	}
 	// make sure eth protocol version is set for negotiation
 	if c.negotiatedProtoVersion == 0 {
-		return nil, fmt.Errorf("eth protocol version must be set in Conn")
+		return nil, errors.New("eth protocol version must be set in Conn")
 	}
 	if status == nil {
 		// default status message

--- a/cmd/devp2p/internal/ethtest/transaction.go
+++ b/cmd/devp2p/internal/ethtest/transaction.go
@@ -17,6 +17,7 @@
 package ethtest
 
 import (
+	"errors"
 	"fmt"
 	"math/big"
 	"strings"
@@ -39,7 +40,7 @@ func (s *Suite) sendSuccessfulTxs(t *utesting.T) error {
 	}
 	for i, tx := range tests {
 		if tx == nil {
-			return fmt.Errorf("could not find tx to send")
+			return errors.New("could not find tx to send")
 		}
 		t.Logf("Testing tx propagation %d: sending tx %v %v %v\n", i, tx.Hash().String(), tx.GasPrice(), tx.Gas())
 		// get previous tx if exists for reference in case of old tx propagation
@@ -348,7 +349,7 @@ func generateTxs(s *Suite, numTxs int) (map[common.Hash]common.Hash, []*types.Tr
 
 	nextTx := getNextTxFromChain(s)
 	if nextTx == nil {
-		return nil, nil, fmt.Errorf("failed to get the next transaction")
+		return nil, nil, errors.New("failed to get the next transaction")
 	}
 	gas := nextTx.Gas()
 
@@ -357,7 +358,7 @@ func generateTxs(s *Suite, numTxs int) (map[common.Hash]common.Hash, []*types.Tr
 	for i := 0; i < numTxs; i++ {
 		tx := generateTx(s.chain.chainConfig, nonce, gas)
 		if tx == nil {
-			return nil, nil, fmt.Errorf("failed to get the next transaction")
+			return nil, nil, errors.New("failed to get the next transaction")
 		}
 		txHashMap[tx.Hash()] = tx.Hash()
 		txs[i] = tx

--- a/cmd/devp2p/internal/ethtest/types.go
+++ b/cmd/devp2p/internal/ethtest/types.go
@@ -18,6 +18,7 @@ package ethtest
 
 import (
 	"crypto/ecdsa"
+	"errors"
 	"fmt"
 	"time"
 
@@ -286,5 +287,5 @@ func (c *Conn) ReadSnap(id uint64) (Message, error) {
 		}
 		return snpMsg.(Message), nil
 	}
-	return nil, fmt.Errorf("request timed out")
+	return nil, errors.New("request timed out")
 }

--- a/cmd/devp2p/internal/v4test/discv4tests.go
+++ b/cmd/devp2p/internal/v4test/discv4tests.go
@@ -19,6 +19,7 @@ package v4test
 import (
 	"bytes"
 	"crypto/rand"
+	"errors"
 	"fmt"
 	"net"
 	"time"
@@ -119,7 +120,7 @@ func (te *testenv) checkPingPong(pingHash []byte) error {
 // and a PING. The two packets do not have to be in any particular order.
 func (te *testenv) checkPong(reply v4wire.Packet, pingHash []byte) error {
 	if reply == nil {
-		return fmt.Errorf("expected PONG reply, got nil")
+		return errors.New("expected PONG reply, got nil")
 	}
 	if reply.Kind() != v4wire.PongPacket {
 		return fmt.Errorf("expected PONG reply, got %v %v", reply.Name(), reply)

--- a/cmd/devp2p/keycmd.go
+++ b/cmd/devp2p/keycmd.go
@@ -17,6 +17,7 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 	"net"
 
@@ -86,7 +87,7 @@ var (
 
 func genkey(ctx *cli.Context) error {
 	if ctx.NArg() != 1 {
-		return fmt.Errorf("need key file as argument")
+		return errors.New("need key file as argument")
 	}
 	file := ctx.Args().Get(0)
 
@@ -126,7 +127,7 @@ func keyToRecord(ctx *cli.Context) error {
 
 func makeRecord(ctx *cli.Context) (*enode.Node, error) {
 	if ctx.NArg() != 1 {
-		return nil, fmt.Errorf("need key file as argument")
+		return nil, errors.New("need key file as argument")
 	}
 
 	var (

--- a/cmd/devp2p/nodesetcmd.go
+++ b/cmd/devp2p/nodesetcmd.go
@@ -59,7 +59,7 @@ var (
 
 func nodesetInfo(ctx *cli.Context) error {
 	if ctx.NArg() < 1 {
-		return fmt.Errorf("need nodes file as argument")
+		return errors.New("need nodes file as argument")
 	}
 
 	ns := loadNodesJSON(ctx.Args().First())
@@ -98,7 +98,7 @@ func showAttributeCounts(ns nodeSet) {
 
 func nodesetFilter(ctx *cli.Context) error {
 	if ctx.NArg() < 1 {
-		return fmt.Errorf("need nodes file as argument")
+		return errors.New("need nodes file as argument")
 	}
 	// Parse -limit.
 	limit, err := parseFilterLimit(ctx.Args().Tail())

--- a/cmd/devp2p/rlpxcmd.go
+++ b/cmd/devp2p/rlpxcmd.go
@@ -17,6 +17,7 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 	"net"
 
@@ -91,7 +92,7 @@ func rlpxPing(ctx *cli.Context) error {
 	case 1:
 		var msg []p2p.DiscReason
 		if rlp.DecodeBytes(data, &msg); len(msg) == 0 {
-			return fmt.Errorf("invalid disconnect message")
+			return errors.New("invalid disconnect message")
 		}
 		return fmt.Errorf("received disconnect message: %v", msg[0])
 	default:

--- a/cmd/evm/internal/t8ntool/block.go
+++ b/cmd/evm/internal/t8ntool/block.go
@@ -171,18 +171,18 @@ func (i *bbInput) sealClique(block *types.Block) (*types.Block, error) {
 	// If any clique value overwrites an explicit header value, fail
 	// to avoid silently building a block with unexpected values.
 	if i.Header.Extra != nil {
-		return nil, NewError(ErrorConfig, fmt.Errorf("sealing with clique will overwrite provided extra data"))
+		return nil, NewError(ErrorConfig, errors.New("sealing with clique will overwrite provided extra data"))
 	}
 	header := block.Header()
 	if i.Clique.Voted != nil {
 		if i.Header.Coinbase != nil {
-			return nil, NewError(ErrorConfig, fmt.Errorf("sealing with clique and voting will overwrite provided coinbase"))
+			return nil, NewError(ErrorConfig, errors.New("sealing with clique and voting will overwrite provided coinbase"))
 		}
 		header.Coinbase = *i.Clique.Voted
 	}
 	if i.Clique.Authorize != nil {
 		if i.Header.Nonce != nil {
-			return nil, NewError(ErrorConfig, fmt.Errorf("sealing with clique and voting will overwrite provided nonce"))
+			return nil, NewError(ErrorConfig, errors.New("sealing with clique and voting will overwrite provided nonce"))
 		}
 		if *i.Clique.Authorize {
 			header.Nonce = [8]byte{}

--- a/cmd/faucet/faucet.go
+++ b/cmd/faucet/faucet.go
@@ -893,6 +893,6 @@ func getGenesis(genesisFlag string, goerliFlag bool, rinkebyFlag bool, sepoliaFl
 	case sepoliaFlag:
 		return core.DefaultSepoliaGenesisBlock(), nil
 	default:
-		return nil, fmt.Errorf("no genesis flag provided")
+		return nil, errors.New("no genesis flag provided")
 	}
 }

--- a/cmd/geth/chaincmd.go
+++ b/cmd/geth/chaincmd.go
@@ -478,7 +478,7 @@ func dump(ctx *cli.Context) error {
 		if conf.OnlyWithAddresses {
 			fmt.Fprintf(os.Stderr, "If you want to include accounts with missing preimages, you need iterative output, since"+
 				" otherwise the accounts will overwrite each other in the resulting mapping.")
-			return fmt.Errorf("incompatible options")
+			return errors.New("incompatible options")
 		}
 		fmt.Println(string(state.Dump(conf)))
 	}

--- a/cmd/geth/verkle.go
+++ b/cmd/geth/verkle.go
@@ -100,7 +100,7 @@ func checkChildren(root verkle.VerkleNode, resolver verkle.NodeResolverFn) error
 				return nil
 			}
 		}
-		return fmt.Errorf("Both balance and nonce are 0")
+		return errors.New("Both balance and nonce are 0")
 	case verkle.Empty:
 		// nothing to do
 	default:

--- a/cmd/utils/cmd.go
+++ b/cmd/utils/cmd.go
@@ -184,7 +184,7 @@ func ImportChain(chain *core.BlockChain, fn string) error {
 	for batch := 0; ; batch++ {
 		// Load a batch of RLP blocks.
 		if checkInterrupt() {
-			return fmt.Errorf("interrupted")
+			return errors.New("interrupted")
 		}
 		i := 0
 		for ; i < importBatchSize; i++ {
@@ -207,7 +207,7 @@ func ImportChain(chain *core.BlockChain, fn string) error {
 		}
 		// Import the batch.
 		if checkInterrupt() {
-			return fmt.Errorf("interrupted")
+			return errors.New("interrupted")
 		}
 		missing := missingBlocks(chain, blocks[:i])
 		if len(missing) == 0 {


### PR DESCRIPTION
Seems `errors.New` is super fast then the empty `fmt.Errorf`, here is an benchmark test case from https://blog.imberkay.com/errorsnew-vs-fmterrorf

```go
package main

import (
    "errors"
    "fmt"
    "time"
)

func testErrors() error {
    return errors.New("test errors package")
}

func testFmt() error {
    return fmt.Errorf("test fmt package")
}

func main() {
    repeat := 100000000
    start := time.Now()
    for i := 0; i < repeat; i++ {
        testErrors()
    }
    duration := time.Since(start)
    fmt.Println("errors.New", duration)

    start = time.Now()
    for i := 0; i < repeat; i++ {
        testFmt()
    }
    duration = time.Since(start)
    fmt.Println("fmt.Errorf", duration)
}

```

In my macbook air m1, the result as below:

```bash
$ go version
go version go1.20.3 darwin/arm64

$ go run t.go

errors.New 63.858083ms
fmt.Errorf 5.240530083s


```