### PR TITLE
eth/protocols/snap: fix batch writer when resuming an aborted sync

### DIFF
--- a/eth/protocols/snap/sync.go
+++ b/eth/protocols/snap/sync.go
@@ -730,6 +730,8 @@ func (s *Syncer) loadSyncStatus() {
 			}
 			s.tasks = progress.Tasks
 			for _, task := range s.tasks {
+				task := task // closure for task.genBatch in the stacktrie writer callback
+
 				task.genBatch = ethdb.HookedBatch{
 					Batch: s.db.NewBatch(),
 					OnPut: func(key []byte, value []byte) {
@@ -741,6 +743,8 @@ func (s *Syncer) loadSyncStatus() {
 				})
 				for accountHash, subtasks := range task.SubTasks {
 					for _, subtask := range subtasks {
+						subtask := subtask // closure for subtask.genBatch in the stacktrie writer callback
+
 						subtask.genBatch = ethdb.HookedBatch{
 							Batch: s.db.NewBatch(),
 							OnPut: func(key []byte, value []byte) {


### PR DESCRIPTION
Fixes https://github.com/ethereum/go-ethereum/issues/27813.

The closure caused all subtasks to reference the same one batch when writing, so instead of each subtask of a contract growing and flushing it's own batch, they all grew the last one's, but flushed their own.

Interestingly however, this should only be an issue if there's also a lack of peers, otherwise whenever a delivery into the last batch is made, it should have flushed out everyone else's data too.

Edit: Actually, it might happen that the last chunk finishes earlier than the rest, which will cause memory to keep piling there. This will result in the node growing in memory until the pivot moves and sync restarts. This was confirmed via a bench pair comparing master (yellow) with PR (green):

<img width="528" alt="Screenshot 2023-08-03 at 13 44 55" src="https://github.com/ethereum/go-ethereum/assets/129561/c3d5efc9-e3ca-4ab4-bd72-1c5f626fffbc">

Additionally, this might also mean that all that extra memory that was piled into the last batch post-last-chunk-completion will actually get lost and the healer will need to redownload it. Waiting for benchmarkers to progress to the heal phase to verify.