### PR TITLE
internal/ethapi: reduce hi and low range on DoEstimateGas

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,7 @@ profile.cov
 
 # IdeaIDE
 .idea
+*.iml
 
 # VS Code
 .vscode


### PR DESCRIPTION
Perform a pre-check to see if `gasUsed` on the executable was enough.

Change the binary search to start with a lo of `gasUsed` and a hi of the theoretical max given the previous `gasUsed`. 
Then perform a binary search with curtailed bounds.