### PR TITLE
graphql: fix race in withdrawals test

### DIFF
--- a/graphql/graphql_test.go
+++ b/graphql/graphql_test.go
@@ -445,18 +445,20 @@ func newGQLService(t *testing.T, stack *node.Node, shanghai bool, gspec *core.Ge
 		TrieTimeout:    60 * time.Minute,
 		SnapshotCache:  5,
 	}
-	ethBackend, err := eth.New(stack, ethConf)
-	if err != nil {
-		t.Fatalf("could not create eth backend: %v", err)
-	}
 	var engine consensus.Engine = ethash.NewFaker()
 	if shanghai {
 		engine = beacon.NewFaker()
 		chainCfg := gspec.Config
 		chainCfg.TerminalTotalDifficultyPassed = true
 		chainCfg.TerminalTotalDifficulty = common.Big0
-		shanghaiTime := uint64(0)
+		// GenerateChain will increment timestamps by 10.
+		// Shanghai upgrade at block 1.
+		shanghaiTime := uint64(5)
 		chainCfg.ShanghaiTime = &shanghaiTime
+	}
+	ethBackend, err := eth.New(stack, ethConf)
+	if err != nil {
+		t.Fatalf("could not create eth backend: %v", err)
 	}
 	// Create some blocks and import them
 	chain, _ := core.GenerateChain(params.AllEthashProtocolChanges, ethBackend.BlockChain().Genesis(),


### PR DESCRIPTION
Log of the race:

```console
==================
WARNING: DATA RACE
Write at 0x00010267cf48 by goroutine 30:
  github.com/ethereum/go-ethereum/graphql.newGQLService()
      /Users/sina/dev/go/src/github.com/ethereum/go-ethereum/graphql/graphql_test.go:457 +0x31d
  github.com/ethereum/go-ethereum/graphql.TestWithdrawals()
      /Users/sina/dev/go/src/github.com/ethereum/go-ethereum/graphql/graphql_test.go:383 +0x4b1
  testing.tRunner()
      /usr/local/Cellar/go/1.19.3/libexec/src/testing/testing.go:1446 +0x216
  testing.(*T).Run.func1()
      /usr/local/Cellar/go/1.19.3/libexec/src/testing/testing.go:1493 +0x47

Previous read at 0x00010267cf48 by goroutine 44:
  github.com/ethereum/go-ethereum/consensus/beacon.IsTTDReached()
      /Users/sina/dev/go/src/github.com/ethereum/go-ethereum/consensus/beacon/consensus.go:457 +0x64
  github.com/ethereum/go-ethereum/consensus/beacon.(*Beacon).Prepare()
      /Users/sina/dev/go/src/github.com/ethereum/go-ethereum/consensus/beacon/consensus.go:331 +0x116
  github.com/ethereum/go-ethereum/miner.(*worker).prepareWork()
      /Users/sina/dev/go/src/github.com/ethereum/go-ethereum/miner/worker.go:885 +0xa3e
  github.com/ethereum/go-ethereum/miner.(*worker).commitWork()
      /Users/sina/dev/go/src/github.com/ethereum/go-ethereum/miner/worker.go:975 +0x1b1
  github.com/ethereum/go-ethereum/miner.(*worker).mainLoop()
      /Users/sina/dev/go/src/github.com/ethereum/go-ethereum/miner/worker.go:515 +0x6e5
  github.com/ethereum/go-ethereum/miner.newWorker.func1()
      /Users/sina/dev/go/src/github.com/ethereum/go-ethereum/miner/worker.go:281 +0x39

Goroutine 30 (running) created at:
  testing.(*T).Run()
      /usr/local/Cellar/go/1.19.3/libexec/src/testing/testing.go:1493 +0x75d
  testing.runTests.func1()
      /usr/local/Cellar/go/1.19.3/libexec/src/testing/testing.go:1846 +0x99
  testing.tRunner()
      /usr/local/Cellar/go/1.19.3/libexec/src/testing/testing.go:1446 +0x216
  testing.runTests()
      /usr/local/Cellar/go/1.19.3/libexec/src/testing/testing.go:1844 +0x7ec
  testing.(*M).Run()
      /usr/local/Cellar/go/1.19.3/libexec/src/testing/testing.go:1726 +0xa84
  main.main()
      _testmain.go:57 +0x2e9

Goroutine 44 (running) created at:
  github.com/ethereum/go-ethereum/miner.newWorker()
      /Users/sina/dev/go/src/github.com/ethereum/go-ethereum/miner/worker.go:281 +0xdf3
  github.com/ethereum/go-ethereum/miner.New()
      /Users/sina/dev/go/src/github.com/ethereum/go-ethereum/miner/miner.go:92 +0x111
  github.com/ethereum/go-ethereum/eth.New()
      /Users/sina/dev/go/src/github.com/ethereum/go-ethereum/eth/backend.go:234 +0x21d7
  github.com/ethereum/go-ethereum/graphql.newGQLService()
      /Users/sina/dev/go/src/github.com/ethereum/go-ethereum/graphql/graphql_test.go:448 +0x1c4
  github.com/ethereum/go-ethereum/graphql.TestWithdrawals()
      /Users/sina/dev/go/src/github.com/ethereum/go-ethereum/graphql/graphql_test.go:383 +0x4b1
  testing.tRunner()
      /usr/local/Cellar/go/1.19.3/libexec/src/testing/testing.go:1446 +0x216
  testing.(*T).Run.func1()
      /usr/local/Cellar/go/1.19.3/libexec/src/testing/testing.go:1493 +0x47
==================
```

Happened because we modified the chain config after passing it to `eth.New`. At some point the miner reads `TotalTerminalDifficulty` and that's the race.