### PR TITLE
core, eth/downloader: validate blobtx.To at serialization time

### DIFF
--- a/core/block_validator.go
+++ b/core/block_validator.go
@@ -89,9 +89,6 @@ func (v *BlockValidator) ValidateBody(block *types.Block) error {
 
 		// Validate the data blobs individually too
 		if tx.Type() == types.BlobTxType {
-			if tx.To() == nil {
-				return errors.New("contract creation attempt by blob transaction") // TODO(karalabe): Why not make the field non-nil-able
-			}
 			if len(tx.BlobHashes()) == 0 {
 				return errors.New("no-blob blob transaction present in block body")
 			}

--- a/core/types/receipt_test.go
+++ b/core/types/receipt_test.go
@@ -130,7 +130,7 @@ var (
 		}),
 		// EIP-4844 transactions.
 		NewTx(&BlobTx{
-			To:         &to6,
+			To:         to6,
 			Nonce:      6,
 			Value:      uint256.NewInt(6),
 			Gas:        6,
@@ -139,7 +139,7 @@ var (
 			BlobFeeCap: uint256.NewInt(100066),
 		}),
 		NewTx(&BlobTx{
-			To:         &to7,
+			To:         to7,
 			Nonce:      7,
 			Value:      uint256.NewInt(7),
 			Gas:        7,

--- a/core/types/transaction_marshalling.go
+++ b/core/types/transaction_marshalling.go
@@ -290,9 +290,10 @@ func (tx *Transaction) UnmarshalJSON(input []byte) error {
 			return errors.New("missing required field 'nonce' in transaction")
 		}
 		itx.Nonce = uint64(*dec.Nonce)
-		if dec.To != nil {
-			itx.To = dec.To
+		if dec.To == nil {
+			return errors.New("missing required field 'to' in transaction")
 		}
+		itx.To = *dec.To
 		if dec.Gas == nil {
 			return errors.New("missing required field 'gas' for txdata")
 		}

--- a/core/types/tx_blob.go
+++ b/core/types/tx_blob.go
@@ -31,7 +31,7 @@ type BlobTx struct {
 	GasTipCap  *uint256.Int // a.k.a. maxPriorityFeePerGas
 	GasFeeCap  *uint256.Int // a.k.a. maxFeePerGas
 	Gas        uint64
-	To         *common.Address `rlp:"nil"` // nil means contract creation
+	To         common.Address
 	Value      *uint256.Int
 	Data       []byte
 	AccessList AccessList
@@ -48,7 +48,7 @@ type BlobTx struct {
 func (tx *BlobTx) copy() TxData {
 	cpy := &BlobTx{
 		Nonce: tx.Nonce,
-		To:    copyAddressPtr(tx.To),
+		To:    tx.To,
 		Data:  common.CopyBytes(tx.Data),
 		Gas:   tx.Gas,
 		// These are copied below.
@@ -104,7 +104,7 @@ func (tx *BlobTx) gasTipCap() *big.Int       { return tx.GasTipCap.ToBig() }
 func (tx *BlobTx) gasPrice() *big.Int        { return tx.GasFeeCap.ToBig() }
 func (tx *BlobTx) value() *big.Int           { return tx.Value.ToBig() }
 func (tx *BlobTx) nonce() uint64             { return tx.Nonce }
-func (tx *BlobTx) to() *common.Address       { return tx.To }
+func (tx *BlobTx) to() *common.Address       { tmp := tx.To; return &tmp }
 func (tx *BlobTx) blobGas() uint64           { return params.BlobTxDataGasPerBlob * uint64(len(tx.BlobHashes)) }
 func (tx *BlobTx) blobGasFeeCap() *big.Int   { return tx.BlobFeeCap.ToBig() }
 func (tx *BlobTx) blobHashes() []common.Hash { return tx.BlobHashes }

--- a/eth/downloader/queue.go
+++ b/eth/downloader/queue.go
@@ -806,9 +806,6 @@ func (q *queue) DeliverBodies(id string, txLists [][]*types.Transaction, txListH
 
 			// Validate the data blobs individually too
 			if tx.Type() == types.BlobTxType {
-				if tx.To() == nil {
-					return errInvalidBody // TODO(karalabe): Why not make the field non-nil-able
-				}
 				if len(tx.BlobHashes()) == 0 {
 					return errInvalidBody
 				}


### PR DESCRIPTION
The current 4844 spec states that the data format of blob txs allows the `To` field to be `null`, but such transactions are rejected as invalid during block processing. This is a weird take (probably an omission to be fixed) since this essentially means that the `To` fields *cannot* be `null`, but rejects the fact later in the processing pipeline.

This PR changes the `To` field from `*common.Address` to `common.Address`. This will ensure that `nil` will never enter Geth inside a blob transaction. Interestingly, this PR can be merged even now without a spec change, since both versions of this (reject at parse time vs reject at interpretation time) have the same effect.

Still, would be nice to confirm in the spec that nilness should be forbidden altogether.