### PR TITLE
core: infer blobGasUsed in chain maker

### DIFF
--- a/core/chain_makers.go
+++ b/core/chain_makers.go
@@ -88,11 +88,6 @@ func (b *BlockGen) SetPoS() {
 	b.header.Difficulty = new(big.Int)
 }
 
-// SetBlobGas sets the data gas used by the blob in the generated block.
-func (b *BlockGen) SetBlobGas(blobGasUsed uint64) {
-	b.header.BlobGasUsed = &blobGasUsed
-}
-
 // addTx adds a transaction to the generated block. If no coinbase has
 // been set, the block's coinbase is set to the zero address.
 //
@@ -111,6 +106,9 @@ func (b *BlockGen) addTx(bc *BlockChain, vmConfig vm.Config, tx *types.Transacti
 	}
 	b.txs = append(b.txs, tx)
 	b.receipts = append(b.receipts, receipt)
+	if b.header.BlobGasUsed != nil {
+		*b.header.BlobGasUsed += receipt.BlobGasUsed
+	}
 }
 
 // AddTx adds a transaction to the generated block. If no coinbase has

--- a/internal/ethapi/api_test.go
+++ b/internal/ethapi/api_test.go
@@ -1448,9 +1448,6 @@ func setupReceiptBackend(t *testing.T, genBlocks int) (*testBackend, []common.Ha
 			b.AddTx(tx)
 			txHashes[i] = tx.Hash()
 		}
-		if i == 5 {
-			b.SetBlobGas(params.BlobTxBlobGasPerBlob)
-		}
 		b.SetPoS()
 	})
 	return backend, txHashes


### PR DESCRIPTION
Same way that the gasUsed in header is updated when a tx is added we should update blob gas used instead of requiring caller to set it manually.