### PR TITLE
core/types: add derived chain ID to LegacyTx JSON encoding

### DIFF
--- a/core/types/transaction_marshalling.go
+++ b/core/types/transaction_marshalling.go
@@ -60,10 +60,6 @@ func (tx *Transaction) MarshalJSON() ([]byte, error) {
 	// Other fields are set conditionally depending on tx type.
 	switch itx := tx.inner.(type) {
 	case *LegacyTx:
-		// Only derive the chain ID if tx is signed and post EIP-155
-		if (itx.V.Sign() != 0 || itx.R.Sign() != 0 || itx.S.Sign() != 0) && tx.ChainId().Sign() != 0 {
-			enc.ChainID = (*hexutil.Big)(tx.ChainId())
-		}
 		enc.Nonce = (*hexutil.Uint64)(&itx.Nonce)
 		enc.To = tx.To()
 		enc.Gas = (*hexutil.Uint64)(&itx.Gas)
@@ -73,6 +69,10 @@ func (tx *Transaction) MarshalJSON() ([]byte, error) {
 		enc.V = (*hexutil.Big)(itx.V)
 		enc.R = (*hexutil.Big)(itx.R)
 		enc.S = (*hexutil.Big)(itx.S)
+		// Only derive the chain ID if tx is signed and post EIP-155
+		if tx.Protected() {
+			enc.ChainID = (*hexutil.Big)(tx.ChainId())
+		}
 
 	case *AccessListTx:
 		enc.ChainID = (*hexutil.Big)(itx.ChainID)

--- a/core/types/transaction_marshalling.go
+++ b/core/types/transaction_marshalling.go
@@ -60,10 +60,9 @@ func (tx *Transaction) MarshalJSON() ([]byte, error) {
 	// Other fields are set conditionally depending on tx type.
 	switch itx := tx.inner.(type) {
 	case *LegacyTx:
-		if itx.V.Sign() != 0 || itx.R.Sign() != 0 || itx.S.Sign() != 0 {
+		// Only derive the chain ID if tx is signed and post EIP-155
+		if (itx.V.Sign() != 0 || itx.R.Sign() != 0 || itx.S.Sign() != 0) && tx.ChainId().Sign() != 0 {
 			enc.ChainID = (*hexutil.Big)(tx.ChainId())
-		} else {
-			enc.ChainID = (*hexutil.Big)(new(big.Int))
 		}
 		enc.Nonce = (*hexutil.Uint64)(&itx.Nonce)
 		enc.To = tx.To()

--- a/core/types/transaction_marshalling.go
+++ b/core/types/transaction_marshalling.go
@@ -60,6 +60,11 @@ func (tx *Transaction) MarshalJSON() ([]byte, error) {
 	// Other fields are set conditionally depending on tx type.
 	switch itx := tx.inner.(type) {
 	case *LegacyTx:
+		if itx.V.Sign() != 0 || itx.R.Sign() != 0 || itx.S.Sign() != 0 {
+			enc.ChainID = (*hexutil.Big)(tx.ChainId())
+		} else {
+			enc.ChainID = (*hexutil.Big)(new(big.Int))
+		}
 		enc.Nonce = (*hexutil.Uint64)(&itx.Nonce)
 		enc.To = tx.To()
 		enc.Gas = (*hexutil.Uint64)(&itx.Gas)

--- a/core/types/transaction_marshalling.go
+++ b/core/types/transaction_marshalling.go
@@ -69,7 +69,6 @@ func (tx *Transaction) MarshalJSON() ([]byte, error) {
 		enc.V = (*hexutil.Big)(itx.V)
 		enc.R = (*hexutil.Big)(itx.R)
 		enc.S = (*hexutil.Big)(itx.S)
-		// Only derive the chain ID if tx is signed and post EIP-155
 		if tx.Protected() {
 			enc.ChainID = (*hexutil.Big)(tx.ChainId())
 		}

--- a/core/types/transaction_test.go
+++ b/core/types/transaction_test.go
@@ -25,6 +25,7 @@ import (
 	"math/big"
 	"math/rand"
 	"reflect"
+	"strings"
 	"testing"
 	"time"
 
@@ -500,6 +501,10 @@ func encodeDecodeJSON(tx *Transaction) (*Transaction, error) {
 	var parsedTx = &Transaction{}
 	if err := json.Unmarshal(data, &parsedTx); err != nil {
 		return nil, fmt.Errorf("json decoding failed: %v", err)
+	}
+
+	if !strings.Contains(string(data), "chainId") {
+		return nil, fmt.Errorf("json encoding does not contain chainId: %v", string(data))
 	}
 	return parsedTx, nil
 }

--- a/core/types/transaction_test.go
+++ b/core/types/transaction_test.go
@@ -25,7 +25,6 @@ import (
 	"math/big"
 	"math/rand"
 	"reflect"
-	"strings"
 	"testing"
 	"time"
 
@@ -501,10 +500,6 @@ func encodeDecodeJSON(tx *Transaction) (*Transaction, error) {
 	var parsedTx = &Transaction{}
 	if err := json.Unmarshal(data, &parsedTx); err != nil {
 		return nil, fmt.Errorf("json decoding failed: %v", err)
-	}
-
-	if !strings.Contains(string(data), "chainId") {
-		return nil, fmt.Errorf("json encoding does not contain chainId: %v", string(data))
 	}
 	return parsedTx, nil
 }


### PR DESCRIPTION
When marshalling a legacy type transaction to JSON, the chain ID field is always omitted, despite the fact that it can be derived using the signature values after [EIP-155](https://eips.ethereum.org/EIPS/eip-155). 

This change adds the chain ID to a legacy transaction's JSON encoding when it can be derived. 

If the transaction is not signed or is pre EIP-155, the chain ID will be omitted.