### PR TITLE
ethdb, internal/ethapi: support exposing Pebble stats too, beside LevelDB

### DIFF
--- a/ethdb/leveldb/leveldb.go
+++ b/ethdb/leveldb/leveldb.go
@@ -22,6 +22,7 @@ package leveldb
 
 import (
 	"fmt"
+	"strings"
 	"sync"
 	"time"
 
@@ -245,6 +246,11 @@ func (db *Database) NewSnapshot() (ethdb.Snapshot, error) {
 
 // Stat returns a particular internal stat of the database.
 func (db *Database) Stat(property string) (string, error) {
+	if property == "" {
+		property = "leveldb.stats"
+	} else if !strings.HasPrefix(property, "leveldb.") {
+		property = "leveldb." + property
+	}
 	return db.db.GetProperty(property)
 }
 

--- a/ethdb/pebble/pebble.go
+++ b/ethdb/pebble/pebble.go
@@ -379,9 +379,12 @@ func upperBound(prefix []byte) (limit []byte) {
 	return limit
 }
 
-// Stat returns a particular internal stat of the database.
+// Stat returns the internal metrics of Pebble in a text format. It's a developer
+// method to read everything there is to read independent of Pebble version.
+//
+// The property is unused in Pebble as there's only one thing to retrieve.
 func (d *Database) Stat(property string) (string, error) {
-	return "", nil
+	return d.db.Metrics().String(), nil
 }
 
 // Compact flattens the underlying data store for the given key range. In essence,

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -2191,11 +2191,6 @@ func (api *DebugAPI) PrintBlock(ctx context.Context, number uint64) (string, err
 
 // ChaindbProperty returns leveldb properties of the key-value database.
 func (api *DebugAPI) ChaindbProperty(property string) (string, error) {
-	if property == "" {
-		property = "leveldb.stats"
-	} else if !strings.HasPrefix(property, "leveldb.") {
-		property = "leveldb." + property
-	}
 	return api.b.ChainDb().Stat(property)
 }
 


### PR DESCRIPTION
LevelDB has a method exposed via the API to expose all internal counters. This is rarely useful to debug things.

With the current Pebble issues, turns out Pebble also has a similar mechanism, but unfortunately we never exposed it. This PR exposes it.