### PR TITLE
metrics: apply selected changes from upstream

### DIFF
--- a/metrics/ewma_test.go
+++ b/metrics/ewma_test.go
@@ -14,6 +14,18 @@ func BenchmarkEWMA(b *testing.B) {
 	}
 }
 
+func BenchmarkEWMAParallel(b *testing.B) {
+	a := NewEWMA1()
+	b.ResetTimer()
+
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			a.Update(1)
+			a.Tick()
+		}
+	})
+}
+
 func TestEWMA1(t *testing.T) {
 	a := NewEWMA1()
 	a.Update(3)

--- a/metrics/timer.go
+++ b/metrics/timer.go
@@ -199,7 +199,7 @@ func (t *StandardTimer) Snapshot() Timer {
 	defer t.mutex.Unlock()
 	return &TimerSnapshot{
 		histogram: t.histogram.Snapshot().(*HistogramSnapshot),
-		meter:     t.meter.Snapshot().(*MeterSnapshot),
+		meter:     t.meter.Snapshot().(*meterSnapshot),
 	}
 }
 
@@ -249,7 +249,7 @@ func (t *StandardTimer) Variance() float64 {
 // TimerSnapshot is a read-only copy of another Timer.
 type TimerSnapshot struct {
 	histogram *HistogramSnapshot
-	meter     *MeterSnapshot
+	meter     *meterSnapshot
 }
 
 // Count returns the number of events recorded at the time the snapshot was


### PR DESCRIPTION
Back in 2018 with PR  https://github.com/ethereum/go-ethereum/pull/15910, we took an external metrics-lib and made it internal. 
Since then, we have applied updates, and also some updates have been applied in the source repo. In this PR, I will cherry-pick and adapt some of those changes that make sense. 

```
name            old time/op  new time/op  delta
EWMA-8          58.8ns ±17%  59.0ns ± 1%     ~     (p=0.690 n=5+5)
EWMAParallel-8   217ns ± 7%   151ns ± 2%  -30.53%  (p=0.008 n=5+5)
```

For `meter`, the change becomes lock-free, but it slightly changes the semantics too (same way upstream also does it: https://github.com/rcrowley/go-metrics/blob/master/meter.go ) . It is not racy, as in, the golang race detector would not find any flaws. That said, with the locks removed, it _is_ possible that during short intervals, the results are inconsistent. If an update happens while a `tick` happens, the `rate1` ewma may contain a datapoint that has not been added to the `rate5` ewma. I don't think it's a problem, and neither does upstream, but still worth mentioning. 