### PR TITLE
trie: add getter for preimage store in trie.Database

### DIFF
--- a/trie/database.go
+++ b/trie/database.go
@@ -189,6 +189,15 @@ func (db *Database) WritePreimages() {
 	}
 }
 
+// Preimage retrieves a cached trie node pre-image from memory. If it cannot be
+// found cached, the method queries the persistent database for the content.
+func (db *Database) Preimage(hash common.Hash) []byte {
+	if db.preimages == nil {
+		return nil
+	}
+	return db.preimages.preimage(hash)
+}
+
 // Cap iteratively flushes old but still referenced trie nodes until the total
 // memory usage goes below the given threshold. The held pre-images accumulated
 // up to this point will be flushed in case the size exceeds the threshold.


### PR DESCRIPTION
Rebasing the verkle code on top of PBSS broke the overlay transition code in the following way:

 * The overlay code used `rawdb.ReadPreimage` while enumerating the snapshot in order to re-hash the key for insertion in the verkle tree
 * The preimages are no longer directly flushed to disk at the end of a block, but bulk-saved at specific times (e.g. when the blockchain stops or the cache gets above a certain threshold).

This means that the overlay conversion method will miss some preimages if they are in the cache and not yet on disk. In order to fix this issue, the conversion code needs to check both the disk and cache stores for preimages. This is done by adding a getter to `trie.Database`, so that it can call `(*preimageStore).preimage`.