### PR TITLE
eth/tracers/native: panic on memory read in prestateTracer

### DIFF
--- a/eth/tracers/internal/tracetest/calltrace_test.go
+++ b/eth/tracers/internal/tracetest/calltrace_test.go
@@ -302,13 +302,13 @@ func TestInternals(t *testing.T) {
 				byte(vm.CALL),
 			},
 			tracer: mkTracer("callTracer", nil),
-			want:   `{"from":"0x000000000000000000000000000000000000feed","gas":"0xc350","gasUsed":"0x54d8","to":"0x00000000000000000000000000000000deadbeef","input":"0x","calls":[{"from":"0x00000000000000000000000000000000deadbeef","gas":"0x6cbf","gasUsed":"0x0","to":"0x00000000000000000000000000000000000000ff","input":"0x","value":"0x0","type":"CALL"}],"value":"0x0","type":"CALL"}`,
+			want:   `{"from":"0x000000000000000000000000000000000000feed","gas":"0x13880","gasUsed":"0x54d8","to":"0x00000000000000000000000000000000deadbeef","input":"0x","calls":[{"from":"0x00000000000000000000000000000000deadbeef","gas":"0xe01a","gasUsed":"0x0","to":"0x00000000000000000000000000000000000000ff","input":"0x","value":"0x0","type":"CALL"}],"value":"0x0","type":"CALL"}`,
 		},
 		{
 			name:   "Stack depletion in LOG0",
 			code:   []byte{byte(vm.LOG3)},
 			tracer: mkTracer("callTracer", json.RawMessage(`{ "withLog": true }`)),
-			want:   `{"from":"0x000000000000000000000000000000000000feed","gas":"0xc350","gasUsed":"0xc350","to":"0x00000000000000000000000000000000deadbeef","input":"0x","error":"stack underflow (0 \u003c=\u003e 5)","value":"0x0","type":"CALL"}`,
+			want:   `{"from":"0x000000000000000000000000000000000000feed","gas":"0x13880","gasUsed":"0x13880","to":"0x00000000000000000000000000000000deadbeef","input":"0x","error":"stack underflow (0 \u003c=\u003e 5)","value":"0x0","type":"CALL"}`,
 		},
 		{
 			name: "Mem expansion in LOG0",
@@ -321,11 +321,11 @@ func TestInternals(t *testing.T) {
 				byte(vm.LOG0),
 			},
 			tracer: mkTracer("callTracer", json.RawMessage(`{ "withLog": true }`)),
-			want:   `{"from":"0x000000000000000000000000000000000000feed","gas":"0xc350","gasUsed":"0x5b9e","to":"0x00000000000000000000000000000000deadbeef","input":"0x","logs":[{"address":"0x00000000000000000000000000000000deadbeef","topics":[],"data":"0x000000000000000000000000000000000000000000000000000000000000000100000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000"}],"value":"0x0","type":"CALL"}`,
+			want:   `{"from":"0x000000000000000000000000000000000000feed","gas":"0x13880","gasUsed":"0x5b9e","to":"0x00000000000000000000000000000000deadbeef","input":"0x","logs":[{"address":"0x00000000000000000000000000000000deadbeef","topics":[],"data":"0x000000000000000000000000000000000000000000000000000000000000000100000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000"}],"value":"0x0","type":"CALL"}`,
 		},
 		{
 			// Leads to OOM on the prestate tracer
-			name: "Prestate-tracer - mem expansion in CREATE2",
+			name: "Prestate-tracer - CREATE2 OOM",
 			code: []byte{
 				byte(vm.PUSH1), 0x1,
 				byte(vm.PUSH1), 0x0,
@@ -339,41 +339,62 @@ func TestInternals(t *testing.T) {
 				byte(vm.PUSH1), 0x0,
 				byte(vm.LOG0),
 			},
-			tracer: mkTracer("prestateTracer", json.RawMessage(`{ "withLog": true }`)),
-			want:   `{"0x0000000000000000000000000000000000000000":{"balance":"0x0"},"0x000000000000000000000000000000000000feed":{"balance":"0x1c6bf52640350"},"0x00000000000000000000000000000000deadbeef":{"balance":"0x0","code":"0x6001600052600164ffffffffff60016000f560ff6000a0"}}`,
+			tracer: mkTracer("prestateTracer", nil),
+			want:   `{"0x0000000000000000000000000000000000000000":{"balance":"0x0"},"0x000000000000000000000000000000000000feed":{"balance":"0x1c6bf52647880"},"0x00000000000000000000000000000000deadbeef":{"balance":"0x0","code":"0x6001600052600164ffffffffff60016000f560ff6000a0"}}`,
+		},
+		{
+			// CREATE2 which requires padding memory by prestate tracer
+			name: "Prestate-tracer - CREATE2 Memory padding",
+			code: []byte{
+				byte(vm.PUSH1), 0x1,
+				byte(vm.PUSH1), 0x0,
+				byte(vm.MSTORE),
+				byte(vm.PUSH1), 0x1,
+				byte(vm.PUSH1), 0xff,
+				byte(vm.PUSH1), 0x1,
+				byte(vm.PUSH1), 0x0,
+				byte(vm.CREATE2),
+				byte(vm.PUSH1), 0xff,
+				byte(vm.PUSH1), 0x0,
+				byte(vm.LOG0),
+			},
+			tracer: mkTracer("prestateTracer", nil),
+			want:   `{"0x0000000000000000000000000000000000000000":{"balance":"0x0"},"0x000000000000000000000000000000000000feed":{"balance":"0x1c6bf52647880"},"0x00000000000000000000000000000000deadbeef":{"balance":"0x0","code":"0x6001600052600160ff60016000f560ff6000a0"},"0x91ff9a805d36f54e3e272e230f3e3f5c1b330804":{"balance":"0x0"}}`,
 		},
 	} {
-		_, statedb := tests.MakePreState(rawdb.NewMemoryDatabase(),
-			core.GenesisAlloc{
-				to: core.GenesisAccount{
-					Code: tc.code,
-				},
-				origin: core.GenesisAccount{
-					Balance: big.NewInt(500000000000000),
-				},
-			}, false)
-		evm := vm.NewEVM(context, txContext, statedb, params.MainnetChainConfig, vm.Config{Tracer: tc.tracer})
-		msg := &core.Message{
-			To:                &to,
-			From:              origin,
-			Value:             big.NewInt(0),
-			GasLimit:          50000,
-			GasPrice:          big.NewInt(0),
-			GasFeeCap:         big.NewInt(0),
-			GasTipCap:         big.NewInt(0),
-			SkipAccountChecks: false,
-		}
-		st := core.NewStateTransition(evm, msg, new(core.GasPool).AddGas(msg.GasLimit))
-		if _, err := st.TransitionDb(); err != nil {
-			t.Fatalf("test %v: failed to execute transaction: %v", tc.name, err)
-		}
-		// Retrieve the trace result and compare against the expected
-		res, err := tc.tracer.GetResult()
-		if err != nil {
-			t.Fatalf("test %v: failed to retrieve trace result: %v", tc.name, err)
-		}
-		if string(res) != tc.want {
-			t.Fatalf("test %v: trace mismatch\n have: %v\n want: %v\n", tc.name, string(res), tc.want)
-		}
+		t.Run(tc.name, func(t *testing.T) {
+			_, statedb := tests.MakePreState(rawdb.NewMemoryDatabase(),
+				core.GenesisAlloc{
+					to: core.GenesisAccount{
+						Code: tc.code,
+					},
+					origin: core.GenesisAccount{
+						Balance: big.NewInt(500000000000000),
+					},
+				}, false)
+			evm := vm.NewEVM(context, txContext, statedb, params.MainnetChainConfig, vm.Config{Tracer: tc.tracer})
+			msg := &core.Message{
+				To:                &to,
+				From:              origin,
+				Value:             big.NewInt(0),
+				GasLimit:          80000,
+				GasPrice:          big.NewInt(0),
+				GasFeeCap:         big.NewInt(0),
+				GasTipCap:         big.NewInt(0),
+				SkipAccountChecks: false,
+			}
+			st := core.NewStateTransition(evm, msg, new(core.GasPool).AddGas(msg.GasLimit))
+			if _, err := st.TransitionDb(); err != nil {
+				t.Fatalf("test %v: failed to execute transaction: %v", tc.name, err)
+			}
+			// Retrieve the trace result and compare against the expected
+			res, err := tc.tracer.GetResult()
+			if err != nil {
+				t.Fatalf("test %v: failed to retrieve trace result: %v", tc.name, err)
+			}
+			if string(res) != tc.want {
+				t.Errorf("test %v: trace mismatch\n have: %v\n want: %v\n", tc.name, string(res), tc.want)
+			}
+		})
 	}
 }

--- a/eth/tracers/native/call.go
+++ b/eth/tracers/native/call.go
@@ -27,6 +27,7 @@ import (
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/core/vm"
 	"github.com/ethereum/go-ethereum/eth/tracers"
+	"github.com/ethereum/go-ethereum/log"
 )
 
 //go:generate go run github.com/fjl/gencodec -type callFrame -field-override callFrameMarshaling -out gen_callframe_json.go
@@ -183,6 +184,7 @@ func (t *callTracer) CaptureState(pc uint64, op vm.OpCode, gas, cost uint64, sco
 		data, err := tracers.GetMemoryCopyPadded(scope.Memory, int64(mStart.Uint64()), int64(mSize.Uint64()))
 		if err != nil {
 			// mSize was unrealistically large
+			log.Warn("failed to copy CREATE2 input", "err", err, "tracer", "callTracer", "offset", mStart, "size", mSize)
 			return
 		}
 

--- a/eth/tracers/native/prestate.go
+++ b/eth/tracers/native/prestate.go
@@ -165,7 +165,11 @@ func (t *prestateTracer) CaptureState(pc uint64, op vm.OpCode, gas, cost uint64,
 	case stackLen >= 4 && op == vm.CREATE2:
 		offset := stackData[stackLen-2]
 		size := stackData[stackLen-3]
-		init := scope.Memory.GetCopy(int64(offset.Uint64()), int64(size.Uint64()))
+		init, err := tracers.GetMemoryCopyPadded(scope.Memory, int64(offset.Uint64()), int64(size.Uint64()))
+		if err != nil {
+			// TODO: ???
+			return
+		}
 		inithash := crypto.Keccak256(init)
 		salt := stackData[stackLen-4]
 		addr := crypto.CreateAddress2(caller, salt.Bytes32(), inithash)

--- a/eth/tracers/native/prestate.go
+++ b/eth/tracers/native/prestate.go
@@ -27,6 +27,7 @@ import (
 	"github.com/ethereum/go-ethereum/core/vm"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/eth/tracers"
+	"github.com/ethereum/go-ethereum/log"
 )
 
 //go:generate go run github.com/fjl/gencodec -type account -field-override accountMarshaling -out gen_account_json.go
@@ -167,7 +168,7 @@ func (t *prestateTracer) CaptureState(pc uint64, op vm.OpCode, gas, cost uint64,
 		size := stackData[stackLen-3]
 		init, err := tracers.GetMemoryCopyPadded(scope.Memory, int64(offset.Uint64()), int64(size.Uint64()))
 		if err != nil {
-			// TODO: ???
+			log.Warn("failed to copy CREATE2 input", "err", err, "tracer", "prestateTracer", "offset", offset, "size", size)
 			return
 		}
 		inithash := crypto.Keccak256(init)


### PR DESCRIPTION
We've run into a panic mentioned in https://github.com/ethereum/go-ethereum/issues/26845 inside the prestate tracer, not that https://github.com/ethereum/go-ethereum/pull/26848 fixed the issue in `callTracer` but did not fixed the `prestateTracer` issue also mentioned in the original issue, this PR goes back and fixes that as well.

However, I'm not sure what I should do, if anything, with the returned error, since `CaptureState` doesn't return an error itself.  Looks like `tracers.GetMemoryCopyPadded` only really fails if the arguments are wrong or the copy is more than 1024KB, in which sae I personally think it's ok to `panic(err)` but wanted to discuss before doing so.

Also unsure if there should have been a unit test to cover this, FWIW this is the payload we hit on goerli to get a panic:

```
curl -X "POST" http://0.0.0.0:8545 \
     -H 'Content-Type: application/json' \
     -d $'{
  "id": 1,
  "method": "debug_traceBlockByHash",
  "jsonrpc": "2.0",
  "params": [
    "0x81804b81d6aac4f72878f73c044cf49303944a856a5d8e572c0abb9a97893385",
    {
      "tracer": "prestateTracer"
    }
  ]
}'
```

With this panic log:

```
 ERROR[07-10|16:03:13.685] RPC method debug_traceBlockByHash crashed: runtime error: slice bounds out of range [:4448] with capacity 3072
 goroutine 248641109 [running]:
 github.com/ethereum/go-ethereum/rpc.(*callback).call.func1()
         github.com/ethereum/go-ethereum/rpc/service.go:199 +0x89
 panic({0x1880f60, 0xc044486390})
         runtime/panic.go:884 +0x213
 github.com/ethereum/go-ethereum/core/vm.(*Memory).GetCopy(...)
         github.com/ethereum/go-ethereum/core/vm/memory.go:76
 github.com/ethereum/go-ethereum/eth/tracers/native.(*prestateTracer).CaptureState(0xc0c087a000, 0xc0043fcef0?, 0xf5, 0xc00282e0d0?, 0x41359a?, 0xc0877c7fb0, {0x1c0?, 0x1a8?, 0xc00282e0d0>
         github.com/ethereum/go-ethereum/eth/tracers/native/prestate.go:168 +0x770
 github.com/ethereum/go-ethereum/core/vm.(*EVMInterpreter).Run(0xc0c087a300, 0xc02a91dec0, {0xc0420c9200, 0x8c4, 0x900}, 0x0)
         github.com/ethereum/go-ethereum/core/vm/interpreter.go:217 +0x83a
 github.com/ethereum/go-ethereum/core/vm.(*EVM).DelegateCall(0xc06d0a6e00, {0x1cb75e0, 0xc02a91de00?}, {0xb5, 0xf, 0x59, 0x20, 0x9f, 0xfc, 0x86,...}, ...)
         github.com/ethereum/go-ethereum/core/vm/evm.go:336 +0x5de
 github.com/ethereum/go-ethereum/core/vm.opDelegateCall(0x1?, 0xc0c087a300, 0xc0877c7500)
         github.com/ethereum/go-ethereum/core/vm/instructions.go:750 +0x47f
 github.com/ethereum/go-ethereum/core/vm.(*EVMInterpreter).Run(0xc0c087a300, 0xc02a91de00, {0xc0d45af600, 0x8c4, 0x8c4}, 0x0)
         github.com/ethereum/go-ethereum/core/vm/interpreter.go:228 +0xa39
 github.com/ethereum/go-ethereum/core/vm.(*EVM).Call(0xc06d0a6e00, {0x1cbb640, 0xc044486270}, {0x6e, 0x10, 0x4, 0x4d, 0x6, 0xa1, 0x0, ...}, ...)
         github.com/ethereum/go-ethereum/core/vm/evm.go:235 +0xb9e
 github.com/ethereum/go-ethereum/core.(*StateTransition).TransitionDb(0xc00282ee68)
         github.com/ethereum/go-ethereum/core/state_transition.go:375 +0x895
 github.com/ethereum/go-ethereum/core.ApplyMessage(0x1cc4ef8?, 0xc007f3b130?, 0xc0b23ecff0?)
```