### PR TITLE
eth/catalyst: add timestamp checks to fcu and new payload and improve param checks

### DIFF
--- a/eth/catalyst/api.go
+++ b/eth/catalyst/api.go
@@ -190,7 +190,7 @@ func (api *ConsensusAPI) ForkchoiceUpdatedV2(update engine.ForkchoiceStateV1, pa
 			return engine.STATUS_INVALID, engine.InvalidParams.With(errors.New("missing withdrawals"))
 		}
 		if params.BeaconRoot != nil {
-			return engine.STATUS_INVALID, engine.InvalidParams.With(errors.New("missing beacon root"))
+			return engine.STATUS_INVALID, engine.InvalidParams.With(errors.New("unexpected beacon root"))
 		}
 		c := api.eth.BlockChain().Config()
 		if !active(c.IsShanghai, c.IsCancun, c.LondonBlock, params.Timestamp) {

--- a/eth/catalyst/api.go
+++ b/eth/catalyst/api.go
@@ -202,6 +202,10 @@ func (api *ConsensusAPI) ForkchoiceUpdatedV2(update engine.ForkchoiceStateV1, pa
 // ForkchoiceUpdatedV3 is equivalent to V2 with the addition of parent beacon block root in the payload attributes.
 func (api *ConsensusAPI) ForkchoiceUpdatedV3(update engine.ForkchoiceStateV1, params *engine.PayloadAttributes) (engine.ForkChoiceResponse, error) {
 	if params != nil {
+		// TODO(matt): according to https://github.com/ethereum/execution-apis/pull/498,
+		// payload attributes that are invalid should return error
+		// engine.InvalidPayloadAttributes. Once hive updates this, we should update
+		// on our end.
 		if params.Withdrawals == nil {
 			return engine.STATUS_INVALID, engine.InvalidParams.With(errors.New("missing withdrawals"))
 		}

--- a/eth/catalyst/api.go
+++ b/eth/catalyst/api.go
@@ -212,6 +212,10 @@ func (api *ConsensusAPI) ForkchoiceUpdatedV3(update engine.ForkchoiceStateV1, pa
 			return engine.STATUS_INVALID, engine.UnsupportedFork.With(errors.New("forkchoiceUpdatedV3 must only be called for cancun payloads"))
 		}
 	}
+	// TODO(matt): the spec requires that fcu is applied when called on a valid
+	// hash, even if params are wrong. To do this we need to split up
+	// forkchoiceUpdate into a function that only updates the head and then a
+	// function that kicks off block construction.
 	return api.forkchoiceUpdated(update, params)
 }
 

--- a/eth/catalyst/api.go
+++ b/eth/catalyst/api.go
@@ -453,6 +453,9 @@ func (api *ConsensusAPI) NewPayloadV1(params engine.ExecutableData) (engine.Payl
 
 // NewPayloadV2 creates an Eth1 block, inserts it in the chain, and returns the status of the chain.
 func (api *ConsensusAPI) NewPayloadV2(params engine.ExecutableData) (engine.PayloadStatusV1, error) {
+	if api.eth.BlockChain().Config().IsCancun(api.eth.BlockChain().Config().LondonBlock, params.Timestamp) {
+		return engine.PayloadStatusV1{Status: engine.INVALID}, engine.InvalidParams.With(errors.New("can't use new payload v2 post-shanghai"))
+	}
 	if api.eth.BlockChain().Config().LatestFork(params.Timestamp) == forks.Shanghai {
 		if params.Withdrawals == nil {
 			return engine.PayloadStatusV1{Status: engine.INVALID}, engine.InvalidParams.With(errors.New("nil withdrawals post-shanghai"))

--- a/eth/catalyst/api.go
+++ b/eth/catalyst/api.go
@@ -452,22 +452,16 @@ func (api *ConsensusAPI) NewPayloadV2(params engine.ExecutableData) (engine.Payl
 		if params.Withdrawals == nil {
 			return engine.PayloadStatusV1{Status: engine.INVALID}, engine.InvalidParams.With(errors.New("nil withdrawals post-shanghai"))
 		}
-		if params.ExcessBlobGas != nil {
-			return engine.PayloadStatusV1{Status: engine.INVALID}, engine.InvalidParams.With(errors.New("non-nil excessBlobGas pre-cancun"))
-		}
-		if params.BlobGasUsed != nil {
-			return engine.PayloadStatusV1{Status: engine.INVALID}, engine.InvalidParams.With(errors.New("non-nil params.BlobGasUsed pre-cancun"))
-		}
 	} else {
 		if params.Withdrawals != nil {
 			return engine.PayloadStatusV1{Status: engine.INVALID}, engine.InvalidParams.With(errors.New("non-nil withdrawals pre-shanghai"))
 		}
-		if params.ExcessBlobGas != nil {
-			return engine.PayloadStatusV1{Status: engine.INVALID}, engine.InvalidParams.With(errors.New("non-nil excessBlobGas pre-cancun"))
-		}
-		if params.BlobGasUsed != nil {
-			return engine.PayloadStatusV1{Status: engine.INVALID}, engine.InvalidParams.With(errors.New("non-nil params.BlobGasUsed pre-cancun"))
-		}
+	}
+	if params.ExcessBlobGas != nil {
+		return engine.PayloadStatusV1{Status: engine.INVALID}, engine.InvalidParams.With(errors.New("non-nil excessBlobGas pre-cancun"))
+	}
+	if params.BlobGasUsed != nil {
+		return engine.PayloadStatusV1{Status: engine.INVALID}, engine.InvalidParams.With(errors.New("non-nil params.BlobGasUsed pre-cancun"))
 	}
 	return api.newPayload(params, nil, nil)
 }

--- a/eth/catalyst/api_test.go
+++ b/eth/catalyst/api_test.go
@@ -1267,9 +1267,7 @@ func TestNilWithdrawals(t *testing.T) {
 		if err != nil {
 			t.Fatalf("error getting payload, err=%v", err)
 		}
-		var (
-			status engine.PayloadStatusV1
-		)
+		var status engine.PayloadStatusV1
 		if !shanghai {
 			status, err = api.NewPayloadV1(*execData.ExecutionPayload)
 		} else {

--- a/eth/catalyst/api_test.go
+++ b/eth/catalyst/api_test.go
@@ -1237,7 +1237,15 @@ func TestNilWithdrawals(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		_, err := api.ForkchoiceUpdatedV2(fcState, &test.blockParams)
+		var (
+			err      error
+			shanghai = genesis.Config.IsShanghai(genesis.Config.LondonBlock, test.blockParams.Timestamp)
+		)
+		if !shanghai {
+			_, err = api.ForkchoiceUpdatedV1(fcState, &test.blockParams)
+		} else {
+			_, err = api.ForkchoiceUpdatedV2(fcState, &test.blockParams)
+		}
 		if test.wantErr {
 			if err == nil {
 				t.Fatal("wanted error on fcuv2 with invalid withdrawals")
@@ -1254,14 +1262,21 @@ func TestNilWithdrawals(t *testing.T) {
 			Timestamp:    test.blockParams.Timestamp,
 			FeeRecipient: test.blockParams.SuggestedFeeRecipient,
 			Random:       test.blockParams.Random,
-			BeaconRoot:   test.blockParams.BeaconRoot,
 		}).Id()
 		execData, err := api.GetPayloadV2(payloadID)
 		if err != nil {
 			t.Fatalf("error getting payload, err=%v", err)
 		}
-		if status, err := api.NewPayloadV2(*execData.ExecutionPayload); err != nil {
-			t.Fatalf("error validating payload: %v", err)
+		var (
+			status engine.PayloadStatusV1
+		)
+		if !shanghai {
+			status, err = api.NewPayloadV1(*execData.ExecutionPayload)
+		} else {
+			status, err = api.NewPayloadV2(*execData.ExecutionPayload)
+		}
+		if err != nil {
+			t.Fatalf("error validating payload: %v", err.(*engine.EngineAPIError).ErrorData())
 		} else if status.Status != engine.VALID {
 			t.Fatalf("invalid payload")
 		}

--- a/eth/catalyst/api_test.go
+++ b/eth/catalyst/api_test.go
@@ -1600,7 +1600,7 @@ func TestParentBeaconBlockRoot(t *testing.T) {
 	fcState := engine.ForkchoiceStateV1{
 		HeadBlockHash: parent.Hash(),
 	}
-	resp, err := api.ForkchoiceUpdatedV2(fcState, &blockParams)
+	resp, err := api.ForkchoiceUpdatedV3(fcState, &blockParams)
 	if err != nil {
 		t.Fatalf("error preparing payload, err=%v", err.(*engine.EngineAPIError).ErrorData())
 	}

--- a/params/config.go
+++ b/params/config.go
@@ -21,6 +21,7 @@ import (
 	"math/big"
 
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/params/forks"
 )
 
 // Genesis hashes to enforce below configs on.
@@ -748,6 +749,21 @@ func (c *ChainConfig) BaseFeeChangeDenominator() uint64 {
 // ElasticityMultiplier bounds the maximum gas limit an EIP-1559 block may have.
 func (c *ChainConfig) ElasticityMultiplier() uint64 {
 	return DefaultElasticityMultiplier
+}
+
+// LatestFork returns the latest time-based fork that would be active for the given time.
+func (c *ChainConfig) LatestFork(time uint64) forks.Fork {
+	// Assume last non-time-based fork has passed.
+	london := c.LondonBlock
+
+	switch {
+	case c.IsCancun(london, time):
+		return forks.Cancun
+	case c.IsShanghai(london, time):
+		return forks.Shanghai
+	default:
+		return forks.Paris
+	}
 }
 
 // isForkBlockIncompatible returns true if a fork scheduled at block s1 cannot be

--- a/params/config.go
+++ b/params/config.go
@@ -757,6 +757,8 @@ func (c *ChainConfig) LatestFork(time uint64) forks.Fork {
 	london := c.LondonBlock
 
 	switch {
+	case c.IsPrague(london, time):
+		return forks.Prague
 	case c.IsCancun(london, time):
 		return forks.Cancun
 	case c.IsShanghai(london, time):

--- a/params/forks/forks.go
+++ b/params/forks/forks.go
@@ -1,0 +1,42 @@
+// Copyright 2023 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+
+package forks
+
+// Fork is a numerical identifier of specific network upgrades (forks).
+type Fork int
+
+const (
+	Frontier = iota
+	FrontierThawing
+	Homestead
+	DAO
+	TangerineWhistle
+	SpuriousDragon
+	Byzantium
+	Constantinople
+	Petersburg
+	Istanbul
+	MuirGlacier
+	Berlin
+	London
+	ArrowGlacier
+	GrayGlacier
+	Paris
+	Shanghai
+	Cancun
+	Prague
+)


### PR DESCRIPTION
 This PR introduces a few changes with respect to payload verification in fcu and new payload requests:

* First of all, it undoes the `verifyPayloadAttributes(..)` simplification I attempted in #27872. At the time I expected the pattern from `forkchoiceUpdatedV2` to continue where the previous version's payload attributes would be accepted by the method _if_ the timestamp allowed. It turns out this is only a special case in `forkchoiceUpdatedV2`. In `forkchoiceUpdatedV3` is _not_ possible to provide `PayloadAttributesV2`. Only `V3` is accepted. This sort of defeats the purpose of the shared method.

  To see this in the spec, you may first view the parameters for [`forkchoiceUpdatedV2`](https://github.com/ethereum/execution-apis/blob/main/src/engine/shanghai.md#engine_forkchoiceupdatedv2) which accepts both `PayloadAttributesV1` and `PayloadAttributesV2` versus the parameters for [`forkchoiceUpdatedV3`](https://github.com/ethereum/execution-apis/blob/main/src/engine/cancun.md#engine_forkchoiceupdatedv3) which accepts _only_ `PayloadAttributesV3`.

  For this reason I have removed `verifyPayloadAttributes(..)` and its related functions in favor of a more straight forward approach of verifying the existence of optional values on `engine.PayloadAttributes`. I went ahead and updated this logic for `forkchoiceUpdatedV2` even though it should technically still allow `V1` payload attributes, because we have passed Paris on all networks and have no need to continue support of building V1 blocks via `forkchoiceUpdatedV2`. I think it also simplifies the API to not have these two conflicting approaches for V1 vs. V2 fcu.

* Next I have added timestamp validation to fcu payload attributes [as required](https://github.com/ethereum/execution-apis/blob/main/src/engine/cancun.md#specification-1) (section 2) by the Engine API spec. I back ported this from `forkchoiceUpdatedV3` to `forkchoiceUpdatedV2` so that it is only possible to call `forkchoiceUpdatedV2` with attributes occurring in the Shanghai fork. This is done for the same reason a referenced above.

* For the new payload methods, I also update the verification of the executable data. For `newPayloadV2`, it does not currently ensure that cancun values are `nil`. Which could make it possible to submit cancun payloads through it. ~Additionally, it verifies the timestamp of the payload is exactly within the Shanghai fork. Both of these break the ability to use `newPayloadV2` for pre-shanghai blocks, but as already stated, all networks are past this point and it is not necessary to continue support.~ Decided to retain support for v1 payloads in new payload v2.

  On `newPayloadV3` the same types of checks are added. All shanghai and cancun related fields in the executable data must be non-nil, with the addition that the timestamp is _only_ with cancun.

* Finally it updates a newly failing catalyst test to call the correct fcu and new payload methods depending on the fork.

--

The general flow of all engine API methods are:
* check the well-formedness of the parameters -- this makes sense because the spec is written in a way were object is versioned, whereas we use a single object with optional values. So it would expect an immediate rejection by the API in case an object does not meet the expected criteria.
* check the timing of the request -- although the fcu V2 and new payload V2 methods are special and also accept V1 requests, it is clear that going forward (as we see in V3) that the methods will be locked strictly to the fork they are related to and so we should check this after the well-formedness.
* the thing -- after the checks are complete we can continue with processing the request