### PR TITLE
core/rawdb/freezer: subtract size of hidden items from AncientSize()

### DIFF
--- a/core/rawdb/freezer.go
+++ b/core/rawdb/freezer.go
@@ -226,7 +226,15 @@ func (f *Freezer) AncientSize(kind string) (uint64, error) {
 	defer f.writeLock.RUnlock()
 
 	if table := f.tables[kind]; table != nil {
-		return table.size()
+		size, err := table.size()
+		if err != nil {
+			return 0, err
+		}
+		hiddenSize, err := table.sizeHidden()
+		if err != nil {
+			return 0, err
+		}
+		return size - hiddenSize, nil
 	}
 	return 0, errUnknownTable
 }

--- a/core/rawdb/freezer_table.go
+++ b/core/rawdb/freezer_table.go
@@ -858,12 +858,6 @@ func (t *freezerTable) sizeHidden() (uint64, error) {
 	t.lock.RLock()
 	defer t.lock.RUnlock()
 
-	return t.sizeHiddenNoLock()
-}
-
-// sizeHiddenNoLock returns the total data size of hidden items in the freezer table
-// without obtaining the mutex first.
-func (t *freezerTable) sizeHiddenNoLock() (uint64, error) {
 	hiddenItems := t.itemHidden.Load()
 	offsetItems := t.itemOffset.Load()
 	if hiddenItems <= offsetItems {

--- a/core/rawdb/freezer_table_test.go
+++ b/core/rawdb/freezer_table_test.go
@@ -683,7 +683,9 @@ func TestTruncateTail(t *testing.T) {
 	require.NoError(t, batch.commit())
 
 	// nothing to do, all the items should still be there.
-	f.truncateTail(0)
+	if err := f.truncateTail(0); err != nil {
+		t.Fatal(err)
+	}
 	fmt.Println(f.dumpIndexString(0, 1000))
 	checkRetrieve(t, f, map[uint64][]byte{
 		0: getChunk(13, 0xFF),
@@ -698,7 +700,9 @@ func TestTruncateTail(t *testing.T) {
 
 	// truncate single element( item 0 ), deletion is only supported at file level
 	// hiddenSize should be 13 (size of item 0)
-	f.truncateTail(1)
+	if err := f.truncateTail(1); err != nil {
+		t.Fatal(err)
+	}
 	fmt.Println(f.dumpIndexString(0, 1000))
 	checkRetrieveError(t, f, map[uint64]error{
 		0: errOutOfBounds,
@@ -736,7 +740,9 @@ func TestTruncateTail(t *testing.T) {
 
 	// truncate two elements( item 0, item 1 ), the file 0 should be deleted
 	// hiddenSize should be 0, as file 0 was deleted
-	f.truncateTail(2)
+	if err := f.truncateTail(2); err != nil {
+		t.Fatal(err)
+	}
 	fmt.Println(f.dumpIndexString(0, 1000))
 	checkRetrieveError(t, f, map[uint64]error{
 		0: errOutOfBounds,
@@ -776,7 +782,9 @@ func TestTruncateTail(t *testing.T) {
 
 	// truncate two elements( item 0, item 1, item 2 ), the file 0 should be deleted
 	// hiddenSize should be 15 (size of item 2), as item 0 and item 1 was deleted with file 0
-	f.truncateTail(3)
+	if err := f.truncateTail(3); err != nil {
+		t.Fatal(err)
+	}
 	fmt.Println(f.dumpIndexString(0, 1000))
 	checkRetrieveError(t, f, map[uint64]error{
 		0: errOutOfBounds,
@@ -816,7 +824,9 @@ func TestTruncateTail(t *testing.T) {
 
 	// truncate all, the entire freezer should be deleted
 	// the hidden size should be 23 (hidden items in last file) as the new tailId is actually the headId
-	f.truncateTail(8)
+	if err := f.truncateTail(8); err != nil {
+		t.Fatal(err)
+	}
 	fmt.Println(f.dumpIndexString(0, 1000))
 	checkRetrieveError(t, f, map[uint64]error{
 		0: errOutOfBounds,

--- a/core/rawdb/freezer_table_test.go
+++ b/core/rawdb/freezer_table_test.go
@@ -703,7 +703,6 @@ func TestTruncateTail(t *testing.T) {
 	if err := f.truncateTail(1); err != nil {
 		t.Fatal(err)
 	}
-	fmt.Println(f.dumpIndexString(0, 1000))
 	checkRetrieveError(t, f, map[uint64]error{
 		0: errOutOfBounds,
 	})
@@ -743,7 +742,6 @@ func TestTruncateTail(t *testing.T) {
 	if err := f.truncateTail(2); err != nil {
 		t.Fatal(err)
 	}
-	fmt.Println(f.dumpIndexString(0, 1000))
 	checkRetrieveError(t, f, map[uint64]error{
 		0: errOutOfBounds,
 		1: errOutOfBounds,
@@ -785,7 +783,6 @@ func TestTruncateTail(t *testing.T) {
 	if err := f.truncateTail(3); err != nil {
 		t.Fatal(err)
 	}
-	fmt.Println(f.dumpIndexString(0, 1000))
 	checkRetrieveError(t, f, map[uint64]error{
 		0: errOutOfBounds,
 		1: errOutOfBounds,
@@ -827,7 +824,6 @@ func TestTruncateTail(t *testing.T) {
 	if err := f.truncateTail(8); err != nil {
 		t.Fatal(err)
 	}
-	fmt.Println(f.dumpIndexString(0, 1000))
 	checkRetrieveError(t, f, map[uint64]error{
 		0: errOutOfBounds,
 		1: errOutOfBounds,


### PR DESCRIPTION
This PR changes how `Freezer.AncientSize()` reports the total data size, as the issue addressed in #27483 .

It introduces two changes:

1. A new function `freezerTable.sizeHidden()` return the total data size of the hidden items by summing up the sizes from the hidden `indexEntry`s (indices from `itemOffset` to `itemHidden`).
2. The return value of `Freezer.AncientSize()` is now `size - sizeHidden` to get the actual size of the live items.

