### PR TITLE
metrics: Synchronous EWMA

### DIFF
--- a/metrics/doc.go
+++ b/metrics/doc.go
@@ -1,4 +1,0 @@
-package metrics
-
-const epsilon = 0.0000000000000001
-const epsilonPercentile = .00000000001

--- a/metrics/ewma_test.go
+++ b/metrics/ewma_test.go
@@ -2,7 +2,9 @@ package metrics
 
 import (
 	"math"
+	"math/rand"
 	"testing"
+	"time"
 )
 
 func BenchmarkEWMA(b *testing.B) {
@@ -10,219 +12,56 @@ func BenchmarkEWMA(b *testing.B) {
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		a.Update(1)
-		a.Tick()
+	}
+}
+
+func testEWMA(t *testing.T, alpha float64) {
+	r := rand.New(rand.NewSource(time.Now().Unix()))
+	a := NewEWMA(alpha)
+
+	// Base case.
+
+	if rate := a.Rate(); 0 != rate {
+		t.Errorf("(A) Base Case a.Rate(): 0 != %v\n", rate)
+	}
+	a.Update(10)
+	if rate := a.Rate(); 10 != rate {
+		t.Errorf("(B) Base Case a.Rate(): 10 != %v\n", rate)
+	}
+
+	// Recursive case.
+
+	for i := 0; i < 100; i++ {
+		rnd := r.Int63n(1000)
+		td, _ := NewEWMA(alpha).(*StandardEWMA)
+		td.Update(10)
+		td.addToTimestamp(-(rnd * 1e9))
+		expect := math.Pow(1-alpha, float64(rnd)) * 10.00
+		if rate := td.Rate(); expect != rate {
+			t.Fatalf("(A) Recursive Case a.Rate(): %v != %v\n", expect, rate)
+		}
+
+		expect = alpha*25 + (1-alpha)*expect
+		td.Update(25)
+		td.addToTimestamp(-1e9)
+
+		if rate := td.Rate(); rate != expect {
+			t.Fatalf("(B) Recursive Case a.Rate(): %v != %v\n", expect, rate)
+		}
 	}
 }
 
 func TestEWMA1(t *testing.T) {
-	a := NewEWMA1()
-	a.Update(3)
-	a.Tick()
-	if rate := a.Rate(); math.Abs(0.6-rate) > epsilon {
-		t.Errorf("initial a.Rate(): 0.6 != %v\n", rate)
-	}
-	elapseMinute(a)
-	if rate := a.Rate(); math.Abs(0.22072766470286553-rate) > epsilon {
-		t.Errorf("1 minute a.Rate(): 0.22072766470286553 != %v\n", rate)
-	}
-	elapseMinute(a)
-	if rate := a.Rate(); math.Abs(0.08120116994196772-rate) > epsilon {
-		t.Errorf("2 minute a.Rate(): 0.08120116994196772 != %v\n", rate)
-	}
-	elapseMinute(a)
-	if rate := a.Rate(); math.Abs(0.029872241020718428-rate) > epsilon {
-		t.Errorf("3 minute a.Rate(): 0.029872241020718428 != %v\n", rate)
-	}
-	elapseMinute(a)
-	if rate := a.Rate(); math.Abs(0.01098938333324054-rate) > epsilon {
-		t.Errorf("4 minute a.Rate(): 0.01098938333324054 != %v\n", rate)
-	}
-	elapseMinute(a)
-	if rate := a.Rate(); math.Abs(0.004042768199451294-rate) > epsilon {
-		t.Errorf("5 minute a.Rate(): 0.004042768199451294 != %v\n", rate)
-	}
-	elapseMinute(a)
-	if rate := a.Rate(); math.Abs(0.0014872513059998212-rate) > epsilon {
-		t.Errorf("6 minute a.Rate(): 0.0014872513059998212 != %v\n", rate)
-	}
-	elapseMinute(a)
-	if rate := a.Rate(); math.Abs(0.0005471291793327122-rate) > epsilon {
-		t.Errorf("7 minute a.Rate(): 0.0005471291793327122 != %v\n", rate)
-	}
-	elapseMinute(a)
-	if rate := a.Rate(); math.Abs(0.00020127757674150815-rate) > epsilon {
-		t.Errorf("8 minute a.Rate(): 0.00020127757674150815 != %v\n", rate)
-	}
-	elapseMinute(a)
-	if rate := a.Rate(); math.Abs(7.404588245200814e-05-rate) > epsilon {
-		t.Errorf("9 minute a.Rate(): 7.404588245200814e-05 != %v\n", rate)
-	}
-	elapseMinute(a)
-	if rate := a.Rate(); math.Abs(2.7239957857491083e-05-rate) > epsilon {
-		t.Errorf("10 minute a.Rate(): 2.7239957857491083e-05 != %v\n", rate)
-	}
-	elapseMinute(a)
-	if rate := a.Rate(); math.Abs(1.0021020474147462e-05-rate) > epsilon {
-		t.Errorf("11 minute a.Rate(): 1.0021020474147462e-05 != %v\n", rate)
-	}
-	elapseMinute(a)
-	if rate := a.Rate(); math.Abs(3.6865274119969525e-06-rate) > epsilon {
-		t.Errorf("12 minute a.Rate(): 3.6865274119969525e-06 != %v\n", rate)
-	}
-	elapseMinute(a)
-	if rate := a.Rate(); math.Abs(1.3561976441886433e-06-rate) > epsilon {
-		t.Errorf("13 minute a.Rate(): 1.3561976441886433e-06 != %v\n", rate)
-	}
-	elapseMinute(a)
-	if rate := a.Rate(); math.Abs(4.989172314621449e-07-rate) > epsilon {
-		t.Errorf("14 minute a.Rate(): 4.989172314621449e-07 != %v\n", rate)
-	}
-	elapseMinute(a)
-	if rate := a.Rate(); math.Abs(1.8354139230109722e-07-rate) > epsilon {
-		t.Errorf("15 minute a.Rate(): 1.8354139230109722e-07 != %v\n", rate)
-	}
+	// 1-minute moving average.
+	testEWMA(t, 1-math.Exp(-1.0/60.0/1))
 }
 
 func TestEWMA5(t *testing.T) {
-	a := NewEWMA5()
-	a.Update(3)
-	a.Tick()
-	if rate := a.Rate(); math.Abs(0.6-rate) > epsilon {
-		t.Errorf("initial a.Rate(): 0.6 != %v\n", rate)
-	}
-	elapseMinute(a)
-	if rate := a.Rate(); math.Abs(0.49123845184678905-rate) > epsilon {
-		t.Errorf("1 minute a.Rate(): 0.49123845184678905 != %v\n", rate)
-	}
-	elapseMinute(a)
-	if rate := a.Rate(); math.Abs(0.4021920276213837-rate) > epsilon {
-		t.Errorf("2 minute a.Rate(): 0.4021920276213837 != %v\n", rate)
-	}
-	elapseMinute(a)
-	if rate := a.Rate(); math.Abs(0.32928698165641596-rate) > epsilon {
-		t.Errorf("3 minute a.Rate(): 0.32928698165641596 != %v\n", rate)
-	}
-	elapseMinute(a)
-	if rate := a.Rate(); math.Abs(0.269597378470333-rate) > epsilon {
-		t.Errorf("4 minute a.Rate(): 0.269597378470333 != %v\n", rate)
-	}
-	elapseMinute(a)
-	if rate := a.Rate(); math.Abs(0.2207276647028654-rate) > epsilon {
-		t.Errorf("5 minute a.Rate(): 0.2207276647028654 != %v\n", rate)
-	}
-	elapseMinute(a)
-	if rate := a.Rate(); math.Abs(0.18071652714732128-rate) > epsilon {
-		t.Errorf("6 minute a.Rate(): 0.18071652714732128 != %v\n", rate)
-	}
-	elapseMinute(a)
-	if rate := a.Rate(); math.Abs(0.14795817836496392-rate) > epsilon {
-		t.Errorf("7 minute a.Rate(): 0.14795817836496392 != %v\n", rate)
-	}
-	elapseMinute(a)
-	if rate := a.Rate(); math.Abs(0.12113791079679326-rate) > epsilon {
-		t.Errorf("8 minute a.Rate(): 0.12113791079679326 != %v\n", rate)
-	}
-	elapseMinute(a)
-	if rate := a.Rate(); math.Abs(0.09917933293295193-rate) > epsilon {
-		t.Errorf("9 minute a.Rate(): 0.09917933293295193 != %v\n", rate)
-	}
-	elapseMinute(a)
-	if rate := a.Rate(); math.Abs(0.08120116994196763-rate) > epsilon {
-		t.Errorf("10 minute a.Rate(): 0.08120116994196763 != %v\n", rate)
-	}
-	elapseMinute(a)
-	if rate := a.Rate(); math.Abs(0.06648189501740036-rate) > epsilon {
-		t.Errorf("11 minute a.Rate(): 0.06648189501740036 != %v\n", rate)
-	}
-	elapseMinute(a)
-	if rate := a.Rate(); math.Abs(0.05443077197364752-rate) > epsilon {
-		t.Errorf("12 minute a.Rate(): 0.05443077197364752 != %v\n", rate)
-	}
-	elapseMinute(a)
-	if rate := a.Rate(); math.Abs(0.04456414692860035-rate) > epsilon {
-		t.Errorf("13 minute a.Rate(): 0.04456414692860035 != %v\n", rate)
-	}
-	elapseMinute(a)
-	if rate := a.Rate(); math.Abs(0.03648603757513079-rate) > epsilon {
-		t.Errorf("14 minute a.Rate(): 0.03648603757513079 != %v\n", rate)
-	}
-	elapseMinute(a)
-	if rate := a.Rate(); math.Abs(0.0298722410207183831020718428-rate) > epsilon {
-		t.Errorf("15 minute a.Rate(): 0.0298722410207183831020718428 != %v\n", rate)
-	}
+	// 5-minute moving average.
+	testEWMA(t, 1-math.Exp(-1.0/60.0/5))
 }
 
 func TestEWMA15(t *testing.T) {
-	a := NewEWMA15()
-	a.Update(3)
-	a.Tick()
-	if rate := a.Rate(); math.Abs(0.6-rate) > epsilon {
-		t.Errorf("initial a.Rate(): 0.6 != %v\n", rate)
-	}
-	elapseMinute(a)
-	if rate := a.Rate(); math.Abs(0.5613041910189706-rate) > epsilon {
-		t.Errorf("1 minute a.Rate(): 0.5613041910189706 != %v\n", rate)
-	}
-	elapseMinute(a)
-	if rate := a.Rate(); math.Abs(0.5251039914257684-rate) > epsilon {
-		t.Errorf("2 minute a.Rate(): 0.5251039914257684 != %v\n", rate)
-	}
-	elapseMinute(a)
-	if rate := a.Rate(); math.Abs(0.4912384518467888184678905-rate) > epsilon {
-		t.Errorf("3 minute a.Rate(): 0.4912384518467888184678905 != %v\n", rate)
-	}
-	elapseMinute(a)
-	if rate := a.Rate(); math.Abs(0.459557003018789-rate) > epsilon {
-		t.Errorf("4 minute a.Rate(): 0.459557003018789 != %v\n", rate)
-	}
-	elapseMinute(a)
-	if rate := a.Rate(); math.Abs(0.4299187863442732-rate) > epsilon {
-		t.Errorf("5 minute a.Rate(): 0.4299187863442732 != %v\n", rate)
-	}
-	elapseMinute(a)
-	if rate := a.Rate(); math.Abs(0.4021920276213831-rate) > epsilon {
-		t.Errorf("6 minute a.Rate(): 0.4021920276213831 != %v\n", rate)
-	}
-	elapseMinute(a)
-	if rate := a.Rate(); math.Abs(0.37625345116383313-rate) > epsilon {
-		t.Errorf("7 minute a.Rate(): 0.37625345116383313 != %v\n", rate)
-	}
-	elapseMinute(a)
-	if rate := a.Rate(); math.Abs(0.3519877317060185-rate) > epsilon {
-		t.Errorf("8 minute a.Rate(): 0.3519877317060185 != %v\n", rate)
-	}
-	elapseMinute(a)
-	if rate := a.Rate(); math.Abs(0.3292869816564153165641596-rate) > epsilon {
-		t.Errorf("9 minute a.Rate(): 0.3292869816564153165641596 != %v\n", rate)
-	}
-	elapseMinute(a)
-	if rate := a.Rate(); math.Abs(0.3080502714195546-rate) > epsilon {
-		t.Errorf("10 minute a.Rate(): 0.3080502714195546 != %v\n", rate)
-	}
-	elapseMinute(a)
-	if rate := a.Rate(); math.Abs(0.2881831806538789-rate) > epsilon {
-		t.Errorf("11 minute a.Rate(): 0.2881831806538789 != %v\n", rate)
-	}
-	elapseMinute(a)
-	if rate := a.Rate(); math.Abs(0.26959737847033216-rate) > epsilon {
-		t.Errorf("12 minute a.Rate(): 0.26959737847033216 != %v\n", rate)
-	}
-	elapseMinute(a)
-	if rate := a.Rate(); math.Abs(0.2522102307052083-rate) > epsilon {
-		t.Errorf("13 minute a.Rate(): 0.2522102307052083 != %v\n", rate)
-	}
-	elapseMinute(a)
-	if rate := a.Rate(); math.Abs(0.23594443252115815-rate) > epsilon {
-		t.Errorf("14 minute a.Rate(): 0.23594443252115815 != %v\n", rate)
-	}
-	elapseMinute(a)
-	if rate := a.Rate(); math.Abs(0.2207276647028646247028654470286553-rate) > epsilon {
-		t.Errorf("15 minute a.Rate(): 0.2207276647028646247028654470286553 != %v\n", rate)
-	}
-}
-
-func elapseMinute(a EWMA) {
-	for i := 0; i < 12; i++ {
-		a.Tick()
-	}
+	// 15-minute moving average.
+	testEWMA(t, 1-math.Exp(-1.0/60.0/15))
 }

--- a/metrics/meter.go
+++ b/metrics/meter.go
@@ -2,7 +2,6 @@ package metrics
 
 import (
 	"sync"
-	"sync/atomic"
 	"time"
 )
 
@@ -16,13 +15,10 @@ type Meter interface {
 	Rate15() float64
 	RateMean() float64
 	Snapshot() Meter
-	Stop()
 }
 
 // GetOrRegisterMeter returns an existing Meter or constructs and registers a
 // new StandardMeter.
-// Be sure to unregister the meter from the registry once it is of no use to
-// allow for garbage collection.
 func GetOrRegisterMeter(name string, r Registry) Meter {
 	if nil == r {
 		r = DefaultRegistry
@@ -32,8 +28,6 @@ func GetOrRegisterMeter(name string, r Registry) Meter {
 
 // GetOrRegisterMeterForced returns an existing Meter or constructs and registers a
 // new StandardMeter no matter the global switch is enabled or not.
-// Be sure to unregister the meter from the registry once it is of no use to
-// allow for garbage collection.
 func GetOrRegisterMeterForced(name string, r Registry) Meter {
 	if nil == r {
 		r = DefaultRegistry
@@ -42,41 +36,21 @@ func GetOrRegisterMeterForced(name string, r Registry) Meter {
 }
 
 // NewMeter constructs a new StandardMeter and launches a goroutine.
-// Be sure to call Stop() once the meter is of no use to allow for garbage collection.
 func NewMeter() Meter {
 	if !Enabled {
 		return NilMeter{}
 	}
-	m := newStandardMeter()
-	arbiter.Lock()
-	defer arbiter.Unlock()
-	arbiter.meters[m] = struct{}{}
-	if !arbiter.started {
-		arbiter.started = true
-		go arbiter.tick()
-	}
-	return m
+	return newStandardMeter()
 }
 
 // NewMeterForced constructs a new StandardMeter and launches a goroutine no matter
 // the global switch is enabled or not.
-// Be sure to call Stop() once the meter is of no use to allow for garbage collection.
 func NewMeterForced() Meter {
-	m := newStandardMeter()
-	arbiter.Lock()
-	defer arbiter.Unlock()
-	arbiter.meters[m] = struct{}{}
-	if !arbiter.started {
-		arbiter.started = true
-		go arbiter.tick()
-	}
-	return m
+	return newStandardMeter()
 }
 
 // NewRegisteredMeter constructs and registers a new StandardMeter
 // and launches a goroutine.
-// Be sure to unregister the meter from the registry once it is of no use to
-// allow for garbage collection.
 func NewRegisteredMeter(name string, r Registry) Meter {
 	c := NewMeter()
 	if nil == r {
@@ -88,8 +62,6 @@ func NewRegisteredMeter(name string, r Registry) Meter {
 
 // NewRegisteredMeterForced constructs and registers a new StandardMeter
 // and launches a goroutine no matter the global switch is enabled or not.
-// Be sure to unregister the meter from the registry once it is of no use to
-// allow for garbage collection.
 func NewRegisteredMeterForced(name string, r Registry) Meter {
 	c := NewMeterForced()
 	if nil == r {
@@ -101,7 +73,6 @@ func NewRegisteredMeterForced(name string, r Registry) Meter {
 
 // MeterSnapshot is a read-only copy of another Meter.
 type MeterSnapshot struct {
-	temp                           atomic.Int64
 	count                          int64
 	rate1, rate5, rate15, rateMean float64
 }
@@ -133,9 +104,6 @@ func (m *MeterSnapshot) RateMean() float64 { return m.rateMean }
 // Snapshot returns the snapshot.
 func (m *MeterSnapshot) Snapshot() Meter { return m }
 
-// Stop is a no-op.
-func (m *MeterSnapshot) Stop() {}
-
 // NilMeter is a no-op Meter.
 type NilMeter struct{}
 
@@ -160,21 +128,16 @@ func (NilMeter) RateMean() float64 { return 0.0 }
 // Snapshot is a no-op.
 func (NilMeter) Snapshot() Meter { return NilMeter{} }
 
-// Stop is a no-op.
-func (NilMeter) Stop() {}
-
 // StandardMeter is the standard implementation of a Meter.
 type StandardMeter struct {
 	lock        sync.RWMutex
-	snapshot    *MeterSnapshot
+	count       int64
 	a1, a5, a15 EWMA
 	startTime   time.Time
-	stopped     atomic.Bool
 }
 
 func newStandardMeter() *StandardMeter {
 	return &StandardMeter{
-		snapshot:  &MeterSnapshot{},
 		a1:        NewEWMA1(),
 		a5:        NewEWMA5(),
 		a15:       NewEWMA15(),
@@ -182,123 +145,53 @@ func newStandardMeter() *StandardMeter {
 	}
 }
 
-// Stop stops the meter, Mark() will be a no-op if you use it after being stopped.
-func (m *StandardMeter) Stop() {
-	stopped := m.stopped.Swap(true)
-	if !stopped {
-		arbiter.Lock()
-		delete(arbiter.meters, m)
-		arbiter.Unlock()
-	}
-}
-
 // Count returns the number of events recorded.
 // It updates the meter to be as accurate as possible
 func (m *StandardMeter) Count() int64 {
-	m.lock.Lock()
-	defer m.lock.Unlock()
-	m.updateMeter()
-	return m.snapshot.count
+	m.lock.RLock()
+	defer m.lock.RUnlock()
+	return m.count
 }
 
 // Mark records the occurrence of n events.
 func (m *StandardMeter) Mark(n int64) {
-	m.snapshot.temp.Add(n)
+	m.lock.Lock()
+	defer m.lock.Unlock()
+	m.count += n
+	m.a1.Update(n)
+	m.a5.Update(n)
+	m.a15.Update(n)
 }
 
 // Rate1 returns the one-minute moving average rate of events per second.
 func (m *StandardMeter) Rate1() float64 {
-	m.lock.RLock()
-	defer m.lock.RUnlock()
-	return m.snapshot.rate1
+	return m.a1.Rate()
 }
 
 // Rate5 returns the five-minute moving average rate of events per second.
 func (m *StandardMeter) Rate5() float64 {
-	m.lock.RLock()
-	defer m.lock.RUnlock()
-	return m.snapshot.rate5
+	return m.a5.Rate()
 }
 
 // Rate15 returns the fifteen-minute moving average rate of events per second.
 func (m *StandardMeter) Rate15() float64 {
-	m.lock.RLock()
-	defer m.lock.RUnlock()
-	return m.snapshot.rate15
+	return m.a15.Rate()
 }
 
 // RateMean returns the meter's mean rate of events per second.
 func (m *StandardMeter) RateMean() float64 {
 	m.lock.RLock()
 	defer m.lock.RUnlock()
-	return m.snapshot.rateMean
+	return float64(m.count) / (1 + time.Since(m.startTime).Seconds())
 }
 
 // Snapshot returns a read-only copy of the meter.
 func (m *StandardMeter) Snapshot() Meter {
-	m.lock.RLock()
-	snapshot := MeterSnapshot{
-		count:    m.snapshot.count,
-		rate1:    m.snapshot.rate1,
-		rate5:    m.snapshot.rate5,
-		rate15:   m.snapshot.rate15,
-		rateMean: m.snapshot.rateMean,
-	}
-	snapshot.temp.Store(m.snapshot.temp.Load())
-	m.lock.RUnlock()
-	return &snapshot
-}
-
-func (m *StandardMeter) updateSnapshot() {
-	// should run with write lock held on m.lock
-	snapshot := m.snapshot
-	snapshot.rate1 = m.a1.Rate()
-	snapshot.rate5 = m.a5.Rate()
-	snapshot.rate15 = m.a15.Rate()
-	snapshot.rateMean = float64(snapshot.count) / time.Since(m.startTime).Seconds()
-}
-
-func (m *StandardMeter) updateMeter() {
-	// should only run with write lock held on m.lock
-	n := m.snapshot.temp.Swap(0)
-	m.snapshot.count += n
-	m.a1.Update(n)
-	m.a5.Update(n)
-	m.a15.Update(n)
-}
-
-func (m *StandardMeter) tick() {
-	m.lock.Lock()
-	defer m.lock.Unlock()
-	m.updateMeter()
-	m.a1.Tick()
-	m.a5.Tick()
-	m.a15.Tick()
-	m.updateSnapshot()
-}
-
-// meterArbiter ticks meters every 5s from a single goroutine.
-// meters are references in a set for future stopping.
-type meterArbiter struct {
-	sync.RWMutex
-	started bool
-	meters  map[*StandardMeter]struct{}
-	ticker  *time.Ticker
-}
-
-var arbiter = meterArbiter{ticker: time.NewTicker(5 * time.Second), meters: make(map[*StandardMeter]struct{})}
-
-// Ticks meters on the scheduled interval
-func (ma *meterArbiter) tick() {
-	for range ma.ticker.C {
-		ma.tickMeters()
-	}
-}
-
-func (ma *meterArbiter) tickMeters() {
-	ma.RLock()
-	defer ma.RUnlock()
-	for meter := range ma.meters {
-		meter.tick()
+	return &MeterSnapshot{
+		count:    m.Count(),
+		rate1:    m.Rate1(),
+		rate5:    m.Rate5(),
+		rate15:   m.Rate15(),
+		rateMean: m.RateMean(),
 	}
 }

--- a/metrics/prometheus/collector_test.go
+++ b/metrics/prometheus/collector_test.go
@@ -36,12 +36,10 @@ func TestCollector(t *testing.T) {
 	c.addHistogram("test/histogram", histogram)
 
 	meter := metrics.NewMeter()
-	defer meter.Stop()
 	meter.Mark(9999999)
 	c.addMeter("test/meter", meter)
 
 	timer := metrics.NewTimer()
-	defer timer.Stop()
 	timer.Update(20 * time.Millisecond)
 	timer.Update(21 * time.Millisecond)
 	timer.Update(22 * time.Millisecond)

--- a/metrics/registry_test.go
+++ b/metrics/registry_test.go
@@ -145,19 +145,27 @@ func TestRegistryGetOrRegisterWithLazyInstantiation(t *testing.T) {
 }
 
 func TestRegistryUnregister(t *testing.T) {
-	l := len(arbiter.meters)
+	count := 0
+	counter := func(string, interface{}) {
+		count++
+	}
+
 	r := NewRegistry()
 	r.Register("foo", NewCounter())
 	r.Register("bar", NewMeter())
 	r.Register("baz", NewTimer())
-	if len(arbiter.meters) != l+2 {
-		t.Errorf("arbiter.meters: %d != %d\n", l+2, len(arbiter.meters))
+	r.Each(counter)
+	if count != 3 {
+		t.Errorf("Register() count: %d != %d\n", 3, count)
 	}
+
 	r.Unregister("foo")
 	r.Unregister("bar")
 	r.Unregister("baz")
-	if len(arbiter.meters) != l {
-		t.Errorf("arbiter.meters: %d != %d\n", l+2, len(arbiter.meters))
+	count = 0
+	r.Each(counter)
+	if count != 0 {
+		t.Errorf("Unregister() count: %d != %d\n", 0, count)
 	}
 }
 

--- a/metrics/sample_test.go
+++ b/metrics/sample_test.go
@@ -296,6 +296,8 @@ func testExpDecaySampleStatistics(t *testing.T, s Sample) {
 }
 
 func testUniformSampleStatistics(t *testing.T, s Sample) {
+	epsilonPercentile := .00000000001
+
 	if count := s.Count(); count != 10000 {
 		t.Errorf("s.Count(): 10000 != %v\n", count)
 	}

--- a/metrics/timer.go
+++ b/metrics/timer.go
@@ -19,7 +19,6 @@ type Timer interface {
 	RateMean() float64
 	Snapshot() Timer
 	StdDev() float64
-	Stop()
 	Sum() int64
 	Time(func())
 	Update(time.Duration)
@@ -29,8 +28,6 @@ type Timer interface {
 
 // GetOrRegisterTimer returns an existing Timer or constructs and registers a
 // new StandardTimer.
-// Be sure to unregister the meter from the registry once it is of no use to
-// allow for garbage collection.
 func GetOrRegisterTimer(name string, r Registry) Timer {
 	if nil == r {
 		r = DefaultRegistry
@@ -39,7 +36,6 @@ func GetOrRegisterTimer(name string, r Registry) Timer {
 }
 
 // NewCustomTimer constructs a new StandardTimer from a Histogram and a Meter.
-// Be sure to call Stop() once the timer is of no use to allow for garbage collection.
 func NewCustomTimer(h Histogram, m Meter) Timer {
 	if !Enabled {
 		return NilTimer{}
@@ -51,8 +47,6 @@ func NewCustomTimer(h Histogram, m Meter) Timer {
 }
 
 // NewRegisteredTimer constructs and registers a new StandardTimer.
-// Be sure to unregister the meter from the registry once it is of no use to
-// allow for garbage collection.
 func NewRegisteredTimer(name string, r Registry) Timer {
 	c := NewTimer()
 	if nil == r {
@@ -64,7 +58,6 @@ func NewRegisteredTimer(name string, r Registry) Timer {
 
 // NewTimer constructs a new StandardTimer using an exponentially-decaying
 // sample with the same reservoir size and alpha as UNIX load averages.
-// Be sure to call Stop() once the timer is of no use to allow for garbage collection.
 func NewTimer() Timer {
 	if !Enabled {
 		return NilTimer{}
@@ -115,9 +108,6 @@ func (NilTimer) Snapshot() Timer { return NilTimer{} }
 
 // StdDev is a no-op.
 func (NilTimer) StdDev() float64 { return 0.0 }
-
-// Stop is a no-op.
-func (NilTimer) Stop() {}
 
 // Sum is a no-op.
 func (NilTimer) Sum() int64 { return 0 }
@@ -208,11 +198,6 @@ func (t *StandardTimer) StdDev() float64 {
 	return t.histogram.StdDev()
 }
 
-// Stop stops the meter.
-func (t *StandardTimer) Stop() {
-	t.meter.Stop()
-}
-
 // Sum returns the sum in the sample.
 func (t *StandardTimer) Sum() int64 {
 	return t.histogram.Sum()
@@ -299,9 +284,6 @@ func (t *TimerSnapshot) Snapshot() Timer { return t }
 // StdDev returns the standard deviation of the values at the time the snapshot
 // was taken.
 func (t *TimerSnapshot) StdDev() float64 { return t.histogram.StdDev() }
-
-// Stop is a no-op.
-func (t *TimerSnapshot) Stop() {}
 
 // Sum returns the sum at the time the snapshot was taken.
 func (t *TimerSnapshot) Sum() int64 { return t.histogram.Sum() }

--- a/metrics/timer_test.go
+++ b/metrics/timer_test.go
@@ -32,18 +32,6 @@ func TestTimerExtremes(t *testing.T) {
 	}
 }
 
-func TestTimerStop(t *testing.T) {
-	l := len(arbiter.meters)
-	tm := NewTimer()
-	if l+1 != len(arbiter.meters) {
-		t.Errorf("arbiter.meters: %d != %d\n", l+1, len(arbiter.meters))
-	}
-	tm.Stop()
-	if l != len(arbiter.meters) {
-		t.Errorf("arbiter.meters: %d != %d\n", l, len(arbiter.meters))
-	}
-}
-
 func TestTimerFunc(t *testing.T) {
 	var (
 		tm         = NewTimer()


### PR DESCRIPTION
Implements #27846 

Note:
Updating the EWMA every nanosecond would yield erratically inflated results, especially if Rate() was called immediately after EWMA initialization. I've thus opted for a 1-second interval (allowing uncounted events to accumulate) before updating the EWMA.

Previously, the StandardMeter struct held a snapshot that would be continuously updated by the Tick() function. Since metrics are no longer governed by a clock, I've reworked the Snapshot() function to create a new snapshot struct whenever it is called.