### PR TITLE
rpc: make websocket ping interval shorter than pong timeout

### DIFF
--- a/rpc/websocket.go
+++ b/rpc/websocket.go
@@ -35,7 +35,7 @@ import (
 const (
 	wsReadBuffer       = 1024
 	wsWriteBuffer      = 1024
-	wsPingInterval     = 30 * time.Second
+	wsPingInterval     = (wsPongTimeout * 9) / 10
 	wsPingWriteTimeout = 5 * time.Second
 	wsPongTimeout      = 30 * time.Second
 	wsMessageSizeLimit = 32 * 1024 * 1024


### PR DESCRIPTION
With the current ping/pong configuration, after the client establishes a websocket connection with the server, if the two do not send any message for a long time, a read error will occur on the server so that the server will disconnect the connection.

This PR adjusts the websocket ping interval according to the [official example](https://github.com/gorilla/websocket/blob/main/examples/chat/client.go#L24) of the websocket to fix the bug.