### PR TITLE
core: remove unnecessary log copy

### DIFF
--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -2053,11 +2053,10 @@ func (bc *BlockChain) collectLogs(b *types.Block, removed bool) []*types.Log {
 	var logs []*types.Log
 	for _, receipt := range receipts {
 		for _, log := range receipt.Logs {
-			l := *log
 			if removed {
-				l.Removed = true
+				log.Removed = true
 			}
-			logs = append(logs, &l)
+			logs = append(logs, log)
 		}
 	}
 	return logs


### PR DESCRIPTION
This PR removes an unnecessary copy from `bc.collectLogs`