### PR TITLE
node: increase batch limits for auth rpc API

### DIFF
--- a/node/defaults.go
+++ b/node/defaults.go
@@ -36,6 +36,13 @@ const (
 	DefaultAuthPort = 8551        // Default port for the authenticated apis
 )
 
+const (
+	// Engine API batch limits: these are not configurable by users, and should cover the
+	// needs of all CLs.
+	engineAPIBatchItemLimit         = 2000
+	engineAPIBatchResponseSizeLimit = 100 * 1000 * 1000
+)
+
 var (
 	DefaultAuthCors    = []string{"localhost"} // Default cors domain for the authenticated apis
 	DefaultAuthVhosts  = []string{"localhost"} // Default virtual hosts for the authenticated apis

--- a/node/defaults.go
+++ b/node/defaults.go
@@ -40,7 +40,7 @@ const (
 	// Engine API batch limits: these are not configurable by users, and should cover the
 	// needs of all CLs.
 	engineAPIBatchItemLimit         = 2000
-	engineAPIBatchResponseSizeLimit = 100 * 1000 * 1000
+	engineAPIBatchResponseSizeLimit = 250 * 1000 * 1000
 )
 
 var (

--- a/node/node.go
+++ b/node/node.go
@@ -449,8 +449,10 @@ func (n *Node) startRPC() error {
 		if err := server.setListenAddr(n.config.AuthAddr, port); err != nil {
 			return err
 		}
-		sharedConfig := rpcConfig
-		sharedConfig.jwtSecret = secret
+		// Don't limit the requests to the auth endpoint
+		sharedConfig := rpcEndpointConfig{
+			jwtSecret: secret,
+		}
 		if err := server.enableRPC(allAPIs, httpConfig{
 			CorsAllowedOrigins: DefaultAuthCors,
 			Vhosts:             n.config.AuthVirtualHosts,

--- a/node/node.go
+++ b/node/node.go
@@ -449,9 +449,10 @@ func (n *Node) startRPC() error {
 		if err := server.setListenAddr(n.config.AuthAddr, port); err != nil {
 			return err
 		}
-		// Don't limit the requests to the auth endpoint
 		sharedConfig := rpcEndpointConfig{
-			jwtSecret: secret,
+			jwtSecret:              secret,
+			batchItemLimit:         engineAPIBatchItemLimit,
+			batchResponseSizeLimit: engineAPIBatchResponseSizeLimit,
 		}
 		if err := server.enableRPC(allAPIs, httpConfig{
 			CorsAllowedOrigins: DefaultAuthCors,


### PR DESCRIPTION
Fixes https://github.com/ethereum/go-ethereum/issues/27923

This raises the JSON-RPC batch request limits significantly for the engine API endpoint.
The limits are now also hard-coded, so users won't get them wrong. I have chosen these limits:

- maximum batch items: 2000
- maximum batch response size: 250MB

While it would also be possible to disable batch limits completely for the engine API, I think having
the limits is a good safety net against misbehaving CLs.