### PR TITLE
common/lru: Add BasicLRU.Peek testcase

### DIFF
--- a/common/lru/basiclru_test.go
+++ b/common/lru/basiclru_test.go
@@ -170,6 +170,20 @@ func TestBasicLRUContains(t *testing.T) {
 	}
 }
 
+// Test that Peek doesn't update recent-ness
+func TestBasicLRUPeek(t *testing.T) {
+	cache := NewBasicLRU[int, int](2)
+	cache.Add(1, 1)
+	cache.Add(2, 2)
+	if v, ok := cache.Peek(1); !ok || v != 1 {
+		t.Errorf("1 shoud be set to 1")
+	}
+	cache.Add(3, 3)
+	if cache.Contains(1) {
+		t.Errorf("should not have updated recent-ness of 1")
+	}
+}
+
 func BenchmarkLRU(b *testing.B) {
 	var (
 		capacity = 1000

--- a/common/lru/basiclru_test.go
+++ b/common/lru/basiclru_test.go
@@ -176,7 +176,7 @@ func TestBasicLRUPeek(t *testing.T) {
 	cache.Add(1, 1)
 	cache.Add(2, 2)
 	if v, ok := cache.Peek(1); !ok || v != 1 {
-		t.Errorf("1 shoud be set to 1")
+		t.Errorf("1 should be set to 1")
 	}
 	cache.Add(3, 3)
 	if cache.Contains(1) {


### PR DESCRIPTION
We don't have test that Peek() function doesn't affect to recent-ness.
Reference: https://github.com/hashicorp/golang-lru/blob/master/simplelru/lru_test.go#L154