### PR TITLE
cmd/geth: disable automaxprocs log

### DIFF
--- a/cmd/geth/main.go
+++ b/cmd/geth/main.go
@@ -243,6 +243,7 @@ func init() {
 	)
 
 	app.Before = func(ctx *cli.Context) error {
+		maxprocs.Set() // Automatically set GOMAXPROCS to match Linux container CPU quota.
 		flags.MigrateGlobalFlags(ctx)
 		return debug.Setup(ctx)
 	}
@@ -323,9 +324,6 @@ func geth(ctx *cli.Context) error {
 	if args := ctx.Args().Slice(); len(args) > 0 {
 		return fmt.Errorf("invalid command: %q", args[0])
 	}
-
-	// Automatically set GOMAXPROCS to match Linux container CPU quota.
-	maxprocs.Set()
 
 	prepare(ctx)
 	stack, backend := makeFullNode(ctx)

--- a/cmd/geth/main.go
+++ b/cmd/geth/main.go
@@ -325,7 +325,7 @@ func geth(ctx *cli.Context) error {
 	}
 
 	// Automatically set GOMAXPROCS to match Linux container CPU quota.
-	maxprocs.Set(maxprocs.Logger(func(string, ...interface{}) {}))
+	maxprocs.Set()
 
 	prepare(ctx)
 	stack, backend := makeFullNode(ctx)

--- a/cmd/geth/main.go
+++ b/cmd/geth/main.go
@@ -39,13 +39,11 @@ import (
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/metrics"
 	"github.com/ethereum/go-ethereum/node"
+	"go.uber.org/automaxprocs/maxprocs"
 
 	// Force-load the tracer engines to trigger registration
 	_ "github.com/ethereum/go-ethereum/eth/tracers/js"
 	_ "github.com/ethereum/go-ethereum/eth/tracers/native"
-
-	// Automatically set GOMAXPROCS to match Linux container CPU quota.
-	_ "go.uber.org/automaxprocs"
 
 	"github.com/urfave/cli/v2"
 )
@@ -325,6 +323,9 @@ func geth(ctx *cli.Context) error {
 	if args := ctx.Args().Slice(); len(args) > 0 {
 		return fmt.Errorf("invalid command: %q", args[0])
 	}
+
+	// Automatically set GOMAXPROCS to match Linux container CPU quota.
+	maxprocs.Set(maxprocs.Logger(func(string, ...interface{}) {}))
 
 	prepare(ctx)
 	stack, backend := makeFullNode(ctx)


### PR DESCRIPTION
Disable the annoying automaxproc logs

eg: 

```bash
$ ./build/bin/geth --version

2023/07/31 14:30:26 maxprocs: Leaving GOMAXPROCS=8: CPU quota undefined
geth version 1.12.1-unstable-xyz
```

Ref https://github.com/uber-go/automaxprocs/issues/18

And we only set CPU limit in geth main process
