### PR TITLE
internal/ethapi: pass the state and header into the OnCall function

### DIFF
--- a/graphql/graphql.go
+++ b/graphql/graphql.go
@@ -1068,7 +1068,14 @@ func (c *CallResult) Status() hexutil.Uint64 {
 func (b *Block) Call(ctx context.Context, args struct {
 	Data ethapi.TransactionArgs
 }) (*CallResult, error) {
-	result, err := ethapi.DoCall(ctx, b.r.backend, args.Data, *b.numberOrHash, nil, nil, b.r.backend.RPCEVMTimeout(), b.r.backend.RPCGasCap())
+	if b.numberOrHash == nil {
+		return nil, errors.New("block number or block hash not found")
+	}
+	state, header, err := b.r.backend.StateAndHeaderByNumberOrHash(ctx, *b.numberOrHash)
+	if err != nil {
+		return nil, err
+	}
+	result, err := ethapi.DoCall(ctx, b.r.backend, args.Data, state, header, nil, nil, b.r.backend.RPCEVMTimeout(), b.r.backend.RPCGasCap())
 	if err != nil {
 		return nil, err
 	}
@@ -1131,7 +1138,11 @@ func (p *Pending) Call(ctx context.Context, args struct {
 	Data ethapi.TransactionArgs
 }) (*CallResult, error) {
 	pendingBlockNr := rpc.BlockNumberOrHashWithNumber(rpc.PendingBlockNumber)
-	result, err := ethapi.DoCall(ctx, p.r.backend, args.Data, pendingBlockNr, nil, nil, p.r.backend.RPCEVMTimeout(), p.r.backend.RPCGasCap())
+	state, header, err := p.r.backend.StateAndHeaderByNumberOrHash(ctx, pendingBlockNr)
+	if err != nil {
+		return nil, err
+	}
+	result, err := ethapi.DoCall(ctx, p.r.backend, args.Data, state, header, nil, nil, p.r.backend.RPCEVMTimeout(), p.r.backend.RPCGasCap())
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This PR:
- Refactor the code when we execute `DoCall` function on `internal/ethapi`. When the case: 
https://github.com/ethereum/go-ethereum/blob/1816cdc9fdad7af6085369efb9864d934aae2c81/internal/ethapi/api.go#L1133-L1137
And we will call the function named `StateAndHeaderByNumberOrHash` and `DoEstimateGas` and call on `OnCall` again. It will be duplicated to get the state and header by the block number or block hash:
https://github.com/ethereum/go-ethereum/blob/1816cdc9fdad7af6085369efb9864d934aae2c81/internal/ethapi/api.go#L994-L997

- Check some pointers can be `nil`