### PR TITLE
graphql: don't allocate greedily

### DIFF
--- a/graphql/graphql.go
+++ b/graphql/graphql.go
@@ -1268,10 +1268,8 @@ func (r *Resolver) Blocks(ctx context.Context, args struct {
 			break
 		}
 		ret = append(ret, block)
-		select {
-		case <-ctx.Done():
-			return nil, ctx.Err()
-		default:
+		if err := ctx.Err(); err != nil {
+		    return nil, err
 		}
 	}
 	return ret, nil

--- a/graphql/graphql.go
+++ b/graphql/graphql.go
@@ -1268,6 +1268,11 @@ func (r *Resolver) Blocks(ctx context.Context, args struct {
 			break
 		}
 		ret = append(ret, block)
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		default:
+		}
 	}
 	return ret, nil
 }

--- a/graphql/graphql.go
+++ b/graphql/graphql.go
@@ -1250,7 +1250,7 @@ func (r *Resolver) Blocks(ctx context.Context, args struct {
 	if to < from {
 		return []*Block{}, nil
 	}
-	ret := make([]*Block, 0, to-from+1)
+	var ret []*Block
 	for i := from; i <= to; i++ {
 		numberOrHash := rpc.BlockNumberOrHashWithNumber(i)
 		block := &Block{

--- a/graphql/graphql.go
+++ b/graphql/graphql.go
@@ -1269,7 +1269,7 @@ func (r *Resolver) Blocks(ctx context.Context, args struct {
 		}
 		ret = append(ret, block)
 		if err := ctx.Err(); err != nil {
-		    return nil, err
+			return nil, err
 		}
 	}
 	return ret, nil


### PR DESCRIPTION
The graphql code greedily allocated for the response. A query such as 
``` 
{ "query": " { blocks(from:-2147483647 to:2147483647) {number hash parent { number hash } }}" }
```
Would thus instantly allocate space for 4 Bn pointers, going out of memory. 
With this change, it will still go out of memory, but much slower. 

A more rigorous fix requires us to add limits, so that anything which returns `a list of things` is capped at some point. 

----

PSA: Graphql is not secure, it should not be exposed in untrusted environments, such as the internet.  This has been said before, and apparently cannot be said too often. 