### PR TITLE
eth/filters: performance improvement on filterLogs

### DIFF
--- a/eth/filters/filter.go
+++ b/eth/filters/filter.go
@@ -358,6 +358,13 @@ func includes(addresses []common.Address, a common.Address) bool {
 	return false
 }
 
+// topicFilter checks if the given log topics match the filter topics.
+// It returns true if there is a match, false otherwise.
+//
+// So the full logic is:
+// - Wildcard filter topics (empty) always match
+// - If any non-wildcard filter topic does NOT match, the function returns false
+// - Otherwise, it returns true
 func topicFilter(topics [][]common.Hash, filter func(i int, topic common.Hash) bool) bool {
 	for i, sub := range topics {
 		match := len(sub) == 0 // empty rule set == wildcard

--- a/eth/filters/filter.go
+++ b/eth/filters/filter.go
@@ -25,7 +25,6 @@ import (
 	"github.com/ethereum/go-ethereum/core/bloombits"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/rpc"
-	"golang.org/x/exp/slices"
 )
 
 // Filter can be used to retrieve and filter logs.
@@ -375,16 +374,13 @@ func filterLogs(logs []*types.Log, fromBlock, toBlock *big.Int, addresses []comm
 		to = toBlock.Uint64()
 	}
 
-	// sort logs in asc order if to block is compared with
-	if to > 0 {
-		slices.SortFunc(logs, func(a, b *types.Log) bool { return a.BlockNumber < b.BlockNumber })
-	}
-
 	for _, log := range logs {
-		if from > log.BlockNumber {
+		// Beyond the left boundary
+		if log.BlockNumber < from {
 			continue
 		}
-		// skip if the queried block number is smaller then current one
+		// Logs are arrived in ascending order,
+		// so skip if the queried block number is smaller than current one
 		if to > 0 && to < log.BlockNumber {
 			break
 		}

--- a/eth/filters/filter.go
+++ b/eth/filters/filter.go
@@ -25,6 +25,7 @@ import (
 	"github.com/ethereum/go-ethereum/core/bloombits"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/rpc"
+	"golang.org/x/exp/slices"
 )
 
 // Filter can be used to retrieve and filter logs.
@@ -379,12 +380,16 @@ func filterLogs(logs []*types.Log, fromBlock, toBlock *big.Int, addresses []comm
 	addrLen := len(addresses)
 	topicLen := len(topics)
 
+	// sort logs in asc order
+	slices.SortFunc(logs, func(a, b *types.Log) bool { return a.BlockNumber < b.BlockNumber })
+
 	for _, log := range logs {
 		if fromBlock != nil && fromBlock.Sign() >= 0 && fromBlock.Uint64() > log.BlockNumber {
 			continue
 		}
+		// skip if the queried block number is smaller then current one
 		if toBlock != nil && toBlock.Sign() >= 0 && toBlock.Uint64() < log.BlockNumber {
-			continue
+			break
 		}
 
 		if addrLen > 0 && !includes(addresses, log.Address) {

--- a/eth/filters/filter.go
+++ b/eth/filters/filter.go
@@ -358,29 +358,6 @@ func includes(addresses []common.Address, a common.Address) bool {
 	return false
 }
 
-// topicFilter checks if the given log topics match the filter topics.
-// It returns true if there is a match, false otherwise.
-//
-// So the full logic is:
-// - Wildcard filter topics (empty) always match
-// - If any non-wildcard filter topic does NOT match, the function returns false
-// - Otherwise, it returns true
-func topicFilter(topics [][]common.Hash, filter func(i int, topic common.Hash) bool) bool {
-	for i, sub := range topics {
-		match := len(sub) == 0 // empty rule set == wildcard
-		for _, topic := range sub {
-			if filter(i, topic) {
-				match = true
-				break
-			}
-		}
-		if !match {
-			return false
-		}
-	}
-	return true
-}
-
 // filterLogs creates a slice of logs matching the given criteria.
 func filterLogs(logs []*types.Log, fromBlock, toBlock *big.Int, addresses []common.Address, topics [][]common.Hash) []*types.Log {
 	var (
@@ -427,6 +404,30 @@ func filterLogs(logs []*types.Log, fromBlock, toBlock *big.Int, addresses []comm
 	return ret
 }
 
+// topicFilter checks if the given log topics match the filter topics.
+// It returns true if there is a match, false otherwise.
+//
+// So the full logic is:
+// - Wildcard filter topics (empty) always match
+// - If any non-wildcard filter topic does NOT match, the function returns false
+// - Otherwise, it returns true
+func topicFilter(topics [][]common.Hash, filter func(i int, topic common.Hash) bool) bool {
+	for i, sub := range topics {
+		match := len(sub) == 0 // empty rule set == wildcard
+		for _, topic := range sub {
+			if filter(i, topic) {
+				match = true
+				break
+			}
+		}
+		if !match {
+			return false
+		}
+	}
+	return true
+}
+
+// bloomFilter checks if the given address and topics match the block bloom
 func bloomFilter(bloom types.Bloom, addresses []common.Address, topics [][]common.Hash) bool {
 	if len(addresses) > 0 {
 		var included bool
@@ -441,9 +442,5 @@ func bloomFilter(bloom types.Bloom, addresses []common.Address, topics [][]commo
 		}
 	}
 
-	if !topicFilter(topics, func(i int, topic common.Hash) bool { return types.BloomLookup(bloom, topic) }) {
-		return false
-	}
-
-	return true
+	return topicFilter(topics, func(i int, topic common.Hash) bool { return types.BloomLookup(bloom, topic) })
 }

--- a/eth/filters/filter.go
+++ b/eth/filters/filter.go
@@ -380,10 +380,10 @@ func filterLogs(logs []*types.Log, fromBlock, toBlock *big.Int, addresses []comm
 	topicLen := len(topics)
 
 	for _, log := range logs {
-		if fromBlock != nil && fromBlock.Int64() >= 0 && fromBlock.Uint64() > log.BlockNumber {
+		if fromBlock != nil && fromBlock.Sign() >= 0 && fromBlock.Uint64() > log.BlockNumber {
 			continue
 		}
-		if toBlock != nil && toBlock.Int64() >= 0 && toBlock.Uint64() < log.BlockNumber {
+		if toBlock != nil && toBlock.Sign() >= 0 && toBlock.Uint64() < log.BlockNumber {
 			continue
 		}
 

--- a/eth/filters/filter.go
+++ b/eth/filters/filter.go
@@ -358,6 +358,7 @@ func includes(addresses []common.Address, a common.Address) bool {
 }
 
 // filterLogs creates a slice of logs matching the given criteria.
+// filterLogs expects logs to be in ascending order by block number.
 func filterLogs(logs []*types.Log, fromBlock, toBlock *big.Int, addresses []common.Address, topics [][]common.Hash) []*types.Log {
 	var (
 		ret      []*types.Log


### PR DESCRIPTION
Because the logs have arrived in asc order, so if the `to block` in query criteria is bigger than the current `log.BlockNumber`, then no need to filter the later logs anymore.


Here is a benchmark with:


```bash
cd eth/filters
go test -bench='BenchmarkFilterLogs' . -count 5  -run BenchmarkFilterLogs
```

> the result of master branch


```
goos: darwin
goarch: arm64
pkg: github.com/ethereum/go-ethereum/eth/filters
BenchmarkFilterLogs-8              12616             92477 ns/op
BenchmarkFilterLogs-8              12992             92284 ns/op
BenchmarkFilterLogs-8              12940             91975 ns/op
BenchmarkFilterLogs-8              12987             92502 ns/op
BenchmarkFilterLogs-8              13009             88202 ns/op
```

> the result of this branch

```
goos: darwin
goarch: arm64
pkg: github.com/ethereum/go-ethereum/eth/filters
BenchmarkFilterLogs-8              13528             86444 ns/op
BenchmarkFilterLogs-8              13440             86351 ns/op
BenchmarkFilterLogs-8              14128             86022 ns/op
BenchmarkFilterLogs-8              13968             84665 ns/op
BenchmarkFilterLogs-8              13959             85568 ns/op
```

about 6.2% improvement


BTW,  also add a new function `topicFilter`, used to improve the readability of `filterLogs`