### PR TITLE
core: ensure txindex will be triggered at least once

### DIFF
--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -2398,10 +2398,9 @@ func (bc *BlockChain) maintainTxIndex() {
 	// useful in these scenarios that chain has no progress and indexer
 	// is never triggered.
 	head := rawdb.ReadHeadBlock(bc.db)
-	tail := rawdb.ReadTxIndexTail(bc.db)
-	if head != nil && tail != nil {
+	if head != nil {
 		done = make(chan struct{})
-		bc.indexBlocks(tail, head.NumberU64(), done)
+		go bc.indexBlocks(rawdb.ReadTxIndexTail(bc.db), head.NumberU64(), done)
 	}
 
 	for {

--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -2403,8 +2403,7 @@ func (bc *BlockChain) maintainTxIndex() {
 	// Launch the initial processing if chain is not empty. This step is
 	// useful in these scenarios that chain has no progress and indexer
 	// is never triggered.
-	head := rawdb.ReadHeadBlock(bc.db)
-	if head != nil {
+	if head := rawdb.ReadHeadBlock(bc.db); head != nil {
 		done = make(chan struct{})
 		go bc.indexBlocks(rawdb.ReadTxIndexTail(bc.db), head.NumberU64(), done)
 	}

--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -2398,9 +2398,10 @@ func (bc *BlockChain) maintainTxIndex() {
 	// useful in these scenarios that chain has no progress and indexer
 	// is never triggered.
 	head := rawdb.ReadHeadBlock(bc.db)
-	if head != nil {
+	tail := rawdb.ReadTxIndexTail(bc.db)
+	if head != nil && tail != nil {
 		done = make(chan struct{})
-		bc.indexBlocks(rawdb.ReadTxIndexTail(bc.db), head.NumberU64(), done)
+		bc.indexBlocks(tail, head.NumberU64(), done)
 	}
 
 	for {

--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -2336,6 +2336,12 @@ func (bc *BlockChain) skipBlock(err error, it *insertIterator) bool {
 func (bc *BlockChain) indexBlocks(tail *uint64, head uint64, done chan struct{}) {
 	defer func() { close(done) }()
 
+	// If head is 0, it means the chain is just initialized and no blocks are inserted,
+	// so don't need to indexing anything.
+	if head == 0 {
+		return
+	}
+
 	// The tail flag is not existent, it means the node is just initialized
 	// and all blocks(may from ancient store) are not indexed yet.
 	if tail == nil {


### PR DESCRIPTION
Currently, we trigger the logic to (un)index transactions when the node receives a new block. However, in some cases the node may not receive new blocks (eg, when the Geth node is configured with `--nodiscovery`, or when it acts as an RPC node for historical only data). 
In these situations, the Geth node user may not have previously configured `txlookuplimit` (i.e. the default of around one year), but later he realizes they need to index all historical blocks. However, adding `txlookuplimit=0` and restarting geth has no effect.

So in this case, I think if we start a timer, there would at least be one opportunity to run the indexing process.