### PR TITLE
Adjust RPCTxFeeCap

### DIFF
--- a/eth/ethconfig/config.go
+++ b/eth/ethconfig/config.go
@@ -75,7 +75,7 @@ var Defaults = Config{
 	RPCGasCap:               50000000,
 	RPCEVMTimeout:           5 * time.Second,
 	GPO:                     FullNodeGPO,
-	RPCTxFeeCap:             1, // 1 ether
+	RPCTxFeeCap:             10, // 10 ether
 }
 
 //go:generate go run github.com/fjl/gencodec -type Config -formats toml -out gen_config.go


### PR DESCRIPTION
RPCTxFeeCap is the default fee a deployment can have before the client throws a fit. This value was chosen fairly arbitrarily when it was first hardcoded, however I propose adjusting this value to 10 from 1, because it is easily conceivable that:

a) We find ourselves in an sustained environment where the _average_ fee is around 1000Gwei like has happened previously. The max intentional fee we have saw is around 10X this.
b) We want to deploy a large smart contract - 10,000,000 gas used
c) We have a corresponding total tx fee of 10^-9 ETH * 1000 * 10,000,000 = 10 ETH