### PR TITLE
internal: fast exit if getTxReceipt notfound

### DIFF
--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -1681,7 +1681,7 @@ func (s *TransactionAPI) GetRawTransactionByHash(ctx context.Context, hash commo
 // GetTransactionReceipt returns the transaction receipt for the given transaction hash.
 func (s *TransactionAPI) GetTransactionReceipt(ctx context.Context, hash common.Hash) (map[string]interface{}, error) {
 	tx, blockHash, blockNumber, index, err := s.b.GetTransaction(ctx, hash)
-	if err != nil {
+	if tx == nil || err != nil {
 		// When the transaction doesn't exist, the RPC method should return JSON null
 		// as per specification.
 		return nil, nil


### PR DESCRIPTION
In the eth backend, the `GetTransaction` will always return nil error, but the tx maybe is null, so we don't have to continue the following logic if tx notfound


https://github.com/ethereum/go-ethereum/blob/4b06e4f25e9a97880ddf834b571b05a59fa1290c/eth/api_backend.go#L316-L319