### PR TITLE
core/txpool: add PriceBump API

### DIFF
--- a/core/txpool/legacypool/legacypool.go
+++ b/core/txpool/legacypool/legacypool.go
@@ -1586,6 +1586,11 @@ func (pool *LegacyPool) demoteUnexecutables() {
 	}
 }
 
+// PriceBump returns the current price bump percentage from the LegacyPool's configuration.
+func (pool *LegacyPool) PriceBump() uint64 {
+    return pool.config.PriceBump
+}
+
 // addressByHeartbeat is an account address tagged with its last activity timestamp.
 type addressByHeartbeat struct {
 	address   common.Address
@@ -1845,3 +1850,4 @@ func (t *lookup) RemotesBelowTip(threshold *big.Int) types.Transactions {
 func numSlots(tx *types.Transaction) int {
 	return int((tx.Size() + txSlotSize - 1) / txSlotSize)
 }
+

--- a/core/txpool/subpool.go
+++ b/core/txpool/subpool.go
@@ -108,4 +108,11 @@ type SubPool interface {
 	// Status returns the known status (unknown/pending/queued) of a transaction
 	// identified by their hashes.
 	Status(hash common.Hash) TxStatus
+
+	// PriceBump returns the minimum price increase percentage required by the subpool
+	// for a new transaction to replace an existing one. If a transaction with the 
+	// same nonce already exists in the pool, the incoming transaction's price must 
+	// be higher than the existing one's price by at least the percentage returned 
+	// by PriceBump.
+	PriceBump() uint64
 }

--- a/core/txpool/txpool.go
+++ b/core/txpool/txpool.go
@@ -342,3 +342,20 @@ func (p *TxPool) Status(hash common.Hash) TxStatus {
 	}
 	return TxStatusUnknown
 }
+
+func (p *TxPool) PriceBump() uint64 {
+    // Initialize the priceBump as 0
+    var priceBump uint64
+
+    // Loop over each subpool
+    for _, subpool := range p.subpools {
+        // Get the priceBump of the current subpool
+        if currentPriceBump := subpool.PriceBump(); currentPriceBump > priceBump {
+            // If the currentPriceBump is larger than the priceBump, update the priceBump
+            priceBump = currentPriceBump
+        }
+    }
+
+    // Return the maximum priceBump found
+    return priceBump
+}

--- a/eth/api_backend.go
+++ b/eth/api_backend.go
@@ -322,6 +322,10 @@ func (b *EthAPIBackend) GetPoolNonce(ctx context.Context, addr common.Address) (
 	return b.eth.txPool.Nonce(addr), nil
 }
 
+func (b *EthAPIBackend) GetPoolPriceBump() (uint64, error) {
+	return b.eth.txPool.PriceBump(), nil
+}
+
 func (b *EthAPIBackend) Stats() (runnable int, blocked int) {
 	return b.eth.txPool.Stats()
 }

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -218,6 +218,12 @@ func (s *TxPoolAPI) Status() map[string]hexutil.Uint {
 	}
 }
 
+// PriceBump returns the PriceBump of the transaction pool.
+func (s *TxPoolAPI) PriceBump() hexutil.Uint {
+    priceBump, _ := s.b.GetPoolPriceBump()
+    return hexutil.Uint(priceBump)
+}
+
 // Inspect retrieves the content of the transaction pool and flattens it into an
 // easily inspectable list.
 func (s *TxPoolAPI) Inspect() map[string]map[string]map[string]string {

--- a/internal/ethapi/backend.go
+++ b/internal/ethapi/backend.go
@@ -79,6 +79,7 @@ type Backend interface {
 	GetPoolTransactions() (types.Transactions, error)
 	GetPoolTransaction(txHash common.Hash) *types.Transaction
 	GetPoolNonce(ctx context.Context, addr common.Address) (uint64, error)
+	GetPoolPriceBump() (uint64, error)
 	Stats() (pending int, queued int)
 	TxPoolContent() (map[common.Address][]*types.Transaction, map[common.Address][]*types.Transaction)
 	TxPoolContentFrom(addr common.Address) ([]*types.Transaction, []*types.Transaction)


### PR DESCRIPTION
Due to the inability to capture PriceBump externally, external wallets such as MetaMask face challenges in accurately retrieving the current bound RPC's PriceBump when the initial gas price is set too low and acceleration is required. As a result, the provided Max Priority fee may be inaccurate, leading to rejection (`replacement transaction underpriced`) by the connected RPC's txpool. Please refer to the following link for more information: [Link](https://community.metamask.io/t/ethjs-query-while-formatting-outputs-from-rpc-value-code-32000-message-replacement-transaction-underpriced/22489/9).

To address this issue, this pull request exposes PriceBump, allowing third parties to recalculate the lowest acceptable Max Priority fee that can be accepted by nodes. Currently, only PriceBump is exposed, but theoretically, other txpool configurations could be exposed as well.