### PR TITLE
cmd/evm: add back stateroot to jsonl-output

### DIFF
--- a/cmd/evm/staterunner.go
+++ b/cmd/evm/staterunner.go
@@ -107,18 +107,17 @@ func runStateTest(fname string, cfg vm.Config, jsonOut, dump bool) error {
 			// Run the test and aggregate the result
 			result := &StatetestResult{Name: key, Fork: st.Fork, Pass: true}
 			test.Run(st, cfg, false, rawdb.HashScheme, func(err error, snaps *snapshot.Tree, state *state.StateDB) {
+				root := state.IntermediateRoot(false)
+				result.Root = &root
+				if jsonOut {
+					fmt.Fprintf(os.Stderr, "{\"stateRoot\": \"%#x\"}\n", root)
+				}
 				if err != nil {
 					// Test failed, mark as so and dump any state to aid debugging
 					result.Pass, result.Error = false, err.Error()
 					if dump {
 						dump := state.RawDump(nil)
 						result.State = &dump
-					}
-				} else {
-					root := state.IntermediateRoot(false)
-					result.Root = &root
-					if jsonOut {
-						fmt.Fprintf(os.Stderr, "{\"stateRoot\": \"%#x\"}\n", root)
 					}
 				}
 			})

--- a/cmd/evm/staterunner.go
+++ b/cmd/evm/staterunner.go
@@ -107,10 +107,12 @@ func runStateTest(fname string, cfg vm.Config, jsonOut, dump bool) error {
 			// Run the test and aggregate the result
 			result := &StatetestResult{Name: key, Fork: st.Fork, Pass: true}
 			test.Run(st, cfg, false, rawdb.HashScheme, func(err error, snaps *snapshot.Tree, state *state.StateDB) {
-				root := state.IntermediateRoot(false)
-				result.Root = &root
-				if jsonOut {
-					fmt.Fprintf(os.Stderr, "{\"stateRoot\": \"%#x\"}\n", root)
+				if state != nil {
+					root := state.IntermediateRoot(false)
+					result.Root = &root
+					if jsonOut {
+						fmt.Fprintf(os.Stderr, "{\"stateRoot\": \"%#x\"}\n", root)
+					}
 				}
 				if err != nil {
 					// Test failed, mark as so and dump any state to aid debugging


### PR DESCRIPTION
The PR #26274 broke the `evm statetest` command a bit, in that it stopped spitting out the stateroot following a non-successful statetest-execution. Specifically https://github.com/ethereum/go-ethereum/commit/503f1f7ada6d44714c93647e89a7677b7b706305#diff-b65701f0424f8a0db413f64508b663f424cff1fd3b35095b09493edb0b39ca29

This PR changes it back, so the stateroot is unconditionally output on stderr, and makes it so fuzzing works again. 
I am not sure why the change was needed in the first place, cc @rjl493456442 PTAL and see if I am doing something wrong. 