### PR TITLE
eth/catalyst: set finalized block hash properly in dev mode

### DIFF
--- a/eth/catalyst/simulated_beacon.go
+++ b/eth/catalyst/simulated_beacon.go
@@ -32,6 +32,8 @@ import (
 	"github.com/ethereum/go-ethereum/rpc"
 )
 
+const devEpochLength = 32
+
 // withdrawalQueue implements a FIFO queue which holds withdrawals that are
 // pending inclusion.
 type withdrawalQueue struct {
@@ -158,7 +160,7 @@ func (c *SimulatedBeacon) sealBlock(withdrawals []*types.Withdrawal) error {
 	payload := envelope.ExecutionPayload
 
 	var finalizedHash common.Hash
-	if payload.Number%32 == 0 {
+	if payload.Number%devEpochLength == 0 {
 		finalizedHash = payload.BlockHash
 	} else {
 		finalizedHash = c.eth.BlockChain().GetBlockByNumber((payload.Number - 1) / 32 * 32).Hash()

--- a/eth/catalyst/simulated_beacon.go
+++ b/eth/catalyst/simulated_beacon.go
@@ -163,7 +163,7 @@ func (c *SimulatedBeacon) sealBlock(withdrawals []*types.Withdrawal) error {
 	if payload.Number%devEpochLength == 0 {
 		finalizedHash = payload.BlockHash
 	} else {
-		finalizedHash = c.eth.BlockChain().GetBlockByNumber((payload.Number - 1) / 32 * 32).Hash()
+		finalizedHash = c.eth.BlockChain().GetBlockByNumber((payload.Number - 1) / devEpochLength * devEpochLength).Hash()
 	}
 
 	// mark the payload as canon

--- a/eth/catalyst/simulated_beacon.go
+++ b/eth/catalyst/simulated_beacon.go
@@ -157,6 +157,13 @@ func (c *SimulatedBeacon) sealBlock(withdrawals []*types.Withdrawal) error {
 	}
 	payload := envelope.ExecutionPayload
 
+	var finalizedHash common.Hash
+	if payload.Number % 32 == 0 {
+		finalizedHash = payload.BlockHash
+	} else {
+		finalizedHash = c.eth.BlockChain().GetBlockByNumber((payload.Number - 1) / 32 * 32).Hash()
+	}
+
 	// mark the payload as canon
 	if _, err = c.engineAPI.NewPayloadV2(*payload); err != nil {
 		return fmt.Errorf("failed to mark payload as canonical: %v", err)
@@ -164,7 +171,7 @@ func (c *SimulatedBeacon) sealBlock(withdrawals []*types.Withdrawal) error {
 	c.curForkchoiceState = engine.ForkchoiceStateV1{
 		HeadBlockHash:      payload.BlockHash,
 		SafeBlockHash:      payload.BlockHash,
-		FinalizedBlockHash: payload.BlockHash,
+		FinalizedBlockHash: finalizedHash,
 	}
 	// mark the block containing the payload as canonical
 	if _, err = c.engineAPI.ForkchoiceUpdatedV2(c.curForkchoiceState, nil); err != nil {

--- a/eth/catalyst/simulated_beacon.go
+++ b/eth/catalyst/simulated_beacon.go
@@ -158,7 +158,7 @@ func (c *SimulatedBeacon) sealBlock(withdrawals []*types.Withdrawal) error {
 	payload := envelope.ExecutionPayload
 
 	var finalizedHash common.Hash
-	if payload.Number % 32 == 0 {
+	if payload.Number%32 == 0 {
 		finalizedHash = payload.BlockHash
 	} else {
 		finalizedHash = c.eth.BlockChain().GetBlockByNumber((payload.Number - 1) / 32 * 32).Hash()


### PR DESCRIPTION
In dev mode, the finalized block should be the block that was produced at the start of the current epoch (block number 0, 32, 64, ...)