### PR TITLE
core/types: ensure receipts EncodeIndex writes + support blobtx-receipts

### DIFF
--- a/core/types/receipt.go
+++ b/core/types/receipt.go
@@ -302,11 +302,7 @@ func (rs Receipts) EncodeIndex(i int, w *bytes.Buffer) {
 	}
 	w.WriteByte(r.Type)
 	switch r.Type {
-	case AccessListTxType:
-		rlp.Encode(w, data)
-	case DynamicFeeTxType:
-		rlp.Encode(w, data)
-	case BlobTxType:
+	case AccessListTxType, DynamicFeeTxType, BlobTxType:
 		rlp.Encode(w, data)
 	default:
 		// For unsupported types, write nothing. Since this is for

--- a/core/types/receipt.go
+++ b/core/types/receipt.go
@@ -296,14 +296,17 @@ func (rs Receipts) Len() int { return len(rs) }
 func (rs Receipts) EncodeIndex(i int, w *bytes.Buffer) {
 	r := rs[i]
 	data := &receiptRLP{r.statusEncoding(), r.CumulativeGasUsed, r.Bloom, r.Logs}
-	switch r.Type {
-	case LegacyTxType:
+	if r.Type == LegacyTxType {
 		rlp.Encode(w, data)
+		return
+	}
+	w.WriteByte(r.Type)
+	switch r.Type {
 	case AccessListTxType:
-		w.WriteByte(AccessListTxType)
 		rlp.Encode(w, data)
 	case DynamicFeeTxType:
-		w.WriteByte(DynamicFeeTxType)
+		rlp.Encode(w, data)
+	case BlobTxType:
 		rlp.Encode(w, data)
 	default:
 		// For unsupported types, write nothing. Since this is for

--- a/core/types/receipt.go
+++ b/core/types/receipt.go
@@ -194,7 +194,7 @@ func (r *Receipt) decodeTyped(b []byte) error {
 		return errShortTypedReceipt
 	}
 	switch b[0] {
-	case DynamicFeeTxType, AccessListTxType:
+	case DynamicFeeTxType, AccessListTxType, BlobTxType:
 		var data receiptRLP
 		err := rlp.DecodeBytes(b[1:], &data)
 		if err != nil {


### PR DESCRIPTION
This PR fixes an issue which can happen on blob-tx-testnets, where we try to encode the receipt of a blob-transaction, but ends up writing nothing: which is "deletion" as far as the stacktrie is concerned, causing panic. 

This PR does two things: 
- Always write type first, thereby making sure that even unsupported things cause a write of at least one byte, 
- Add support for blob receipts. 

As for the second bullet, a different way of doing it would be to do what the transactions already does 
```golang
	if tx.Type() == LegacyTxType {
		rlp.Encode(w, tx.inner)
	} else {
		tx.encodeTyped(w)
	}
}

func (tx *Transaction) encodeTyped(w *bytes.Buffer) error {
	w.WriteByte(tx.Type())
	return rlp.Encode(w, tx.inner)
}
```
Simply write `type ... rlp(data)` for typed data. That way we wouldn't have to bother with "adding support for type x", it would just work. 

I don't know which is best, I currently left it as is. 