### PR TITLE
trie: reduce allocs in recHash

### DIFF
--- a/trie/encoding.go
+++ b/trie/encoding.go
@@ -53,7 +53,7 @@ func hexToCompact(hex []byte) []byte {
 
 // hexToCompactInPlace places the compact key in input buffer, returning the length
 // needed for the representation
-func hexToCompactInPlace(hex []byte) int {
+func hexToCompactInPlace(hex []byte) []byte {
 	var (
 		hexLen    = len(hex) // length of the hex input
 		firstByte = byte(0)
@@ -77,7 +77,7 @@ func hexToCompactInPlace(hex []byte) int {
 		hex[bi] = hex[ni]<<4 | hex[ni+1]
 	}
 	hex[0] = firstByte
-	return binLen
+	return hex[:binLen]
 }
 
 func compactToHex(compact []byte) []byte {

--- a/trie/encoding.go
+++ b/trie/encoding.go
@@ -51,8 +51,7 @@ func hexToCompact(hex []byte) []byte {
 	return buf
 }
 
-// hexToCompactInPlace places the compact key in input buffer, returning the length
-// needed for the representation
+// hexToCompactInPlace places the compact key in input buffer, returning the compacted key.
 func hexToCompactInPlace(hex []byte) []byte {
 	var (
 		hexLen    = len(hex) // length of the hex input

--- a/trie/encoding_test.go
+++ b/trie/encoding_test.go
@@ -86,8 +86,7 @@ func TestHexToCompactInPlace(t *testing.T) {
 	} {
 		hexBytes, _ := hex.DecodeString(key)
 		exp := hexToCompact(hexBytes)
-		sz := hexToCompactInPlace(hexBytes)
-		got := hexBytes[:sz]
+		got := hexToCompactInPlace(hexBytes)
 		if !bytes.Equal(exp, got) {
 			t.Fatalf("test %d: encoding err\ninp %v\ngot %x\nexp %x\n", i, key, got, exp)
 		}
@@ -102,8 +101,7 @@ func TestHexToCompactInPlaceRandom(t *testing.T) {
 		hexBytes := keybytesToHex(key)
 		hexOrig := []byte(string(hexBytes))
 		exp := hexToCompact(hexBytes)
-		sz := hexToCompactInPlace(hexBytes)
-		got := hexBytes[:sz]
+		got := hexToCompactInPlace(hexBytes)
 
 		if !bytes.Equal(exp, got) {
 			t.Fatalf("encoding err \ncpt %x\nhex %x\ngot %x\nexp %x\n",
@@ -116,6 +114,13 @@ func BenchmarkHexToCompact(b *testing.B) {
 	testBytes := []byte{0, 15, 1, 12, 11, 8, 16 /*term*/}
 	for i := 0; i < b.N; i++ {
 		hexToCompact(testBytes)
+	}
+}
+
+func BenchmarkHexToCompactInPlace(b *testing.B) {
+	testBytes := []byte{0, 15, 1, 12, 11, 8, 16 /*term*/}
+	for i := 0; i < b.N; i++ {
+		hexToCompactInPlace(testBytes)
 	}
 }
 

--- a/trie/stacktrie.go
+++ b/trie/stacktrie.go
@@ -444,7 +444,7 @@ func (st *StackTrie) hashRec(hasher *hasher, path []byte) {
 	case extNode:
 		st.children[0].hashRec(hasher, append(path, st.key...))
 
-		n := shortNode{Key: hexToCompact(st.key)}
+		n := shortNode{Key: hexToCompactInPlace(st.key)}
 		if len(st.children[0].val) < 32 {
 			n.Val = rawNode(st.children[0].val)
 		} else {
@@ -460,7 +460,7 @@ func (st *StackTrie) hashRec(hasher *hasher, path []byte) {
 
 	case leafNode:
 		st.key = append(st.key, byte(16))
-		n := shortNode{Key: hexToCompact(st.key), Val: valueNode(st.val)}
+		n := shortNode{Key: hexToCompactInPlace(st.key), Val: valueNode(st.val)}
 
 		n.encode(hasher.encbuf)
 		encodedNode = hasher.encodedBytes()


### PR DESCRIPTION
Reduces allocations in recHash.
I noticed during profiling, that a lot of allocations (3.8% of total) is spent on hexToCompact. This uses the existing HexToCompactInPlace to reduce allocations. 
Since we reset the key anyway after this operation, it should be fine imo

```
ROUTINE ======================== github.com/ethereum/go-ethereum/trie.keybytesToHex in github.com/ethereum/go-ethereum/trie/encoding.go
 150455888  150455888 (flat, cum)  3.22% of Total
         .          .     97:func keybytesToHex(str []byte) []byte {
         .          .     98:    l := len(str)*2 + 1
 150455888  150455888     99:    var nibbles = make([]byte, l)
         .          .    100:    for i, b := range str {
         .          .    101:        nibbles[i*2] = b / 16
         .          .    102:        nibbles[i*2+1] = b % 16
         .          .    103:    }
         .          .    104:    nibbles[l-1] = 16
(pprof) list hexTo    
Total: 4677552141
ROUTINE ======================== github.com/ethereum/go-ethereum/trie.hexToCompact in github.com/ethereum/go-ethereum/trie/encoding.go
 178393826  178393826 (flat, cum)  3.81% of Total
         .          .     37:func hexToCompact(hex []byte) []byte {
         .          .     38:    terminator := byte(0)
         .          .     39:    if hasTerm(hex) {
         .          .     40:        terminator = 1
         .          .     41:        hex = hex[:len(hex)-1]
         .          .     42:    }
 178393826  178393826     43:    buf := make([]byte, len(hex)/2+1)
         .          .     44:    buf[0] = terminator << 5 // the flag byte
         .          .     45:    if len(hex)&1 == 1 {
         .          .     46:        buf[0] |= 1 << 4 // odd flag
         .          .     47:        buf[0] |= hex[0] // first nibble is contained in the first byte
         .          .     48:        hex = hex[1:]
```

Benchmarks:
```
BenchmarkHexToCompact-24    	94361824	        21.67 ns/op	       4 B/op	       1 allocs/op
BenchmarkHexToCompactInPlace-24    	285524278	         4.462 ns/op	       0 B/op	       0 allocs/op
```