### PR TITLE
cmd/geth, internal/flags: print envvar config source and bad names

### DIFF
--- a/cmd/geth/main.go
+++ b/cmd/geth/main.go
@@ -249,7 +249,11 @@ func init() {
 	app.Before = func(ctx *cli.Context) error {
 		maxprocs.Set() // Automatically set GOMAXPROCS to match Linux container CPU quota.
 		flags.MigrateGlobalFlags(ctx)
-		return debug.Setup(ctx)
+		if err := debug.Setup(ctx); err != nil {
+			return err
+		}
+		flags.CheckEnvVars(ctx, app.Flags, "GETH")
+		return nil
 	}
 	app.After = func(ctx *cli.Context) error {
 		debug.Exit()


### PR DESCRIPTION
One catch with env vars is that they might silently change Geth's behavior, in both directions:

- A set config var might be unexpected to the user and they might not know where it originates from (since it's not specified on the CLI).
- An old / mistyped env var might be present that is not actually consumed by Geth because a name mismatch, which would lead to a silent ignore.

Both cases would be quite tricky to debug. Further it would be a PITA for us to debug user issues when they don't share their env list, and sharing them may not be best security practice.

This PR tries to solve all 3 issues, by listing all the consumed env vars, as well as all the env vars that "seem" like GETH ones, but that are not consumed in the end.

TL;DR:

<img width="993" alt="Screenshot 2023-09-14 at 17 24 26" src="https://github.com/ethereum/go-ethereum/assets/129561/16cf624f-e43b-4842-a12c-d48c9f2bf6fa">
