### PR TITLE
ethdb/pebble: fix NewBatchWithSize to set db

### DIFF
--- a/ethdb/pebble/pebble.go
+++ b/ethdb/pebble/pebble.go
@@ -307,7 +307,8 @@ func (d *Database) NewBatch() ethdb.Batch {
 // batch object without any pre-allocated space.
 func (d *Database) NewBatchWithSize(_ int) ethdb.Batch {
 	return &batch{
-		b: d.db.NewBatch(),
+		b:  d.db.NewBatch(),
+		db: d,
 	}
 }
 


### PR DESCRIPTION
Fixes a flaw in one pebble batch constructor .

Credit to @ty-sentio-xyz via https://github.com/ethereum/go-ethereum/commit/99394adcb8e5d2708e773b838dc92b4a0896ed2d#commitcomment-114912702 !