### PR TITLE
log: avoid stack lookups when not needed/used

### DIFF
--- a/common/types_test.go
+++ b/common/types_test.go
@@ -25,6 +25,7 @@ import (
 	"reflect"
 	"strings"
 	"testing"
+	"time"
 )
 
 func TestBytesConversion(t *testing.T) {
@@ -582,4 +583,15 @@ func TestAddressEIP55(t *testing.T) {
 	if addr != dec {
 		t.Fatal("Unexpected address after unmarshal")
 	}
+}
+
+func BenchmarkPrettyDuration(b *testing.B) {
+	var x = PrettyDuration(time.Duration(int64(1203123912312)))
+	b.Logf("Pre %s", time.Duration(x).String())
+	var a string
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		a = x.String()
+	}
+	b.Logf("Post %s", a)
 }

--- a/log/format.go
+++ b/log/format.go
@@ -38,7 +38,7 @@ func PrintOrigins(print bool) {
 	}
 }
 
-// storeStackRecords is an atomic flag controlling whether the log handler needs
+// stackEnabled is an atomic flag controlling whether the log handler needs
 // to store the callsite stack. This is needed in case any handler wants to
 // print locations (locationEnabled), use vmodule, or print full stacks (BacktraceAt).
 var stackEnabled atomic.Bool

--- a/log/format.go
+++ b/log/format.go
@@ -33,7 +33,15 @@ var locationTrims = []string{
 // format output.
 func PrintOrigins(print bool) {
 	locationEnabled.Store(print)
+	if print {
+		stackEnabled.Store(true)
+	}
 }
+
+// storeStackRecords is an atomic flag controlling whether the log handler needs
+// to store the callsite stack. This is needed in case any handler wants to
+// print locations (locationEnabled), use vmodule, or print full stacks (BacktraceAt).
+var stackEnabled atomic.Bool
 
 // locationEnabled is an atomic flag controlling whether the terminal formatter
 // should append the log locations too when printing entries.

--- a/log/handler_glog.go
+++ b/log/handler_glog.go
@@ -141,7 +141,7 @@ func (h *GlogHandler) Vmodule(ruleset string) error {
 	h.override.Store(len(filter) != 0)
 	// Enable location storage (globally)
 	if len(h.patterns) > 0 {
-		locationEnabled.Store(true)
+		stackEnabled.Store(true)
 	}
 	return nil
 }
@@ -176,7 +176,7 @@ func (h *GlogHandler) BacktraceAt(location string) error {
 	h.location = location
 	h.backtrace.Store(len(location) > 0)
 	// Enable location storage (globally)
-	locationEnabled.Store(true)
+	stackEnabled.Store(true)
 	return nil
 }
 

--- a/log/handler_glog.go
+++ b/log/handler_glog.go
@@ -139,7 +139,10 @@ func (h *GlogHandler) Vmodule(ruleset string) error {
 	h.patterns = filter
 	h.siteCache = make(map[uintptr]Lvl)
 	h.override.Store(len(filter) != 0)
-
+	// Enable location storage (globally)
+	if len(h.patterns) > 0 {
+		locationEnabled.Store(true)
+	}
 	return nil
 }
 

--- a/log/handler_glog.go
+++ b/log/handler_glog.go
@@ -172,7 +172,8 @@ func (h *GlogHandler) BacktraceAt(location string) error {
 
 	h.location = location
 	h.backtrace.Store(len(location) > 0)
-
+	// Enable location storage (globally)
+	locationEnabled.Store(true)
 	return nil
 }
 

--- a/log/logger.go
+++ b/log/logger.go
@@ -177,19 +177,22 @@ type logger struct {
 }
 
 func (l *logger) write(msg string, lvl Lvl, ctx []interface{}, skip int) {
-	l.h.Log(&Record{
+	record := &Record{
 		Time: time.Now(),
 		Lvl:  lvl,
 		Msg:  msg,
 		Ctx:  newContext(l.ctx, ctx),
-		Call: stack.Caller(skip),
 		KeyNames: RecordKeyNames{
 			Time: timeKey,
 			Msg:  msgKey,
 			Lvl:  lvlKey,
 			Ctx:  ctxKey,
 		},
-	})
+	}
+	if locationEnabled.Load() {
+		record.Call = stack.Caller(skip)
+	}
+	l.h.Log(record)
 }
 
 func (l *logger) New(ctx ...interface{}) Logger {

--- a/log/logger.go
+++ b/log/logger.go
@@ -189,7 +189,7 @@ func (l *logger) write(msg string, lvl Lvl, ctx []interface{}, skip int) {
 			Ctx:  ctxKey,
 		},
 	}
-	if locationEnabled.Load() {
+	if stackEnabled.Load() {
 		record.Call = stack.Caller(skip)
 	}
 	l.h.Log(record)

--- a/log/logger_test.go
+++ b/log/logger_test.go
@@ -1,8 +1,11 @@
 package log
 
 import (
+	"bytes"
 	"os"
+	"strings"
 	"testing"
+	"time"
 )
 
 func BenchmarkTraceLogging(b *testing.B) {
@@ -10,5 +13,57 @@ func BenchmarkTraceLogging(b *testing.B) {
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		Trace("a message", "v", i)
+	}
+}
+
+type notimeHandler struct {
+	next Handler
+}
+
+func (n notimeHandler) Log(r *Record) error {
+	r.Time = time.Unix(0, 0)
+	return n.next.Log(r)
+}
+
+func TestLoggingNoTrace(t *testing.T) {
+	out := new(bytes.Buffer)
+	logger := New()
+	{
+		glog := NewGlogHandler(StreamHandler(out, TerminalFormat(false)))
+		glog.Verbosity(LvlTrace)
+		if err := glog.BacktraceAt("logger_test.go:38"); err != nil {
+			t.Fatal(err)
+		}
+		logger.SetHandler(notimeHandler{glog})
+	}
+	logger.Trace("a message", "foo", "bar")
+	have := out.String()
+	want := `TRACE[01-01|01:00:00.000] a message                                foo=bar
+`
+	if have != want {
+		t.Errorf("\nhave: '%v'\nwant: '%v'\n", have, want)
+	}
+}
+
+func TestLoggingWithTrace(t *testing.T) {
+	PrintOrigins(true)
+	defer PrintOrigins(false)
+	out := new(bytes.Buffer)
+	logger := New()
+	{
+		glog := NewGlogHandler(StreamHandler(out, TerminalFormat(false)))
+		glog.Verbosity(LvlTrace)
+		if err := glog.BacktraceAt("logger_test.go:59"); err != nil {
+			t.Fatal(err)
+		}
+		logger.SetHandler(notimeHandler{glog})
+	}
+	logger.Trace("a message", "foo", "bar")
+	have := out.String()
+	wantPrefix := `INFO [01-01|01:00:00.000|log/logger_test.go:59] a message
+        
+        goroutine`
+	if len(have) < len(wantPrefix) || strings.HasPrefix(have, wantPrefix) {
+		t.Errorf("\nhave: '%v'\nwant: '%v'\n", have, wantPrefix)
 	}
 }

--- a/log/logger_test.go
+++ b/log/logger_test.go
@@ -25,40 +25,21 @@ func (n notimeHandler) Log(r *Record) error {
 	return n.next.Log(r)
 }
 
-func TestLoggingNoTrace(t *testing.T) {
-	out := new(bytes.Buffer)
-	logger := New()
-	{
-		glog := NewGlogHandler(StreamHandler(out, TerminalFormat(false)))
-		glog.Verbosity(LvlTrace)
-		if err := glog.BacktraceAt("logger_test.go:38"); err != nil {
-			t.Fatal(err)
-		}
-		logger.SetHandler(notimeHandler{glog})
-	}
-	logger.Trace("a message", "foo", "bar")
-	have := out.String()
-	want := `TRACE[01-01|01:00:00.000] a message                                foo=bar
-`
-	if have != want {
-		t.Errorf("\nhave: '%v'\nwant: '%v'\n", have, want)
-	}
-}
-
+// TestLoggingWithTrace checks that if BackTraceAt is set, then the
+// gloghandler is capable of spitting out a stacktrace
 func TestLoggingWithTrace(t *testing.T) {
-	PrintOrigins(true)
-	defer PrintOrigins(false)
+	defer locationEnabled.Store(locationEnabled.Load())
 	out := new(bytes.Buffer)
 	logger := New()
 	{
 		glog := NewGlogHandler(StreamHandler(out, TerminalFormat(false)))
 		glog.Verbosity(LvlTrace)
-		if err := glog.BacktraceAt("logger_test.go:59"); err != nil {
+		if err := glog.BacktraceAt("logger_test.go:42"); err != nil {
 			t.Fatal(err)
 		}
 		logger.SetHandler(notimeHandler{glog})
 	}
-	logger.Trace("a message", "foo", "bar")
+	logger.Trace("a message", "foo", "bar") // Will be bumped to INFO
 	have := out.String()
 	wantPrefix := `INFO [01-01|01:00:00.000|log/logger_test.go:59] a message
         

--- a/log/logger_test.go
+++ b/log/logger_test.go
@@ -1,0 +1,14 @@
+package log
+
+import (
+	"os"
+	"testing"
+)
+
+func BenchmarkTraceLogging(b *testing.B) {
+	Root().SetHandler(LvlFilterHandler(LvlInfo, StreamHandler(os.Stderr, TerminalFormat(true))))
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		Trace("a message", "v", i)
+	}
+}

--- a/log/logger_test.go
+++ b/log/logger_test.go
@@ -5,25 +5,7 @@ import (
 	"os"
 	"strings"
 	"testing"
-	"time"
 )
-
-func BenchmarkTraceLogging(b *testing.B) {
-	Root().SetHandler(LvlFilterHandler(LvlInfo, StreamHandler(os.Stderr, TerminalFormat(true))))
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
-		Trace("a message", "v", i)
-	}
-}
-
-type notimeHandler struct {
-	next Handler
-}
-
-func (n notimeHandler) Log(r *Record) error {
-	r.Time = time.Unix(0, 0)
-	return n.next.Log(r)
-}
 
 // TestLoggingWithTrace checks that if BackTraceAt is set, then the
 // gloghandler is capable of spitting out a stacktrace
@@ -34,15 +16,21 @@ func TestLoggingWithTrace(t *testing.T) {
 	{
 		glog := NewGlogHandler(StreamHandler(out, TerminalFormat(false)))
 		glog.Verbosity(LvlTrace)
-		if err := glog.BacktraceAt("logger_test.go:42"); err != nil {
+		if err := glog.BacktraceAt("logger_test.go:24"); err != nil {
 			t.Fatal(err)
 		}
-		logger.SetHandler(notimeHandler{glog})
+		logger.SetHandler(glog)
 	}
 	logger.Trace("a message", "foo", "bar") // Will be bumped to INFO
 	have := out.String()
-	wantPrefix := "INFO [01-01|01:00:00.000] a message\n\ngoroutine"
-	if len(have) < len(wantPrefix) || !strings.HasPrefix(have, wantPrefix) {
+	if !strings.HasPrefix(have, "INFO") {
+		t.Fatalf("backtraceat should bump level to info: %s", have)
+	}
+	// The timestamp is locale-dependent, so we want to trim that off
+	// "INFO [01-01|00:00:00.000] a messag ..." -> "a messag..."
+	have = strings.Split(have, "]")[1]
+	wantPrefix := " a message\n\ngoroutine"
+	if !strings.HasPrefix(have, wantPrefix) {
 		t.Errorf("\nhave: %q\nwant: %q\n", have, wantPrefix)
 	}
 }
@@ -55,14 +43,25 @@ func TestLoggingWithVmodule(t *testing.T) {
 	{
 		glog := NewGlogHandler(StreamHandler(out, TerminalFormat(false)))
 		glog.Verbosity(LvlCrit)
-		logger.SetHandler(notimeHandler{glog})
+		logger.SetHandler(glog)
 		logger.Warn("This should not be seen", "ignored", "true")
 		glog.Vmodule("logger_test.go=5")
 	}
 	logger.Trace("a message", "foo", "bar")
 	have := out.String()
-	want := "TRACE[01-01|01:00:00.000] a message                                foo=bar\n"
+	// The timestamp is locale-dependent, so we want to trim that off
+	// "INFO [01-01|00:00:00.000] a messag ..." -> "a messag..."
+	have = strings.Split(have, "]")[1]
+	want := " a message                                foo=bar\n"
 	if have != want {
 		t.Errorf("\nhave: %q\nwant: %q\n", have, want)
+	}
+}
+
+func BenchmarkTraceLogging(b *testing.B) {
+	Root().SetHandler(LvlFilterHandler(LvlInfo, StreamHandler(os.Stderr, TerminalFormat(true))))
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		Trace("a message", "v", i)
 	}
 }


### PR DESCRIPTION
We can avoid the somewhat expensive `stack.Caller` invocation by checking the atomic global. 

```
name            old time/op    new time/op    delta
TraceLogging-8    2.84µs ± 8%    0.97µs ± 4%  -65.87%  (p=0.008 n=5+5)

name            old alloc/op   new alloc/op   delta
TraceLogging-8      511B ± 0%      263B ± 0%  -48.53%  (p=0.008 n=5+5)

name            old allocs/op  new allocs/op  delta
TraceLogging-8      4.00 ± 0%      2.00 ± 0%  -50.00%  (p=0.008 n=5+5)

```
Closes https://github.com/ethereum/go-ethereum/issues/28064 