### PR TITLE
Update the Engine-API Specification

### DIFF
--- a/docs/fundamentals/node-architecture.md
+++ b/docs/fundamentals/node-architecture.md
@@ -11,7 +11,7 @@ The relationship between the two Ethereum clients is shown in the schematic belo
 
 ![node-architecture](/images/docs/node-architecture-text-background.png)
 
-For this two-client structure to work, consensus clients must be able to pass bundles of transactions to Geth to be executed. Executing the transactions locally is how the client validates that the transactions do not violate any Ethereum rules and that the proposed update to Ethereum’s state is correct. Likewise, when the node is selected to be a block producer the consensus client must be able to request bundles of transactions from Geth to include in the new block. This inter-client communication is handled by a local RPC connection using the [engine API](https://github.com/ethereum/execution-apis/blob/main/src/engine/specification.md).
+For this two-client structure to work, consensus clients must be able to pass bundles of transactions to Geth to be executed. Executing the transactions locally is how the client validates that the transactions do not violate any Ethereum rules and that the proposed update to Ethereum’s state is correct. Likewise, when the node is selected to be a block producer the consensus client must be able to request bundles of transactions from Geth to include in the new block. This inter-client communication is handled by a local RPC connection using the [engine API](https://github.com/ethereum/execution-apis/blob/main/src/engine/).
 
 ## What does Geth do? {#what-does-geth-do}
 


### PR DESCRIPTION
Since there is no specification specified at https://github.com/ethereum/execution-apis/blob/main/src/engine/specification.md , hence it is good to point to https://github.com/ethereum/execution-apis/blob/main/src/engine where user can view the documentation.