### PR TITLE
trie: remove prover parameter 'fromLevel'

### DIFF
--- a/core/state/database.go
+++ b/core/state/database.go
@@ -123,7 +123,7 @@ type Trie interface {
 	// If the trie does not contain a value for key, the returned proof contains all
 	// nodes of the longest existing prefix of the key (at least the root), ending
 	// with the node that proves the absence of the key.
-	Prove(key []byte, fromLevel uint, proofDb ethdb.KeyValueWriter) error
+	Prove(key []byte, proofDb ethdb.KeyValueWriter) error
 }
 
 // NewDatabase creates a backing store for state. The returned database is safe for

--- a/core/state/snapshot/generate.go
+++ b/core/state/snapshot/generate.go
@@ -256,7 +256,7 @@ func (dl *diskLayer) proveRange(ctx *generatorContext, trieId *trie.ID, prefix [
 	if origin == nil {
 		origin = common.Hash{}.Bytes()
 	}
-	if err := tr.Prove(origin, 0, proof); err != nil {
+	if err := tr.Prove(origin, proof); err != nil {
 		log.Debug("Failed to prove range", "kind", kind, "origin", origin, "err", err)
 		return &proofResult{
 			keys:     keys,
@@ -267,7 +267,7 @@ func (dl *diskLayer) proveRange(ctx *generatorContext, trieId *trie.ID, prefix [
 		}, nil
 	}
 	if last != nil {
-		if err := tr.Prove(last, 0, proof); err != nil {
+		if err := tr.Prove(last, proof); err != nil {
 			log.Debug("Failed to prove range", "kind", kind, "last", last, "err", err)
 			return &proofResult{
 				keys:     keys,

--- a/core/state/statedb.go
+++ b/core/state/statedb.go
@@ -332,7 +332,7 @@ func (s *StateDB) GetProof(addr common.Address) ([][]byte, error) {
 // GetProofByHash returns the Merkle proof for a given account.
 func (s *StateDB) GetProofByHash(addrHash common.Hash) ([][]byte, error) {
 	var proof proofList
-	err := s.trie.Prove(addrHash[:], 0, &proof)
+	err := s.trie.Prove(addrHash[:], &proof)
 	return proof, err
 }
 
@@ -346,7 +346,7 @@ func (s *StateDB) GetStorageProof(a common.Address, key common.Hash) ([][]byte, 
 		return nil, errors.New("storage trie for requested address does not exist")
 	}
 	var proof proofList
-	err = trie.Prove(crypto.Keccak256(key.Bytes()), 0, &proof)
+	err = trie.Prove(crypto.Keccak256(key.Bytes()), &proof)
 	if err != nil {
 		return nil, err
 	}

--- a/eth/protocols/snap/handler.go
+++ b/eth/protocols/snap/handler.go
@@ -322,12 +322,12 @@ func ServiceGetAccountRangeQuery(chain *core.BlockChain, req *GetAccountRangePac
 
 	// Generate the Merkle proofs for the first and last account
 	proof := light.NewNodeSet()
-	if err := tr.Prove(req.Origin[:], 0, proof); err != nil {
+	if err := tr.Prove(req.Origin[:], proof); err != nil {
 		log.Warn("Failed to prove account range", "origin", req.Origin, "err", err)
 		return nil, nil
 	}
 	if last != (common.Hash{}) {
-		if err := tr.Prove(last[:], 0, proof); err != nil {
+		if err := tr.Prove(last[:], proof); err != nil {
 			log.Warn("Failed to prove account range", "last", last, "err", err)
 			return nil, nil
 		}
@@ -428,12 +428,12 @@ func ServiceGetStorageRangesQuery(chain *core.BlockChain, req *GetStorageRangesP
 				return nil, nil
 			}
 			proof := light.NewNodeSet()
-			if err := stTrie.Prove(origin[:], 0, proof); err != nil {
+			if err := stTrie.Prove(origin[:], proof); err != nil {
 				log.Warn("Failed to prove storage range", "origin", req.Origin, "err", err)
 				return nil, nil
 			}
 			if last != (common.Hash{}) {
-				if err := stTrie.Prove(last[:], 0, proof); err != nil {
+				if err := stTrie.Prove(last[:], proof); err != nil {
 					log.Warn("Failed to prove storage range", "last", last, "err", err)
 					return nil, nil
 				}

--- a/eth/protocols/snap/sync_test.go
+++ b/eth/protocols/snap/sync_test.go
@@ -273,12 +273,12 @@ func createAccountRequestResponse(t *testPeer, root common.Hash, origin common.H
 	// Actually, we need to supply proofs either way! This seems to be an implementation
 	// quirk in go-ethereum
 	proof := light.NewNodeSet()
-	if err := t.accountTrie.Prove(origin[:], 0, proof); err != nil {
+	if err := t.accountTrie.Prove(origin[:], proof); err != nil {
 		t.logger.Error("Could not prove inexistence of origin", "origin", origin, "error", err)
 	}
 	if len(keys) > 0 {
 		lastK := (keys[len(keys)-1])[:]
-		if err := t.accountTrie.Prove(lastK, 0, proof); err != nil {
+		if err := t.accountTrie.Prove(lastK, proof); err != nil {
 			t.logger.Error("Could not prove last item", "error", err)
 		}
 	}
@@ -358,12 +358,12 @@ func createStorageRequestResponse(t *testPeer, root common.Hash, accounts []comm
 			// Here's a potential gotcha: when constructing the proof, we cannot
 			// use the 'origin' slice directly, but must use the full 32-byte
 			// hash form.
-			if err := stTrie.Prove(originHash[:], 0, proof); err != nil {
+			if err := stTrie.Prove(originHash[:], proof); err != nil {
 				t.logger.Error("Could not prove inexistence of origin", "origin", originHash, "error", err)
 			}
 			if len(keys) > 0 {
 				lastK := (keys[len(keys)-1])[:]
-				if err := stTrie.Prove(lastK, 0, proof); err != nil {
+				if err := stTrie.Prove(lastK, proof); err != nil {
 					t.logger.Error("Could not prove last item", "error", err)
 				}
 			}
@@ -416,13 +416,13 @@ func createStorageRequestResponseAlwaysProve(t *testPeer, root common.Hash, acco
 			// Here's a potential gotcha: when constructing the proof, we cannot
 			// use the 'origin' slice directly, but must use the full 32-byte
 			// hash form.
-			if err := stTrie.Prove(origin[:], 0, proof); err != nil {
+			if err := stTrie.Prove(origin[:], proof); err != nil {
 				t.logger.Error("Could not prove inexistence of origin", "origin", origin,
 					"error", err)
 			}
 			if len(keys) > 0 {
 				lastK := (keys[len(keys)-1])[:]
-				if err := stTrie.Prove(lastK, 0, proof); err != nil {
+				if err := stTrie.Prove(lastK, proof); err != nil {
 					t.logger.Error("Could not prove last item", "error", err)
 				}
 			}
@@ -594,12 +594,12 @@ func TestSyncBloatedProof(t *testing.T) {
 		}
 		// The proofs
 		proof := light.NewNodeSet()
-		if err := t.accountTrie.Prove(origin[:], 0, proof); err != nil {
+		if err := t.accountTrie.Prove(origin[:], proof); err != nil {
 			t.logger.Error("Could not prove origin", "origin", origin, "error", err)
 		}
 		// The bloat: add proof of every single element
 		for _, entry := range t.accountValues {
-			if err := t.accountTrie.Prove(entry.k, 0, proof); err != nil {
+			if err := t.accountTrie.Prove(entry.k, proof); err != nil {
 				t.logger.Error("Could not prove item", "error", err)
 			}
 		}

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -705,7 +705,7 @@ func (s *BlockChainAPI) GetProof(ctx context.Context, address common.Address, st
 			continue
 		}
 		var proof proofList
-		if err := storageTrie.Prove(crypto.Keccak256(key.Bytes()), 0, &proof); err != nil {
+		if err := storageTrie.Prove(crypto.Keccak256(key.Bytes()), &proof); err != nil {
 			return nil, err
 		}
 		storageProof[i] = StorageResult{storageKeys[i],

--- a/les/handler_test.go
+++ b/les/handler_test.go
@@ -414,7 +414,7 @@ func testGetProofs(t *testing.T, protocol int) {
 				Key:   crypto.Keccak256(acc[:]),
 			}
 			proofreqs = append(proofreqs, req)
-			trie.Prove(crypto.Keccak256(acc[:]), 0, proofsV2)
+			trie.Prove(crypto.Keccak256(acc[:]), proofsV2)
 		}
 	}
 	// Send the proof request and verify the response
@@ -458,7 +458,7 @@ func testGetStaleProof(t *testing.T, protocol int) {
 		if wantOK {
 			proofsV2 := light.NewNodeSet()
 			t, _ := trie.New(trie.StateTrieID(header.Root), trie.NewDatabase(server.db))
-			t.Prove(account, 0, proofsV2)
+			t.Prove(account, proofsV2)
 			expected = proofsV2.NodeList()
 		}
 		if err := expectResponse(rawPeer.app, ProofsV2Msg, 42, testBufLimit, expected); err != nil {
@@ -514,7 +514,7 @@ func testGetCHTProofs(t *testing.T, protocol int) {
 	}
 	root := light.GetChtRoot(server.db, 0, bc.GetHeaderByNumber(config.ChtSize-1).Hash())
 	trie, _ := trie.New(trie.TrieID(root), trie.NewDatabase(rawdb.NewTable(server.db, string(rawdb.ChtTablePrefix))))
-	trie.Prove(key, 0, &proofsV2.Proofs)
+	trie.Prove(key, &proofsV2.Proofs)
 	// Assemble the requests for the different protocols
 	requestsV2 := []HelperTrieReq{{
 		Type:    htCanonical,
@@ -579,7 +579,7 @@ func testGetBloombitsProofs(t *testing.T, protocol int) {
 
 		root := light.GetBloomTrieRoot(server.db, 0, bc.GetHeaderByNumber(config.BloomTrieSize-1).Hash())
 		trie, _ := trie.New(trie.TrieID(root), trie.NewDatabase(rawdb.NewTable(server.db, string(rawdb.BloomTrieTablePrefix))))
-		trie.Prove(key, 0, &proofs.Proofs)
+		trie.Prove(key, &proofs.Proofs)
 
 		// Send the proof request and verify the response
 		sendRequest(rawPeer.app, GetHelperTrieProofsMsg, 42, requests)

--- a/les/server_requests.go
+++ b/les/server_requests.go
@@ -436,7 +436,7 @@ func handleGetProofs(msg Decoder) (serveRequestFn, uint64, uint64, error) {
 				}
 			}
 			// Prove the user's request from the account or storage trie
-			if err := trie.Prove(request.Key, request.FromLevel, nodes); err != nil {
+			if err := trie.Prove(request.Key, nodes); err != nil {
 				p.Log().Warn("Failed to prove state request", "block", header.Number, "hash", header.Hash(), "err", err)
 				continue
 			}
@@ -480,7 +480,7 @@ func handleGetHelperTrieProofs(msg Decoder) (serveRequestFn, uint64, uint64, err
 			// the headers with no valid proof. Keep the compatibility for
 			// legacy les protocol and drop this hack when the les2/3 are
 			// not supported.
-			err := auxTrie.Prove(request.Key, request.FromLevel, nodes)
+			err := auxTrie.Prove(request.Key, nodes)
 			if p.version >= lpv4 && err != nil {
 				return nil
 			}

--- a/light/odr_test.go
+++ b/light/odr_test.go
@@ -95,7 +95,7 @@ func (odr *testOdr) Retrieve(ctx context.Context, req OdrRequest) error {
 			panic(err)
 		}
 		nodes := NewNodeSet()
-		t.Prove(req.Key, 0, nodes)
+		t.Prove(req.Key, nodes)
 		req.Proof = nodes
 	case *CodeRequest:
 		req.Data = rawdb.ReadCode(odr.sdb, req.Hash)

--- a/light/trie.go
+++ b/light/trie.go
@@ -192,7 +192,7 @@ func (t *odrTrie) GetKey(sha []byte) []byte {
 	return nil
 }
 
-func (t *odrTrie) Prove(key []byte, fromLevel uint, proofDb ethdb.KeyValueWriter) error {
+func (t *odrTrie) Prove(key []byte, proofDb ethdb.KeyValueWriter) error {
 	return errors.New("not implemented, needs client/server interface split")
 }
 

--- a/tests/fuzzers/rangeproof/rangeproof-fuzzer.go
+++ b/tests/fuzzers/rangeproof/rangeproof-fuzzer.go
@@ -117,10 +117,10 @@ func (f *fuzzer) fuzz() int {
 			break
 		}
 		proof := memorydb.New()
-		if err := tr.Prove(entries[start].k, 0, proof); err != nil {
+		if err := tr.Prove(entries[start].k, proof); err != nil {
 			panic(fmt.Sprintf("Failed to prove the first node %v", err))
 		}
-		if err := tr.Prove(entries[end-1].k, 0, proof); err != nil {
+		if err := tr.Prove(entries[end-1].k, proof); err != nil {
 			panic(fmt.Sprintf("Failed to prove the last node %v", err))
 		}
 		var keys [][]byte

--- a/tests/fuzzers/trie/trie-fuzzer.go
+++ b/tests/fuzzers/trie/trie-fuzzer.go
@@ -187,7 +187,7 @@ func runRandTest(rt randTest) error {
 				return errors.New("hash mismatch in opItercheckhash")
 			}
 		case opProve:
-			rt[i].err = tr.Prove(step.key, 0, proofDb{})
+			rt[i].err = tr.Prove(step.key, proofDb{})
 		}
 		// Abort the test on error.
 		if rt[i].err != nil {

--- a/trie/proof.go
+++ b/trie/proof.go
@@ -33,7 +33,7 @@ import (
 // If the trie does not contain a value for key, the returned proof contains all
 // nodes of the longest existing prefix of the key (at least the root node), ending
 // with the node that proves the absence of the key.
-func (t *Trie) Prove(key []byte, fromLevel uint, proofDb ethdb.KeyValueWriter) error {
+func (t *Trie) Prove(key []byte, proofDb ethdb.KeyValueWriter) error {
 	// Collect all nodes on the path to key.
 	var (
 		prefix []byte
@@ -81,10 +81,6 @@ func (t *Trie) Prove(key []byte, fromLevel uint, proofDb ethdb.KeyValueWriter) e
 	defer returnHasherToPool(hasher)
 
 	for i, n := range nodes {
-		if fromLevel > 0 {
-			fromLevel--
-			continue
-		}
 		var hn node
 		n, hn = hasher.proofHash(n)
 		if hash, ok := hn.(hashNode); ok || i == 0 {
@@ -107,8 +103,8 @@ func (t *Trie) Prove(key []byte, fromLevel uint, proofDb ethdb.KeyValueWriter) e
 // If the trie does not contain a value for key, the returned proof contains all
 // nodes of the longest existing prefix of the key (at least the root node), ending
 // with the node that proves the absence of the key.
-func (t *StateTrie) Prove(key []byte, fromLevel uint, proofDb ethdb.KeyValueWriter) error {
-	return t.trie.Prove(key, fromLevel, proofDb)
+func (t *StateTrie) Prove(key []byte, proofDb ethdb.KeyValueWriter) error {
+	return t.trie.Prove(key, proofDb)
 }
 
 // VerifyProof checks merkle proofs. The given proof must contain the value for

--- a/trie/proof_test.go
+++ b/trie/proof_test.go
@@ -57,7 +57,7 @@ func makeProvers(trie *Trie) []func(key []byte) *memorydb.Database {
 	// Create a direct trie based Merkle prover
 	provers = append(provers, func(key []byte) *memorydb.Database {
 		proof := memorydb.New()
-		trie.Prove(key, 0, proof)
+		trie.Prove(key, proof)
 		return proof
 	})
 	// Create a leaf iterator based Merkle prover
@@ -150,7 +150,7 @@ func TestMissingKeyProof(t *testing.T) {
 
 	for i, key := range []string{"a", "j", "l", "z"} {
 		proof := memorydb.New()
-		trie.Prove([]byte(key), 0, proof)
+		trie.Prove([]byte(key), proof)
 
 		if proof.Len() != 1 {
 			t.Errorf("test %d: proof should have one element", i)
@@ -185,10 +185,10 @@ func TestRangeProof(t *testing.T) {
 		end := mrand.Intn(len(entries)-start) + start + 1
 
 		proof := memorydb.New()
-		if err := trie.Prove(entries[start].k, 0, proof); err != nil {
+		if err := trie.Prove(entries[start].k, proof); err != nil {
 			t.Fatalf("Failed to prove the first node %v", err)
 		}
-		if err := trie.Prove(entries[end-1].k, 0, proof); err != nil {
+		if err := trie.Prove(entries[end-1].k, proof); err != nil {
 			t.Fatalf("Failed to prove the last node %v", err)
 		}
 		var keys [][]byte
@@ -236,10 +236,10 @@ func TestRangeProofWithNonExistentProof(t *testing.T) {
 		if bytes.Compare(last, entries[end-1].k) < 0 {
 			continue
 		}
-		if err := trie.Prove(first, 0, proof); err != nil {
+		if err := trie.Prove(first, proof); err != nil {
 			t.Fatalf("Failed to prove the first node %v", err)
 		}
-		if err := trie.Prove(last, 0, proof); err != nil {
+		if err := trie.Prove(last, proof); err != nil {
 			t.Fatalf("Failed to prove the last node %v", err)
 		}
 		var keys [][]byte
@@ -257,10 +257,10 @@ func TestRangeProofWithNonExistentProof(t *testing.T) {
 	proof := memorydb.New()
 	first := common.HexToHash("0x0000000000000000000000000000000000000000000000000000000000000000").Bytes()
 	last := common.HexToHash("0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff").Bytes()
-	if err := trie.Prove(first, 0, proof); err != nil {
+	if err := trie.Prove(first, proof); err != nil {
 		t.Fatalf("Failed to prove the first node %v", err)
 	}
-	if err := trie.Prove(last, 0, proof); err != nil {
+	if err := trie.Prove(last, proof); err != nil {
 		t.Fatalf("Failed to prove the last node %v", err)
 	}
 	var k [][]byte
@@ -291,10 +291,10 @@ func TestRangeProofWithInvalidNonExistentProof(t *testing.T) {
 	first := decreaseKey(common.CopyBytes(entries[start].k))
 
 	proof := memorydb.New()
-	if err := trie.Prove(first, 0, proof); err != nil {
+	if err := trie.Prove(first, proof); err != nil {
 		t.Fatalf("Failed to prove the first node %v", err)
 	}
-	if err := trie.Prove(entries[end-1].k, 0, proof); err != nil {
+	if err := trie.Prove(entries[end-1].k, proof); err != nil {
 		t.Fatalf("Failed to prove the last node %v", err)
 	}
 	start = 105 // Gap created
@@ -313,10 +313,10 @@ func TestRangeProofWithInvalidNonExistentProof(t *testing.T) {
 	start, end = 100, 200
 	last := increaseKey(common.CopyBytes(entries[end-1].k))
 	proof = memorydb.New()
-	if err := trie.Prove(entries[start].k, 0, proof); err != nil {
+	if err := trie.Prove(entries[start].k, proof); err != nil {
 		t.Fatalf("Failed to prove the first node %v", err)
 	}
-	if err := trie.Prove(last, 0, proof); err != nil {
+	if err := trie.Prove(last, proof); err != nil {
 		t.Fatalf("Failed to prove the last node %v", err)
 	}
 	end = 195 // Capped slice
@@ -347,7 +347,7 @@ func TestOneElementRangeProof(t *testing.T) {
 	// point to the SAME key.
 	start := 1000
 	proof := memorydb.New()
-	if err := trie.Prove(entries[start].k, 0, proof); err != nil {
+	if err := trie.Prove(entries[start].k, proof); err != nil {
 		t.Fatalf("Failed to prove the first node %v", err)
 	}
 	_, err := VerifyRangeProof(trie.Hash(), entries[start].k, entries[start].k, [][]byte{entries[start].k}, [][]byte{entries[start].v}, proof)
@@ -359,10 +359,10 @@ func TestOneElementRangeProof(t *testing.T) {
 	start = 1000
 	first := decreaseKey(common.CopyBytes(entries[start].k))
 	proof = memorydb.New()
-	if err := trie.Prove(first, 0, proof); err != nil {
+	if err := trie.Prove(first, proof); err != nil {
 		t.Fatalf("Failed to prove the first node %v", err)
 	}
-	if err := trie.Prove(entries[start].k, 0, proof); err != nil {
+	if err := trie.Prove(entries[start].k, proof); err != nil {
 		t.Fatalf("Failed to prove the last node %v", err)
 	}
 	_, err = VerifyRangeProof(trie.Hash(), first, entries[start].k, [][]byte{entries[start].k}, [][]byte{entries[start].v}, proof)
@@ -374,10 +374,10 @@ func TestOneElementRangeProof(t *testing.T) {
 	start = 1000
 	last := increaseKey(common.CopyBytes(entries[start].k))
 	proof = memorydb.New()
-	if err := trie.Prove(entries[start].k, 0, proof); err != nil {
+	if err := trie.Prove(entries[start].k, proof); err != nil {
 		t.Fatalf("Failed to prove the first node %v", err)
 	}
-	if err := trie.Prove(last, 0, proof); err != nil {
+	if err := trie.Prove(last, proof); err != nil {
 		t.Fatalf("Failed to prove the last node %v", err)
 	}
 	_, err = VerifyRangeProof(trie.Hash(), entries[start].k, last, [][]byte{entries[start].k}, [][]byte{entries[start].v}, proof)
@@ -389,10 +389,10 @@ func TestOneElementRangeProof(t *testing.T) {
 	start = 1000
 	first, last = decreaseKey(common.CopyBytes(entries[start].k)), increaseKey(common.CopyBytes(entries[start].k))
 	proof = memorydb.New()
-	if err := trie.Prove(first, 0, proof); err != nil {
+	if err := trie.Prove(first, proof); err != nil {
 		t.Fatalf("Failed to prove the first node %v", err)
 	}
-	if err := trie.Prove(last, 0, proof); err != nil {
+	if err := trie.Prove(last, proof); err != nil {
 		t.Fatalf("Failed to prove the last node %v", err)
 	}
 	_, err = VerifyRangeProof(trie.Hash(), first, last, [][]byte{entries[start].k}, [][]byte{entries[start].v}, proof)
@@ -408,10 +408,10 @@ func TestOneElementRangeProof(t *testing.T) {
 	first = common.HexToHash("0x0000000000000000000000000000000000000000000000000000000000000000").Bytes()
 	last = entry.k
 	proof = memorydb.New()
-	if err := tinyTrie.Prove(first, 0, proof); err != nil {
+	if err := tinyTrie.Prove(first, proof); err != nil {
 		t.Fatalf("Failed to prove the first node %v", err)
 	}
-	if err := tinyTrie.Prove(last, 0, proof); err != nil {
+	if err := tinyTrie.Prove(last, proof); err != nil {
 		t.Fatalf("Failed to prove the last node %v", err)
 	}
 	_, err = VerifyRangeProof(tinyTrie.Hash(), first, last, [][]byte{entry.k}, [][]byte{entry.v}, proof)
@@ -443,10 +443,10 @@ func TestAllElementsProof(t *testing.T) {
 
 	// With edge proofs, it should still work.
 	proof := memorydb.New()
-	if err := trie.Prove(entries[0].k, 0, proof); err != nil {
+	if err := trie.Prove(entries[0].k, proof); err != nil {
 		t.Fatalf("Failed to prove the first node %v", err)
 	}
-	if err := trie.Prove(entries[len(entries)-1].k, 0, proof); err != nil {
+	if err := trie.Prove(entries[len(entries)-1].k, proof); err != nil {
 		t.Fatalf("Failed to prove the last node %v", err)
 	}
 	_, err = VerifyRangeProof(trie.Hash(), k[0], k[len(k)-1], k, v, proof)
@@ -458,10 +458,10 @@ func TestAllElementsProof(t *testing.T) {
 	proof = memorydb.New()
 	first := common.HexToHash("0x0000000000000000000000000000000000000000000000000000000000000000").Bytes()
 	last := common.HexToHash("0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff").Bytes()
-	if err := trie.Prove(first, 0, proof); err != nil {
+	if err := trie.Prove(first, proof); err != nil {
 		t.Fatalf("Failed to prove the first node %v", err)
 	}
-	if err := trie.Prove(last, 0, proof); err != nil {
+	if err := trie.Prove(last, proof); err != nil {
 		t.Fatalf("Failed to prove the last node %v", err)
 	}
 	_, err = VerifyRangeProof(trie.Hash(), first, last, k, v, proof)
@@ -485,10 +485,10 @@ func TestSingleSideRangeProof(t *testing.T) {
 		var cases = []int{0, 1, 50, 100, 1000, 2000, len(entries) - 1}
 		for _, pos := range cases {
 			proof := memorydb.New()
-			if err := trie.Prove(common.Hash{}.Bytes(), 0, proof); err != nil {
+			if err := trie.Prove(common.Hash{}.Bytes(), proof); err != nil {
 				t.Fatalf("Failed to prove the first node %v", err)
 			}
-			if err := trie.Prove(entries[pos].k, 0, proof); err != nil {
+			if err := trie.Prove(entries[pos].k, proof); err != nil {
 				t.Fatalf("Failed to prove the first node %v", err)
 			}
 			k := make([][]byte, 0)
@@ -520,11 +520,11 @@ func TestReverseSingleSideRangeProof(t *testing.T) {
 		var cases = []int{0, 1, 50, 100, 1000, 2000, len(entries) - 1}
 		for _, pos := range cases {
 			proof := memorydb.New()
-			if err := trie.Prove(entries[pos].k, 0, proof); err != nil {
+			if err := trie.Prove(entries[pos].k, proof); err != nil {
 				t.Fatalf("Failed to prove the first node %v", err)
 			}
 			last := common.HexToHash("0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff")
-			if err := trie.Prove(last.Bytes(), 0, proof); err != nil {
+			if err := trie.Prove(last.Bytes(), proof); err != nil {
 				t.Fatalf("Failed to prove the last node %v", err)
 			}
 			k := make([][]byte, 0)
@@ -555,10 +555,10 @@ func TestBadRangeProof(t *testing.T) {
 		start := mrand.Intn(len(entries))
 		end := mrand.Intn(len(entries)-start) + start + 1
 		proof := memorydb.New()
-		if err := trie.Prove(entries[start].k, 0, proof); err != nil {
+		if err := trie.Prove(entries[start].k, proof); err != nil {
 			t.Fatalf("Failed to prove the first node %v", err)
 		}
-		if err := trie.Prove(entries[end-1].k, 0, proof); err != nil {
+		if err := trie.Prove(entries[end-1].k, proof); err != nil {
 			t.Fatalf("Failed to prove the last node %v", err)
 		}
 		var keys [][]byte
@@ -624,10 +624,10 @@ func TestGappedRangeProof(t *testing.T) {
 	}
 	first, last := 2, 8
 	proof := memorydb.New()
-	if err := trie.Prove(entries[first].k, 0, proof); err != nil {
+	if err := trie.Prove(entries[first].k, proof); err != nil {
 		t.Fatalf("Failed to prove the first node %v", err)
 	}
-	if err := trie.Prove(entries[last-1].k, 0, proof); err != nil {
+	if err := trie.Prove(entries[last-1].k, proof); err != nil {
 		t.Fatalf("Failed to prove the last node %v", err)
 	}
 	var keys [][]byte
@@ -660,10 +660,10 @@ func TestSameSideProofs(t *testing.T) {
 	last := decreaseKey(common.CopyBytes(entries[pos].k))
 
 	proof := memorydb.New()
-	if err := trie.Prove(first, 0, proof); err != nil {
+	if err := trie.Prove(first, proof); err != nil {
 		t.Fatalf("Failed to prove the first node %v", err)
 	}
-	if err := trie.Prove(last, 0, proof); err != nil {
+	if err := trie.Prove(last, proof); err != nil {
 		t.Fatalf("Failed to prove the last node %v", err)
 	}
 	_, err := VerifyRangeProof(trie.Hash(), first, last, [][]byte{entries[pos].k}, [][]byte{entries[pos].v}, proof)
@@ -676,10 +676,10 @@ func TestSameSideProofs(t *testing.T) {
 	last = increaseKey(last)
 
 	proof = memorydb.New()
-	if err := trie.Prove(first, 0, proof); err != nil {
+	if err := trie.Prove(first, proof); err != nil {
 		t.Fatalf("Failed to prove the first node %v", err)
 	}
-	if err := trie.Prove(last, 0, proof); err != nil {
+	if err := trie.Prove(last, proof); err != nil {
 		t.Fatalf("Failed to prove the last node %v", err)
 	}
 	_, err = VerifyRangeProof(trie.Hash(), first, last, [][]byte{entries[pos].k}, [][]byte{entries[pos].v}, proof)
@@ -724,23 +724,23 @@ func TestHasRightElement(t *testing.T) {
 		)
 		if c.start == -1 {
 			firstKey, start = common.Hash{}.Bytes(), 0
-			if err := trie.Prove(firstKey, 0, proof); err != nil {
+			if err := trie.Prove(firstKey, proof); err != nil {
 				t.Fatalf("Failed to prove the first node %v", err)
 			}
 		} else {
 			firstKey = entries[c.start].k
-			if err := trie.Prove(entries[c.start].k, 0, proof); err != nil {
+			if err := trie.Prove(entries[c.start].k, proof); err != nil {
 				t.Fatalf("Failed to prove the first node %v", err)
 			}
 		}
 		if c.end == -1 {
 			lastKey, end = common.HexToHash("0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff").Bytes(), len(entries)
-			if err := trie.Prove(lastKey, 0, proof); err != nil {
+			if err := trie.Prove(lastKey, proof); err != nil {
 				t.Fatalf("Failed to prove the first node %v", err)
 			}
 		} else {
 			lastKey = entries[c.end-1].k
-			if err := trie.Prove(entries[c.end-1].k, 0, proof); err != nil {
+			if err := trie.Prove(entries[c.end-1].k, proof); err != nil {
 				t.Fatalf("Failed to prove the first node %v", err)
 			}
 		}
@@ -780,7 +780,7 @@ func TestEmptyRangeProof(t *testing.T) {
 	for _, c := range cases {
 		proof := memorydb.New()
 		first := increaseKey(common.CopyBytes(entries[c.pos].k))
-		if err := trie.Prove(first, 0, proof); err != nil {
+		if err := trie.Prove(first, proof); err != nil {
 			t.Fatalf("Failed to prove the first node %v", err)
 		}
 		_, err := VerifyRangeProof(trie.Hash(), first, nil, nil, nil, proof)
@@ -811,7 +811,7 @@ func TestBloatedProof(t *testing.T) {
 	// In the 'malicious' case, we add proofs for every single item
 	// (but only one key/value pair used as leaf)
 	for i, entry := range entries {
-		trie.Prove(entry.k, 0, proof)
+		trie.Prove(entry.k, proof)
 		if i == 50 {
 			keys = append(keys, entry.k)
 			vals = append(vals, entry.v)
@@ -820,8 +820,8 @@ func TestBloatedProof(t *testing.T) {
 	// For reference, we use the same function, but _only_ prove the first
 	// and last element
 	want := memorydb.New()
-	trie.Prove(keys[0], 0, want)
-	trie.Prove(keys[len(keys)-1], 0, want)
+	trie.Prove(keys[0], want)
+	trie.Prove(keys[len(keys)-1], want)
 
 	if _, err := VerifyRangeProof(trie.Hash(), keys[0], keys[len(keys)-1], keys, vals, proof); err != nil {
 		t.Fatalf("expected bloated proof to succeed, got %v", err)
@@ -854,10 +854,10 @@ func TestEmptyValueRangeProof(t *testing.T) {
 	start, end := 1, len(entries)-1
 
 	proof := memorydb.New()
-	if err := trie.Prove(entries[start].k, 0, proof); err != nil {
+	if err := trie.Prove(entries[start].k, proof); err != nil {
 		t.Fatalf("Failed to prove the first node %v", err)
 	}
-	if err := trie.Prove(entries[end-1].k, 0, proof); err != nil {
+	if err := trie.Prove(entries[end-1].k, proof); err != nil {
 		t.Fatalf("Failed to prove the last node %v", err)
 	}
 	var keys [][]byte
@@ -949,7 +949,7 @@ func BenchmarkProve(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		kv := vals[keys[i%len(keys)]]
 		proofs := memorydb.New()
-		if trie.Prove(kv.k, 0, proofs); proofs.Len() == 0 {
+		if trie.Prove(kv.k, proofs); proofs.Len() == 0 {
 			b.Fatalf("zero length proof for %x", kv.k)
 		}
 	}
@@ -963,7 +963,7 @@ func BenchmarkVerifyProof(b *testing.B) {
 	for k := range vals {
 		keys = append(keys, k)
 		proof := memorydb.New()
-		trie.Prove([]byte(k), 0, proof)
+		trie.Prove([]byte(k), proof)
 		proofs = append(proofs, proof)
 	}
 
@@ -992,10 +992,10 @@ func benchmarkVerifyRangeProof(b *testing.B, size int) {
 	start := 2
 	end := start + size
 	proof := memorydb.New()
-	if err := trie.Prove(entries[start].k, 0, proof); err != nil {
+	if err := trie.Prove(entries[start].k, proof); err != nil {
 		b.Fatalf("Failed to prove the first node %v", err)
 	}
-	if err := trie.Prove(entries[end-1].k, 0, proof); err != nil {
+	if err := trie.Prove(entries[end-1].k, proof); err != nil {
 		b.Fatalf("Failed to prove the last node %v", err)
 	}
 	var keys [][]byte
@@ -1094,10 +1094,10 @@ func TestRangeProofKeysWithSharedPrefix(t *testing.T) {
 	proof := memorydb.New()
 	start := common.Hex2Bytes("0000000000000000000000000000000000000000000000000000000000000000")
 	end := common.Hex2Bytes("ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff")
-	if err := trie.Prove(start, 0, proof); err != nil {
+	if err := trie.Prove(start, proof); err != nil {
 		t.Fatalf("failed to prove start: %v", err)
 	}
-	if err := trie.Prove(end, 0, proof); err != nil {
+	if err := trie.Prove(end, proof); err != nil {
 		t.Fatalf("failed to prove end: %v", err)
 	}
 

--- a/trie/tracer_test.go
+++ b/trie/tracer_test.go
@@ -241,7 +241,7 @@ func TestAccessListLeak(t *testing.T) {
 		{
 			func(tr *Trie) {
 				for _, val := range standard {
-					tr.Prove([]byte(val.k), 0, rawdb.NewMemoryDatabase())
+					tr.Prove([]byte(val.k), rawdb.NewMemoryDatabase())
 				}
 			},
 		},

--- a/trie/trie_test.go
+++ b/trie/trie_test.go
@@ -490,7 +490,7 @@ func runRandTest(rt randTest) bool {
 				continue
 			}
 			proofDb := rawdb.NewMemoryDatabase()
-			err := tr.Prove(step.key, 0, proofDb)
+			err := tr.Prove(step.key, proofDb)
 			if err != nil {
 				rt[i].err = fmt.Errorf("failed for proving key %#x, %v", step.key, err)
 			}


### PR DESCRIPTION
This PR removes the "unused" feature in trie prover by specifying the start level for collecting nodes as proof.

The main motivation for this PR is
- this feature is not used, even in LES
- this notion is a bit weird in mpt/verkle, we always expect the complete proof(please correct me if I am wrong, @gballet )


