### PR TITLE
core, params: update Holesky testnet to relaunched spec

### DIFF
--- a/core/genesis.go
+++ b/core/genesis.go
@@ -587,10 +587,9 @@ func DefaultHoleskyGenesisBlock() *Genesis {
 	return &Genesis{
 		Config:     params.HoleskyChainConfig,
 		Nonce:      0x1234,
-		ExtraData:  hexutil.MustDecode("0x686f77206d7563682069732074686520666973683f"),
 		GasLimit:   0x17d7840,
 		Difficulty: big.NewInt(0x01),
-		Timestamp:  1694786100,
+		Timestamp:  1695902100,
 		Alloc:      decodePrealloc(holeskyAllocData),
 	}
 }

--- a/params/config.go
+++ b/params/config.go
@@ -80,8 +80,7 @@ var (
 		TerminalTotalDifficulty:       big.NewInt(0),
 		TerminalTotalDifficultyPassed: true,
 		MergeNetsplitBlock:            nil,
-		ShanghaiTime:                  newUint64(1694790240),
-		CancunTime:                    newUint64(2000000000),
+		ShanghaiTime:                  newUint64(1696000704),
 		Ethash:                        new(EthashConfig),
 	}
 	// SepoliaChainConfig contains the chain parameters to run a node on the Sepolia test network.


### PR DESCRIPTION
Updates the Holesky genesis specs to the relaunched testnet.