### PR TITLE
rpc: check Dial error

### DIFF
--- a/rpc/client_test.go
+++ b/rpc/client_test.go
@@ -523,7 +523,11 @@ func TestClientSubscriptionChannelClose(t *testing.T) {
 	defer httpsrv.Close()
 
 	srv.RegisterName("nftest", new(notificationTestService))
-	client, _ := Dial(wsURL)
+	client, err := Dial(wsURL)
+	if err != nil {
+		t.Fatal("failed to dial test server:", err)
+	}
+	defer client.Close()
 
 	for i := 0; i < 100; i++ {
 		ch := make(chan int, 100)


### PR DESCRIPTION
I've just noticed this Job failed of panic https://ci.appveyor.com/project/ethereum/go-ethereum/builds/47162044/job/v0frtfsm0yd5sml6#L890

```
--- FAIL: TestClientSubscriptionChannelClose (0.01s)
panic: runtime error: invalid memory address or nil pointer dereference [recovered]
	panic: runtime error: invalid memory address or nil pointer dereference
[signal 0xc0000005 code=0x0 addr=0x4 pc=0x6b041f]
goroutine 320 [running]:
testing.tRunner.func1.2({0x72b820, 0xac11a0})
	C:/Users/appveyor/AppData/Local/geth-go-1.20.3-windows-amd64/go/src/testing/testing.go:1526 +0x2ab
testing.tRunner.func1()
	C:/Users/appveyor/AppData/Local/geth-go-1.20.3-windows-amd64/go/src/testing/testing.go:1529 +0x44c
panic({0x72b820, 0xac11a0})
	C:/Users/appveyor/AppData/Local/geth-go-1.20.3-windows-amd64/go/src/runtime/panic.go:884 +0x1b7
github.com/ethereum/go-ethereum/rpc.(*Client).Subscribe(0x0, {0x824c34, 0x9c880b0}, {0x77a99f, 0x6}, {0x704840, 0x9d08000}, {0x9d0af30, 0x3, 0x3})
	C:/projects/go-ethereum/rpc/client.go:473 +0x17f
github.com/ethereum/go-ethereum/rpc.TestClientSubscriptionChannelClose(0x9c84ff0)
	C:/projects/go-ethereum/rpc/client_test.go:530 +0x2fb
testing.tRunner(0x9c84ff0, 0x7a4020)
	C:/Users/appveyor/AppData/Local/geth-go-1.20.3-windows-amd64/go/src/testing/testing.go:1576 +0x113
created by testing.(*T).Run
	C:/Users/appveyor/AppData/Local/geth-go-1.20.3-windows-amd64/go/src/testing/testing.go:1629 +0x427
FAIL	github.com/ethereum/go-ethereum/rpc	11.225s
```

I'm not sure why the connection is failed, but let's make sure we check the error before use