### PR TITLE
[EthClient] Fixed nil dereferences at EthClient package

### DIFF
--- a/ethclient/ethclient.go
+++ b/ethclient/ethclient.go
@@ -247,6 +247,9 @@ func (ec *Client) TransactionByHash(ctx context.Context, hash common.Hash) (tx *
 // There is a fast-path for transactions retrieved by TransactionByHash and
 // TransactionInBlock. Getting their sender address can be done without an RPC interaction.
 func (ec *Client) TransactionSender(ctx context.Context, tx *types.Transaction, block common.Hash, index uint) (common.Address, error) {
+	if tx == nil {
+		return common.Address{}, errors.New("Transaction must not be nil")
+	}
 	// Try to load the address from the cache.
 	sender, err := types.Sender(&senderFromServer{blockhash: block}, tx)
 	if err == nil {
@@ -581,6 +584,9 @@ func (ec *Client) EstimateGas(ctx context.Context, msg ethereum.CallMsg) (uint64
 // If the transaction was a contract creation use the TransactionReceipt method to get the
 // contract address after the transaction has been mined.
 func (ec *Client) SendTransaction(ctx context.Context, tx *types.Transaction) error {
+	if tx == nil {
+		return errors.New("Transaction must not be nil")
+	}
 	data, err := tx.MarshalBinary()
 	if err != nil {
 		return err


### PR DESCRIPTION
This PR aims to address potential nil dereference issues and prevent crashes caused by invalid input. The changes made in this PR ensure that if a value is found to be nil, an appropriate error is returned instead of attempting to proceed with the nil value (crash). 