### PR TITLE
internal/build: ignore some files in FindMainPackages

### DIFF
--- a/internal/build/util.go
+++ b/internal/build/util.go
@@ -197,6 +197,9 @@ func FindMainPackages(dir string) []string {
 	}
 	for _, cmd := range cmds {
 		pkgdir := filepath.Join(dir, cmd.Name())
+		if !cmd.IsDir() {
+			continue
+		}
 		pkgs, err := parser.ParseDir(token.NewFileSet(), pkgdir, nil, parser.PackageClauseOnly)
 		if err != nil {
 			log.Fatal(err)


### PR DESCRIPTION
In macOS, there may exist hidden [`.DS_Store`](https://en.wikipedia.org/wiki/.DS_Store) files inside some directories. These are filesystem metadata files created by Finder.
 If one of these `.DS_Store` files is inside the [./cmd](./cmd) directory, then running `make test` will fail with an error:


```bash 
$ make test
env GO111MODULE=on go run build/ci.go install  
util.go:202: fdopendir cmd/.DS_Store: not a directory  
exit status 1
make: *** [all] Error 1
```

This happens because the Go build tools try to process all files in the [./cmd](./cmd) directory, including the `.DS_Store` file, resulting in an error.

To fix this, we can ignore any files when parsing the package directory.
