### PR TITLE
all: live chain-aware tracing - add tracers subscription

### DIFF
--- a/cmd/evm/README.md
+++ b/cmd/evm/README.md
@@ -342,7 +342,7 @@ To make `t8n` apply these, the following inputs are required:
   - For ethash, it is `5000000000000000000` `wei`,
   - If this is not defined, mining rewards are not applied,
   - A value of `0` is valid, and causes accounts to be 'touched'.
-- For each ommer, the tool needs to be given an `addres\` and a `delta`. This
+- For each ommer, the tool needs to be given an `address\` and a `delta`. This
   is done via the `ommers` field in `env`.
 
 Note: the tool does not verify that e.g. the normal uncle rules apply,

--- a/cmd/evm/internal/t8ntool/execution.go
+++ b/cmd/evm/internal/t8ntool/execution.go
@@ -183,6 +183,7 @@ func (pre *Prestate) Apply(vmConfig vm.Config, chainConfig *params.ChainConfig,
 		)
 		evm := vm.NewEVM(vmContext, txContext, statedb, chainConfig, vmConfig)
 
+		tracer.CaptureTxStart(tx)
 		// (ret []byte, usedGas uint64, failed bool, err error)
 		msgResult, err := core.ApplyMessage(evm, msg, gaspool)
 		if err != nil {
@@ -231,6 +232,7 @@ func (pre *Prestate) Apply(vmConfig vm.Config, chainConfig *params.ChainConfig,
 			//receipt.BlockNumber
 			receipt.TransactionIndex = uint(txIndex)
 			receipts = append(receipts, receipt)
+			tracer.CaptureTxEnd(receipt)
 		}
 
 		txIndex++

--- a/cmd/evm/transition-test.sh
+++ b/cmd/evm/transition-test.sh
@@ -280,7 +280,7 @@ To make `t8n` apply these, the following inputs are required:
   - For ethash, it is `5000000000000000000` `wei`,
   - If this is not defined, mining rewards are not applied,
   - A value of `0` is valid, and causes accounts to be 'touched'.
-- For each ommer, the tool needs to be given an `addres\` and a `delta`. This
+- For each ommer, the tool needs to be given an `address\` and a `delta`. This
   is done via the `ommers` field in `env`.
 
 Note: the tool does not verify that e.g. the normal uncle rules apply,

--- a/cmd/geth/chaincmd.go
+++ b/cmd/geth/chaincmd.go
@@ -94,6 +94,7 @@ if one is set.  Otherwise it prints the genesis from the datadir.`,
 			utils.MetricsInfluxDBBucketFlag,
 			utils.MetricsInfluxDBOrganizationFlag,
 			utils.TxLookupLimitFlag,
+			utils.VMTraceFlag,
 		}, utils.DatabasePathFlags),
 		Description: `
 The import command imports blocks from an RLP-encoded form. The form can be one file

--- a/cmd/geth/main.go
+++ b/cmd/geth/main.go
@@ -130,6 +130,7 @@ var (
 		utils.DeveloperPeriodFlag,
 		utils.DeveloperGasLimitFlag,
 		utils.VMEnableDebugFlag,
+		utils.VMTraceFlag,
 		utils.NetworkIdFlag,
 		utils.EthStatsURLFlag,
 		utils.NoCompactionFlag,

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -2163,15 +2163,15 @@ func MakeChain(ctx *cli.Context, stack *node.Node, readonly bool) (*core.BlockCh
 		cache.TrieDirtyLimit = ctx.Int(CacheFlag.Name) * ctx.Int(CacheGCFlag.Name) / 100
 	}
 	vmcfg := vm.Config{EnablePreimageRecording: ctx.Bool(VMEnableDebugFlag.Name)}
-
+	if ctx.IsSet(VMTraceFlag.Name) {
+		vmcfg.Tracer = tracers.NewPrinter()
+	}
 	// Disable transaction indexing/unindexing by default.
 	chain, err := core.NewBlockChain(chainDb, cache, gspec, nil, engine, vmcfg, nil, nil)
 	if err != nil {
 		Fatalf("Can't create BlockChain: %v", err)
 	}
-	if ctx.IsSet(VMTraceFlag.Name) {
-		chain.SetLogger(tracers.NewPrinter())
-	}
+
 	return chain, chainDb
 }
 

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -1741,6 +1741,9 @@ func SetEthConfig(ctx *cli.Context, stack *node.Node, cfg *ethconfig.Config) {
 		// TODO(fjl): force-enable this in --dev mode
 		cfg.EnablePreimageRecording = ctx.Bool(VMEnableDebugFlag.Name)
 	}
+	if ctx.IsSet(VMTraceFlag.Name) {
+		cfg.LiveTrace = ctx.Bool(VMTraceFlag.Name)
+	}
 
 	if ctx.IsSet(RPCGlobalGasCapFlag.Name) {
 		cfg.RPCGasCap = ctx.Uint64(RPCGlobalGasCapFlag.Name)

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -529,6 +529,11 @@ var (
 		Usage:    "Record information useful for VM and contract debugging",
 		Category: flags.VMCategory,
 	}
+	VMTraceFlag = &cli.BoolFlag{
+		Name:     "vmtrace",
+		Usage:    "Record internal VM operations (costly)",
+		Category: flags.VMCategory,
+	}
 
 	// API options.
 	RPCGlobalGasCapFlag = &cli.Uint64Flag{
@@ -2163,6 +2168,9 @@ func MakeChain(ctx *cli.Context, stack *node.Node, readonly bool) (*core.BlockCh
 	chain, err := core.NewBlockChain(chainDb, cache, gspec, nil, engine, vmcfg, nil, nil)
 	if err != nil {
 		Fatalf("Can't create BlockChain: %v", err)
+	}
+	if ctx.IsSet(VMTraceFlag.Name) {
+		chain.SetLogger(tracers.NewPrinter())
 	}
 	return chain, chainDb
 }

--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -2053,11 +2053,10 @@ func (bc *BlockChain) collectLogs(b *types.Block, removed bool) []*types.Log {
 	var logs []*types.Log
 	for _, receipt := range receipts {
 		for _, log := range receipt.Logs {
-			l := *log
 			if removed {
-				l.Removed = true
+				log.Removed = true
 			}
-			logs = append(logs, &l)
+			logs = append(logs, log)
 		}
 	}
 	return logs

--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -2525,6 +2525,6 @@ func (bc *BlockChain) GetTrieFlushInterval() time.Duration {
 	return time.Duration(bc.flushInterval.Load())
 }
 
-func (bc *BlockChain) TracersEventsSent(data json.RawMessage) {
+func (bc *BlockChain) TracersEventsSent(data []json.RawMessage) {
 	bc.tracesFeed.Send(data)
 }

--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -18,6 +18,7 @@
 package core
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -2522,4 +2523,8 @@ func (bc *BlockChain) SetTrieFlushInterval(interval time.Duration) {
 // GetTrieFlushInterval gets the in-memroy tries flush interval
 func (bc *BlockChain) GetTrieFlushInterval() time.Duration {
 	return time.Duration(bc.flushInterval.Load())
+}
+
+func (bc *BlockChain) TracersEventsSent(data json.RawMessage) {
+	bc.tracesFeed.Send(data)
 }

--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -153,6 +153,12 @@ var defaultCacheConfig = &CacheConfig{
 	SnapshotWait:   true,
 }
 
+type BlockchainLogger interface {
+	vm.EVMLogger
+	CaptureBlockStart(*types.Block)
+	CaptureBlockEnd()
+}
+
 // BlockChain represents the canonical chain given a database with a genesis
 // block. The Blockchain manages chain imports, reverts, chain reorganisations.
 //
@@ -226,6 +232,7 @@ type BlockChain struct {
 	processor  Processor // Block transaction processor interface
 	forker     *ForkChoice
 	vmConfig   vm.Config
+	logger     BlockchainLogger
 }
 
 // NewBlockChain returns a fully initialised block chain using information
@@ -441,6 +448,12 @@ func NewBlockChain(db ethdb.Database, cacheConfig *CacheConfig, genesis *Genesis
 		go bc.maintainTxIndex()
 	}
 	return bc, nil
+}
+
+// TODO: need to move this to NewBlockchain to capture genesis block
+func (bc *BlockChain) SetLogger(l BlockchainLogger) {
+	bc.logger = l
+	bc.vmConfig.Tracer = l
 }
 
 // empty returns an indicator whether the blockchain is empty.

--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -205,6 +205,7 @@ type BlockChain struct {
 	chainHeadFeed event.Feed
 	logsFeed      event.Feed
 	blockProcFeed event.Feed
+	tracesFeed    event.Feed
 	scope         event.SubscriptionScope
 	genesisBlock  *types.Block
 

--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -153,6 +153,8 @@ var defaultCacheConfig = &CacheConfig{
 	SnapshotWait:   true,
 }
 
+// BlockchainLogger is used to collect traces during chain processing.
+// Please make a copy of the referenced types if you intend to retain them.
 type BlockchainLogger interface {
 	vm.EVMLogger
 	state.StateLogger

--- a/core/blockchain_reader.go
+++ b/core/blockchain_reader.go
@@ -17,6 +17,7 @@
 package core
 
 import (
+	"encoding/json"
 	"math/big"
 
 	"github.com/ethereum/go-ethereum/common"
@@ -408,4 +409,9 @@ func (bc *BlockChain) SubscribeLogsEvent(ch chan<- []*types.Log) event.Subscript
 // block processing has started while false means it has stopped.
 func (bc *BlockChain) SubscribeBlockProcessingEvent(ch chan<- bool) event.Subscription {
 	return bc.scope.Track(bc.blockProcFeed.Subscribe(ch))
+}
+
+// SubscribeTracesEvent registers a subscription of TracesEvent.
+func (bc *BlockChain) SubscribeTracesEvent(ch chan<- json.RawMessage) event.Subscription {
+	return bc.scope.Track(bc.tracesFeed.Subscribe(ch))
 }

--- a/core/blockchain_reader.go
+++ b/core/blockchain_reader.go
@@ -412,6 +412,6 @@ func (bc *BlockChain) SubscribeBlockProcessingEvent(ch chan<- bool) event.Subscr
 }
 
 // SubscribeTracesEvent registers a subscription of TracesEvent.
-func (bc *BlockChain) SubscribeTracesEvent(ch chan<- json.RawMessage) event.Subscription {
+func (bc *BlockChain) SubscribeTracesEvent(ch chan<- []json.RawMessage) event.Subscription {
 	return bc.scope.Track(bc.tracesFeed.Subscribe(ch))
 }

--- a/core/chain_makers.go
+++ b/core/chain_makers.go
@@ -350,7 +350,7 @@ func GenerateChain(config *params.ChainConfig, parent *types.Block, engine conse
 // then generate chain on top.
 func GenerateChainWithGenesis(genesis *Genesis, engine consensus.Engine, n int, gen func(int, *BlockGen)) (ethdb.Database, []*types.Block, []types.Receipts) {
 	db := rawdb.NewMemoryDatabase()
-	_, err := genesis.Commit(db, trie.NewDatabase(db))
+	_, err := genesis.Commit(db, trie.NewDatabase(db), nil)
 	if err != nil {
 		panic(err)
 	}

--- a/core/state/state_object.go
+++ b/core/state/state_object.go
@@ -236,6 +236,9 @@ func (s *stateObject) SetState(db Database, key, value common.Hash) {
 		key:      key,
 		prevalue: prev,
 	})
+	if s.db.logger != nil {
+		s.db.logger.OnStorageChange(s.address, key, prev, value)
+	}
 	s.setState(key, value)
 }
 
@@ -399,6 +402,9 @@ func (s *stateObject) SetBalance(amount *big.Int) {
 		account: &s.address,
 		prev:    new(big.Int).Set(s.data.Balance),
 	})
+	if s.db.logger != nil {
+		s.db.logger.OnBalanceChange(s.address, s.Balance(), amount)
+	}
 	s.setBalance(amount)
 }
 
@@ -470,6 +476,9 @@ func (s *stateObject) SetCode(codeHash common.Hash, code []byte) {
 		prevhash: s.CodeHash(),
 		prevcode: prevcode,
 	})
+	if s.db.logger != nil {
+		s.db.logger.OnCodeChange(s.address, common.BytesToHash(s.CodeHash()), prevcode, codeHash, code)
+	}
 	s.setCode(codeHash, code)
 }
 
@@ -484,6 +493,9 @@ func (s *stateObject) SetNonce(nonce uint64) {
 		account: &s.address,
 		prev:    s.data.Nonce,
 	})
+	if s.db.logger != nil {
+		s.db.logger.OnNonceChange(s.address, s.data.Nonce, nonce)
+	}
 	s.setNonce(nonce)
 }
 

--- a/core/state/statedb.go
+++ b/core/state/statedb.go
@@ -53,6 +53,10 @@ func (n *proofList) Delete(key []byte) error {
 	panic("not supported")
 }
 
+// StateLogger is used to collect state update traces from  EVM transaction
+// execution.
+// Note that reference types are actual VM data structures; make copies
+// if you need to retain them beyond the current call.
 type StateLogger interface {
 	OnBalanceChange(addr common.Address, prev, new *big.Int)
 	OnNonceChange(addr common.Address, prev, new uint64)
@@ -171,7 +175,7 @@ func New(root common.Hash, db Database, snaps *snapshot.Tree) (*StateDB, error) 
 	return sdb, nil
 }
 
-// TODO: move to New
+// SetLogger sets the logger for account update hooks.
 func (s *StateDB) SetLogger(l StateLogger) {
 	s.logger = l
 }

--- a/core/state/statedb.go
+++ b/core/state/statedb.go
@@ -648,6 +648,10 @@ func (s *StateDB) createObject(addr common.Address) (newobj, prev *stateObject) 
 	newobj = newObject(s, addr, types.StateAccount{})
 	if prev == nil {
 		s.journal.append(createObjectChange{account: &addr})
+		// TODO: add isPrecompile check
+		if s.logger != nil {
+			s.logger.OnNewAccount(addr)
+		}
 	} else {
 		// The original account should be marked as destructed and all cached
 		// account and storage data should be cleared as well. Note, it must
@@ -678,11 +682,7 @@ func (s *StateDB) createObject(addr common.Address) (newobj, prev *stateObject) 
 			prevStorage:  storage,
 		})
 	}
-	// TODO: add isPrecompile check
-	// TODO: should we emit on account reset?
-	if s.logger != nil {
-		s.logger.OnNewAccount(addr)
-	}
+
 	s.setStateObject(newobj)
 	if prev != nil && !prev.deleted {
 		return newobj, prev

--- a/core/state_processor.go
+++ b/core/state_processor.go
@@ -67,6 +67,10 @@ func (p *StateProcessor) Process(block *types.Block, statedb *state.StateDB, cfg
 		allLogs     []*types.Log
 		gp          = new(GasPool).AddGas(block.GasLimit())
 	)
+	if p.bc.logger != nil {
+		p.bc.logger.CaptureBlockStart(block)
+		defer p.bc.logger.CaptureBlockEnd()
+	}
 	// Mutate the block and state according to any hard-fork specs
 	if p.config.DAOForkSupport && p.config.DAOForkBlock != nil && p.config.DAOForkBlock.Cmp(block.Number()) == 0 {
 		misc.ApplyDAOHardFork(statedb)

--- a/core/state_processor.go
+++ b/core/state_processor.go
@@ -66,10 +66,18 @@ func (p *StateProcessor) Process(block *types.Block, statedb *state.StateDB, cfg
 		blockNumber = block.Number()
 		allLogs     []*types.Log
 		gp          = new(GasPool).AddGas(block.GasLimit())
+		err         error
 	)
 	if p.bc.logger != nil {
-		p.bc.logger.CaptureBlockStart(block)
-		defer p.bc.logger.CaptureBlockEnd()
+		p.bc.logger.OnBlockStart(block)
+		defer func() {
+			var td *big.Int
+			if err == nil {
+				td = p.bc.GetTd(block.ParentHash(), block.NumberU64()-1)
+				td.Add(td, block.Difficulty())
+			}
+			p.bc.logger.OnBlockEnd(td, err)
+		}()
 	}
 	// Mutate the block and state according to any hard-fork specs
 	if p.config.DAOForkSupport && p.config.DAOForkBlock != nil && p.config.DAOForkBlock.Cmp(block.Number()) == 0 {
@@ -82,13 +90,15 @@ func (p *StateProcessor) Process(block *types.Block, statedb *state.StateDB, cfg
 	)
 	// Iterate over and process the individual transactions
 	for i, tx := range block.Transactions() {
-		msg, err := TransactionToMessage(tx, signer, header.BaseFee)
+		var msg *Message
+		msg, err = TransactionToMessage(tx, signer, header.BaseFee)
 		if err != nil {
 			return nil, nil, 0, fmt.Errorf("could not apply tx %d [%v]: %w", i, tx.Hash().Hex(), err)
 		}
 		statedb.SetTxContext(tx.Hash(), i)
 
-		receipt, err := applyTransaction(msg, p.config, gp, statedb, blockNumber, blockHash, tx, usedGas, vmenv)
+		var receipt *types.Receipt
+		receipt, err = applyTransaction(msg, p.config, gp, statedb, blockNumber, blockHash, tx, usedGas, vmenv)
 		if vmenv.Config.Tracer != nil {
 			vmenv.Config.Tracer.CaptureTxEnd(receipt)
 		}
@@ -101,7 +111,8 @@ func (p *StateProcessor) Process(block *types.Block, statedb *state.StateDB, cfg
 	// Fail if Shanghai not enabled and len(withdrawals) is non-zero.
 	withdrawals := block.Withdrawals()
 	if len(withdrawals) > 0 && !p.config.IsShanghai(block.Number(), block.Time()) {
-		return nil, nil, 0, errors.New("withdrawals before shanghai")
+		err = errors.New("withdrawals before shanghai")
+		return nil, nil, 0, err
 	}
 	// Finalize the block, applying any consensus engine specific extras (e.g. block rewards)
 	p.engine.Finalize(p.bc, header, statedb, block.Transactions(), block.Uncles(), withdrawals)

--- a/core/state_processor.go
+++ b/core/state_processor.go
@@ -87,7 +87,13 @@ func (p *StateProcessor) Process(block *types.Block, statedb *state.StateDB, cfg
 			return nil, nil, 0, fmt.Errorf("could not apply tx %d [%v]: %w", i, tx.Hash().Hex(), err)
 		}
 		statedb.SetTxContext(tx.Hash(), i)
+		if vmenv.Config.Tracer != nil {
+			vmenv.Config.Tracer.CaptureTxStart(tx)
+		}
 		receipt, err := applyTransaction(msg, p.config, gp, statedb, blockNumber, blockHash, tx, usedGas, vmenv)
+		if vmenv.Config.Tracer != nil {
+			vmenv.Config.Tracer.CaptureTxEnd(receipt)
+		}
 		if err != nil {
 			return nil, nil, 0, fmt.Errorf("could not apply tx %d [%v]: %w", i, tx.Hash().Hex(), err)
 		}

--- a/core/state_processor.go
+++ b/core/state_processor.go
@@ -112,7 +112,7 @@ func (p *StateProcessor) Process(block *types.Block, statedb *state.StateDB, cfg
 func applyTransaction(msg *Message, config *params.ChainConfig, gp *GasPool, statedb *state.StateDB, blockNumber *big.Int, blockHash common.Hash, tx *types.Transaction, usedGas *uint64, evm *vm.EVM) (*types.Receipt, error) {
 	var receipt *types.Receipt
 	if evm.Config.Tracer != nil {
-		evm.Config.Tracer.CaptureTxStart(tx)
+		evm.Config.Tracer.CaptureTxStart(evm, tx)
 		defer func() {
 			evm.Config.Tracer.CaptureTxEnd(receipt)
 		}()

--- a/core/state_transition.go
+++ b/core/state_transition.go
@@ -348,6 +348,9 @@ func (st *StateTransition) TransitionDb() (*ExecutionResult, error) {
 	if st.gasRemaining < gas {
 		return nil, fmt.Errorf("%w: have %d, want %d", ErrIntrinsicGas, st.gasRemaining, gas)
 	}
+	if t := st.evm.Config.Tracer; t != nil {
+		t.OnGasConsumed(st.gasRemaining, gas)
+	}
 	st.gasRemaining -= gas
 
 	// Check clause 6

--- a/core/state_transition.go
+++ b/core/state_transition.go
@@ -326,13 +326,6 @@ func (st *StateTransition) TransitionDb() (*ExecutionResult, error) {
 		return nil, err
 	}
 
-	if tracer := st.evm.Config.Tracer; tracer != nil {
-		tracer.CaptureTxStart(st.initialGas)
-		defer func() {
-			tracer.CaptureTxEnd(st.gasRemaining)
-		}()
-	}
-
 	var (
 		msg              = st.msg
 		sender           = vm.AccountRef(msg.From)

--- a/core/vm/contract.go
+++ b/core/vm/contract.go
@@ -159,9 +159,12 @@ func (c *Contract) Caller() common.Address {
 }
 
 // UseGas attempts the use gas and subtracts it and returns true on success
-func (c *Contract) UseGas(gas uint64) (ok bool) {
+func (c *Contract) UseGas(gas uint64, logger EVMLogger) (ok bool) {
 	if c.Gas < gas {
 		return false
+	}
+	if logger != nil {
+		logger.OnGasConsumed(c.Gas, gas)
 	}
 	c.Gas -= gas
 	return true

--- a/core/vm/contracts.go
+++ b/core/vm/contracts.go
@@ -168,10 +168,13 @@ func ActivePrecompiles(rules params.Rules) []common.Address {
 // - the returned bytes,
 // - the _remaining_ gas,
 // - any error that occurred
-func RunPrecompiledContract(p PrecompiledContract, input []byte, suppliedGas uint64) (ret []byte, remainingGas uint64, err error) {
+func RunPrecompiledContract(p PrecompiledContract, input []byte, suppliedGas uint64, logger EVMLogger) (ret []byte, remainingGas uint64, err error) {
 	gasCost := p.RequiredGas(input)
 	if suppliedGas < gasCost {
 		return nil, 0, ErrOutOfGas
+	}
+	if logger != nil {
+		logger.OnGasConsumed(suppliedGas, gasCost)
 	}
 	suppliedGas -= gasCost
 	output, err := p.Run(input)

--- a/core/vm/contracts_test.go
+++ b/core/vm/contracts_test.go
@@ -97,7 +97,7 @@ func testPrecompiled(addr string, test precompiledTest, t *testing.T) {
 	in := common.Hex2Bytes(test.Input)
 	gas := p.RequiredGas(in)
 	t.Run(fmt.Sprintf("%s-Gas=%d", test.Name, gas), func(t *testing.T) {
-		if res, _, err := RunPrecompiledContract(p, in, gas); err != nil {
+		if res, _, err := RunPrecompiledContract(p, in, gas, nil); err != nil {
 			t.Error(err)
 		} else if common.Bytes2Hex(res) != test.Expected {
 			t.Errorf("Expected %v, got %v", test.Expected, common.Bytes2Hex(res))
@@ -119,7 +119,7 @@ func testPrecompiledOOG(addr string, test precompiledTest, t *testing.T) {
 	gas := p.RequiredGas(in) - 1
 
 	t.Run(fmt.Sprintf("%s-Gas=%d", test.Name, gas), func(t *testing.T) {
-		_, _, err := RunPrecompiledContract(p, in, gas)
+		_, _, err := RunPrecompiledContract(p, in, gas, nil)
 		if err.Error() != "out of gas" {
 			t.Errorf("Expected error [out of gas], got [%v]", err)
 		}
@@ -136,7 +136,7 @@ func testPrecompiledFailure(addr string, test precompiledFailureTest, t *testing
 	in := common.Hex2Bytes(test.Input)
 	gas := p.RequiredGas(in)
 	t.Run(test.Name, func(t *testing.T) {
-		_, _, err := RunPrecompiledContract(p, in, gas)
+		_, _, err := RunPrecompiledContract(p, in, gas, nil)
 		if err.Error() != test.ExpectedError {
 			t.Errorf("Expected error [%v], got [%v]", test.ExpectedError, err)
 		}
@@ -168,7 +168,7 @@ func benchmarkPrecompiled(addr string, test precompiledTest, bench *testing.B) {
 		bench.ResetTimer()
 		for i := 0; i < bench.N; i++ {
 			copy(data, in)
-			res, _, err = RunPrecompiledContract(p, data, reqGas)
+			res, _, err = RunPrecompiledContract(p, data, reqGas, nil)
 		}
 		bench.StopTimer()
 		elapsed := uint64(time.Since(start))

--- a/core/vm/evm.go
+++ b/core/vm/evm.go
@@ -192,7 +192,7 @@ func (evm *EVM) Call(caller ContractRef, addr common.Address, input []byte, gas 
 			// Calling a non existing account, don't do anything, but ping the tracer
 			if debug {
 				if evm.depth == 0 {
-					evm.Config.Tracer.CaptureStart(evm, caller.Address(), addr, false, input, gas, value)
+					evm.Config.Tracer.CaptureStart(caller.Address(), addr, false, input, gas, value)
 					evm.Config.Tracer.CaptureEnd(ret, 0, nil)
 				} else {
 					evm.Config.Tracer.CaptureEnter(CALL, caller.Address(), addr, input, gas, value)
@@ -208,7 +208,7 @@ func (evm *EVM) Call(caller ContractRef, addr common.Address, input []byte, gas 
 	// Capture the tracer start/end events in debug mode
 	if debug {
 		if evm.depth == 0 {
-			evm.Config.Tracer.CaptureStart(evm, caller.Address(), addr, false, input, gas, value)
+			evm.Config.Tracer.CaptureStart(caller.Address(), addr, false, input, gas, value)
 			defer func(startGas uint64) { // Lazy evaluation of the parameters
 				evm.Config.Tracer.CaptureEnd(ret, startGas-gas, err)
 			}(gas)
@@ -456,7 +456,7 @@ func (evm *EVM) create(caller ContractRef, codeAndHash *codeAndHash, gas uint64,
 
 	if evm.Config.Tracer != nil {
 		if evm.depth == 0 {
-			evm.Config.Tracer.CaptureStart(evm, caller.Address(), address, true, codeAndHash.code, gas, value)
+			evm.Config.Tracer.CaptureStart(caller.Address(), address, true, codeAndHash.code, gas, value)
 		} else {
 			evm.Config.Tracer.CaptureEnter(typ, caller.Address(), address, codeAndHash.code, gas, value)
 		}

--- a/core/vm/instructions.go
+++ b/core/vm/instructions.go
@@ -247,7 +247,9 @@ func opKeccak256(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) (
 	if evm.Config.EnablePreimageRecording {
 		evm.StateDB.AddPreimage(interpreter.hasherBuf, data)
 	}
-
+	if interpreter.evm.Config.Tracer != nil {
+		interpreter.evm.Config.Tracer.CaptureKeccakPreimage(common.BytesToHash(interpreter.hasherBuf[:]), data)
+	}
 	size.SetBytes(interpreter.hasherBuf[:])
 	return nil, nil
 }

--- a/core/vm/instructions.go
+++ b/core/vm/instructions.go
@@ -591,7 +591,7 @@ func opCreate(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([]b
 	// reuse size int for stackvalue
 	stackvalue := size
 
-	scope.Contract.UseGas(gas)
+	scope.Contract.UseGas(gas, interpreter.evm.Config.Tracer)
 	//TODO: use uint256.Int instead of converting with toBig()
 	var bigVal = big0
 	if !value.IsZero() {
@@ -634,7 +634,7 @@ func opCreate2(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([]
 	)
 	// Apply EIP150
 	gas -= gas / 64
-	scope.Contract.UseGas(gas)
+	scope.Contract.UseGas(gas, interpreter.evm.Config.Tracer)
 	// reuse size int for stackvalue
 	stackvalue := size
 	//TODO: use uint256.Int instead of converting with toBig()

--- a/core/vm/interpreter.go
+++ b/core/vm/interpreter.go
@@ -185,7 +185,7 @@ func (in *EVMInterpreter) Run(contract *Contract, input []byte, readOnly bool) (
 		} else if sLen > operation.maxStack {
 			return nil, &ErrStackOverflow{stackLen: sLen, limit: operation.maxStack}
 		}
-		if !contract.UseGas(cost) {
+		if !contract.UseGas(cost, in.evm.Config.Tracer) {
 			return nil, ErrOutOfGas
 		}
 		if operation.dynamicGas != nil {
@@ -211,7 +211,7 @@ func (in *EVMInterpreter) Run(contract *Contract, input []byte, readOnly bool) (
 			var dynamicCost uint64
 			dynamicCost, err = operation.dynamicGas(in.evm, contract, stack, mem, memorySize)
 			cost += dynamicCost // for tracing
-			if err != nil || !contract.UseGas(dynamicCost) {
+			if err != nil || !contract.UseGas(dynamicCost, in.evm.Config.Tracer) {
 				return nil, ErrOutOfGas
 			}
 			// Do tracing before memory expansion

--- a/core/vm/logger.go
+++ b/core/vm/logger.go
@@ -20,6 +20,7 @@ import (
 	"math/big"
 
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
 )
 
 // EVMLogger is used to collect execution traces from an EVM transaction
@@ -29,8 +30,8 @@ import (
 // if you need to retain them beyond the current call.
 type EVMLogger interface {
 	// Transaction level
-	CaptureTxStart(gasLimit uint64)
-	CaptureTxEnd(restGas uint64)
+	CaptureTxStart(tx *types.Transaction)
+	CaptureTxEnd(receipt *types.Receipt)
 	// Top call frame
 	CaptureStart(env *EVM, from common.Address, to common.Address, create bool, input []byte, gas uint64, value *big.Int)
 	CaptureEnd(output []byte, gasUsed uint64, err error)

--- a/core/vm/logger.go
+++ b/core/vm/logger.go
@@ -40,4 +40,5 @@ type EVMLogger interface {
 	// Opcode level
 	CaptureState(pc uint64, op OpCode, gas, cost uint64, scope *ScopeContext, rData []byte, depth int, err error)
 	CaptureFault(pc uint64, op OpCode, gas, cost uint64, scope *ScopeContext, depth int, err error)
+	CaptureKeccakPreimage(hash common.Hash, data []byte)
 }

--- a/core/vm/logger.go
+++ b/core/vm/logger.go
@@ -41,4 +41,6 @@ type EVMLogger interface {
 	CaptureState(pc uint64, op OpCode, gas, cost uint64, scope *ScopeContext, rData []byte, depth int, err error)
 	CaptureFault(pc uint64, op OpCode, gas, cost uint64, scope *ScopeContext, depth int, err error)
 	CaptureKeccakPreimage(hash common.Hash, data []byte)
+	// Misc
+	OnGasConsumed(gas, amount uint64)
 }

--- a/core/vm/logger.go
+++ b/core/vm/logger.go
@@ -30,10 +30,10 @@ import (
 // if you need to retain them beyond the current call.
 type EVMLogger interface {
 	// Transaction level
-	CaptureTxStart(tx *types.Transaction)
+	CaptureTxStart(evm *EVM, tx *types.Transaction)
 	CaptureTxEnd(receipt *types.Receipt)
 	// Top call frame
-	CaptureStart(env *EVM, from common.Address, to common.Address, create bool, input []byte, gas uint64, value *big.Int)
+	CaptureStart(from common.Address, to common.Address, create bool, input []byte, gas uint64, value *big.Int)
 	CaptureEnd(output []byte, gasUsed uint64, err error)
 	// Rest of call frames
 	CaptureEnter(typ OpCode, from common.Address, to common.Address, input []byte, gas uint64, value *big.Int)

--- a/core/vm/operations_acl.go
+++ b/core/vm/operations_acl.go
@@ -169,7 +169,7 @@ func makeCallVariantGasCallEIP2929(oldCalculator gasFunc) gasFunc {
 			evm.StateDB.AddAddressToAccessList(addr)
 			// Charge the remaining difference here already, to correctly calculate available
 			// gas for call
-			if !contract.UseGas(coldCost) {
+			if !contract.UseGas(coldCost, evm.Config.Tracer) {
 				return 0, ErrOutOfGas
 			}
 		}

--- a/eth/api_backend.go
+++ b/eth/api_backend.go
@@ -414,6 +414,6 @@ func (b *EthAPIBackend) StateAtBlock(ctx context.Context, block *types.Block, re
 	return b.eth.StateAtBlock(ctx, block, reexec, base, readOnly, preferDisk)
 }
 
-func (b *EthAPIBackend) StateAtTransaction(ctx context.Context, block *types.Block, txIndex int, reexec uint64) (*core.Message, vm.BlockContext, *state.StateDB, tracers.StateReleaseFunc, error) {
+func (b *EthAPIBackend) StateAtTransaction(ctx context.Context, block *types.Block, txIndex int, reexec uint64) (*types.Transaction, vm.BlockContext, *state.StateDB, tracers.StateReleaseFunc, error) {
 	return b.eth.stateAtTransaction(ctx, block, txIndex, reexec)
 }

--- a/eth/api_backend.go
+++ b/eth/api_backend.go
@@ -278,7 +278,7 @@ func (b *EthAPIBackend) SubscribePendingLogsEvent(ch chan<- []*types.Log) event.
 	return b.eth.miner.SubscribePendingLogs(ch)
 }
 
-func (b *EthAPIBackend) SubscribeTracesEvent(ch chan<- json.RawMessage) event.Subscription {
+func (b *EthAPIBackend) SubscribeTracesEvent(ch chan<- []json.RawMessage) event.Subscription {
 	return b.eth.BlockChain().SubscribeTracesEvent(ch)
 }
 

--- a/eth/api_backend.go
+++ b/eth/api_backend.go
@@ -18,6 +18,7 @@ package eth
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"math/big"
 	"time"
@@ -275,6 +276,10 @@ func (b *EthAPIBackend) SubscribeRemovedLogsEvent(ch chan<- core.RemovedLogsEven
 
 func (b *EthAPIBackend) SubscribePendingLogsEvent(ch chan<- []*types.Log) event.Subscription {
 	return b.eth.miner.SubscribePendingLogs(ch)
+}
+
+func (b *EthAPIBackend) SubscribeTracesEvent(ch chan<- json.RawMessage) event.Subscription {
+	return b.eth.BlockChain().SubscribeTracesEvent(ch)
 }
 
 func (b *EthAPIBackend) SubscribeChainEvent(ch chan<- core.ChainEvent) event.Subscription {

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -42,6 +42,7 @@ import (
 	"github.com/ethereum/go-ethereum/eth/gasprice"
 	"github.com/ethereum/go-ethereum/eth/protocols/eth"
 	"github.com/ethereum/go-ethereum/eth/protocols/snap"
+	"github.com/ethereum/go-ethereum/eth/tracers"
 	"github.com/ethereum/go-ethereum/ethdb"
 	"github.com/ethereum/go-ethereum/event"
 	"github.com/ethereum/go-ethereum/internal/ethapi"
@@ -192,6 +193,9 @@ func New(stack *node.Node, config *ethconfig.Config) (*Ethereum, error) {
 			Preimages:           config.Preimages,
 		}
 	)
+	if config.LiveTrace {
+		vmConfig.Tracer = tracers.NewPrinter()
+	}
 	// Override the chain config with provided settings.
 	var overrides core.ChainOverrides
 	if config.OverrideCancun != nil {

--- a/eth/ethconfig/config.go
+++ b/eth/ethconfig/config.go
@@ -147,6 +147,9 @@ type Config struct {
 	// Enables tracking of SHA3 preimages in the VM
 	EnablePreimageRecording bool
 
+	// LiveTrace will enable tracing during normal chain processing.
+	LiveTrace bool
+
 	// Miscellaneous options
 	DocRoot string `toml:"-"`
 

--- a/eth/filters/api.go
+++ b/eth/filters/api.go
@@ -294,7 +294,7 @@ func (api *FilterAPI) Traces(ctx context.Context) (*rpc.Subscription, error) {
 	rpcSub := notifier.CreateSubscription()
 
 	go func() {
-		traces := make(chan json.RawMessage)
+		traces := make(chan []json.RawMessage)
 		tracesSub := api.events.SubscribeTraces(traces)
 
 		for {

--- a/eth/filters/filter_system.go
+++ b/eth/filters/filter_system.go
@@ -164,10 +164,10 @@ const (
 	PendingTransactionsSubscription
 	// BlocksSubscription queries hashes for blocks that are imported
 	BlocksSubscription
-	// LastIndexSubscription keeps track of the last index
-	LastIndexSubscription
 	// TracesSubscription keeps track of the normal chain processing operations
 	TracesSubscription
+	// LastIndexSubscription keeps track of the last index
+	LastIndexSubscription
 )
 
 const (
@@ -180,6 +180,8 @@ const (
 	logsChanSize = 10
 	// chainEvChanSize is the size of channel listening to ChainEvent.
 	chainEvChanSize = 10
+	// tracesChanSize is the size of channel listening to TracesEvent.
+	tracesChanSize = 100
 )
 
 type subscription struct {
@@ -240,6 +242,7 @@ func NewEventSystem(sys *FilterSystem, lightMode bool) *EventSystem {
 		rmLogsCh:      make(chan core.RemovedLogsEvent, rmLogsChanSize),
 		pendingLogsCh: make(chan []*types.Log, logsChanSize),
 		chainCh:       make(chan core.ChainEvent, chainEvChanSize),
+		tracesCh:      make(chan []json.RawMessage, tracesChanSize),
 	}
 
 	// Subscribe events
@@ -586,6 +589,7 @@ func (es *EventSystem) eventLoop() {
 		es.rmLogsSub.Unsubscribe()
 		es.pendingLogsSub.Unsubscribe()
 		es.chainSub.Unsubscribe()
+		es.tracesSub.Unsubscribe()
 	}()
 
 	index := make(filterIndex)

--- a/eth/filters/filter_test.go
+++ b/eth/filters/filter_test.go
@@ -180,7 +180,7 @@ func TestFilters(t *testing.T) {
 
 	// Hack: GenerateChainWithGenesis creates a new db.
 	// Commit the genesis manually and use GenerateChain.
-	_, err = gspec.Commit(db, trie.NewDatabase(db))
+	_, err = gspec.Commit(db, trie.NewDatabase(db), nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/eth/state_accessor.go
+++ b/eth/state_accessor.go
@@ -189,7 +189,7 @@ func (eth *Ethereum) StateAtBlock(ctx context.Context, block *types.Block, reexe
 }
 
 // stateAtTransaction returns the execution environment of a certain transaction.
-func (eth *Ethereum) stateAtTransaction(ctx context.Context, block *types.Block, txIndex int, reexec uint64) (*core.Message, vm.BlockContext, *state.StateDB, tracers.StateReleaseFunc, error) {
+func (eth *Ethereum) stateAtTransaction(ctx context.Context, block *types.Block, txIndex int, reexec uint64) (*types.Transaction, vm.BlockContext, *state.StateDB, tracers.StateReleaseFunc, error) {
 	// Short circuit if it's genesis block.
 	if block.NumberU64() == 0 {
 		return nil, vm.BlockContext{}, nil, nil, errors.New("no transaction in genesis")
@@ -216,7 +216,7 @@ func (eth *Ethereum) stateAtTransaction(ctx context.Context, block *types.Block,
 		txContext := core.NewEVMTxContext(msg)
 		context := core.NewEVMBlockContext(block.Header(), eth.blockchain, nil)
 		if idx == txIndex {
-			return msg, context, statedb, release, nil
+			return tx, context, statedb, release, nil
 		}
 		// Not yet the searched for transaction, execute on top of the current state
 		vmenv := vm.NewEVM(context, txContext, statedb, eth.blockchain.Config(), vm.Config{})

--- a/eth/tracers/api.go
+++ b/eth/tracers/api.go
@@ -790,7 +790,7 @@ func (api *API) standardTraceBlockToFile(ctx context.Context, block *types.Block
 		// Execute the transaction and flush any traces to disk
 		vmenv := vm.NewEVM(vmctx, txContext, statedb, chainConfig, vmConf)
 		statedb.SetTxContext(tx.Hash(), i)
-		vmConf.Tracer.CaptureTxStart(tx)
+		vmConf.Tracer.CaptureTxStart(vmenv, tx)
 		vmRet, err := core.ApplyMessage(vmenv, msg, new(core.GasPool).AddGas(msg.GasLimit))
 		vmConf.Tracer.CaptureTxEnd(&types.Receipt{GasUsed: vmRet.UsedGas})
 		if writer != nil {
@@ -973,7 +973,7 @@ func (api *API) traceTx(ctx context.Context, tx *types.Transaction, message *cor
 
 	// Call Prepare to clear out the statedb access list
 	statedb.SetTxContext(txctx.TxHash, txctx.TxIndex)
-	tracer.CaptureTxStart(tx)
+	tracer.CaptureTxStart(vmenv, tx)
 	res, err := core.ApplyMessage(vmenv, message, new(core.GasPool).AddGas(message.GasLimit))
 	if err != nil {
 		return nil, fmt.Errorf("tracing failed: %w", err)

--- a/eth/tracers/api.go
+++ b/eth/tracers/api.go
@@ -952,6 +952,7 @@ func (api *API) traceTx(ctx context.Context, tx *types.Transaction, message *cor
 		}
 	}
 	vmenv := vm.NewEVM(vmctx, txContext, statedb, api.backend.ChainConfig(), vm.Config{Tracer: tracer, NoBaseFee: true})
+	statedb.SetLogger(tracer)
 
 	// Define a meaningful timeout of a single transaction trace
 	if config.Timeout != nil {

--- a/eth/tracers/api.go
+++ b/eth/tracers/api.go
@@ -23,6 +23,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"math/big"
 	"os"
 	"runtime"
 	"sync"
@@ -87,7 +88,7 @@ type Backend interface {
 	Engine() consensus.Engine
 	ChainDb() ethdb.Database
 	StateAtBlock(ctx context.Context, block *types.Block, reexec uint64, base *state.StateDB, readOnly bool, preferDisk bool) (*state.StateDB, StateReleaseFunc, error)
-	StateAtTransaction(ctx context.Context, block *types.Block, txIndex int, reexec uint64) (*core.Message, vm.BlockContext, *state.StateDB, StateReleaseFunc, error)
+	StateAtTransaction(ctx context.Context, block *types.Block, txIndex int, reexec uint64) (*types.Transaction, vm.BlockContext, *state.StateDB, StateReleaseFunc, error)
 }
 
 // API is the collection of tracing APIs exposed over the private debugging endpoint.
@@ -277,7 +278,7 @@ func (api *API) traceChain(start, end *types.Block, config *TraceConfig, closed 
 						TxIndex:     i,
 						TxHash:      tx.Hash(),
 					}
-					res, err := api.traceTx(ctx, msg, txctx, blockCtx, task.statedb, config)
+					res, err := api.traceTx(ctx, tx, msg, txctx, blockCtx, task.statedb, config)
 					if err != nil {
 						task.results[i] = &txTraceResult{TxHash: tx.Hash(), Error: err.Error()}
 						log.Warn("Tracing failed", "hash", tx.Hash(), "block", task.block.NumberU64(), "err", err)
@@ -612,7 +613,7 @@ func (api *API) traceBlock(ctx context.Context, block *types.Block, config *Trac
 			TxIndex:     i,
 			TxHash:      tx.Hash(),
 		}
-		res, err := api.traceTx(ctx, msg, txctx, blockCtx, statedb, config)
+		res, err := api.traceTx(ctx, tx, msg, txctx, blockCtx, statedb, config)
 		if err != nil {
 			return nil, err
 		}
@@ -655,7 +656,7 @@ func (api *API) traceBlockParallel(ctx context.Context, block *types.Block, stat
 					TxIndex:     task.index,
 					TxHash:      txs[task.index].Hash(),
 				}
-				res, err := api.traceTx(ctx, msg, txctx, blockCtx, task.statedb, config)
+				res, err := api.traceTx(ctx, txs[task.index], msg, txctx, blockCtx, task.statedb, config)
 				if err != nil {
 					results[task.index] = &txTraceResult{TxHash: txs[task.index].Hash(), Error: err.Error()}
 					continue
@@ -789,7 +790,9 @@ func (api *API) standardTraceBlockToFile(ctx context.Context, block *types.Block
 		// Execute the transaction and flush any traces to disk
 		vmenv := vm.NewEVM(vmctx, txContext, statedb, chainConfig, vmConf)
 		statedb.SetTxContext(tx.Hash(), i)
-		_, err = core.ApplyMessage(vmenv, msg, new(core.GasPool).AddGas(msg.GasLimit))
+		vmConf.Tracer.CaptureTxStart(tx)
+		vmRet, err := core.ApplyMessage(vmenv, msg, new(core.GasPool).AddGas(msg.GasLimit))
+		vmConf.Tracer.CaptureTxEnd(&types.Receipt{GasUsed: vmRet.UsedGas})
 		if writer != nil {
 			writer.Flush()
 		}
@@ -846,11 +849,15 @@ func (api *API) TraceTransaction(ctx context.Context, hash common.Hash, config *
 	if err != nil {
 		return nil, err
 	}
-	msg, vmctx, statedb, release, err := api.backend.StateAtTransaction(ctx, block, int(index), reexec)
+	tx, vmctx, statedb, release, err := api.backend.StateAtTransaction(ctx, block, int(index), reexec)
 	if err != nil {
 		return nil, err
 	}
 	defer release()
+	msg, err := core.TransactionToMessage(tx, types.MakeSigner(api.backend.ChainConfig(), block.Number(), block.Time()), block.BaseFee())
+	if err != nil {
+		return nil, err
+	}
 
 	txctx := &Context{
 		BlockHash:   blockHash,
@@ -858,7 +865,7 @@ func (api *API) TraceTransaction(ctx context.Context, hash common.Hash, config *
 		TxIndex:     int(index),
 		TxHash:      hash,
 	}
-	return api.traceTx(ctx, msg, txctx, vmctx, statedb, config)
+	return api.traceTx(ctx, tx, msg, txctx, vmctx, statedb, config)
 }
 
 // TraceCall lets you trace a given eth_call. It collects the structured logs
@@ -912,18 +919,21 @@ func (api *API) TraceCall(ctx context.Context, args ethapi.TransactionArgs, bloc
 	if err != nil {
 		return nil, err
 	}
-
+	tx, err := argsToTransaction(api.backend, &args, msg)
+	if err != nil {
+		return nil, err
+	}
 	var traceConfig *TraceConfig
 	if config != nil {
 		traceConfig = &config.TraceConfig
 	}
-	return api.traceTx(ctx, msg, new(Context), vmctx, statedb, traceConfig)
+	return api.traceTx(ctx, tx, msg, new(Context), vmctx, statedb, traceConfig)
 }
 
 // traceTx configures a new tracer according to the provided configuration, and
 // executes the given message in the provided environment. The return value will
 // be tracer dependent.
-func (api *API) traceTx(ctx context.Context, message *core.Message, txctx *Context, vmctx vm.BlockContext, statedb *state.StateDB, config *TraceConfig) (interface{}, error) {
+func (api *API) traceTx(ctx context.Context, tx *types.Transaction, message *core.Message, txctx *Context, vmctx vm.BlockContext, statedb *state.StateDB, config *TraceConfig) (interface{}, error) {
 	var (
 		tracer    Tracer
 		err       error
@@ -962,9 +972,13 @@ func (api *API) traceTx(ctx context.Context, message *core.Message, txctx *Conte
 
 	// Call Prepare to clear out the statedb access list
 	statedb.SetTxContext(txctx.TxHash, txctx.TxIndex)
-	if _, err = core.ApplyMessage(vmenv, message, new(core.GasPool).AddGas(message.GasLimit)); err != nil {
+	tracer.CaptureTxStart(tx)
+	res, err := core.ApplyMessage(vmenv, message, new(core.GasPool).AddGas(message.GasLimit))
+	if err != nil {
 		return nil, fmt.Errorf("tracing failed: %w", err)
 	}
+	r := &types.Receipt{GasUsed: res.UsedGas}
+	tracer.CaptureTxEnd(r)
 	return tracer.GetResult()
 }
 
@@ -1022,4 +1036,55 @@ func overrideConfig(original *params.ChainConfig, override *params.ChainConfig) 
 	}
 
 	return copy, canon
+}
+
+// argsToTransaction produces a Transaction object given call arguments.
+// The `msg` field must be converted from the same arguments.
+func argsToTransaction(b Backend, args *ethapi.TransactionArgs, msg *core.Message) (*types.Transaction, error) {
+	chainID := b.ChainConfig().ChainID
+	if args.ChainID != nil {
+		if have := (*big.Int)(args.ChainID); have.Cmp(chainID) != 0 {
+			return nil, fmt.Errorf("chainId does not match node's (have=%v, want=%v)", have, chainID)
+		}
+	}
+	var data types.TxData
+	switch {
+	case args.MaxFeePerGas != nil:
+		al := types.AccessList{}
+		if args.AccessList != nil {
+			al = *args.AccessList
+		}
+		data = &types.DynamicFeeTx{
+			To:         args.To,
+			ChainID:    chainID,
+			Nonce:      msg.Nonce,
+			Gas:        msg.GasLimit,
+			GasFeeCap:  msg.GasFeeCap,
+			GasTipCap:  msg.GasTipCap,
+			Value:      msg.Value,
+			Data:       msg.Data,
+			AccessList: al,
+		}
+	case args.AccessList != nil:
+		data = &types.AccessListTx{
+			To:         args.To,
+			ChainID:    chainID,
+			Nonce:      msg.Nonce,
+			Gas:        msg.GasLimit,
+			GasPrice:   msg.GasPrice,
+			Value:      msg.Value,
+			Data:       msg.Data,
+			AccessList: *args.AccessList,
+		}
+	default:
+		data = &types.LegacyTx{
+			To:       args.To,
+			Nonce:    msg.Nonce,
+			Gas:      msg.GasLimit,
+			GasPrice: msg.GasPrice,
+			Value:    msg.Value,
+			Data:     msg.Data,
+		}
+	}
+	return types.NewTx(data), nil
 }

--- a/eth/tracers/api_test.go
+++ b/eth/tracers/api_test.go
@@ -156,7 +156,7 @@ func (b *testBackend) StateAtBlock(ctx context.Context, block *types.Block, reex
 	return statedb, release, nil
 }
 
-func (b *testBackend) StateAtTransaction(ctx context.Context, block *types.Block, txIndex int, reexec uint64) (*core.Message, vm.BlockContext, *state.StateDB, StateReleaseFunc, error) {
+func (b *testBackend) StateAtTransaction(ctx context.Context, block *types.Block, txIndex int, reexec uint64) (*types.Transaction, vm.BlockContext, *state.StateDB, StateReleaseFunc, error) {
 	parent := b.chain.GetBlock(block.ParentHash(), block.NumberU64()-1)
 	if parent == nil {
 		return nil, vm.BlockContext{}, nil, nil, errBlockNotFound
@@ -175,7 +175,7 @@ func (b *testBackend) StateAtTransaction(ctx context.Context, block *types.Block
 		txContext := core.NewEVMTxContext(msg)
 		context := core.NewEVMBlockContext(block.Header(), b.chain, nil)
 		if idx == txIndex {
-			return msg, context, statedb, release, nil
+			return tx, context, statedb, release, nil
 		}
 		vmenv := vm.NewEVM(context, txContext, statedb, b.chainConfig, vm.Config{})
 		if _, err := core.ApplyMessage(vmenv, msg, new(core.GasPool).AddGas(tx.Gas())); err != nil {

--- a/eth/tracers/internal/tracetest/calltrace_test.go
+++ b/eth/tracers/internal/tracetest/calltrace_test.go
@@ -145,6 +145,7 @@ func testCallTracer(tracerName string, dirPath string, t *testing.T) {
 			if err != nil {
 				t.Fatalf("failed to create call tracer: %v", err)
 			}
+			statedb.SetLogger(tracer)
 			evm := vm.NewEVM(context, txContext, statedb, test.Genesis.Config, vm.Config{Tracer: tracer})
 			msg, err := core.TransactionToMessage(tx, signer, nil)
 			if err != nil {
@@ -360,6 +361,7 @@ func TestInternals(t *testing.T) {
 					Balance: big.NewInt(500000000000000),
 				},
 			}, false)
+		statedb.SetLogger(tc.tracer)
 		evm := vm.NewEVM(context, txContext, statedb, params.MainnetChainConfig, vm.Config{Tracer: tc.tracer})
 		tx, err := types.SignNewTx(key, signer, &types.LegacyTx{
 			To:       &to,

--- a/eth/tracers/internal/tracetest/flat_calltrace_test.go
+++ b/eth/tracers/internal/tracetest/flat_calltrace_test.go
@@ -114,7 +114,7 @@ func flatCallTracerTestRunner(tracerName string, filename string, dirPath string
 	if err != nil {
 		return fmt.Errorf("failed to prepare transaction for tracing: %v", err)
 	}
-	tracer.CaptureTxStart(tx)
+	tracer.CaptureTxStart(evm, tx)
 	vmRet, err := core.ApplyMessage(evm, msg, new(core.GasPool).AddGas(tx.Gas()))
 	if err != nil {
 		return fmt.Errorf("failed to execute transaction: %v", err)

--- a/eth/tracers/internal/tracetest/flat_calltrace_test.go
+++ b/eth/tracers/internal/tracetest/flat_calltrace_test.go
@@ -107,6 +107,7 @@ func flatCallTracerTestRunner(tracerName string, filename string, dirPath string
 	if err != nil {
 		return fmt.Errorf("failed to create call tracer: %v", err)
 	}
+	statedb.SetLogger(tracer)
 	evm := vm.NewEVM(context, txContext, statedb, test.Genesis.Config, vm.Config{Tracer: tracer})
 
 	msg, err := core.TransactionToMessage(tx, signer, nil)

--- a/eth/tracers/internal/tracetest/flat_calltrace_test.go
+++ b/eth/tracers/internal/tracetest/flat_calltrace_test.go
@@ -113,11 +113,12 @@ func flatCallTracerTestRunner(tracerName string, filename string, dirPath string
 	if err != nil {
 		return fmt.Errorf("failed to prepare transaction for tracing: %v", err)
 	}
-	st := core.NewStateTransition(evm, msg, new(core.GasPool).AddGas(tx.Gas()))
-
-	if _, err = st.TransitionDb(); err != nil {
+	tracer.CaptureTxStart(tx)
+	vmRet, err := core.ApplyMessage(evm, msg, new(core.GasPool).AddGas(tx.Gas()))
+	if err != nil {
 		return fmt.Errorf("failed to execute transaction: %v", err)
 	}
+	tracer.CaptureTxEnd(&types.Receipt{GasUsed: vmRet.UsedGas})
 
 	// Retrieve the trace result and compare against the etalon
 	res, err := tracer.GetResult()

--- a/eth/tracers/internal/tracetest/prestate_test.go
+++ b/eth/tracers/internal/tracetest/prestate_test.go
@@ -119,10 +119,12 @@ func testPrestateDiffTracer(tracerName string, dirPath string, t *testing.T) {
 			if err != nil {
 				t.Fatalf("failed to prepare transaction for tracing: %v", err)
 			}
-			st := core.NewStateTransition(evm, msg, new(core.GasPool).AddGas(tx.Gas()))
-			if _, err = st.TransitionDb(); err != nil {
+			tracer.CaptureTxStart(tx)
+			vmRet, err := core.ApplyMessage(evm, msg, new(core.GasPool).AddGas(tx.Gas()))
+			if err != nil {
 				t.Fatalf("failed to execute transaction: %v", err)
 			}
+			tracer.CaptureTxEnd(&types.Receipt{GasUsed: vmRet.UsedGas})
 			// Retrieve the trace result and compare against the expected
 			res, err := tracer.GetResult()
 			if err != nil {

--- a/eth/tracers/internal/tracetest/prestate_test.go
+++ b/eth/tracers/internal/tracetest/prestate_test.go
@@ -120,7 +120,7 @@ func testPrestateDiffTracer(tracerName string, dirPath string, t *testing.T) {
 			if err != nil {
 				t.Fatalf("failed to prepare transaction for tracing: %v", err)
 			}
-			tracer.CaptureTxStart(tx)
+			tracer.CaptureTxStart(evm, tx)
 			vmRet, err := core.ApplyMessage(evm, msg, new(core.GasPool).AddGas(tx.Gas()))
 			if err != nil {
 				t.Fatalf("failed to execute transaction: %v", err)

--- a/eth/tracers/internal/tracetest/prestate_test.go
+++ b/eth/tracers/internal/tracetest/prestate_test.go
@@ -114,6 +114,7 @@ func testPrestateDiffTracer(tracerName string, dirPath string, t *testing.T) {
 			if err != nil {
 				t.Fatalf("failed to create call tracer: %v", err)
 			}
+			statedb.SetLogger(tracer)
 			evm := vm.NewEVM(context, txContext, statedb, test.Genesis.Config, vm.Config{Tracer: tracer})
 			msg, err := core.TransactionToMessage(tx, signer, nil)
 			if err != nil {

--- a/eth/tracers/js/goja.go
+++ b/eth/tracers/js/goja.go
@@ -286,6 +286,9 @@ func (t *jsTracer) CaptureFault(pc uint64, op vm.OpCode, gas, cost uint64, scope
 	}
 }
 
+// CaptureKeccakPreimage is called during the KECCAK256 opcode.
+func (t *jsTracer) CaptureKeccakPreimage(hash common.Hash, data []byte) {}
+
 // CaptureEnd is called after the call finishes to finalize the tracing.
 func (t *jsTracer) CaptureEnd(output []byte, gasUsed uint64, err error) {
 	t.ctx["output"] = t.vm.ToValue(output)

--- a/eth/tracers/js/goja.go
+++ b/eth/tracers/js/goja.go
@@ -23,6 +23,7 @@ import (
 	"math/big"
 
 	"github.com/dop251/goja"
+	"github.com/ethereum/go-ethereum/core/types"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
@@ -214,14 +215,14 @@ func newJsTracer(code string, ctx *tracers.Context, cfg json.RawMessage) (tracer
 
 // CaptureTxStart implements the Tracer interface and is invoked at the beginning of
 // transaction processing.
-func (t *jsTracer) CaptureTxStart(gasLimit uint64) {
-	t.gasLimit = gasLimit
+func (t *jsTracer) CaptureTxStart(tx *types.Transaction) {
+	t.gasLimit = tx.Gas()
 }
 
 // CaptureTxEnd implements the Tracer interface and is invoked at the end of
 // transaction processing.
-func (t *jsTracer) CaptureTxEnd(restGas uint64) {
-	t.ctx["gasUsed"] = t.vm.ToValue(t.gasLimit - restGas)
+func (t *jsTracer) CaptureTxEnd(receipt *types.Receipt) {
+	t.ctx["gasUsed"] = t.vm.ToValue(receipt.GasUsed)
 }
 
 // CaptureStart implements the Tracer interface to initialize the tracing operation.

--- a/eth/tracers/js/goja.go
+++ b/eth/tracers/js/goja.go
@@ -95,6 +95,8 @@ func fromBuf(vm *goja.Runtime, bufType goja.Value, buf goja.Value, allowString b
 // jsTracer is an implementation of the Tracer interface which evaluates
 // JS functions on the relevant EVM hooks. It uses Goja as its JS engine.
 type jsTracer struct {
+	tracers.NoopTracer
+
 	vm                *goja.Runtime
 	env               *vm.EVM
 	toBig             toBigFn               // Converts a hex string into a JS bigint
@@ -285,9 +287,6 @@ func (t *jsTracer) CaptureFault(pc uint64, op vm.OpCode, gas, cost uint64, scope
 		t.onError("fault", err)
 	}
 }
-
-// CaptureKeccakPreimage is called during the KECCAK256 opcode.
-func (t *jsTracer) CaptureKeccakPreimage(hash common.Hash, data []byte) {}
 
 // CaptureEnd is called after the call finishes to finalize the tracing.
 func (t *jsTracer) CaptureEnd(output []byte, gasUsed uint64, err error) {

--- a/eth/tracers/js/tracer_test.go
+++ b/eth/tracers/js/tracer_test.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/state"
+	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/core/vm"
 	"github.com/ethereum/go-ethereum/eth/tracers"
 	"github.com/ethereum/go-ethereum/params"
@@ -73,12 +74,12 @@ func runTrace(tracer tracers.Tracer, vmctx *vmContext, chaincfg *params.ChainCon
 		contract.Code = contractCode
 	}
 
-	tracer.CaptureTxStart(gasLimit)
+	tracer.CaptureTxStart(types.NewTx(&types.LegacyTx{Gas: gasLimit}))
 	tracer.CaptureStart(env, contract.Caller(), contract.Address(), false, []byte{}, startGas, value)
 	ret, err := env.Interpreter().Run(contract, []byte{}, false)
 	tracer.CaptureEnd(ret, startGas-contract.Gas, err)
 	// Rest gas assumes no refund
-	tracer.CaptureTxEnd(contract.Gas)
+	tracer.CaptureTxEnd(&types.Receipt{GasUsed: gasLimit - contract.Gas})
 	if err != nil {
 		return nil, err
 	}

--- a/eth/tracers/logger/access_list_tracer.go
+++ b/eth/tracers/logger/access_list_tracer.go
@@ -176,6 +176,19 @@ func (*AccessListTracer) CaptureTxStart(tx *types.Transaction) {}
 
 func (*AccessListTracer) CaptureTxEnd(receipt *types.Receipt) {}
 
+func (*AccessListTracer) OnBalanceChange(a common.Address, prev, new *big.Int) {}
+
+func (*AccessListTracer) OnNonceChange(a common.Address, prev, new uint64) {}
+
+func (*AccessListTracer) OnCodeChange(a common.Address, prevCodeHash common.Hash, prev []byte, codeHash common.Hash, code []byte) {
+}
+
+func (*AccessListTracer) OnStorageChange(a common.Address, k, prev, new common.Hash) {}
+
+func (*AccessListTracer) OnLog(log *types.Log) {}
+
+func (*AccessListTracer) OnNewAccount(a common.Address) {}
+
 // AccessList returns the current accesslist maintained by the tracer.
 func (a *AccessListTracer) AccessList() types.AccessList {
 	return a.list.accessList()

--- a/eth/tracers/logger/access_list_tracer.go
+++ b/eth/tracers/logger/access_list_tracer.go
@@ -163,6 +163,8 @@ func (*AccessListTracer) CaptureFault(pc uint64, op vm.OpCode, gas, cost uint64,
 
 func (*AccessListTracer) CaptureKeccakPreimage(hash common.Hash, data []byte) {}
 
+func (*AccessListTracer) OnGasConsumed(gas, amount uint64) {}
+
 func (*AccessListTracer) CaptureEnd(output []byte, gasUsed uint64, err error) {}
 
 func (*AccessListTracer) CaptureEnter(typ vm.OpCode, from common.Address, to common.Address, input []byte, gas uint64, value *big.Int) {

--- a/eth/tracers/logger/access_list_tracer.go
+++ b/eth/tracers/logger/access_list_tracer.go
@@ -161,6 +161,8 @@ func (a *AccessListTracer) CaptureState(pc uint64, op vm.OpCode, gas, cost uint6
 func (*AccessListTracer) CaptureFault(pc uint64, op vm.OpCode, gas, cost uint64, scope *vm.ScopeContext, depth int, err error) {
 }
 
+func (*AccessListTracer) CaptureKeccakPreimage(hash common.Hash, data []byte) {}
+
 func (*AccessListTracer) CaptureEnd(output []byte, gasUsed uint64, err error) {}
 
 func (*AccessListTracer) CaptureEnter(typ vm.OpCode, from common.Address, to common.Address, input []byte, gas uint64, value *big.Int) {

--- a/eth/tracers/logger/access_list_tracer.go
+++ b/eth/tracers/logger/access_list_tracer.go
@@ -132,7 +132,7 @@ func NewAccessListTracer(acl types.AccessList, from, to common.Address, precompi
 	}
 }
 
-func (a *AccessListTracer) CaptureStart(env *vm.EVM, from common.Address, to common.Address, create bool, input []byte, gas uint64, value *big.Int) {
+func (a *AccessListTracer) CaptureStart(from common.Address, to common.Address, create bool, input []byte, gas uint64, value *big.Int) {
 }
 
 // CaptureState captures all opcodes that touch storage or addresses and adds them to the accesslist.
@@ -172,7 +172,7 @@ func (*AccessListTracer) CaptureEnter(typ vm.OpCode, from common.Address, to com
 
 func (*AccessListTracer) CaptureExit(output []byte, gasUsed uint64, err error) {}
 
-func (*AccessListTracer) CaptureTxStart(tx *types.Transaction) {}
+func (*AccessListTracer) CaptureTxStart(env *vm.EVM, tx *types.Transaction) {}
 
 func (*AccessListTracer) CaptureTxEnd(receipt *types.Receipt) {}
 

--- a/eth/tracers/logger/access_list_tracer.go
+++ b/eth/tracers/logger/access_list_tracer.go
@@ -172,9 +172,9 @@ func (*AccessListTracer) CaptureEnter(typ vm.OpCode, from common.Address, to com
 
 func (*AccessListTracer) CaptureExit(output []byte, gasUsed uint64, err error) {}
 
-func (*AccessListTracer) CaptureTxStart(gasLimit uint64) {}
+func (*AccessListTracer) CaptureTxStart(tx *types.Transaction) {}
 
-func (*AccessListTracer) CaptureTxEnd(restGas uint64) {}
+func (*AccessListTracer) CaptureTxEnd(receipt *types.Receipt) {}
 
 // AccessList returns the current accesslist maintained by the tracer.
 func (a *AccessListTracer) AccessList() types.AccessList {

--- a/eth/tracers/logger/logger.go
+++ b/eth/tracers/logger/logger.go
@@ -139,8 +139,7 @@ func (l *StructLogger) Reset() {
 }
 
 // CaptureStart implements the EVMLogger interface to initialize the tracing operation.
-func (l *StructLogger) CaptureStart(env *vm.EVM, from common.Address, to common.Address, create bool, input []byte, gas uint64, value *big.Int) {
-	l.env = env
+func (l *StructLogger) CaptureStart(from common.Address, to common.Address, create bool, input []byte, gas uint64, value *big.Int) {
 }
 
 // CaptureState logs a new structured log message and pushes it out to the environment
@@ -265,7 +264,9 @@ func (l *StructLogger) Stop(err error) {
 	l.interrupt.Store(true)
 }
 
-func (l *StructLogger) CaptureTxStart(tx *types.Transaction) {}
+func (l *StructLogger) CaptureTxStart(env *vm.EVM, tx *types.Transaction) {
+	l.env = env
+}
 
 func (l *StructLogger) CaptureTxEnd(receipt *types.Receipt) {
 	l.usedGas = receipt.GasUsed
@@ -356,8 +357,7 @@ func NewMarkdownLogger(cfg *Config, writer io.Writer) *mdLogger {
 	return l
 }
 
-func (t *mdLogger) CaptureStart(env *vm.EVM, from common.Address, to common.Address, create bool, input []byte, gas uint64, value *big.Int) {
-	t.env = env
+func (t *mdLogger) CaptureStart(from common.Address, to common.Address, create bool, input []byte, gas uint64, value *big.Int) {
 	if !create {
 		fmt.Fprintf(t.out, "From: `%v`\nTo: `%v`\nData: `%#x`\nGas: `%d`\nValue `%v` wei\n",
 			from.String(), to.String(),
@@ -413,7 +413,7 @@ func (t *mdLogger) CaptureEnter(typ vm.OpCode, from common.Address, to common.Ad
 
 func (t *mdLogger) CaptureExit(output []byte, gasUsed uint64, err error) {}
 
-func (*mdLogger) CaptureTxStart(tx *types.Transaction) {}
+func (*mdLogger) CaptureTxStart(env *vm.EVM, tx *types.Transaction) {}
 
 func (*mdLogger) CaptureTxEnd(receipt *types.Receipt) {}
 

--- a/eth/tracers/logger/logger.go
+++ b/eth/tracers/logger/logger.go
@@ -217,6 +217,9 @@ func (l *StructLogger) CaptureState(pc uint64, op vm.OpCode, gas, cost uint64, s
 func (l *StructLogger) CaptureFault(pc uint64, op vm.OpCode, gas, cost uint64, scope *vm.ScopeContext, depth int, err error) {
 }
 
+// CaptureKeccakPreimage is called during the KECCAK256 opcode.
+func (l *StructLogger) CaptureKeccakPreimage(hash common.Hash, data []byte) {}
+
 // CaptureEnd is called after the call finishes to finalize the tracing.
 func (l *StructLogger) CaptureEnd(output []byte, gasUsed uint64, err error) {
 	l.output = output
@@ -383,6 +386,8 @@ func (t *mdLogger) CaptureState(pc uint64, op vm.OpCode, gas, cost uint64, scope
 func (t *mdLogger) CaptureFault(pc uint64, op vm.OpCode, gas, cost uint64, scope *vm.ScopeContext, depth int, err error) {
 	fmt.Fprintf(t.out, "\nError: at pc=%d, op=%v: %v\n", pc, op, err)
 }
+
+func (t *mdLogger) CaptureKeccakPreimage(hash common.Hash, data []byte) {}
 
 func (t *mdLogger) CaptureEnd(output []byte, gasUsed uint64, err error) {
 	fmt.Fprintf(t.out, "\nOutput: `%#x`\nConsumed gas: `%d`\nError: `%v`\n",

--- a/eth/tracers/logger/logger.go
+++ b/eth/tracers/logger/logger.go
@@ -271,6 +271,19 @@ func (l *StructLogger) CaptureTxEnd(receipt *types.Receipt) {
 	l.usedGas = receipt.GasUsed
 }
 
+func (l *StructLogger) OnBalanceChange(a common.Address, prev, new *big.Int) {}
+
+func (l *StructLogger) OnNonceChange(a common.Address, prev, new uint64) {}
+
+func (l *StructLogger) OnCodeChange(a common.Address, prevCodeHash common.Hash, prev []byte, codeHash common.Hash, code []byte) {
+}
+
+func (l *StructLogger) OnStorageChange(a common.Address, k, prev, new common.Hash) {}
+
+func (l *StructLogger) OnLog(log *types.Log) {}
+
+func (l *StructLogger) OnNewAccount(a common.Address) {}
+
 // StructLogs returns the captured log entries.
 func (l *StructLogger) StructLogs() []StructLog { return l.logs }
 
@@ -403,6 +416,19 @@ func (t *mdLogger) CaptureExit(output []byte, gasUsed uint64, err error) {}
 func (*mdLogger) CaptureTxStart(tx *types.Transaction) {}
 
 func (*mdLogger) CaptureTxEnd(receipt *types.Receipt) {}
+
+func (*mdLogger) OnBalanceChange(a common.Address, prev, new *big.Int) {}
+
+func (*mdLogger) OnNonceChange(a common.Address, prev, new uint64) {}
+
+func (*mdLogger) OnCodeChange(a common.Address, prevCodeHash common.Hash, prev []byte, codeHash common.Hash, code []byte) {
+}
+
+func (*mdLogger) OnStorageChange(a common.Address, k, prev, new common.Hash) {}
+
+func (*mdLogger) OnLog(log *types.Log) {}
+
+func (*mdLogger) OnNewAccount(a common.Address) {}
 
 // ExecutionResult groups all structured logs emitted by the EVM
 // while replaying a transaction in debug mode as well as transaction

--- a/eth/tracers/logger/logger.go
+++ b/eth/tracers/logger/logger.go
@@ -109,12 +109,11 @@ type StructLogger struct {
 	cfg Config
 	env *vm.EVM
 
-	storage  map[common.Address]Storage
-	logs     []StructLog
-	output   []byte
-	err      error
-	gasLimit uint64
-	usedGas  uint64
+	storage map[common.Address]Storage
+	logs    []StructLog
+	output  []byte
+	err     error
+	usedGas uint64
 
 	interrupt atomic.Bool // Atomic flag to signal execution interruption
 	reason    error       // Textual reason for the interruption
@@ -266,12 +265,10 @@ func (l *StructLogger) Stop(err error) {
 	l.interrupt.Store(true)
 }
 
-func (l *StructLogger) CaptureTxStart(gasLimit uint64) {
-	l.gasLimit = gasLimit
-}
+func (l *StructLogger) CaptureTxStart(tx *types.Transaction) {}
 
-func (l *StructLogger) CaptureTxEnd(restGas uint64) {
-	l.usedGas = l.gasLimit - restGas
+func (l *StructLogger) CaptureTxEnd(receipt *types.Receipt) {
+	l.usedGas = receipt.GasUsed
 }
 
 // StructLogs returns the captured log entries.
@@ -403,9 +400,9 @@ func (t *mdLogger) CaptureEnter(typ vm.OpCode, from common.Address, to common.Ad
 
 func (t *mdLogger) CaptureExit(output []byte, gasUsed uint64, err error) {}
 
-func (*mdLogger) CaptureTxStart(gasLimit uint64) {}
+func (*mdLogger) CaptureTxStart(tx *types.Transaction) {}
 
-func (*mdLogger) CaptureTxEnd(restGas uint64) {}
+func (*mdLogger) CaptureTxEnd(receipt *types.Receipt) {}
 
 // ExecutionResult groups all structured logs emitted by the EVM
 // while replaying a transaction in debug mode as well as transaction

--- a/eth/tracers/logger/logger.go
+++ b/eth/tracers/logger/logger.go
@@ -220,6 +220,8 @@ func (l *StructLogger) CaptureFault(pc uint64, op vm.OpCode, gas, cost uint64, s
 // CaptureKeccakPreimage is called during the KECCAK256 opcode.
 func (l *StructLogger) CaptureKeccakPreimage(hash common.Hash, data []byte) {}
 
+func (l *StructLogger) OnGasConsumed(gas, amount uint64) {}
+
 // CaptureEnd is called after the call finishes to finalize the tracing.
 func (l *StructLogger) CaptureEnd(output []byte, gasUsed uint64, err error) {
 	l.output = output
@@ -388,6 +390,8 @@ func (t *mdLogger) CaptureFault(pc uint64, op vm.OpCode, gas, cost uint64, scope
 }
 
 func (t *mdLogger) CaptureKeccakPreimage(hash common.Hash, data []byte) {}
+
+func (t *mdLogger) OnGasConsumed(gas, amount uint64) {}
 
 func (t *mdLogger) CaptureEnd(output []byte, gasUsed uint64, err error) {
 	fmt.Fprintf(t.out, "\nOutput: `%#x`\nConsumed gas: `%d`\nError: `%v`\n",

--- a/eth/tracers/logger/logger_json.go
+++ b/eth/tracers/logger/logger_json.go
@@ -43,8 +43,7 @@ func NewJSONLogger(cfg *Config, writer io.Writer) *JSONLogger {
 	return l
 }
 
-func (l *JSONLogger) CaptureStart(env *vm.EVM, from, to common.Address, create bool, input []byte, gas uint64, value *big.Int) {
-	l.env = env
+func (l *JSONLogger) CaptureStart(from, to common.Address, create bool, input []byte, gas uint64, value *big.Int) {
 }
 
 func (l *JSONLogger) CaptureFault(pc uint64, op vm.OpCode, gas uint64, cost uint64, scope *vm.ScopeContext, depth int, err error) {
@@ -103,7 +102,9 @@ func (l *JSONLogger) CaptureEnter(typ vm.OpCode, from common.Address, to common.
 
 func (l *JSONLogger) CaptureExit(output []byte, gasUsed uint64, err error) {}
 
-func (l *JSONLogger) CaptureTxStart(tx *types.Transaction) {}
+func (l *JSONLogger) CaptureTxStart(env *vm.EVM, tx *types.Transaction) {
+	l.env = env
+}
 
 func (l *JSONLogger) CaptureTxEnd(receipt *types.Receipt) {}
 

--- a/eth/tracers/logger/logger_json.go
+++ b/eth/tracers/logger/logger_json.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/math"
+	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/core/vm"
 )
 
@@ -102,6 +103,6 @@ func (l *JSONLogger) CaptureEnter(typ vm.OpCode, from common.Address, to common.
 
 func (l *JSONLogger) CaptureExit(output []byte, gasUsed uint64, err error) {}
 
-func (l *JSONLogger) CaptureTxStart(gasLimit uint64) {}
+func (l *JSONLogger) CaptureTxStart(tx *types.Transaction) {}
 
-func (l *JSONLogger) CaptureTxEnd(restGas uint64) {}
+func (l *JSONLogger) CaptureTxEnd(receipt *types.Receipt) {}

--- a/eth/tracers/logger/logger_json.go
+++ b/eth/tracers/logger/logger_json.go
@@ -81,6 +81,8 @@ func (l *JSONLogger) CaptureState(pc uint64, op vm.OpCode, gas, cost uint64, sco
 // CaptureKeccakPreimage is called during the KECCAK256 opcode.
 func (l *JSONLogger) CaptureKeccakPreimage(hash common.Hash, data []byte) {}
 
+func (l *JSONLogger) OnGasConsumed(gas, amount uint64) {}
+
 // CaptureEnd is triggered at end of execution.
 func (l *JSONLogger) CaptureEnd(output []byte, gasUsed uint64, err error) {
 	type endLog struct {

--- a/eth/tracers/logger/logger_json.go
+++ b/eth/tracers/logger/logger_json.go
@@ -78,6 +78,9 @@ func (l *JSONLogger) CaptureState(pc uint64, op vm.OpCode, gas, cost uint64, sco
 	l.encoder.Encode(log)
 }
 
+// CaptureKeccakPreimage is called during the KECCAK256 opcode.
+func (l *JSONLogger) CaptureKeccakPreimage(hash common.Hash, data []byte) {}
+
 // CaptureEnd is triggered at end of execution.
 func (l *JSONLogger) CaptureEnd(output []byte, gasUsed uint64, err error) {
 	type endLog struct {

--- a/eth/tracers/logger/logger_json.go
+++ b/eth/tracers/logger/logger_json.go
@@ -106,3 +106,16 @@ func (l *JSONLogger) CaptureExit(output []byte, gasUsed uint64, err error) {}
 func (l *JSONLogger) CaptureTxStart(tx *types.Transaction) {}
 
 func (l *JSONLogger) CaptureTxEnd(receipt *types.Receipt) {}
+
+func (*JSONLogger) OnBalanceChange(a common.Address, prev, new *big.Int) {}
+
+func (*JSONLogger) OnNonceChange(a common.Address, prev, new uint64) {}
+
+func (*JSONLogger) OnCodeChange(a common.Address, prevCodeHash common.Hash, prev []byte, codeHash common.Hash, code []byte) {
+}
+
+func (*JSONLogger) OnStorageChange(a common.Address, k, prev, new common.Hash) {}
+
+func (*JSONLogger) OnLog(log *types.Log) {}
+
+func (*JSONLogger) OnNewAccount(a common.Address) {}

--- a/eth/tracers/native/4byte.go
+++ b/eth/tracers/native/4byte.go
@@ -46,7 +46,7 @@ func init() {
 //	  0xc281d19e-0: 1
 //	}
 type fourByteTracer struct {
-	noopTracer
+	tracers.NoopTracer
 	ids               map[string]int   // ids aggregates the 4byte ids found
 	interrupt         atomic.Bool      // Atomic flag to signal execution interruption
 	reason            error            // Textual reason for the interruption

--- a/eth/tracers/native/call.go
+++ b/eth/tracers/native/call.go
@@ -98,7 +98,7 @@ type callFrameMarshaling struct {
 }
 
 type callTracer struct {
-	noopTracer
+	tracers.NoopTracer
 	callstack []callFrame
 	config    callTracerConfig
 	gasLimit  uint64

--- a/eth/tracers/native/call.go
+++ b/eth/tracers/native/call.go
@@ -128,7 +128,7 @@ func newCallTracer(ctx *tracers.Context, cfg json.RawMessage) (tracers.Tracer, e
 }
 
 // CaptureStart implements the EVMLogger interface to initialize the tracing operation.
-func (t *callTracer) CaptureStart(env *vm.EVM, from common.Address, to common.Address, create bool, input []byte, gas uint64, value *big.Int) {
+func (t *callTracer) CaptureStart(from common.Address, to common.Address, create bool, input []byte, gas uint64, value *big.Int) {
 	toCopy := to
 	t.callstack[0] = callFrame{
 		Type:  vm.CALL,
@@ -196,7 +196,7 @@ func (t *callTracer) CaptureExit(output []byte, gasUsed uint64, err error) {
 	t.callstack[size-1].Calls = append(t.callstack[size-1].Calls, call)
 }
 
-func (t *callTracer) CaptureTxStart(tx *types.Transaction) {
+func (t *callTracer) CaptureTxStart(env *vm.EVM, tx *types.Transaction) {
 	t.gasLimit = tx.Gas()
 }
 

--- a/eth/tracers/native/call.go
+++ b/eth/tracers/native/call.go
@@ -25,6 +25,7 @@ import (
 	"github.com/ethereum/go-ethereum/accounts/abi"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/core/vm"
 	"github.com/ethereum/go-ethereum/eth/tracers"
 )
@@ -233,12 +234,12 @@ func (t *callTracer) CaptureExit(output []byte, gasUsed uint64, err error) {
 	t.callstack[size-1].Calls = append(t.callstack[size-1].Calls, call)
 }
 
-func (t *callTracer) CaptureTxStart(gasLimit uint64) {
-	t.gasLimit = gasLimit
+func (t *callTracer) CaptureTxStart(tx *types.Transaction) {
+	t.gasLimit = tx.Gas()
 }
 
-func (t *callTracer) CaptureTxEnd(restGas uint64) {
-	t.callstack[0].GasUsed = t.gasLimit - restGas
+func (t *callTracer) CaptureTxEnd(receipt *types.Receipt) {
+	t.callstack[0].GasUsed = receipt.GasUsed
 	if t.config.WithLog {
 		// Logs are not emitted when the call fails
 		clearFailedLogs(&t.callstack[0], false)

--- a/eth/tracers/native/call_flat.go
+++ b/eth/tracers/native/call_flat.go
@@ -108,7 +108,7 @@ type flatCallResultMarshaling struct {
 // flatCallTracer reports call frame information of a tx in a flat format, i.e.
 // as opposed to the nested format of `callTracer`.
 type flatCallTracer struct {
-	noopTracer
+	tracers.NoopTracer
 	tracer            *callTracer
 	config            flatCallTracerConfig
 	ctx               *tracers.Context // Holds tracer context data

--- a/eth/tracers/native/call_flat.go
+++ b/eth/tracers/native/call_flat.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/core/vm"
 	"github.com/ethereum/go-ethereum/eth/tracers"
 )
@@ -202,12 +203,12 @@ func (t *flatCallTracer) CaptureExit(output []byte, gasUsed uint64, err error) {
 	}
 }
 
-func (t *flatCallTracer) CaptureTxStart(gasLimit uint64) {
-	t.tracer.CaptureTxStart(gasLimit)
+func (t *flatCallTracer) CaptureTxStart(tx *types.Transaction) {
+	t.tracer.CaptureTxStart(tx)
 }
 
-func (t *flatCallTracer) CaptureTxEnd(restGas uint64) {
-	t.tracer.CaptureTxEnd(restGas)
+func (t *flatCallTracer) CaptureTxEnd(receipt *types.Receipt) {
+	t.tracer.CaptureTxEnd(receipt)
 }
 
 // GetResult returns an empty json object.

--- a/eth/tracers/native/call_flat.go
+++ b/eth/tracers/native/call_flat.go
@@ -146,11 +146,8 @@ func newFlatCallTracer(ctx *tracers.Context, cfg json.RawMessage) (tracers.Trace
 }
 
 // CaptureStart implements the EVMLogger interface to initialize the tracing operation.
-func (t *flatCallTracer) CaptureStart(env *vm.EVM, from common.Address, to common.Address, create bool, input []byte, gas uint64, value *big.Int) {
-	t.tracer.CaptureStart(env, from, to, create, input, gas, value)
-	// Update list of precompiles based on current block
-	rules := env.ChainConfig().Rules(env.Context.BlockNumber, env.Context.Random != nil, env.Context.Time)
-	t.activePrecompiles = vm.ActivePrecompiles(rules)
+func (t *flatCallTracer) CaptureStart(from common.Address, to common.Address, create bool, input []byte, gas uint64, value *big.Int) {
+	t.tracer.CaptureStart(from, to, create, input, gas, value)
 }
 
 // CaptureEnd is called after the call finishes to finalize the tracing.
@@ -203,8 +200,11 @@ func (t *flatCallTracer) CaptureExit(output []byte, gasUsed uint64, err error) {
 	}
 }
 
-func (t *flatCallTracer) CaptureTxStart(tx *types.Transaction) {
-	t.tracer.CaptureTxStart(tx)
+func (t *flatCallTracer) CaptureTxStart(env *vm.EVM, tx *types.Transaction) {
+	t.tracer.CaptureTxStart(env, tx)
+	// Update list of precompiles based on current block
+	rules := env.ChainConfig().Rules(env.Context.BlockNumber, env.Context.Random != nil, env.Context.Time)
+	t.activePrecompiles = vm.ActivePrecompiles(rules)
 }
 
 func (t *flatCallTracer) CaptureTxEnd(receipt *types.Receipt) {

--- a/eth/tracers/native/call_flat.go
+++ b/eth/tracers/native/call_flat.go
@@ -108,6 +108,7 @@ type flatCallResultMarshaling struct {
 // flatCallTracer reports call frame information of a tx in a flat format, i.e.
 // as opposed to the nested format of `callTracer`.
 type flatCallTracer struct {
+	noopTracer
 	tracer            *callTracer
 	config            flatCallTracerConfig
 	ctx               *tracers.Context // Holds tracer context data

--- a/eth/tracers/native/mux.go
+++ b/eth/tracers/native/mux.go
@@ -128,6 +128,42 @@ func (t *muxTracer) CaptureTxEnd(receipt *types.Receipt) {
 	}
 }
 
+func (t *muxTracer) OnBalanceChange(a common.Address, prev, new *big.Int) {
+	for _, t := range t.tracers {
+		t.OnBalanceChange(a, prev, new)
+	}
+}
+
+func (t *muxTracer) OnNonceChange(a common.Address, prev, new uint64) {
+	for _, t := range t.tracers {
+		t.OnNonceChange(a, prev, new)
+	}
+}
+
+func (t *muxTracer) OnCodeChange(a common.Address, prevCodeHash common.Hash, prev []byte, codeHash common.Hash, code []byte) {
+	for _, t := range t.tracers {
+		t.OnCodeChange(a, prevCodeHash, prev, codeHash, code)
+	}
+}
+
+func (t *muxTracer) OnStorageChange(a common.Address, k, prev, new common.Hash) {
+	for _, t := range t.tracers {
+		t.OnStorageChange(a, k, prev, new)
+	}
+}
+
+func (t *muxTracer) OnLog(log *types.Log) {
+	for _, t := range t.tracers {
+		t.OnLog(log)
+	}
+}
+
+func (t *muxTracer) OnNewAccount(a common.Address) {
+	for _, t := range t.tracers {
+		t.OnNewAccount(a)
+	}
+}
+
 // GetResult returns an empty json object.
 func (t *muxTracer) GetResult() (json.RawMessage, error) {
 	resObject := make(map[string]json.RawMessage)

--- a/eth/tracers/native/mux.go
+++ b/eth/tracers/native/mux.go
@@ -60,9 +60,9 @@ func newMuxTracer(ctx *tracers.Context, cfg json.RawMessage) (tracers.Tracer, er
 }
 
 // CaptureStart implements the EVMLogger interface to initialize the tracing operation.
-func (t *muxTracer) CaptureStart(env *vm.EVM, from common.Address, to common.Address, create bool, input []byte, gas uint64, value *big.Int) {
+func (t *muxTracer) CaptureStart(from common.Address, to common.Address, create bool, input []byte, gas uint64, value *big.Int) {
 	for _, t := range t.tracers {
-		t.CaptureStart(env, from, to, create, input, gas, value)
+		t.CaptureStart(from, to, create, input, gas, value)
 	}
 }
 
@@ -116,9 +116,9 @@ func (t *muxTracer) CaptureExit(output []byte, gasUsed uint64, err error) {
 	}
 }
 
-func (t *muxTracer) CaptureTxStart(tx *types.Transaction) {
+func (t *muxTracer) CaptureTxStart(env *vm.EVM, tx *types.Transaction) {
 	for _, t := range t.tracers {
-		t.CaptureTxStart(tx)
+		t.CaptureTxStart(env, tx)
 	}
 }
 

--- a/eth/tracers/native/mux.go
+++ b/eth/tracers/native/mux.go
@@ -86,6 +86,13 @@ func (t *muxTracer) CaptureFault(pc uint64, op vm.OpCode, gas, cost uint64, scop
 	}
 }
 
+// CaptureKeccakPreimage is called during the KECCAK256 opcode.
+func (t *muxTracer) CaptureKeccakPreimage(hash common.Hash, data []byte) {
+	for _, t := range t.tracers {
+		t.CaptureKeccakPreimage(hash, data)
+	}
+}
+
 // CaptureEnter is called when EVM enters a new scope (via call, create or selfdestruct).
 func (t *muxTracer) CaptureEnter(typ vm.OpCode, from common.Address, to common.Address, input []byte, gas uint64, value *big.Int) {
 	for _, t := range t.tracers {

--- a/eth/tracers/native/mux.go
+++ b/eth/tracers/native/mux.go
@@ -21,6 +21,7 @@ import (
 	"math/big"
 
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/core/vm"
 	"github.com/ethereum/go-ethereum/eth/tracers"
 )
@@ -115,15 +116,15 @@ func (t *muxTracer) CaptureExit(output []byte, gasUsed uint64, err error) {
 	}
 }
 
-func (t *muxTracer) CaptureTxStart(gasLimit uint64) {
+func (t *muxTracer) CaptureTxStart(tx *types.Transaction) {
 	for _, t := range t.tracers {
-		t.CaptureTxStart(gasLimit)
+		t.CaptureTxStart(tx)
 	}
 }
 
-func (t *muxTracer) CaptureTxEnd(restGas uint64) {
+func (t *muxTracer) CaptureTxEnd(receipt *types.Receipt) {
 	for _, t := range t.tracers {
-		t.CaptureTxEnd(restGas)
+		t.CaptureTxEnd(receipt)
 	}
 }
 

--- a/eth/tracers/native/mux.go
+++ b/eth/tracers/native/mux.go
@@ -93,6 +93,13 @@ func (t *muxTracer) CaptureKeccakPreimage(hash common.Hash, data []byte) {
 	}
 }
 
+// CaptureGasConsumed is called when gas is consumed.
+func (t *muxTracer) OnGasConsumed(gas, amount uint64) {
+	for _, t := range t.tracers {
+		t.OnGasConsumed(gas, amount)
+	}
+}
+
 // CaptureEnter is called when EVM enters a new scope (via call, create or selfdestruct).
 func (t *muxTracer) CaptureEnter(typ vm.OpCode, from common.Address, to common.Address, input []byte, gas uint64, value *big.Int) {
 	for _, t := range t.tracers {

--- a/eth/tracers/native/noop.go
+++ b/eth/tracers/native/noop.go
@@ -54,6 +54,9 @@ func (t *noopTracer) CaptureState(pc uint64, op vm.OpCode, gas, cost uint64, sco
 func (t *noopTracer) CaptureFault(pc uint64, op vm.OpCode, gas, cost uint64, _ *vm.ScopeContext, depth int, err error) {
 }
 
+// CaptureKeccakPreimage is called during the KECCAK256 opcode.
+func (t *noopTracer) CaptureKeccakPreimage(hash common.Hash, data []byte) {}
+
 // CaptureEnter is called when EVM enters a new scope (via call, create or selfdestruct).
 func (t *noopTracer) CaptureEnter(typ vm.OpCode, from common.Address, to common.Address, input []byte, gas uint64, value *big.Int) {
 }

--- a/eth/tracers/native/prestate.go
+++ b/eth/tracers/native/prestate.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/core/vm"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/eth/tracers"
@@ -174,11 +175,11 @@ func (t *prestateTracer) CaptureState(pc uint64, op vm.OpCode, gas, cost uint64,
 	}
 }
 
-func (t *prestateTracer) CaptureTxStart(gasLimit uint64) {
-	t.gasLimit = gasLimit
+func (t *prestateTracer) CaptureTxStart(tx *types.Transaction) {
+	t.gasLimit = tx.Gas()
 }
 
-func (t *prestateTracer) CaptureTxEnd(restGas uint64) {
+func (t *prestateTracer) CaptureTxEnd(receipt *types.Receipt) {
 	if !t.config.DiffMode {
 		return
 	}

--- a/eth/tracers/native/prestate.go
+++ b/eth/tracers/native/prestate.go
@@ -54,7 +54,7 @@ type accountMarshaling struct {
 }
 
 type prestateTracer struct {
-	noopTracer
+	tracers.NoopTracer
 	env       *vm.EVM
 	pre       state
 	post      state

--- a/eth/tracers/native/prestate.go
+++ b/eth/tracers/native/prestate.go
@@ -19,6 +19,7 @@ package native
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"math/big"
 	"sync/atomic"
 
@@ -61,7 +62,6 @@ type prestateTracer struct {
 	post      state
 	create    bool
 	to        common.Address
-	gasLimit  uint64 // Amount of gas bought for the whole tx
 	config    prestateTracerConfig
 	interrupt atomic.Bool // Atomic flag to signal execution interruption
 	reason    error       // Textual reason for the interruption
@@ -90,31 +90,7 @@ func newPrestateTracer(ctx *tracers.Context, cfg json.RawMessage) (tracers.Trace
 }
 
 // CaptureStart implements the EVMLogger interface to initialize the tracing operation.
-func (t *prestateTracer) CaptureStart(env *vm.EVM, from common.Address, to common.Address, create bool, input []byte, gas uint64, value *big.Int) {
-	t.env = env
-	t.create = create
-	t.to = to
-
-	t.lookupAccount(from)
-	t.lookupAccount(to)
-	t.lookupAccount(env.Context.Coinbase)
-
-	// The recipient balance includes the value transferred.
-	toBal := new(big.Int).Sub(t.pre[to].Balance, value)
-	t.pre[to].Balance = toBal
-
-	// The sender balance is after reducing: value and gasLimit.
-	// We need to re-add them to get the pre-tx balance.
-	fromBal := new(big.Int).Set(t.pre[from].Balance)
-	gasPrice := env.TxContext.GasPrice
-	consumedGas := new(big.Int).Mul(gasPrice, new(big.Int).SetUint64(t.gasLimit))
-	fromBal.Add(fromBal, new(big.Int).Add(value, consumedGas))
-	t.pre[from].Balance = fromBal
-	t.pre[from].Nonce--
-
-	if create && t.config.DiffMode {
-		t.created[to] = true
-	}
+func (t *prestateTracer) CaptureStart(from common.Address, to common.Address, create bool, input []byte, gas uint64, value *big.Int) {
 }
 
 // CaptureEnd is called after the call finishes to finalize the tracing.
@@ -175,8 +151,29 @@ func (t *prestateTracer) CaptureState(pc uint64, op vm.OpCode, gas, cost uint64,
 	}
 }
 
-func (t *prestateTracer) CaptureTxStart(tx *types.Transaction) {
-	t.gasLimit = tx.Gas()
+func (t *prestateTracer) CaptureTxStart(env *vm.EVM, tx *types.Transaction) {
+	t.env = env
+	signer := types.MakeSigner(env.ChainConfig(), env.Context.BlockNumber, env.Context.Time)
+	from, err := types.Sender(signer, tx)
+	if err != nil {
+		t.Stop(fmt.Errorf("could not recover sender address: %v", err))
+		return
+	}
+	if tx.To() == nil {
+		t.create = true
+		t.to = crypto.CreateAddress(from, env.StateDB.GetNonce(from))
+	} else {
+		t.to = *tx.To()
+		t.create = false
+	}
+
+	t.lookupAccount(from)
+	t.lookupAccount(t.to)
+	t.lookupAccount(env.Context.Coinbase)
+
+	if t.create && t.config.DiffMode {
+		t.created[t.to] = true
+	}
 }
 
 func (t *prestateTracer) CaptureTxEnd(receipt *types.Receipt) {

--- a/eth/tracers/noop.go
+++ b/eth/tracers/noop.go
@@ -21,6 +21,7 @@ import (
 	"math/big"
 
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/core/vm"
 )
 
@@ -68,9 +69,9 @@ func (t *NoopTracer) CaptureEnter(typ vm.OpCode, from common.Address, to common.
 func (t *NoopTracer) CaptureExit(output []byte, gasUsed uint64, err error) {
 }
 
-func (*NoopTracer) CaptureTxStart(gasLimit uint64) {}
+func (*NoopTracer) CaptureTxStart(tx *types.Transaction) {}
 
-func (*NoopTracer) CaptureTxEnd(restGas uint64) {}
+func (*NoopTracer) CaptureTxEnd(receipt *types.Receipt) {}
 
 // GetResult returns an empty json object.
 func (t *NoopTracer) GetResult() (json.RawMessage, error) {

--- a/eth/tracers/noop.go
+++ b/eth/tracers/noop.go
@@ -73,6 +73,19 @@ func (*NoopTracer) CaptureTxStart(tx *types.Transaction) {}
 
 func (*NoopTracer) CaptureTxEnd(receipt *types.Receipt) {}
 
+func (*NoopTracer) OnBalanceChange(a common.Address, prev, new *big.Int) {}
+
+func (*NoopTracer) OnNonceChange(a common.Address, prev, new uint64) {}
+
+func (*NoopTracer) OnCodeChange(a common.Address, prevCodeHash common.Hash, prev []byte, codeHash common.Hash, code []byte) {
+}
+
+func (*NoopTracer) OnStorageChange(a common.Address, k, prev, new common.Hash) {}
+
+func (*NoopTracer) OnLog(log *types.Log) {}
+
+func (*NoopTracer) OnNewAccount(a common.Address) {}
+
 // GetResult returns an empty json object.
 func (t *NoopTracer) GetResult() (json.RawMessage, error) {
 	return json.RawMessage(`{}`), nil

--- a/eth/tracers/noop.go
+++ b/eth/tracers/noop.go
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
 
-package native
+package tracers
 
 import (
 	"encoding/json"
@@ -22,59 +22,61 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/vm"
-	"github.com/ethereum/go-ethereum/eth/tracers"
 )
 
 func init() {
-	tracers.DefaultDirectory.Register("noopTracer", newNoopTracer, false)
+	DefaultDirectory.Register("noopTracer", newNoopTracer, false)
 }
 
-// noopTracer is a go implementation of the Tracer interface which
+// NoopTracer is a go implementation of the Tracer interface which
 // performs no action. It's mostly useful for testing purposes.
-type noopTracer struct{}
+type NoopTracer struct{}
 
 // newNoopTracer returns a new noop tracer.
-func newNoopTracer(ctx *tracers.Context, _ json.RawMessage) (tracers.Tracer, error) {
-	return &noopTracer{}, nil
+func newNoopTracer(ctx *Context, _ json.RawMessage) (Tracer, error) {
+	return &NoopTracer{}, nil
 }
 
 // CaptureStart implements the EVMLogger interface to initialize the tracing operation.
-func (t *noopTracer) CaptureStart(env *vm.EVM, from common.Address, to common.Address, create bool, input []byte, gas uint64, value *big.Int) {
+func (t *NoopTracer) CaptureStart(env *vm.EVM, from common.Address, to common.Address, create bool, input []byte, gas uint64, value *big.Int) {
 }
 
 // CaptureEnd is called after the call finishes to finalize the tracing.
-func (t *noopTracer) CaptureEnd(output []byte, gasUsed uint64, err error) {
+func (t *NoopTracer) CaptureEnd(output []byte, gasUsed uint64, err error) {
 }
 
 // CaptureState implements the EVMLogger interface to trace a single step of VM execution.
-func (t *noopTracer) CaptureState(pc uint64, op vm.OpCode, gas, cost uint64, scope *vm.ScopeContext, rData []byte, depth int, err error) {
+func (t *NoopTracer) CaptureState(pc uint64, op vm.OpCode, gas, cost uint64, scope *vm.ScopeContext, rData []byte, depth int, err error) {
 }
 
 // CaptureFault implements the EVMLogger interface to trace an execution fault.
-func (t *noopTracer) CaptureFault(pc uint64, op vm.OpCode, gas, cost uint64, _ *vm.ScopeContext, depth int, err error) {
+func (t *NoopTracer) CaptureFault(pc uint64, op vm.OpCode, gas, cost uint64, _ *vm.ScopeContext, depth int, err error) {
 }
 
 // CaptureKeccakPreimage is called during the KECCAK256 opcode.
-func (t *noopTracer) CaptureKeccakPreimage(hash common.Hash, data []byte) {}
+func (t *NoopTracer) CaptureKeccakPreimage(hash common.Hash, data []byte) {}
+
+// OnGasConsumed is called when gas is consumed.
+func (t *NoopTracer) OnGasConsumed(gas, amount uint64) {}
 
 // CaptureEnter is called when EVM enters a new scope (via call, create or selfdestruct).
-func (t *noopTracer) CaptureEnter(typ vm.OpCode, from common.Address, to common.Address, input []byte, gas uint64, value *big.Int) {
+func (t *NoopTracer) CaptureEnter(typ vm.OpCode, from common.Address, to common.Address, input []byte, gas uint64, value *big.Int) {
 }
 
 // CaptureExit is called when EVM exits a scope, even if the scope didn't
 // execute any code.
-func (t *noopTracer) CaptureExit(output []byte, gasUsed uint64, err error) {
+func (t *NoopTracer) CaptureExit(output []byte, gasUsed uint64, err error) {
 }
 
-func (*noopTracer) CaptureTxStart(gasLimit uint64) {}
+func (*NoopTracer) CaptureTxStart(gasLimit uint64) {}
 
-func (*noopTracer) CaptureTxEnd(restGas uint64) {}
+func (*NoopTracer) CaptureTxEnd(restGas uint64) {}
 
 // GetResult returns an empty json object.
-func (t *noopTracer) GetResult() (json.RawMessage, error) {
+func (t *NoopTracer) GetResult() (json.RawMessage, error) {
 	return json.RawMessage(`{}`), nil
 }
 
 // Stop terminates execution of the tracer at the first opportune moment.
-func (t *noopTracer) Stop(err error) {
+func (t *NoopTracer) Stop(err error) {
 }

--- a/eth/tracers/noop.go
+++ b/eth/tracers/noop.go
@@ -39,7 +39,7 @@ func newNoopTracer(ctx *Context, _ json.RawMessage) (Tracer, error) {
 }
 
 // CaptureStart implements the EVMLogger interface to initialize the tracing operation.
-func (t *NoopTracer) CaptureStart(env *vm.EVM, from common.Address, to common.Address, create bool, input []byte, gas uint64, value *big.Int) {
+func (t *NoopTracer) CaptureStart(from common.Address, to common.Address, create bool, input []byte, gas uint64, value *big.Int) {
 }
 
 // CaptureEnd is called after the call finishes to finalize the tracing.
@@ -69,7 +69,7 @@ func (t *NoopTracer) CaptureEnter(typ vm.OpCode, from common.Address, to common.
 func (t *NoopTracer) CaptureExit(output []byte, gasUsed uint64, err error) {
 }
 
-func (*NoopTracer) CaptureTxStart(tx *types.Transaction) {}
+func (*NoopTracer) CaptureTxStart(env *vm.EVM, tx *types.Transaction) {}
 
 func (*NoopTracer) CaptureTxEnd(receipt *types.Receipt) {}
 

--- a/eth/tracers/printer.go
+++ b/eth/tracers/printer.go
@@ -1,6 +1,7 @@
 package tracers
 
 import (
+	"encoding/json"
 	"fmt"
 	"math/big"
 
@@ -10,16 +11,26 @@ import (
 	"github.com/ethereum/go-ethereum/core/vm"
 )
 
-type Printer struct{}
-
-func NewPrinter() *Printer {
-	return &Printer{}
+type Printer struct {
+	eventsChan chan json.RawMessage
+	feed bool
 }
 
-func NewPrinterWithFeed(bc core.BlockChain) *Printer {
-    Ptr := &Printer{}
-	Ptr.EventLoop(bc)
-	return Ptr
+func NewPrinter() *Printer {
+	return &Printer{
+		eventsChan: make(chan json.RawMessage, 100),
+	}
+}
+
+func NewPrinterWithFeed(bc *core.BlockChain) *Printer {
+	p := &Printer{
+		eventsChan: make(chan json.RawMessage, 100),
+        feed: true,
+	}
+	//TODO: Collecting streaming logs through the event loop and distributing them 
+	//triggered by specific events, such as onBlockEnd.
+	//go p.EventLoop(bc)
+	return p
 }
 
 // CaptureStart implements the EVMLogger interface to initialize the tracing operation.
@@ -112,13 +123,14 @@ func (p *Printer) OnGasConsumed(gas, amount uint64) {
 // EventLoop receives data from channels, adds them to Trace,
 // and sends Trace when the OnBlockEnd event occurs. This function operates
 // in a loop and should typically be run in a separate goroutine.
-func (p *Printer) EventLoop(bc core.BlockChain) {
+
+//TODO: Collecting streaming logs through the event loop and distributing them 
+//triggered by specific events, such as onBlockEnd.
+/* func (p *Printer) EventLoop(bc *core.BlockChain) {
 	for {
 		select {
-		//TODO
-		case <-bc.quit:
-			return
-
+		case data := <-p.eventsChan:
+			bc.TracersEventsSent(data)
 		}
 	}
-}
+} */

--- a/eth/tracers/printer.go
+++ b/eth/tracers/printer.go
@@ -93,3 +93,7 @@ func (p *Printer) OnLog(l *types.Log) {
 func (p *Printer) OnNewAccount(a common.Address) {
 	fmt.Printf("OnNewAccount: a=%v\n", a)
 }
+
+func (p *Printer) OnGasConsumed(gas, amount uint64) {
+	fmt.Printf("OnGasConsumed: gas=%v, amount=%v\n", gas, amount)
+}

--- a/eth/tracers/printer.go
+++ b/eth/tracers/printer.go
@@ -16,7 +16,7 @@ func NewPrinter() *Printer {
 }
 
 // CaptureStart implements the EVMLogger interface to initialize the tracing operation.
-func (p *Printer) CaptureStart(env *vm.EVM, from common.Address, to common.Address, create bool, input []byte, gas uint64, value *big.Int) {
+func (p *Printer) CaptureStart(from common.Address, to common.Address, create bool, input []byte, gas uint64, value *big.Int) {
 	fmt.Printf("CaptureStart: from=%v, to=%v, create=%v, input=%v, gas=%v, value=%v\n", from, to, create, input, gas, value)
 }
 
@@ -49,7 +49,7 @@ func (p *Printer) CaptureExit(output []byte, gasUsed uint64, err error) {
 	fmt.Printf("CaptureExit: output=%v, gasUsed=%v, err=%v\n", output, gasUsed, err)
 }
 
-func (p *Printer) CaptureTxStart(tx *types.Transaction) {
+func (p *Printer) CaptureTxStart(env *vm.EVM, tx *types.Transaction) {
 	fmt.Printf("CaptureTxStart: tx=%v\n", tx)
 
 }

--- a/eth/tracers/printer.go
+++ b/eth/tracers/printer.go
@@ -49,13 +49,13 @@ func (p *Printer) CaptureExit(output []byte, gasUsed uint64, err error) {
 	fmt.Printf("CaptureExit: output=%v, gasUsed=%v, err=%v\n", output, gasUsed, err)
 }
 
-func (p *Printer) CaptureTxStart(gasLimit uint64) {
-	fmt.Printf("CaptureTxStart: gasLimit=%v\n", gasLimit)
+func (p *Printer) CaptureTxStart(tx *types.Transaction) {
+	fmt.Printf("CaptureTxStart: tx=%v\n", tx)
 
 }
 
-func (p *Printer) CaptureTxEnd(restGas uint64) {
-	fmt.Printf("CaptureTxEnd: restGas=%v\n", restGas)
+func (p *Printer) CaptureTxEnd(receipt *types.Receipt) {
+	fmt.Printf("CaptureTxEnd: receipt=%v\n", receipt)
 }
 
 func (p *Printer) CaptureBlockStart(b *types.Block) {

--- a/eth/tracers/printer.go
+++ b/eth/tracers/printer.go
@@ -5,6 +5,7 @@ import (
 	"math/big"
 
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/core/vm"
 )
@@ -13,6 +14,12 @@ type Printer struct{}
 
 func NewPrinter() *Printer {
 	return &Printer{}
+}
+
+func NewPrinterWithFeed(bc core.BlockChain) *Printer {
+    Ptr := &Printer{}
+	Ptr.EventLoop(bc)
+	return Ptr
 }
 
 // CaptureStart implements the EVMLogger interface to initialize the tracing operation.
@@ -100,4 +107,18 @@ func (p *Printer) OnNewAccount(a common.Address) {
 
 func (p *Printer) OnGasConsumed(gas, amount uint64) {
 	fmt.Printf("OnGasConsumed: gas=%v, amount=%v\n", gas, amount)
+}
+
+// EventLoop receives data from channels, adds them to Trace,
+// and sends Trace when the OnBlockEnd event occurs. This function operates
+// in a loop and should typically be run in a separate goroutine.
+func (p *Printer) EventLoop(bc core.BlockChain) {
+	for {
+		select {
+		//TODO
+		case <-bc.quit:
+			return
+
+		}
+	}
 }

--- a/eth/tracers/printer.go
+++ b/eth/tracers/printer.go
@@ -85,3 +85,11 @@ func (p *Printer) OnCodeChange(a common.Address, prevCodeHash common.Hash, prev 
 func (p *Printer) OnStorageChange(a common.Address, k, prev, new common.Hash) {
 	fmt.Printf("OnStorageChange: a=%v, k=%v, prev=%v, new=%v\n", a, k, prev, new)
 }
+
+func (p *Printer) OnLog(l *types.Log) {
+	fmt.Printf("OnLog: l=%v\n", l)
+}
+
+func (p *Printer) OnNewAccount(a common.Address) {
+	fmt.Printf("OnNewAccount: a=%v\n", a)
+}

--- a/eth/tracers/printer.go
+++ b/eth/tracers/printer.go
@@ -35,6 +35,9 @@ func (p *Printer) CaptureFault(pc uint64, op vm.OpCode, gas, cost uint64, _ *vm.
 	fmt.Printf("CaptureFault: pc=%v, op=%v, gas=%v, cost=%v, depth=%v, err=%v\n", pc, op, gas, cost, depth, err)
 }
 
+// CaptureKeccakPreimage is called during the KECCAK256 opcode.
+func (p *Printer) CaptureKeccakPreimage(hash common.Hash, data []byte) {}
+
 // CaptureEnter is called when EVM enters a new scope (via call, create or selfdestruct).
 func (p *Printer) CaptureEnter(typ vm.OpCode, from common.Address, to common.Address, input []byte, gas uint64, value *big.Int) {
 	fmt.Printf("CaptureEnter: typ=%v, from=%v, to=%v, input=%v, gas=%v, value=%v\n", typ, from, to, input, gas, value)

--- a/eth/tracers/printer.go
+++ b/eth/tracers/printer.go
@@ -65,3 +65,23 @@ func (p *Printer) CaptureBlockStart(b *types.Block) {
 func (p *Printer) CaptureBlockEnd() {
 	fmt.Printf("CaptureBlockEnd\n")
 }
+
+func (p *Printer) OnGenesisBlock(b *types.Block) {
+	fmt.Printf("OnGenesisBlock: b=%v\n", b.NumberU64())
+}
+
+func (p *Printer) OnBalanceChange(a common.Address, prev, new *big.Int) {
+	fmt.Printf("OnBalanceChange: a=%v, prev=%v, new=%v\n", a, prev, new)
+}
+
+func (p *Printer) OnNonceChange(a common.Address, prev, new uint64) {
+	fmt.Printf("OnNonceChange: a=%v, prev=%v, new=%v\n", a, prev, new)
+}
+
+func (p *Printer) OnCodeChange(a common.Address, prevCodeHash common.Hash, prev []byte, codeHash common.Hash, code []byte) {
+	fmt.Printf("OnCodeChange: a=%v, prevCodeHash=%v, prev=%v, codeHash=%v, code=%v\n", a, prevCodeHash, prev, codeHash, code)
+}
+
+func (p *Printer) OnStorageChange(a common.Address, k, prev, new common.Hash) {
+	fmt.Printf("OnStorageChange: a=%v, k=%v, prev=%v, new=%v\n", a, k, prev, new)
+}

--- a/eth/tracers/printer.go
+++ b/eth/tracers/printer.go
@@ -12,45 +12,123 @@ import (
 )
 
 type Printer struct {
-	eventsChan chan json.RawMessage
-	feed bool
+	eventsChan     chan json.RawMessage
+	triggerEvent   chan json.RawMessage
+	feed           bool
+	eventsBuffer   []json.RawMessage  // added field to buffer events
 }
 
 func NewPrinter() *Printer {
-	return &Printer{
-		eventsChan: make(chan json.RawMessage, 100),
-	}
+	return &Printer{}
 }
 
 func NewPrinterWithFeed(bc *core.BlockChain) *Printer {
 	p := &Printer{
-		eventsChan: make(chan json.RawMessage, 100),
-        feed: true,
+		eventsChan:   make(chan json.RawMessage, 100),
+		triggerEvent: make(chan json.RawMessage, 100),
+        feed:         true,
 	}
 	//TODO: Collecting streaming logs through the event loop and distributing them 
 	//triggered by specific events, such as onBlockEnd.
-	//go p.EventLoop(bc)
+	go p.EventLoop(bc)
 	return p
 }
 
 // CaptureStart implements the EVMLogger interface to initialize the tracing operation.
 func (p *Printer) CaptureStart(from common.Address, to common.Address, create bool, input []byte, gas uint64, value *big.Int) {
 	fmt.Printf("CaptureStart: from=%v, to=%v, create=%v, input=%v, gas=%v, value=%v\n", from, to, create, input, gas, value)
+	if p.feed {
+		message := map[string]interface{}{
+			"event": "CaptureStart",
+			"from":  from.Hex(),
+			"to":    to.Hex(),
+			"create": create,
+			"input":  input,
+			"gas":    gas,
+			"value":  value.String(),
+		}
+
+		data, err := json.Marshal(message)
+		if err != nil {
+			fmt.Printf("Failed to marshal json: %v\n", err)
+			return
+		}
+
+		p.eventsChan <- json.RawMessage(data)
+	}
 }
 
 // CaptureEnd is called after the call finishes to finalize the tracing.
 func (p *Printer) CaptureEnd(output []byte, gasUsed uint64, err error) {
 	fmt.Printf("CaptureEnd: output=%v, gasUsed=%v, err=%v\n", output, gasUsed, err)
+
+	if p.feed {
+		message := map[string]interface{}{
+			"event": "CaptureEnd",
+			"output": output,
+			"gasUsed": gasUsed,
+			"error": err.Error(),
+		}
+
+		data, err := json.Marshal(message)
+		if err != nil {
+			fmt.Printf("Failed to marshal json: %v\n", err)
+			return
+		}
+
+		p.eventsChan <- json.RawMessage(data)
+	}
 }
 
 // CaptureState implements the EVMLogger interface to trace a single step of VM execution.
 func (p *Printer) CaptureState(pc uint64, op vm.OpCode, gas, cost uint64, scope *vm.ScopeContext, rData []byte, depth int, err error) {
 	//fmt.Printf("CaptureState: pc=%v, op=%v, gas=%v, cost=%v, scope=%v, rData=%v, depth=%v, err=%v\n", pc, op, gas, cost, scope, rData, depth, err)
+/* 	if p.feed {
+		message := map[string]interface{}{
+			"event": "CaptureState",
+			"pc":    pc,
+			"op":    op,
+			"gas":   gas,
+			"cost":  cost,
+			"scope": scope,
+			"rData": rData,
+			"depth": depth,
+			"error": err,
+		}
+
+		data, err := json.Marshal(message)
+		if err != nil {
+			fmt.Printf("CaptureState: failed to marshal JSON: %v\n", err)
+			return
+		}
+
+		p.eventsChan <- data
+	} */
 }
 
 // CaptureFault implements the EVMLogger interface to trace an execution fault.
 func (p *Printer) CaptureFault(pc uint64, op vm.OpCode, gas, cost uint64, _ *vm.ScopeContext, depth int, err error) {
 	fmt.Printf("CaptureFault: pc=%v, op=%v, gas=%v, cost=%v, depth=%v, err=%v\n", pc, op, gas, cost, depth, err)
+
+	if p.feed {
+		message := map[string]interface{}{
+			"event": "CaptureFault",
+			"pc":    pc,
+			"op":    op.String(),
+			"gas":   gas,
+			"cost":  cost,
+			"depth": depth,
+			"error": err.Error(),
+		}
+
+		data, err := json.Marshal(message)
+		if err != nil {
+			fmt.Printf("Failed to marshal json: %v\n", err)
+			return
+		}
+
+		p.eventsChan <- json.RawMessage(data)
+	}
 }
 
 // CaptureKeccakPreimage is called during the KECCAK256 opcode.
@@ -59,65 +137,310 @@ func (p *Printer) CaptureKeccakPreimage(hash common.Hash, data []byte) {}
 // CaptureEnter is called when EVM enters a new scope (via call, create or selfdestruct).
 func (p *Printer) CaptureEnter(typ vm.OpCode, from common.Address, to common.Address, input []byte, gas uint64, value *big.Int) {
 	fmt.Printf("CaptureEnter: typ=%v, from=%v, to=%v, input=%v, gas=%v, value=%v\n", typ, from, to, input, gas, value)
+
+	if p.feed {
+		message := map[string]interface{}{
+			"event": "CaptureEnter",
+			"typ":   typ.String(),
+			"from":  from.Hex(),
+			"to":    to.Hex(),
+			"input": input,
+			"gas":   gas,
+			"value": value.String(),
+		}
+
+		data, err := json.Marshal(message)
+		if err != nil {
+			fmt.Printf("Failed to marshal json: %v\n", err)
+			return
+		}
+
+		p.eventsChan <- json.RawMessage(data)
+	}
 }
 
 // CaptureExit is called when EVM exits a scope, even if the scope didn't
 // execute any code.
 func (p *Printer) CaptureExit(output []byte, gasUsed uint64, err error) {
 	fmt.Printf("CaptureExit: output=%v, gasUsed=%v, err=%v\n", output, gasUsed, err)
+
+	if p.feed {
+		message := map[string]interface{}{
+			"event": "CaptureExit",
+			"output": output,
+			"gasUsed": gasUsed,
+			"error": err.Error(),
+		}
+
+		data, err := json.Marshal(message)
+		if err != nil {
+			fmt.Printf("Failed to marshal json: %v\n", err)
+			return
+		}
+
+		p.eventsChan <- json.RawMessage(data)
+	}
 }
 
 func (p *Printer) CaptureTxStart(env *vm.EVM, tx *types.Transaction) {
 	fmt.Printf("CaptureTxStart: tx=%v\n", tx)
 
+	if p.feed {
+		message := map[string]interface{}{
+			"event": "CaptureTxStart",
+			"tx":    tx.Hash().Hex(),
+		}
+
+		data, err := json.Marshal(message)
+		if err != nil {
+			fmt.Printf("Failed to marshal json: %v\n", err)
+			return
+		}
+
+		p.triggerEvent <- json.RawMessage(data)
+	}
 }
 
 func (p *Printer) CaptureTxEnd(receipt *types.Receipt) {
 	fmt.Printf("CaptureTxEnd: receipt=%v\n", receipt)
+
+	if p.feed {
+		message := map[string]interface{}{
+			"event": "CaptureTxEnd",
+			"receipt": receipt.TxHash.Hex(),
+		}
+
+		data, err := json.Marshal(message)
+		if err != nil {
+			fmt.Printf("Failed to marshal json: %v\n", err)
+			return
+		}
+
+		p.triggerEvent <- json.RawMessage(data)
+	}
 }
 
 func (p *Printer) OnBlockStart(b *types.Block) {
 	fmt.Printf("OnBlockStart: b=%v\n", b.NumberU64())
+
+	if p.feed {
+		message := map[string]interface{}{
+			"event": "OnBlockStart",
+			"blockNumber": b.NumberU64(),
+		}
+
+		data, err := json.Marshal(message)
+		if err != nil {
+			fmt.Printf("Failed to marshal json: %v\n", err)
+			return
+		}
+
+		p.triggerEvent <- json.RawMessage(data)
+	}
 }
 
 func (p *Printer) OnBlockEnd(td *big.Int, err error) {
 	fmt.Printf("OnBlockEnd: td=%v, err=%v\n", td, err)
+
+	if p.feed {
+		message := map[string]interface{}{
+			"event": "OnBlockEnd",
+			"totalDifficulty": td.String(),
+			"error": err,
+		}
+
+		data, err := json.Marshal(message)
+		if err != nil {
+			fmt.Printf("Failed to marshal json: %v\n", err)
+			return
+		}
+
+		p.triggerEvent <- json.RawMessage(data)
+	}
 }
 
 func (p *Printer) OnBlockValidationError(block *types.Block, err error) {
 	fmt.Printf("OnBlockValidationError: b=%v, err=%v\n", block.NumberU64(), err)
+
+	if p.feed {
+		message := map[string]interface{}{
+			"event": "OnBlockValidationError",
+			"blockNumber": block.NumberU64(),
+			"error": err.Error(),
+		}
+
+		data, err := json.Marshal(message)
+		if err != nil {
+			fmt.Printf("Failed to marshal json: %v\n", err)
+			return
+		}
+
+		p.eventsChan <- json.RawMessage(data)
+	}
 }
 
 func (p *Printer) OnGenesisBlock(b *types.Block) {
 	fmt.Printf("OnGenesisBlock: b=%v\n", b.NumberU64())
+
+	if p.feed {
+		message := map[string]interface{}{
+			"event": "OnGenesisBlock",
+			"blockNumber": b.NumberU64(),
+		}
+
+		data, err := json.Marshal(message)
+		if err != nil {
+			fmt.Printf("Failed to marshal json: %v\n", err)
+			return
+		}
+
+		p.eventsChan <- json.RawMessage(data)
+	}
 }
 
 func (p *Printer) OnBalanceChange(a common.Address, prev, new *big.Int) {
 	fmt.Printf("OnBalanceChange: a=%v, prev=%v, new=%v\n", a, prev, new)
+
+	if p.feed {
+		message := map[string]interface{}{
+			"event": "OnBalanceChange",
+			"address": a.Hex(),
+			"prevBalance": prev.String(),
+			"newBalance": new.String(),
+		}
+
+		data, err := json.Marshal(message)
+		if err != nil {
+			fmt.Printf("Failed to marshal json: %v\n", err)
+			return
+		}
+
+		p.eventsChan <- json.RawMessage(data)
+	}
 }
 
 func (p *Printer) OnNonceChange(a common.Address, prev, new uint64) {
 	fmt.Printf("OnNonceChange: a=%v, prev=%v, new=%v\n", a, prev, new)
+
+	if p.feed {
+		message := map[string]interface{}{
+			"event": "OnNonceChange",
+			"address": a.Hex(),
+			"prevNonce": prev,
+			"newNonce": new,
+		}
+
+		data, err := json.Marshal(message)
+		if err != nil {
+			fmt.Printf("Failed to marshal json: %v\n", err)
+			return
+		}
+
+		p.eventsChan <- json.RawMessage(data)
+	}
 }
 
 func (p *Printer) OnCodeChange(a common.Address, prevCodeHash common.Hash, prev []byte, codeHash common.Hash, code []byte) {
 	fmt.Printf("OnCodeChange: a=%v, prevCodeHash=%v, prev=%v, codeHash=%v, code=%v\n", a, prevCodeHash, prev, codeHash, code)
+
+	if p.feed {
+		message := map[string]interface{}{
+			"event": "OnCodeChange",
+			"address": a.Hex(),
+			"prevCodeHash": prevCodeHash.Hex(),
+			"prevCode": string(prev),
+			"codeHash": codeHash.Hex(),
+			"code": string(code),
+		}
+
+		data, err := json.Marshal(message)
+		if err != nil {
+			fmt.Printf("Failed to marshal json: %v\n", err)
+			return
+		}
+
+		p.eventsChan <- json.RawMessage(data)
+	}
 }
 
 func (p *Printer) OnStorageChange(a common.Address, k, prev, new common.Hash) {
 	fmt.Printf("OnStorageChange: a=%v, k=%v, prev=%v, new=%v\n", a, k, prev, new)
+
+	if p.feed {
+		message := map[string]interface{}{
+			"event": "OnStorageChange",
+			"address": a.Hex(),
+			"key": k.Hex(),
+			"prevHash": prev.Hex(),
+			"newHash": new.Hex(),
+		}
+
+		data, err := json.Marshal(message)
+		if err != nil {
+			fmt.Printf("Failed to marshal json: %v\n", err)
+			return
+		}
+
+		p.eventsChan <- json.RawMessage(data)
+	}
 }
 
 func (p *Printer) OnLog(l *types.Log) {
 	fmt.Printf("OnLog: l=%v\n", l)
+
+	if p.feed {
+		message := map[string]interface{}{
+			"event": "OnLog",
+			"log": l,
+		}
+
+		data, err := json.Marshal(message)
+		if err != nil {
+			fmt.Printf("Failed to marshal json: %v\n", err)
+			return
+		}
+
+		p.eventsChan <- json.RawMessage(data)
+	}
 }
 
 func (p *Printer) OnNewAccount(a common.Address) {
 	fmt.Printf("OnNewAccount: a=%v\n", a)
+
+	if p.feed {
+		message := map[string]interface{}{
+			"event": "OnNewAccount",
+			"address": a.Hex(),
+		}
+
+		data, err := json.Marshal(message)
+		if err != nil {
+			fmt.Printf("Failed to marshal json: %v\n", err)
+			return
+		}
+
+		p.eventsChan <- json.RawMessage(data)
+	}
 }
 
 func (p *Printer) OnGasConsumed(gas, amount uint64) {
 	fmt.Printf("OnGasConsumed: gas=%v, amount=%v\n", gas, amount)
+
+	if p.feed {
+		message := map[string]interface{}{
+			"event": "OnGasConsumed",
+			"gas": gas,
+			"amount": amount,
+		}
+
+		data, err := json.Marshal(message)
+		if err != nil {
+			fmt.Printf("Failed to marshal json: %v\n", err)
+			return
+		}
+
+		p.eventsChan <- json.RawMessage(data)
+	}
 }
 
 // EventLoop receives data from channels, adds them to Trace,
@@ -126,11 +449,19 @@ func (p *Printer) OnGasConsumed(gas, amount uint64) {
 
 //TODO: Collecting streaming logs through the event loop and distributing them 
 //triggered by specific events, such as onBlockEnd.
-/* func (p *Printer) EventLoop(bc *core.BlockChain) {
+func (p *Printer) EventLoop(bc *core.BlockChain) {
 	for {
 		select {
+		case data := <-p.triggerEvent:
+			// Append the triggerEvent to the buffer
+			p.eventsBuffer = append(p.eventsBuffer, data)
+			// Send all buffered events
+			bc.TracersEventsSent(p.eventsBuffer)
+			// Clear the events buffer
+			p.eventsBuffer = []json.RawMessage{}
 		case data := <-p.eventsChan:
-			bc.TracersEventsSent(data)
+			// Buffer the events from eventsChan
+			p.eventsBuffer = append(p.eventsBuffer, data)
 		}
 	}
-} */
+}

--- a/eth/tracers/printer.go
+++ b/eth/tracers/printer.go
@@ -1,0 +1,64 @@
+package tracers
+
+import (
+	"fmt"
+	"math/big"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/core/vm"
+)
+
+type Printer struct{}
+
+func NewPrinter() *Printer {
+	return &Printer{}
+}
+
+// CaptureStart implements the EVMLogger interface to initialize the tracing operation.
+func (p *Printer) CaptureStart(env *vm.EVM, from common.Address, to common.Address, create bool, input []byte, gas uint64, value *big.Int) {
+	fmt.Printf("CaptureStart: from=%v, to=%v, create=%v, input=%v, gas=%v, value=%v\n", from, to, create, input, gas, value)
+}
+
+// CaptureEnd is called after the call finishes to finalize the tracing.
+func (p *Printer) CaptureEnd(output []byte, gasUsed uint64, err error) {
+	fmt.Printf("CaptureEnd: output=%v, gasUsed=%v, err=%v\n", output, gasUsed, err)
+}
+
+// CaptureState implements the EVMLogger interface to trace a single step of VM execution.
+func (p *Printer) CaptureState(pc uint64, op vm.OpCode, gas, cost uint64, scope *vm.ScopeContext, rData []byte, depth int, err error) {
+	//fmt.Printf("CaptureState: pc=%v, op=%v, gas=%v, cost=%v, scope=%v, rData=%v, depth=%v, err=%v\n", pc, op, gas, cost, scope, rData, depth, err)
+}
+
+// CaptureFault implements the EVMLogger interface to trace an execution fault.
+func (p *Printer) CaptureFault(pc uint64, op vm.OpCode, gas, cost uint64, _ *vm.ScopeContext, depth int, err error) {
+	fmt.Printf("CaptureFault: pc=%v, op=%v, gas=%v, cost=%v, depth=%v, err=%v\n", pc, op, gas, cost, depth, err)
+}
+
+// CaptureEnter is called when EVM enters a new scope (via call, create or selfdestruct).
+func (p *Printer) CaptureEnter(typ vm.OpCode, from common.Address, to common.Address, input []byte, gas uint64, value *big.Int) {
+	fmt.Printf("CaptureEnter: typ=%v, from=%v, to=%v, input=%v, gas=%v, value=%v\n", typ, from, to, input, gas, value)
+}
+
+// CaptureExit is called when EVM exits a scope, even if the scope didn't
+// execute any code.
+func (p *Printer) CaptureExit(output []byte, gasUsed uint64, err error) {
+	fmt.Printf("CaptureExit: output=%v, gasUsed=%v, err=%v\n", output, gasUsed, err)
+}
+
+func (p *Printer) CaptureTxStart(gasLimit uint64) {
+	fmt.Printf("CaptureTxStart: gasLimit=%v\n", gasLimit)
+
+}
+
+func (p *Printer) CaptureTxEnd(restGas uint64) {
+	fmt.Printf("CaptureTxEnd: restGas=%v\n", restGas)
+}
+
+func (p *Printer) CaptureBlockStart(b *types.Block) {
+	fmt.Printf("CaptureBlockStart: b=%v\n", b.NumberU64())
+}
+
+func (p *Printer) CaptureBlockEnd() {
+	fmt.Printf("CaptureBlockEnd\n")
+}

--- a/eth/tracers/printer.go
+++ b/eth/tracers/printer.go
@@ -58,12 +58,16 @@ func (p *Printer) CaptureTxEnd(receipt *types.Receipt) {
 	fmt.Printf("CaptureTxEnd: receipt=%v\n", receipt)
 }
 
-func (p *Printer) CaptureBlockStart(b *types.Block) {
-	fmt.Printf("CaptureBlockStart: b=%v\n", b.NumberU64())
+func (p *Printer) OnBlockStart(b *types.Block) {
+	fmt.Printf("OnBlockStart: b=%v\n", b.NumberU64())
 }
 
-func (p *Printer) CaptureBlockEnd() {
-	fmt.Printf("CaptureBlockEnd\n")
+func (p *Printer) OnBlockEnd(td *big.Int, err error) {
+	fmt.Printf("OnBlockEnd: td=%v, err=%v\n", td, err)
+}
+
+func (p *Printer) OnBlockValidationError(block *types.Block, err error) {
+	fmt.Printf("OnBlockValidationError: b=%v, err=%v\n", block.NumberU64(), err)
 }
 
 func (p *Printer) OnGenesisBlock(b *types.Block) {

--- a/eth/tracers/tracers.go
+++ b/eth/tracers/tracers.go
@@ -24,6 +24,7 @@ import (
 	"math/big"
 
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/state"
 	"github.com/ethereum/go-ethereum/core/vm"
 )
 
@@ -36,10 +37,13 @@ type Context struct {
 	TxHash      common.Hash // Hash of the transaction being traced (zero if dangling call)
 }
 
-// Tracer interface extends vm.EVMLogger and additionally
-// allows collecting the tracing result.
+// The set of methods that must be exposed by a tracer
+// for it to be available through the RPC interface.
+// This involves a method to retrieve results and one to
+// stop tracing.
 type Tracer interface {
 	vm.EVMLogger
+	state.StateLogger
 	GetResult() (json.RawMessage, error)
 	// Stop terminates execution of the tracer at the first opportune moment.
 	Stop(err error)

--- a/les/api_backend.go
+++ b/les/api_backend.go
@@ -333,6 +333,6 @@ func (b *LesApiBackend) StateAtBlock(ctx context.Context, block *types.Block, re
 	return b.eth.stateAtBlock(ctx, block, reexec)
 }
 
-func (b *LesApiBackend) StateAtTransaction(ctx context.Context, block *types.Block, txIndex int, reexec uint64) (*core.Message, vm.BlockContext, *state.StateDB, tracers.StateReleaseFunc, error) {
+func (b *LesApiBackend) StateAtTransaction(ctx context.Context, block *types.Block, txIndex int, reexec uint64) (*types.Transaction, vm.BlockContext, *state.StateDB, tracers.StateReleaseFunc, error) {
 	return b.eth.stateAtTransaction(ctx, block, txIndex, reexec)
 }

--- a/les/client.go
+++ b/les/client.go
@@ -97,7 +97,7 @@ func New(stack *node.Node, config *ethconfig.Config) (*LightEthereum, error) {
 	if config.OverrideCancun != nil {
 		overrides.OverrideCancun = config.OverrideCancun
 	}
-	chainConfig, genesisHash, genesisErr := core.SetupGenesisBlockWithOverride(chainDb, trie.NewDatabase(chainDb), config.Genesis, &overrides)
+	chainConfig, genesisHash, genesisErr := core.SetupGenesisBlockWithOverride(chainDb, trie.NewDatabase(chainDb), config.Genesis, &overrides, nil)
 	if _, isCompat := genesisErr.(*params.ConfigCompatError); genesisErr != nil && !isCompat {
 		return nil, genesisErr
 	}

--- a/les/state_accessor.go
+++ b/les/state_accessor.go
@@ -39,7 +39,7 @@ func (leth *LightEthereum) stateAtBlock(ctx context.Context, block *types.Block,
 }
 
 // stateAtTransaction returns the execution environment of a certain transaction.
-func (leth *LightEthereum) stateAtTransaction(ctx context.Context, block *types.Block, txIndex int, reexec uint64) (*core.Message, vm.BlockContext, *state.StateDB, tracers.StateReleaseFunc, error) {
+func (leth *LightEthereum) stateAtTransaction(ctx context.Context, block *types.Block, txIndex int, reexec uint64) (*types.Transaction, vm.BlockContext, *state.StateDB, tracers.StateReleaseFunc, error) {
 	// Short circuit if it's genesis block.
 	if block.NumberU64() == 0 {
 		return nil, vm.BlockContext{}, nil, nil, errors.New("no transaction in genesis")
@@ -65,7 +65,7 @@ func (leth *LightEthereum) stateAtTransaction(ctx context.Context, block *types.
 		context := core.NewEVMBlockContext(block.Header(), leth.blockchain, nil)
 		statedb.SetTxContext(tx.Hash(), idx)
 		if idx == txIndex {
-			return msg, context, statedb, release, nil
+			return tx, context, statedb, release, nil
 		}
 		// Not yet the searched for transaction, execute on top of the current state
 		vmenv := vm.NewEVM(context, txContext, statedb, leth.blockchain.Config(), vm.Config{})

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -30,6 +30,7 @@ import (
 	"github.com/ethereum/go-ethereum/core"
 	"github.com/ethereum/go-ethereum/core/state"
 	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/core/vm"
 	"github.com/ethereum/go-ethereum/event"
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/params"
@@ -732,7 +733,7 @@ func (w *worker) commitTransaction(env *environment, tx *types.Transaction) ([]*
 		snap = env.state.Snapshot()
 		gp   = env.gasPool.Gas()
 	)
-	receipt, err := core.ApplyTransaction(w.chainConfig, w.chain, &env.coinbase, env.gasPool, env.state, env.header, tx, &env.header.GasUsed, *w.chain.GetVMConfig())
+	receipt, err := core.ApplyTransaction(w.chainConfig, w.chain, &env.coinbase, env.gasPool, env.state, env.header, tx, &env.header.GasUsed, vm.Config{})
 	if err != nil {
 		env.state.RevertToSnapshot(snap)
 		env.gasPool.SetGas(gp)


### PR DESCRIPTION
Depends on https://github.com/ethereum/go-ethereum/pull/27629.
This PR makes it possible to subscribe to traces being produced during normal block processing. So you can do `eth_subscribe('traces')` and get notifications from the tracer that has been configured on node start-up to be run alongside the chain. Details of the notifications depend on each tracer. This PR only as a sample adds some notifications in the Printer.
Todo： find a solution that works for all tracers.