### PR TITLE
cmd/geth: read metric from config file

### DIFF
--- a/cmd/geth/chaincmd.go
+++ b/cmd/geth/chaincmd.go
@@ -37,7 +37,6 @@ import (
 	"github.com/ethereum/go-ethereum/ethdb"
 	"github.com/ethereum/go-ethereum/internal/flags"
 	"github.com/ethereum/go-ethereum/log"
-	"github.com/ethereum/go-ethereum/metrics"
 	"github.com/ethereum/go-ethereum/node"
 	"github.com/urfave/cli/v2"
 )

--- a/cmd/geth/chaincmd.go
+++ b/cmd/geth/chaincmd.go
@@ -258,9 +258,7 @@ func importChain(ctx *cli.Context) error {
 		utils.Fatalf("This command requires an argument.")
 	}
 	// Start metrics export if enabled
-	utils.SetupMetrics(ctx)
-	// Start system runtime metrics collection
-	go metrics.CollectProcessMetrics(3 * time.Second)
+	utils.SetupMetricsFromCLI(ctx)
 
 	stack, _ := makeConfigNode(ctx)
 	defer stack.Close()

--- a/cmd/geth/config.go
+++ b/cmd/geth/config.go
@@ -145,7 +145,7 @@ func loadBaseConfig(ctx *cli.Context) gethConfig {
 }
 
 // makeConfigNode loads geth configuration and creates a blank node instance.
-func makeConfigNode(ctx *cli.Context) (*node.Node, gethConfig) {
+func makeConfigNode(ctx *cli.Context) (*node.Node, *gethConfig) {
 	cfg := loadBaseConfig(ctx)
 	stack, err := node.New(&cfg.Node)
 	if err != nil {
@@ -162,12 +162,11 @@ func makeConfigNode(ctx *cli.Context) (*node.Node, gethConfig) {
 	}
 	applyMetricConfig(ctx, &cfg)
 
-	return stack, cfg
+	return stack, &cfg
 }
 
 // makeFullNode loads geth configuration and creates the Ethereum backend.
-func makeFullNode(ctx *cli.Context) (*node.Node, ethapi.Backend) {
-	stack, cfg := makeConfigNode(ctx)
+func makeFullNode(ctx *cli.Context, stack *node.Node, cfg *gethConfig) ethapi.Backend {
 	if ctx.IsSet(utils.OverrideCancun.Name) {
 		v := ctx.Uint64(utils.OverrideCancun.Name)
 		cfg.Eth.OverrideCancun = &v
@@ -225,7 +224,7 @@ func makeFullNode(ctx *cli.Context) (*node.Node, ethapi.Backend) {
 			utils.Fatalf("failed to register catalyst service: %v", err)
 		}
 	}
-	return stack, backend
+	return backend
 }
 
 // dumpConfig is the dumpconfig command.

--- a/cmd/geth/config.go
+++ b/cmd/geth/config.go
@@ -257,12 +257,6 @@ func dumpConfig(ctx *cli.Context) error {
 }
 
 func applyMetricConfig(ctx *cli.Context, cfg *gethConfig) {
-	if ctx.IsSet(utils.MetricsEnabledFlag.Name) {
-		cfg.Metrics.Enabled = ctx.Bool(utils.MetricsEnabledFlag.Name)
-	}
-	if ctx.IsSet(utils.MetricsEnabledExpensiveFlag.Name) {
-		cfg.Metrics.EnabledExpensive = ctx.Bool(utils.MetricsEnabledExpensiveFlag.Name)
-	}
 	if ctx.IsSet(utils.MetricsHTTPFlag.Name) {
 		cfg.Metrics.HTTP = ctx.String(utils.MetricsHTTPFlag.Name)
 	}

--- a/cmd/geth/consolecmd.go
+++ b/cmd/geth/consolecmd.go
@@ -70,7 +70,9 @@ JavaScript API. See https://geth.ethereum.org/docs/interacting-with-geth/javascr
 func localConsole(ctx *cli.Context) error {
 	// Create and start the node based on the CLI flags
 	prepare(ctx)
-	stack, backend := makeFullNode(ctx)
+	stack, cfg := makeConfigNode(ctx)
+	utils.SetupMetricsFromConfig(&cfg.Metrics)
+	backend := makeFullNode(ctx, stack, cfg)
 	startNode(ctx, stack, backend, true)
 	defer stack.Close()
 

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -2044,7 +2044,7 @@ func SetupMetrics(ctx *cli.Context) {
 }
 
 func SetupMetricsFromConfig(c *metrics.Config) {
-	if !c.Enabled {
+	if metrics.Enabled {
 		return
 	}
 

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -2044,7 +2044,7 @@ func SetupMetricsFromCLI(ctx *cli.Context) {
 }
 
 func SetupMetricsFromConfig(c *metrics.Config) {
-	if metrics.Enabled {
+	if !metrics.Enabled {
 		return
 	}
 

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -1982,65 +1982,65 @@ func RegisterFullSyncTester(stack *node.Node, eth *eth.Ethereum, path string) {
 	log.Info("Registered full-sync tester", "number", block.NumberU64(), "hash", block.Hash())
 }
 
-func SetupMetrics(ctx *cli.Context) {
-	if metrics.Enabled {
-		log.Info("Enabling metrics collection")
+func SetupMetricsFromCLI(ctx *cli.Context) {
+	if !metrics.Enabled {
+		return
+	}
 
-		var (
-			enableExport   = ctx.Bool(MetricsEnableInfluxDBFlag.Name)
-			enableExportV2 = ctx.Bool(MetricsEnableInfluxDBV2Flag.Name)
-		)
+	log.Info("Enabling metrics collection")
 
-		if enableExport || enableExportV2 {
-			CheckExclusive(ctx, MetricsEnableInfluxDBFlag, MetricsEnableInfluxDBV2Flag)
+	var (
+		enableExport   = ctx.Bool(MetricsEnableInfluxDBFlag.Name)
+		enableExportV2 = ctx.Bool(MetricsEnableInfluxDBV2Flag.Name)
+	)
 
-			v1FlagIsSet := ctx.IsSet(MetricsInfluxDBUsernameFlag.Name) ||
-				ctx.IsSet(MetricsInfluxDBPasswordFlag.Name)
+	if enableExport || enableExportV2 {
+		CheckExclusive(ctx, MetricsEnableInfluxDBFlag, MetricsEnableInfluxDBV2Flag)
 
-			v2FlagIsSet := ctx.IsSet(MetricsInfluxDBTokenFlag.Name) ||
-				ctx.IsSet(MetricsInfluxDBOrganizationFlag.Name) ||
-				ctx.IsSet(MetricsInfluxDBBucketFlag.Name)
+		v1FlagIsSet := ctx.IsSet(MetricsInfluxDBUsernameFlag.Name) ||
+			ctx.IsSet(MetricsInfluxDBPasswordFlag.Name)
 
-			if enableExport && v2FlagIsSet {
-				Fatalf("Flags --influxdb.metrics.organization, --influxdb.metrics.token, --influxdb.metrics.bucket are only available for influxdb-v2")
-			} else if enableExportV2 && v1FlagIsSet {
-				Fatalf("Flags --influxdb.metrics.username, --influxdb.metrics.password are only available for influxdb-v1")
-			}
-		}
+		v2FlagIsSet := ctx.IsSet(MetricsInfluxDBTokenFlag.Name) ||
+			ctx.IsSet(MetricsInfluxDBOrganizationFlag.Name) ||
+			ctx.IsSet(MetricsInfluxDBBucketFlag.Name)
 
-		var (
-			endpoint = ctx.String(MetricsInfluxDBEndpointFlag.Name)
-			database = ctx.String(MetricsInfluxDBDatabaseFlag.Name)
-			username = ctx.String(MetricsInfluxDBUsernameFlag.Name)
-			password = ctx.String(MetricsInfluxDBPasswordFlag.Name)
-
-			token        = ctx.String(MetricsInfluxDBTokenFlag.Name)
-			bucket       = ctx.String(MetricsInfluxDBBucketFlag.Name)
-			organization = ctx.String(MetricsInfluxDBOrganizationFlag.Name)
-		)
-
-		if enableExport {
-			tagsMap := SplitTagsFlag(ctx.String(MetricsInfluxDBTagsFlag.Name))
-
-			log.Info("Enabling metrics export to InfluxDB")
-
-			go influxdb.InfluxDBWithTags(metrics.DefaultRegistry, 10*time.Second, endpoint, database, username, password, "geth.", tagsMap)
-		} else if enableExportV2 {
-			tagsMap := SplitTagsFlag(ctx.String(MetricsInfluxDBTagsFlag.Name))
-
-			log.Info("Enabling metrics export to InfluxDB (v2)")
-
-			go influxdb.InfluxDBV2WithTags(metrics.DefaultRegistry, 10*time.Second, endpoint, token, bucket, organization, "geth.", tagsMap)
-		}
-
-		if ctx.IsSet(MetricsHTTPFlag.Name) {
-			address := net.JoinHostPort(ctx.String(MetricsHTTPFlag.Name), fmt.Sprintf("%d", ctx.Int(MetricsPortFlag.Name)))
-			log.Info("Enabling stand-alone metrics HTTP endpoint", "address", address)
-			exp.Setup(address)
-		} else if ctx.IsSet(MetricsPortFlag.Name) {
-			log.Warn(fmt.Sprintf("--%s specified without --%s, metrics server will not start.", MetricsPortFlag.Name, MetricsHTTPFlag.Name))
+		if enableExport && v2FlagIsSet {
+			Fatalf("Flags --influxdb.metrics.organization, --influxdb.metrics.token, --influxdb.metrics.bucket are only available for influxdb-v2")
+		} else if enableExportV2 && v1FlagIsSet {
+			Fatalf("Flags --influxdb.metrics.username, --influxdb.metrics.password are only available for influxdb-v1")
 		}
 	}
+
+	var (
+		tagsMap  = SplitTagsFlag(ctx.String(MetricsInfluxDBTagsFlag.Name))
+		endpoint = ctx.String(MetricsInfluxDBEndpointFlag.Name)
+		database = ctx.String(MetricsInfluxDBDatabaseFlag.Name)
+		username = ctx.String(MetricsInfluxDBUsernameFlag.Name)
+		password = ctx.String(MetricsInfluxDBPasswordFlag.Name)
+
+		token        = ctx.String(MetricsInfluxDBTokenFlag.Name)
+		bucket       = ctx.String(MetricsInfluxDBBucketFlag.Name)
+		organization = ctx.String(MetricsInfluxDBOrganizationFlag.Name)
+	)
+
+	if enableExport {
+		log.Info("Enabling metrics export to InfluxDB")
+		go influxdb.InfluxDBWithTags(metrics.DefaultRegistry, 10*time.Second, endpoint, database, username, password, "geth.", tagsMap)
+	} else if enableExportV2 {
+		log.Info("Enabling metrics export to InfluxDB (v2)")
+		go influxdb.InfluxDBV2WithTags(metrics.DefaultRegistry, 10*time.Second, endpoint, token, bucket, organization, "geth.", tagsMap)
+	}
+
+	if ctx.IsSet(MetricsHTTPFlag.Name) {
+		address := net.JoinHostPort(ctx.String(MetricsHTTPFlag.Name), fmt.Sprintf("%d", ctx.Int(MetricsPortFlag.Name)))
+		log.Info("Enabling stand-alone metrics HTTP endpoint", "address", address)
+		exp.Setup(address)
+	} else if ctx.IsSet(MetricsPortFlag.Name) {
+		log.Warn(fmt.Sprintf("--%s specified without --%s, metrics server will not start.", MetricsPortFlag.Name, MetricsHTTPFlag.Name))
+	}
+
+	// Start system runtime metrics collection
+	go metrics.CollectProcessMetrics(3 * time.Second)
 }
 
 func SetupMetricsFromConfig(c *metrics.Config) {

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -2081,6 +2081,9 @@ func SetupMetricsFromConfig(c *metrics.Config) {
 	} else if c.Port != 0 {
 		log.Warn("influxdb.port specified without inflxdb.addr, metrics server will not start.")
 	}
+
+	// Start system runtime metrics collection
+	go metrics.CollectProcessMetrics(3 * time.Second)
 }
 
 func SplitTagsFlag(tagsFlag string) map[string]string {

--- a/metrics/config.go
+++ b/metrics/config.go
@@ -16,6 +16,10 @@
 
 package metrics
 
+import (
+	"errors"
+)
+
 // Config contains the configuration for the metric collection.
 type Config struct {
 	Enabled          bool   `toml:",omitempty"`
@@ -33,6 +37,20 @@ type Config struct {
 	InfluxDBToken        string `toml:",omitempty"`
 	InfluxDBBucket       string `toml:",omitempty"`
 	InfluxDBOrganization string `toml:",omitempty"`
+}
+
+func (c *Config) Validate() error {
+	if c.EnableInfluxDB || c.EnableInfluxDBV2 {
+		v1FlagIsSet := c.InfluxDBUsername != "" || c.InfluxDBPassword != ""
+		v2FlagIsSet := c.InfluxDBToken != "" || c.InfluxDBOrganization != "" || c.InfluxDBBucket != ""
+
+		if c.EnableInfluxDB && v2FlagIsSet {
+			return errors.New("Flags --influxdb.metrics.organization, --influxdb.metrics.token, --influxdb.metrics.bucket are only available for influxdb-v2")
+		} else if c.EnableInfluxDBV2 && v1FlagIsSet {
+			return errors.New("Flags --influxdb.metrics.username, --influxdb.metrics.password are only available for influxdb-v1")
+		}
+	}
+	return nil
 }
 
 // DefaultConfig is the default config for metrics used in go-ethereum.

--- a/metrics/config.go
+++ b/metrics/config.go
@@ -40,15 +40,14 @@ type Config struct {
 }
 
 func (c *Config) Validate() error {
-	if c.EnableInfluxDB || c.EnableInfluxDBV2 {
-		v1FlagIsSet := c.InfluxDBUsername != "" || c.InfluxDBPassword != ""
-		v2FlagIsSet := c.InfluxDBToken != "" || c.InfluxDBOrganization != "" || c.InfluxDBBucket != ""
+	v1FlagIsSet := c.InfluxDBUsername != "" || c.InfluxDBPassword != ""
+	v2FlagIsSet := c.InfluxDBToken != "" || c.InfluxDBOrganization != "" || c.InfluxDBBucket != ""
 
-		if c.EnableInfluxDB && v2FlagIsSet {
-			return errors.New("Flags --influxdb.metrics.organization, --influxdb.metrics.token, --influxdb.metrics.bucket are only available for influxdb-v2")
-		} else if c.EnableInfluxDBV2 && v1FlagIsSet {
-			return errors.New("Flags --influxdb.metrics.username, --influxdb.metrics.password are only available for influxdb-v1")
-		}
+	if c.EnableInfluxDB && v2FlagIsSet {
+		return errors.New("Flags --influxdb.metrics.organization, --influxdb.metrics.token, --influxdb.metrics.bucket are only available for influxdb-v2")
+	}
+	if c.EnableInfluxDBV2 && v1FlagIsSet {
+		return errors.New("Flags --influxdb.metrics.username, --influxdb.metrics.password are only available for influxdb-v1")
 	}
 	return nil
 }

--- a/metrics/config.go
+++ b/metrics/config.go
@@ -22,8 +22,6 @@ import (
 
 // Config contains the configuration for the metric collection.
 type Config struct {
-	Enabled          bool   `toml:",omitempty"`
-	EnabledExpensive bool   `toml:",omitempty"`
 	HTTP             string `toml:",omitempty"`
 	Port             int    `toml:",omitempty"`
 	EnableInfluxDB   bool   `toml:",omitempty"`
@@ -54,8 +52,6 @@ func (c *Config) Validate() error {
 
 // DefaultConfig is the default config for metrics used in go-ethereum.
 var DefaultConfig = Config{
-	Enabled:          false,
-	EnabledExpensive: false,
 	HTTP:             "127.0.0.1",
 	Port:             6060,
 	EnableInfluxDB:   false,


### PR DESCRIPTION
As in https://github.com/ethereum/go-ethereum/pull/22083 we can dump metric configs into toml file, but we can't start geth to use those configurations.