### PR TITLE
console: add cleanup to avoid leaks in newTester

### DIFF
--- a/console/console_test.go
+++ b/console/console_test.go
@@ -111,6 +111,10 @@ func newTester(t *testing.T, confOverride func(*ethconfig.Config)) *tester {
 		t.Fatalf("failed to start test stack: %v", err)
 	}
 	client := stack.Attach()
+	t.Cleanup(func() {
+		client.Close()
+	})
+
 	prompter := &hookedPrompter{scheduler: make(chan string)}
 	printer := new(bytes.Buffer)
 


### PR DESCRIPTION
In #27152 , I found that some goroutines that are not expected to be leaked (instead of cache-related global routines mentioned in #27247) existing blocking here:
```
[Goroutine 27 in state select, with github.com/ethereum/go-ethereum/rpc.(*Client).dispatch on top of the stack:
goroutine 27 [select]:
github.com/ethereum/go-ethereum/rpc.(*Client).dispatch(0xc0015a0080, {0x185ade0?, 0xc00043e300})
        /tool/go-ethereum/rpc/client.go:619 +0x2b7
created by github.com/ethereum/go-ethereum/rpc.initClient
        /tool/go-ethereum/rpc/client.go:259 +0x311
```
This pr fix it by closing it in `t.Cleanup` to avoid leaks in any cases.