### PR TITLE
core: simplify recoverAncestors

### DIFF
--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -2006,10 +2006,10 @@ func (bc *BlockChain) recoverAncestors(block *types.Block) (common.Hash, error) 
 	// Gather all the sidechain hashes (full blocks may be memory heavy)
 	var (
 		parent = block
-		chains []*types.Block
+		chain  []*types.Block
 	)
 	for parent != nil && !bc.HasState(parent.Root()) {
-		chains = append(chains, parent)
+		chain = append(chain, parent)
 		parent = bc.GetBlock(parent.ParentHash(), parent.NumberU64()-1)
 
 		// If the chain is terminating, stop iteration
@@ -2022,14 +2022,14 @@ func (bc *BlockChain) recoverAncestors(block *types.Block) (common.Hash, error) 
 		return common.Hash{}, errors.New("missing parent")
 	}
 	// Import all the pruned blocks to make the state available
-	for i := len(chains) - 1; i >= 0; i-- {
+	for i := len(chain) - 1; i >= 0; i-- {
 		// If the chain is terminating, stop processing blocks
 		if bc.insertStopped() {
 			log.Debug("Abort during blocks processing")
 			return common.Hash{}, errInsertionInterrupted
 		}
-		if _, err := bc.insertChain(types.Blocks{chains[i]}, false); err != nil {
-			return chains[i].ParentHash(), err
+		if _, err := bc.insertChain(types.Blocks{chain[i]}, false); err != nil {
+			return chain[i].ParentHash(), err
 		}
 	}
 	return block.Hash(), nil


### PR DESCRIPTION
It seems that it's unnecessary to retrieve the block twice within this function. So, can we simplify it?