### PR TITLE
Allow calls to signTransaction to assign a default tip in the event that feepergas is specified and gasprice is missing from the API call

### DIFF
--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -1877,8 +1877,8 @@ func (s *TransactionAPI) SignTransaction(ctx context.Context, args TransactionAr
 	if args.Gas == nil {
 		return nil, errors.New("gas not specified")
 	}
-	if args.GasPrice == nil && (args.MaxPriorityFeePerGas == nil || args.MaxFeePerGas == nil) {
-		return nil, errors.New("missing gasPrice or maxFeePerGas/maxPriorityFeePerGas")
+	if args.GasPrice == nil && args.MaxFeePerGas == nil{
+		return nil, errors.New("missing gasPrice or maxFeePerGas")
 	}
 	if args.Nonce == nil {
 		return nil, errors.New("nonce not specified")


### PR DESCRIPTION
A transaction shouldn't be blocked from being signed via the transaction API just because it has no tip explicitly set int the API request. Defaults are set below this line for all values that aren't set. gasprice ==nil && feepergas non nil implies a London execution, so surely you should be able to have the api accent a request with Feepergas positive and priorityfeepergas = nil and then just fill in the default for priorityfeepergas only?

setLondonFeeDefaults is ok with this
