### PR TITLE
crypto/kzg4844: do lazy init in all ckzg funcs

### DIFF
--- a/crypto/kzg4844/kzg4844.go
+++ b/crypto/kzg4844/kzg4844.go
@@ -54,7 +54,7 @@ func UseCKZG(use bool) error {
 	useCKZG.Store(use)
 
 	// Initializing the library can take 2-4 seconds - and can potentially crash
-	// on CKZG and non-ADX CPUs - so might as well so it now and don't wait until
+	// on CKZG and non-ADX CPUs - so might as well do it now and don't wait until
 	// a crypto operation is actually needed live.
 	if use {
 		ckzgIniter.Do(ckzgInit)

--- a/crypto/kzg4844/kzg4844_ckzg_cgo.go
+++ b/crypto/kzg4844/kzg4844_ckzg_cgo.go
@@ -62,8 +62,6 @@ func ckzgInit() {
 
 // ckzgBlobToCommitment creates a small commitment out of a data blob.
 func ckzgBlobToCommitment(blob Blob) (Commitment, error) {
-	ckzgIniter.Do(ckzgInit)
-
 	commitment, err := ckzg4844.BlobToKZGCommitment((ckzg4844.Blob)(blob))
 	if err != nil {
 		return Commitment{}, err

--- a/crypto/kzg4844/kzg4844_ckzg_cgo.go
+++ b/crypto/kzg4844/kzg4844_ckzg_cgo.go
@@ -62,6 +62,8 @@ func ckzgInit() {
 
 // ckzgBlobToCommitment creates a small commitment out of a data blob.
 func ckzgBlobToCommitment(blob Blob) (Commitment, error) {
+	ckzgIniter.Do(ckzgInit)
+
 	commitment, err := ckzg4844.BlobToKZGCommitment((ckzg4844.Blob)(blob))
 	if err != nil {
 		return Commitment{}, err
@@ -72,6 +74,8 @@ func ckzgBlobToCommitment(blob Blob) (Commitment, error) {
 // ckzgComputeProof computes the KZG proof at the given point for the polynomial
 // represented by the blob.
 func ckzgComputeProof(blob Blob, point Point) (Proof, Claim, error) {
+	ckzgIniter.Do(ckzgInit)
+
 	proof, claim, err := ckzg4844.ComputeKZGProof((ckzg4844.Blob)(blob), (ckzg4844.Bytes32)(point))
 	if err != nil {
 		return Proof{}, Claim{}, err
@@ -82,6 +86,8 @@ func ckzgComputeProof(blob Blob, point Point) (Proof, Claim, error) {
 // ckzgVerifyProof verifies the KZG proof that the polynomial represented by the blob
 // evaluated at the given point is the claimed value.
 func ckzgVerifyProof(commitment Commitment, point Point, claim Claim, proof Proof) error {
+	ckzgIniter.Do(ckzgInit)
+
 	valid, err := ckzg4844.VerifyKZGProof((ckzg4844.Bytes48)(commitment), (ckzg4844.Bytes32)(point), (ckzg4844.Bytes32)(claim), (ckzg4844.Bytes48)(proof))
 	if err != nil {
 		return err
@@ -97,6 +103,8 @@ func ckzgVerifyProof(commitment Commitment, point Point, claim Claim, proof Proo
 //
 // This method does not verify that the commitment is correct with respect to blob.
 func ckzgComputeBlobProof(blob Blob, commitment Commitment) (Proof, error) {
+	ckzgIniter.Do(ckzgInit)
+
 	proof, err := ckzg4844.ComputeBlobKZGProof((ckzg4844.Blob)(blob), (ckzg4844.Bytes48)(commitment))
 	if err != nil {
 		return Proof{}, err
@@ -106,6 +114,8 @@ func ckzgComputeBlobProof(blob Blob, commitment Commitment) (Proof, error) {
 
 // ckzgVerifyBlobProof verifies that the blob data corresponds to the provided commitment.
 func ckzgVerifyBlobProof(blob Blob, commitment Commitment, proof Proof) error {
+	ckzgIniter.Do(ckzgInit)
+
 	valid, err := ckzg4844.VerifyBlobKZGProof((ckzg4844.Blob)(blob), (ckzg4844.Bytes48)(commitment), (ckzg4844.Bytes48)(proof))
 	if err != nil {
 		return err

--- a/crypto/kzg4844/kzg4844_test.go
+++ b/crypto/kzg4844/kzg4844_test.go
@@ -48,10 +48,11 @@ func randBlob() Blob {
 func TestCKZGWithPoint(t *testing.T)  { testKZGWithPoint(t, true) }
 func TestGoKZGWithPoint(t *testing.T) { testKZGWithPoint(t, false) }
 func testKZGWithPoint(t *testing.T, ckzg bool) {
-	err := UseCKZG(ckzg)
-	if err != nil {
-		t.Skip(err)
+	if ckzg && !ckzgAvailable {
+		t.Skip("CKZG unavailable in this test build")
 	}
+	defer func(old bool) { useCKZG.Store(old) }(useCKZG.Load())
+	useCKZG.Store(ckzg)
 
 	blob := randBlob()
 
@@ -72,10 +73,11 @@ func testKZGWithPoint(t *testing.T, ckzg bool) {
 func TestCKZGWithBlob(t *testing.T)  { testKZGWithBlob(t, true) }
 func TestGoKZGWithBlob(t *testing.T) { testKZGWithBlob(t, false) }
 func testKZGWithBlob(t *testing.T, ckzg bool) {
-	err := UseCKZG(ckzg)
-	if err != nil {
-		t.Skip(err)
+	if ckzg && !ckzgAvailable {
+		t.Skip("CKZG unavailable in this test build")
 	}
+	defer func(old bool) { useCKZG.Store(old) }(useCKZG.Load())
+	useCKZG.Store(ckzg)
 
 	blob := randBlob()
 
@@ -95,10 +97,11 @@ func testKZGWithBlob(t *testing.T, ckzg bool) {
 func BenchmarkCKZGBlobToCommitment(b *testing.B)  { benchmarkBlobToCommitment(b, true) }
 func BenchmarkGoKZGBlobToCommitment(b *testing.B) { benchmarkBlobToCommitment(b, false) }
 func benchmarkBlobToCommitment(b *testing.B, ckzg bool) {
-	err := UseCKZG(ckzg)
-	if err != nil {
-		b.Skip(err)
+	if ckzg && !ckzgAvailable {
+		b.Skip("CKZG unavailable in this test build")
 	}
+	defer func(old bool) { useCKZG.Store(old) }(useCKZG.Load())
+	useCKZG.Store(ckzg)
 
 	blob := randBlob()
 
@@ -111,10 +114,11 @@ func benchmarkBlobToCommitment(b *testing.B, ckzg bool) {
 func BenchmarkCKZGComputeProof(b *testing.B)  { benchmarkComputeProof(b, true) }
 func BenchmarkGoKZGComputeProof(b *testing.B) { benchmarkComputeProof(b, false) }
 func benchmarkComputeProof(b *testing.B, ckzg bool) {
-	err := UseCKZG(ckzg)
-	if err != nil {
-		b.Skip(err)
+	if ckzg && !ckzgAvailable {
+		b.Skip("CKZG unavailable in this test build")
 	}
+	defer func(old bool) { useCKZG.Store(old) }(useCKZG.Load())
+	useCKZG.Store(ckzg)
 
 	var (
 		blob  = randBlob()
@@ -130,10 +134,11 @@ func benchmarkComputeProof(b *testing.B, ckzg bool) {
 func BenchmarkCKZGVerifyProof(b *testing.B)  { benchmarkVerifyProof(b, true) }
 func BenchmarkGoKZGVerifyProof(b *testing.B) { benchmarkVerifyProof(b, false) }
 func benchmarkVerifyProof(b *testing.B, ckzg bool) {
-	err := UseCKZG(ckzg)
-	if err != nil {
-		b.Skip(err)
+	if ckzg && !ckzgAvailable {
+		b.Skip("CKZG unavailable in this test build")
 	}
+	defer func(old bool) { useCKZG.Store(old) }(useCKZG.Load())
+	useCKZG.Store(ckzg)
 
 	var (
 		blob            = randBlob()
@@ -151,10 +156,11 @@ func benchmarkVerifyProof(b *testing.B, ckzg bool) {
 func BenchmarkCKZGComputeBlobProof(b *testing.B)  { benchmarkComputeBlobProof(b, true) }
 func BenchmarkGoKZGComputeBlobProof(b *testing.B) { benchmarkComputeBlobProof(b, false) }
 func benchmarkComputeBlobProof(b *testing.B, ckzg bool) {
-	err := UseCKZG(ckzg)
-	if err != nil {
-		b.Skip(err)
+	if ckzg && !ckzgAvailable {
+		b.Skip("CKZG unavailable in this test build")
 	}
+	defer func(old bool) { useCKZG.Store(old) }(useCKZG.Load())
+	useCKZG.Store(ckzg)
 
 	var (
 		blob          = randBlob()
@@ -170,10 +176,11 @@ func benchmarkComputeBlobProof(b *testing.B, ckzg bool) {
 func BenchmarkCKZGVerifyBlobProof(b *testing.B)  { benchmarkVerifyBlobProof(b, true) }
 func BenchmarkGoKZGVerifyBlobProof(b *testing.B) { benchmarkVerifyBlobProof(b, false) }
 func benchmarkVerifyBlobProof(b *testing.B, ckzg bool) {
-	err := UseCKZG(ckzg)
-	if err != nil {
-		b.Skip(err)
+	if ckzg && !ckzgAvailable {
+		b.Skip("CKZG unavailable in this test build")
 	}
+	defer func(old bool) { useCKZG.Store(old) }(useCKZG.Load())
+	useCKZG.Store(ckzg)
 
 	var (
 		blob          = randBlob()

--- a/crypto/kzg4844/kzg4844_test.go
+++ b/crypto/kzg4844/kzg4844_test.go
@@ -47,13 +47,11 @@ func randBlob() Blob {
 
 func TestCKZGWithPoint(t *testing.T)  { testKZGWithPoint(t, true) }
 func TestGoKZGWithPoint(t *testing.T) { testKZGWithPoint(t, false) }
-
 func testKZGWithPoint(t *testing.T, ckzg bool) {
-	if ckzg && !ckzgAvailable {
-		t.Skip("CKZG unavailable in this test build")
+	err := UseCKZG(ckzg)
+	if err != nil {
+		t.Skip(err)
 	}
-	defer func(old bool) { useCKZG.Store(old) }(useCKZG.Load())
-	useCKZG.Store(ckzg)
 
 	blob := randBlob()
 
@@ -73,13 +71,11 @@ func testKZGWithPoint(t *testing.T, ckzg bool) {
 
 func TestCKZGWithBlob(t *testing.T)  { testKZGWithBlob(t, true) }
 func TestGoKZGWithBlob(t *testing.T) { testKZGWithBlob(t, false) }
-
 func testKZGWithBlob(t *testing.T, ckzg bool) {
-	if ckzg && !ckzgAvailable {
-		t.Skip("CKZG unavailable in this test build")
+	err := UseCKZG(ckzg)
+	if err != nil {
+		t.Skip(err)
 	}
-	defer func(old bool) { useCKZG.Store(old) }(useCKZG.Load())
-	useCKZG.Store(ckzg)
 
 	blob := randBlob()
 
@@ -99,13 +95,14 @@ func testKZGWithBlob(t *testing.T, ckzg bool) {
 func BenchmarkCKZGBlobToCommitment(b *testing.B)  { benchmarkBlobToCommitment(b, true) }
 func BenchmarkGoKZGBlobToCommitment(b *testing.B) { benchmarkBlobToCommitment(b, false) }
 func benchmarkBlobToCommitment(b *testing.B, ckzg bool) {
-	if ckzg && !ckzgAvailable {
-		b.Skip("CKZG unavailable in this test build")
+	err := UseCKZG(ckzg)
+	if err != nil {
+		b.Skip(err)
 	}
-	defer func(old bool) { useCKZG.Store(old) }(useCKZG.Load())
-	useCKZG.Store(ckzg)
 
 	blob := randBlob()
+
+	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		BlobToCommitment(blob)
 	}
@@ -114,16 +111,17 @@ func benchmarkBlobToCommitment(b *testing.B, ckzg bool) {
 func BenchmarkCKZGComputeProof(b *testing.B)  { benchmarkComputeProof(b, true) }
 func BenchmarkGoKZGComputeProof(b *testing.B) { benchmarkComputeProof(b, false) }
 func benchmarkComputeProof(b *testing.B, ckzg bool) {
-	if ckzg && !ckzgAvailable {
-		b.Skip("CKZG unavailable in this test build")
+	err := UseCKZG(ckzg)
+	if err != nil {
+		b.Skip(err)
 	}
-	defer func(old bool) { useCKZG.Store(old) }(useCKZG.Load())
-	useCKZG.Store(ckzg)
 
 	var (
 		blob  = randBlob()
 		point = randFieldElement()
 	)
+
+	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		ComputeProof(blob, point)
 	}
@@ -132,11 +130,10 @@ func benchmarkComputeProof(b *testing.B, ckzg bool) {
 func BenchmarkCKZGVerifyProof(b *testing.B)  { benchmarkVerifyProof(b, true) }
 func BenchmarkGoKZGVerifyProof(b *testing.B) { benchmarkVerifyProof(b, false) }
 func benchmarkVerifyProof(b *testing.B, ckzg bool) {
-	if ckzg && !ckzgAvailable {
-		b.Skip("CKZG unavailable in this test build")
+	err := UseCKZG(ckzg)
+	if err != nil {
+		b.Skip(err)
 	}
-	defer func(old bool) { useCKZG.Store(old) }(useCKZG.Load())
-	useCKZG.Store(ckzg)
 
 	var (
 		blob            = randBlob()
@@ -144,6 +141,8 @@ func benchmarkVerifyProof(b *testing.B, ckzg bool) {
 		commitment, _   = BlobToCommitment(blob)
 		proof, claim, _ = ComputeProof(blob, point)
 	)
+
+	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		VerifyProof(commitment, point, claim, proof)
 	}
@@ -152,16 +151,17 @@ func benchmarkVerifyProof(b *testing.B, ckzg bool) {
 func BenchmarkCKZGComputeBlobProof(b *testing.B)  { benchmarkComputeBlobProof(b, true) }
 func BenchmarkGoKZGComputeBlobProof(b *testing.B) { benchmarkComputeBlobProof(b, false) }
 func benchmarkComputeBlobProof(b *testing.B, ckzg bool) {
-	if ckzg && !ckzgAvailable {
-		b.Skip("CKZG unavailable in this test build")
+	err := UseCKZG(ckzg)
+	if err != nil {
+		b.Skip(err)
 	}
-	defer func(old bool) { useCKZG.Store(old) }(useCKZG.Load())
-	useCKZG.Store(ckzg)
 
 	var (
 		blob          = randBlob()
 		commitment, _ = BlobToCommitment(blob)
 	)
+
+	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		ComputeBlobProof(blob, commitment)
 	}
@@ -170,17 +170,18 @@ func benchmarkComputeBlobProof(b *testing.B, ckzg bool) {
 func BenchmarkCKZGVerifyBlobProof(b *testing.B)  { benchmarkVerifyBlobProof(b, true) }
 func BenchmarkGoKZGVerifyBlobProof(b *testing.B) { benchmarkVerifyBlobProof(b, false) }
 func benchmarkVerifyBlobProof(b *testing.B, ckzg bool) {
-	if ckzg && !ckzgAvailable {
-		b.Skip("CKZG unavailable in this test build")
+	err := UseCKZG(ckzg)
+	if err != nil {
+		b.Skip(err)
 	}
-	defer func(old bool) { useCKZG.Store(old) }(useCKZG.Load())
-	useCKZG.Store(ckzg)
 
 	var (
 		blob          = randBlob()
 		commitment, _ = BlobToCommitment(blob)
 		proof, _      = ComputeBlobProof(blob, commitment)
 	)
+
+	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		VerifyBlobProof(blob, commitment, proof)
 	}


### PR DESCRIPTION
* Add `ckzgIniter.Do(ckzgInit)` call to all c-kzg functions.
* Add `b.ResetTimer()` in benchmarks for accuracy.
* Delete some unnecessary blank lines for consistency.
* Fix a minor typo in a comment.