### PR TITLE
rpc: update win-library + use atomics

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.19
 
 require (
 	github.com/Azure/azure-sdk-for-go/sdk/storage/azblob v0.3.0
+	github.com/Ne0nd0g/npipe v1.1.0
 	github.com/VictoriaMetrics/fastcache v1.6.0
 	github.com/aws/aws-sdk-go-v2 v1.2.0
 	github.com/aws/aws-sdk-go-v2/config v1.1.1
@@ -70,7 +71,6 @@ require (
 	golang.org/x/time v0.3.0
 	golang.org/x/tools v0.9.1
 	gopkg.in/natefinch/lumberjack.v2 v2.0.0
-	gopkg.in/natefinch/npipe.v2 v2.0.0-20160621034901-c1b8fa8bdcce
 	gopkg.in/yaml.v3 v3.0.1
 )
 

--- a/go.sum
+++ b/go.sum
@@ -13,6 +13,8 @@ github.com/CloudyKit/jet/v3 v3.0.0/go.mod h1:HKQPgSJmdK8hdoAbKUUWajkHyHo4RaU5rMd
 github.com/DataDog/zstd v1.5.2 h1:vUG4lAyuPCXO0TLbXvPv7EB7cNK1QV/luu55UHLrrn8=
 github.com/DataDog/zstd v1.5.2/go.mod h1:g4AWEaM3yOg3HYfnJ3YIawPnVdXJh9QME85blwSAmyw=
 github.com/Joker/hpp v1.0.0/go.mod h1:8x5n+M1Hp5hC0g8okX3sR3vFQwynaX/UgSOM9MeBKzY=
+github.com/Ne0nd0g/npipe v1.1.0 h1:oTDJfD8yrr2BLGZpKEllCmeGpcbmx6LW1uuS2bxIBoM=
+github.com/Ne0nd0g/npipe v1.1.0/go.mod h1:GKyLKRkYambQuI9VIfMrz1Mf5hOGlEvZkhw1chph/IQ=
 github.com/Shopify/goreferrer v0.0.0-20181106222321-ec9c9a553398/go.mod h1:a1uqRtAwp2Xwc6WNPJEufxJ7fx3npB4UV/JOLmbu5I0=
 github.com/StackExchange/wmi v0.0.0-20180116203802-5d049714c4a6 h1:fLjPD/aNc3UIOA6tDi6QXUemppXK3P9BI7mr2hd6gx8=
 github.com/StackExchange/wmi v0.0.0-20180116203802-5d049714c4a6/go.mod h1:3eOhrUMpNV+6aFIbp5/iudMxNCF27Vw2OZgy4xEx0Fg=
@@ -653,8 +655,6 @@ gopkg.in/ini.v1 v1.51.1/go.mod h1:pNLf8WUiyNEtQjuu5G5vTm06TEv9tsIgeAvK8hOrP4k=
 gopkg.in/mgo.v2 v2.0.0-20180705113604-9856a29383ce/go.mod h1:yeKp02qBN3iKW1OzL3MGk2IdtZzaj7SFntXj72NppTA=
 gopkg.in/natefinch/lumberjack.v2 v2.0.0 h1:1Lc07Kr7qY4U2YPouBjpCLxpiyxIVoxqXgkXLknAOE8=
 gopkg.in/natefinch/lumberjack.v2 v2.0.0/go.mod h1:l0ndWWf7gzL7RNwBG7wST/UCcT4T24xpD6X8LsfU/+k=
-gopkg.in/natefinch/npipe.v2 v2.0.0-20160621034901-c1b8fa8bdcce h1:+JknDZhAj8YMt7GC73Ei8pv4MzjDUNPHgQWJdtMAaDU=
-gopkg.in/natefinch/npipe.v2 v2.0.0-20160621034901-c1b8fa8bdcce/go.mod h1:5AcXVHNjg+BDxry382+8OKon8SEWiKktQR07RKPsv1c=
 gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7 h1:uRGJdciOHaEIrze2W8Q3AKkepLTh2hOroT7a+7czfdQ=
 gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7/go.mod h1:dt/ZhP58zS4L8KSrWDmTeBkI65Dw0HsyUHuEVlX15mw=
 gopkg.in/yaml.v2 v2.2.1/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=

--- a/rpc/ipc_windows.go
+++ b/rpc/ipc_windows.go
@@ -24,7 +24,7 @@ import (
 	"net"
 	"time"
 
-	"gopkg.in/natefinch/npipe.v2"
+	"github.com/Ne0nd0g/npipe"
 )
 
 // This is used if the dialing context has no deadline. It is much smaller than the

--- a/rpc/testservice_test.go
+++ b/rpc/testservice_test.go
@@ -21,7 +21,7 @@ import (
 	"encoding/binary"
 	"errors"
 	"strings"
-	"sync"
+	"sync/atomic"
 	"time"
 )
 
@@ -38,16 +38,10 @@ func newTestServer() *Server {
 }
 
 func sequentialIDGenerator() func() ID {
-	var (
-		mu      sync.Mutex
-		counter uint64
-	)
+	var counter atomic.Uint64
 	return func() ID {
-		mu.Lock()
-		defer mu.Unlock()
-		counter++
 		id := make([]byte, 8)
-		binary.BigEndian.PutUint64(id, counter)
+		binary.BigEndian.PutUint64(id, counter.Add(1))
 		return encodeID(id)
 	}
 }


### PR DESCRIPTION
The windows named-pipe implementation hasn't been kept up to date for the last seven years, this PR switches it over to a somewhat more active fork. I want to see if it builds successfully on windows/386, which most often is failing with errors like 

```
panic: The handle is invalid.
goroutine 10385 [running]:
internal/poll.execIO(0xa5eedd4, 0xce9620)
	C:/Users/appveyor/AppData/Local/geth-go-1.20.6-windows-amd64/go/src/internal/poll/fd_windows.go:201 +0x44f
internal/poll.(*FD).Read(0xa5eedc0, {0xb1db000, 0x1000, 0x1000})
	C:/Users/appveyor/AppData/Local/geth-go-1.20.6-windows-amd64/go/src/internal/poll/fd_windows.go:436 +0x13b
net.(*netFD).Read(0xa5eedc0, {0xb1db000, 0x1000, 0x1000})
	C:/Users/appveyor/AppData/Local/geth-go-1.20.6-windows-amd64/go/src/net/fd_posix.go:55 +0x3f
net.(*conn).Read(0xb199728, {0xb1db000, 0x1000, 0x1000})
	C:/Users/appveyor/AppData/Local/geth-go-1.20.6-windows-amd64/go/src/net/net.go:183 +0x4f
net/http.(*persistConn).Read(0xa9e2780, {0xb1db000, 0x1000, 0x1000})
	C:/Users/appveyor/AppData/Local/geth-go-1.20.6-windows-amd64/go/src/net/http/transport.go:1943 +0x141
bufio.(*Reader).fill(0xa687170)
	C:/Users/appveyor/AppData/Local/geth-go-1.20.6-windows-amd64/go/src/bufio/bufio.go:106 +0xe9
bufio.(*Reader).Peek(0xa687170, 0x1)
	C:/Users/appveyor/AppData/Local/geth-go-1.20.6-windows-amd64/go/src/bufio/bufio.go:144 +0x6d
net/http.(*persistConn).readLoop(0xa9e2780)
	C:/Users/appveyor/AppData/Local/geth-go-1.20.6-windows-amd64/go/src/net/http/transport.go:2107 +0x1df
created by net/http.(*Transport).dialConn
	C:/Users/appveyor/AppData/Local/geth-go-1.20.6-windows-amd64/go/src/net/http/transport.go:1765 +0x1480
FAIL	github.com/ethereum/go-ethereum/rpc	14.792s

```
and
```
ok  	github.com/ethereum/go-ethereum/rlp/rlpgen	3.318s
runtime.preemptM: duplicatehandle failed; errno=6
fatal error: runtime.preemptM: duplicatehandle failed
runtime stack:
runtime.throw({0x132f707?, 0xffffffffffffffff?})
	C:/Users/appveyor/AppData/Local/geth-go-1.20.6-windows-amd64/go/src/runtime/panic.go:1047 +0x65 fp=0xd5731ff870 sp=0xd5731ff840 pc=0xe6a7e5
runtime.preemptM(0xd5731ffdf0?)
	C:/Users/appveyor/AppData/Local/geth-go-1.20.6-windows-amd64/go/src/runtime/os_windows.go:1345 +0x4a5 fp=0xd5731ffdd0 sp=0xd5731ff870 pc=0xe67f85
runtime.preemptone(0xc006023800?)
	C:/Users/appveyor/AppData/Local/geth-go-1.20.6-windows-amd64/go/src/runtime/proc.go:5572 +0x5e fp=0xd5731ffde8 sp=0xd5731ffdd0 pc=0xe788fe
runtime.preemptall()
	C:/Users/appveyor/AppData/Local/geth-go-1.20.6-windows-amd64/go/src/runtime/proc.go:5534 +0x55 fp=0xd5731ffe20 sp=0xd5731ffde8 pc=0xe78855
runtime.forEachP(0x1358c50)
	C:/Users/appveyor/AppData/Local/geth-go-1.20.6-windows-amd64/go/src/runtime/proc.go:1676 +0xdb fp=0xd5731ffe88 sp=0xd5731ffe20 pc=0xe6fe7b
runtime.gcMarkDone.func1()
	C:/U
```