### PR TITLE
Periodically clear underpriced

### DIFF
--- a/eth/fetcher/tx_fetcher_test.go
+++ b/eth/fetcher/tx_fetcher_test.go
@@ -1509,8 +1509,8 @@ func testTransactionFetcher(t *testing.T, tt txFetcherTest) {
 			}
 
 		case isUnderpriced:
-			if fetcher.underpriced.Cardinality() != int(step) {
-				t.Errorf("step %d: underpriced set size mismatch: have %d, want %d", i, fetcher.underpriced.Cardinality(), step)
+			if len(fetcher.underpriced) != int(step) {
+				t.Errorf("step %d: underpriced set size mismatch: have %d, want %d", i, len(fetcher.underpriced), step)
 			}
 
 		default:


### PR DESCRIPTION
This PR will allow a previously underpriced transaction back in after a timeout of 5 minutes.
This will block most transaction spam but allow for transactions to be re-broadcasted on networks with less transaction flow.

closes https://github.com/ethereum/go-ethereum/issues/28018


