### PR TITLE
eth/filters: add newBlocks, newReceipts subscriptions

### DIFF
--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -1934,7 +1934,7 @@ func RegisterFilterAPI(stack *node.Node, backend ethapi.Backend, ethcfg *ethconf
 	})
 	stack.RegisterAPIs([]rpc.API{{
 		Namespace: "eth",
-		Service:   filters.NewFilterAPI(filterSystem, isLightClient),
+		Service:   filters.NewFilterAPI(backend.ChainConfig(), filterSystem, isLightClient),
 	}})
 	return filterSystem
 }

--- a/core/events.go
+++ b/core/events.go
@@ -31,9 +31,10 @@ type NewMinedBlockEvent struct{ Block *types.Block }
 type RemovedLogsEvent struct{ Logs []*types.Log }
 
 type ChainEvent struct {
-	Block *types.Block
-	Hash  common.Hash
-	Logs  []*types.Log
+	Block    *types.Block
+	Hash     common.Hash
+	Logs     []*types.Log
+	Receipts []*types.Receipt
 }
 
 type ChainSideEvent struct {

--- a/eth/filters/filter_system.go
+++ b/eth/filters/filter_system.go
@@ -354,6 +354,7 @@ func (es *EventSystem) subscribeMinedPendingLogs(crit ethereum.FilterQuery, logs
 		txs:       make(chan []*types.Transaction),
 		headers:   make(chan *types.Header),
 		blocks:    make(chan *types.Block),
+		receipts:  make(chan []*types.Receipt),
 		installed: make(chan struct{}),
 		err:       make(chan error),
 	}
@@ -372,6 +373,7 @@ func (es *EventSystem) subscribeLogs(crit ethereum.FilterQuery, logs chan []*typ
 		txs:       make(chan []*types.Transaction),
 		headers:   make(chan *types.Header),
 		blocks:    make(chan *types.Block),
+		receipts:  make(chan []*types.Receipt),
 		installed: make(chan struct{}),
 		err:       make(chan error),
 	}
@@ -390,6 +392,7 @@ func (es *EventSystem) subscribePendingLogs(crit ethereum.FilterQuery, logs chan
 		txs:       make(chan []*types.Transaction),
 		headers:   make(chan *types.Header),
 		blocks:    make(chan *types.Block),
+		receipts:  make(chan []*types.Receipt),
 		installed: make(chan struct{}),
 		err:       make(chan error),
 	}
@@ -407,6 +410,7 @@ func (es *EventSystem) SubscribeNewHeads(headers chan *types.Header) *Subscripti
 		txs:       make(chan []*types.Transaction),
 		headers:   headers,
 		blocks:    make(chan *types.Block),
+		receipts:  make(chan []*types.Receipt),
 		installed: make(chan struct{}),
 		err:       make(chan error),
 	}
@@ -424,6 +428,7 @@ func (es *EventSystem) SubscribeNewBlocks(blocks chan *types.Block) *Subscriptio
 		txs:       make(chan []*types.Transaction),
 		headers:   make(chan *types.Header),
 		blocks:    blocks,
+		receipts:  make(chan []*types.Receipt),
 		installed: make(chan struct{}),
 		err:       make(chan error),
 	}
@@ -459,6 +464,7 @@ func (es *EventSystem) SubscribePendingTxs(txs chan []*types.Transaction) *Subsc
 		txs:       txs,
 		headers:   make(chan *types.Header),
 		blocks:    make(chan *types.Block),
+		receipts:  make(chan []*types.Receipt),
 		installed: make(chan struct{}),
 		err:       make(chan error),
 	}

--- a/eth/filters/filter_system.go
+++ b/eth/filters/filter_system.go
@@ -504,7 +504,6 @@ func (es *EventSystem) handleTxsEvent(filters filterIndex, ev core.NewTxsEvent) 
 }
 
 func (es *EventSystem) handleChainEvent(filters filterIndex, ev core.ChainEvent) {
-
 	for _, f := range filters[BlockHeadersSubscription] {
 		f.headers <- ev.Block.Header()
 	}

--- a/eth/filters/filter_system_test.go
+++ b/eth/filters/filter_system_test.go
@@ -195,9 +195,15 @@ func TestBlockSubscription(t *testing.T) {
 	t.Parallel()
 
 	var (
+		cfg = &params.ChainConfig{
+			ChainID:        big.NewInt(1),
+			EIP150Block:    big.NewInt(0),
+			EIP155Block:    big.NewInt(2),
+			HomesteadBlock: new(big.Int),
+		}
 		db           = rawdb.NewMemoryDatabase()
 		backend, sys = newTestFilterSystem(t, db, Config{})
-		api          = NewFilterAPI(sys, false)
+		api          = NewFilterAPI(cfg, sys, false)
 		genesis      = &core.Genesis{
 			Config:  params.TestChainConfig,
 			BaseFee: big.NewInt(params.InitialBaseFee),
@@ -250,9 +256,15 @@ func TestPendingTxFilter(t *testing.T) {
 	t.Parallel()
 
 	var (
+		cfg = &params.ChainConfig{
+			ChainID:        big.NewInt(1),
+			EIP150Block:    big.NewInt(0),
+			EIP155Block:    big.NewInt(2),
+			HomesteadBlock: new(big.Int),
+		}
 		db           = rawdb.NewMemoryDatabase()
 		backend, sys = newTestFilterSystem(t, db, Config{})
-		api          = NewFilterAPI(sys, false)
+		api          = NewFilterAPI(cfg, sys, false)
 
 		transactions = []*types.Transaction{
 			types.NewTransaction(0, common.HexToAddress("0xb794f5ea0ba39494ce83a213fffba74279579268"), new(big.Int), 0, new(big.Int), nil),
@@ -306,9 +318,15 @@ func TestPendingTxFilterFullTx(t *testing.T) {
 	t.Parallel()
 
 	var (
+		cfg = &params.ChainConfig{
+			ChainID:        big.NewInt(1),
+			EIP150Block:    big.NewInt(0),
+			EIP155Block:    big.NewInt(2),
+			HomesteadBlock: new(big.Int),
+		}
 		db           = rawdb.NewMemoryDatabase()
 		backend, sys = newTestFilterSystem(t, db, Config{})
-		api          = NewFilterAPI(sys, false)
+		api          = NewFilterAPI(cfg, sys, false)
 
 		transactions = []*types.Transaction{
 			types.NewTransaction(0, common.HexToAddress("0xb794f5ea0ba39494ce83a213fffba74279579268"), new(big.Int), 0, new(big.Int), nil),
@@ -362,9 +380,15 @@ func TestPendingTxFilterFullTx(t *testing.T) {
 // If not it must return an error.
 func TestLogFilterCreation(t *testing.T) {
 	var (
+		cfg = &params.ChainConfig{
+			ChainID:        big.NewInt(1),
+			EIP150Block:    big.NewInt(0),
+			EIP155Block:    big.NewInt(2),
+			HomesteadBlock: new(big.Int),
+		}
 		db     = rawdb.NewMemoryDatabase()
 		_, sys = newTestFilterSystem(t, db, Config{})
-		api    = NewFilterAPI(sys, false)
+		api    = NewFilterAPI(cfg, sys, false)
 
 		testCases = []struct {
 			crit    FilterCriteria
@@ -409,9 +433,15 @@ func TestInvalidLogFilterCreation(t *testing.T) {
 	t.Parallel()
 
 	var (
+		cfg = &params.ChainConfig{
+			ChainID:        big.NewInt(1),
+			EIP150Block:    big.NewInt(0),
+			EIP155Block:    big.NewInt(2),
+			HomesteadBlock: new(big.Int),
+		}
 		db     = rawdb.NewMemoryDatabase()
 		_, sys = newTestFilterSystem(t, db, Config{})
-		api    = NewFilterAPI(sys, false)
+		api    = NewFilterAPI(cfg, sys, false)
 	)
 
 	// different situations where log filter creation should fail.
@@ -431,9 +461,15 @@ func TestInvalidLogFilterCreation(t *testing.T) {
 
 func TestInvalidGetLogsRequest(t *testing.T) {
 	var (
+		cfg = &params.ChainConfig{
+			ChainID:        big.NewInt(1),
+			EIP150Block:    big.NewInt(0),
+			EIP155Block:    big.NewInt(2),
+			HomesteadBlock: new(big.Int),
+		}
 		db        = rawdb.NewMemoryDatabase()
 		_, sys    = newTestFilterSystem(t, db, Config{})
-		api       = NewFilterAPI(sys, false)
+		api       = NewFilterAPI(cfg, sys, false)
 		blockHash = common.HexToHash("0x1111111111111111111111111111111111111111111111111111111111111111")
 	)
 
@@ -456,9 +492,15 @@ func TestLogFilter(t *testing.T) {
 	t.Parallel()
 
 	var (
+		cfg = &params.ChainConfig{
+			ChainID:        big.NewInt(1),
+			EIP150Block:    big.NewInt(0),
+			EIP155Block:    big.NewInt(2),
+			HomesteadBlock: new(big.Int),
+		}
 		db           = rawdb.NewMemoryDatabase()
 		backend, sys = newTestFilterSystem(t, db, Config{})
-		api          = NewFilterAPI(sys, false)
+		api          = NewFilterAPI(cfg, sys, false)
 
 		firstAddr      = common.HexToAddress("0x1111111111111111111111111111111111111111")
 		secondAddr     = common.HexToAddress("0x2222222222222222222222222222222222222222")
@@ -570,9 +612,15 @@ func TestPendingLogsSubscription(t *testing.T) {
 	t.Parallel()
 
 	var (
+		cfg = &params.ChainConfig{
+			ChainID:        big.NewInt(1),
+			EIP150Block:    big.NewInt(0),
+			EIP155Block:    big.NewInt(2),
+			HomesteadBlock: new(big.Int),
+		}
 		db           = rawdb.NewMemoryDatabase()
 		backend, sys = newTestFilterSystem(t, db, Config{})
-		api          = NewFilterAPI(sys, false)
+		api          = NewFilterAPI(cfg, sys, false)
 
 		firstAddr      = common.HexToAddress("0x1111111111111111111111111111111111111111")
 		secondAddr     = common.HexToAddress("0x2222222222222222222222222222222222222222")
@@ -750,9 +798,15 @@ func TestLightFilterLogs(t *testing.T) {
 	t.Parallel()
 
 	var (
+		cfg = &params.ChainConfig{
+			ChainID:        big.NewInt(1),
+			EIP150Block:    big.NewInt(0),
+			EIP155Block:    big.NewInt(2),
+			HomesteadBlock: new(big.Int),
+		}
 		db           = rawdb.NewMemoryDatabase()
 		backend, sys = newTestFilterSystem(t, db, Config{})
-		api          = NewFilterAPI(sys, true)
+		api          = NewFilterAPI(cfg, sys, true)
 		signer       = types.HomesteadSigner{}
 
 		firstAddr      = common.HexToAddress("0x1111111111111111111111111111111111111111")
@@ -891,9 +945,15 @@ func TestPendingTxFilterDeadlock(t *testing.T) {
 	timeout := 100 * time.Millisecond
 
 	var (
+		cfg = &params.ChainConfig{
+			ChainID:        big.NewInt(1),
+			EIP150Block:    big.NewInt(0),
+			EIP155Block:    big.NewInt(2),
+			HomesteadBlock: new(big.Int),
+		}
 		db           = rawdb.NewMemoryDatabase()
 		backend, sys = newTestFilterSystem(t, db, Config{Timeout: timeout})
-		api          = NewFilterAPI(sys, false)
+		api          = NewFilterAPI(cfg, sys, false)
 		done         = make(chan struct{})
 	)
 

--- a/ethclient/gethclient/gethclient_test.go
+++ b/ethclient/gethclient/gethclient_test.go
@@ -61,9 +61,15 @@ func newTestBackend(t *testing.T) (*node.Node, []*types.Block) {
 		t.Fatalf("can't create new ethereum service: %v", err)
 	}
 	filterSystem := filters.NewFilterSystem(ethservice.APIBackend, filters.Config{})
+	cfg := &params.ChainConfig{
+		ChainID:        big.NewInt(1),
+		EIP150Block:    big.NewInt(0),
+		EIP155Block:    big.NewInt(2),
+		HomesteadBlock: new(big.Int),
+	}
 	n.RegisterAPIs([]rpc.API{{
 		Namespace: "eth",
-		Service:   filters.NewFilterAPI(filterSystem, false),
+		Service:   filters.NewFilterAPI(cfg, filterSystem, false),
 	}})
 
 	// Import the test chain.


### PR DESCRIPTION
1. eth_newReceipts: We need to continuously query receipt information using the RPC interface to check whether transactions have been confirmed. It would be convenient if we could obtain receipts in real-time to facilitate this process.
2. eth_newBlock: Sometimes, we obtain real-time block information through a two-step process: First, fetching block hashes through WebSocket. Second, querying blocks using the RPC interface. Supporting for this interface would simplify the operation workflow.