### PR TITLE
core/txpool: remove use of errors.Join function

### DIFF
--- a/core/txpool/txpool.go
+++ b/core/txpool/txpool.go
@@ -88,18 +88,17 @@ func (p *TxPool) Close() error {
 	// Terminate the reset loop and wait for it to finish
 	errc := make(chan error)
 	p.quit <- errc
-	errs = append(errs, <-errc)
+	if err := <-errc; err != nil {
+		errs = append(errs, err)
+	}
 
 	// Terminate each subpool
-	var anyErr bool
 	for _, subpool := range p.subpools {
-		err := subpool.Close()
-		if err != nil {
-			anyErr = true
+		if err := subpool.Close(); err != nil {
 			errs = append(errs, err)
 		}
 	}
-	if anyErr {
+	if len(errs) > 0 {
 		return fmt.Errorf("subpool close errors: %v", errs)
 	}
 	return nil

--- a/core/txpool/txpool.go
+++ b/core/txpool/txpool.go
@@ -17,7 +17,7 @@
 package txpool
 
 import (
-	"errors"
+	"fmt"
 	"math/big"
 
 	"github.com/ethereum/go-ethereum/common"
@@ -91,10 +91,18 @@ func (p *TxPool) Close() error {
 	errs = append(errs, <-errc)
 
 	// Terminate each subpool
+	var anyErr bool
 	for _, subpool := range p.subpools {
-		errs = append(errs, subpool.Close())
+		err := subpool.Close()
+		if err != nil {
+			anyErr = true
+			errs = append(errs, err)
+		}
 	}
-	return errors.Join(errs...)
+	if anyErr {
+		return fmt.Errorf("subpool close errors: %v", errs)
+	}
+	return nil
 }
 
 // loop is the transaction pool's main event loop, waiting for and reacting to


### PR DESCRIPTION
This function was added in Go 1.20, but our compatibility target is Go 1.19.