### PR TITLE
core: remove unnecessary check that storedcfg matches newcfg before writing to disk

### DIFF
--- a/core/genesis.go
+++ b/core/genesis.go
@@ -367,7 +367,6 @@ func SetupGenesisBlockWithOverride(db ethdb.Database, triedb *trie.Database, gen
 		rawdb.WriteChainConfig(db, stored, newcfg)
 		return newcfg, stored, nil
 	}
-	storedData, _ := json.Marshal(storedcfg)
 	// Special case: if a private network is being used (no genesis and also no
 	// mainnet hash in the database), we must not apply the `configOrDefault`
 	// chain config as that would be AllProtocolChanges (applying any new fork
@@ -387,10 +386,7 @@ func SetupGenesisBlockWithOverride(db ethdb.Database, triedb *trie.Database, gen
 	if compatErr != nil && ((head.Number.Uint64() != 0 && compatErr.RewindToBlock != 0) || (head.Time != 0 && compatErr.RewindToTime != 0)) {
 		return newcfg, stored, compatErr
 	}
-	// Don't overwrite if the old is identical to the new
-	if newData, _ := json.Marshal(newcfg); !bytes.Equal(storedData, newData) {
-		rawdb.WriteChainConfig(db, stored, newcfg)
-	}
+	rawdb.WriteChainConfig(db, stored, newcfg)
 	return newcfg, stored, nil
 }
 


### PR DESCRIPTION
This PR removes an unnecessary check that if the new chain config matches the old config it will not write the new config to disk.

In the case, that they are an exact match overwriting the stored config is a no-op change. The current check saves a single DB write on startup, so switching to writing every time instead of performing this check should not be expensive and provides a small simplification to the code.