### PR TITLE
core/vm/runtime: Add Random field to config

### DIFF
--- a/core/vm/runtime/env.go
+++ b/core/vm/runtime/env.go
@@ -37,6 +37,7 @@ func NewEnv(cfg *Config) *vm.EVM {
 		Difficulty:  cfg.Difficulty,
 		GasLimit:    cfg.GasLimit,
 		BaseFee:     cfg.BaseFee,
+		Random:      cfg.Random,
 	}
 
 	return vm.NewEVM(blockContext, txContext, cfg.State, cfg.ChainConfig, cfg.EVMConfig)

--- a/core/vm/runtime/runtime.go
+++ b/core/vm/runtime/runtime.go
@@ -45,6 +45,7 @@ type Config struct {
 	EVMConfig   vm.Config
 	BaseFee     *big.Int
 	BlobHashes  []common.Hash
+	Random      *common.Hash
 
 	State     *state.StateDB
 	GetHashFn func(n uint64) common.Hash


### PR DESCRIPTION
Make the Random field configurable through the Runtime interface. The RANDOM opcode will otherwise crash due to a nil pointer if it is run via Runtime.