### PR TITLE
eth: remove check for tdd reached on pos api block tags

### DIFF
--- a/eth/api_backend.go
+++ b/eth/api_backend.go
@@ -90,7 +90,6 @@ func (b *EthAPIBackend) HeaderByNumber(ctx context.Context, number rpc.BlockNumb
 			return nil, errors.New("safe block not found")
 		}
 		return block, nil
-
 	}
 	return b.eth.blockchain.GetHeaderByNumber(uint64(number)), nil
 }

--- a/eth/api_backend.go
+++ b/eth/api_backend.go
@@ -78,24 +78,19 @@ func (b *EthAPIBackend) HeaderByNumber(ctx context.Context, number rpc.BlockNumb
 		return b.eth.blockchain.CurrentBlock(), nil
 	}
 	if number == rpc.FinalizedBlockNumber {
-		if !b.eth.Merger().TDDReached() {
-			return nil, errors.New("'finalized' tag not supported on pre-merge network")
-		}
 		block := b.eth.blockchain.CurrentFinalBlock()
-		if block != nil {
-			return block, nil
+		if block == nil {
+			return nil, errors.New("finalized block not found")
 		}
-		return nil, errors.New("finalized block not found")
+		return block, nil
 	}
 	if number == rpc.SafeBlockNumber {
-		if !b.eth.Merger().TDDReached() {
-			return nil, errors.New("'safe' tag not supported on pre-merge network")
-		}
 		block := b.eth.blockchain.CurrentSafeBlock()
-		if block != nil {
-			return block, nil
+		if block == nil {
+			return nil, errors.New("safe block not found")
 		}
-		return nil, errors.New("safe block not found")
+		return block, nil
+
 	}
 	return b.eth.blockchain.GetHeaderByNumber(uint64(number)), nil
 }
@@ -136,9 +131,6 @@ func (b *EthAPIBackend) BlockByNumber(ctx context.Context, number rpc.BlockNumbe
 		return b.eth.blockchain.GetBlock(header.Hash(), header.Number.Uint64()), nil
 	}
 	if number == rpc.FinalizedBlockNumber {
-		if !b.eth.Merger().TDDReached() {
-			return nil, errors.New("'finalized' tag not supported on pre-merge network")
-		}
 		header := b.eth.blockchain.CurrentFinalBlock()
 		if header == nil {
 			return nil, errors.New("finalized block not found")
@@ -146,9 +138,6 @@ func (b *EthAPIBackend) BlockByNumber(ctx context.Context, number rpc.BlockNumbe
 		return b.eth.blockchain.GetBlock(header.Hash(), header.Number.Uint64()), nil
 	}
 	if number == rpc.SafeBlockNumber {
-		if !b.eth.Merger().TDDReached() {
-			return nil, errors.New("'safe' tag not supported on pre-merge network")
-		}
 		header := b.eth.blockchain.CurrentSafeBlock()
 		if header == nil {
 			return nil, errors.New("safe block not found")


### PR DESCRIPTION
We're dealing with a bit of a problem over in [rpctestgen](https://github.com/lightclient/rpctestgen/pull/21#discussion_r1270725621) where we would like to generate some rpc test interactions using the `safe` and `finalized` block tags, but it is not currently possible without making some Engine API requests.

This is a relatively specialized use case, but the error returned is sort of incorrect here when a genesis has `terminalTotalDifficultyPassed` set in genesis: `'xxxxx' tag not supported on pre-merge network`. Now it will return `nil` if the network is pre-merge or the network is post-merge but we haven't determined which block is `safe` / `final` yet. This behavior seems more correct.