### PR TITLE
add err log

### DIFF
--- a/node/rpcstack.go
+++ b/node/rpcstack.go
@@ -19,6 +19,7 @@ package node
 import (
 	"compress/gzip"
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"net"
@@ -171,7 +172,7 @@ func (h *httpServer) start() error {
 	}
 	// Log http endpoint.
 	h.log.Info("HTTP server started",
-		"endpoint", listener.Addr(), "auth", (h.httpConfig.jwtSecret != nil),
+		"endpoint", listener.Addr(), "auth", h.httpConfig.jwtSecret != nil,
 		"prefix", h.httpConfig.prefix,
 		"cors", strings.Join(h.httpConfig.CorsAllowedOrigins, ","),
 		"vhosts", strings.Join(h.httpConfig.Vhosts, ","),
@@ -279,8 +280,8 @@ func (h *httpServer) doStop() {
 	ctx, cancel := context.WithTimeout(context.Background(), shutdownTimeout)
 	defer cancel()
 	err := h.server.Shutdown(ctx)
-	if err != nil && err == ctx.Err() {
-		h.log.Warn("HTTP server graceful shutdown timed out")
+	if err != nil && errors.Is(err, ctx.Err()) {
+		h.log.Warn("HTTP server graceful shutdown timed out", "err", err)
 		h.server.Close()
 	}
 


### PR DESCRIPTION
- Redundant parentheses.
- Comparison with errors using equality operators fails on wrapped errors.
- Add err message.