### PR TITLE
build: add c-std=c99 for ci.go 

### DIFF
--- a/build/ci.go
+++ b/build/ci.go
@@ -210,6 +210,7 @@ func doInstall(cmdline []string) {
 	// Disable CLI markdown doc generation in release builds and enable linking
 	// the CKZG library since we can make it portable here.
 	buildTags := []string{"urfave_cli_no_docs", "ckzg"}
+	buildTags = []string{"CGO_CFLAGS", "-std=c99"}
 
 	// Configure the build.
 	env := build.Env()


### PR DESCRIPTION
fix build failed see #27440 