### PR TITLE
cmd/clef: suppress fsnotify error if keydir not exists

### DIFF
--- a/accounts/keystore/watch.go
+++ b/accounts/keystore/watch.go
@@ -20,6 +20,7 @@
 package keystore
 
 import (
+	"os"
 	"time"
 
 	"github.com/ethereum/go-ethereum/log"
@@ -77,7 +78,9 @@ func (w *watcher) loop() {
 	}
 	defer watcher.Close()
 	if err := watcher.Add(w.ac.keydir); err != nil {
-		logger.Warn("Failed to watch keystore folder", "err", err)
+		if !os.IsNotExist(err) {
+			logger.Warn("Failed to watch keystore folder", "err", err)
+		}
 		return
 	}
 


### PR DESCRIPTION
close https://github.com/ethereum/go-ethereum/issues/28132

As the keydir will be automatically created after an account is created, no error message if the watcher is failed. 