### PR TITLE
core/state, light, trie: add UpdateContractCode to the Trie interface

### DIFF
--- a/core/state/database.go
+++ b/core/state/database.go
@@ -91,7 +91,7 @@ type Trie interface {
 	// UpdateAccount abstracts an account write to the trie. It encodes the
 	// provided account object with associated algorithm and then updates it
 	// in the trie with provided address.
-	UpdateAccount(address common.Address, account *types.StateAccount) error
+	UpdateAccount(address common.Address, account *types.StateAccount, code []byte, dirtyCode bool) error
 
 	// DeleteStorage removes any existing value for key from the trie. If a node
 	// was not found in the database, a trie.MissingNodeError is returned.

--- a/core/state/database.go
+++ b/core/state/database.go
@@ -91,7 +91,11 @@ type Trie interface {
 	// UpdateAccount abstracts an account write to the trie. It encodes the
 	// provided account object with associated algorithm and then updates it
 	// in the trie with provided address.
-	UpdateAccount(address common.Address, account *types.StateAccount, code []byte, dirtyCode bool) error
+	UpdateAccount(address common.Address, account *types.StateAccount) error
+
+	// UpdateContractCode abstracts code write to the trie. It is expected
+	// to be moved to the stateWriter interface when the latter is ready.
+	UpdateContractCode(address common.Address, codeHash common.Hash, code []byte) error
 
 	// DeleteStorage removes any existing value for key from the trie. If a node
 	// was not found in the database, a trie.MissingNodeError is returned.

--- a/core/state/statedb.go
+++ b/core/state/statedb.go
@@ -513,7 +513,7 @@ func (s *StateDB) updateStateObject(obj *stateObject) {
 	}
 	// Encode the account and update the account trie
 	addr := obj.Address()
-	if err := s.trie.UpdateAccount(addr, &obj.data); err != nil {
+	if err := s.trie.UpdateAccount(addr, &obj.data, obj.code, obj.dirtyCode); err != nil {
 		s.setError(fmt.Errorf("updateStateObject (%x) error: %v", addr[:], err))
 	}
 

--- a/core/state/statedb.go
+++ b/core/state/statedb.go
@@ -513,7 +513,7 @@ func (s *StateDB) updateStateObject(obj *stateObject) {
 	}
 	// Encode the account and update the account trie
 	addr := obj.Address()
-	if err := s.trie.UpdateAccount(addr, &obj.data, obj.code, obj.dirtyCode); err != nil {
+	if err := s.trie.UpdateAccount(addr, &obj.data); err != nil {
 		s.setError(fmt.Errorf("updateStateObject (%x) error: %v", addr[:], err))
 	}
 
@@ -998,6 +998,7 @@ func (s *StateDB) Commit(deleteEmptyObjects bool) (common.Hash, error) {
 		if obj := s.stateObjects[addr]; !obj.deleted {
 			// Write any contract code associated with the state object
 			if obj.code != nil && obj.dirtyCode {
+				s.trie.UpdateContractCode(obj.Address(), common.BytesToHash(obj.CodeHash()), obj.code)
 				rawdb.WriteCode(codeWriter, common.BytesToHash(obj.CodeHash()), obj.code)
 				obj.dirtyCode = false
 			}

--- a/light/trie.go
+++ b/light/trie.go
@@ -136,7 +136,7 @@ func (t *odrTrie) GetAccount(address common.Address) (*types.StateAccount, error
 	return &res, err
 }
 
-func (t *odrTrie) UpdateAccount(address common.Address, acc *types.StateAccount, _ []byte, _ bool) error {
+func (t *odrTrie) UpdateAccount(address common.Address, acc *types.StateAccount) error {
 	key := crypto.Keccak256(address.Bytes())
 	value, err := rlp.EncodeToBytes(acc)
 	if err != nil {
@@ -145,6 +145,10 @@ func (t *odrTrie) UpdateAccount(address common.Address, acc *types.StateAccount,
 	return t.do(key, func() error {
 		return t.trie.Update(key, value)
 	})
+}
+
+func (t *odrTrie) UpdateContractCode(_ common.Address, _ common.Hash, _ []byte) error {
+	return nil
 }
 
 func (t *odrTrie) UpdateStorage(_ common.Address, key, value []byte) error {

--- a/light/trie.go
+++ b/light/trie.go
@@ -136,7 +136,7 @@ func (t *odrTrie) GetAccount(address common.Address) (*types.StateAccount, error
 	return &res, err
 }
 
-func (t *odrTrie) UpdateAccount(address common.Address, acc *types.StateAccount) error {
+func (t *odrTrie) UpdateAccount(address common.Address, acc *types.StateAccount, _ []byte, _ bool) error {
 	key := crypto.Keccak256(address.Bytes())
 	value, err := rlp.EncodeToBytes(acc)
 	if err != nil {

--- a/trie/secure_trie.go
+++ b/trie/secure_trie.go
@@ -163,7 +163,7 @@ func (t *StateTrie) UpdateStorage(_ common.Address, key, value []byte) error {
 }
 
 // UpdateAccount will abstract the write of an account to the secure trie.
-func (t *StateTrie) UpdateAccount(address common.Address, acc *types.StateAccount, _ []byte, _ bool) error {
+func (t *StateTrie) UpdateAccount(address common.Address, acc *types.StateAccount) error {
 	hk := t.hashKey(address.Bytes())
 	data, err := rlp.EncodeToBytes(acc)
 	if err != nil {
@@ -173,6 +173,10 @@ func (t *StateTrie) UpdateAccount(address common.Address, acc *types.StateAccoun
 		return err
 	}
 	t.getSecKeyCache()[string(hk)] = address.Bytes()
+	return nil
+}
+
+func (t *StateTrie) UpdateContractCode(_ common.Address, _ common.Hash, _ []byte) error {
 	return nil
 }
 

--- a/trie/secure_trie.go
+++ b/trie/secure_trie.go
@@ -163,7 +163,7 @@ func (t *StateTrie) UpdateStorage(_ common.Address, key, value []byte) error {
 }
 
 // UpdateAccount will abstract the write of an account to the secure trie.
-func (t *StateTrie) UpdateAccount(address common.Address, acc *types.StateAccount) error {
+func (t *StateTrie) UpdateAccount(address common.Address, acc *types.StateAccount, _ []byte, _ bool) error {
 	hk := t.hashKey(address.Bytes())
 	data, err := rlp.EncodeToBytes(acc)
 	if err != nil {


### PR DESCRIPTION
Rationale: verkle trees store the code inside the trie. This PR changes the interface to pass the code, as well as the `dirty` flag to tell the trie package if the code is dirty and needs to be updated. This is a no-op for the MPT and the odr trie.