### PR TITLE
consensus, core, eth/downloader: add 4844 excessDataGas validations

### DIFF
--- a/consensus/beacon/consensus.go
+++ b/consensus/beacon/consensus.go
@@ -257,7 +257,7 @@ func (beacon *Beacon) verifyHeader(chain consensus.ChainHeaderReader, header, pa
 		return consensus.ErrInvalidNumber
 	}
 	// Verify the header's EIP-1559 attributes.
-	if err := misc.VerifyEip1559Header(chain.Config(), parent, header); err != nil {
+	if err := misc.VerifyEIP1559Header(chain.Config(), parent, header); err != nil {
 		return err
 	}
 	// Verify existence / non-existence of withdrawalsHash.
@@ -270,11 +270,13 @@ func (beacon *Beacon) verifyHeader(chain consensus.ChainHeaderReader, header, pa
 	}
 	// Verify the existence / non-existence of excessDataGas
 	cancun := chain.Config().IsCancun(header.Number, header.Time)
-	if cancun && header.ExcessDataGas == nil {
-		return errors.New("missing excessDataGas")
-	}
 	if !cancun && header.ExcessDataGas != nil {
 		return fmt.Errorf("invalid excessDataGas: have %d, expected nil", header.ExcessDataGas)
+	}
+	if cancun {
+		if err := misc.VerifyEIP4844Header(parent, header); err != nil {
+			return nil
+		}
 	}
 	return nil
 }

--- a/consensus/beacon/consensus.go
+++ b/consensus/beacon/consensus.go
@@ -275,7 +275,7 @@ func (beacon *Beacon) verifyHeader(chain consensus.ChainHeaderReader, header, pa
 	}
 	if cancun {
 		if err := misc.VerifyEIP4844Header(parent, header); err != nil {
-			return nil
+			return err
 		}
 	}
 	return nil

--- a/consensus/clique/clique.go
+++ b/consensus/clique/clique.go
@@ -343,7 +343,7 @@ func (c *Clique) verifyCascadingFields(chain consensus.ChainHeaderReader, header
 		if err := misc.VerifyGaslimit(parent.GasLimit, header.GasLimit); err != nil {
 			return err
 		}
-	} else if err := misc.VerifyEip1559Header(chain.Config(), parent, header); err != nil {
+	} else if err := misc.VerifyEIP1559Header(chain.Config(), parent, header); err != nil {
 		// Verify the header's EIP-1559 attributes.
 		return err
 	}

--- a/consensus/ethash/consensus.go
+++ b/consensus/ethash/consensus.go
@@ -254,7 +254,7 @@ func (ethash *Ethash) verifyHeader(chain consensus.ChainHeaderReader, header, pa
 		if err := misc.VerifyGaslimit(parent.GasLimit, header.GasLimit); err != nil {
 			return err
 		}
-	} else if err := misc.VerifyEip1559Header(chain.Config(), parent, header); err != nil {
+	} else if err := misc.VerifyEIP1559Header(chain.Config(), parent, header); err != nil {
 		// Verify the header's EIP-1559 attributes.
 		return err
 	}

--- a/consensus/misc/eip1559.go
+++ b/consensus/misc/eip1559.go
@@ -27,10 +27,10 @@ import (
 	"github.com/ethereum/go-ethereum/params"
 )
 
-// VerifyEip1559Header verifies some header attributes which were changed in EIP-1559,
+// VerifyEIP1559Header verifies some header attributes which were changed in EIP-1559,
 // - gas limit check
 // - basefee check
-func VerifyEip1559Header(config *params.ChainConfig, parent, header *types.Header) error {
+func VerifyEIP1559Header(config *params.ChainConfig, parent, header *types.Header) error {
 	// Verify that the gas limit remains within allowed bounds
 	parentGasLimit := parent.GasLimit
 	if !config.IsLondon(parent.Number) {

--- a/consensus/misc/eip1559_test.go
+++ b/consensus/misc/eip1559_test.go
@@ -95,7 +95,7 @@ func TestBlockGasLimits(t *testing.T) {
 			BaseFee:  initial,
 			Number:   big.NewInt(tc.pNum + 1),
 		}
-		err := VerifyEip1559Header(config(), parent, header)
+		err := VerifyEIP1559Header(config(), parent, header)
 		if tc.ok && err != nil {
 			t.Errorf("test %d: Expected valid header: %s", i, err)
 		}

--- a/consensus/misc/eip4844.go
+++ b/consensus/misc/eip4844.go
@@ -17,8 +17,11 @@
 package misc
 
 import (
+	"errors"
+	"fmt"
 	"math/big"
 
+	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/params"
 )
 
@@ -27,7 +30,59 @@ var (
 	dataGaspriceUpdateFraction = big.NewInt(params.BlobTxDataGaspriceUpdateFraction)
 )
 
+// VerifyEIP4844Header verifies the presence of the excessDataGas field and that
+// if the current block contains no transactions, the excessDataGas is updated
+// accordingly.
+//
+// We cannot verify excessDataGas if there *are* transactions included as that
+// would require the block body. However, it is nonetheless useful to verify the
+// header in case of an empty body since certain code might skip body validations
+// with no included transactions (e.g. snap sync).
+func VerifyEIP4844Header(parent, header *types.Header) error {
+	// Verify the header is not malformed
+	if header.ExcessDataGas == nil {
+		return errors.New("header is missing excessDataGas")
+	}
+	// Verify the excessDataGas is correct based on the parent header iff the
+	// transaction list is empty. For non-empty blocks, validation needs to be
+	// done later.
+	if header.TxHash == types.EmptyTxsHash {
+		expectedExcessDataGas := CalcExcessDataGas(parent.ExcessDataGas, 0)
+		if header.ExcessDataGas.Cmp(expectedExcessDataGas) != 0 {
+			return fmt.Errorf("invalid excessDataGas: have %s, want %s, parentExcessDataGas %s, blob txs %d",
+				header.ExcessDataGas, expectedExcessDataGas, parent.ExcessDataGas, 0)
+		}
+	}
+	return nil
+}
+
+// CalcExcessDataGas calculates the excess data gas after applying the set of
+// blobs on top of the paren't excess data gas.
+//
+// Note, the excessDataGas is akin to gasUsed, in that it's calculated post-
+// execution of the blob transactions not before. Hence, the blob fee used to
+// pay for the blobs are actually derived from the parent data gas.
+func CalcExcessDataGas(parentExcessDataGas *big.Int, blobs int) *big.Int {
+	excessDataGas := new(big.Int)
+	if parentExcessDataGas != nil {
+		excessDataGas.Set(parentExcessDataGas)
+	}
+	consumed := big.NewInt(params.BlobTxDataGasPerBlob)
+	consumed.Mul(consumed, big.NewInt(int64(blobs)))
+	excessDataGas.Add(excessDataGas, consumed)
+
+	targetGas := big.NewInt(params.BlobTxTargetDataGasPerBlock)
+	if excessDataGas.Cmp(targetGas) < 0 {
+		return new(big.Int)
+	}
+	return new(big.Int).Sub(excessDataGas, targetGas)
+}
+
 // CalcBlobFee calculates the blobfee from the header's excess data gas field.
+//
+// Note, the blob fee used to pay for blob transactions should be derived from
+// the parent block's excess data gas, since it is a post-execution field akin
+// to gas used.
 func CalcBlobFee(excessDataGas *big.Int) *big.Int {
 	// If this block does not yet have EIP-4844 enabled, return the starting fee
 	if excessDataGas == nil {

--- a/consensus/misc/eip4844.go
+++ b/consensus/misc/eip4844.go
@@ -73,9 +73,9 @@ func CalcExcessDataGas(parentExcessDataGas *big.Int, blobs int) *big.Int {
 
 	targetGas := big.NewInt(params.BlobTxTargetDataGasPerBlock)
 	if excessDataGas.Cmp(targetGas) < 0 {
-		return new(big.Int)
+		return excessDataGas.SetUint64(0)
 	}
-	return new(big.Int).Sub(excessDataGas, targetGas)
+	return excessDataGas.Sub(excessDataGas, targetGas)
 }
 
 // CalcBlobFee calculates the blobfee from the header's excess data gas field.

--- a/core/block_validator.go
+++ b/core/block_validator.go
@@ -95,7 +95,7 @@ func (v *BlockValidator) ValidateBody(parent *types.Header, block *types.Block) 
 			blobs += len(tx.BlobHashes())
 		}
 		if blobs > params.BlobTxMaxDataGasPerBlock/params.BlobTxDataGasPerBlob {
-			fmt.Errorf("exceeded block capacity (permitted %d, included %d)", params.BlobTxMaxDataGasPerBlock/params.BlobTxDataGasPerBlob, blobs)
+			return fmt.Errorf("exceeded block capacity (permitted %d, included %d)", params.BlobTxMaxDataGasPerBlock/params.BlobTxDataGasPerBlob, blobs)
 		}
 		if parent == nil {
 			if parent = v.bc.GetHeader(block.ParentHash(), block.NumberU64()-1); parent == nil {

--- a/core/blockchain_insert.go
+++ b/core/blockchain_insert.go
@@ -121,7 +121,11 @@ func (it *insertIterator) next() (*types.Block, error) {
 		return it.chain[it.index], it.errors[it.index]
 	}
 	// Block header valid, run body validation and return
-	return it.chain[it.index], it.validator.ValidateBody(it.chain[it.index])
+	var parent *types.Header
+	if it.index > 0 {
+		parent = it.chain[it.index-1].Header()
+	}
+	return it.chain[it.index], it.validator.ValidateBody(parent, it.chain[it.index])
 }
 
 // peek returns the next block in the iterator, along with any potential validation

--- a/core/blockchain_test.go
+++ b/core/blockchain_test.go
@@ -150,7 +150,7 @@ func testBlockChainImport(chain types.Blocks, blockchain *BlockChain) error {
 		// Try and process the block
 		err := blockchain.engine.VerifyHeader(blockchain, block.Header())
 		if err == nil {
-			err = blockchain.validator.ValidateBody(block)
+			err = blockchain.validator.ValidateBody(nil, block)
 		}
 		if err != nil {
 			if err == ErrKnownBlock {

--- a/core/types.go
+++ b/core/types.go
@@ -28,8 +28,9 @@ import (
 // is only responsible for validating block contents, as the header validation is
 // done by the specific consensus engines.
 type Validator interface {
-	// ValidateBody validates the given block's content.
-	ValidateBody(block *types.Block) error
+	// ValidateBody validates the given block's content. If the parent is nil,
+	// but it is required, the validator should look it up on chain.
+	ValidateBody(parent *types.Header, block *types.Block) error
 
 	// ValidateState validates the given statedb and optionally the receipts and
 	// gas used.

--- a/core/types/block.go
+++ b/core/types/block.go
@@ -152,10 +152,10 @@ func (h *Header) SanityCheck() error {
 // EmptyBody returns true if there is no additional 'body' to complete the header
 // that is: no transactions, no uncles and no withdrawals.
 func (h *Header) EmptyBody() bool {
-	if h.WithdrawalsHash == nil {
-		return h.TxHash == EmptyTxsHash && h.UncleHash == EmptyUncleHash
+	if h.WithdrawalsHash != nil {
+		return h.TxHash == EmptyTxsHash && *h.WithdrawalsHash == EmptyWithdrawalsHash
 	}
-	return h.TxHash == EmptyTxsHash && h.UncleHash == EmptyUncleHash && *h.WithdrawalsHash == EmptyWithdrawalsHash
+	return h.TxHash == EmptyTxsHash && h.UncleHash == EmptyUncleHash
 }
 
 // EmptyReceipts returns true if there are no receipts for this header/block.
@@ -351,6 +351,13 @@ func (b *Block) BaseFee() *big.Int {
 
 func (b *Block) Withdrawals() Withdrawals {
 	return b.withdrawals
+}
+
+func (b *Block) ExcessDataGas() *big.Int {
+	if b.header.ExcessDataGas == nil {
+		return nil
+	}
+	return new(big.Int).Set(b.header.ExcessDataGas)
 }
 
 func (b *Block) Header() *Header { return CopyHeader(b.header) }

--- a/eth/downloader/downloader_test.go
+++ b/eth/downloader/downloader_test.go
@@ -787,10 +787,10 @@ func testEmptyShortCircuit(t *testing.T, protocol uint, mode SyncMode) {
 
 	// Instrument the downloader to signal body requests
 	var bodiesHave, receiptsHave atomic.Int32
-	tester.downloader.bodyFetchHook = func(headers []*types.Header) {
+	tester.downloader.bodyFetchHook = func(headers []*fetchTask) {
 		bodiesHave.Add(int32(len(headers)))
 	}
-	tester.downloader.receiptFetchHook = func(headers []*types.Header) {
+	tester.downloader.receiptFetchHook = func(headers []*fetchTask) {
 		receiptsHave.Add(int32(len(headers)))
 	}
 	// Synchronise with the peer and make sure all blocks were retrieved

--- a/eth/downloader/fetchers_concurrent_bodies.go
+++ b/eth/downloader/fetchers_concurrent_bodies.go
@@ -74,14 +74,13 @@ func (q *bodyQueue) unreserve(peer string) int {
 // request is responsible for converting a generic fetch request into a body
 // one and sending it to the remote peer for fulfillment.
 func (q *bodyQueue) request(peer *peerConnection, req *fetchRequest, resCh chan *eth.Response) (*eth.Request, error) {
-	peer.log.Trace("Requesting new batch of bodies", "count", len(req.Headers), "from", req.Headers[0].Number)
+	peer.log.Trace("Requesting new batch of bodies", "count", len(req.Tasks), "from", req.Tasks[0].header.Number)
 	if q.bodyFetchHook != nil {
-		q.bodyFetchHook(req.Headers)
+		q.bodyFetchHook(req.Tasks)
 	}
-
-	hashes := make([]common.Hash, 0, len(req.Headers))
-	for _, header := range req.Headers {
-		hashes = append(hashes, header.Hash())
+	hashes := make([]common.Hash, 0, len(req.Tasks))
+	for _, task := range req.Tasks {
+		hashes = append(hashes, task.header.Hash())
 	}
 	return peer.peer.RequestBodies(hashes, resCh)
 }

--- a/eth/downloader/fetchers_concurrent_receipts.go
+++ b/eth/downloader/fetchers_concurrent_receipts.go
@@ -74,13 +74,13 @@ func (q *receiptQueue) unreserve(peer string) int {
 // request is responsible for converting a generic fetch request into a receipt
 // one and sending it to the remote peer for fulfillment.
 func (q *receiptQueue) request(peer *peerConnection, req *fetchRequest, resCh chan *eth.Response) (*eth.Request, error) {
-	peer.log.Trace("Requesting new batch of receipts", "count", len(req.Headers), "from", req.Headers[0].Number)
+	peer.log.Trace("Requesting new batch of receipts", "count", len(req.Tasks), "from", req.Tasks[0].header.Number)
 	if q.receiptFetchHook != nil {
-		q.receiptFetchHook(req.Headers)
+		q.receiptFetchHook(req.Tasks)
 	}
-	hashes := make([]common.Hash, 0, len(req.Headers))
-	for _, header := range req.Headers {
-		hashes = append(hashes, header.Hash())
+	hashes := make([]common.Hash, 0, len(req.Tasks))
+	for _, task := range req.Tasks {
+		hashes = append(hashes, task.header.Hash())
 	}
 	return peer.peer.RequestReceipts(hashes, resCh)
 }

--- a/eth/downloader/queue.go
+++ b/eth/downloader/queue.go
@@ -309,7 +309,7 @@ func (q *queue) Schedule(parent *types.Header, headers []*types.Header, hashes [
 		// Make sure chain order is honoured and preserved throughout
 		hash := hashes[i]
 		if header.Number == nil || header.Number.Uint64() != parent.Number.Uint64()+1 {
-			log.Warn("Header broke chain ordering", "number", header.Number, "hash", hash, "expected", parent.Number)
+			log.Warn("Header broke chain ordering", "number", header.Number, "hash", hash, "expected", parent.Number.Uint64()+1)
 			break
 		}
 		if q.headerHead != (common.Hash{}) && q.headerHead != header.ParentHash {

--- a/eth/downloader/resultstore.go
+++ b/eth/downloader/resultstore.go
@@ -20,8 +20,6 @@ import (
 	"fmt"
 	"sync"
 	"sync/atomic"
-
-	"github.com/ethereum/go-ethereum/core/types"
 )
 
 // resultStore implements a structure for maintaining fetchResults, tracking their
@@ -76,17 +74,17 @@ func (r *resultStore) SetThrottleThreshold(threshold uint64) uint64 {
 //	throttled - if true, the store is at capacity, this particular header is not prio now
 //	item      - the result to store data into
 //	err       - any error that occurred
-func (r *resultStore) AddFetch(header *types.Header, fastSync bool) (stale, throttled bool, item *fetchResult, err error) {
+func (r *resultStore) AddFetch(task *fetchTask, fastSync bool) (stale, throttled bool, item *fetchResult, err error) {
 	r.lock.Lock()
 	defer r.lock.Unlock()
 
 	var index int
-	item, index, stale, throttled, err = r.getFetchResult(header.Number.Uint64())
+	item, index, stale, throttled, err = r.getFetchResult(task.header.Number.Uint64())
 	if err != nil || stale || throttled {
 		return stale, throttled, item, err
 	}
 	if item == nil {
-		item = newFetchResult(header, fastSync)
+		item = newFetchResult(task.header, fastSync)
 		r.items[index] = item
 	}
 	return stale, throttled, item, err

--- a/params/protocol_params.go
+++ b/params/protocol_params.go
@@ -160,6 +160,8 @@ const (
 	RefundQuotient        uint64 = 2
 	RefundQuotientEIP3529 uint64 = 5
 
+	BlobTxMaxDataGasPerBlock         = 1 << 19 // Maximum consumable data gas for data blobs per block
+	BlobTxTargetDataGasPerBlock      = 1 << 18 // Target consumable data gas for data blobs per block (for 1559-like pricing)
 	BlobTxDataGasPerBlob             = 1 << 17 // Gas consumption of a single data blob (== blob byte size)
 	BlobTxMinDataGasprice            = 1       // Minimum gas price for data blobs
 	BlobTxDataGaspriceUpdateFraction = 2225652 // Controls the maximum rate of change for data gas price


### PR DESCRIPTION
This PR implements validating the excessDataGas field of Cancun headers.

The validations are significantly more complex than previous header validations because the excessDataGas field combines two notions into one: the price for data blobs and the gas used by data blobs. To validate the combo field, we need access to both the parent's excessDataGas as well as the current block's transaction list (blob count). This makes validation more convoluted in both the chain's block processor as well as the downloader, which both needs to juggle two entities (parent header, current block) from now on.