### PR TITLE
cmd/geth: print progress logs when iterating large contracts too

### DIFF
--- a/cmd/geth/snapshot.go
+++ b/cmd/geth/snapshot.go
@@ -332,6 +332,11 @@ func traverseState(ctx *cli.Context) error {
 			storageIter := trie.NewIterator(storageIt)
 			for storageIter.Next() {
 				slots += 1
+
+				if time.Since(lastReport) > time.Second*8 {
+					log.Info("Traversing state", "accounts", accounts, "slots", slots, "codes", codes, "elapsed", common.PrettyDuration(time.Since(start)))
+					lastReport = time.Now()
+				}
 			}
 			if storageIter.Err != nil {
 				log.Error("Failed to traverse storage trie", "root", acc.Root, "err", storageIter.Err)
@@ -485,6 +490,10 @@ func traverseRawState(ctx *cli.Context) error {
 					// Bump the counter if it's leaf node.
 					if storageIter.Leaf() {
 						slots += 1
+					}
+					if time.Since(lastReport) > time.Second*8 {
+						log.Info("Traversing state", "nodes", nodes, "accounts", accounts, "slots", slots, "codes", codes, "elapsed", common.PrettyDuration(time.Since(start)))
+						lastReport = time.Now()
 					}
 				}
 				if storageIter.Error() != nil {


### PR DESCRIPTION
When running state traversal, we only log progress for accounts. That's unfortunate when iterating a huge contract as it can take a very long time without output. This PR adds the logging for storage iteration too.

I.e. This is what I want to fix

```
INFO [09-22|07:37:48.021] Traversing state                         nodes=6,395,005 accounts=451,926 slots=2,271,664 codes=73378 elapsed=1m58.960s
INFO [09-22|07:42:05.237] Traversing state                         nodes=21,319,313 accounts=482,117 slots=8,634,942 codes=78166 elapsed=6m16.175s
```

Note the 5 minute gap in the logs.