### PR TITLE
graphql: validate block params

### DIFF
--- a/graphql/graphql.go
+++ b/graphql/graphql.go
@@ -1208,7 +1208,7 @@ func (r *Resolver) Block(ctx context.Context, args struct {
 	Hash   *common.Hash
 }) (*Block, error) {
 	if args.Number != nil && args.Hash != nil {
-		return nil, errors.New("either number or hash must be specified")
+		return nil, errors.New("only one of number or hash must be specified")
 	}
 	var numberOrHash rpc.BlockNumberOrHash
 	if args.Number != nil {

--- a/graphql/graphql.go
+++ b/graphql/graphql.go
@@ -1207,6 +1207,9 @@ func (r *Resolver) Block(ctx context.Context, args struct {
 	Number *Long
 	Hash   *common.Hash
 }) (*Block, error) {
+	if args.Number != nil && args.Hash != nil {
+		return nil, errors.New("either number or hash must be specified")
+	}
 	var numberOrHash rpc.BlockNumberOrHash
 	if args.Number != nil {
 		if *args.Number < 0 {


### PR DESCRIPTION
Block takes a `number` and a `hash`. The spec is unclear on this. My interpretation is either of these should be provided and we should error in case both are passed in.

Fixes https://github.com/ethereum/go-ethereum/issues/25899