### PR TITLE
eth: better active protocol handler tracking

### DIFF
--- a/eth/handler.go
+++ b/eth/handler.go
@@ -326,11 +326,13 @@ func (h *handler) protoTracker() {
 // incHandlers signals to increment the number of active handlers if not
 // quitting.
 func (h *handler) incHandlers() bool {
-	if h.chainSync.handlePeerEvent() {
+	select {
+	case <-h.quitSync:
+		return false
+	default:
 		h.handlerStartCh <- struct{}{}
 		return true
 	}
-	return false
 }
 
 // decHandlers signals to decrement the number of active handlers.

--- a/eth/handler.go
+++ b/eth/handler.go
@@ -327,11 +327,10 @@ func (h *handler) protoTracker() {
 // quitting.
 func (h *handler) incHandlers() bool {
 	select {
+	case h.handlerStartCh <- struct{}{}:
+		return true
 	case <-h.quitSync:
 		return false
-	default:
-		h.handlerStartCh <- struct{}{}
-		return true
 	}
 }
 

--- a/eth/handler.go
+++ b/eth/handler.go
@@ -304,9 +304,9 @@ func (h *handler) protoTracker() {
 		for {
 			select {
 			case <-h.handlerStartCh:
-				active--
-			case <-h.handlerDoneCh:
 				active++
+			case <-h.handlerDoneCh:
+				active--
 			case <-done:
 				return
 			}

--- a/eth/handler_eth.go
+++ b/eth/handler_eth.go
@@ -134,7 +134,7 @@ func (h *ethHandler) handleBlockBroadcast(peer *eth.Peer, block *types.Block, td
 	// Update the peer's total difficulty if better than the previous
 	if _, td := peer.Head(); trueTD.Cmp(td) > 0 {
 		peer.SetHead(trueHead, trueTD)
-		h.chainSync.handlePeerEvent(peer)
+		h.chainSync.handlePeerEvent()
 	}
 	return nil
 }

--- a/eth/sync.go
+++ b/eth/sync.go
@@ -89,7 +89,7 @@ func newChainSyncer(handler *handler) *chainSyncer {
 // handlePeerEvent notifies the syncer about a change in the peer set.
 // This is called for new peers and every time a peer announces a new
 // chain head.
-func (cs *chainSyncer) handlePeerEvent(peer *eth.Peer) bool {
+func (cs *chainSyncer) handlePeerEvent() bool {
 	select {
 	case cs.peerEventCh <- struct{}{}:
 		return true


### PR DESCRIPTION
fixes #27509

Wasn't able to reproduce the original race condition, but this does remove the `WaitGroup`, so it should suffice.

The idea here is to use two unbuffered channels to track active protocol handlers. `handlerStartCh` is called when a new protocol handler is started up, as long as we aren't actively quitting. When the handler closes, it writes to `handlerDoneCh`.

A separate goroutine watches theses channels and converts the writes into an integer tracking the total number of active routines. When quit is initiated, it waits until the active count goes down to zero before exiting, thus releasing the overarching `handler.wg`.