### PR TITLE
eth/downloader: drop beacon head updates if the syncer is restarting

### DIFF
--- a/eth/downloader/skeleton.go
+++ b/eth/downloader/skeleton.go
@@ -210,7 +210,6 @@ type skeleton struct {
 	requests map[uint64]*headerRequest // Header requests currently running
 
 	headEvents chan *headUpdate // Notification channel for new heads
-	restarting chan struct{}    // Channel to signal that the syncer is offline
 	terminate  chan chan error  // Termination channel to abort sync
 	terminated chan struct{}    // Channel to signal that the syncer is dead
 
@@ -228,7 +227,6 @@ func newSkeleton(db ethdb.Database, peers *peerSet, drop peerDropFn, filler back
 		drop:       drop,
 		requests:   make(map[uint64]*headerRequest),
 		headEvents: make(chan *headUpdate),
-		restarting: make(chan struct{}, 1),
 		terminate:  make(chan chan error),
 		terminated: make(chan struct{}),
 	}
@@ -265,7 +263,6 @@ func (s *skeleton) startup() {
 			event.errc <- nil // forced head accepted for startup
 			head := event.header
 			s.started = time.Now()
-			s.restarting <- struct{}{} // start the restart notifier
 
 			for {
 				// If the sync cycle terminated or was terminated, propagate up when
@@ -331,22 +328,8 @@ func (s *skeleton) Sync(head *types.Header, final *types.Header, force bool) err
 	errc := make(chan error)
 
 	select {
-	// If the head is consumed, wait for the processing result and return it
 	case s.headEvents <- &headUpdate{header: head, final: final, force: force, errc: errc}:
 		return <-errc
-
-	// If the skeleton syncer is restarting, it may finish fast, ot it may take
-	// a very long time if it needs to tear down an active full sync loop with
-	// thousands of blocks pending import.
-	case <-s.restarting:
-		// Place the restart marker back into the notifier. This could be a bit
-		// less convoluted with an atomic flag, but the select requires relying
-		// on channels.
-		s.restarting <- struct{}{}
-
-		// Return an error so the caller is aware that we're ignored their update
-		return errors.New("header syncer busy")
-
 	case <-s.terminated:
 		return errTerminated
 	}
@@ -384,22 +367,33 @@ func (s *skeleton) sync(head *types.Header) (*types.Header, error) {
 		s.filler.resume()
 	}
 	defer func() {
-		if filled := s.filler.suspend(); filled != nil {
-			// If something was filled, try to delete stale sync helpers. If
-			// unsuccessful, warn the user, but not much else we can do (it's
-			// a programming error, just let users report an issue and don't
-			// choke in the meantime).
-			if err := s.cleanStales(filled); err != nil {
-				log.Error("Failed to clean stale beacon headers", "err", err)
+		// The filler needs to be suspended, but since it can block for a while
+		// when there are many blocks queued up for full-sync importing, run it
+		// on a separate goroutine and consume head messages that need instant
+		// replies.
+		done := make(chan struct{})
+		go func() {
+			defer close(done)
+			if filled := s.filler.suspend(); filled != nil {
+				// If something was filled, try to delete stale sync helpers. If
+				// unsuccessful, warn the user, but not much else we can do (it's
+				// a programming error, just let users report an issue and don't
+				// choke in the meantime).
+				if err := s.cleanStales(filled); err != nil {
+					log.Error("Failed to clean stale beacon headers", "err", err)
+				}
+			}
+		}()
+		// Wait for the suspend to finish, consuming head events in the meantime
+		// and dropping them on the floor.
+		for {
+			select {
+			case <-done:
+				return
+			case event := <-s.headEvents:
+				event.errc <- errors.New("beacon syncer reorging")
 			}
 		}
-	}()
-	// The syncer needs to consume head events non-stop. If it is restarting due
-	// to a reorg and stuck on importing long downloaded chain segments, signal
-	// the head notifiers to not wait pointlessly.
-	<-s.restarting
-	defer func() {
-		s.restarting <- struct{}{}
 	}()
 	// Create a set of unique channels for this sync cycle. We need these to be
 	// ephemeral so a data race doesn't accidentally deliver something stale on


### PR DESCRIPTION
Fixes https://github.com/ethereum/go-ethereum/issues/27386.

When a reorg happens, the beacon/skeleton syncer needs to stop, swap out it's internal state to the new head and restart. If the downloader is busy importing blocks in the mean time, it will prevent the beacon syncer from completing it's restart loop until all queued blocks are consumed.

During this "hang", any newly arriving newPayload or forckchoiceUpdate messages will get blocked as they cannot feed their respective new data to the beacon syncer. If the "hang" lasts 15 minutes, these update messages will keep piling and piling, consuming RAM and goroutines.

The PR "fixes" this issue by dropping update messages on the floor while in this limbo state. This should unblock engine API events and prevent bloat.

That said, it does introduce a wonky behavior: if a newPayload arrives back to back after a fockchoiceUpdate that triggered a reorg, that newPayload might get ignored. This isn't a big of a deal for a syncing node, but if the node is already in sync, it will "miss" a block and will need to wait for the next one to come back into sync. If the entire network does this however, will it ever come back into sync? Not clear, seems a bit unsafe.

![Screenshot 2023-06-05 at 09 54 39](https://github.com/ethereum/go-ethereum/assets/129561/218faf05-0650-415a-a857-6e15226a1971)