### PR TITLE
Correctly calculate effective gas price

### DIFF
--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -1520,8 +1520,8 @@ func newRPCTransaction(tx *types.Transaction, blockHash common.Hash, blockNumber
 func effectiveGasPrice(tx *types.Transaction, baseFee *big.Int) *big.Int {
 	fee := tx.GasTipCap()
 	fee = fee.Add(fee, baseFee)
-	if tx.GasTipCapIntCmp(fee) < 0 {
-		return tx.GasTipCap()
+	if tx.GasFeeCapIntCmp(fee) < 0 {
+		return tx.GasFeeCap()
 	}
 	return fee
 }


### PR DESCRIPTION
The latest release doesn't calculate the effective gas price correctly. The behavior implemented is `price = min(gasTipCap + baseFee, gasTipCap)`, but it is supposed to be `price = min(gasTipCap + baseFee, gasFeeCap)`, according to the comment above `effectiveGasPrice()`.

As an example, this can be observed by calling `eth_getBlockByNumber`, and observing that the `gasPrice` and `maxPriorityFeePerGas` are equivalent for all reported transactions.

```
curl --location '<GETH_NODE_URL>' \
--header 'Content-Type: application/json' \
--data '{
    "jsonrpc": "2.0",
    "method": "eth_getBlockByNumber",
    "params": [
        "0x114D27E",
        true
    ],
    "id": "1"
}' 

snip

"blockHash": "0xa14e2a59a71b44ea305df73069e4c4229cc0ea357009c2970c170150825520f9",
"blockNumber": "0x114d27e",
"from": "0xe087a57d55017a2d6a8110ab48e5a0e3dd25e2ea",
"gas": "0x2c570",
"gasPrice": "0x5f5e100",
"maxFeePerGas": "0x575957902",
"maxPriorityFeePerGas": "0x5f5e100",
"hash": "0x9df855734500dc051ce02283bcea25bccea75a2a468779058806346fd1fdaef9",
"input": "0x7ff36ab5000000000000000000000000000000000000000000078efe2a338bdc65acdcd60000000000000000000000000000000000000000000000000000000000000080000000000000000000000000e087a57d55017a2d6a8110ab48e5a0e3dd25e2ea0000000000000000000000000000000000000000000000000000000065045e730000000000000000000000000000000000000000000000000000000000000002000000000000000000000000c02aaa39b223fe8d0a0e5c4f27ead9083c756cc2000000000000000000000000ff836a5821e69066c87e268bc51b849fab94240c",
"nonce": "0xb0",
"to": "0x2ec705d306b51e486b1bc0d6ebee708e0661add1",
"transactionIndex": "0x1",
"value": "0x9b6e64a8ec60000",
"type": "0x2",
"accessList": [],
"chainId": "0x1",
"v": "0x1",
"r": "0x7aecbc5e8ee20905a68e2b489c6d018e9c83b01fbd2650366a01c0f305109161",
"s": "0xdca8c0f6adb3352d98acad4f13f079c124d2eac9f4aa28712258dbcd30457a7",
"yParity": "0x1"
```