### PR TITLE
core: use string.Builder to concat string

### DIFF
--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -2435,18 +2435,21 @@ func (bc *BlockChain) reportBlock(block *types.Block, receipts types.Receipts, e
 // summarizeBadBlock returns a string summarizing the bad block and other
 // relevant information.
 func summarizeBadBlock(block *types.Block, receipts []*types.Receipt, config *params.ChainConfig, err error) string {
-	var receiptString string
+	var sb strings.Builder
+
 	for i, receipt := range receipts {
-		receiptString += fmt.Sprintf("\n  %d: cumulative: %v gas: %v contract: %v status: %v tx: %v logs: %v bloom: %x state: %x",
+		sb.WriteString(fmt.Sprintf("\n  %d: cumulative: %v gas: %v contract: %v status: %v tx: %v logs: %v bloom: %x state: %x",
 			i, receipt.CumulativeGasUsed, receipt.GasUsed, receipt.ContractAddress.Hex(),
-			receipt.Status, receipt.TxHash.Hex(), receipt.Logs, receipt.Bloom, receipt.PostState)
+			receipt.Status, receipt.TxHash.Hex(), receipt.Logs, receipt.Bloom, receipt.PostState))
 	}
+
 	version, vcs := version.Info()
 	platform := fmt.Sprintf("%s %s %s %s", version, runtime.Version(), runtime.GOARCH, runtime.GOOS)
 	if vcs != "" {
 		vcs = fmt.Sprintf("\nVCS: %s", vcs)
 	}
-	return fmt.Sprintf(`
+
+	sb.WriteString(fmt.Sprintf(`
 ########## BAD BLOCK #########
 Block: %v (%#x)
 Error: %v
@@ -2454,7 +2457,9 @@ Platform: %v%v
 Chain config: %#v
 Receipts: %v
 ##############################
-`, block.Number(), block.Hash(), err, platform, vcs, config, receiptString)
+`, block.Number(), block.Hash(), err, platform, vcs, config, sb.String()))
+
+	return sb.String()
 }
 
 // InsertHeaderChain attempts to insert the given header chain in to the local


### PR DESCRIPTION
string.Builder has a better performance than concatting string directly. 