### PR TITLE
eth: ignore genesis block on importChain

### DIFF
--- a/eth/api_admin.go
+++ b/eth/api_admin.go
@@ -118,6 +118,10 @@ func (api *AdminAPI) ImportChain(file string) (bool, error) {
 			} else if err != nil {
 				return false, fmt.Errorf("block %d: failed to parse: %v", index, err)
 			}
+			// ignore the genesis block when importing blocks
+			if block.NumberU64() == 0 {
+				continue
+			}
 			blocks = append(blocks, block)
 			index++
 		}


### PR DESCRIPTION
This PR ignores the genesis block when importing a previously exported chain. 
The genesis block can not be imported anyway which will lead to bad blocks due to `unknown ancestor`.