### PR TITLE
internal,cmd: validation of port flags

### DIFF
--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -569,6 +569,7 @@ var (
 		Usage:    "Listening port for authenticated APIs",
 		Value:    node.DefaultConfig.AuthPort,
 		Category: flags.APICategory,
+		Action:   flags.ValidatePort("authrpc.port"),
 	}
 	AuthVirtualHostsFlag = &cli.StringFlag{
 		Name:     "authrpc.vhosts",
@@ -629,6 +630,7 @@ var (
 		Usage:    "HTTP-RPC server listening port",
 		Value:    node.DefaultHTTPPort,
 		Category: flags.APICategory,
+		Action:   flags.ValidatePort("http.port"),
 	}
 	HTTPCORSDomainFlag = &cli.StringFlag{
 		Name:     "http.corsdomain",
@@ -687,6 +689,7 @@ var (
 		Usage:    "WS-RPC server listening port",
 		Value:    node.DefaultWSPort,
 		Category: flags.APICategory,
+		Action:   flags.ValidatePort("ws.port"),
 	}
 	WSApiFlag = &cli.StringFlag{
 		Name:     "ws.api",
@@ -757,6 +760,7 @@ var (
 		Usage:    "Network listening port",
 		Value:    30303,
 		Category: flags.NetworkingCategory,
+		Action:   flags.ValidatePort("port"),
 	}
 	BootnodesFlag = &cli.StringFlag{
 		Name:     "bootnodes",
@@ -813,6 +817,7 @@ var (
 		Usage:    "Use a custom UDP port for P2P discovery",
 		Value:    30303,
 		Category: flags.NetworkingCategory,
+		Action:   flags.ValidatePort("discovery.port"),
 	}
 
 	// Console
@@ -882,6 +887,7 @@ var (
 Please note that --` + MetricsHTTPFlag.Name + ` must be set to start the server.`,
 		Value:    metrics.DefaultConfig.Port,
 		Category: flags.MetricsCategory,
+		Action:   flags.ValidatePort("metrics.port"),
 	}
 	MetricsEnableInfluxDBFlag = &cli.BoolFlag{
 		Name:     "metrics.influxdb",

--- a/internal/debug/flags.go
+++ b/internal/debug/flags.go
@@ -125,6 +125,7 @@ var (
 		Usage:    "pprof HTTP server listening port",
 		Value:    6060,
 		Category: flags.LoggingCategory,
+		Action:   flags.ValidatePort("pprof.port"),
 	}
 	pprofAddrFlag = &cli.StringFlag{
 		Name:     "pprof.addr",

--- a/internal/flags/flags.go
+++ b/internal/flags/flags.go
@@ -375,3 +375,13 @@ func eachName(f cli.Flag, fn func(string)) {
 		fn(name)
 	}
 }
+
+// ValidatePort validates the port number is in the valid range.
+func ValidatePort(name string) func(*cli.Context, int) error {
+	return func(ctx *cli.Context, port int) error {
+		if port < 0 || port >= 65535 {
+			return fmt.Errorf("Flag %s value %v out of range[0-65535]", name, port)
+		}
+		return nil
+	}
+}


### PR DESCRIPTION
After adding the validation, the geth process will check the `xxx.port` flags, eg:

```bash
$ ./build/bin/geth --port=303012
Flag port value 303012 out of range[0-65535]

$ GETH_PORT=123456 ./build/bin/geth
INFO [09-27|23:51:22.974] Config environment variable found        envvar=GETH_PORT
Flag port value 123456 out of range[0-65535]

$ GETH_AUTHRPC_PORT=123456 ./build/bin/geth
INFO [09-27|23:51:35.643] Config environment variable found        envvar=GETH_AUTHRPC_PORT
Flag authrpc.port value 123456 out of range[0-65535]

```