### PR TITLE
fix vulnerability-file

### DIFF
--- a/public/docs/vulnerabilities/vulnerabilities.json
+++ b/public/docs/vulnerabilities/vulnerabilities.json
@@ -93,7 +93,9 @@
     "fixed": "v1.9.20",
     "summary": "A consensus-vulnerability in Geth could cause a chain split, where vulnerable versions refuse to accept the canonical chain.",
     "description": "A flaw was repoted at 2020-08-11 by John Youngseok Yang (Software Platform Lab), where a particular sequence of transactions could cause a consensus failure.\n\n- Tx 1:\n - `sender` invokes `caller`.\n - `caller` invokes `0xaa`. `0xaa` has 3 wei, does a self-destruct-to-self\n - `caller` does a  `1 wei` -call to `0xaa`, who thereby has 1 wei (the code in `0xaa` still executed, since the tx is still ongoing, but doesn't redo the selfdestruct, it takes a different path if callvalue is non-zero)\n\n-Tx 2:\n - `sender` does a 5-wei call to 0xaa. No exec (since no code). \n\nIn geth, the result would be that `0xaa` had `6 wei`, whereas OE reported (correctly) `5` wei. Furthermore, in geth, if the second tx was not executed, the `0xaa` would be destructed, resulting in `0 wei`. Thus obviously wrong. \n\nIt was determined that the root cause was this [commit](https://github.com/ethereum/go-ethereum/commit/223b950944f494a5b4e0957fd9f92c48b09037ad) from [this PR](https://github.com/ethereum/go-ethereum/pull/19953). The semantics of `createObject` was subtly changd, into returning a non-nil object (with `deleted=true`) where it previously did not if the account had been destructed. This return value caused the new object to inherit the old `balance`.\n",
-    "links": ["https://github.com/ethereum/go-ethereum/security/advisories/GHSA-xw37-57qp-9mm4"],
+    "links": [
+      "https://github.com/ethereum/go-ethereum/security/advisories/GHSA-xw37-57qp-9mm4"
+    ],
     "published": "2020-12-10",
     "severity": "High",
     "CVE": "CVE-2020-26265",
@@ -135,7 +137,7 @@
     "name": "DoS via malicious `snap/1` request",
     "uid": "GETH-2021-03",
     "summary": "A vulnerable node is susceptible to crash when processing a maliciously crafted message from a peer, via the snap/1 protocol. The crash can be triggered by sending a malicious snap/1 GetTrieNodes package.",
-    "description": "The `snap/1` protocol handler contains two vulnerabilities related to the `GetTrieNodes` packet, which can be exploited to crash the node. Full details are available at the GitHub security [advisory](https://github.com/ethereum/go-ethereum/security/advisories/GHSA-59hh-656j-3p7v)",
+    "description": "The `snap/1` protocol handler contains two vulnerabilities related to the `GetTrieNodes` packet, which can be exploited to crash the node. Full details are available at the Github security [advisory](https://github.com/ethereum/go-ethereum/security/advisories/GHSA-59hh-656j-3p7v)",
     "links": [
       "https://github.com/ethereum/go-ethereum/security/advisories/GHSA-59hh-656j-3p7v",
       "https://geth.ethereum.org/docs/vulnerabilities/vulnerabilities",
@@ -152,7 +154,7 @@
     "name": "DoS via malicious p2p message",
     "uid": "GETH-2022-01",
     "summary": "A vulnerable node can crash via p2p messages sent from an attacker node, if running with non-default log options.",
-    "description": "A vulnerable node, if configured to use high verbosity logging, can be made to crash when handling specially crafted p2p messages sent from an attacker node. Full details are available at the GitHub security [advisory](https://github.com/ethereum/go-ethereum/security/advisories/GHSA-wjxw-gh3m-7pm5)",
+    "description": "A vulnerable node, if configured to use high verbosity logging, can be made to crash when handling specially crafted p2p messages sent from an attacker node. Full details are available at the Github security [advisory](https://github.com/ethereum/go-ethereum/security/advisories/GHSA-wjxw-gh3m-7pm5)",
     "links": [
       "https://github.com/ethereum/go-ethereum/security/advisories/GHSA-wjxw-gh3m-7pm5",
       "https://geth.ethereum.org/docs/vulnerabilities/vulnerabilities",


### PR DESCRIPTION
The vulnerability-info had been touched by two prettyfying-operations, which made it not checkable: 

```
$ geth version-check
INFO [07-07|09:48:06.746] Checking vulnerabilities                 version=Geth/v1.12.1-unstable-b45fa869-20230706/linux-amd64/go1.20.1 url=https://geth.ethereum.org/docs/vulnerabilities/vulnerabilities.json
INFO [07-07|09:48:07.317] Verification failed error                keyid=FB1D084D39BAEC24 error="Invalid signature"
```
This PR reverts the changes made in https://github.com/ethereum/go-ethereum/commit/27769604a3afc0332376039b6a71f4fc434b718f and https://github.com/ethereum/go-ethereum/commit/6a05a9dbecdcdcaae8e3d247504451597078fd4b 

After reverting it: 

```
geth version-check --check.url=file:///home/user/go/src/github.com/ethereum/go-ethereum/public/docs/vulnerabilities/vulnerabilities.json
INFO [07-07|10:07:36.563] Checking vulnerabilities                 version=Geth/v1.12.1-unstable-b45fa869-20230706/linux-amd64/go1.20.1 url=file:///home/user/go/src/github.com/ethereum/go-ethereum/public/docs/vulnerabilities/vulnerabilities.json
No vulnerabilities found
```
