### PR TITLE
all: remove deprecated method strings.Title

### DIFF
--- a/cmd/geth/misccmd.go
+++ b/cmd/geth/misccmd.go
@@ -18,13 +18,13 @@ package main
 
 import (
 	"fmt"
-	"os"
-	"runtime"
-	"strings"
-
 	"github.com/ethereum/go-ethereum/internal/version"
 	"github.com/ethereum/go-ethereum/params"
 	"github.com/urfave/cli/v2"
+	"golang.org/x/text/cases"
+	"golang.org/x/text/language"
+	"os"
+	"runtime"
 )
 
 var (
@@ -72,7 +72,7 @@ and displays information about any security vulnerabilities that affect the curr
 func printVersion(ctx *cli.Context) error {
 	git, _ := version.VCS()
 
-	fmt.Println(strings.Title(clientIdentifier))
+	fmt.Println(cases.Title(language.English).String(clientIdentifier))
 	fmt.Println("Version:", params.VersionWithMeta)
 	if git.Commit != "" {
 		fmt.Println("Git Commit:", git.Commit)

--- a/core/rawdb/database.go
+++ b/core/rawdb/database.go
@@ -20,6 +20,8 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
+	"golang.org/x/text/cases"
+	"golang.org/x/text/language"
 	"os"
 	"path"
 	"path/filepath"
@@ -602,8 +604,8 @@ func InspectDatabase(db ethdb.Database, keyPrefix, keyStart []byte) error {
 	for _, ancient := range ancients {
 		for _, table := range ancient.sizes {
 			stats = append(stats, []string{
-				fmt.Sprintf("Ancient store (%s)", strings.Title(ancient.name)),
-				strings.Title(table.name),
+				fmt.Sprintf("Ancient store (%s)", cases.Title(language.English).String(ancient.name)),
+				cases.Title(language.English).String(table.name),
 				table.size.String(),
 				fmt.Sprintf("%d", ancient.count()),
 			})

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -19,6 +19,8 @@ package version
 
 import (
 	"fmt"
+	"golang.org/x/text/cases"
+	"golang.org/x/text/language"
 	"runtime"
 	"runtime/debug"
 	"strings"
@@ -58,7 +60,7 @@ func VCS() (VCSInfo, bool) {
 func ClientName(clientIdentifier string) string {
 	git, _ := VCS()
 	return fmt.Sprintf("%s/v%v/%v-%v/%v",
-		strings.Title(clientIdentifier),
+		cases.Title(language.English).String(clientIdentifier),
 		params.VersionWithCommit(git.Commit, git.Date),
 		runtime.GOOS, runtime.GOARCH,
 		runtime.Version(),


### PR DESCRIPTION
strings.Title has been deprecated since Go 1.18 and an alternative has been available since Go 1.0: The rule Title uses for word boundaries does not handle Unicode punctuation properly. Use golang.org/x/text/cases instead.