### PR TITLE
eth/catalyst: disable heartbeat for simulated beacon node

### DIFF
--- a/eth/catalyst/api.go
+++ b/eth/catalyst/api.go
@@ -151,6 +151,23 @@ func NewConsensusAPI(eth *eth.Ethereum) *ConsensusAPI {
 	return api
 }
 
+// newConsensusAPIWithoutHeartbeat creates a new consensus api for the SimulatedBeacon Node.
+func newConsensusAPIWithoutHeartbeat(eth *eth.Ethereum) *ConsensusAPI {
+	if eth.BlockChain().Config().TerminalTotalDifficulty == nil {
+		log.Warn("Engine API started but chain not configured for merge yet")
+	}
+	api := &ConsensusAPI{
+		eth:               eth,
+		remoteBlocks:      newHeaderQueue(),
+		localBlocks:       newPayloadQueue(),
+		invalidBlocksHits: make(map[common.Hash]int),
+		invalidTipsets:    make(map[common.Hash]*types.Header),
+	}
+	eth.Downloader().SetBadBlockCallback(api.setInvalidAncestor)
+
+	return api
+}
+
 // ForkchoiceUpdatedV1 has several responsibilities:
 //
 // We try to set our blockchain to the headBlock.

--- a/eth/catalyst/api.go
+++ b/eth/catalyst/api.go
@@ -135,19 +135,8 @@ type ConsensusAPI struct {
 // NewConsensusAPI creates a new consensus api for the given backend.
 // The underlying blockchain needs to have a valid terminal total difficulty set.
 func NewConsensusAPI(eth *eth.Ethereum) *ConsensusAPI {
-	if eth.BlockChain().Config().TerminalTotalDifficulty == nil {
-		log.Warn("Engine API started but chain not configured for merge yet")
-	}
-	api := &ConsensusAPI{
-		eth:               eth,
-		remoteBlocks:      newHeaderQueue(),
-		localBlocks:       newPayloadQueue(),
-		invalidBlocksHits: make(map[common.Hash]int),
-		invalidTipsets:    make(map[common.Hash]*types.Header),
-	}
-	eth.Downloader().SetBadBlockCallback(api.setInvalidAncestor)
+	api := newConsensusAPIWithoutHeartbeat(eth)
 	go api.heartbeat()
-
 	return api
 }
 
@@ -164,7 +153,6 @@ func newConsensusAPIWithoutHeartbeat(eth *eth.Ethereum) *ConsensusAPI {
 		invalidTipsets:    make(map[common.Hash]*types.Header),
 	}
 	eth.Downloader().SetBadBlockCallback(api.setInvalidAncestor)
-
 	return api
 }
 

--- a/eth/catalyst/simulated_beacon.go
+++ b/eth/catalyst/simulated_beacon.go
@@ -92,7 +92,7 @@ func NewSimulatedBeacon(period uint64, eth *eth.Ethereum) (*SimulatedBeacon, err
 		SafeBlockHash:      block.Hash(),
 		FinalizedBlockHash: block.Hash(),
 	}
-	engineAPI := NewConsensusAPI(eth)
+	engineAPI := newConsensusAPIWithoutHeartbeat(eth)
 
 	// if genesis block, send forkchoiceUpdated to trigger transition to PoS
 	if block.Number.Sign() == 0 {

--- a/eth/catalyst/tester.go
+++ b/eth/catalyst/tester.go
@@ -42,7 +42,7 @@ type FullSyncTester struct {
 // stack for launching and stopping the service controlled by node.
 func RegisterFullSyncTester(stack *node.Node, backend *eth.Ethereum, block *types.Block) (*FullSyncTester, error) {
 	cl := &FullSyncTester{
-		api:    NewConsensusAPI(backend),
+		api:    newConsensusAPIWithoutHeartbeat(backend),
 		block:  block,
 		closed: make(chan struct{}),
 	}


### PR DESCRIPTION
When running geth with `--dev` mode, there are a lot of disturbing warning messages as below:

```
> WARN [08-23|11:54:51.740] Beacon client online, but no consensus updates received in a while. Please fix your beacon client to follow the chain!
> WARN [08-23|11:59:51.786] Beacon client online, but no consensus updates received in a while. Please fix your beacon client to follow the chain!
```

This PR disabled the heartbeat to remove those messages.