### PR TITLE
core/state: mark account as dirty when resetObject occurs

### DIFF
--- a/core/state/journal.go
+++ b/core/state/journal.go
@@ -90,6 +90,7 @@ type (
 		account *common.Address
 	}
 	resetObjectChange struct {
+		account      *common.Address
 		prev         *stateObject
 		prevdestruct bool
 	}
@@ -162,7 +163,7 @@ func (ch resetObjectChange) revert(s *StateDB) {
 }
 
 func (ch resetObjectChange) dirtied() *common.Address {
-	return nil
+	return ch.account
 }
 
 func (ch suicideChange) revert(s *StateDB) {


### PR DESCRIPTION
This PR aligns the dirty marker behavior in state journal. It's OK to not mark it as dirty in resetObject, but would be nice to align the behavior with other changes.