### PR TITLE
Update ethclient.go

### DIFF
--- a/ethclient/ethclient.go
+++ b/ethclient/ethclient.go
@@ -619,7 +619,7 @@ func toCallArg(msg ethereum.CallMsg) interface{} {
 		"to":   msg.To,
 	}
 	if len(msg.Data) > 0 {
-		arg["input"] = hexutil.Bytes(msg.Data)
+		arg["data"] = hexutil.Bytes(msg.Data)
 	}
 	if msg.Value != nil {
 		arg["value"] = (*hexutil.Big)(msg.Value)


### PR DESCRIPTION
Fix: Revert "input" field to "data" in `ethclient.go` for Smart Contract Calls in v13

The field name change from "data" to "input" in `ethclient.go` in version 13 has caused Smart Contract calls to not properly receive the data payload. This was not an issue in version 12 where the field was named "data". This commit reverts the field name back to "data" to fix Smart Contract call issues.