### PR TITLE
core/txpool: fix isGapped implementation

### DIFF
--- a/core/txpool/txpool.go
+++ b/core/txpool/txpool.go
@@ -823,8 +823,10 @@ func (pool *TxPool) add(tx *types.Transaction, local bool) (replaced bool, err e
 
 // isGapped reports whether the given transaction is immediately executable.
 func (pool *TxPool) isGapped(from common.Address, tx *types.Transaction) bool {
-	// Short circuit if transaction matches pending nonce and can be promoted
-	// to pending list as an executable transaction.
+	// Short circuit if transaction falls within the scope of the pending list
+	// or matches the next pending nonce which can be promoted as an executable
+	// transaction afterwards. Note, the tx staleness is already checked in
+	// 'validateTx' function previously.
 	next := pool.pendingNonces.get(from)
 	if tx.Nonce() <= next {
 		return false

--- a/core/txpool/txpool.go
+++ b/core/txpool/txpool.go
@@ -826,7 +826,7 @@ func (pool *TxPool) isGapped(from common.Address, tx *types.Transaction) bool {
 	// Short circuit if transaction matches pending nonce and can be promoted
 	// to pending list as an executable transaction.
 	next := pool.pendingNonces.get(from)
-	if tx.Nonce() == next {
+	if tx.Nonce() <= next {
 		return false
 	}
 	// The transaction has a nonce gap with pending list, it's only considered


### PR DESCRIPTION
This fix a minor implementation issue with the newly introduced isGapped function
and it is described in this ticket: https://github.com/ethereum/go-ethereum/issues/27401