### PR TITLE
fixing blobpool metrics name from - to _ for prometheus

### DIFF
--- a/core/txpool/blobpool/metrics.go
+++ b/core/txpool/blobpool/metrics.go
@@ -35,15 +35,15 @@ var (
 
 	// The below metrics track the per-shelf metrics for the primary blob store
 	// and the temporary limbo store.
-	shelfDatausedGaugeName = "blobpool/shelf-%d/dataused"
-	shelfDatagapsGaugeName = "blobpool/shelf-%d/datagaps"
-	shelfSlotusedGaugeName = "blobpool/shelf-%d/slotused"
-	shelfSlotgapsGaugeName = "blobpool/shelf-%d/slotgaps"
+	shelfDatausedGaugeName = "blobpool/shelf_%d/dataused"
+	shelfDatagapsGaugeName = "blobpool/shelf_%d/datagaps"
+	shelfSlotusedGaugeName = "blobpool/shelf_%d/slotused"
+	shelfSlotgapsGaugeName = "blobpool/shelf_%d/slotgaps"
 
-	limboShelfDatausedGaugeName = "blobpool/limbo/shelf-%d/dataused"
-	limboShelfDatagapsGaugeName = "blobpool/limbo/shelf-%d/datagaps"
-	limboShelfSlotusedGaugeName = "blobpool/limbo/shelf-%d/slotused"
-	limboShelfSlotgapsGaugeName = "blobpool/limbo/shelf-%d/slotgaps"
+	limboShelfDatausedGaugeName = "blobpool/limbo/shelf_%d/dataused"
+	limboShelfDatagapsGaugeName = "blobpool/limbo/shelf_%d/datagaps"
+	limboShelfSlotusedGaugeName = "blobpool/limbo/shelf_%d/slotused"
+	limboShelfSlotgapsGaugeName = "blobpool/limbo/shelf_%d/slotgaps"
 
 	// The oversized metrics aggregate the shelf stats above the max blob count
 	// limits to track transactions that are just huge, but don't contain blobs.


### PR DESCRIPTION
 Created this PR per https://github.com/ethereum/go-ethereum/issues/27900. I am running telegraf as a prometheus server and unable to scrape metrics because the blobpool metrics does not conform to Prometheus metrics naming standards. Please refer to https://prometheus.io/docs/practices/naming/.
 All I am doing is changing the - to a _. 
 I tested and built this and my node was syncing and metrics names are still easily readable:
 ```# TYPE blobpool_shelf_3_slotused gauge
blobpool_shelf_3_slotused 0

# TYPE blobpool_shelf_4_datagaps gauge
blobpool_shelf_4_datagaps 0
```
Apologies if I missed something here. First time open a PR in this repo. 

