### PR TITLE
core/txpool/blobpool: fix missing reference

### DIFF
--- a/core/txpool/blobpool/blobpool.go
+++ b/core/txpool/blobpool/blobpool.go
@@ -714,7 +714,7 @@ func (p *BlobPool) offload(addr common.Address, nonce uint64, id uint64, inclusi
 		return
 	}
 	var tx types.Transaction
-	if err = rlp.DecodeBytes(data, tx); err != nil {
+	if err = rlp.DecodeBytes(data, &tx); err != nil {
 		log.Error("Blobs corrupted for included transaction", "from", addr, "nonce", nonce, "id", id, "err", err)
 		return
 	}


### PR DESCRIPTION
Noticed that this tx object should be referenced when used as decode target.