### PR TITLE
core: speed up chain tests by using leveldb

### DIFF
--- a/core/blockchain_repair_test.go
+++ b/core/blockchain_repair_test.go
@@ -1757,6 +1757,7 @@ func testRepair(t *testing.T, tt *rewindTest, snapshots bool) {
 	datadir := t.TempDir()
 
 	db, err := rawdb.Open(rawdb.OpenOptions{
+		Type:              "leveldb",
 		Directory:         datadir,
 		AncientsDirectory: datadir,
 	})
@@ -1833,6 +1834,7 @@ func testRepair(t *testing.T, tt *rewindTest, snapshots bool) {
 
 	// Start a new blockchain back up and see where the repair leads us
 	db, err = rawdb.Open(rawdb.OpenOptions{
+		Type:              "leveldb",
 		Directory:         datadir,
 		AncientsDirectory: datadir,
 	})
@@ -1892,6 +1894,7 @@ func TestIssue23496(t *testing.T) {
 	datadir := t.TempDir()
 
 	db, err := rawdb.Open(rawdb.OpenOptions{
+		Type:              "leveldb",
 		Directory:         datadir,
 		AncientsDirectory: datadir,
 	})
@@ -1956,6 +1959,7 @@ func TestIssue23496(t *testing.T) {
 
 	// Start a new blockchain back up and see where the repair leads us
 	db, err = rawdb.Open(rawdb.OpenOptions{
+		Type:              "leveldb",
 		Directory:         datadir,
 		AncientsDirectory: datadir,
 	})

--- a/core/blockchain_sethead_test.go
+++ b/core/blockchain_sethead_test.go
@@ -1957,6 +1957,7 @@ func testSetHead(t *testing.T, tt *rewindTest, snapshots bool) {
 	datadir := t.TempDir()
 
 	db, err := rawdb.Open(rawdb.OpenOptions{
+		Type:              "leveldb",
 		Directory:         datadir,
 		AncientsDirectory: datadir,
 	})

--- a/core/blockchain_snapshot_test.go
+++ b/core/blockchain_snapshot_test.go
@@ -62,6 +62,7 @@ func (basic *snapshotTestBasic) prepare(t *testing.T) (*BlockChain, []*types.Blo
 	datadir := t.TempDir()
 
 	db, err := rawdb.Open(rawdb.OpenOptions{
+		Type:              "leveldb",
 		Directory:         datadir,
 		AncientsDirectory: datadir,
 	})
@@ -254,6 +255,7 @@ func (snaptest *crashSnapshotTest) test(t *testing.T) {
 
 	// Start a new blockchain back up and see where the repair leads us
 	newdb, err := rawdb.Open(rawdb.OpenOptions{
+		Type:              "leveldb",
 		Directory:         snaptest.datadir,
 		AncientsDirectory: snaptest.datadir,
 	})


### PR DESCRIPTION
This PR replaces the pebble with leveldb in chain tests, which can
speed up the test a lot.

e.g. running test suite in file `blockchain_repair_test` with leveldb
takes 50s, while pebble takes 2m45s, roughly 3 times slower.


However, further investigation is required why pebble is a lot slower.