### PR TITLE
cmd/evm: make evm blocktest output logs if so instructed

### DIFF
--- a/cmd/evm/blockrunner.go
+++ b/cmd/evm/blockrunner.go
@@ -22,6 +22,8 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/ethereum/go-ethereum/core/vm"
+	"github.com/ethereum/go-ethereum/eth/tracers/logger"
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/tests"
 	"github.com/urfave/cli/v2"
@@ -42,7 +44,16 @@ func blockTestCmd(ctx *cli.Context) error {
 	glogger := log.NewGlogHandler(log.StreamHandler(os.Stderr, log.TerminalFormat(false)))
 	glogger.Verbosity(log.Lvl(ctx.Int(VerbosityFlag.Name)))
 	log.Root().SetHandler(glogger)
-
+	var tracer vm.EVMLogger
+	// Configure the EVM logger
+	if ctx.Bool(MachineFlag.Name) {
+		tracer = logger.NewJSONLogger(&logger.Config{
+			EnableMemory:     !ctx.Bool(DisableMemoryFlag.Name),
+			DisableStack:     ctx.Bool(DisableStackFlag.Name),
+			DisableStorage:   ctx.Bool(DisableStorageFlag.Name),
+			EnableReturnData: !ctx.Bool(DisableReturnDataFlag.Name),
+		}, os.Stderr)
+	}
 	// Load the test content from the input file
 	src, err := os.ReadFile(ctx.Args().First())
 	if err != nil {
@@ -53,7 +64,7 @@ func blockTestCmd(ctx *cli.Context) error {
 		return err
 	}
 	for i, test := range tests {
-		if err := test.Run(false); err != nil {
+		if err := test.Run(false, tracer); err != nil {
 			return fmt.Errorf("test %v: %w", i, err)
 		}
 	}

--- a/tests/block_test.go
+++ b/tests/block_test.go
@@ -48,10 +48,10 @@ func TestBlockchain(t *testing.T) {
 	bt.skipLoad(`.*randomStatetest94.json.*`)
 
 	bt.walk(t, blockTestDir, func(t *testing.T, name string, test *BlockTest) {
-		if err := bt.checkFailure(t, test.Run(false), nil); err != nil {
+		if err := bt.checkFailure(t, test.Run(false, nil)); err != nil {
 			t.Errorf("test without snapshotter failed: %v", err)
 		}
-		if err := bt.checkFailure(t, test.Run(true), nil); err != nil {
+		if err := bt.checkFailure(t, test.Run(true, nil)); err != nil {
 			t.Errorf("test with snapshotter failed: %v", err)
 		}
 	})

--- a/tests/block_test.go
+++ b/tests/block_test.go
@@ -48,10 +48,10 @@ func TestBlockchain(t *testing.T) {
 	bt.skipLoad(`.*randomStatetest94.json.*`)
 
 	bt.walk(t, blockTestDir, func(t *testing.T, name string, test *BlockTest) {
-		if err := bt.checkFailure(t, test.Run(false)); err != nil {
+		if err := bt.checkFailure(t, test.Run(false), nil); err != nil {
 			t.Errorf("test without snapshotter failed: %v", err)
 		}
-		if err := bt.checkFailure(t, test.Run(true)); err != nil {
+		if err := bt.checkFailure(t, test.Run(true), nil); err != nil {
 			t.Errorf("test with snapshotter failed: %v", err)
 		}
 	})

--- a/tests/block_test_util.go
+++ b/tests/block_test_util.go
@@ -100,7 +100,7 @@ type btHeaderMarshaling struct {
 	BaseFeePerGas *math.HexOrDecimal256
 }
 
-func (t *BlockTest) Run(snapshotter bool) error {
+func (t *BlockTest) Run(snapshotter bool, tracer vm.EVMLogger) error {
 	config, ok := Forks[t.json.Network]
 	if !ok {
 		return UnsupportedForkError{t.json.Network}
@@ -124,7 +124,9 @@ func (t *BlockTest) Run(snapshotter bool) error {
 		cache.SnapshotLimit = 1
 		cache.SnapshotWait = true
 	}
-	chain, err := core.NewBlockChain(db, cache, gspec, nil, engine, vm.Config{}, nil, nil)
+	chain, err := core.NewBlockChain(db, cache, gspec, nil, engine, vm.Config{
+		Tracer: tracer,
+	}, nil, nil)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
This PR fixes https://github.com/ethereum/go-ethereum/issues/27363, and spits out logs while the evm is executing