### PR TITLE
tests: make tests pass on windows/386

### DIFF
--- a/build/ci.go
+++ b/build/ci.go
@@ -299,6 +299,8 @@ func doTest(cmdline []string) {
 		tc.Root = build.DownloadGo(csdb, dlgoVersion)
 	}
 	gotest := tc.Go("test", "-tags=ckzg")
+	// CI needs a bit more time for the statetests (default 10m).
+	gotest.Args = append(gotest.Args, "-timeout=20m")
 
 	// Test a single package at a time. CI builders are slow
 	// and some tests run into timeouts under load.

--- a/tests/state_test.go
+++ b/tests/state_test.go
@@ -35,7 +35,24 @@ import (
 	"github.com/ethereum/go-ethereum/eth/tracers/logger"
 )
 
-func TestState(t *testing.T) {
+func TestStateCurrent(t *testing.T) {
+	testState(t, stateTestDir)
+}
+
+func TestStateLegacy(t *testing.T) {
+	// For Istanbul, older tests were moved into LegacyTests
+	testState(t, legacyStateTestDir)
+}
+
+func TestStateBenchmarks(t *testing.T) {
+	testState(t, benchmarksDir)
+}
+
+func TestStateFuture(t *testing.T) {
+	testState(t, filepath.Join(baseDir, "EIPTests", "StateTests"))
+}
+
+func testState(t *testing.T, dir string) {
 	t.Parallel()
 
 	st := new(testMatcher)
@@ -66,38 +83,30 @@ func TestState(t *testing.T) {
 	st.fails(`stEIP4844-blobtransactions/opcodeBlobhashOutOfRange.json`, "test has incorrect state root")
 	st.fails(`stEIP4844-blobtransactions/opcodeBlobhBounds.json`, "test has incorrect state root")
 
-	// For Istanbul, older tests were moved into LegacyTests
-	for _, dir := range []string{
-		filepath.Join(baseDir, "EIPTests", "StateTests"),
-		stateTestDir,
-		legacyStateTestDir,
-		benchmarksDir,
-	} {
-		st.walk(t, dir, func(t *testing.T, name string, test *StateTest) {
-			for _, subtest := range test.Subtests() {
-				subtest := subtest
-				key := fmt.Sprintf("%s/%d", subtest.Fork, subtest.Index)
+	st.walk(t, dir, func(t *testing.T, name string, test *StateTest) {
+		for _, subtest := range test.Subtests() {
+			subtest := subtest
+			key := fmt.Sprintf("%s/%d", subtest.Fork, subtest.Index)
 
-				t.Run(key+"/trie", func(t *testing.T) {
-					withTrace(t, test.gasLimit(subtest), func(vmconfig vm.Config) error {
-						_, _, err := test.Run(subtest, vmconfig, false)
-						return st.checkFailure(t, err)
-					})
+			t.Run(key+"/trie", func(t *testing.T) {
+				withTrace(t, test.gasLimit(subtest), func(vmconfig vm.Config) error {
+					_, _, err := test.Run(subtest, vmconfig, false)
+					return st.checkFailure(t, err)
 				})
-				t.Run(key+"/snap", func(t *testing.T) {
-					withTrace(t, test.gasLimit(subtest), func(vmconfig vm.Config) error {
-						snaps, statedb, err := test.Run(subtest, vmconfig, true)
-						if snaps != nil && statedb != nil {
-							if _, err := snaps.Journal(statedb.IntermediateRoot(false)); err != nil {
-								return err
-							}
+			})
+			t.Run(key+"/snap", func(t *testing.T) {
+				withTrace(t, test.gasLimit(subtest), func(vmconfig vm.Config) error {
+					snaps, statedb, err := test.Run(subtest, vmconfig, true)
+					if snaps != nil && statedb != nil {
+						if _, err := snaps.Journal(statedb.IntermediateRoot(false)); err != nil {
+							return err
 						}
-						return st.checkFailure(t, err)
-					})
+					}
+					return st.checkFailure(t, err)
 				})
-			}
-		})
-	}
+			})
+		}
+	})
 }
 
 // Transactions with gasLimit above this value will not get a VM trace on failure.


### PR DESCRIPTION
Our windows `386` builds are timing out on appveyor, on the individual test exceeding 10 minutes
```
panic: test timed out after 10m0s
running tests:
    TestState (10m0s)
    TestState/stLogTests/log4_MaxTopic.json (0s)
    TestState/stLogTests/log4_MaxTopic.json/London/0/trie (0s)
    TestState/stMemoryTest/buffer.json (14s)
    TestState/stMemoryTest/buffer.json/Merge/334/snap (0s)
```
This PR splits up the tests execution, might make it work again. 