### PR TITLE
cmd/evm/testdata: fix typos in docs

### DIFF
--- a/cmd/evm/testdata/3/readme.md
+++ b/cmd/evm/testdata/3/readme.md
@@ -1,2 +1,2 @@
-These files exemplify a transition where a transaction (excuted on block 5) requests
+These files exemplify a transition where a transaction (executed on block 5) requests
 the blockhash for block `1`. 

--- a/cmd/evm/testdata/4/readme.md
+++ b/cmd/evm/testdata/4/readme.md
@@ -1,3 +1,3 @@
-These files exemplify a transition where a transaction (excuted on block 5) requests
+These files exemplify a transition where a transaction (executed on block 5) requests
 the blockhash for block `4`, but where the hash for that block is missing. 
 It's expected that executing these should cause `exit` with errorcode `4`.

--- a/cmd/evm/testdata/8/readme.md
+++ b/cmd/evm/testdata/8/readme.md
@@ -7,7 +7,7 @@ This test contains testcases for EIP-2930, which uses transactions with access l
 The alloc portion contains one contract (`0x000000000000000000000000000000000000aaaa`), containing the 
 following code: `0x5854505854`: `PC ;SLOAD; POP; PC; SLOAD`.
 
-Essentialy, this contract does `SLOAD(0)` and `SLOAD(3)`.
+Essentially, this contract does `SLOAD(0)` and `SLOAD(3)`.
 
 The alloc also contains some funds on `0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b`. 
 

--- a/cmd/evm/testdata/9/readme.md
+++ b/cmd/evm/testdata/9/readme.md
@@ -7,7 +7,7 @@ This test contains testcases for EIP-1559, which uses an new transaction type an
 The alloc portion contains one contract (`0x000000000000000000000000000000000000aaaa`), containing the 
 following code: `0x58585454`: `PC; PC; SLOAD; SLOAD`.
 
-Essentialy, this contract does `SLOAD(0)` and `SLOAD(1)`.
+Essentially, this contract does `SLOAD(0)` and `SLOAD(1)`.
 
 The alloc also contains some funds on `0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b`. 
 


### PR DESCRIPTION
Hey :wave:,

This PR will fix :

1 typo in `cmd/evm/testdata/3/readme.md`
1 typo in `cmd/evm/testdata/4/readme.md`
1 typo in `cmd/evm/testdata/8/readme.md`
1 typo in `cmd/evm/testdata/9/readme.md`


Best!