### PR TITLE
eth/filters, core/rawdb: remove unused param, refactor filtering-loop

### DIFF
--- a/accounts/abi/bind/backends/simulated.go
+++ b/accounts/abi/bind/backends/simulated.go
@@ -892,7 +892,7 @@ func (fb *filterBackend) GetReceipts(ctx context.Context, hash common.Hash) (typ
 }
 
 func (fb *filterBackend) GetLogs(ctx context.Context, hash common.Hash, number uint64) ([][]*types.Log, error) {
-	logs := rawdb.ReadLogs(fb.db, hash, number, fb.bc.Config())
+	logs := rawdb.ReadLogs(fb.db, hash, number)
 	return logs, nil
 }
 

--- a/core/rawdb/accessors_chain.go
+++ b/core/rawdb/accessors_chain.go
@@ -731,7 +731,7 @@ func deriveLogFields(receipts []*receiptLogs, hash common.Hash, number uint64, t
 // ReadLogs retrieves the logs for all transactions in a block. In case
 // receipts is not found, a nil is returned.
 // Note: ReadLogs does not derive unstored log fields.
-func ReadLogs(db ethdb.Reader, hash common.Hash, number uint64, config *params.ChainConfig) [][]*types.Log {
+func ReadLogs(db ethdb.Reader, hash common.Hash, number uint64) [][]*types.Log {
 	// Retrieve the flattened receipt slice
 	data := ReadReceiptsRLP(db, hash, number)
 	if len(data) == 0 {

--- a/core/rawdb/accessors_chain_test.go
+++ b/core/rawdb/accessors_chain_test.go
@@ -736,7 +736,7 @@ func TestReadLogs(t *testing.T) {
 	// Insert the receipt slice into the database and check presence
 	WriteReceipts(db, hash, 0, receipts)
 
-	logs := ReadLogs(db, hash, 0, params.TestChainConfig)
+	logs := ReadLogs(db, hash, 0)
 	if len(logs) == 0 {
 		t.Fatalf("no logs returned")
 	}

--- a/eth/api_backend.go
+++ b/eth/api_backend.go
@@ -245,7 +245,7 @@ func (b *EthAPIBackend) GetReceipts(ctx context.Context, hash common.Hash) (type
 }
 
 func (b *EthAPIBackend) GetLogs(ctx context.Context, hash common.Hash, number uint64) ([][]*types.Log, error) {
-	return rawdb.ReadLogs(b.eth.chainDb, hash, number, b.ChainConfig()), nil
+	return rawdb.ReadLogs(b.eth.chainDb, hash, number), nil
 }
 
 func (b *EthAPIBackend) GetTd(ctx context.Context, hash common.Hash) *big.Int {

--- a/eth/filters/filter.go
+++ b/eth/filters/filter.go
@@ -347,48 +347,47 @@ func (f *Filter) pendingLogs() []*types.Log {
 	return nil
 }
 
-func includes(addresses []common.Address, a common.Address) bool {
-	for _, addr := range addresses {
-		if addr == a {
+// includes returns true if the element is present in the list.
+func includes[T comparable](things []T, element T) bool {
+	for _, thing := range things {
+		if thing == element {
 			return true
 		}
 	}
-
 	return false
 }
 
 // filterLogs creates a slice of logs matching the given criteria.
 func filterLogs(logs []*types.Log, fromBlock, toBlock *big.Int, addresses []common.Address, topics [][]common.Hash) []*types.Log {
-	var ret []*types.Log
-Logs:
-	for _, log := range logs {
+	var check = func(log *types.Log) bool {
 		if fromBlock != nil && fromBlock.Int64() >= 0 && fromBlock.Uint64() > log.BlockNumber {
-			continue
+			return false
 		}
 		if toBlock != nil && toBlock.Int64() >= 0 && toBlock.Uint64() < log.BlockNumber {
-			continue
+			return false
 		}
-
 		if len(addresses) > 0 && !includes(addresses, log.Address) {
-			continue
+			return false
 		}
 		// If the to filtered topics is greater than the amount of topics in logs, skip.
 		if len(topics) > len(log.Topics) {
-			continue
+			return false
 		}
 		for i, sub := range topics {
-			match := len(sub) == 0 // empty rule set == wildcard
-			for _, topic := range sub {
-				if log.Topics[i] == topic {
-					match = true
-					break
-				}
+			if len(sub) == 0 {
+				continue // empty rule set == wildcard
 			}
-			if !match {
-				continue Logs
+			if !includes(sub, log.Topics[i]) {
+				return false
 			}
 		}
-		ret = append(ret, log)
+		return true
+	}
+	var ret []*types.Log
+	for _, log := range logs {
+		if check(log) {
+			ret = append(ret, log)
+		}
 	}
 	return ret
 }

--- a/eth/filters/filter_system_test.go
+++ b/eth/filters/filter_system_test.go
@@ -121,7 +121,7 @@ func (b *testBackend) GetReceipts(ctx context.Context, hash common.Hash) (types.
 }
 
 func (b *testBackend) GetLogs(ctx context.Context, hash common.Hash, number uint64) ([][]*types.Log, error) {
-	logs := rawdb.ReadLogs(b.db, hash, number, params.TestChainConfig)
+	logs := rawdb.ReadLogs(b.db, hash, number)
 	return logs, nil
 }
 


### PR DESCRIPTION
This PR removes a chainconfig parameter passed into `rawdb.ReadLogs`, which is not used nor needed. 
It also modifies the filter loop slightly, avoiding a labeled break and instead using a method. 

None of the changes in this PR  (intentionally) modify behaviour.  