### PR TITLE
crypto/secp256k1: define NDEBUG only if not defined

### DIFF
--- a/crypto/secp256k1/secp256.go
+++ b/crypto/secp256k1/secp256.go
@@ -21,11 +21,14 @@ package secp256k1
 #  define USE_SCALAR_8X32
 #endif
 
+#ifndef NDEBUG
+#  define NDEBUG
+#endif
+
 #define USE_ENDOMORPHISM
 #define USE_NUM_NONE
 #define USE_FIELD_INV_BUILTIN
 #define USE_SCALAR_INV_BUILTIN
-#define NDEBUG
 #include "./libsecp256k1/src/secp256k1.c"
 #include "./libsecp256k1/src/modules/recovery/main_impl.h"
 #include "ext.h"


### PR DESCRIPTION
NDEBUG can be defined in some architechtures, by checking it with ifndef we avoid compiler warning problems, such as:
```
Error: ../../../go/pkg/mod/github.com/ethereum/go-ethereum@v1.10.26/crypto/secp256k1/secp256.go:28:9: warning: 'NDEBUG' macro redefined [-Wmacro-redefined]
```