### PR TITLE
internal/ethapi: remove header.Size in rpc getHeaderByXXX

### DIFF
--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -1237,7 +1237,6 @@ func RPCMarshalHeader(head *types.Header) map[string]interface{} {
 		"miner":            head.Coinbase,
 		"difficulty":       (*hexutil.Big)(head.Difficulty),
 		"extraData":        hexutil.Bytes(head.Extra),
-		"size":             hexutil.Uint64(head.Size()),
 		"gasLimit":         hexutil.Uint64(head.GasLimit),
 		"gasUsed":          hexutil.Uint64(head.GasUsed),
 		"timestamp":        hexutil.Uint64(head.Time),


### PR DESCRIPTION
As discussed with @rjl493456442 and also in https://github.com/ethereum/go-ethereum/pull/27325#issuecomment-1560779871. Currently, the PRC of `eth_getHeaderByXXX`'s response will return the header's Size, which depends on the `struct Header`'s size:

https://github.com/ethereum/go-ethereum/blob/dc8d91a65c2ca1c08cb019a62d716116c165b68e/core/types/block.go#L116-L126

And this struct's size differs in the different distros(x32 VS x64), so I proposed to remove this field for:

1. `getHeaderByXXX` is Geth's own RPC, not in [standard ones](https://ethereum.org/en/developers/docs/apis/json-rpc/);
2. We have [block's size](https://github.com/ethereum/go-ethereum/blob/dc8d91a65c2ca1c08cb019a62d716116c165b68e/core/types/block.go#L363)(Guaranteed by consensus), someone may be confused about those two.
