### PR TITLE
core/txpool: check for overdraft when adding tx

### DIFF
--- a/core/txpool/legacypool/legacypool.go
+++ b/core/txpool/legacypool/legacypool.go
@@ -884,7 +884,7 @@ func (pool *LegacyPool) promoteTx(addr common.Address, hash common.Hash, tx *typ
 		return false
 	}
 
-	//Check balance for Overdraft
+	// Check balance for overdraft
 	balance := pool.currentState.GetBalance(addr)
 	if list.totalcost.Cmp(balance) > 0 {
 		pool.all.Remove(hash)

--- a/core/txpool/legacypool/legacypool.go
+++ b/core/txpool/legacypool/legacypool.go
@@ -883,6 +883,16 @@ func (pool *LegacyPool) promoteTx(addr common.Address, hash common.Hash, tx *typ
 		pendingDiscardMeter.Mark(1)
 		return false
 	}
+
+	//Check balance for Overdraft
+	balance := pool.currentState.GetBalance(addr)
+	if list.totalcost.Cmp(balance) > 0 {
+		pool.all.Remove(hash)
+		pool.priced.Removed(1)
+		pendingDiscardMeter.Mark(1)
+		return false
+	}
+	
 	// Otherwise discard any previous transaction and mark this
 	if old != nil {
 		pool.all.Remove(old.Hash())

--- a/core/txpool/legacypool/legacypool.go
+++ b/core/txpool/legacypool/legacypool.go
@@ -889,7 +889,8 @@ func (pool *LegacyPool) promoteTx(addr common.Address, hash common.Hash, tx *typ
 	if list.totalcost.Cmp(balance) > 0 {
 		pool.all.Remove(hash)
 		pool.priced.Removed(1)
-		pendingDiscardMeter.Mark(1)
+		// pendingDiscardMeter.Mark(1)
+		pool.pending[addr].Remove(tx)
 		return false
 	}
 	


### PR DESCRIPTION
Defense against Mempurge Attack, described in this preprint: https://eprint.iacr.org/2023/956.pdf

The cause of MemPurge attacks is the following: The detection code of latent overdraft txs in Geth 1.11.4 does not kick in if arriving transactions are first future transactions in the future-tx pool and then turned into pending-but-overdraft txs.

We propose just one code change, that is, enforcing the account balance check when future transactions are moved to the pending pool. 

We add only six lines of code to Geth 1.12.2 codebase from Line 887 to Line 894 as follows.

https://github.com/fs3l/go-ethereum-TNX-defense/blob/eb9bfb43705c2ab94088bb21b5bbf0c257720034/core/txpool/legacypool/legacypool.go#L887

We have tested our patch using the Geth benchmark:   
https://github.com/ethereum/go-ethereum/blob/master/core/txpool/legacypool/legacypool_test.go

The performance overhead under this benchmark is negligible, as shown in the attachment. 
[result.pdf](https://github.com/ethereum/go-ethereum/files/12553008/result.pdf)
