### PR TITLE
core/vm: define cancun + enable 1153 (tstore/tload) in cancun

### DIFF
--- a/core/vm/jump_table.go
+++ b/core/vm/jump_table.go
@@ -83,6 +83,7 @@ func validate(jt JumpTable) JumpTable {
 func newCancunInstructionSet() JumpTable {
 	instructionSet := newShanghaiInstructionSet()
 	enable4844(&instructionSet) // BLOBHASH opcode
+	enable1153(&instructionSet) // EIP-1153 "Transient Storage"
 	return validate(instructionSet)
 }
 

--- a/core/vm/jump_table_export.go
+++ b/core/vm/jump_table_export.go
@@ -27,11 +27,11 @@ import (
 func LookupInstructionSet(rules params.Rules) (JumpTable, error) {
 	switch {
 	case rules.IsVerkle:
-		return newShanghaiInstructionSet(), errors.New("verkle-fork not defined yet")
+		return newCancunInstructionSet(), errors.New("verkle-fork not defined yet")
 	case rules.IsPrague:
-		return newShanghaiInstructionSet(), errors.New("prague-fork not defined yet")
+		return newCancunInstructionSet(), errors.New("prague-fork not defined yet")
 	case rules.IsCancun:
-		return newShanghaiInstructionSet(), errors.New("cancun-fork not defined yet")
+		return newCancunInstructionSet(), nil
 	case rules.IsShanghai:
 		return newShanghaiInstructionSet(), nil
 	case rules.IsMerge:

--- a/tests/init.go
+++ b/tests/init.go
@@ -299,6 +299,25 @@ var Forks = map[string]*params.ChainConfig{
 		TerminalTotalDifficulty: big.NewInt(0),
 		ShanghaiTime:            u64(15_000),
 	},
+	"Cancun": {
+		ChainID:                 big.NewInt(1),
+		HomesteadBlock:          big.NewInt(0),
+		EIP150Block:             big.NewInt(0),
+		EIP155Block:             big.NewInt(0),
+		EIP158Block:             big.NewInt(0),
+		ByzantiumBlock:          big.NewInt(0),
+		ConstantinopleBlock:     big.NewInt(0),
+		PetersburgBlock:         big.NewInt(0),
+		IstanbulBlock:           big.NewInt(0),
+		MuirGlacierBlock:        big.NewInt(0),
+		BerlinBlock:             big.NewInt(0),
+		LondonBlock:             big.NewInt(0),
+		ArrowGlacierBlock:       big.NewInt(0),
+		MergeNetsplitBlock:      big.NewInt(0),
+		TerminalTotalDifficulty: big.NewInt(0),
+		ShanghaiTime:            u64(0),
+		CancunTime:              u64(0),
+	},
 }
 
 // AvailableForks returns the set of defined fork names


### PR DESCRIPTION
This PR enables 1153, TSTORE/TLOAD for Cancun, and also "defines" `Cancun` for tests. 
With this PR, this test for 1153 works fine: https://github.com/ethereum/tests/blob/f0f23929eac50c2eb898b2949efc48b253ed84a7/EIPTests/StateTests/stEIP1153-transientStorage/03_tloadAfterStoreIs0.json . 

Nothing special about that test, just a random one I picked as a sanity-check. 