### PR TITLE
core: fix metrics of validation time of pre-byzantium blocks

### DIFF
--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -1780,7 +1780,12 @@ func (bc *BlockChain) insertChain(chain types.Blocks, setHead bool) (int, error)
 		trieRead := statedb.SnapshotAccountReads + statedb.AccountReads // The time spent on account read
 		trieRead += statedb.SnapshotStorageReads + statedb.StorageReads // The time spent on storage read
 		blockExecutionTimer.Update(ptime - trieRead)                    // The time spent on EVM processing
-		blockValidationTimer.Update(vtime - (triehash + trieUpdate))    // The time spent on block validation
+		// The time spent on block validation
+		if bc.chainConfig.IsByzantium(block.Number()) {
+			blockValidationTimer.Update(vtime - (triehash + trieUpdate))
+		} else {
+			blockValidationTimer.Update(vtime)
+		}
 
 		// Write the block to the chain and get the status.
 		var (


### PR DESCRIPTION
When processing pre-Byzantium blocks, the time cost of trieUpdate and trieHash should not be subtracted from the block validation time (vTime), as these two steps are performed at the end of every transaction.