### PR TITLE
core/txpool: drop the zero balance

### DIFF
--- a/core/txpool/validation.go
+++ b/core/txpool/validation.go
@@ -208,6 +208,9 @@ func ValidateTransactionWithState(tx *types.Transaction, signer types.Signer, op
 		balance = opts.State.GetBalance(from)
 		cost    = tx.Cost()
 	)
+	if balance.Sign() == 0 {
+		return fmt.Errorf("%w: balance 0", core.ErrInsufficientFunds)
+	}
 	if balance.Cmp(cost) < 0 {
 		return fmt.Errorf("%w: balance %v, tx cost %v, overshot %v", core.ErrInsufficientFunds, balance, cost, new(big.Int).Sub(cost, balance))
 	}


### PR DESCRIPTION
As the `tx.Cost()` equals to https://github.com/ethereum/go-ethereum/blob/7de748d3f62cec172ddf0dda110beca55648f306/core/types/transaction.go#L312

But someone maybe sends a tx with zero gasPrice and zero value so that the later check will be passed https://github.com/ethereum/go-ethereum/blob/7de748d3f62cec172ddf0dda110beca55648f306/core/txpool/validation.go#L211

But after EIP1559, a base fee should be always be paid out, if the EOA's balance is zero, we don't need to add this tx into txpool.
