### PR TITLE
ethclient: use 'input', not 'data' as field for transaction input

### DIFF
--- a/ethclient/ethclient.go
+++ b/ethclient/ethclient.go
@@ -619,7 +619,7 @@ func toCallArg(msg ethereum.CallMsg) interface{} {
 		"to":   msg.To,
 	}
 	if len(msg.Data) > 0 {
-		arg["data"] = hexutil.Bytes(msg.Data)
+		arg["input"] = hexutil.Bytes(msg.Data)
 	}
 	if msg.Value != nil {
 		arg["value"] = (*hexutil.Big)(msg.Value)

--- a/ethclient/gethclient/gethclient.go
+++ b/ethclient/gethclient/gethclient.go
@@ -225,7 +225,7 @@ func toCallArg(msg ethereum.CallMsg) interface{} {
 		"to":   msg.To,
 	}
 	if len(msg.Data) > 0 {
-		arg["data"] = hexutil.Bytes(msg.Data)
+		arg["input"] = hexutil.Bytes(msg.Data)
 	}
 	if msg.Value != nil {
 		arg["value"] = (*hexutil.Big)(msg.Value)


### PR DESCRIPTION
Closes https://github.com/ethereum/go-ethereum/issues/28077 

This makes ethclient / gethclient use `input` instead of `data` for passing input with a transaction. `input` is the preferred way. 

See https://github.com/ethereum/go-ethereum/issues/15628, and https://github.com/ethereum/go-ethereum/blob/master/signer/core/apitypes/types.go#L93
