### PR TITLE
docker: reduce docker build context sending

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,5 +1,6 @@
 **/*_test.go
 
-build/_workspace
-build/_bin
+.git/
+build/
+!build/ci.go
 tests/testdata


### PR DESCRIPTION
go-ethereum's .git directory now is 200MB+, and docker build will sent all the contents in the working dir except for the file patterns specified in `.dockerignore`, eg:

```bash
$ git clone https://github.com/ethereum/go-ethereum && cd go-ethereum
$ docker build -t ethereum .
Sending build context to Docker daemon  251.8MB
Step 1/19 : ARG COMMIT=""
```

It will send 251.8MB into docker daemon. 


After adding more build unnecessary files in `.dockerignore`:

```diff
-build/_workspace
-build/_bin
+.git/
+build/
+!build/ci.go
```


```bash
$ docker build -t ethereum .
Sending build context to Docker daemon  36.12MB
```

Then it is reduced to 36MB only, this will speed up the building process

