### PR TITLE
Remove duplicate add to known tx set during gossip

### DIFF
--- a/eth/protocols/eth/peer.go
+++ b/eth/protocols/eth/peer.go
@@ -203,8 +203,6 @@ func (p *Peer) SendTransactions(txs types.Transactions) error {
 func (p *Peer) AsyncSendTransactions(hashes []common.Hash) {
 	select {
 	case p.txBroadcast <- hashes:
-		// Mark all the transactions as known, but ensure we don't overflow our limits
-		p.knownTxs.Add(hashes...)
 	case <-p.term:
 		p.Log().Debug("Dropping transaction propagation", "count", len(hashes))
 	}


### PR DESCRIPTION
`AsyncSendTransactions` enqueues a set of txs by hash to the peer to be gossiped [here](https://github.com/ethereum/go-ethereum/blob/f58ebd9696326082b10cb19ee5e071952e872e9e/eth/protocols/eth/peer.go#L207). The later call to `SendTransactions` performs the same operation, re-adding the elements to the set [here](https://github.com/ethereum/go-ethereum/blob/f58ebd9696326082b10cb19ee5e071952e872e9e/eth/protocols/eth/peer.go#L195). 

I believe this is not intended. Feel free to close if my understanding of this is incorrect.