### PR TITLE
p2p: exclude NAT and Logger from toml

### DIFF
--- a/p2p/server.go
+++ b/p2p/server.go
@@ -142,7 +142,7 @@ type Config struct {
 	// If set to a non-nil value, the given NAT port mapper
 	// is used to make the listening port available to the
 	// Internet.
-	NAT nat.Interface `toml:",omitempty"`
+	NAT nat.Interface `toml:"-"`
 
 	// If Dialer is set to a non-nil value, the given Dialer
 	// is used to dial outbound peer connections.
@@ -156,7 +156,7 @@ type Config struct {
 	EnableMsgEvents bool
 
 	// Logger is a custom logger to use with the p2p.Server.
-	Logger log.Logger `toml:",omitempty"`
+	Logger log.Logger `toml:"-"`
 
 	clock mclock.Clock
 }


### PR DESCRIPTION
This PR excludes the fields Logger and NAT from toml, thereby fixing https://github.com/ethereum/go-ethereum/issues/27394  .

The issue is fixed by not putting the field in the toml, it could be fixed instead by putting an expression into the toml, which we then re-parse into an actual nat interface. That change would be a bit more complicated. 

In general, I think toml files should be reusable, and the specific external ip used for natting feels like a very instance-specific thing, that one might not want/need in a toml file. 