### PR TITLE
eth: Error Checking Upward Migration

### DIFF
--- a/eth/api_debug.go
+++ b/eth/api_debug.go
@@ -281,6 +281,9 @@ func (api *DebugAPI) GetModifiedAccountsByNumber(startNum uint64, endNum *uint64
 		if endBlock == nil {
 			return nil, fmt.Errorf("end block %d not found", *endNum)
 		}
+		if startBlock.Number().Uint64() >= endBlock.Number().Uint64() {
+			return nil, fmt.Errorf("start block height (%d) must be less than end block height (%d)", startBlock.Number().Uint64(), endBlock.Number().Uint64())
+		}
 	}
 	return api.getModifiedAccounts(startBlock, endBlock)
 }
@@ -308,14 +311,14 @@ func (api *DebugAPI) GetModifiedAccountsByHash(startHash common.Hash, endHash *c
 		if endBlock == nil {
 			return nil, fmt.Errorf("end block %x not found", *endHash)
 		}
+		if startBlock.Number().Uint64() >= endBlock.Number().Uint64() {
+			return nil, fmt.Errorf("start block height (%d) must be less than end block height (%d)", startBlock.Number().Uint64(), endBlock.Number().Uint64())
+		}
 	}
 	return api.getModifiedAccounts(startBlock, endBlock)
 }
 
 func (api *DebugAPI) getModifiedAccounts(startBlock, endBlock *types.Block) ([]common.Address, error) {
-	if startBlock.Number().Uint64() >= endBlock.Number().Uint64() {
-		return nil, fmt.Errorf("start block height (%d) must be less than end block height (%d)", startBlock.Number().Uint64(), endBlock.Number().Uint64())
-	}
 	triedb := api.eth.BlockChain().StateCache().TrieDB()
 
 	oldTrie, err := trie.NewStateTrie(trie.StateTrieID(startBlock.Root()), triedb)


### PR DESCRIPTION
Error Checking Upward Migration
 When **endNum/endHash** is nil, `startBlock is set to api.eth.blockchain.GetBlockByHash(startBlock.ParentHash())`. In this scenario, it is not possible for `startBlock.Number().Uint64() >= endBlock.Number().Uint64()` to occur.