### PR TITLE
accounts/abi: return rawdata when revert is custom type

### DIFF
--- a/accounts/abi/abi.go
+++ b/accounts/abi/abi.go
@@ -21,7 +21,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"github.com/status-im/keycard-go/hexutils"
 	"io"
 
 	"github.com/ethereum/go-ethereum/common"
@@ -256,7 +255,7 @@ func UnpackRevert(data []byte) (string, error) {
 		return "", errors.New("invalid data for unpacking")
 	}
 	if !bytes.Equal(data[:4], revertSelector) {
-		return hexutils.BytesToHex(data), nil
+		return "", errors.New("invalid data for unpacking")
 	}
 	typ, err := NewType("string", "", nil)
 	if err != nil {

--- a/accounts/abi/abi.go
+++ b/accounts/abi/abi.go
@@ -21,6 +21,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"github.com/status-im/keycard-go/hexutils"
 	"io"
 
 	"github.com/ethereum/go-ethereum/common"
@@ -255,7 +256,7 @@ func UnpackRevert(data []byte) (string, error) {
 		return "", errors.New("invalid data for unpacking")
 	}
 	if !bytes.Equal(data[:4], revertSelector) {
-		return "", errors.New("invalid data for unpacking")
+		return hexutils.BytesToHex(data), nil
 	}
 	typ, err := NewType("string", "", nil)
 	if err != nil {

--- a/accounts/abi/bind/backends/simulated.go
+++ b/accounts/abi/bind/backends/simulated.go
@@ -407,6 +407,8 @@ func newRevertError(result *core.ExecutionResult) *revertError {
 	err := errors.New("execution reverted")
 	if errUnpack == nil {
 		err = fmt.Errorf("execution reverted: %v", reason)
+	} else if len(result.Revert()) >= 4 {
+		err = fmt.Errorf("%#x", result.Revert())
 	}
 	return &revertError{
 		error:  err,

--- a/eth/tracers/native/call.go
+++ b/eth/tracers/native/call.go
@@ -19,6 +19,7 @@ package native
 import (
 	"encoding/json"
 	"errors"
+	"fmt"
 	"math/big"
 	"sync/atomic"
 
@@ -85,6 +86,8 @@ func (f *callFrame) processOutput(output []byte, err error) {
 	}
 	if unpacked, err := abi.UnpackRevert(output); err == nil {
 		f.RevertReason = unpacked
+	} else if len(output) >= 4 {
+		f.RevertReason = fmt.Sprintf("%#x", output)
 	}
 }
 

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -1091,7 +1091,7 @@ func newRevertError(result *core.ExecutionResult) *revertError {
 	err := errors.New("execution reverted")
 	if errUnpack == nil {
 		err = fmt.Errorf("execution reverted: %v", reason)
-	} else {
+	} else if len(result.Revert()) >= 4 {
 		err = fmt.Errorf("%#x", result.Revert())
 	}
 	return &revertError{

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -1091,6 +1091,8 @@ func newRevertError(result *core.ExecutionResult) *revertError {
 	err := errors.New("execution reverted")
 	if errUnpack == nil {
 		err = fmt.Errorf("execution reverted: %v", reason)
+	} else {
+		err = fmt.Errorf("%#x", result.Revert())
 	}
 	return &revertError{
 		error:  err,


### PR DESCRIPTION
If the revert type is a custom type, we can't decode the reason because we currently only support standard revert type. As an alternative solution, we could consider directly returning the raw data information when the revert type is a custom type. 