### PR TITLE
p2p: Make NAT-spec toml-friendly

### DIFF
--- a/cmd/faucet/faucet.go
+++ b/cmd/faucet/faucet.go
@@ -228,7 +228,7 @@ func newFaucet(genesis *core.Genesis, port int, enodes []*enode.Node, network ui
 		Version: params.VersionWithCommit(git.Commit, git.Date),
 		DataDir: filepath.Join(os.Getenv("HOME"), ".faucet"),
 		P2P: p2p.Config{
-			NAT:              nat.Any(),
+			NAT:              nat.MustFromSpec("any"),
 			NoDiscovery:      true,
 			DiscoveryV5:      true,
 			ListenAddr:       fmt.Sprintf(":%d", port),

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -1077,7 +1077,7 @@ func setListenAddress(ctx *cli.Context, cfg *p2p.Config) {
 // setNAT creates a port mapper from command line flags.
 func setNAT(ctx *cli.Context, cfg *p2p.Config) {
 	if ctx.IsSet(NATFlag.Name) {
-		natif, err := nat.Parse(ctx.String(NATFlag.Name))
+		natif, err := nat.NewFromSpec(ctx.String(NATFlag.Name))
 		if err != nil {
 			Fatalf("Option %s: %v", NATFlag.Name, err)
 		}

--- a/node/defaults.go
+++ b/node/defaults.go
@@ -60,7 +60,7 @@ var DefaultConfig = Config{
 	P2P: p2p.Config{
 		ListenAddr: ":30303",
 		MaxPeers:   50,
-		NAT:        nat.Any(),
+		NAT:        nat.MustFromSpec("any"),
 	},
 	DBEngine: "", // Use whatever exists, will default to Pebble if non-existent and supported
 }

--- a/p2p/nat/nat.go
+++ b/p2p/nat/nat.go
@@ -34,23 +34,36 @@ type Spec struct {
 	instance Interface
 }
 
+// NewFromSpec parses the spec and returns a Spec. If the string specification
+// is "none", then nil will be returned.
 func NewFromSpec(spec string) (*Spec, error) {
 	instance, err := Parse(spec)
 	if err != nil {
 		return nil, err
 	}
+	if instance == nil {
+		return nil, nil
+	}
 	return &Spec{spec, instance}, nil
 }
 
+// MustFromSpec parses the spec and returns a Spec. If the string specification
+// is "none", then nil will be returned.
 func MustFromSpec(spec string) *Spec {
 	instance, err := Parse(spec)
 	if err != nil {
 		panic(err)
 	}
+	if instance == nil {
+		return nil
+	}
 	return &Spec{spec, instance}
 }
 
 func (s *Spec) Implementation() Interface {
+	if s == nil {
+		return nil
+	}
 	return s.instance
 }
 

--- a/p2p/nat/nat.go
+++ b/p2p/nat/nat.go
@@ -29,6 +29,34 @@ import (
 	natpmp "github.com/jackpal/go-nat-pmp"
 )
 
+type Spec struct {
+	spec     string
+	instance Interface
+}
+
+func NewFromSpec(spec string) (*Spec, error) {
+	instance, err := Parse(spec)
+	if err != nil {
+		return nil, err
+	}
+	return &Spec{spec, instance}, nil
+}
+
+func MustFromSpec(spec string) *Spec {
+	instance, err := Parse(spec)
+	if err != nil {
+		panic(err)
+	}
+	return &Spec{spec, instance}
+}
+
+func (s *Spec) Implementation() Interface {
+	return s.instance
+}
+func (s *Spec) MarshalTOML() ([]byte, error) {
+	return []byte(fmt.Sprintf("%q", s.spec)), nil
+}
+
 // Interface An implementation of nat.Interface can map local ports to ports
 // accessible from the Internet.
 type Interface interface {

--- a/p2p/nat/nat.go
+++ b/p2p/nat/nat.go
@@ -53,8 +53,23 @@ func MustFromSpec(spec string) *Spec {
 func (s *Spec) Implementation() Interface {
 	return s.instance
 }
+
+// MarshalTOML implements toml.MarshalerRec.
 func (s *Spec) MarshalTOML() ([]byte, error) {
 	return []byte(fmt.Sprintf("%q", s.spec)), nil
+}
+
+// UnmarshalTOML implements toml.UnmarshalerRec.
+func (s *Spec) UnmarshalTOML(fn func(interface{}) error) error {
+	var spec string
+	fn(&spec)
+	instance, err := Parse(spec)
+	if err != nil {
+		return err
+	}
+	s.instance = instance
+	s.spec = spec
+	return nil
 }
 
 // Interface An implementation of nat.Interface can map local ports to ports

--- a/p2p/server.go
+++ b/p2p/server.go
@@ -142,7 +142,7 @@ type Config struct {
 	// If set to a non-nil value, the given NAT port mapper
 	// is used to make the listening port available to the
 	// Internet.
-	NAT nat.Interface `toml:",omitempty"`
+	NAT nat.Interface `toml:"-"`
 
 	// If Dialer is set to a non-nil value, the given Dialer
 	// is used to dial outbound peer connections.
@@ -156,7 +156,7 @@ type Config struct {
 	EnableMsgEvents bool
 
 	// Logger is a custom logger to use with the p2p.Server.
-	Logger log.Logger `toml:",omitempty"`
+	Logger log.Logger `toml:"-"`
 
 	clock mclock.Clock
 }


### PR DESCRIPTION
Spitting it out: 
```
[user@work go-ethereum]$ go run ./cmd/geth --nat extip:182.168.1.2 dumpconfig   | grep NAT
INFO [06-02|11:18:02.627] Maximum peer count                       ETH=50 LES=0 total=50
INFO [06-02|11:18:02.643] Set global gas cap                       cap=50,000,000
INFO [06-02|11:18:02.644] Initializing the KZG library             backend=gokzg
NAT = "extip:182.168.1.2"
[user@work go-ethereum]$ go run ./cmd/geth --nat nay dumpconfig   | grep NAT
Fatal: Option nat: unknown mechanism "nay"
exit status 1
[user@work go-ethereum]$ go run ./cmd/geth --nat any dumpconfig   | grep NAT
INFO [06-02|11:18:18.677] Maximum peer count                       ETH=50 LES=0 total=50
INFO [06-02|11:18:18.697] Set global gas cap                       cap=50,000,000
INFO [06-02|11:18:18.697] Initializing the KZG library             backend=gokzg
NAT = "any"
```

Souping it back up: 
```
[user@work go-ethereum]$ cat config.any 
[Node.P2P]
NAT = "any"
[user@work go-ethereum]$ go run ./cmd/geth --config config.any dumpconfig | grep NAT
INFO [06-02|11:27:23.141] Maximum peer count                       ETH=50 LES=0 total=50
INFO [06-02|11:27:23.150] Set global gas cap                       cap=50,000,000
INFO [06-02|11:27:23.150] Initializing the KZG library             backend=gokzg
NAT = "any"
[user@work go-ethereum]$ cat config.extip 
[Node.P2P]
NAT = "extip:182.168.1.2"
[user@work go-ethereum]$ go run ./cmd/geth --config config.extip dumpconfig | grep NAT
INFO [06-02|11:27:32.252] Maximum peer count                       ETH=50 LES=0 total=50
INFO [06-02|11:27:32.266] Set global gas cap                       cap=50,000,000
INFO [06-02|11:27:32.267] Initializing the KZG library             backend=gokzg
NAT = "extip:182.168.1.2"
[user@work go-ethereum]$ cat config.nay 
[Node.P2P]
NAT = "nay"
[user@work go-ethereum]$ go run ./cmd/geth --config config.nay dumpconfig
Fatal: config.nay, line 2: (p2p.Config.NAT) unknown mechanism "nay"
exit status 1
```
