### PR TITLE
trie, core/state: revert error removal in (*state.Trie).Commit

### DIFF
--- a/core/state/database.go
+++ b/core/state/database.go
@@ -114,7 +114,7 @@ type Trie interface {
 	// The returned nodeset can be nil if the trie is clean(nothing to commit).
 	// Once the trie is committed, it's not usable anymore. A new trie must
 	// be created with new root and updated trie database for following usage
-	Commit(collectLeaf bool) (common.Hash, *trienode.NodeSet)
+	Commit(collectLeaf bool) (common.Hash, *trienode.NodeSet, error)
 
 	// NodeIterator returns an iterator that returns nodes of the trie. Iteration
 	// starts at the key after the given start key. And error will be returned

--- a/core/state/snapshot/generate.go
+++ b/core/state/snapshot/generate.go
@@ -361,7 +361,10 @@ func (dl *diskLayer) generateRange(ctx *generatorContext, trieId *trie.ID, prefi
 		for i, key := range result.keys {
 			snapTrie.Update(key, result.vals[i])
 		}
-		root, nodes := snapTrie.Commit(false)
+		root, nodes, err := snapTrie.Commit(false)
+		if err != nil {
+			return false, nil, err
+		}
 		if nodes != nil {
 			tdb.Update(root, types.EmptyRootHash, trienode.NewWithNodeSet(nodes))
 			tdb.Commit(root, false)

--- a/core/state/snapshot/generate_test.go
+++ b/core/state/snapshot/generate_test.go
@@ -191,7 +191,7 @@ func (t *testHelper) makeStorageTrie(owner common.Hash, keys []string, vals []st
 	if !commit {
 		return stTrie.Hash()
 	}
-	root, nodes := stTrie.Commit(false)
+	root, nodes, _ := stTrie.Commit(false)
 	if nodes != nil {
 		t.nodes.Merge(nodes)
 	}
@@ -199,7 +199,7 @@ func (t *testHelper) makeStorageTrie(owner common.Hash, keys []string, vals []st
 }
 
 func (t *testHelper) Commit() common.Hash {
-	root, nodes := t.accTrie.Commit(true)
+	root, nodes, _ := t.accTrie.Commit(true)
 	if nodes != nil {
 		t.nodes.Merge(nodes)
 	}

--- a/core/state/state_object.go
+++ b/core/state/state_object.go
@@ -366,9 +366,11 @@ func (s *stateObject) commitTrie(db Database) (*trienode.NodeSet, error) {
 	if metrics.EnabledExpensive {
 		defer func(start time.Time) { s.db.StorageCommits += time.Since(start) }(time.Now())
 	}
-	root, nodes := tr.Commit(false)
-	s.data.Root = root
-	return nodes, nil
+	root, nodes, err := tr.Commit(false)
+	if err == nil {
+		s.data.Root = root
+	}
+	return nodes, err
 }
 
 // AddBalance adds amount to s's balance.

--- a/core/state/state_object.go
+++ b/core/state/state_object.go
@@ -367,10 +367,11 @@ func (s *stateObject) commitTrie(db Database) (*trienode.NodeSet, error) {
 		defer func(start time.Time) { s.db.StorageCommits += time.Since(start) }(time.Now())
 	}
 	root, nodes, err := tr.Commit(false)
-	if err == nil {
-		s.data.Root = root
+	if err != nil {
+		return nil, err
 	}
-	return nodes, err
+	s.data.Root = root
+	return nodes, nil
 }
 
 // AddBalance adds amount to s's balance.

--- a/core/state/statedb.go
+++ b/core/state/statedb.go
@@ -1051,7 +1051,10 @@ func (s *StateDB) Commit(deleteEmptyObjects bool) (common.Hash, error) {
 	if metrics.EnabledExpensive {
 		start = time.Now()
 	}
-	root, set := s.trie.Commit(true)
+	root, set, err := s.trie.Commit(true)
+	if err != nil {
+		return common.Hash{}, err
+	}
 	// Merge the dirty nodes of account trie into global set
 	if set != nil {
 		if err := nodes.Merge(set); err != nil {

--- a/eth/protocols/snap/sync_test.go
+++ b/eth/protocols/snap/sync_test.go
@@ -1386,7 +1386,7 @@ func makeAccountTrieNoStorage(n int) (string, *trie.Trie, []*kv) {
 
 	// Commit the state changes into db and re-create the trie
 	// for accessing later.
-	root, nodes := accTrie.Commit(false)
+	root, nodes, _ := accTrie.Commit(false)
 	db.Update(root, types.EmptyRootHash, trienode.NewWithNodeSet(nodes))
 
 	accTrie, _ = trie.New(trie.StateTrieID(root), db)
@@ -1448,7 +1448,7 @@ func makeBoundaryAccountTrie(n int) (string, *trie.Trie, []*kv) {
 
 	// Commit the state changes into db and re-create the trie
 	// for accessing later.
-	root, nodes := accTrie.Commit(false)
+	root, nodes, _ := accTrie.Commit(false)
 	db.Update(root, types.EmptyRootHash, trienode.NewWithNodeSet(nodes))
 
 	accTrie, _ = trie.New(trie.StateTrieID(root), db)
@@ -1494,7 +1494,7 @@ func makeAccountTrieWithStorageWithUniqueStorage(accounts, slots int, code bool)
 	slices.SortFunc(entries, (*kv).less)
 
 	// Commit account trie
-	root, set := accTrie.Commit(true)
+	root, set, _ := accTrie.Commit(true)
 	nodes.Merge(set)
 
 	// Commit gathered dirty nodes into database
@@ -1559,7 +1559,7 @@ func makeAccountTrieWithStorage(accounts, slots int, code, boundary bool) (strin
 	slices.SortFunc(entries, (*kv).less)
 
 	// Commit account trie
-	root, set := accTrie.Commit(true)
+	root, set, _ := accTrie.Commit(true)
 	nodes.Merge(set)
 
 	// Commit gathered dirty nodes into database
@@ -1601,7 +1601,7 @@ func makeStorageTrieWithSeed(owner common.Hash, n, seed uint64, db *trie.Databas
 		entries = append(entries, elem)
 	}
 	slices.SortFunc(entries, (*kv).less)
-	root, nodes := trie.Commit(false)
+	root, nodes, _ := trie.Commit(false)
 	return root, nodes, entries
 }
 
@@ -1652,7 +1652,7 @@ func makeBoundaryStorageTrie(owner common.Hash, n int, db *trie.Database) (commo
 		entries = append(entries, elem)
 	}
 	slices.SortFunc(entries, (*kv).less)
-	root, nodes := trie.Commit(false)
+	root, nodes, _ := trie.Commit(false)
 	return root, nodes, entries
 }
 

--- a/light/postprocess.go
+++ b/light/postprocess.go
@@ -214,7 +214,10 @@ func (c *ChtIndexerBackend) Process(ctx context.Context, header *types.Header) e
 
 // Commit implements core.ChainIndexerBackend
 func (c *ChtIndexerBackend) Commit() error {
-	root, nodes := c.trie.Commit(false)
+	root, nodes, err := c.trie.Commit(false)
+	if err != nil {
+		return err
+	}
 	// Commit trie changes into trie database in case it's not nil.
 	if nodes != nil {
 		if err := c.triedb.Update(root, c.originRoot, trienode.NewWithNodeSet(nodes)); err != nil {
@@ -225,7 +228,6 @@ func (c *ChtIndexerBackend) Commit() error {
 		}
 	}
 	// Re-create trie with newly generated root and updated database.
-	var err error
 	c.trie, err = trie.New(trie.TrieID(root), c.triedb)
 	if err != nil {
 		return err
@@ -465,7 +467,10 @@ func (b *BloomTrieIndexerBackend) Commit() error {
 			return terr
 		}
 	}
-	root, nodes := b.trie.Commit(false)
+	root, nodes, err := b.trie.Commit(false)
+	if err != nil {
+		return err
+	}
 	// Commit trie changes into trie database in case it's not nil.
 	if nodes != nil {
 		if err := b.triedb.Update(root, b.originRoot, trienode.NewWithNodeSet(nodes)); err != nil {
@@ -476,7 +481,6 @@ func (b *BloomTrieIndexerBackend) Commit() error {
 		}
 	}
 	// Re-create trie with newly generated root and updated database.
-	var err error
 	b.trie, err = trie.New(trie.TrieID(root), b.triedb)
 	if err != nil {
 		return err

--- a/light/trie.go
+++ b/light/trie.go
@@ -174,9 +174,9 @@ func (t *odrTrie) DeleteAccount(address common.Address) error {
 	})
 }
 
-func (t *odrTrie) Commit(collectLeaf bool) (common.Hash, *trienode.NodeSet) {
+func (t *odrTrie) Commit(collectLeaf bool) (common.Hash, *trienode.NodeSet, error) {
 	if t.trie == nil {
-		return t.id.Root, nil
+		return t.id.Root, nil, nil
 	}
 	return t.trie.Commit(collectLeaf)
 }

--- a/tests/fuzzers/stacktrie/trie_fuzzer.go
+++ b/tests/fuzzers/stacktrie/trie_fuzzer.go
@@ -171,7 +171,10 @@ func (f *fuzzer) fuzz() int {
 		return 0
 	}
 	// Flush trie -> database
-	rootA, nodes := trieA.Commit(false)
+	rootA, nodes, err := trieA.Commit(false)
+	if err != nil {
+		panic(err)
+	}
 	if nodes != nil {
 		dbA.Update(rootA, types.EmptyRootHash, trienode.NewWithNodeSet(nodes))
 	}

--- a/tests/fuzzers/trie/trie-fuzzer.go
+++ b/tests/fuzzers/trie/trie-fuzzer.go
@@ -165,7 +165,10 @@ func runRandTest(rt randTest) error {
 		case opHash:
 			tr.Hash()
 		case opCommit:
-			hash, nodes := tr.Commit(false)
+			hash, nodes, err := tr.Commit(false)
+			if err != nil {
+				return err
+			}
 			if nodes != nil {
 				if err := triedb.Update(hash, origin, trienode.NewWithNodeSet(nodes)); err != nil {
 					return err

--- a/trie/iterator_test.go
+++ b/trie/iterator_test.go
@@ -62,7 +62,7 @@ func TestIterator(t *testing.T) {
 		all[val.k] = val.v
 		trie.MustUpdate([]byte(val.k), []byte(val.v))
 	}
-	root, nodes := trie.Commit(false)
+	root, nodes, _ := trie.Commit(false)
 	db.Update(root, types.EmptyRootHash, trienode.NewWithNodeSet(nodes))
 
 	trie, _ = New(TrieID(root), db)
@@ -254,7 +254,7 @@ func TestDifferenceIterator(t *testing.T) {
 	for _, val := range testdata1 {
 		triea.MustUpdate([]byte(val.k), []byte(val.v))
 	}
-	rootA, nodesA := triea.Commit(false)
+	rootA, nodesA, _ := triea.Commit(false)
 	dba.Update(rootA, types.EmptyRootHash, trienode.NewWithNodeSet(nodesA))
 	triea, _ = New(TrieID(rootA), dba)
 
@@ -263,7 +263,7 @@ func TestDifferenceIterator(t *testing.T) {
 	for _, val := range testdata2 {
 		trieb.MustUpdate([]byte(val.k), []byte(val.v))
 	}
-	rootB, nodesB := trieb.Commit(false)
+	rootB, nodesB, _ := trieb.Commit(false)
 	dbb.Update(rootB, types.EmptyRootHash, trienode.NewWithNodeSet(nodesB))
 	trieb, _ = New(TrieID(rootB), dbb)
 
@@ -296,7 +296,7 @@ func TestUnionIterator(t *testing.T) {
 	for _, val := range testdata1 {
 		triea.MustUpdate([]byte(val.k), []byte(val.v))
 	}
-	rootA, nodesA := triea.Commit(false)
+	rootA, nodesA, _ := triea.Commit(false)
 	dba.Update(rootA, types.EmptyRootHash, trienode.NewWithNodeSet(nodesA))
 	triea, _ = New(TrieID(rootA), dba)
 
@@ -305,7 +305,7 @@ func TestUnionIterator(t *testing.T) {
 	for _, val := range testdata2 {
 		trieb.MustUpdate([]byte(val.k), []byte(val.v))
 	}
-	rootB, nodesB := trieb.Commit(false)
+	rootB, nodesB, _ := trieb.Commit(false)
 	dbb.Update(rootB, types.EmptyRootHash, trienode.NewWithNodeSet(nodesB))
 	trieb, _ = New(TrieID(rootB), dbb)
 
@@ -367,7 +367,7 @@ func testIteratorContinueAfterError(t *testing.T, memonly bool, scheme string) {
 	for _, val := range testdata1 {
 		tr.MustUpdate([]byte(val.k), []byte(val.v))
 	}
-	root, nodes := tr.Commit(false)
+	root, nodes, _ := tr.Commit(false)
 	tdb.Update(root, types.EmptyRootHash, trienode.NewWithNodeSet(nodes))
 	if !memonly {
 		tdb.Commit(root, false)
@@ -477,7 +477,7 @@ func testIteratorContinueAfterSeekError(t *testing.T, memonly bool, scheme strin
 	for _, val := range testdata1 {
 		ctr.MustUpdate([]byte(val.k), []byte(val.v))
 	}
-	root, nodes := ctr.Commit(false)
+	root, nodes, _ := ctr.Commit(false)
 	for path, n := range nodes.Nodes {
 		if n.Hash == barNodeHash {
 			barNodePath = []byte(path)
@@ -604,7 +604,7 @@ func makeLargeTestTrie() (*Database, *StateTrie, *loggingDb) {
 		val = crypto.Keccak256(val)
 		trie.MustUpdate(key, val)
 	}
-	root, nodes := trie.Commit(false)
+	root, nodes, _ := trie.Commit(false)
 	triedb.Update(root, types.EmptyRootHash, trienode.NewWithNodeSet(nodes))
 	triedb.Commit(root, false)
 
@@ -647,7 +647,7 @@ func testIteratorNodeBlob(t *testing.T, scheme string) {
 		all[val.k] = val.v
 		trie.MustUpdate([]byte(val.k), []byte(val.v))
 	}
-	root, nodes := trie.Commit(false)
+	root, nodes, _ := trie.Commit(false)
 	triedb.Update(root, types.EmptyRootHash, trienode.NewWithNodeSet(nodes))
 	triedb.Commit(root, false)
 

--- a/trie/secure_trie.go
+++ b/trie/secure_trie.go
@@ -223,7 +223,7 @@ func (t *StateTrie) GetKey(shaKey []byte) []byte {
 // All cached preimages will be also flushed if preimages recording is enabled.
 // Once the trie is committed, it's not usable anymore. A new trie must
 // be created with new root and updated trie database for following usage
-func (t *StateTrie) Commit(collectLeaf bool) (common.Hash, *trienode.NodeSet) {
+func (t *StateTrie) Commit(collectLeaf bool) (common.Hash, *trienode.NodeSet, error) {
 	// Write all the pre-images to the actual disk database
 	if len(t.getSecKeyCache()) > 0 {
 		if t.preimages != nil {

--- a/trie/secure_trie_test.go
+++ b/trie/secure_trie_test.go
@@ -60,7 +60,7 @@ func makeTestStateTrie() (*Database, *StateTrie, map[string][]byte) {
 			trie.MustUpdate(key, val)
 		}
 	}
-	root, nodes := trie.Commit(false)
+	root, nodes, _ := trie.Commit(false)
 	if err := triedb.Update(root, types.EmptyRootHash, trienode.NewWithNodeSet(nodes)); err != nil {
 		panic(fmt.Errorf("failed to commit db %v", err))
 	}

--- a/trie/sync_test.go
+++ b/trie/sync_test.go
@@ -56,7 +56,7 @@ func makeTestTrie(scheme string) (ethdb.Database, *Database, *StateTrie, map[str
 			trie.MustUpdate(key, val)
 		}
 	}
-	root, nodes := trie.Commit(false)
+	root, nodes, _ := trie.Commit(false)
 	if err := triedb.Update(root, types.EmptyRootHash, trienode.NewWithNodeSet(nodes)); err != nil {
 		panic(fmt.Errorf("failed to commit db %v", err))
 	}
@@ -739,7 +739,7 @@ func testSyncMovingTarget(t *testing.T, scheme string) {
 		srcTrie.MustUpdate(key, val)
 		diff[string(key)] = val
 	}
-	root, nodes := srcTrie.Commit(false)
+	root, nodes, _ := srcTrie.Commit(false)
 	if err := srcDb.Update(root, preRoot, trienode.NewWithNodeSet(nodes)); err != nil {
 		panic(err)
 	}
@@ -764,7 +764,7 @@ func testSyncMovingTarget(t *testing.T, scheme string) {
 		srcTrie.MustUpdate([]byte(k), val)
 		reverted[k] = val
 	}
-	root, nodes = srcTrie.Commit(false)
+	root, nodes, _ = srcTrie.Commit(false)
 	if err := srcDb.Update(root, preRoot, trienode.NewWithNodeSet(nodes)); err != nil {
 		panic(err)
 	}

--- a/trie/tracer_test.go
+++ b/trie/tracer_test.go
@@ -70,7 +70,7 @@ func testTrieTracer(t *testing.T, vals []struct{ k, v string }) {
 	}
 	insertSet := copySet(trie.tracer.inserts) // copy before commit
 	deleteSet := copySet(trie.tracer.deletes) // copy before commit
-	root, nodes := trie.Commit(false)
+	root, nodes, _ := trie.Commit(false)
 	db.Update(root, types.EmptyRootHash, trienode.NewWithNodeSet(nodes))
 
 	seen := setKeys(iterNodes(db, root))
@@ -136,7 +136,7 @@ func testAccessList(t *testing.T, vals []struct{ k, v string }) {
 	for _, val := range vals {
 		trie.MustUpdate([]byte(val.k), []byte(val.v))
 	}
-	root, nodes := trie.Commit(false)
+	root, nodes, _ := trie.Commit(false)
 	db.Update(root, types.EmptyRootHash, trienode.NewWithNodeSet(nodes))
 
 	trie, _ = New(TrieID(root), db)
@@ -151,7 +151,7 @@ func testAccessList(t *testing.T, vals []struct{ k, v string }) {
 	for _, val := range vals {
 		trie.MustUpdate([]byte(val.k), randBytes(32))
 	}
-	root, nodes = trie.Commit(false)
+	root, nodes, _ = trie.Commit(false)
 	db.Update(root, parent, trienode.NewWithNodeSet(nodes))
 
 	trie, _ = New(TrieID(root), db)
@@ -169,7 +169,7 @@ func testAccessList(t *testing.T, vals []struct{ k, v string }) {
 		keys = append(keys, string(key))
 		trie.MustUpdate(key, randBytes(32))
 	}
-	root, nodes = trie.Commit(false)
+	root, nodes, _ = trie.Commit(false)
 	db.Update(root, parent, trienode.NewWithNodeSet(nodes))
 
 	trie, _ = New(TrieID(root), db)
@@ -184,7 +184,7 @@ func testAccessList(t *testing.T, vals []struct{ k, v string }) {
 	for _, key := range keys {
 		trie.MustUpdate([]byte(key), nil)
 	}
-	root, nodes = trie.Commit(false)
+	root, nodes, _ = trie.Commit(false)
 	db.Update(root, parent, trienode.NewWithNodeSet(nodes))
 
 	trie, _ = New(TrieID(root), db)
@@ -199,7 +199,7 @@ func testAccessList(t *testing.T, vals []struct{ k, v string }) {
 	for _, val := range vals {
 		trie.MustUpdate([]byte(val.k), nil)
 	}
-	root, nodes = trie.Commit(false)
+	root, nodes, _ = trie.Commit(false)
 	db.Update(root, parent, trienode.NewWithNodeSet(nodes))
 
 	trie, _ = New(TrieID(root), db)
@@ -218,7 +218,7 @@ func TestAccessListLeak(t *testing.T) {
 	for _, val := range standard {
 		trie.MustUpdate([]byte(val.k), []byte(val.v))
 	}
-	root, nodes := trie.Commit(false)
+	root, nodes, _ := trie.Commit(false)
 	db.Update(root, types.EmptyRootHash, trienode.NewWithNodeSet(nodes))
 
 	var cases = []struct {
@@ -268,7 +268,7 @@ func TestTinyTree(t *testing.T) {
 	for _, val := range tiny {
 		trie.MustUpdate([]byte(val.k), randBytes(32))
 	}
-	root, set := trie.Commit(false)
+	root, set, _ := trie.Commit(false)
 	db.Update(root, types.EmptyRootHash, trienode.NewWithNodeSet(set))
 
 	parent := root
@@ -277,7 +277,7 @@ func TestTinyTree(t *testing.T) {
 	for _, val := range tiny {
 		trie.MustUpdate([]byte(val.k), []byte(val.v))
 	}
-	root, set = trie.Commit(false)
+	root, set, _ = trie.Commit(false)
 	db.Update(root, parent, trienode.NewWithNodeSet(set))
 
 	trie, _ = New(TrieID(root), db)

--- a/trie/trie.go
+++ b/trie/trie.go
@@ -607,7 +607,7 @@ func (t *Trie) Hash() common.Hash {
 // The returned nodeset can be nil if the trie is clean (nothing to commit).
 // Once the trie is committed, it's not usable anymore. A new trie must
 // be created with new root and updated trie database for following usage
-func (t *Trie) Commit(collectLeaf bool) (common.Hash, *trienode.NodeSet) {
+func (t *Trie) Commit(collectLeaf bool) (common.Hash, *trienode.NodeSet, error) {
 	defer t.tracer.reset()
 	defer func() {
 		t.committed = true
@@ -619,7 +619,7 @@ func (t *Trie) Commit(collectLeaf bool) (common.Hash, *trienode.NodeSet) {
 	// - The trie was empty and no update happens
 	// - The trie was non-empty and all nodes are dropped
 	if t.root == nil {
-		return types.EmptyRootHash, nodes
+		return types.EmptyRootHash, nodes, nil
 	}
 	// Derive the hash for all dirty nodes first. We hold the assumption
 	// in the following procedure that all nodes are hashed.
@@ -631,10 +631,10 @@ func (t *Trie) Commit(collectLeaf bool) (common.Hash, *trienode.NodeSet) {
 		// Replace the root node with the origin hash in order to
 		// ensure all resolved nodes are dropped after the commit.
 		t.root = hashedNode
-		return rootHash, nil
+		return rootHash, nil, nil
 	}
 	t.root = newCommitter(nodes, t.tracer, collectLeaf).Commit(t.root)
-	return rootHash, nodes
+	return rootHash, nodes, nil
 }
 
 // hashRoot calculates the root hash of the given trie

--- a/trie/trie_test.go
+++ b/trie/trie_test.go
@@ -88,7 +88,7 @@ func testMissingNode(t *testing.T, memonly bool, scheme string) {
 	trie := NewEmpty(triedb)
 	updateString(trie, "120000", "qwerqwerqwerqwerqwerqwerqwerqwer")
 	updateString(trie, "123456", "asdfasdfasdfasdfasdfasdfasdfasdf")
-	root, nodes := trie.Commit(false)
+	root, nodes, _ := trie.Commit(false)
 	triedb.Update(root, types.EmptyRootHash, trienode.NewWithNodeSet(nodes))
 
 	if !memonly {
@@ -177,7 +177,7 @@ func TestInsert(t *testing.T) {
 	updateString(trie, "A", "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
 
 	exp = common.HexToHash("d23786fb4a010da3ce639d66d5e904a11dbc02746d1ce25029e53290cabf28ab")
-	root, _ = trie.Commit(false)
+	root, _, _ = trie.Commit(false)
 	if root != exp {
 		t.Errorf("case 2: exp %x got %x", exp, root)
 	}
@@ -202,7 +202,7 @@ func TestGet(t *testing.T) {
 		if i == 1 {
 			return
 		}
-		root, nodes := trie.Commit(false)
+		root, nodes, _ := trie.Commit(false)
 		db.Update(root, types.EmptyRootHash, trienode.NewWithNodeSet(nodes))
 		trie, _ = New(TrieID(root), db)
 	}
@@ -274,7 +274,7 @@ func TestReplication(t *testing.T) {
 	for _, val := range vals {
 		updateString(trie, val.k, val.v)
 	}
-	root, nodes := trie.Commit(false)
+	root, nodes, _ := trie.Commit(false)
 	db.Update(root, types.EmptyRootHash, trienode.NewWithNodeSet(nodes))
 
 	// create a new trie on top of the database and check that lookups work.
@@ -287,7 +287,7 @@ func TestReplication(t *testing.T) {
 			t.Errorf("trie2 doesn't have %q => %q", kv.k, kv.v)
 		}
 	}
-	hash, nodes := trie2.Commit(false)
+	hash, nodes, _ := trie2.Commit(false)
 	if hash != root {
 		t.Errorf("root failure. expected %x got %x", root, hash)
 	}
@@ -501,7 +501,7 @@ func runRandTest(rt randTest) bool {
 		case opHash:
 			tr.Hash()
 		case opCommit:
-			root, nodes := tr.Commit(true)
+			root, nodes, _ := tr.Commit(true)
 			if nodes != nil {
 				triedb.Update(root, origin, trienode.NewWithNodeSet(nodes))
 			}
@@ -734,7 +734,7 @@ func TestCommitAfterHash(t *testing.T) {
 	if exp != root {
 		t.Errorf("got %x, exp %x", root, exp)
 	}
-	root, _ = trie.Commit(false)
+	root, _, _ = trie.Commit(false)
 	if exp != root {
 		t.Errorf("got %x, exp %x", root, exp)
 	}
@@ -837,7 +837,7 @@ func TestCommitSequence(t *testing.T) {
 			trie.MustUpdate(crypto.Keccak256(addresses[i][:]), accounts[i])
 		}
 		// Flush trie -> database
-		root, nodes := trie.Commit(false)
+		root, nodes, _ := trie.Commit(false)
 		db.Update(root, types.EmptyRootHash, trienode.NewWithNodeSet(nodes))
 		// Flush memdb -> disk (sponge)
 		db.Commit(root, false)
@@ -878,7 +878,7 @@ func TestCommitSequenceRandomBlobs(t *testing.T) {
 			trie.MustUpdate(key, val)
 		}
 		// Flush trie -> database
-		root, nodes := trie.Commit(false)
+		root, nodes, _ := trie.Commit(false)
 		db.Update(root, types.EmptyRootHash, trienode.NewWithNodeSet(nodes))
 		// Flush memdb -> disk (sponge)
 		db.Commit(root, false)
@@ -917,7 +917,7 @@ func TestCommitSequenceStackTrie(t *testing.T) {
 			stTrie.Update(key, val)
 		}
 		// Flush trie -> database
-		root, nodes := trie.Commit(false)
+		root, nodes, _ := trie.Commit(false)
 		// Flush memdb -> disk (sponge)
 		db.Update(root, types.EmptyRootHash, trienode.NewWithNodeSet(nodes))
 		db.Commit(root, false)
@@ -965,7 +965,7 @@ func TestCommitSequenceSmallRoot(t *testing.T) {
 	trie.Update(key, []byte{0x1})
 	stTrie.Update(key, []byte{0x1})
 	// Flush trie -> database
-	root, nodes := trie.Commit(false)
+	root, nodes, _ := trie.Commit(false)
 	// Flush memdb -> disk (sponge)
 	db.Update(root, types.EmptyRootHash, trienode.NewWithNodeSet(nodes))
 	db.Commit(root, false)
@@ -1138,7 +1138,7 @@ func benchmarkDerefRootFixedSize(b *testing.B, addresses [][20]byte, accounts []
 		trie.MustUpdate(crypto.Keccak256(addresses[i][:]), accounts[i])
 	}
 	h := trie.Hash()
-	root, nodes := trie.Commit(false)
+	root, nodes, _ := trie.Commit(false)
 	triedb.Update(root, types.EmptyRootHash, trienode.NewWithNodeSet(nodes))
 	b.StartTimer()
 	triedb.Dereference(h)


### PR DESCRIPTION
This has been discussed with @rjl493456442 : the `error` result was removed from `(*state.Trie).Commit` as no error could occur in the MPT's `Commit` function. In verkle, however, errors can happen and should be reported.