### PR TITLE
core: fix processing metrics of pre-byzantium blocks

### DIFF
--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -1763,7 +1763,7 @@ func (bc *BlockChain) insertChain(chain types.Blocks, setHead bool) (int, error)
 		var trieHashUpdate time.Duration
 		if !bc.chainConfig.IsByzantium(block.Number()) {
 			// IntermediateRoot (trieHash, trieUpdate) is performed at the end of every tx for pre-Byzantium blocks
-			// thus, trieHashUpdate time should be substracted from blockExecution time
+			// thus, trieHashUpdate time should be subtracted from blockExecution time
 			trieHashUpdate = statedb.AccountHashes + statedb.StorageHashes + statedb.AccountUpdates + statedb.StorageUpdates
 			blockExecution -= trieHashUpdate
 		}


### PR DESCRIPTION
IntermediateRoot (trieHash, trieUpdate) is performed both at the end of every tx and in block validation for pre-Byzantium blocks. Thus: 
execution time = ptime - (trie read time + trieHashUpdate time (in processing));
validation time = vtime - (trieHashUpdate time (in validation)).