### PR TITLE
core, eth/downloader, params: validate blob tx bodies

### DIFF
--- a/params/protocol_params.go
+++ b/params/protocol_params.go
@@ -160,6 +160,7 @@ const (
 	RefundQuotient        uint64 = 2
 	RefundQuotientEIP3529 uint64 = 5
 
+	BlobTxHashVersion                = 0x01    // Version byte of the commitment hash
 	BlobTxMaxDataGasPerBlock         = 1 << 19 // Maximum consumable data gas for data blobs per block
 	BlobTxTargetDataGasPerBlock      = 1 << 18 // Target consumable data gas for data blobs per block (for 1559-like pricing)
 	BlobTxDataGasPerBlob             = 1 << 17 // Gas consumption of a single data blob (== blob byte size)


### PR DESCRIPTION
This PR adds the blob hash validations for the blob transactions. An open question however is whether setting to `to` field to `nil` should be rejected (as in the spec and PR currently), or whether the data type itself should be changed to never be able to be `nil`. I vote for the latter, but that needs a spec change.