### PR TITLE
Website fixed Clef rules js example

### DIFF
--- a/docs/tools/clef/rules.md
+++ b/docs/tools/clef/rules.md
@@ -40,7 +40,7 @@ function ApproveTx(req) {
 	var limit = big.Newint("0xb1a2bc2ec50000")
 	var value = asBig(req.transaction.value);
 
-	if (req.transaction.to.toLowerCase() == "0xae967917c465db8578ca9024c205720b1a3651a9") && value.lt(limit)) {
+	if (req.transaction.to.toLowerCase() == "0xae967917c465db8578ca9024c205720b1a3651a9" && value.lt(limit)) {
 		return "Approve"
 	}
 	// If we return "Reject", it will be rejected.


### PR DESCRIPTION
Fixed the invalid if statement by removing the extra closing parenthesis of the if statement in the rules example of Clef. website/docs/tools/clef/rules.md