### PR TITLE
trie/trie_test: Fix Trie Benchmark Bug: Ensure Key Immutability in geth Benchmarks

### DIFF
--- a/trie/trie_test.go
+++ b/trie/trie_test.go
@@ -627,11 +627,13 @@ func benchGet(b *testing.B) {
 
 func benchUpdate(b *testing.B, e binary.ByteOrder) *Trie {
 	trie := NewEmpty(NewDatabase(rawdb.NewMemoryDatabase(), nil))
-	k := make([]byte, 32)
 	b.ReportAllocs()
 	for i := 0; i < b.N; i++ {
+		k := make([]byte, 32)
+		v := make([]byte, 32)
 		e.PutUint64(k, uint64(i))
-		trie.MustUpdate(k, k)
+		e.PutUint64(v, uint64(i))
+		trie.MustUpdate(k, v)
 	}
 	return trie
 }


### PR DESCRIPTION
This PR fixes the bug for Trie Benchmarks Break invariant of trie. In the existing code, a key-value pair is constructed for use in the trie. However, the same key byte slice is reused for multiple update operations within a loop.

Bug: https://github.com/ethereum/go-ethereum/issues/28214