### PR TITLE
rlp: remove allocation of bytes.Reader in DecodeBytes

### DIFF
--- a/rlp/decode.go
+++ b/rlp/decode.go
@@ -90,7 +90,7 @@ func Decode(r io.Reader, val interface{}) error {
 // DecodeBytes parses RLP data from b into val. Please see package-level documentation for
 // the decoding rules. The input must contain exactly one value and no trailing data.
 func DecodeBytes(b []byte, val interface{}) error {
-	r := bytes.NewReader(b)
+	r := (*sliceReader)(&b)
 
 	stream := streamPool.Get().(*Stream)
 	defer streamPool.Put(stream)
@@ -99,7 +99,7 @@ func DecodeBytes(b []byte, val interface{}) error {
 	if err := stream.Decode(val); err != nil {
 		return err
 	}
-	if r.Len() > 0 {
+	if len(b) > 0 {
 		return ErrMoreThanOneValue
 	}
 	return nil
@@ -1181,4 +1181,24 @@ func (s *Stream) listLimit() (inList bool, limit uint64) {
 		return false, 0
 	}
 	return true, s.stack[len(s.stack)-1]
+}
+
+type sliceReader []byte
+
+func (sr *sliceReader) Read(b []byte) (int, error) {
+	if len(*sr) == 0 {
+		return 0, io.EOF
+	}
+	n := copy(b, *sr)
+	*sr = (*sr)[n:]
+	return n, nil
+}
+
+func (sr *sliceReader) ReadByte() (byte, error) {
+	if len(*sr) == 0 {
+		return 0, io.EOF
+	}
+	b := (*sr)[0]
+	*sr = (*sr)[1:]
+	return b, nil
 }


### PR DESCRIPTION
This removes a small allocation per DecodeBytes call. Performance impact of this change is hard to assess, but it will certainly not be slower than before.