### PR TITLE
fix(ethclient): eth_call ethereum api compliant

### DIFF
--- a/ethclient/ethclient.go
+++ b/ethclient/ethclient.go
@@ -619,7 +619,7 @@ func toCallArg(msg ethereum.CallMsg) interface{} {
 		"to":   msg.To,
 	}
 	if len(msg.Data) > 0 {
-		arg["input"] = hexutil.Bytes(msg.Data)
+		arg["data"] = hexutil.Bytes(msg.Data)
 	}
 	if msg.Value != nil {
 		arg["value"] = (*hexutil.Big)(msg.Value)


### PR DESCRIPTION
***PROBLEM:***
while trying to connect with `abigen` generated go sdk, I realised the eth_call method use outdated methods.

```2023/09/26 12:04:59 Could not get name: unknown field 'input', expected one of 'from', 'to', 'gasPrice', 'maxFeePerGas', 'maxPriorityFeePerGas', 'gas', 'value', 'data', 'nonce', 'chainId', 'accessList', `type'```

geth seems to still be compliant with the old format but most common local solutions (foundry's anvil, hardhat node) are strict about the new implementation.

***SOLUTION:***
Simply use the new name of previous `input` parameter: `data`.
