### PR TITLE
p2p/discover: swap verification order in discv4 ping handler

### DIFF
--- a/p2p/discover/v4_udp.go
+++ b/p2p/discover/v4_udp.go
@@ -643,12 +643,12 @@ type packetHandlerV4 struct {
 func (t *UDPv4) verifyPing(h *packetHandlerV4, from *net.UDPAddr, fromID enode.ID, fromKey v4wire.Pubkey) error {
 	req := h.Packet.(*v4wire.Ping)
 
+	if v4wire.Expired(req.Expiration) {
+		return errExpired
+	}
 	senderKey, err := v4wire.DecodePubkey(crypto.S256(), fromKey)
 	if err != nil {
 		return err
-	}
-	if v4wire.Expired(req.Expiration) {
-		return errExpired
 	}
 	h.senderKey = senderKey
 	return nil


### PR DESCRIPTION
This PR swaps the order of ping verification. 
In all other UDPv4 methods, the deadline is checked first. It seems weird to me that ping is an exception. Deadline comparison is also less resource intensive.