### PR TITLE
travis: get rid of old useless GO111MODULE directives

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -66,7 +66,6 @@ jobs:
       go: 1.21.x
       env:
         - azure-linux
-        - GO111MODULE=on
       git:
         submodules: false # avoid cloning ethereum/tests
       addons:
@@ -100,7 +99,6 @@ jobs:
       go: 1.21.x
       env:
         - azure-osx
-        - GO111MODULE=on
       git:
         submodules: false # avoid cloning ethereum/tests
       script:
@@ -113,8 +111,6 @@ jobs:
       arch: amd64
       dist: bionic
       go: 1.21.x
-      env:
-        - GO111MODULE=on
       script:
         - travis_wait 30 go run build/ci.go test $TEST_PACKAGES
 
@@ -124,8 +120,6 @@ jobs:
       arch: arm64
       dist: bionic
       go: 1.20.x
-      env:
-        - GO111MODULE=on
       script:
         - travis_wait 30 go run build/ci.go test $TEST_PACKAGES
 
@@ -133,8 +127,6 @@ jobs:
       os: linux
       dist: bionic
       go: 1.20.x
-      env:
-        - GO111MODULE=on
       script:
         - travis_wait 30 go run build/ci.go test $TEST_PACKAGES
 
@@ -146,7 +138,6 @@ jobs:
       go: 1.21.x
       env:
         - ubuntu-ppa
-        - GO111MODULE=on
       git:
         submodules: false # avoid cloning ethereum/tests
       addons:
@@ -170,7 +161,6 @@ jobs:
       go: 1.21.x
       env:
         - azure-purge
-        - GO111MODULE=on
       git:
         submodules: false # avoid cloning ethereum/tests
       script:
@@ -182,8 +172,6 @@ jobs:
       os: linux
       dist: bionic
       go: 1.21.x
-      env:
-        - GO111MODULE=on
       script:
         - travis_wait 30 go run build/ci.go test  -race $TEST_PACKAGES
 

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@
 
 GOBIN = ./build/bin
 GO ?= latest
-GORUN = env GO111MODULE=on go run
+GORUN = go run
 
 geth:
 	$(GORUN) build/ci.go install ./cmd/geth
@@ -23,7 +23,7 @@ lint: ## Run linters.
 	$(GORUN) build/ci.go lint
 
 clean:
-	env GO111MODULE=on go clean -cache
+	go clean -cache
 	rm -fr build/_workspace/pkg/ $(GOBIN)/*
 
 # The devtools target installs tools required for 'go generate'.


### PR DESCRIPTION
GO111MODULE defaults to `on` since Go 1.16