### PR TITLE
[wip]: boundary corrections

### DIFF
--- a/core/state/snapshot/generate.go
+++ b/core/state/snapshot/generate.go
@@ -228,16 +228,8 @@ func (dl *diskLayer) proveRange(ctx *generatorContext, trieId *trie.ID, prefix [
 	// The snap state is exhausted, pass the entire key/val set for verification
 	root := trieId.Root
 	if origin == nil && !diskMore {
-		stackTr := trie.NewStackTrie(nil)
-		for i, key := range keys {
-			stackTr.Update(key, vals[i])
-		}
-		if gotRoot := stackTr.Hash(); gotRoot != root {
-			return &proofResult{
-				keys:     keys,
-				vals:     vals,
-				proofErr: fmt.Errorf("wrong root: have %#x want %#x", gotRoot, root),
-			}, nil
+		if err := trie.VerifyStandaloneRange(root, keys, vals); err != nil {
+			return &proofResult{keys: keys, vals: vals, proofErr: err}, nil
 		}
 		return &proofResult{keys: keys, vals: vals}, nil
 	}

--- a/core/state/snapshot/generate.go
+++ b/core/state/snapshot/generate.go
@@ -272,7 +272,7 @@ func (dl *diskLayer) proveRange(ctx *generatorContext, trieId *trie.ID, prefix [
 	}
 	// Verify the snapshot segment with range prover, ensure that all flat states
 	// in this range correspond to merkle trie.
-	cont, err := trie.VerifyRangeProof(root, origin, last, keys, vals, proof)
+	cont, _, err := trie.VerifyRangeProof(root, origin, last, keys, vals, proof)
 	return &proofResult{
 			keys:     keys,
 			vals:     vals,

--- a/eth/protocols/snap/sync.go
+++ b/eth/protocols/snap/sync.go
@@ -2664,7 +2664,7 @@ func (s *Syncer) OnStorage(peer SyncPeer, id uint64, hashes [][]common.Hash, slo
 			if len(keys) > 0 {
 				end = keys[len(keys)-1]
 			}
-			cont, _, err = trie.VerifyRangeProof(req.roots[i], req.origin[:], end, keys, slots[i], proofdb)
+			cont, trie, err = trie.VerifyRangeProof(req.roots[i], req.origin[:], end, keys, slots[i], proofdb)
 			if err != nil {
 				s.scheduleRevertStorageRequest(req) // reschedule request
 				logger.Warn("Storage range failed proof", "err", err)

--- a/eth/protocols/snap/sync.go
+++ b/eth/protocols/snap/sync.go
@@ -2404,7 +2404,7 @@ func (s *Syncer) OnAccounts(peer SyncPeer, id uint64, hashes []common.Hash, acco
 	if len(keys) > 0 {
 		end = keys[len(keys)-1]
 	}
-	cont, err := trie.VerifyRangeProof(root, req.origin[:], end, keys, accounts, proofdb)
+	cont, _, err := trie.VerifyRangeProof(root, req.origin[:], end, keys, accounts, proofdb)
 	if err != nil {
 		logger.Warn("Account range failed proof", "err", err)
 		// Signal this request as failed, and ready for rescheduling
@@ -2664,7 +2664,7 @@ func (s *Syncer) OnStorage(peer SyncPeer, id uint64, hashes [][]common.Hash, slo
 			if len(keys) > 0 {
 				end = keys[len(keys)-1]
 			}
-			cont, err = trie.VerifyRangeProof(req.roots[i], req.origin[:], end, keys, slots[i], proofdb)
+			cont, _, err = trie.VerifyRangeProof(req.roots[i], req.origin[:], end, keys, slots[i], proofdb)
 			if err != nil {
 				s.scheduleRevertStorageRequest(req) // reschedule request
 				logger.Warn("Storage range failed proof", "err", err)

--- a/trie/proof_test.go
+++ b/trie/proof_test.go
@@ -191,7 +191,7 @@ func TestRangeProof(t *testing.T) {
 			keys = append(keys, entries[i].k)
 			vals = append(vals, entries[i].v)
 		}
-		_, err := VerifyRangeProof(trie.Hash(), keys[0], keys[len(keys)-1], keys, vals, proof)
+		_, _, err := VerifyRangeProof(trie.Hash(), keys[0], keys[len(keys)-1], keys, vals, proof)
 		if err != nil {
 			t.Fatalf("Case %d(%d->%d) expect no error, got %v", i, start, end-1, err)
 		}
@@ -242,7 +242,7 @@ func TestRangeProofWithNonExistentProof(t *testing.T) {
 			keys = append(keys, entries[i].k)
 			vals = append(vals, entries[i].v)
 		}
-		_, err := VerifyRangeProof(trie.Hash(), first, last, keys, vals, proof)
+		_, _, err := VerifyRangeProof(trie.Hash(), first, last, keys, vals, proof)
 		if err != nil {
 			t.Fatalf("Case %d(%d->%d) expect no error, got %v", i, start, end-1, err)
 		}
@@ -263,7 +263,7 @@ func TestRangeProofWithNonExistentProof(t *testing.T) {
 		k = append(k, entries[i].k)
 		v = append(v, entries[i].v)
 	}
-	_, err := VerifyRangeProof(trie.Hash(), first, last, k, v, proof)
+	_, _, err := VerifyRangeProof(trie.Hash(), first, last, k, v, proof)
 	if err != nil {
 		t.Fatal("Failed to verify whole rang with non-existent edges")
 	}
@@ -298,7 +298,7 @@ func TestRangeProofWithInvalidNonExistentProof(t *testing.T) {
 		k = append(k, entries[i].k)
 		v = append(v, entries[i].v)
 	}
-	_, err := VerifyRangeProof(trie.Hash(), first, k[len(k)-1], k, v, proof)
+	_, _, err := VerifyRangeProof(trie.Hash(), first, k[len(k)-1], k, v, proof)
 	if err == nil {
 		t.Fatalf("Expected to detect the error, got nil")
 	}
@@ -320,7 +320,7 @@ func TestRangeProofWithInvalidNonExistentProof(t *testing.T) {
 		k = append(k, entries[i].k)
 		v = append(v, entries[i].v)
 	}
-	_, err = VerifyRangeProof(trie.Hash(), k[0], last, k, v, proof)
+	_, _, err = VerifyRangeProof(trie.Hash(), k[0], last, k, v, proof)
 	if err == nil {
 		t.Fatalf("Expected to detect the error, got nil")
 	}
@@ -344,7 +344,7 @@ func TestOneElementRangeProof(t *testing.T) {
 	if err := trie.Prove(entries[start].k, proof); err != nil {
 		t.Fatalf("Failed to prove the first node %v", err)
 	}
-	_, err := VerifyRangeProof(trie.Hash(), entries[start].k, entries[start].k, [][]byte{entries[start].k}, [][]byte{entries[start].v}, proof)
+	_, _, err := VerifyRangeProof(trie.Hash(), entries[start].k, entries[start].k, [][]byte{entries[start].k}, [][]byte{entries[start].v}, proof)
 	if err != nil {
 		t.Fatalf("Expected no error, got %v", err)
 	}
@@ -359,7 +359,7 @@ func TestOneElementRangeProof(t *testing.T) {
 	if err := trie.Prove(entries[start].k, proof); err != nil {
 		t.Fatalf("Failed to prove the last node %v", err)
 	}
-	_, err = VerifyRangeProof(trie.Hash(), first, entries[start].k, [][]byte{entries[start].k}, [][]byte{entries[start].v}, proof)
+	_, _, err = VerifyRangeProof(trie.Hash(), first, entries[start].k, [][]byte{entries[start].k}, [][]byte{entries[start].v}, proof)
 	if err != nil {
 		t.Fatalf("Expected no error, got %v", err)
 	}
@@ -374,7 +374,7 @@ func TestOneElementRangeProof(t *testing.T) {
 	if err := trie.Prove(last, proof); err != nil {
 		t.Fatalf("Failed to prove the last node %v", err)
 	}
-	_, err = VerifyRangeProof(trie.Hash(), entries[start].k, last, [][]byte{entries[start].k}, [][]byte{entries[start].v}, proof)
+	_, _, err = VerifyRangeProof(trie.Hash(), entries[start].k, last, [][]byte{entries[start].k}, [][]byte{entries[start].v}, proof)
 	if err != nil {
 		t.Fatalf("Expected no error, got %v", err)
 	}
@@ -389,7 +389,7 @@ func TestOneElementRangeProof(t *testing.T) {
 	if err := trie.Prove(last, proof); err != nil {
 		t.Fatalf("Failed to prove the last node %v", err)
 	}
-	_, err = VerifyRangeProof(trie.Hash(), first, last, [][]byte{entries[start].k}, [][]byte{entries[start].v}, proof)
+	_, _, err = VerifyRangeProof(trie.Hash(), first, last, [][]byte{entries[start].k}, [][]byte{entries[start].v}, proof)
 	if err != nil {
 		t.Fatalf("Expected no error, got %v", err)
 	}
@@ -408,7 +408,7 @@ func TestOneElementRangeProof(t *testing.T) {
 	if err := tinyTrie.Prove(last, proof); err != nil {
 		t.Fatalf("Failed to prove the last node %v", err)
 	}
-	_, err = VerifyRangeProof(tinyTrie.Hash(), first, last, [][]byte{entry.k}, [][]byte{entry.v}, proof)
+	_, _, err = VerifyRangeProof(tinyTrie.Hash(), first, last, [][]byte{entry.k}, [][]byte{entry.v}, proof)
 	if err != nil {
 		t.Fatalf("Expected no error, got %v", err)
 	}
@@ -443,7 +443,7 @@ func TestAllElementsProof(t *testing.T) {
 	if err := trie.Prove(entries[len(entries)-1].k, proof); err != nil {
 		t.Fatalf("Failed to prove the last node %v", err)
 	}
-	_, err = VerifyRangeProof(trie.Hash(), k[0], k[len(k)-1], k, v, proof)
+	_, _, err = VerifyRangeProof(trie.Hash(), k[0], k[len(k)-1], k, v, proof)
 	if err != nil {
 		t.Fatalf("Expected no error, got %v", err)
 	}
@@ -458,7 +458,7 @@ func TestAllElementsProof(t *testing.T) {
 	if err := trie.Prove(last, proof); err != nil {
 		t.Fatalf("Failed to prove the last node %v", err)
 	}
-	_, err = VerifyRangeProof(trie.Hash(), first, last, k, v, proof)
+	_, _, err = VerifyRangeProof(trie.Hash(), first, last, k, v, proof)
 	if err != nil {
 		t.Fatalf("Expected no error, got %v", err)
 	}
@@ -491,7 +491,7 @@ func TestSingleSideRangeProof(t *testing.T) {
 				k = append(k, entries[i].k)
 				v = append(v, entries[i].v)
 			}
-			_, err := VerifyRangeProof(trie.Hash(), common.Hash{}.Bytes(), k[len(k)-1], k, v, proof)
+			_, _, err := VerifyRangeProof(trie.Hash(), common.Hash{}.Bytes(), k[len(k)-1], k, v, proof)
 			if err != nil {
 				t.Fatalf("Expected no error, got %v", err)
 			}
@@ -527,7 +527,7 @@ func TestReverseSingleSideRangeProof(t *testing.T) {
 				k = append(k, entries[i].k)
 				v = append(v, entries[i].v)
 			}
-			_, err := VerifyRangeProof(trie.Hash(), k[0], last.Bytes(), k, v, proof)
+			_, _, err := VerifyRangeProof(trie.Hash(), k[0], last.Bytes(), k, v, proof)
 			if err != nil {
 				t.Fatalf("Expected no error, got %v", err)
 			}
@@ -599,7 +599,7 @@ func TestBadRangeProof(t *testing.T) {
 			index = mrand.Intn(end - start)
 			vals[index] = nil
 		}
-		_, err := VerifyRangeProof(trie.Hash(), first, last, keys, vals, proof)
+		_, _, err := VerifyRangeProof(trie.Hash(), first, last, keys, vals, proof)
 		if err == nil {
 			t.Fatalf("%d Case %d index %d range: (%d->%d) expect error, got nil", i, testcase, index, start, end-1)
 		}
@@ -633,7 +633,7 @@ func TestGappedRangeProof(t *testing.T) {
 		keys = append(keys, entries[i].k)
 		vals = append(vals, entries[i].v)
 	}
-	_, err := VerifyRangeProof(trie.Hash(), keys[0], keys[len(keys)-1], keys, vals, proof)
+	_, _, err := VerifyRangeProof(trie.Hash(), keys[0], keys[len(keys)-1], keys, vals, proof)
 	if err == nil {
 		t.Fatal("expect error, got nil")
 	}
@@ -660,7 +660,7 @@ func TestSameSideProofs(t *testing.T) {
 	if err := trie.Prove(last, proof); err != nil {
 		t.Fatalf("Failed to prove the last node %v", err)
 	}
-	_, err := VerifyRangeProof(trie.Hash(), first, last, [][]byte{entries[pos].k}, [][]byte{entries[pos].v}, proof)
+	_, _, err := VerifyRangeProof(trie.Hash(), first, last, [][]byte{entries[pos].k}, [][]byte{entries[pos].v}, proof)
 	if err == nil {
 		t.Fatalf("Expected error, got nil")
 	}
@@ -676,7 +676,7 @@ func TestSameSideProofs(t *testing.T) {
 	if err := trie.Prove(last, proof); err != nil {
 		t.Fatalf("Failed to prove the last node %v", err)
 	}
-	_, err = VerifyRangeProof(trie.Hash(), first, last, [][]byte{entries[pos].k}, [][]byte{entries[pos].v}, proof)
+	_, _, err = VerifyRangeProof(trie.Hash(), first, last, [][]byte{entries[pos].k}, [][]byte{entries[pos].v}, proof)
 	if err == nil {
 		t.Fatalf("Expected error, got nil")
 	}
@@ -744,7 +744,7 @@ func TestHasRightElement(t *testing.T) {
 			k = append(k, entries[i].k)
 			v = append(v, entries[i].v)
 		}
-		hasMore, err := VerifyRangeProof(trie.Hash(), firstKey, lastKey, k, v, proof)
+		hasMore, _, err := VerifyRangeProof(trie.Hash(), firstKey, lastKey, k, v, proof)
 		if err != nil {
 			t.Fatalf("Expected no error, got %v", err)
 		}
@@ -777,7 +777,7 @@ func TestEmptyRangeProof(t *testing.T) {
 		if err := trie.Prove(first, proof); err != nil {
 			t.Fatalf("Failed to prove the first node %v", err)
 		}
-		_, err := VerifyRangeProof(trie.Hash(), first, nil, nil, nil, proof)
+		_, _, err := VerifyRangeProof(trie.Hash(), first, nil, nil, nil, proof)
 		if c.err && err == nil {
 			t.Fatalf("Expected error, got nil")
 		}
@@ -817,7 +817,7 @@ func TestBloatedProof(t *testing.T) {
 	trie.Prove(keys[0], want)
 	trie.Prove(keys[len(keys)-1], want)
 
-	if _, err := VerifyRangeProof(trie.Hash(), keys[0], keys[len(keys)-1], keys, vals, proof); err != nil {
+	if _, _, err := VerifyRangeProof(trie.Hash(), keys[0], keys[len(keys)-1], keys, vals, proof); err != nil {
 		t.Fatalf("expected bloated proof to succeed, got %v", err)
 	}
 }
@@ -860,7 +860,7 @@ func TestEmptyValueRangeProof(t *testing.T) {
 		keys = append(keys, entries[i].k)
 		vals = append(vals, entries[i].v)
 	}
-	_, err := VerifyRangeProof(trie.Hash(), keys[0], keys[len(keys)-1], keys, vals, proof)
+	_, _, err := VerifyRangeProof(trie.Hash(), keys[0], keys[len(keys)-1], keys, vals, proof)
 	if err == nil {
 		t.Fatalf("Expected failure on noop entry")
 	}
@@ -1000,7 +1000,7 @@ func benchmarkVerifyRangeProof(b *testing.B, size int) {
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		_, err := VerifyRangeProof(trie.Hash(), keys[0], keys[len(keys)-1], keys, values, proof)
+		_, _, err := VerifyRangeProof(trie.Hash(), keys[0], keys[len(keys)-1], keys, values, proof)
 		if err != nil {
 			b.Fatalf("Case %d(%d->%d) expect no error, got %v", i, start, end-1, err)
 		}
@@ -1093,7 +1093,7 @@ func TestRangeProofKeysWithSharedPrefix(t *testing.T) {
 		t.Fatalf("failed to prove end: %v", err)
 	}
 
-	more, err := VerifyRangeProof(root, start, end, keys, vals, proof)
+	more, _, err := VerifyRangeProof(root, start, end, keys, vals, proof)
 	if err != nil {
 		t.Fatalf("failed to verify range proof: %v", err)
 	}

--- a/trie/proof_test.go
+++ b/trie/proof_test.go
@@ -430,7 +430,7 @@ func TestAllElementsProof(t *testing.T) {
 		k = append(k, entries[i].k)
 		v = append(v, entries[i].v)
 	}
-	_, err := VerifyRangeProof(trie.Hash(), nil, nil, k, v, nil)
+	err := VerifyStandaloneRange(trie.Hash(), k, v)
 	if err != nil {
 		t.Fatalf("Expected no error, got %v", err)
 	}
@@ -895,8 +895,7 @@ func TestAllElementsEmptyValueRangeProof(t *testing.T) {
 		keys = append(keys, entries[i].k)
 		vals = append(vals, entries[i].v)
 	}
-	_, err := VerifyRangeProof(trie.Hash(), nil, nil, keys, vals, nil)
-	if err == nil {
+	if err := VerifyStandaloneRange(trie.Hash(), keys, vals); err == nil {
 		t.Fatalf("Expected failure on noop entry")
 	}
 }
@@ -1028,8 +1027,7 @@ func benchmarkVerifyRangeNoProof(b *testing.B, size int) {
 	}
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		_, err := VerifyRangeProof(trie.Hash(), keys[0], keys[len(keys)-1], keys, values, nil)
-		if err != nil {
+		if err := VerifyStandaloneRange(trie.Hash(), keys, values); err != nil {
 			b.Fatalf("Expected no error, got %v", err)
 		}
 	}


### PR DESCRIPTION
What we do now, in the case of a huge storage trie (a response where we have neither the first nor last leaf in the trie): 

1. Use a regular trie, for verification. This tries builds up all internal nodes, (correct nodes, not a single moot node: but possibly dangling parents on the edges) (proof.go:573).
2. Discard this trie, and all internal nodes
3. Deliver the verified slice of leafs (sync.go:2686)
 4. At this point, it is a bit complicated. But we merge these things into a stacktrie(s) that we call genTrie (sync.go:2092)

The genTrie stacktrie essentially recreates internal nodes for a larger section of keys than fit in a single response: but on the edges it will generate an incorrect shape, due to not being "pushed down". 


Observation 1: if we did not discard the data in step 2, we would not have to lossly regenerate it later. 
Observation 2: if the stacktrie supported addHash(), or, pushing down the left and right-hand side by adding hashes, then the regeneration would be lossless

This PR addresses observation 1: in the case of chunked storage-responses, we retain the trie that we generated during verification, and simply commits it. That way, we can do away with the whole gentrie and possibly make some codepaths simpler. 

This PR cheats a bit and does not properly avoid comitting the left-side boundary nodes. 

An alternative idea would be to improve stacktrie by "pushing down", initiating it by adding left-side proofs (hashes) and, later on, ending it by adding right-side proofs. 


## This solution

- Minimises CPU processing, the verification processing produces a filled bounded trie, which is then saved to disk. 
- Increases memory slightly, since instead of handling a slice of keys/values, we retain also intermediate nodes in memory longer
- Causes slightly _more_ damages to heal. If the space is divided into 16 chunks, and let's say 20 requests are required to fill the chunk, then 
  - The `genTrie` solution, currently used on `master`,  will cause in total, 16 areas of corruption (chunk borders), but each chunk internally will be correct, due the ordered sequential filling of a shared `genTrie`.
  - Whereas this PR would cause corruption also in those 16 chunk borders, but additionally in the in-chunk boundaries between requests: `20 * 16 = 320` (`+16`) holes in the trie.

Here is an earlier attempt at "the other" solution: pushing down the stacktrie: https://github.com/ethereum/go-ethereum/pull/24560 
