### PR TITLE
Enforce MinTip in the legacypool for local transactions

### DIFF
--- a/core/txpool/legacypool/legacypool.go
+++ b/core/txpool/legacypool/legacypool.go
@@ -585,9 +585,6 @@ func (pool *LegacyPool) validateTxBasics(tx *types.Transaction, local bool) erro
 		MaxSize: txMaxSize,
 		MinTip:  pool.gasTip.Load(),
 	}
-	if local {
-		opts.MinTip = new(big.Int)
-	}
 	if err := txpool.ValidateTransaction(tx, nil, nil, nil, pool.currentHead.Load(), pool.signer, opts); err != nil {
 		return err
 	}


### PR DESCRIPTION
I'm not clear why this price-check bypass was introduced.  I created [this question](https://github.com/ethereum/go-ethereum/issues/28125) last week, but I figured a PR might be a quicker way to start a conversation around this.

I was able to track the original change to [this PR](https://github.com/ethereum/go-ethereum/pull/1997#issuecomment-158762725), where someone called the change "👏🏻👏🏻👏🏻 Extremely needed!".

It seems to me that by setting `opts.MinTip = new(big.Int)` we no longer enforce the `--miner.gasprice`. 

There may be a reason, and someone in the community can provide the context I'm missing. 

I've tried to follow the contribution guidelines, except I'm targetting `release/1.12` as my team has not upgraded to the latest `master` yet.
