### PR TITLE
docs/interacting-with-geth/rpc: don't set header for Example,Parameters

### DIFF
--- a/docs/developers/evm-tracing/custom-tracer.md
+++ b/docs/developers/evm-tracing/custom-tracer.md
@@ -251,11 +251,11 @@ And these fields are only available for tracing mined transactions (i.e. not ava
 - `getOutput()` - returns the output as a buffer
 - `getError()` - returns an error if one occurred during execution and `undefined` otherwise
 
-### Usage
+**Usage:**
 
-Note that several values are Golang big.Int objects, not JavaScript numbers or JS bigints. As such, they have the same interface as described in the godocs. Their default serialization to JSON is as a Javascript number; to serialize large numbers accurately call `.String()` on them. For convenience, `big.NewInt(x)` is provided, and will convert a uint to a Go BigInt.
+Note that several values are Golang `big.Int` objects, not JavaScript numbers or JS bigints. As such, they have the same interface as described in the godocs. Their default serialization to JSON is as a Javascript number; to serialize large numbers accurately call `.String()` on them. For convenience, `big.NewInt(x)` is provided, and will convert a uint to a Go BigInt.
 
-Usage example, returns the top element of the stack at each CALL opcode only:
+Here is an example, returns the top element of the stack at each CALL opcode only:
 
 ```js
 debug.traceTransaction(txhash, {

--- a/docs/interacting-with-geth/rpc/ns-admin.md
+++ b/docs/interacting-with-geth/rpc/ns-admin.md
@@ -17,7 +17,7 @@ The method accepts a single argument, the [`enode`](https://ethereum.org/en/deve
 | Console | `admin.addPeer(url)`                           |
 | RPC     | `{"method": "admin_addPeer", "params": [url]}` |
 
-### Example
+Example:
 
 ```js
 > admin.addPeer("enode://a979fb575495b8d6db44f750317d0f4622bf4c2aa3365d6af7c284339968eef29b69ad0dce72a4d8db5ebb4968de0e3bec910127f134779fbcb0cb6d3331163c@52.16.188.185:30303")
@@ -43,7 +43,7 @@ The `datadir` administrative property can be queried for the absolute path the r
 | Console | `admin.datadir`                   |
 | RPC     | `{"method": "admin_datadir"}`     |
 
-### Example
+Example:
 
 ```js
 > admin.datadir
@@ -78,7 +78,7 @@ The `nodeInfo` administrative property can be queried for all the information kn
 | Console | `admin.nodeInfo`                          |
 | RPC     | `{"method": "admin_nodeInfo"}`            |
 
-### Example
+Example:
 
 ```js
 > admin.nodeInfo
@@ -122,7 +122,7 @@ The `peers` administrative property can be queried for all the information known
 | Console | `admin.peers`                            |
 | RPC     | `{"method": "admin_peers"}`              |
 
-### Example
+Example:
 
 ```js
 > admin.peers
@@ -194,7 +194,7 @@ The method returns a boolean flag specifying whether the HTTP RPC listener was o
 | Console | `admin.startHTTP(host, port, cors, apis)`                                                      |
 | RPC     | `{"method": "admin_startHTTP", "params": [host, port, cors, apis]}`                            |
 
-### Example
+Example:
 
 ```js
 > admin.startHTTP("127.0.0.1", 8545)
@@ -218,7 +218,7 @@ The method returns a boolean flag specifying whether the WebSocket RPC listener 
 | Console | `admin.startWS(host, port, cors, apis)`                                                      |
 | RPC     | `{"method": "admin_startWS", "params": [host, port, cors, apis]}`                            |
 
-### Example
+Example:
 
 ```js
 > admin.startWS("127.0.0.1", 8546)
@@ -235,7 +235,7 @@ The `stopHTTP` administrative method closes the currently open HTTP RPC endpoint
 | Console | `admin.stopHTTP()`               |
 | RPC     | `{"method": "admin_stopHTTP"`    |
 
-### Example
+Example:
 
 ```js
 > admin.stopHTTP()
@@ -252,7 +252,7 @@ The `stopWS` administrative method closes the currently open WebSocket RPC endpo
 | Console | `admin.stopWS()`               |
 | RPC     | `{"method": "admin_stopWS"`    |
 
-### Example
+Example:
 
 ```js
 > admin.stopWS()

--- a/docs/interacting-with-geth/rpc/ns-admin.md
+++ b/docs/interacting-with-geth/rpc/ns-admin.md
@@ -17,7 +17,7 @@ The method accepts a single argument, the [`enode`](https://ethereum.org/en/deve
 | Console | `admin.addPeer(url)`                           |
 | RPC     | `{"method": "admin_addPeer", "params": [url]}` |
 
-Example:
+**Example:**
 
 ```js
 > admin.addPeer("enode://a979fb575495b8d6db44f750317d0f4622bf4c2aa3365d6af7c284339968eef29b69ad0dce72a4d8db5ebb4968de0e3bec910127f134779fbcb0cb6d3331163c@52.16.188.185:30303")
@@ -43,7 +43,7 @@ The `datadir` administrative property can be queried for the absolute path the r
 | Console | `admin.datadir`                   |
 | RPC     | `{"method": "admin_datadir"}`     |
 
-Example:
+**Example:**
 
 ```js
 > admin.datadir
@@ -78,7 +78,7 @@ The `nodeInfo` administrative property can be queried for all the information kn
 | Console | `admin.nodeInfo`                          |
 | RPC     | `{"method": "admin_nodeInfo"}`            |
 
-Example:
+**Example:**
 
 ```js
 > admin.nodeInfo
@@ -122,7 +122,7 @@ The `peers` administrative property can be queried for all the information known
 | Console | `admin.peers`                            |
 | RPC     | `{"method": "admin_peers"}`              |
 
-Example:
+**Example:**
 
 ```js
 > admin.peers
@@ -194,7 +194,7 @@ The method returns a boolean flag specifying whether the HTTP RPC listener was o
 | Console | `admin.startHTTP(host, port, cors, apis)`                                                      |
 | RPC     | `{"method": "admin_startHTTP", "params": [host, port, cors, apis]}`                            |
 
-Example:
+**Example:**
 
 ```js
 > admin.startHTTP("127.0.0.1", 8545)
@@ -218,7 +218,7 @@ The method returns a boolean flag specifying whether the WebSocket RPC listener 
 | Console | `admin.startWS(host, port, cors, apis)`                                                      |
 | RPC     | `{"method": "admin_startWS", "params": [host, port, cors, apis]}`                            |
 
-Example:
+**Example:**
 
 ```js
 > admin.startWS("127.0.0.1", 8546)
@@ -235,7 +235,7 @@ The `stopHTTP` administrative method closes the currently open HTTP RPC endpoint
 | Console | `admin.stopHTTP()`               |
 | RPC     | `{"method": "admin_stopHTTP"`    |
 
-Example:
+**Example:**
 
 ```js
 > admin.stopHTTP()
@@ -252,7 +252,7 @@ The `stopWS` administrative method closes the currently open WebSocket RPC endpo
 | Console | `admin.stopWS()`               |
 | RPC     | `{"method": "admin_stopWS"`    |
 
-Example:
+**Example:**
 
 ```js
 > admin.stopWS()

--- a/docs/interacting-with-geth/rpc/ns-clique.md
+++ b/docs/interacting-with-geth/rpc/ns-clique.md
@@ -14,7 +14,7 @@ Retrieves a snapshot of all clique state at a given block.
 | Console | `clique.getSnapshot(blockNumber)`                           |
 | RPC     | `{"method": "clique_getSnapshot", "params": [blockNumber]}` |
 
-Example:
+**Example:**
 
 ```js
 > clique.getSnapshot(5463755)
@@ -118,7 +118,7 @@ This is a debugging method which returns statistics about signer activity for th
 | Console | `clique.status()`                           |
 | RPC     | `{"method": "clique_status", "params": []}` |
 
-Example:
+**Example:**
 
 ```js
 > clique.status()

--- a/docs/interacting-with-geth/rpc/ns-debug.md
+++ b/docs/interacting-with-geth/rpc/ns-debug.md
@@ -27,7 +27,7 @@ The location is specified as `<filename>:<line>`.
 | Console | `debug.backtraceAt(string)`                           |
 | RPC     | `{"method": "debug_backtraceAt", "params": [string]}` |
 
-Example:
+**Example:**
 
 ```js
 > debug.backtraceAt("server.go:443")
@@ -112,7 +112,7 @@ Retrieves the state that corresponds to the block number and returns a list of a
 | Console | `debug.traceBlockByHash(number, [options])`           |
 | RPC     | `{"method": "debug_dumpBlock", "params": [number]}`   |
 
-Example:
+**Example:**
 
 ```js
 > debug.dumpBlock(10)
@@ -500,7 +500,7 @@ The `traceBlock` method will return a full stack trace of all invoked opcodes of
 References:
 [RLP](https://ethereum.org/en/developers/docs/data-structures-and-encoding/rlp/)
 
-Example:
+**Example:**
 
 ```js
 > debug.traceBlock("0xblock_rlp")
@@ -585,7 +585,7 @@ The `debug_traceCall` method lets you run an `eth_call` within the context of th
 | Console | `debug.traceCall(object, blockNrOrHash, [options])`                                                                         |
 |   RPC   | `{"method": "debug_traceCall", "params": [object, blockNrOrHash, {}]}`                                                      |
 
-Example:
+**Example:**
 
 No specific call options:
 
@@ -697,7 +697,7 @@ If set, the previous four arguments will be ignored.
 
 Geth comes with a bundle of [built-in tracers](/docs/developers/evm-tracing/built-in-tracers), each providing various data about a transaction. This method defaults to the [struct logger](/docs/developers/evm-tracing/built-in-tracers#structopcode-logger). The `tracer` field of the second parameter can be set to use any of the other tracers. Alternatively a [custom tracer](/docs/developers/evm-tracing/custom-tracer) can be implemented in either Go or Javascript.
 
-Example:
+**Example:**
 
 ```js
 > debug.traceTransaction("0x2059dd53ecac9827faad14d364f9e04b1d5fe5b506e3acc886eff7a6f88a696a")

--- a/docs/interacting-with-geth/rpc/ns-debug.md
+++ b/docs/interacting-with-geth/rpc/ns-debug.md
@@ -112,7 +112,7 @@ Retrieves the state that corresponds to the block number and returns a list of a
 | Console | `debug.traceBlockByHash(number, [options])`           |
 | RPC     | `{"method": "debug_dumpBlock", "params": [number]}`   |
 
-#### Example
+Example:
 
 ```js
 > debug.dumpBlock(10)
@@ -500,7 +500,7 @@ The `traceBlock` method will return a full stack trace of all invoked opcodes of
 References:
 [RLP](https://ethereum.org/en/developers/docs/data-structures-and-encoding/rlp/)
 
-#### Example
+Example:
 
 ```js
 > debug.traceBlock("0xblock_rlp")
@@ -585,7 +585,7 @@ The `debug_traceCall` method lets you run an `eth_call` within the context of th
 | Console | `debug.traceCall(object, blockNrOrHash, [options])`                                                                         |
 |   RPC   | `{"method": "debug_traceCall", "params": [object, blockNrOrHash, {}]}`                                                      |
 
-#### Example
+Example:
 
 No specific call options:
 
@@ -618,15 +618,15 @@ It is possible to supply 'overrides' for both state-data (accounts/storage) and 
 
 ```js
 > debug.traceCall({
-	from: eth.accounts[0],
-	value:"0x1",
-	gasPrice: "0xffffffff",
-	gas: "0xffff",
-	input: "0x43"},
-	"latest",
-	{"blockoverrides":
-		{"number": "0x50"}
-	})
+    from: eth.accounts[0],
+    value:"0x1",
+    gasPrice: "0xffffffff",
+    gas: "0xffff",
+    input: "0x43"},
+    "latest",
+    {"blockoverrides":
+        {"number": "0x50"}
+    })
 {
   failed: false,
   gas: 53018,
@@ -697,7 +697,7 @@ If set, the previous four arguments will be ignored.
 
 Geth comes with a bundle of [built-in tracers](/docs/developers/evm-tracing/built-in-tracers), each providing various data about a transaction. This method defaults to the [struct logger](/docs/developers/evm-tracing/built-in-tracers#structopcode-logger). The `tracer` field of the second parameter can be set to use any of the other tracers. Alternatively a [custom tracer](/docs/developers/evm-tracing/custom-tracer) can be implemented in either Go or Javascript.
 
-#### Example
+Example:
 
 ```js
 > debug.traceTransaction("0x2059dd53ecac9827faad14d364f9e04b1d5fe5b506e3acc886eff7a6f88a696a")
@@ -753,7 +753,7 @@ Sets the logging verbosity pattern.
 | Console | `debug.vmodule(string)`                           |
 | RPC     | `{"method": "debug_vmodule", "params": [string]}` |
 
-#### Examples
+Examples:
 
 If you want to see messages from a particular Go package (directory) and all subdirectories, use:
 

--- a/docs/interacting-with-geth/rpc/ns-debug.md
+++ b/docs/interacting-with-geth/rpc/ns-debug.md
@@ -753,7 +753,7 @@ Sets the logging verbosity pattern.
 | Console | `debug.vmodule(string)`                           |
 | RPC     | `{"method": "debug_vmodule", "params": [string]}` |
 
-Examples:
+**Examples:**
 
 If you want to see messages from a particular Go package (directory) and all subdirectories, use:
 

--- a/docs/interacting-with-geth/rpc/ns-eth.md
+++ b/docs/interacting-with-geth/rpc/ns-eth.md
@@ -17,32 +17,31 @@ Executes a new message call immediately, without creating a transaction on the b
 
 The method takes 3 parameters: an unsigned transaction object to execute in read-only mode; the block number to execute the call against; and an optional state override-set to allow executing the call against a modified chain state.
 
-##### 1. `Object` - Transaction call object
+1. `Object` - Transaction call object
 
-The _transaction call object_ is mandatory. Please see [here](/docs/interacting-with-geth/rpc/objects) for details.
+   The _transaction call object_ is mandatory. Please see [here](/docs/interacting-with-geth/rpc/objects) for details.
 
-##### 2. `Quantity | Tag` - Block number or the string `latest` or `pending`
+2. `Quantity | Tag` - Block number or the string `latest` or `pending`
 
-The _block number_ is mandatory and defines the context (state) against which the specified transaction should be executed. It is not possible to execute calls against reorged blocks; or blocks older than 128 (unless the node is an archive node).
+   The _block number_ is mandatory and defines the context (state) against which the specified transaction should be executed. It is not possible to execute calls against reorged blocks; or blocks older than 128 (unless the node is an archive node).
 
-##### 3. `Object` - State override set
+3. `Object` - State override set
 
-The _state override set_ is an optional address-to-state mapping, where each entry specifies some state to be ephemerally overridden prior to executing the call. Each address maps to an object containing:
+   The _state override set_ is an optional address-to-state mapping, where each entry specifies some state to be ephemerally overridden prior to executing the call. Each address maps to an object containing:
 
-| Field       | Type       | Bytes | Optional | Description                                                                                               |
-| :---------- | :--------- | :---- | :------- | :-------------------------------------------------------------------------------------------------------- |
-| `balance`   | `Quantity` | <32   | Yes      | Fake balance to set for the account before executing the call.                                            |
-| `nonce`     | `Quantity` | <8    | Yes      | Fake nonce to set for the account before executing the call.                                              |
-| `code`      | `Binary`   | any   | Yes      | Fake EVM bytecode to inject into the account before executing the call.                                   |
-| `state`     | `Object`   | any   | Yes      | Fake key-value mapping to override **all** slots in the account storage before executing the call.        |
-| `stateDiff` | `Object`   | any   | Yes      | Fake key-value mapping to override **individual** slots in the account storage before executing the call. |
+   | Field       | Type       | Bytes | Optional | Description                                                                                               |
+   | :---------- | :--------- | :---- | :------- | :-------------------------------------------------------------------------------------------------------- |
+   | `balance`   | `Quantity` | <32   | Yes      | Fake balance to set for the account before executing the call.                                            |
+   | `nonce`     | `Quantity` | <8    | Yes      | Fake nonce to set for the account before executing the call.                                              |
+   | `code`      | `Binary`   | any   | Yes      | Fake EVM bytecode to inject into the account before executing the call.                                   |
+   | `state`     | `Object`   | any   | Yes      | Fake key-value mapping to override **all** slots in the account storage before executing the call.        |
+   | `stateDiff` | `Object`   | any   | Yes      | Fake key-value mapping to override **individual** slots in the account storage before executing the call. |
 
-The goal of the _state override set_ is manyfold:
+   The goal of the _state override set_ is manyfold:
 
-- It can be used by DApps to reduce the amount of contract code needed to be deployed on chain. Code that simply returns internal state or does pre-defined validations can be kept off chain and fed to the node on-demand.
-- It can be used for smart contract analysis by extending the code deployed on chain with custom methods and invoking them. This avoids having to download and reconstruct the entire state in a sandbox to run custom code against.
-
-- It can be used to debug smart contracts in an already deployed large suite of contracts by selectively overriding some code or state and seeing how execution changes. Specialized tooling will probably be necessary.
+   - It can be used by DApps to reduce the amount of contract code needed to be deployed on chain. Code that simply returns internal state or does pre-defined validations can be kept off chain and fed to the node on-demand.
+   - It can be used for smart contract analysis by extending the code deployed on chain with custom methods and invoking them. This avoids having to download and reconstruct the entire state in a sandbox to run custom code against.
+   - It can be used to debug smart contracts in an already deployed large suite of contracts by selectively overriding some code or state and seeing how execution changes. Specialized tooling will probably be necessary.
 
 **Example:**
 
@@ -60,11 +59,11 @@ The goal of the _state override set_ is manyfold:
 }
 ```
 
-#### Return Values
+**Response:**
 
 The method returns a single `Binary` consisting the return value of the executed contract call.
 
-#### Simple example
+#### eth_call Simple example
 
 **note that this example uses the Rinkeby network, which is now deprecated**
 
@@ -93,7 +92,7 @@ Just for the sake of completeness, decoded the response is:
 0xb86e2b0ab5a4b1373e40c51a7c712c70ba2f9f8e
 ```
 
-#### Override example
+#### eth_call Override example
 
 The above _simple example_ showed how to call a method already exposed by an on-chain smart contract. What if we want to access some data not exposed by it?
 
@@ -182,9 +181,9 @@ Returns a block header.
 
 **Parameters:**
 
-| Field              | Type       | Description                        |
-| :----------------- | :--------- | :--------------------------------- |
-| `blockNumber`      | `Quantity` | Block number                       |
+| Field         | Type       | Description  |
+| :------------ | :--------- | :----------- |
+| `blockNumber` | `Quantity` | Block number |
 
 **Usage:**
 
@@ -196,26 +195,26 @@ curl localhost:8545 -X POST -H "Content-Type: application/json" -d '{"jsonrpc":"
 
 ```json
 {
-  baseFeePerGas: "0x6c3f71624",
-  difficulty: "0x0",
-  extraData: "0x496c6c756d696e61746520446d6f63726174697a6520447374726962757465",
-  gasLimit: "0x1c9c380",
-  gasUsed: "0x1312759",
-  hash: "0x4574b6f248bf3295f76ae797454f4ec21c8ef5b53c0f7fee8534b65623d9360a",
-  logsBloom: "0x04a13010898372c9ca19007ccd04eed1f707098f04123de47da9d0b67ce1a60ab8ea324cd8291c36a8ca5a520893d1552711012dba82ad817332008d90ac788047c0fcd2d1200cb82bd1690b32b6d7ab8ab28a86b1f7095a19b59104d062882093746d041b510537a4d0015518c1583de073045981792d0030aa5cd5089a0a700160f74b0b250a9e30ea90596fdf851732815da30d800ace471e2768e09bc0d45e79f97238136523021a4bd52d45a5e184c8c810a9c22afa8670b6bab0eb2636ea1981120a400040829021a3e96cbe0262d8a6ba06006b37249117230968eecc0c16a7ae4090e888673f1101a27159d5cd12a190f5aa85cb524dbc72f5d4ed14",
-  miner: "0xdafea492d9c6733ae3d56b7ed1adb60692c98bc5",
-  mixHash: "0xec33ce424110ddd8f7e7db1cbc1261a63e44dacd158b4e801566cd6d5849295b",
-  nonce: "0x0000000000000000",
-  number: "0x10823a8",
-  parentHash: "0x956846b5012b1df4f4c928b85db2f6456b2faed2c0ca136e89c928a87ceec69c",
-  receiptsRoot: "0x89b73c221ca0d721f8805edbecbf55524b0556dc5111680bac1c4dd02a286457",
-  sha3Uncles: "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
-  size: "0x25e",
-  stateRoot: "0xe38ef58ddfbf00b03f7bd431fca306e5fcaecc138f4208501d2588657a65a0f3",
-  timestamp: "0x646a982b",
-  totalDifficulty: "0xc70d815d562d3cfa955",
-  transactionsRoot: "0xe44699ea734cee851a852db4d257617c8369b8a7e68bd54b6de829377234017b",
-  withdrawalsRoot: "0x917f5a8e4d652233a80b0973ff20bde517ed2a6a93defe7e99c5263089453e17"
+  "baseFeePerGas": "0x6c3f71624",
+  "difficulty": "0x0",
+  "extraData": "0x496c6c756d696e61746520446d6f63726174697a6520447374726962757465",
+  "gasLimit": "0x1c9c380",
+  "gasUsed": "0x1312759",
+  "hash": "0x4574b6f248bf3295f76ae797454f4ec21c8ef5b53c0f7fee8534b65623d9360a",
+  "logsBloom": "0x04a13010898372c9ca19007ccd04eed1f707098f04123de47da9d0b67ce1a60ab8ea324cd8291c36a8ca5a520893d1552711012dba82ad817332008d90ac788047c0fcd2d1200cb82bd1690b32b6d7ab8ab28a86b1f7095a19b59104d062882093746d041b510537a4d0015518c1583de073045981792d0030aa5cd5089a0a700160f74b0b250a9e30ea90596fdf851732815da30d800ace471e2768e09bc0d45e79f97238136523021a4bd52d45a5e184c8c810a9c22afa8670b6bab0eb2636ea1981120a400040829021a3e96cbe0262d8a6ba06006b37249117230968eecc0c16a7ae4090e888673f1101a27159d5cd12a190f5aa85cb524dbc72f5d4ed14",
+  "miner": "0xdafea492d9c6733ae3d56b7ed1adb60692c98bc5",
+  "mixHash": "0xec33ce424110ddd8f7e7db1cbc1261a63e44dacd158b4e801566cd6d5849295b",
+  "nonce": "0x0000000000000000",
+  "number": "0x10823a8",
+  "parentHash": "0x956846b5012b1df4f4c928b85db2f6456b2faed2c0ca136e89c928a87ceec69c",
+  "receiptsRoot": "0x89b73c221ca0d721f8805edbecbf55524b0556dc5111680bac1c4dd02a286457",
+  "sha3Uncles": "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+  "size": "0x25e",
+  "stateRoot": "0xe38ef58ddfbf00b03f7bd431fca306e5fcaecc138f4208501d2588657a65a0f3",
+  "timestamp": "0x646a982b",
+  "totalDifficulty": "0xc70d815d562d3cfa955",
+  "transactionsRoot": "0xe44699ea734cee851a852db4d257617c8369b8a7e68bd54b6de829377234017b",
+  "withdrawalsRoot": "0x917f5a8e4d652233a80b0973ff20bde517ed2a6a93defe7e99c5263089453e17"
 }
 ```
 
@@ -225,9 +224,9 @@ Returns a block header.
 
 **Parameters:**
 
-| Field              | Type       | Description                        |
-| :----------------- | :--------- | :--------------------------------- |
-| `blockHash`        | `string`   | Block hash                         |
+| Field       | Type     | Description |
+| :---------- | :------- | :---------- |
+| `blockHash` | `string` | Block hash  |
 
 **Usage:**
 
@@ -239,25 +238,25 @@ curl localhost:8545 -X POST -H "Content-Type: application/json" -d '{"jsonrpc":"
 
 ```json
 {
-  baseFeePerGas: "0x6c3f71624",
-  difficulty: "0x0",
-  extraData: "0x496c6c756d696e61746520446d6f63726174697a6520447374726962757465",
-  gasLimit: "0x1c9c380",
-  gasUsed: "0x1312759",
-  hash: "0x4574b6f248bf3295f76ae797454f4ec21c8ef5b53c0f7fee8534b65623d9360a",
-  logsBloom: "0x04a13010898372c9ca19007ccd04eed1f707098f04123de47da9d0b67ce1a60ab8ea324cd8291c36a8ca5a520893d1552711012dba82ad817332008d90ac788047c0fcd2d1200cb82bd1690b32b6d7ab8ab28a86b1f7095a19b59104d062882093746d041b510537a4d0015518c1583de073045981792d0030aa5cd5089a0a700160f74b0b250a9e30ea90596fdf851732815da30d800ace471e2768e09bc0d45e79f97238136523021a4bd52d45a5e184c8c810a9c22afa8670b6bab0eb2636ea1981120a400040829021a3e96cbe0262d8a6ba06006b37249117230968eecc0c16a7ae4090e888673f1101a27159d5cd12a190f5aa85cb524dbc72f5d4ed14",
-  miner: "0xdafea492d9c6733ae3d56b7ed1adb60692c98bc5",
-  mixHash: "0xec33ce424110ddd8f7e7db1cbc1261a63e44dacd158b4e801566cd6d5849295b",
-  nonce: "0x0000000000000000",
-  number: "0x10823a8",
-  parentHash: "0x956846b5012b1df4f4c928b85db2f6456b2faed2c0ca136e89c928a87ceec69c",
-  receiptsRoot: "0x89b73c221ca0d721f8805edbecbf55524b0556dc5111680bac1c4dd02a286457",
-  sha3Uncles: "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
-  size: "0x25e",
-  stateRoot: "0xe38ef58ddfbf00b03f7bd431fca306e5fcaecc138f4208501d2588657a65a0f3",
-  timestamp: "0x646a982b",
-  totalDifficulty: "0xc70d815d562d3cfa955",
-  transactionsRoot: "0xe44699ea734cee851a852db4d257617c8369b8a7e68bd54b6de829377234017b",
-  withdrawalsRoot: "0x917f5a8e4d652233a80b0973ff20bde517ed2a6a93defe7e99c5263089453e17"
+  "baseFeePerGas": "0x6c3f71624",
+  "difficulty": "0x0",
+  "extraData": "0x496c6c756d696e61746520446d6f63726174697a6520447374726962757465",
+  "gasLimit": "0x1c9c380",
+  "gasUsed": "0x1312759",
+  "hash": "0x4574b6f248bf3295f76ae797454f4ec21c8ef5b53c0f7fee8534b65623d9360a",
+  "logsBloom": "0x04a13010898372c9ca19007ccd04eed1f707098f04123de47da9d0b67ce1a60ab8ea324cd8291c36a8ca5a520893d1552711012dba82ad817332008d90ac788047c0fcd2d1200cb82bd1690b32b6d7ab8ab28a86b1f7095a19b59104d062882093746d041b510537a4d0015518c1583de073045981792d0030aa5cd5089a0a700160f74b0b250a9e30ea90596fdf851732815da30d800ace471e2768e09bc0d45e79f97238136523021a4bd52d45a5e184c8c810a9c22afa8670b6bab0eb2636ea1981120a400040829021a3e96cbe0262d8a6ba06006b37249117230968eecc0c16a7ae4090e888673f1101a27159d5cd12a190f5aa85cb524dbc72f5d4ed14",
+  "miner": "0xdafea492d9c6733ae3d56b7ed1adb60692c98bc5",
+  "mixHash": "0xec33ce424110ddd8f7e7db1cbc1261a63e44dacd158b4e801566cd6d5849295b",
+  "nonce": "0x0000000000000000",
+  "number": "0x10823a8",
+  "parentHash": "0x956846b5012b1df4f4c928b85db2f6456b2faed2c0ca136e89c928a87ceec69c",
+  "receiptsRoot": "0x89b73c221ca0d721f8805edbecbf55524b0556dc5111680bac1c4dd02a286457",
+  "sha3Uncles": "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+  "size": "0x25e",
+  "stateRoot": "0xe38ef58ddfbf00b03f7bd431fca306e5fcaecc138f4208501d2588657a65a0f3",
+  "timestamp": "0x646a982b",
+  "totalDifficulty": "0xc70d815d562d3cfa955",
+  "transactionsRoot": "0xe44699ea734cee851a852db4d257617c8369b8a7e68bd54b6de829377234017b",
+  "withdrawalsRoot": "0x917f5a8e4d652233a80b0973ff20bde517ed2a6a93defe7e99c5263089453e17"
 }
 ```

--- a/docs/interacting-with-geth/rpc/ns-eth.md
+++ b/docs/interacting-with-geth/rpc/ns-eth.md
@@ -70,7 +70,7 @@ The method returns a single `Binary` consisting the return value of the executed
 With a synced Rinkeby node with RPC exposed on localhost (`geth --rinkeby --http`) we can make a call against the [CheckpointOracle](https://rinkeby.etherscan.io/address/0xebe8efa441b9302a0d7eaecc277c09d20d684540) to retrieve the list of administrators:
 
 ```sh
-$ curl --data '{"method":"eth_call","params":[{"to":"0xebe8efa441b9302a0d7eaecc277c09d20d684540","data":"0x45848dfc"},"latest"],"id":1,"jsonrpc":"2.0"}' -H "Content-Type: application/json" -X POST localhost:8545
+curl --data '{"method":"eth_call","params":[{"to":"0xebe8efa441b9302a0d7eaecc277c09d20d684540","data":"0x45848dfc"},"latest"],"id":1,"jsonrpc":"2.0"}' -H "Content-Type: application/json" -X POST localhost:8545
 ```
 
 And the result is an Ethereum ABI encoded list of accounts:
@@ -121,7 +121,7 @@ With a synced Rinkeby node with RPC exposed on localhost (`geth --rinkeby --http
 threshold field:
 
 ```sh
-$ curl --data '{"method":"eth_call","params":[{"to":"0xebe8efa441b9302a0d7eaecc277c09d20d684540","data":"0x0be5b6ba"}, "latest", {"0xebe8efa441b9302a0d7eaecc277c09d20d684540": {"code":"0x6080604052348015600f57600080fd5b506004361060285760003560e01c80630be5b6ba14602d575b600080fd5b60336045565b60408051918252519081900360200190f35b6007549056fea265627a7a723058206f26bd0433456354d8d1228d8fe524678a8aeeb0594851395bdbd35efc2a65f164736f6c634300050a0032"}}],"id":1,"jsonrpc":"2.0"}' -H "Content-Type: application/json" -X POST localhost:8545
+curl --data '{"method":"eth_call","params":[{"to":"0xebe8efa441b9302a0d7eaecc277c09d20d684540","data":"0x0be5b6ba"}, "latest", {"0xebe8efa441b9302a0d7eaecc277c09d20d684540": {"code":"0x6080604052348015600f57600080fd5b506004361060285760003560e01c80630be5b6ba14602d575b600080fd5b60336045565b60408051918252519081900360200190f35b6007549056fea265627a7a723058206f26bd0433456354d8d1228d8fe524678a8aeeb0594851395bdbd35efc2a65f164736f6c634300050a0032"}}],"id":1,"jsonrpc":"2.0"}' -H "Content-Type: application/json" -X POST localhost:8545
 ```
 
 And the result is the Ethereum ABI encoded threshold number:
@@ -149,7 +149,7 @@ This method creates an [EIP2930](https://eips.ethereum.org/EIPS/eip-2930) type `
 
 **Usage:**
 
-```
+```sh
 curl --data '{"method":"eth_createAccessList","params":[{"from": "0x8cd02c6cbd8375b39b06577f8d50c51d86e8d5cd", "data": "0x608060806080608155"}, "pending"],"id":1,"jsonrpc":"2.0"}' -H "Content-Type: application/json" -X POST localhost:8545
 ```
 
@@ -187,7 +187,7 @@ Returns a block header.
 
 **Usage:**
 
-```
+```sh
 curl localhost:8545 -X POST -H "Content-Type: application/json" -d '{"jsonrpc":"2.0","method":"eth_getHeaderByNumber","params":["0x10823a8"],"id":0}'
 ```
 
@@ -230,7 +230,7 @@ Returns a block header.
 
 **Usage:**
 
-```
+```sh
 curl localhost:8545 -X POST -H "Content-Type: application/json" -d '{"jsonrpc":"2.0","method":"eth_getHeaderByHash","params":["0x4574b6f248bf3295f76ae797454f4ec21c8ef5b53c0f7fee8534b65623d9360a"],"id":0}'
 ```
 

--- a/docs/interacting-with-geth/rpc/ns-eth.md
+++ b/docs/interacting-with-geth/rpc/ns-eth.md
@@ -13,7 +13,7 @@ These methods are used for real-time events through subscriptions. See the [subs
 
 Executes a new message call immediately, without creating a transaction on the block chain. The `eth_call` method can be used to query internal contract state, to execute validations coded into a contract or even to test what the effect of a transaction would be without running it live.
 
-#### Parameters
+Parameters:
 
 The method takes 3 parameters: an unsigned transaction object to execute in read-only mode; the block number to execute the call against; and an optional state override-set to allow executing the call against a modified chain state.
 
@@ -141,7 +141,7 @@ Just for the sake of completeness, decoded the response is: `2`.
 
 This method creates an [EIP2930](https://eips.ethereum.org/EIPS/eip-2930) type `accessList` based on a given `Transaction`. The `accessList` contains all storage slots and addresses read and written by the transaction, except for the sender account and the precompiles. This method uses the same `transaction` call [object](/docs/interacting-with-geth/rpc/objects#transaction-call-object) and `blockNumberOrTag` object as `eth_call`. An `accessList` can be used to unstuck contracts that became inaccessible due to gas cost increases.
 
-#### Parameters
+Parameters:
 
 | Field              | Type     | Description                                    |
 | :----------------- | :------- | :--------------------------------------------- |
@@ -180,7 +180,7 @@ Example:
 
 Returns a block header.
 
-#### Parameters
+Parameters:
 
 | Field              | Type       | Description                        |
 | :----------------- | :--------- | :--------------------------------- |
@@ -223,7 +223,7 @@ curl localhost:8545 -X POST -H "Content-Type: application/json" -d '{"jsonrpc":"
 
 Returns a block header.
 
-#### Parameters
+Parameters:
 
 | Field              | Type       | Description                        |
 | :----------------- | :--------- | :--------------------------------- |

--- a/docs/interacting-with-geth/rpc/ns-eth.md
+++ b/docs/interacting-with-geth/rpc/ns-eth.md
@@ -13,7 +13,7 @@ These methods are used for real-time events through subscriptions. See the [subs
 
 Executes a new message call immediately, without creating a transaction on the block chain. The `eth_call` method can be used to query internal contract state, to execute validations coded into a contract or even to test what the effect of a transaction would be without running it live.
 
-Parameters:
+**Parameters:**
 
 The method takes 3 parameters: an unsigned transaction object to execute in read-only mode; the block number to execute the call against; and an optional state override-set to allow executing the call against a modified chain state.
 
@@ -44,7 +44,7 @@ The goal of the _state override set_ is manyfold:
 
 - It can be used to debug smart contracts in an already deployed large suite of contracts by selectively overriding some code or state and seeing how execution changes. Specialized tooling will probably be necessary.
 
-Example:
+**Example:**
 
 ```json
 {
@@ -141,7 +141,7 @@ Just for the sake of completeness, decoded the response is: `2`.
 
 This method creates an [EIP2930](https://eips.ethereum.org/EIPS/eip-2930) type `accessList` based on a given `Transaction`. The `accessList` contains all storage slots and addresses read and written by the transaction, except for the sender account and the precompiles. This method uses the same `transaction` call [object](/docs/interacting-with-geth/rpc/objects#transaction-call-object) and `blockNumberOrTag` object as `eth_call`. An `accessList` can be used to unstuck contracts that became inaccessible due to gas cost increases.
 
-Parameters:
+**Parameters:**
 
 | Field              | Type     | Description                                    |
 | :----------------- | :------- | :--------------------------------------------- |
@@ -160,7 +160,7 @@ The method `eth_createAccessList` returns list of addresses and storage keys use
 
 That is, it gives the list of addresses and storage keys that will be used by that transaction, plus the gas consumed if the access list is included. Like `eth_estimateGas`, this is an estimation; the list could change when the transaction is actually mined. Adding an `accessList` to a transaction does not necessary result in lower gas usage compared to a transaction without an access list.
 
-Example:
+**Example:**
 
 ```json
 {
@@ -180,7 +180,7 @@ Example:
 
 Returns a block header.
 
-Parameters:
+**Parameters:**
 
 | Field              | Type       | Description                        |
 | :----------------- | :--------- | :--------------------------------- |
@@ -223,7 +223,7 @@ curl localhost:8545 -X POST -H "Content-Type: application/json" -d '{"jsonrpc":"
 
 Returns a block header.
 
-Parameters:
+**Parameters:**
 
 | Field              | Type       | Description                        |
 | :----------------- | :--------- | :--------------------------------- |

--- a/docs/interacting-with-geth/rpc/ns-eth.md
+++ b/docs/interacting-with-geth/rpc/ns-eth.md
@@ -148,13 +148,13 @@ This method creates an [EIP2930](https://eips.ethereum.org/EIPS/eip-2930) type `
 | `transaction`      | `Object` | `TransactionCall` object                       |
 | `blockNumberOrTag` | `Object` | Optional, blocknumber or `latest` or `pending` |
 
-#### Usage
+**Usage:**
 
 ```
 curl --data '{"method":"eth_createAccessList","params":[{"from": "0x8cd02c6cbd8375b39b06577f8d50c51d86e8d5cd", "data": "0x608060806080608155"}, "pending"],"id":1,"jsonrpc":"2.0"}' -H "Content-Type: application/json" -X POST localhost:8545
 ```
 
-#### Response
+**Response:**
 
 The method `eth_createAccessList` returns list of addresses and storage keys used by the transaction, plus the gas consumed when the access list is added.
 
@@ -186,13 +186,13 @@ Returns a block header.
 | :----------------- | :--------- | :--------------------------------- |
 | `blockNumber`      | `Quantity` | Block number                       |
 
-#### Usage
+**Usage:**
 
 ```
 curl localhost:8545 -X POST -H "Content-Type: application/json" -d '{"jsonrpc":"2.0","method":"eth_getHeaderByNumber","params":["0x10823a8"],"id":0}'
 ```
 
-#### Response
+**Response:**
 
 ```json
 {
@@ -229,13 +229,13 @@ Returns a block header.
 | :----------------- | :--------- | :--------------------------------- |
 | `blockHash`        | `string`   | Block hash                         |
 
-#### Usage
+**Usage:**
 
 ```
 curl localhost:8545 -X POST -H "Content-Type: application/json" -d '{"jsonrpc":"2.0","method":"eth_getHeaderByHash","params":["0x4574b6f248bf3295f76ae797454f4ec21c8ef5b53c0f7fee8534b65623d9360a"],"id":0}'
 ```
 
-#### Response
+**Response:**
 
 ```json
 {

--- a/docs/interacting-with-geth/rpc/ns-les.md
+++ b/docs/interacting-with-geth/rpc/ns-les.md
@@ -15,7 +15,7 @@ Get information about currently connected and total/individual allowed connectio
 | Console | `les.serverInfo()`                           |
 | RPC     | `{"method": "les_serverInfo", "params": []}` |
 
-Example:
+**Example:**
 
 ```js
 > les.serverInfo
@@ -39,7 +39,7 @@ Get individual client information (connection, balance, pricing) on the specifie
 | Console | `les.clientInfo([id, ...])`                                          |
 | RPC     | `{"method": "les_clientInfo", "params": [[id, ...]]}`                |
 
-Example:
+**Example:**
 
 ```js
 > les.clientInfo([])
@@ -111,7 +111,7 @@ Get individual client information on clients with a positive balance in the spec
 | Console | `les.priorityClientInfo(id, id, number)`                                                         |
 | RPC     | `{"method": "les_priorityClientInfo", "params": [id, id, number]}`                               |
 
-Example:
+**Example:**
 
 ```js
 > les.priorityClientInfo("0x0000000000000000000000000000000000000000000000000000000000000000", "0x0000000000000000000000000000000000000000000000000000000000000000", 100)
@@ -206,7 +206,7 @@ Add signed value to the token balance of the specified client and update its `me
 | Console | `les.addBalance(id, number, string)`                                        |
 | RPC     | `{"method": "les_addBalance", "params": [id, number, string]}`              |
 
-Example:
+**Example:**
 
 ```js
 > les.addBalance("0x6a47fe7bb23fd335df52ef1690f37ab44265a537b1d18eb616a3e77f898d9e77", 1000000000, "qwerty")
@@ -223,7 +223,7 @@ Set capacity and pricing factors for the specified list of connected clients or 
 | Console | `les.setClientParams([id, ...], {string: value, ...})`                           |
 | RPC     | `{"method": "les_setClientParams", "params": [[id, ...], {string: value, ...}]}` |
 
-Example:
+**Example:**
 
 ```js
 > les.setClientParams(["0x6a47fe7bb23fd335df52ef1690f37ab44265a537b1d18eb616a3e77f898d9e77"], {
@@ -248,7 +248,7 @@ Set default pricing factors for subsequently connected clients.
 | Console | `les.setDefaultParams({string: value, ...})`                           |
 | RPC     | `{"method": "les_setDefaultParams", "params": [{string: value, ...}]}` |
 
-Example:
+**Example:**
 
 ```js
 > les.setDefaultParams({
@@ -272,7 +272,7 @@ Get the index and hashes of the latest known checkpoint.
 | Console | `les.latestCheckpoint()`                           |
 | RPC     | `{"method": "les_latestCheckpoint", "params": []}` |
 
-Example:
+**Example:**
 
 ```js
 > les.latestCheckpoint
@@ -289,7 +289,7 @@ Get checkpoint hashes by index.
 | Console | `les.getCheckpoint(number)`                           |
 | RPC     | `{"method": "les_getCheckpoint", "params": [number]}` |
 
-Example:
+**Example:**
 
 ```js
 > les.getCheckpoint(256)
@@ -306,7 +306,7 @@ Get the address of the checkpoint oracle contract.
 | Console | `les.checkpointContractAddress()`                              |
 | RPC     | `{"method": "les_getCheckpointContractAddress", "params": []}` |
 
-Example:
+**Example:**
 
 ```js
 > les.checkpointContractAddress

--- a/docs/interacting-with-geth/rpc/ns-les.md
+++ b/docs/interacting-with-geth/rpc/ns-les.md
@@ -15,7 +15,7 @@ Get information about currently connected and total/individual allowed connectio
 | Console | `les.serverInfo()`                           |
 | RPC     | `{"method": "les_serverInfo", "params": []}` |
 
-### Example
+Example:
 
 ```js
 > les.serverInfo
@@ -39,7 +39,7 @@ Get individual client information (connection, balance, pricing) on the specifie
 | Console | `les.clientInfo([id, ...])`                                          |
 | RPC     | `{"method": "les_clientInfo", "params": [[id, ...]]}`                |
 
-### Example
+Example:
 
 ```js
 > les.clientInfo([])
@@ -111,7 +111,7 @@ Get individual client information on clients with a positive balance in the spec
 | Console | `les.priorityClientInfo(id, id, number)`                                                         |
 | RPC     | `{"method": "les_priorityClientInfo", "params": [id, id, number]}`                               |
 
-### Example
+Example:
 
 ```js
 > les.priorityClientInfo("0x0000000000000000000000000000000000000000000000000000000000000000", "0x0000000000000000000000000000000000000000000000000000000000000000", 100)
@@ -206,7 +206,7 @@ Add signed value to the token balance of the specified client and update its `me
 | Console | `les.addBalance(id, number, string)`                                        |
 | RPC     | `{"method": "les_addBalance", "params": [id, number, string]}`              |
 
-### Example
+Example:
 
 ```js
 > les.addBalance("0x6a47fe7bb23fd335df52ef1690f37ab44265a537b1d18eb616a3e77f898d9e77", 1000000000, "qwerty")
@@ -223,17 +223,17 @@ Set capacity and pricing factors for the specified list of connected clients or 
 | Console | `les.setClientParams([id, ...], {string: value, ...})`                           |
 | RPC     | `{"method": "les_setClientParams", "params": [[id, ...], {string: value, ...}]}` |
 
-### Example
+Example:
 
 ```js
 > les.setClientParams(["0x6a47fe7bb23fd335df52ef1690f37ab44265a537b1d18eb616a3e77f898d9e77"], {
-	"capacity": 100000,
-	"pricing/timeFactor": 0,
-	"pricing/capacityFactor": 1000000000,
-	"pricing/requestCostFactor": 1000000000,
-	"pricing/negative/timeFactor": 0,
-	"pricing/negative/capacityFactor": 1000000000,
-	"pricing/negative/requestCostFactor": 1000000000,
+    "capacity": 100000,
+    "pricing/timeFactor": 0,
+    "pricing/capacityFactor": 1000000000,
+    "pricing/requestCostFactor": 1000000000,
+    "pricing/negative/timeFactor": 0,
+    "pricing/negative/capacityFactor": 1000000000,
+    "pricing/negative/requestCostFactor": 1000000000,
 })
 null
 ```
@@ -248,16 +248,16 @@ Set default pricing factors for subsequently connected clients.
 | Console | `les.setDefaultParams({string: value, ...})`                           |
 | RPC     | `{"method": "les_setDefaultParams", "params": [{string: value, ...}]}` |
 
-### Example
+Example:
 
 ```js
 > les.setDefaultParams({
-	"pricing/timeFactor": 0,
-	"pricing/capacityFactor": 1000000000,
-	"pricing/requestCostFactor": 1000000000,
-	"pricing/negative/timeFactor": 0,
-	"pricing/negative/capacityFactor": 1000000000,
-	"pricing/negative/requestCostFactor": 1000000000,
+    "pricing/timeFactor": 0,
+    "pricing/capacityFactor": 1000000000,
+    "pricing/requestCostFactor": 1000000000,
+    "pricing/negative/timeFactor": 0,
+    "pricing/negative/capacityFactor": 1000000000,
+    "pricing/negative/requestCostFactor": 1000000000,
 })
 null
 ```
@@ -272,7 +272,7 @@ Get the index and hashes of the latest known checkpoint.
 | Console | `les.latestCheckpoint()`                           |
 | RPC     | `{"method": "les_latestCheckpoint", "params": []}` |
 
-### Example
+Example:
 
 ```js
 > les.latestCheckpoint
@@ -289,7 +289,7 @@ Get checkpoint hashes by index.
 | Console | `les.getCheckpoint(number)`                           |
 | RPC     | `{"method": "les_getCheckpoint", "params": [number]}` |
 
-### Example
+Example:
 
 ```js
 > les.getCheckpoint(256)
@@ -306,7 +306,7 @@ Get the address of the checkpoint oracle contract.
 | Console | `les.checkpointContractAddress()`                              |
 | RPC     | `{"method": "les_getCheckpointContractAddress", "params": []}` |
 
-### Example
+Example:
 
 ```js
 > les.checkpointContractAddress

--- a/docs/interacting-with-geth/rpc/ns-personal.md
+++ b/docs/interacting-with-geth/rpc/ns-personal.md
@@ -13,7 +13,7 @@ The following list shows each method from the `personal` namespace and the inten
 
 `personal_listAccounts` displays the addresses of all accounts in the keystore. It is identical to `eth.accounts`. Calling `eth.accounts` requires manual approval in Clef (unless a rule for it has been attested). There is also Clef's `list-accounts` command that can be called from the terminal.
 
-Examples:
+**Examples:**
 
 ```sh
 # eth_accounts using curl
@@ -38,7 +38,7 @@ clef list-accounts
 
 `personal_ecRecover` returns the address for the account that was used to create a signature. An equivalent method, `account_ecRecover` is available on the Clef external API.
 
-Example call:
+**Example call (curl):**
 
 ```sh
 curl --data '{"id": 4, "jsonrpc": "2.0", "method": "account_ecRecover","params": ["0xaabbccdd",     "0x5b6693f153b48ec1c706ba4169960386dbaa6903e249cc79a8e6ddc434451d417e1e57327872c7f538beeb323c300afa9999a3d4a5de6caf3be0d5ef832b67ef1c"]}' -X POST localhost:8550
@@ -64,13 +64,13 @@ clef list-wallets
 
 `personal_newAccount` was used to create a new account and save it in the keystore. Clef has an equivalent method, `account_new`. It can be accessed on the terminal using an http request or using a Clef command:
 
-Example call (curl):
+**Example call (curl):**
 
 ```sh
 curl --data '{"id": 1, "jsonrpc": "2.0", "method": "account_new", "params": []}' -X POST localhost:8550
 ```
 
-Example call (Clef command):
+**Example call (Clef command):**
 
 ```sh
 clef newaccount
@@ -86,7 +86,7 @@ Both require manual approval in Clef unless a custom ruleset is in place.
 
 `personal_sendTransaction` ws used to sign and submit a transaction. This can be done using `eth_sendTransaction`, requiring manual approval in Clef.
 
-Example call (Javascript console):
+**Example call (Javascript console):**
 
 ```js
 // this command requires 2x approval in Clef because it loads account data via eth.accounts[0]
@@ -97,7 +97,7 @@ var tx = { from: eth.accounts[0], to: eth.accounts[1], value: web3.toWei(0.1, 'e
 eth.sendTransaction(tx);
 ```
 
-Example call (terminal)
+**Example call (curl):**
 
 ```sh
 curl --data '{"id":1, "jsonrpc":"2.0", "method":"eth_sendTransaction", "params":[{"from": "0xE70CAD05D0D54Ae3C9Fe5442f901E0433f9bd14B", "to":"0x4FDc03d09Ffca5Bba3138149E29D85C8A9E2Ac42", "gas":"21000","gasPrice":"20000000000", "nonce":"94"}]}' -H "Content-Type: application/json" -X POST localhost:8545
@@ -109,7 +109,7 @@ The sign method calculates an Ethereum specific signature with `sign(keccak256("
 
 `personal.sign` is equivalent to Clef's `account_signData`. It returns the calculated signature.
 
-Example call:
+**Example call (curl):**
 
 ```sh
 curl --data {"id": 3, "jsonrpc": "2.0", "method": "account_signData", "params": ["data/plain", "0x1923f626bb8dc025849e00f99c25fe2b2f7fb0db","0xaabbccdd"]} -X POST localhost:8550
@@ -117,7 +117,9 @@ curl --data {"id": 3, "jsonrpc": "2.0", "method": "account_signData", "params": 
 
 Clef also has `account_signTypedData` that signs data structured according to [EIP-712](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-712.md) and returns the signature.
 
-Example call (use the following as a template for `<data>` in `curl --data <data> -X POST localhost:8550 -H "Content-Type: application/json"`)
+**Example call (curl):**
+
+Use the following as a template for `<data>` in `curl --data <data> -X POST localhost:8550 -H "Content-Type: application/json"`
 
 ```json
 {
@@ -198,7 +200,7 @@ Example call (use the following as a template for `<data>` in `curl --data <data
 
 `personal_signTransaction` was used to create and sign a transaction from the given arguments. The transaction was returned in RLP-form, not broadcast to other nodes. The equivalent method is Clef's `account_signTransaction` from the external API. The arguments are a transaction object (`{"from": , "to": , "gas": , "maxPriorityFeePerGas": , "MaxFeePerGas": , "value": , "data": , "nonce": }`)) and an optional method signature that enables Clef to decode the calldata and show the user the methods, arguments and values being sent.
 
-Example call (terminal):
+**Example call (curl):**
 
 ```sh
 curl --data '{"id": 2, "jsonrpc": "2.0", "method": "account_signTransaction", "params": [{"from": "0x1923f626bb8dc025849e00f99c25fe2b2f7fb0db", "gas": "0x55555","gasPrice": "0x1234", "input": "0xabcd", "nonce": "0x0", "to": "0x07a565b7ed7d7a678680a4c162885bedbb695fe0", "value": "0x1234"}]}' -X POST -H "Content-Type: application/json" localhost:8550
@@ -266,7 +268,7 @@ Returns all the Ethereum account addresses of all keys in the key store.
 | Console | `personal.listAccounts`                             |
 | RPC     | `{"method": "personal_listAccounts", "params": []}` |
 
-#### Example
+**Example:**
 
 ```js
 > personal.listAccounts
@@ -282,7 +284,7 @@ Returns a list of wallets this node manages.
 | Console | `personal.listWallets`                             |
 | RPC     | `{"method": "personal_listWallets", "params": []}` |
 
-#### Example
+**Example:**
 
 ```js
 > personal.listWallets
@@ -315,7 +317,7 @@ Returns the address of the new account. At the geth console, `newAccount` will p
 | Console | `personal.newAccount()`                                 |
 | RPC     | `{"method": "personal_newAccount", "params": [string]}` |
 
-#### Example
+**Example:**
 
 ```js
 > personal.newAccount()
@@ -354,7 +356,7 @@ The account can be used with `eth_sign` and `eth_sendTransaction` while it is un
 | Console | `personal.unlockAccount(address, passphrase, duration)`                    |
 | RPC     | `{"method": "personal_unlockAccount", "params": [string, string, number]}` |
 
-#### Examples
+**Examples:**
 
 ```js
 > personal.unlockAccount("0x5e97870f263700f46aa00d967821199b9bc5a120")
@@ -399,7 +401,7 @@ The transaction is the same argument as for `eth_sendTransaction` (i.e. [transac
 | Console | `personal.sendTransaction(tx, passphrase)`                       |
 | RPC     | `{"method": "personal_sendTransaction", "params": [tx, string]}` |
 
-#### Examples
+**Example:**
 
 ```js
 > var tx = {from: "0x391694e7e0b0cce554cb130d723a9d27458f9298", to: "0xafa3f8684e54059998bc3a7b0d2b0da075154d66", value: web3.toWei(1.23, "ether")}
@@ -422,7 +424,7 @@ See ecRecover to verify the signature.
 | Console | `personal.sign(message, account, [password])`                         |
 | RPC     | `{"method": "personal_sign", "params": [message, account, password]}` |
 
-#### Examples
+**Example:**
 
 ```js
 > personal.sign("0xdeadbeaf", "0x9b2055d370f73ec7d8a03e965129118dc8f5bf83", "")
@@ -447,7 +449,7 @@ SignTransaction will create a transaction from the given arguments and tries to 
 | Console | `personal.ecRecover(message, signature)`                           |
 | RPC     | `{"method": "personal_ecRecover", "params": [message, signature]}` |
 
-#### Examples
+**Example:**
 
 ```js
 > personal.sign("0xdeadbeaf", "0x9b2055d370f73ec7d8a03e965129118dc8f5bf83", "")

--- a/docs/interacting-with-geth/rpc/ns-txpool.md
+++ b/docs/interacting-with-geth/rpc/ns-txpool.md
@@ -19,7 +19,7 @@ Please note, there may be multiple transactions associated with the same account
 | Console | `txpool.content`                                                      |
 |   RPC   | `{"method": "txpool_content"}`                                        |
 
-Example:
+**Example:**
 
 ```js
 > txpool.content
@@ -127,7 +127,7 @@ Please note, there may be multiple transactions associated with the same account
 | Console | `txpool.inspect`                                             |
 |   RPC   | `{"method": "txpool_inspect"}`                               |
 
-Example:
+**Example:**
 
 ```js
 > txpool.inspect
@@ -194,7 +194,7 @@ The result is an object with two fields `pending` and `queued`, each of which is
 | Console | `txpool.status`                               |
 | RPC     | `{"method": "txpool_status"}`                 |
 
-Example:
+**Example:**
 
 ```js
 > txpool.status

--- a/docs/interacting-with-geth/rpc/ns-txpool.md
+++ b/docs/interacting-with-geth/rpc/ns-txpool.md
@@ -19,7 +19,7 @@ Please note, there may be multiple transactions associated with the same account
 | Console | `txpool.content`                                                      |
 |   RPC   | `{"method": "txpool_content"}`                                        |
 
-### Example
+Example:
 
 ```js
 > txpool.content
@@ -127,7 +127,7 @@ Please note, there may be multiple transactions associated with the same account
 | Console | `txpool.inspect`                                             |
 |   RPC   | `{"method": "txpool_inspect"}`                               |
 
-### Example
+Example:
 
 ```js
 > txpool.inspect
@@ -194,7 +194,7 @@ The result is an object with two fields `pending` and `queued`, each of which is
 | Console | `txpool.status`                               |
 | RPC     | `{"method": "txpool_status"}`                 |
 
-### Example
+Example:
 
 ```js
 > txpool.status

--- a/docs/interacting-with-geth/rpc/pubsub.md
+++ b/docs/interacting-with-geth/rpc/pubsub.md
@@ -42,12 +42,12 @@ to cancel the subscription:
 
 Subscriptions are created with a regular RPC call with `eth_subscribe` as method and the subscription name as first parameter. If successful it returns the subscription id.
 
-### Parameters
+Parameters:
 
 1. Subscription name
 2. Optional arguments
 
-### Example
+Example:
 
 ```sh
 {"id": 1, "jsonrpc": "2.0", "method": "eth_subscribe", "params": ["newHeads"]}
@@ -58,11 +58,11 @@ Subscriptions are created with a regular RPC call with `eth_subscribe` as method
 
 Subscriptions are cancelled with a regular RPC call with `eth_unsubscribe` as method and the subscription id as first parameter. It returns a bool indicating if the subscription was cancelled successful.
 
-### Parameters
+Parameters:
 
 1. subscription id
 
-### Example
+Example:
 
 ```json
 {"id": 1, "jsonrpc": "2.0", "method": "eth_unsubscribe", "params": ["0x9cef478923ff08bf67fde6c64013158d"]}
@@ -119,7 +119,7 @@ Returns logs that are included in new imported blocks and match the given filter
 
 In case of a chain reorganization previous sent logs that are on the old chain will be resent with the `removed` property set to true. Logs from transactions that ended up in the new chain are emitted. Therefore a subscription can emit logs for the same transaction multiple times.
 
-#### Parameters
+Parameters:
 
 1. `object` with the following (optional) fields
    - **address**, either an address or an array of addresses. Only logs that are created from these addresses are returned (optional)
@@ -156,7 +156,7 @@ Returns the hash for all transactions that are added to the pending state and ar
 
 When a transaction that was previously part of the canonical chain isn't part of the new canonical chain after a reorganization its again emitted.
 
-#### Parameters
+Parameters:
 
 none
 
@@ -184,7 +184,7 @@ returns
 
 Indicates when the node starts or stops synchronizing. The result can either be a boolean indicating that the synchronization has started (true), finished (false) or an object with various progress indicators.
 
-#### Parameters
+Parameters:
 
 none
 

--- a/docs/interacting-with-geth/rpc/pubsub.md
+++ b/docs/interacting-with-geth/rpc/pubsub.md
@@ -9,26 +9,37 @@ It works by subscribing to particular events. The node will return a subscriptio
 
 **Example:**
 
-```sh
+```json
 // create subscription
-{"id": 1, "jsonrpc": "2.0", "method": "eth_subscribe", "params": ["newHeads"]}
+{ "id": 1, "jsonrpc": "2.0", "method": "eth_subscribe", "params": ["newHeads"] }
 ```
 
-returns
+**Response:**
 
-```sh
-{"jsonrpc":"2.0","id":1,"result":"0xcd0c3e8af590364c09d0fa6a1210faf5"}
+```json
+{ "id": 1, "jsonrpc": "2.0", "result": "0xcd0c3e8af590364c09d0fa6a1210faf5" }
+
 // incoming notifications
-{"jsonrpc":"2.0","method":"eth_subscription","params":{"subscription":"0xcd0c3e8af590364c09d0fa6a1210faf5","result":{"difficulty":"0xd9263f42a87",<...>, "uncles":[]}}}
-{"jsonrpc":"2.0","method":"eth_subscription","params":{"subscription":"0xcd0c3e8af590364c09d0fa6a1210faf5","result":{"difficulty":"0xd90b1a7ad02", <...>, "uncles":["0x80aacd1ea4c9da32efd8c2cc9ab38f8f70578fcd46a1a4ed73f82f3e0957f936"]}}}
+{ "jsonrpc": "2.0", "method": "eth_subscription", "params": {"subscription": "0xcd0c3e8af590364c09d0fa6a1210faf5", "result": {"difficulty": "0xd9263f42a87", <...>,  "uncles": []}} }
+{ "jsonrpc": "2.0", "method": "eth_subscription", "params": {"subscription": "0xcd0c3e8af590364c09d0fa6a1210faf5", "result": {"difficulty": "0xd90b1a7ad02",  <...>,  "uncles": ["0x80aacd1ea4c9da32efd8c2cc9ab38f8f70578fcd46a1a4ed73f82f3e0957f936"]}} }
+
 ```
 
 to cancel the subscription:
 
-```sh
-// cancel subscription
-{"id": 1, "jsonrpc": "2.0", "method": "eth_unsubscribe", "params": ["0xcd0c3e8af590364c09d0fa6a1210faf5"]}
-{"jsonrpc":"2.0","id":1,"result":true}
+```json
+{
+  "id": 1,
+  "jsonrpc": "2.0",
+  "method": "eth_unsubscribe",
+  "params": ["0xcd0c3e8af590364c09d0fa6a1210faf5"]
+}
+```
+
+**Response:**
+
+```json
+{ "id": 1, "jsonrpc": "2.0", "result": true }
 ```
 
 ## Considerations {#considerations}
@@ -49,9 +60,9 @@ Subscriptions are created with a regular RPC call with `eth_subscribe` as method
 
 **Example:**
 
-```sh
-{"id": 1, "jsonrpc": "2.0", "method": "eth_subscribe", "params": ["newHeads"]}
-{"id": 1, "jsonrpc": "2.0", "result": "0x9cef478923ff08bf67fde6c64013158d"}
+```json
+{ "id": 1, "jsonrpc": "2.0", "method": "eth_subscribe", "params": ["newHeads"] }
+{ "id": 1, "jsonrpc": "2.0", "result": "0x9cef478923ff08bf67fde6c64013158d" }
 ```
 
 ## Cancel subscription {#cancel-subscriptions}
@@ -65,8 +76,8 @@ Subscriptions are cancelled with a regular RPC call with `eth_unsubscribe` as me
 **Example:**
 
 ```json
-{"id": 1, "jsonrpc": "2.0", "method": "eth_unsubscribe", "params": ["0x9cef478923ff08bf67fde6c64013158d"]}
-{"jsonrpc":"2.0","id":1,"result":true}
+{ "id": 1, "jsonrpc": "2.0", "method": "eth_unsubscribe", "params": ["0x9cef478923ff08bf67fde6c64013158d"] }
+{ "id": 1, "jsonrpc": "2.0", "result": true }
 ```
 
 ## Supported Subscriptions {#supported-subscriptions}
@@ -77,17 +88,18 @@ Fires a notification each time a new header is appended to the chain, including 
 
 In case of a chain reorganization the subscription will emit the last header in the new chain. Therefore the subscription can emit multiple headers on the same height.
 
-#### Example
+**Example:**
 
 ```json
-{"id": 1, "jsonrpc": "2.0", "method": "eth_subscribe", "params": ["newHeads"]}
+{ "id": 1, "jsonrpc": "2.0", "method": "eth_subscribe", "params": ["newHeads"] }
 ```
 
-returns
+**Response:**
 
 ```json
-{"jsonrpc":"2.0","id":2,"result":"0x9ce59a13059e417087c02d3236a0b1cc"}
+{ "id": 1, "jsonrpc": "2.0", "result": "0x9ce59a13059e417087c02d3236a0b1cc" }
 
+// incoming notifications
 {
   "jsonrpc": "2.0",
   "method": "eth_subscription",
@@ -125,7 +137,7 @@ In case of a chain reorganization previous sent logs that are on the old chain w
    - **address**, either an address or an array of addresses. Only logs that are created from these addresses are returned (optional)
    - **topics**, only logs which match the specified topics (optional)
 
-#### Example
+**Example:**
 
 ```json
 {
@@ -142,12 +154,29 @@ In case of a chain reorganization previous sent logs that are on the old chain w
 }
 ```
 
-returns
+**Response:**
 
 ```json
-{"jsonrpc":"2.0","id":2,"result":"0x4a8a4c0517381924f9838102c5a4dcb7"}
+{ "id": 2, "jsonrpc": "2.0", "result": "0x4a8a4c0517381924f9838102c5a4dcb7" }
 
-{"jsonrpc":"2.0","method":"eth_subscription","params": {"subscription":"0x4a8a4c0517381924f9838102c5a4dcb7","result":{"address":"0x8320fe7702b96808f7bbc0d4a888ed1468216cfd","blockHash":"0x61cdb2a09ab99abf791d474f20c2ea89bf8de2923a2d42bb49944c8c993cbf04","blockNumber":"0x29e87","data":"0x00000000000000000000000000000000000000000000000000000000000000010000000000000000000000000000000000000000000000000000000000000003","logIndex":"0x0","topics":["0xd78a0cb8bb633d06981248b816e7bd33c2a35a6089241d099fa519e361cab902"],"transactionHash":"0xe044554a0a55067caafd07f8020ab9f2af60bdfe337e395ecd84b4877a3d1ab4","transactionIndex":"0x0"}}}
+// incoming notifications
+{
+  "jsonrpc": "2.0",
+  "method": "eth_subscription",
+  "params": {
+    "subscription": "0x4a8a4c0517381924f9838102c5a4dcb7",
+    "result": {
+      "address": "0x8320fe7702b96808f7bbc0d4a888ed1468216cfd",
+      "blockHash": "0x61cdb2a09ab99abf791d474f20c2ea89bf8de2923a2d42bb49944c8c993cbf04",
+      "blockNumber": "0x29e87",
+      "data": "0x00000000000000000000000000000000000000000000000000000000000000010000000000000000000000000000000000000000000000000000000000000003",
+      "logIndex": "0x0",
+      "topics": ["0xd78a0cb8bb633d06981248b816e7bd33c2a35a6089241d099fa519e361cab902"],
+      "transactionHash": "0xe044554a0a55067caafd07f8020ab9f2af60bdfe337e395ecd84b4877a3d1ab4",
+      "transactionIndex": "0x0"
+    }
+  }
+}
 ```
 
 ### newPendingTransactions {#newpendingtransactions}
@@ -160,16 +189,18 @@ When a transaction that was previously part of the canonical chain isn't part of
 
 none
 
-#### Example
+**Example:**
 
 ```json
-{"id": 1, "jsonrpc": "2.0", "method": "eth_subscribe", "params": ["newPendingTransactions"]}
+{ "id": 1, "jsonrpc": "2.0", "method": "eth_subscribe", "params": ["newPendingTransactions"] }
 ```
 
-returns
+**Response:**
 
 ```json
-{"jsonrpc":"2.0","id":2,"result":"0xc3b33aa549fb9a60e95d21862596617c"}
+{ "id": 1, "jsonrpc": "2.0", "result": "0xc3b33aa549fb9a60e95d21862596617c" }
+
+// incoming notifications
 {
   "jsonrpc":"2.0",
   "method":"eth_subscription",
@@ -188,11 +219,29 @@ Indicates when the node starts or stops synchronizing. The result can either be 
 
 none
 
-#### Example
+**Example:**
 
 ```json
-{"id": 1, "jsonrpc": "2.0", "method": "eth_subscribe", "params": ["syncing"]}
+{ "id": 1, "jsonrpc": "2.0", "method": "eth_subscribe", "params": ["syncing"] }
+```
 
-{"jsonrpc":"2.0","id":2,"result":"0xe2ffeb2703bcf602d42922385829ce96"}
-{"subscription":"0xe2ffeb2703bcf602d42922385829ce96","result":{"syncing":true,"status":{"startingBlock":674427,"currentBlock":67400,"highestBlock":674432,"pulledStates":0,"knownStates":0}}}}
+**Response:**
+
+```json
+{ "id": 1, "jsonrpc": "2.0", "result": "0xe2ffeb2703bcf602d42922385829ce96" }
+
+// incoming notifications
+{
+  "subscription": "0xe2ffeb2703bcf602d42922385829ce96",
+  "result": {
+    "syncing": true,
+    "status": {
+      "startingBlock": 674427,
+      "currentBlock": 67400,
+      "highestBlock": 674432,
+      "pulledStates": 0,
+      "knownStates": 0
+    }
+  }
+}
 ```

--- a/docs/interacting-with-geth/rpc/pubsub.md
+++ b/docs/interacting-with-geth/rpc/pubsub.md
@@ -7,7 +7,7 @@ Geth v1.4 and later support publish / subscribe using JSON-RPC notifications. Th
 
 It works by subscribing to particular events. The node will return a subscription id. For each event that matches the subscription a notification with relevant data is send together with the subscription id.
 
-Example:
+**Example:**
 
 ```sh
 // create subscription
@@ -42,12 +42,12 @@ to cancel the subscription:
 
 Subscriptions are created with a regular RPC call with `eth_subscribe` as method and the subscription name as first parameter. If successful it returns the subscription id.
 
-Parameters:
+**Parameters:**
 
 1. Subscription name
 2. Optional arguments
 
-Example:
+**Example:**
 
 ```sh
 {"id": 1, "jsonrpc": "2.0", "method": "eth_subscribe", "params": ["newHeads"]}
@@ -58,11 +58,11 @@ Example:
 
 Subscriptions are cancelled with a regular RPC call with `eth_unsubscribe` as method and the subscription id as first parameter. It returns a bool indicating if the subscription was cancelled successful.
 
-Parameters:
+**Parameters:**
 
 1. subscription id
 
-Example:
+**Example:**
 
 ```json
 {"id": 1, "jsonrpc": "2.0", "method": "eth_unsubscribe", "params": ["0x9cef478923ff08bf67fde6c64013158d"]}
@@ -119,7 +119,7 @@ Returns logs that are included in new imported blocks and match the given filter
 
 In case of a chain reorganization previous sent logs that are on the old chain will be resent with the `removed` property set to true. Logs from transactions that ended up in the new chain are emitted. Therefore a subscription can emit logs for the same transaction multiple times.
 
-Parameters:
+**Parameters:**
 
 1. `object` with the following (optional) fields
    - **address**, either an address or an array of addresses. Only logs that are created from these addresses are returned (optional)
@@ -156,7 +156,7 @@ Returns the hash for all transactions that are added to the pending state and ar
 
 When a transaction that was previously part of the canonical chain isn't part of the new canonical chain after a reorganization its again emitted.
 
-Parameters:
+**Parameters:**
 
 none
 
@@ -184,7 +184,7 @@ returns
 
 Indicates when the node starts or stops synchronizing. The result can either be a boolean indicating that the synchronization has started (true), finished (false) or an object with various progress indicators.
 
-Parameters:
+**Parameters:**
 
 none
 

--- a/docs/interacting-with-geth/rpc/pubsub.md
+++ b/docs/interacting-with-geth/rpc/pubsub.md
@@ -9,23 +9,28 @@ It works by subscribing to particular events. The node will return a subscriptio
 
 **Example:**
 
+Create subscription:
+
 ```json
-// create subscription
 { "id": 1, "jsonrpc": "2.0", "method": "eth_subscribe", "params": ["newHeads"] }
 ```
 
 **Response:**
 
+Return a subscription id:
+
 ```json
 { "id": 1, "jsonrpc": "2.0", "result": "0xcd0c3e8af590364c09d0fa6a1210faf5" }
-
-// incoming notifications
-{ "jsonrpc": "2.0", "method": "eth_subscription", "params": {"subscription": "0xcd0c3e8af590364c09d0fa6a1210faf5", "result": {"difficulty": "0xd9263f42a87", <...>,  "uncles": []}} }
-{ "jsonrpc": "2.0", "method": "eth_subscription", "params": {"subscription": "0xcd0c3e8af590364c09d0fa6a1210faf5", "result": {"difficulty": "0xd90b1a7ad02",  <...>,  "uncles": ["0x80aacd1ea4c9da32efd8c2cc9ab38f8f70578fcd46a1a4ed73f82f3e0957f936"]}} }
-
 ```
 
-to cancel the subscription:
+After the creation of the subscrition, we can receive incoming notifications related to this subscription:
+
+```json
+{ "jsonrpc": "2.0", "method": "eth_subscription", "params": {"subscription": "0xcd0c3e8af590364c09d0fa6a1210faf5", "result": {"difficulty": "0xd9263f42a87", <...>, "uncles": []}} }
+{ "jsonrpc": "2.0", "method": "eth_subscription", "params": {"subscription": "0xcd0c3e8af590364c09d0fa6a1210faf5", "result": {"difficulty": "0xd90b1a7ad02", <...>, "uncles": ["0x80aacd1ea4c9da32efd8c2cc9ab38f8f70578fcd46a1a4ed73f82f3e0957f936"]}} }
+```
+
+To cancel the subscription:
 
 ```json
 {
@@ -99,7 +104,6 @@ In case of a chain reorganization the subscription will emit the last header in 
 ```json
 { "id": 1, "jsonrpc": "2.0", "result": "0x9ce59a13059e417087c02d3236a0b1cc" }
 
-// incoming notifications
 {
   "jsonrpc": "2.0",
   "method": "eth_subscription",
@@ -159,7 +163,6 @@ In case of a chain reorganization previous sent logs that are on the old chain w
 ```json
 { "id": 2, "jsonrpc": "2.0", "result": "0x4a8a4c0517381924f9838102c5a4dcb7" }
 
-// incoming notifications
 {
   "jsonrpc": "2.0",
   "method": "eth_subscription",
@@ -200,7 +203,6 @@ none
 ```json
 { "id": 1, "jsonrpc": "2.0", "result": "0xc3b33aa549fb9a60e95d21862596617c" }
 
-// incoming notifications
 {
   "jsonrpc":"2.0",
   "method":"eth_subscription",
@@ -230,7 +232,6 @@ none
 ```json
 { "id": 1, "jsonrpc": "2.0", "result": "0xe2ffeb2703bcf602d42922385829ce96" }
 
-// incoming notifications
 {
   "subscription": "0xe2ffeb2703bcf602d42922385829ce96",
   "result": {


### PR DESCRIPTION
Currently, there are many `Example,Parameters` tags on the right side, so it's hard to switch between other useful rpc methods

<img width="272" alt="image" src="https://github.com/ethereum/go-ethereum/assets/3627395/11bc450f-d89e-4b62-adfe-c57a27fb41a4">

<img width="197" alt="image" src="https://github.com/ethereum/go-ethereum/assets/3627395/b05c014e-be88-48a7-b6f6-e2054829f49d">
