### PR TITLE
eth/tracers: add debug_traceCallMany method

### DIFF
--- a/eth/tracers/api.go
+++ b/eth/tracers/api.go
@@ -148,6 +148,34 @@ func (api *API) blockByNumberAndHash(ctx context.Context, number rpc.BlockNumber
 	return api.blockByHash(ctx, hash)
 }
 
+// blockByNumberOrHash is the wrapper of the chain access function offered by backend.
+// It will return an error if the block is not found.
+func (api *API) blockByNumberOrHash(ctx context.Context, blockNrOrHash rpc.BlockNumberOrHash) (*types.Block, error) {
+	var (
+		err   error
+		block *types.Block
+	)
+	if hash, ok := blockNrOrHash.Hash(); ok {
+		block, err = api.blockByHash(ctx, hash)
+	} else if number, ok := blockNrOrHash.Number(); ok {
+		if number == rpc.PendingBlockNumber {
+			// We don't have access to the miner here. For tracing 'future' transactions,
+			// it can be done with block- and state-overrides instead, which offers
+			// more flexibility and stability than trying to trace on 'pending', since
+			// the contents of 'pending' is unstable and probably not a true representation
+			// of what the next actual block is likely to contain.
+			return nil, errors.New("tracing on top of pending is not supported")
+		}
+		block, err = api.blockByNumber(ctx, number)
+	} else {
+		return nil, errors.New("invalid arguments; neither block nor hash specified")
+	}
+	if err != nil {
+		return nil, err
+	}
+	return block, nil
+}
+
 // TraceConfig holds extra parameters to trace functions.
 type TraceConfig struct {
 	*logger.Config
@@ -176,9 +204,9 @@ type StdTraceConfig struct {
 
 // txTraceResult is the result of a single transaction trace.
 type txTraceResult struct {
-	TxHash common.Hash `json:"txHash"`           // transaction hash
-	Result interface{} `json:"result,omitempty"` // Trace results produced by the tracer
-	Error  string      `json:"error,omitempty"`  // Trace failure produced by the tracer
+	TxHash *common.Hash `json:"txHash,omitempty"` // transaction hash
+	Result interface{}  `json:"result,omitempty"` // Trace results produced by the tracer
+	Error  string       `json:"error,omitempty"`  // Trace failure produced by the tracer
 }
 
 // blockTraceTask represents a single block trace task when an entire chain is
@@ -279,13 +307,15 @@ func (api *API) traceChain(start, end *types.Block, config *TraceConfig, closed 
 					}
 					res, err := api.traceTx(ctx, msg, txctx, blockCtx, task.statedb, config)
 					if err != nil {
-						task.results[i] = &txTraceResult{TxHash: tx.Hash(), Error: err.Error()}
+						txHash := tx.Hash()
+						task.results[i] = &txTraceResult{TxHash: &txHash, Error: err.Error()}
 						log.Warn("Tracing failed", "hash", tx.Hash(), "block", task.block.NumberU64(), "err", err)
 						break
 					}
 					// Only delete empty objects if EIP158/161 (a.k.a Spurious Dragon) is in effect
 					task.statedb.Finalise(api.backend.ChainConfig().IsEIP158(task.block.Number()))
-					task.results[i] = &txTraceResult{TxHash: tx.Hash(), Result: res}
+					txHash := tx.Hash()
+					task.results[i] = &txTraceResult{TxHash: &txHash, Result: res}
 				}
 				// Tracing state is used up, queue it for de-referencing. Note the
 				// state is the parent state of trace block, use block.number-1 as
@@ -616,7 +646,8 @@ func (api *API) traceBlock(ctx context.Context, block *types.Block, config *Trac
 		if err != nil {
 			return nil, err
 		}
-		results[i] = &txTraceResult{TxHash: tx.Hash(), Result: res}
+		txHash := tx.Hash()
+		results[i] = &txTraceResult{TxHash: &txHash, Result: res}
 		// Finalize the state so any modifications are written to the trie
 		// Only delete empty objects if EIP158/161 (a.k.a Spurious Dragon) is in effect
 		statedb.Finalise(is158)
@@ -657,10 +688,12 @@ func (api *API) traceBlockParallel(ctx context.Context, block *types.Block, stat
 				}
 				res, err := api.traceTx(ctx, msg, txctx, blockCtx, task.statedb, config)
 				if err != nil {
-					results[task.index] = &txTraceResult{TxHash: txs[task.index].Hash(), Error: err.Error()}
+					txHash := txs[task.index].Hash()
+					results[task.index] = &txTraceResult{TxHash: &txHash, Error: err.Error()}
 					continue
 				}
-				results[task.index] = &txTraceResult{TxHash: txs[task.index].Hash(), Result: res}
+				txHash := txs[task.index].Hash()
+				results[task.index] = &txTraceResult{TxHash: &txHash, Result: res}
 			}
 		}()
 	}
@@ -866,25 +899,7 @@ func (api *API) TraceTransaction(ctx context.Context, hash common.Hash, config *
 // top of the provided block and returns them as a JSON object.
 func (api *API) TraceCall(ctx context.Context, args ethapi.TransactionArgs, blockNrOrHash rpc.BlockNumberOrHash, config *TraceCallConfig) (interface{}, error) {
 	// Try to retrieve the specified block
-	var (
-		err   error
-		block *types.Block
-	)
-	if hash, ok := blockNrOrHash.Hash(); ok {
-		block, err = api.blockByHash(ctx, hash)
-	} else if number, ok := blockNrOrHash.Number(); ok {
-		if number == rpc.PendingBlockNumber {
-			// We don't have access to the miner here. For tracing 'future' transactions,
-			// it can be done with block- and state-overrides instead, which offers
-			// more flexibility and stability than trying to trace on 'pending', since
-			// the contents of 'pending' is unstable and probably not a true representation
-			// of what the next actual block is likely to contain.
-			return nil, errors.New("tracing on top of pending is not supported")
-		}
-		block, err = api.blockByNumber(ctx, number)
-	} else {
-		return nil, errors.New("invalid arguments; neither block nor hash specified")
-	}
+	block, err := api.blockByNumberOrHash(ctx, blockNrOrHash)
 	if err != nil {
 		return nil, err
 	}
@@ -918,6 +933,59 @@ func (api *API) TraceCall(ctx context.Context, args ethapi.TransactionArgs, bloc
 		traceConfig = &config.TraceConfig
 	}
 	return api.traceTx(ctx, msg, new(Context), vmctx, statedb, traceConfig)
+}
+
+// TraceCallMany executes the given calls one after the other,
+// collects the structured logs created during the execution of EVM
+// and returns a number of possible traces for each of it.
+func (api *API) TraceCallMany(ctx context.Context, args []ethapi.TransactionArgs, blockNrOrHash rpc.BlockNumberOrHash, config *TraceCallConfig) ([]*txTraceResult, error) {
+	block, err := api.blockByNumberOrHash(ctx, blockNrOrHash)
+	if err != nil {
+		return nil, err
+	}
+	reexec := defaultTraceReexec
+	if config != nil && config.Reexec != nil {
+		reexec = *config.Reexec
+	}
+	statedb, release, err := api.backend.StateAtBlock(ctx, block, reexec, nil, true, false)
+	if err != nil {
+		return nil, err
+	}
+	defer release()
+
+	var traceConfig *TraceConfig
+	if config != nil {
+		traceConfig = &config.TraceConfig
+	}
+
+	var (
+		is158   = api.backend.ChainConfig().IsEIP158(block.Number())
+		results = make([]*txTraceResult, len(args))
+	)
+
+	vmctx := core.NewEVMBlockContext(block.Header(), api.chainContext(ctx), nil)
+	if config != nil {
+		if err := config.StateOverrides.Apply(statedb); err != nil {
+			return nil, err
+		}
+		config.BlockOverrides.Apply(&vmctx)
+	}
+	for i, arg := range args {
+		msg, err := arg.ToMessage(api.backend.RPCGasCap(), block.BaseFee())
+		if err != nil {
+			return nil, err
+		}
+		res, err := api.traceTx(ctx, msg, new(Context), vmctx, statedb, traceConfig)
+		if err != nil {
+			// If there's an error in tracing the transaction, return the error.
+			// This is because executing subsequent transactions in an erroneous state
+			// would not yield meaningful results.
+			return nil, err
+		}
+		results[i] = &txTraceResult{Result: res}
+		statedb.Finalise(is158)
+	}
+	return results, nil
 }
 
 // traceTx configures a new tracer according to the provided configuration, and

--- a/eth/tracers/api_test.go
+++ b/eth/tracers/api_test.go
@@ -320,6 +320,155 @@ func TestTraceCall(t *testing.T) {
 	}
 }
 
+func TestTraceCallMany(t *testing.T) {
+	t.Parallel()
+
+	// Initialize test accounts
+	accounts := newAccounts(3)
+	genesis := &core.Genesis{
+		Config: params.TestChainConfig,
+		Alloc: core.GenesisAlloc{
+			accounts[0].addr: {Balance: big.NewInt(params.Ether)},
+			accounts[1].addr: {Balance: big.NewInt(params.Ether)},
+			accounts[2].addr: {Balance: big.NewInt(params.Ether)},
+		},
+	}
+	genBlocks := 10
+	signer := types.HomesteadSigner{}
+	backend := newTestBackend(t, genBlocks, genesis, func(i int, b *core.BlockGen) {
+		// Transfer from account[0] to account[1]
+		//    value: 1000 wei
+		//    fee:   0 wei
+		tx, _ := types.SignTx(types.NewTransaction(uint64(i), accounts[1].addr, big.NewInt(1000), params.TxGas, b.BaseFee(), nil), signer, accounts[0].key)
+		b.AddTx(tx)
+	})
+	defer backend.teardown()
+	api := NewAPI(backend)
+	var testSuite = []struct {
+		blockNumber rpc.BlockNumber
+		calls       []ethapi.TransactionArgs
+		config      *TraceCallConfig
+		expectErr   error
+		expect      string
+	}{
+		// Standard JSON trace upon the genesis, plain transfer.
+		{
+			blockNumber: rpc.BlockNumber(0),
+			calls: []ethapi.TransactionArgs{
+				{
+					From:  &accounts[0].addr,
+					To:    &accounts[1].addr,
+					Value: (*hexutil.Big)(big.NewInt(1000)),
+				},
+				{
+					From:  &accounts[1].addr,
+					To:    &accounts[0].addr,
+					Value: (*hexutil.Big)(big.NewInt(1000)),
+				},
+			},
+			config:    nil,
+			expectErr: nil,
+			expect:    `[{"result":{"gas":21000,"failed":false,"returnValue":"","structLogs":[]}},{"result":{"gas":21000,"failed":false,"returnValue":"","structLogs":[]}}]`,
+		},
+		// Standard JSON trace upon the head, plain transfer.
+		{
+			blockNumber: rpc.BlockNumber(genBlocks),
+			calls: []ethapi.TransactionArgs{
+				{
+					From:  &accounts[0].addr,
+					To:    &accounts[1].addr,
+					Value: (*hexutil.Big)(big.NewInt(1000)),
+				},
+				{
+					From:  &accounts[1].addr,
+					To:    &accounts[0].addr,
+					Value: (*hexutil.Big)(big.NewInt(1000)),
+				},
+			},
+			config:    nil,
+			expectErr: nil,
+			expect:    `[{"result":{"gas":21000,"failed":false,"returnValue":"","structLogs":[]}},{"result":{"gas":21000,"failed":false,"returnValue":"","structLogs":[]}}]`,
+		},
+		// Standard JSON trace upon the non-existent block, error expects
+		{
+			blockNumber: rpc.BlockNumber(genBlocks + 1),
+			calls: []ethapi.TransactionArgs{
+				{
+					From:  &accounts[0].addr,
+					To:    &accounts[1].addr,
+					Value: (*hexutil.Big)(big.NewInt(1000)),
+				},
+			},
+			config:    nil,
+			expectErr: fmt.Errorf("block #%d not found", genBlocks+1),
+		},
+		// Standard JSON trace upon the latest block
+		{
+			blockNumber: rpc.LatestBlockNumber,
+			calls: []ethapi.TransactionArgs{
+				{
+					From:  &accounts[0].addr,
+					To:    &accounts[1].addr,
+					Value: (*hexutil.Big)(big.NewInt(1000)),
+				},
+			},
+			config:    nil,
+			expectErr: nil,
+			expect:    `[{"result":{"gas":21000,"failed":false,"returnValue":"","structLogs":[]}}]`,
+		},
+		// Tracing on 'pending' should fail:
+		{
+			blockNumber: rpc.PendingBlockNumber,
+			calls: []ethapi.TransactionArgs{
+				{
+					From:  &accounts[0].addr,
+					To:    &accounts[1].addr,
+					Value: (*hexutil.Big)(big.NewInt(1000)),
+				},
+			},
+			config:    nil,
+			expectErr: errors.New("tracing on top of pending is not supported"),
+		},
+		// Tracing with BlockOverrides
+		{
+			blockNumber: rpc.LatestBlockNumber,
+			calls: []ethapi.TransactionArgs{
+				{
+					From:  &accounts[0].addr,
+					Input: &hexutil.Bytes{0x43}, // blocknumber
+				},
+			},
+			config: &TraceCallConfig{
+				BlockOverrides: &ethapi.BlockOverrides{Number: (*hexutil.Big)(big.NewInt(0x1337))},
+			},
+			expectErr: nil,
+			expect:    `[{"result":{"gas":53018,"failed":false,"returnValue":"","structLogs":[{"pc":0,"op":"NUMBER","gas":24946984,"gasCost":2,"depth":1,"stack":[]},{"pc":1,"op":"STOP","gas":24946982,"gasCost":0,"depth":1,"stack":["0x1337"]}]}}]`,
+		},
+	}
+	for i, testspec := range testSuite {
+		result, err := api.TraceCallMany(context.Background(), testspec.calls, rpc.BlockNumberOrHash{BlockNumber: &testspec.blockNumber}, testspec.config)
+		if testspec.expectErr != nil {
+			if err == nil {
+				t.Errorf("test %d: expect error %v, got nothing", i, testspec.expectErr)
+				continue
+			}
+			if !reflect.DeepEqual(err, testspec.expectErr) {
+				t.Errorf("test %d: error mismatch, want %v, git %v", i, testspec.expectErr, err)
+			}
+			continue
+		}
+		if err != nil {
+			t.Errorf("test %d, want no error, have %v", i, err)
+			continue
+		}
+		have, _ := json.Marshal(result)
+		expect := testspec.expect
+		if string(have) != expect {
+			t.Errorf("test %d, result mismatch, have\n%v\n, expect\n%v\n", i, string(have), expect)
+		}
+	}
+}
+
 func TestTraceTransaction(t *testing.T) {
 	t.Parallel()
 
@@ -874,7 +1023,7 @@ func TestTraceChain(t *testing.T) {
 				t.Fatalf("unexpected result length, have %d want %d", have, want)
 			}
 			for _, trace := range result.Traces {
-				trace.TxHash = common.Hash{}
+				trace.TxHash = &common.Hash{}
 				blob, _ := json.Marshal(trace)
 				if have, want := string(blob), single; have != want {
 					t.Fatalf("unexpected tracing result, have\n%v\nwant:\n%v", have, want)

--- a/internal/web3ext/web3ext.go
+++ b/internal/web3ext/web3ext.go
@@ -438,6 +438,12 @@ web3._extend({
 			inputFormatter: [null, null, null]
 		}),
 		new web3._extend.Method({
+			name: 'traceCallMany',
+			call: 'debug_traceCallMany',
+			params: 3,
+			inputFormatter: [null, null, null]
+		}),
+		new web3._extend.Method({
 			name: 'preimage',
 			call: 'debug_preimage',
 			params: 1,


### PR DESCRIPTION
This PR introduces a new rpc method `debug_traceCallMany` which executes a series of transactions one after the other, collects the structured logs created during the execution of the EVM, and returns a number of possible traces for each transaction.

The `debug_traceCallMany`  enhances the tracing capabilities of our API, allowing users to trace multiple transactions in a single call. This can be particularly useful for debugging complex interactions between multiple transactions.

The defining feature of `debug_traceCallMany` is its sequential execution of transactions, where each transaction is executed based on the final state of the preceding one, thereby creating a cumulative effect on the state.

The primary use case for this feature is pre-execution checks in wallets. When a user wants to understand the potential asset changes from interacting with an unauthorized contract, `debug_traceCall` requires the user to approve the contract before it can estimate the user's asset changes, which introduces potential risks. However, with `debug_traceCallMany`, there's no need for the user to approve the contract to make an estimate (the user's contract approval just needs to be passed in as a preceding transaction). In fact, the pre-transaction balance change feature in Rabby Wallet is based on this method.