### PR TITLE
cmd/geth: rename the protocols field in the metrics gague

### DIFF
--- a/cmd/geth/config.go
+++ b/cmd/geth/config.go
@@ -185,10 +185,10 @@ func makeFullNode(ctx *cli.Context) (*node.Node, ethapi.Backend) {
 			protos = append(protos, fmt.Sprintf("%v/%d", p.Name, p.Version))
 		}
 		metrics.NewRegisteredGaugeInfo("geth/info", nil).Update(metrics.GaugeInfoValue{
-			"arch":          runtime.GOARCH,
-			"os":            runtime.GOOS,
-			"version":       cfg.Node.Version,
-			"eth_protocols": strings.Join(protos, ","),
+			"arch":      runtime.GOARCH,
+			"os":        runtime.GOOS,
+			"version":   cfg.Node.Version,
+			"protocols": strings.Join(protos, ","),
 		})
 	}
 


### PR DESCRIPTION
The eth_protocol seems wrong (it contains all protocols, the eth part originates from the "eth" service the protocols are from, but that's moot in the context of Geth). This PR drops the eth_ prefix.

![F55OMNQakAA-HJV](https://github.com/ethereum/go-ethereum/assets/129561/077d0c71-497c-44fc-97e8-38c7f62ba2b1)
