### PR TITLE
metrics: fix TestExampleOpenTSB on windows

### DIFF
--- a/metrics/opentsdb_test.go
+++ b/metrics/opentsdb_test.go
@@ -46,7 +46,8 @@ func TestExampleOpenTSB(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if have, want := w.String(), string(wantB); have != want {
+	want := strings.ReplaceAll(string(wantB), "\r\n", "\n")
+	if have := w.String(); have != want {
 		t.Errorf("\nhave:\n%v\nwant:\n%v\n", have, want)
 		t.Logf("have vs want:\n%v", findFirstDiffPos(have, want))
 	}


### PR DESCRIPTION
Hi. This change replaces '\r\n' with '\n' after reading the expected file `./testdata/opentsb.want`, allowing TestExampleOpenTSB to pass on windows systems.