### PR TITLE
abi: Update template and add ABI accessor functions to the BoundContract

### DIFF
--- a/accounts/abi/bind/base.go
+++ b/accounts/abi/bind/base.go
@@ -149,6 +149,25 @@ func DeployContract(opts *TransactOpts, abi abi.ABI, bytecode []byte, backend Co
 	return c.address, tx, c, nil
 }
 
+// Address returns the contract deployment address.
+func (c *BoundContract) Address() common.Address {
+	return c.address
+}
+
+// GetABI returns the contract ABI Object of the BoundContract.
+func (c *BoundContract) GetABI() abi.ABI {
+	return c.abi
+}
+
+// Method retrieves the ABI method with the given name.
+func (c *BoundContract) Method(name string) (*abi.Method, error) {
+	method, exist := c.abi.Methods[name]
+	if !exist {
+		return nil, fmt.Errorf("method '%s' not found", name)
+	}
+	return &method, nil
+}
+
 // Call invokes the (constant) contract method with params as input values and
 // sets the output to result. The result type might be a single field for simple
 // returns, a slice of interfaces for anonymous returns and a struct for named
@@ -213,10 +232,15 @@ func (c *BoundContract) Call(opts *CallOpts, results *[]interface{}, method stri
 	return c.abi.UnpackIntoInterface(res[0], method, output)
 }
 
+// Calldata returns the raw calldata to invoke a transact method with params.
+func (c *BoundContract) Calldata(method string, params ...interface{}) ([]byte, error) {
+	return c.abi.Pack(method, params...)
+}
+
 // Transact invokes the (paid) contract method with params as input values.
 func (c *BoundContract) Transact(opts *TransactOpts, method string, params ...interface{}) (*types.Transaction, error) {
 	// Otherwise pack up the parameters and invoke the contract
-	input, err := c.abi.Pack(method, params...)
+	input, err := c.Calldata(method, params...)
 	if err != nil {
 		return nil, err
 	}
@@ -409,6 +433,15 @@ func (c *BoundContract) transact(opts *TransactOpts, contract *common.Address, i
 		return nil, err
 	}
 	return signedTx, nil
+}
+
+// Event returns the event with the given name, or error if no such event exists.
+func (c *BoundContract) Event(name string) (*abi.Event, error) {
+	abiEvent, exist := c.abi.Events[name]
+	if !exist {
+		return nil, fmt.Errorf("event '%s' not found", name)
+	}
+	return &abiEvent, nil
 }
 
 // FilterLogs filters contract logs for past blocks, returning the necessary

--- a/accounts/abi/bind/template.go
+++ b/accounts/abi/bind/template.go
@@ -314,6 +314,13 @@ var (
 	}
 
 	{{range .Calls}}
+		// {{.Normalized.Name}}Method is a call to retrieve the method information 0x{{printf "%x" .Original.ID}}.
+		//
+		// Solidity: {{.Original.String}}
+		func (_{{$contract.Type}} *{{$contract.Type}}Caller) {{.Normalized.Name}}Method() (*abi.Method, error) {
+			return _{{$contract.Type}}.contract.Method("{{.Normalized.Name}}")
+		}
+	
 		// {{.Normalized.Name}} is a free data retrieval call binding the contract method 0x{{printf "%x" .Original.ID}}.
 		//
 		// Solidity: {{.Original.String}}
@@ -356,6 +363,20 @@ var (
 	{{end}}
 
 	{{range .Transacts}}
+		// {{.Normalized.Name}}Method is a call to retrieve the method information 0x{{printf "%x" .Original.ID}}.
+		//
+		// Solidity: {{.Original.String}}
+		func (_{{$contract.Type}} *{{$contract.Type}}Transactor) {{.Normalized.Name}}Method() (*abi.Method, error) {
+			return _{{$contract.Type}}.contract.Method("{{.Normalized.Name}}")
+		}
+
+		// {{.Normalized.Name}}Calldata is the abi packed data binding the contract method 0x{{printf "%x" .Original.ID}}.
+		//
+		// Solidity: {{.Original.String}}
+        func (_{{$contract.Type}} *{{$contract.Type}}Transactor) {{.Normalized.Name}}Calldata({{range $i, $_ := .Normalized.Inputs}}{{if ne $i 0}},{{end}} {{.Name}} {{bindtype .Type $structs}} {{end}}) ([]byte, error) {
+			return _{{$contract.Type}}.contract.Calldata("{{.Original.Name}}" {{range .Normalized.Inputs}}, {{.Name}}{{end}})
+		}
+		
 		// {{.Normalized.Name}} is a paid mutator transaction binding the contract method 0x{{printf "%x" .Original.ID}}.
 		//
 		// Solidity: {{.Original.String}}
@@ -493,6 +514,13 @@ var (
 		type {{$contract.Type}}{{.Normalized.Name}} struct { {{range .Normalized.Inputs}}
 			{{capitalise .Name}} {{if .Indexed}}{{bindtopictype .Type $structs}}{{else}}{{bindtype .Type $structs}}{{end}}; {{end}}
 			Raw types.Log // Blockchain specific contextual infos
+		}
+
+		// {{.Normalized.Name}}Event is a call to retrieve the event information.
+		//
+		// Solidity: {{.Original.String}}
+		func (_{{$contract.Type}} *{{$contract.Type}}Filterer) {{.Normalized.Name}}Event() (*abi.Event, error) {
+			return _{{$contract.Type}}.contract.Event("{{.Normalized.Name}}")
 		}
 
 		// Filter{{.Normalized.Name}} is a free log retrieval operation binding the contract event 0x{{printf "%x" .Original.ID}}.


### PR DESCRIPTION
- accounts/abi/bind/base, accounts/abi/bind/template: Exposes abi.Method, abi.Event, as well as Calldata in the BoundContract, updates the template to support retrieving Calldata for transactions and adds accessors for abi.Method and abi.Event