### PR TITLE
website- remove Noverify

### DIFF
--- a/docs/fundamentals/config-files.md
+++ b/docs/fundamentals/config-files.md
@@ -83,7 +83,6 @@ GasFloor = 0
 GasCeil = 30000000
 GasPrice = 1000000000
 Recommit = 3000000000
-Noverify = false
 
 [Eth.Ethash]
 CacheDir = "ethash"


### PR DESCRIPTION
I'm new to Ethereum. When I read the documentation, I noticed that `Eth.Miner.Noverify` was used for PoW. So it doesn't work now and can be removed.