### PR TITLE
core: log message if DeriveFields returns error

### DIFF
--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -2048,7 +2048,9 @@ func (bc *BlockChain) recoverAncestors(block *types.Block) (common.Hash, error) 
 // the processing of a block. These logs are later announced as deleted or reborn.
 func (bc *BlockChain) collectLogs(b *types.Block, removed bool) []*types.Log {
 	receipts := rawdb.ReadRawReceipts(bc.db, b.Hash(), b.NumberU64())
-	receipts.DeriveFields(bc.chainConfig, b.Hash(), b.NumberU64(), b.Time(), b.BaseFee(), b.Transactions())
+	if err := receipts.DeriveFields(bc.chainConfig, b.Hash(), b.NumberU64(), b.Time(), b.BaseFee(), b.Transactions()); err != nil {
+		log.Error("Failed to derive block receipts fields", "hash", b.Hash(), "number", b.NumberU64(), "err", err)
+	}
 
 	var logs []*types.Log
 	for _, receipt := range receipts {


### PR DESCRIPTION
This PR adds an error log in a case where the error was previously unchecked. This error should never happen and the error message is copied from https://github.com/ethereum/go-ethereum/blob/v1.12.0/core/rawdb/accessors_chain.go#L647