### PR TITLE
fix: defer usage

### DIFF
--- a/cmd/bootnode/main.go
+++ b/cmd/bootnode/main.go
@@ -107,6 +107,7 @@ func main() {
 	if err != nil {
 		utils.Fatalf("-ListenUDP: %v", err)
 	}
+	defer conn.Close()
 
 	realaddr := conn.LocalAddr().(*net.UDPAddr)
 	if natm != nil {

--- a/p2p/discover/v4_udp_test.go
+++ b/p2p/discover/v4_udp_test.go
@@ -569,6 +569,8 @@ func startLocalhostV4(t *testing.T, cfg Config) *UDPv4 {
 	if err != nil {
 		t.Fatal(err)
 	}
+	defer socket.Close()
+
 	realaddr := socket.LocalAddr().(*net.UDPAddr)
 	ln.SetStaticIP(realaddr.IP)
 	ln.SetFallbackUDP(realaddr.Port)

--- a/p2p/discover/v5_udp_test.go
+++ b/p2p/discover/v5_udp_test.go
@@ -91,6 +91,8 @@ func startLocalhostV5(t *testing.T, cfg Config) *UDPv5 {
 	if err != nil {
 		t.Fatal(err)
 	}
+	defer socket.Close()
+
 	realaddr := socket.LocalAddr().(*net.UDPAddr)
 	ln.SetStaticIP(realaddr.IP)
 	ln.Set(enr.UDP(realaddr.Port))

--- a/p2p/server.go
+++ b/p2p/server.go
@@ -568,6 +568,8 @@ func (srv *Server) setupDiscovery() error {
 	if err != nil {
 		return err
 	}
+	defer conn.Close()
+
 	realaddr := conn.LocalAddr().(*net.UDPAddr)
 	srv.log.Debug("UDP listener up", "addr", realaddr)
 	if srv.NAT != nil {


### PR DESCRIPTION
hello Ethereum team
I simply added some defers for closing the ports that node listen to
before using them when a node go shutdown the port can maybe still listening and it can make problems.