### PR TITLE
ethclient: fix BlockReceipts parameter encoding

### DIFF
--- a/ethclient/ethclient.go
+++ b/ethclient/ethclient.go
@@ -108,7 +108,7 @@ func (ec *Client) PeerCount(ctx context.Context) (uint64, error) {
 	return uint64(result), err
 }
 
-// BlockReceipts returns the receipts of a given block number or hash
+// BlockReceipts returns the receipts of a given block number or hash.
 func (ec *Client) BlockReceipts(ctx context.Context, blockNrOrHash rpc.BlockNumberOrHash) ([]*types.Receipt, error) {
 	var r []*types.Receipt
 	err := ec.c.CallContext(ctx, &r, "eth_getBlockReceipts", blockNrOrHash.String())


### PR DESCRIPTION
There is an issue. After marshaling rpc.BlockNumberOrHash we have e.g. {"jsonrpc":"2.0","id":3,"method":"eth_getBlockReceipts","params":[{"blockNumber":"0x2"}]} instead of {"jsonrpc":"2.0","id":3,"method":"eth_getBlockReceipts","params":["0x2"]} and invalid response.