### PR TITLE
eth: when snap is complaining for missing eth, be verbose about the details

### DIFF
--- a/eth/handler.go
+++ b/eth/handler.go
@@ -461,7 +461,7 @@ func (h *handler) runSnapExtension(peer *snap.Peer, handler snap.Handler) error 
 				snap.EgressRegistrationErrorMeter.Mark(1)
 			}
 		}
-		peer.Log().Warn("Snapshot extension registration failed", "err", err)
+		peer.Log().Debug("Snapshot extension registration failed", "err", err)
 		return err
 	}
 	return handler(peer)

--- a/eth/peerset.go
+++ b/eth/peerset.go
@@ -18,6 +18,7 @@ package eth
 
 import (
 	"errors"
+	"fmt"
 	"math/big"
 	"sync"
 
@@ -74,7 +75,7 @@ func (ps *peerSet) registerSnapExtension(peer *snap.Peer) error {
 	// Reject the peer if it advertises `snap` without `eth` as `snap` is only a
 	// satellite protocol meaningful with the chain selection of `eth`
 	if !peer.RunningCap(eth.ProtocolName, eth.ProtocolVersions) {
-		return errSnapWithoutEth
+		return fmt.Errorf("%w: have %v", errSnapWithoutEth, peer.Caps())
 	}
 	// Ensure nobody can double connect
 	ps.lock.Lock()


### PR DESCRIPTION
We have a warning log if somebody connects on snap but doe snot have a valid eth to go along, since the two protocols need each other. This PR extends that log so we can see what exactly is the mismatch to see who the offenders are. It does not make the log less annoying, but that will be solved in a followup PR that does some ENR checks. Then we can see how frequent it remains and what to do about it.

Turns out doing the ENR check also requires exposing devp2p caps into the ENR records. That is going to have to be done on all clients, so it's going to take a while, so for now this PR lowers the warning down to debug. We can revisit when ENR caps are more prevalent.