### PR TITLE
signer/core: Extended logInfo for clef

### DIFF
--- a/signer/core/api.go
+++ b/signer/core/api.go
@@ -552,8 +552,7 @@ func (api *SignerAPI) SignTransaction(ctx context.Context, args apitypes.SendTxA
 	}
 	// If we are in 'rejectMode', then reject rather than show the user warnings
 	if api.rejectMode {
-		err := msgs.GetWarnings()
-		if err != nil {
+		if err := msgs.GetWarnings(); err != nil {
 			log.Info("Signing aborted due to warnings. In order to continue despite warnings, please use the flag '--advanced'.")
 			return nil, err
 		}
@@ -626,8 +625,7 @@ func (api *SignerAPI) SignGnosisSafeTx(ctx context.Context, signerAddress common
 	}
 	// If we are in 'rejectMode', then reject rather than show the user warnings
 	if api.rejectMode {
-		err := msgs.GetWarnings()
-		if err != nil {
+		if err := msgs.GetWarnings(); err != nil {
 			log.Info("Signing aborted due to warnings. In order to continue despite warnings, please use the flag '--advanced'.")
 			return nil, err
 		}

--- a/signer/core/api.go
+++ b/signer/core/api.go
@@ -555,9 +555,7 @@ func (api *SignerAPI) SignTransaction(ctx context.Context, args apitypes.SendTxA
 	if api.rejectMode {
 		err := msgs.GetWarnings()
 		if err != nil {
-			if strings.Contains(err.Error(), "ABI signature could not be found") {
-				return nil, fmt.Errorf("%s. Please use '--advanced' mode or provide the 'selector' argument to force the signing", err.Error())
-			}
+			log.Info("Signing aborted due to warnings. In order to continue despite warnings, please use the flag '--advanced'.")
 			return nil, err
 		}
 	}

--- a/signer/core/api.go
+++ b/signer/core/api.go
@@ -25,7 +25,6 @@ import (
 	"math/big"
 	"os"
 	"reflect"
-	"strings"
 
 	"github.com/ethereum/go-ethereum/accounts"
 	"github.com/ethereum/go-ethereum/accounts/keystore"
@@ -629,9 +628,7 @@ func (api *SignerAPI) SignGnosisSafeTx(ctx context.Context, signerAddress common
 	if api.rejectMode {
 		err := msgs.GetWarnings()
 		if err != nil {
-			if strings.Contains(err.Error(), "ABI signature could not be found") {
-				return nil, fmt.Errorf("%s. Please use '--advanced' mode or provide the 'selector' argument to force the signing", err.Error())
-			}
+			log.Info("Signing aborted due to warnings. In order to continue despite warnings, please use the flag '--advanced'.")
 			return nil, err
 		}
 	}

--- a/signer/core/api.go
+++ b/signer/core/api.go
@@ -25,6 +25,7 @@ import (
 	"math/big"
 	"os"
 	"reflect"
+	"strings"
 
 	"github.com/ethereum/go-ethereum/accounts"
 	"github.com/ethereum/go-ethereum/accounts/keystore"
@@ -552,7 +553,11 @@ func (api *SignerAPI) SignTransaction(ctx context.Context, args apitypes.SendTxA
 	}
 	// If we are in 'rejectMode', then reject rather than show the user warnings
 	if api.rejectMode {
-		if err := msgs.GetWarnings(); err != nil {
+		err := msgs.GetWarnings()
+		if err != nil {
+			if strings.Contains(err.Error(), "ABI signature could not be found") {
+				return nil, fmt.Errorf("%s. Please use '--advanced' mode or provide the 'selector' argument to force the signing", err.Error())
+			}
 			return nil, err
 		}
 	}
@@ -624,7 +629,11 @@ func (api *SignerAPI) SignGnosisSafeTx(ctx context.Context, signerAddress common
 	}
 	// If we are in 'rejectMode', then reject rather than show the user warnings
 	if api.rejectMode {
-		if err := msgs.GetWarnings(); err != nil {
+		err := msgs.GetWarnings()
+		if err != nil {
+			if strings.Contains(err.Error(), "ABI signature could not be found") {
+				return nil, fmt.Errorf("%s. Please use '--advanced' mode or provide the 'selector' argument to force the signing", err.Error())
+			}
 			return nil, err
 		}
 	}

--- a/signer/fourbyte/fourbyte.go
+++ b/signer/fourbyte/fourbyte.go
@@ -111,7 +111,7 @@ func (db *Database) Selector(id []byte) (string, error) {
 	if selector, exists := db.custom[sig]; exists {
 		return selector, nil
 	}
-	return "", fmt.Errorf("signature %v not found, consider using --advanced mode or provide a selector", sig)
+	return "", fmt.Errorf("signature %v not found", sig)
 }
 
 // AddSelector inserts a new 4byte entry into the database. If custom database

--- a/signer/fourbyte/fourbyte.go
+++ b/signer/fourbyte/fourbyte.go
@@ -111,7 +111,7 @@ func (db *Database) Selector(id []byte) (string, error) {
 	if selector, exists := db.custom[sig]; exists {
 		return selector, nil
 	}
-	return "", fmt.Errorf("signature %v not found", sig)
+	return "", fmt.Errorf("signature %v not found, consider using --advanced mode or provide a selector", sig)
 }
 
 // AddSelector inserts a new 4byte entry into the database. If custom database


### PR DESCRIPTION
When developers first encounter Clef, they might fall into confusion due to failure, possibly because they didn't carefully read the documentation. Therefore, it would be beneficial to supplement information directly in the 'message.Warn'.
like https://github.com/ethereum/go-ethereum/issues/27528 