### PR TITLE
core/state: move UpdateContractCode before the trie hash is computed

### DIFF
--- a/core/state/statedb.go
+++ b/core/state/statedb.go
@@ -546,6 +546,9 @@ func (s *StateDB) updateStateObject(obj *stateObject) {
 	if err := s.trie.UpdateAccount(addr, &obj.data); err != nil {
 		s.setError(fmt.Errorf("updateStateObject (%x) error: %v", addr[:], err))
 	}
+	if obj.dirtyCode {
+		s.trie.UpdateContractCode(obj.Address(), common.BytesToHash(obj.CodeHash()), obj.code)
+	}
 	// Cache the data until commit. Note, this update mechanism is not symmetric
 	// to the deletion, because whereas it is enough to track account updates
 	// at commit time, deletions need tracking at transaction boundary level to
@@ -1189,7 +1192,6 @@ func (s *StateDB) Commit(block uint64, deleteEmptyObjects bool) (common.Hash, er
 		// Write any contract code associated with the state object
 		if obj.code != nil && obj.dirtyCode {
 			rawdb.WriteCode(codeWriter, common.BytesToHash(obj.CodeHash()), obj.code)
-			s.trie.UpdateContractCode(obj.Address(), common.BytesToHash(obj.CodeHash()), obj.code)
 			obj.dirtyCode = false
 		}
 		// Write any storage changes in the state object to its storage trie


### PR DESCRIPTION
Context: The `UpdateContractCode` method was introduced for the state storage commitment schemes that include the whole code for their commitment computation. It must therefore be called before the root hash is computed at the end of `IntermediateRoot`.

This should have no impact on the MPT since, in this context, the method is a no-op.