### PR TITLE
core/txpool/legacypool: move locals-handling out of pool

### DIFF
--- a/core/txpool/legacypool/tx_tracker.go
+++ b/core/txpool/legacypool/tx_tracker.go
@@ -1,0 +1,183 @@
+// Copyright 2023 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+
+// Package legacypool implements the normal EVM execution transaction pool.
+package legacypool
+
+import (
+	"sync"
+	"time"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/txpool"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/log"
+	"github.com/ethereum/go-ethereum/params"
+	"golang.org/x/exp/slices"
+)
+
+var recheckInterval = time.Minute
+
+// TxTracker is a struct used to track priority transactions; it will check from
+// time to time if the main pool has forgotten about any of the transaction
+// it is tracking, and if so, submit it again.
+// This is used to track 'locals'.
+// This struct does not care about transaction validity, price-bumps or account limits,
+// but optimistically accepts transactions.
+type TxTracker struct {
+	all    map[common.Hash]*types.Transaction // All tracked transactions
+	byAddr map[common.Address]*sortedMap      // Transactions by address
+
+	journal  *journal       // Journal of local transaction to back up to disk
+	modified bool           // Modification tracking
+	pool     txpool.SubPool // The 'main' subpool to interact with
+	signer   types.Signer
+
+	shutdownCh chan struct{}
+	mu         sync.Mutex
+	wg         sync.WaitGroup
+}
+
+func NewTxTracker(journalPath string, chainConfig *params.ChainConfig, next txpool.SubPool) *TxTracker {
+	signer := types.LatestSigner(chainConfig)
+	pool := &TxTracker{
+		all:        make(map[common.Hash]*types.Transaction),
+		byAddr:     make(map[common.Address]*sortedMap),
+		signer:     signer,
+		shutdownCh: make(chan struct{}),
+		pool:       next,
+	}
+	if journalPath != "" {
+		pool.journal = newTxJournal(journalPath)
+	}
+	return pool
+}
+
+// Track adds a transaction to the tracked set.
+func (tracker *TxTracker) Track(tx *types.Transaction) {
+	tracker.TrackAll([]*types.Transaction{tx})
+}
+
+// TrackAll adds a list of transactions to the tracked set.
+func (tracker *TxTracker) TrackAll(txs []*types.Transaction) {
+	tracker.mu.Lock()
+	defer tracker.mu.Unlock()
+	for _, tx := range txs {
+		// If we're already tracking it, it's a no-op
+		if _, ok := tracker.all[tx.Hash()]; ok {
+			continue
+		}
+		tracker.all[tx.Hash()] = tx
+		addr, _ := types.Sender(tracker.signer, tx)
+		if tracker.byAddr[addr] == nil {
+			tracker.byAddr[addr] = newSortedMap()
+		}
+		tracker.byAddr[addr].Put(tx)
+		tracker.modified = true
+	}
+}
+
+// recheck checks and returns any transactions that needs to be resubmitted.
+func (tracker *TxTracker) recheck() []*txpool.Transaction {
+	tracker.mu.Lock()
+	defer tracker.mu.Unlock()
+
+	if !tracker.modified {
+		return nil
+	}
+	var (
+		resubmits []*txpool.Transaction
+		nStales   = 0
+		nOk       = 0
+	)
+	for sender, txs := range tracker.byAddr {
+		stales := txs.Forward(tracker.pool.Nonce(sender))
+		// Wipe the stales
+		for _, tx := range stales {
+			delete(tracker.all, tx.Hash())
+		}
+		nStales += len(stales)
+		// Check the non-stale
+		for _, tx := range txs.Flatten() {
+			if tracker.pool.Has(tx.Hash()) {
+				nOk++
+				continue
+			}
+			resubmits = append(resubmits, &txpool.Transaction{
+				Tx: tx,
+			})
+		}
+	}
+
+	{ // rejournal
+		txs := make(map[common.Address]types.Transactions)
+		for _, tx := range tracker.all {
+			addr, _ := types.Sender(tracker.signer, tx)
+			txs[addr] = append(txs[addr], tx)
+		}
+		// Sort them
+		for _, list := range txs {
+			slices.SortFunc(list, func(a, b *types.Transaction) bool {
+				return a.Nonce() < b.Nonce()
+			})
+		}
+		if err := tracker.journal.rotate(txs); err != nil {
+			log.Warn("Transaction journal rotation failed", "err", err)
+		}
+	}
+	log.Debug("Tx tracker status", "need-resubmit", len(resubmits), "stale", nStales, "ok", nOk)
+	return resubmits
+}
+
+// Start implements node.Lifecycle interface
+// Start is called after all services have been constructed and the networking
+// layer was also initialized to spawn any goroutines required by the service.
+func (tracker *TxTracker) Start() error {
+	tracker.wg.Add(1)
+	go tracker.loop()
+	return nil
+}
+
+// Start implements node.Lifecycle interface
+// Stop terminates all goroutines belonging to the service, blocking until they
+// are all terminated.
+func (tracker *TxTracker) Stop() error {
+	close(tracker.shutdownCh)
+	tracker.wg.Wait()
+	return nil
+}
+
+func (tracker *TxTracker) loop() {
+	defer tracker.wg.Done()
+	tracker.journal.load(func(transactions []*types.Transaction) []error {
+		tracker.TrackAll(transactions)
+		return nil
+	})
+	// Do initial check after 10 seconds, do rechecks more seldom.
+	t := time.NewTimer(10 * time.Second)
+	for {
+		select {
+		case <-tracker.shutdownCh:
+			return
+		case <-t.C:
+			// resubmit
+			if resubmits := tracker.recheck(); len(resubmits) > 0 {
+				tracker.pool.Add(resubmits, false, false)
+			}
+			t.Reset(recheckInterval)
+		}
+	}
+}

--- a/core/txpool/txpool.go
+++ b/core/txpool/txpool.go
@@ -217,7 +217,8 @@ func (p *TxPool) Add(txs []*Transaction, local bool, sync bool) []error {
 	// back the errors into the original sort order.
 	errsets := make([][]error, len(p.subpools))
 	for i := 0; i < len(p.subpools); i++ {
-		errsets[i] = p.subpools[i].Add(txsets[i], local, sync)
+		// Note: local is explicitly set to false here.
+		errsets[i] = p.subpools[i].Add(txsets[i], false, sync)
 	}
 	errs := make([]error, len(txs))
 	for i, split := range splits {

--- a/eth/api_backend.go
+++ b/eth/api_backend.go
@@ -294,6 +294,9 @@ func (b *EthAPIBackend) SubscribeLogsEvent(ch chan<- []*types.Log) event.Subscri
 }
 
 func (b *EthAPIBackend) SendTx(ctx context.Context, signedTx *types.Transaction) error {
+	if locals := b.eth.localTxTracker; locals != nil {
+		locals.Track(signedTx)
+	}
 	return b.eth.txPool.Add([]*txpool.Transaction{&txpool.Transaction{Tx: signedTx}}, true, false)[0]
 }
 


### PR DESCRIPTION
This is work in progress.
This PR disables all locals-handling within the legacy transaction pool (it doesn't remove the code (yet) just sets local to false in the txpool during submission).

In place of the locals, this PR instead utilizes a TxTracker, a tracker which, from time to time (every minute), checks on the set of transactions that it tracks, whether the transaction seems to have been forgotten and needs to be resubmitted to the pool.

This design makes the handling of locals be not part of the internals of the pool, which simplifies a lot since it removes a lot of cornercases where handling of locals/nonlocals use different rules.

