### PR TITLE
git: ignore tests/spec-tests folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,5 @@ profile.cov
 
 **/yarn-error.log
 logs/
+
+tests/spec-tests/


### PR DESCRIPTION
Currently when running `make test` the `build/ci.go` will download the execution spec test, thanks to #26985. I don't think there is any reason it should be considered an untracked folder to git since we won't want to actually push that artifact up. For this reason, I've added it to our `.gitignore`.