### PR TITLE
core, miner/types: log warning when transaction has fee cap less than base fee

### DIFF
--- a/core/types/transaction.go
+++ b/core/types/transaction.go
@@ -20,6 +20,7 @@ import (
 	"bytes"
 	"container/heap"
 	"errors"
+	"fmt"
 	"io"
 	"math/big"
 	"sync/atomic"
@@ -613,6 +614,8 @@ func (t *TransactionsByPriceAndNonce) Shift() error {
 		if err == nil {
 			t.heads[0], t.txs[acc] = wrapped, txs[1:]
 			heap.Fix(&t.heads, 0)
+		} else {
+			err = fmt.Errorf("failed to wrap transaction %x: %s", txs[0].Hash(), err)
 		}
 		return err
 	}

--- a/core/types/transaction_test.go
+++ b/core/types/transaction_test.go
@@ -321,7 +321,7 @@ func testTransactionPriceNonceSort(t *testing.T, baseFee *big.Int) {
 		expectedCount += count
 	}
 	// Sort the transactions and cross check the nonce ordering
-	txset := NewTransactionsByPriceAndNonce(signer, groups, baseFee)
+	txset, _ := NewTransactionsByPriceAndNonce(signer, groups, baseFee)
 
 	txs := Transactions{}
 	for tx := txset.Peek(); tx != nil; tx = txset.Peek() {
@@ -378,7 +378,7 @@ func TestTransactionTimeSort(t *testing.T) {
 		groups[addr] = append(groups[addr], tx)
 	}
 	// Sort the transactions and cross check the nonce ordering
-	txset := NewTransactionsByPriceAndNonce(signer, groups, nil)
+	txset, _ := NewTransactionsByPriceAndNonce(signer, groups, nil)
 
 	txs := Transactions{}
 	for tx := txset.Peek(); tx != nil; tx = txset.Peek() {

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -904,11 +904,6 @@ func (w *worker) fillTransactions(interrupt *atomic.Int32, env *environment) err
 	// Split the pending transactions into locals and remotes
 	// Fill the block with all available pending transactions.
 	pending := w.eth.TxPool().Pending(true)
-	/*blobtxs := w.eth.BlobPool().Pending(
-		uint256.MustFromBig(env.header.BaseFee),
-		uint256.MustFromBig(misc.CalcBlobFee(*env.header.ExcessDataGas)),
-	)
-	log.Trace("Side-effect log, much wow", "blobs", len(blobtxs))*/
 
 	localTxs, remoteTxs := make(map[common.Address][]*types.Transaction), pending
 	for _, account := range w.eth.TxPool().Locals() {


### PR DESCRIPTION
This PR surfaces the error that is created when this happens and adds logging for it in the miner to provide more visibility into what is happening.

Otherwise, it will sit in the txpool with no indication of why it hasn't been queued.