### PR TITLE
miner: fix 4844 max check

### DIFF
--- a/miner/worker.go
+++ b/miner/worker.go
@@ -761,7 +761,7 @@ func (w *worker) commitBlobTransaction(env *environment, tx *types.Transaction) 
 	// isn't really a better place right now. The blob gas limit is checked at block validation time
 	// and not during execution. This means core.ApplyTransaction will not return an error if the
 	// tx has too many blobs. So we have to explicitly check it here.
-	if (env.blobs+len(sc.Blobs))*params.BlobTxBlobGasPerBlob > params.MaxBlobGasPerBlock {
+	if (env.blobs + len(sc.Blobs)) > params.MaxBlobGasPerBlock/params.BlobTxBlobGasPerBlob {
 		return nil, errors.New("max data blobs reached")
 	}
 


### PR DESCRIPTION
There was a small error in #27875 where I conflated blob count with blob gas used. This PR rectifies the issue.