### PR TITLE
[website]: remove some ethash info from docs

### DIFF
--- a/docs/fundamentals/command-line-options.md
+++ b/docs/fundamentals/command-line-options.md
@@ -434,7 +434,6 @@ GLOBAL OPTIONS:
     --miner.newpayload-timeout value (default: 2s)
           Specify the maximum time allowance for creating a new payload
 
-    --miner.notify.full            (default: false)
           Notify with pending block headers instead of work packages
 
     --miner.recommit value         (default: 2s)

--- a/docs/fundamentals/command-line-options.md
+++ b/docs/fundamentals/command-line-options.md
@@ -434,7 +434,6 @@ GLOBAL OPTIONS:
     --miner.newpayload-timeout value (default: 2s)
           Specify the maximum time allowance for creating a new payload
 
-          Notify with pending block headers instead of work packages
 
     --miner.recommit value         (default: 2s)
           Time interval to recreate the block being mined

--- a/docs/fundamentals/command-line-options.md
+++ b/docs/fundamentals/command-line-options.md
@@ -44,8 +44,6 @@ COMMANDS:
    init                   Bootstrap and initialize a new genesis block
    js                     (DEPRECATED) Execute the specified JavaScript files
    license                Display license information
-   makecache              Generate ethash verification cache (for testing)
-   makedag                Generate ethash mining DAG (for testing)
    removedb               Remove blockchain and state databases
    show-deprecated-flags  Show flags that have been deprecated
    snapshot               A set of commands based on the snapshot
@@ -207,31 +205,6 @@ GLOBAL OPTIONS:
     --dev.period value             (default: 0)
           Block period to use in developer mode (0 = mine only if transaction pending)
 
-   ETHASH
-
-    --ethash.cachedir value
-          Directory to store the ethash verification caches (default = inside the datadir)
-
-    --ethash.cachesinmem value     (default: 2)
-          Number of recent ethash caches to keep in memory (16MB each)
-
-    --ethash.cacheslockmmap        (default: false)
-          Lock memory maps of recent ethash caches
-
-    --ethash.cachesondisk value    (default: 3)
-          Number of recent ethash caches to keep on disk (16MB each)
-
-    --ethash.dagdir value          (default: /Users/fjl/Library/Ethash)
-          Directory to store the ethash mining DAGs
-
-    --ethash.dagsinmem value       (default: 1)
-          Number of recent ethash mining DAGs to keep in memory (1+GB each)
-
-    --ethash.dagslockmmap          (default: false)
-          Lock memory maps for recent ethash mining DAGs
-
-    --ethash.dagsondisk value      (default: 2)
-          Number of recent ethash mining DAGs to keep on disk (1+GB each)
 
    ETHEREUM
 
@@ -461,20 +434,12 @@ GLOBAL OPTIONS:
     --miner.newpayload-timeout value (default: 2s)
           Specify the maximum time allowance for creating a new payload
 
-    --miner.notify value
-          Comma separated HTTP URL list to notify of new work packages
-
     --miner.notify.full            (default: false)
           Notify with pending block headers instead of work packages
-
-    --miner.noverify               (default: false)
-          Disable remote sealing verification
 
     --miner.recommit value         (default: 2s)
           Time interval to recreate the block being mined
 
-    --miner.threads value          (default: 0)
-          Number of CPU threads to use for mining
 
    MISC
 

--- a/docs/fundamentals/mining.md
+++ b/docs/fundamentals/mining.md
@@ -3,9 +3,10 @@ title: Proof-of-work mining with Ethash
 description: Introduction to proof-of-work mining with Geth
 ---
 
-<Note>Proof-of-work mining is no longer used to secure Ethereum Mainnet. The information below is included because the Ethash code is still part of Geth and it could be used to create a private proof-of-work network or testnet.</Note>
+<Note>Proof-of-work mining is no longer used to secure Ethereum Mainnet.</Note>
 
 Blockchains grow when individual nodes create valid blocks and distribute them to their peers who check the blocks and add them to their own local databases.
+
 Nodes that add blocks are rewarded with ether payouts. On Ethereum Mainnet, the proof-of-stake consensus engine randomly selects a node to produce each block.
 
 Ethereum wasn't always secured this way. Originally, a proof-of-work based consensus mechanism was used instead. Under proof-of-work, block producers are not selected randomly in each slot. Instead they compete for the right to add a block. The node that is fastest to compute a certain value that can only be found using brute force calculations is the one that gets to add a block. Only if a node can demonstrate that they have calculated this value, and therefore expended energy, will their block be accepted by other nodes. This process of creating blocks and securing them using proof-of-work is known as "mining".
@@ -15,9 +16,9 @@ Much more information about mining, including details about the specific algorit
 
 ## CPU vs GPU {#cpu-vs-gpu}
 
-Ethereum mining used an algorithm called ["Ethash"](https://ethereum.org/en/developers/docs/consensus-mechanisms/pow/mining-algorithms/ethash). Geth includes a CPU miner which runs Ethash within the Geth process. Everything required to mine on a CPU is bundled with Geth. However, to mine using GPUs an additional piece of third-party software is required. The most commonly used GPU mining software is [Ethminer](https://github.com/ethereum-mining/ethminer).
+Everything required to mine on a CPU used to come bundled with Geth. However, to mine using GPUs an additional piece of third-party software was required. The most commonly used GPU mining software is [Ethminer](https://github.com/ethereum-mining/ethminer).
 
-Regardless of the mining method, the blockchain must be fully synced before mining is started, otherwise the miner will build on an outdated side chain,meaning block rewards will not be recognized by the main network.
+Regardless of the mining method, the blockchain must be fully synced before mining is started, otherwise the miner will build on an outdated side chain, meaning block rewards will not be recognized by the main network.
 
 ## GPU Mining {#gpu-mining}
 
@@ -97,16 +98,16 @@ More verbose logs can be configured using `-v` and a value between 0-9. The Etha
 
 ## CPU Mining with Geth {#cpu-mining-with-geth}
 
-When Geth is started it is not mining by default. Unless it is specifically instructed to mine, it acts only as a node, not a miner. Geth starts as a (CPU) miner if the `--mine` flag is provided. The `--miner.threads` parameter can be used to set the number parallel mining threads (defaulting to the total number of processor cores).
+When Geth is started it is not mining by default. Unless it is specifically instructed to mine, it acts only as a node, not a miner. Geth starts as a (CPU) miner if the `--mine` flag is provided. 
 
 ```sh
-geth --mine --miner.threads=4
+geth --mine
 ```
 
-CPU mining can also be started and stopped at runtime using the [console](/docs/interacting-with-geth/javascript-console). The command `miner.start` takes an optional parameter for the number of miner threads.
+CPU mining can also be started and stopped at runtime using the [console](/docs/interacting-with-geth/javascript-console).
 
 ```js
-miner.start(8);
+miner.start();
 true;
 miner.stop();
 true;
@@ -170,8 +171,7 @@ function minedBlocks(lastn, addr) {
 minedBlocks(1000, eth.coinbase)[(352708, 352655, 352559)];
 ```
 
-The etherbase balance will fluctuate if a mined block is re-org'd out of the canonical chain. This means that when the local Geth node includes the mined block
-in its own local blockchain the account balance appears higher because the block rewards are applied. When the node switches to another version of the chain due to information received from peers, that block may not be included and the block rewards are not applied.
+The etherbase balance will fluctuate if a mined block is re-org'd out of the canonical chain. This means that when the local Geth node includes the mined block in its own local blockchain the account balance appears higher because the block rewards are applied. When the node switches to another version of the chain due to information received from peers, that block may not be included and the block rewards are not applied.
 
 The logs show locally mined blocks confirmed after 5 blocks.
 

--- a/docs/interacting-with-geth/rpc/ns-miner.md
+++ b/docs/interacting-with-geth/rpc/ns-miner.md
@@ -45,13 +45,13 @@ Updates the interval for recomitting the miner sealing work.
 
 ## miner_start {#miner-start}
 
-Start the CPU mining process with the given number of threads and generate a new DAG if need be.
+Start the CPU mining process and generate a new DAG if need be.
 
-| Client  | Method invocation                                   |
-| :------ | --------------------------------------------------- |
-| Go      | `miner.Start(threads *rpc.HexNumber) (bool, error)` |
-| Console | `miner.start(number)`                               |
-| RPC     | `{"method": "miner_start", "params": [number]}`     |
+| Client  | Method invocation                         |
+| :------ | ----------------------------------------- |
+| Go      | `miner.Start() (bool, error)`             |
+| Console | `miner.start()`                           |
+| RPC     | `{"method": "miner_start", "params": []}` |
 
 ## miner_stop {#miner-stop}
 

--- a/docs/interacting-with-geth/rpc/ns-miner.md
+++ b/docs/interacting-with-geth/rpc/ns-miner.md
@@ -45,11 +45,11 @@ Updates the interval for recomitting the miner sealing work.
 
 ## miner_start {#miner-start}
 
-Start the CPU mining process and generate a new DAG if need be.
+Start the CPU mining process.
 
 | Client  | Method invocation                         |
 | :------ | ----------------------------------------- |
-| Go      | `miner.Start() (bool, error)`             |
+| Go      | `miner.Start() error`             |
 | Console | `miner.start()`                           |
 | RPC     | `{"method": "miner_start", "params": []}` |
 


### PR DESCRIPTION
Removes threads arg from `miner.start()` and removes ethash cli flags from the `command line arguments` page.
Seems like there might be some more info that needs to change resulting from https://github.com/ethereum/go-ethereum/pull/27178 ? @lightclient 