### PR TITLE
fix: missing close udp connection

### DIFF
--- a/cmd/bootnode/main.go
+++ b/cmd/bootnode/main.go
@@ -108,6 +108,7 @@ func main() {
 	if err != nil {
 		utils.Fatalf("-ListenUDP: %v", err)
 	}
+	defer conn.Close()
 
 	db, _ := enode.OpenDB("")
 	ln := enode.NewLocalNode(db, nodeKey)


### PR DESCRIPTION
# Description
To avoid the `port already listening` error when restarting a node, it's recommended to use a defer statement to close the UDP connection when the node goes into shutdown. This way, when the node is booted again, the error won't be encountered.

# Changes
- [x] Bugfix (non-breaking change that solves an issue)