### PR TITLE
WIP: allow to choose memorydb as an alternative database engine

### DIFF
--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -102,7 +102,7 @@ var (
 	}
 	DBEngineFlag = &cli.StringFlag{
 		Name:     "db.engine",
-		Usage:    "Backing database implementation to use ('pebble' or 'leveldb')",
+		Usage:    "Backing database implementation to use ('leveldb' or 'pebble' or 'memorydb')",
 		Value:    node.DefaultConfig.DBEngine,
 		Category: flags.EthCategory,
 	}
@@ -1432,8 +1432,8 @@ func SetNodeConfig(ctx *cli.Context, cfg *node.Config) {
 	}
 	if ctx.IsSet(DBEngineFlag.Name) {
 		dbEngine := ctx.String(DBEngineFlag.Name)
-		if dbEngine != "leveldb" && dbEngine != "pebble" {
-			Fatalf("Invalid choice for db.engine '%s', allowed 'leveldb' or 'pebble'", dbEngine)
+		if dbEngine != "leveldb" && dbEngine != "pebble" && dbEngine != "memorydb" {
+			Fatalf("Invalid choice for db.engine '%s', allowed 'leveldb' or 'pebble' or 'memorydb'", dbEngine)
 		}
 		log.Info(fmt.Sprintf("Using %s as db engine", dbEngine))
 		cfg.DBEngine = dbEngine


### PR DESCRIPTION
As part of an [ongoing effort by flashbots and konVera](https://writings.flashbots.net/block-building-inside-sgx) to run geth within TEEs, we want to move the state DB into memory on production nodes.

The main reason for this is that we require geth accessing the state to be oblivious from the POV of the host machine. IO access to disk, even if it is encrypted, is not oblivious and can be analyzed by an attacker on the host machine.

Running geth within TEEs is interesting for various different use cases, such as [2FA for rollups](https://ethresear.ch/t/2fa-zk-rollups-using-sgx/14462).

I've written this simple patch that adds a memorydb option for the freezer backed key value database storage. I already figured that this won't work out of the box, since syncing goerli failed (will attach error log soon).

Before I invest more time into this, I first wanted to get some feedback on a few questions

1. The memorydb is mostly used in dev environments and for test cases. Is it stable enough to consider it for production nodes?
2. Are there any obvious issues of this approach?
3. Will the memorydb use about the same space as pebble on disk?
4. Would a patch that allows using the memorydb as an alternative database engine have any chance of being merged?