### PR TITLE
core/state: clear out cached state data when reset occurs

### DIFF
--- a/core/state/journal.go
+++ b/core/state/journal.go
@@ -93,6 +93,8 @@ type (
 		account      *common.Address
 		prev         *stateObject
 		prevdestruct bool
+		prevAccount  []byte
+		prevStorage  map[common.Hash][]byte
 	}
 	suicideChange struct {
 		account     *common.Address
@@ -159,6 +161,12 @@ func (ch resetObjectChange) revert(s *StateDB) {
 	s.setStateObject(ch.prev)
 	if !ch.prevdestruct {
 		delete(s.stateObjectsDestruct, ch.prev.address)
+	}
+	if len(ch.prevAccount) > 0 {
+		s.snapAccounts[ch.prev.addrHash] = ch.prevAccount
+	}
+	if len(ch.prevStorage) > 0 {
+		s.snapStorage[ch.prev.addrHash] = ch.prevStorage
 	}
 }
 

--- a/core/state/journal.go
+++ b/core/state/journal.go
@@ -162,10 +162,10 @@ func (ch resetObjectChange) revert(s *StateDB) {
 	if !ch.prevdestruct {
 		delete(s.stateObjectsDestruct, ch.prev.address)
 	}
-	if len(ch.prevAccount) > 0 {
+	if ch.prevAccount != nil {
 		s.snapAccounts[ch.prev.addrHash] = ch.prevAccount
 	}
-	if len(ch.prevStorage) > 0 {
+	if ch.prevStorage != nil {
 		s.snapStorage[ch.prev.addrHash] = ch.prevStorage
 	}
 }

--- a/core/state/statedb.go
+++ b/core/state/statedb.go
@@ -627,11 +627,36 @@ func (s *StateDB) createObject(addr common.Address) (newobj, prev *stateObject) 
 	if prev == nil {
 		s.journal.append(createObjectChange{account: &addr})
 	} else {
+		// The original account should be marked as destructed and all cached
+		// account and storage data should be cleared as well. Note, it must
+		// be done here, otherwise the destruction event of original one will
+		// be lost.
 		_, prevdestruct := s.stateObjectsDestruct[prev.address]
 		if !prevdestruct {
 			s.stateObjectsDestruct[prev.address] = struct{}{}
 		}
-		s.journal.append(resetObjectChange{account: &addr, prev: prev, prevdestruct: prevdestruct})
+		var (
+			account []byte
+			storage map[common.Hash][]byte
+		)
+		// There may be some cached account/storage data already since IntermediateRoot
+		// will be called for each transaction before byzantium fork which will always
+		// cache the latest account/storage data.
+		if s.snapAccounts != nil {
+			account = s.snapAccounts[prev.addrHash]
+			delete(s.snapAccounts, prev.addrHash)
+		}
+		if s.snapStorage != nil {
+			storage = s.snapStorage[prev.addrHash]
+			delete(s.snapStorage, prev.addrHash)
+		}
+		s.journal.append(resetObjectChange{
+			account:      &addr,
+			prev:         prev,
+			prevdestruct: prevdestruct,
+			prevAccount:  account,
+			prevStorage:  storage,
+		})
 	}
 	s.setStateObject(newobj)
 	if prev != nil && !prev.deleted {

--- a/core/state/statedb.go
+++ b/core/state/statedb.go
@@ -642,12 +642,10 @@ func (s *StateDB) createObject(addr common.Address) (newobj, prev *stateObject) 
 		// There may be some cached account/storage data already since IntermediateRoot
 		// will be called for each transaction before byzantium fork which will always
 		// cache the latest account/storage data.
-		if s.snapAccounts != nil {
+		if s.snap != nil {
 			account = s.snapAccounts[prev.addrHash]
-			delete(s.snapAccounts, prev.addrHash)
-		}
-		if s.snapStorage != nil {
 			storage = s.snapStorage[prev.addrHash]
+			delete(s.snapAccounts, prev.addrHash)
 			delete(s.snapStorage, prev.addrHash)
 		}
 		s.journal.append(resetObjectChange{


### PR DESCRIPTION
It's a following PR based on https://github.com/ethereum/go-ethereum/pull/27339

Before byzantium fork, state root will be computed for each transaction. Specifically,
`IntermediateRoot` will be called at the end of transaction processing. Inside of it,
account/storage data will be cached if snapshot is available.

However, whenever account reset occurs, these cached state data should be cleared
out, otherwise we have no way to distinguish whether these data belongs to the
original one or the new one.

This PR fixes it by handling destruction at `CreateAccount` function.