### PR TITLE
miner: optimistically import built payloads to lower API latency

### DIFF
--- a/miner/payload_building.go
+++ b/miner/payload_building.go
@@ -193,6 +193,7 @@ func (w *worker) buildPayload(args *BuildPayloadArgs) (*Payload, error) {
 	if empty.err != nil {
 		return nil, empty.err
 	}
+	w.chain.InsertBlockWithoutSetHead(empty.block) // ignore error, we're caching (also chain will log)
 
 	// Construct a payload object for return.
 	payload := newPayload(empty.block, args.Id())
@@ -228,6 +229,7 @@ func (w *worker) buildPayload(args *BuildPayloadArgs) (*Payload, error) {
 				r := w.getSealingBlock(fullParams)
 				if r.err == nil {
 					payload.update(r, time.Since(start))
+					w.chain.InsertBlockWithoutSetHead(r.block) // ignore error, we're caching (also chain will log)
 				}
 				timer.Reset(w.recommit)
 			case <-payload.stop:


### PR DESCRIPTION
This is a stab at one of the issues in https://github.com/ethereum/go-ethereum/issues/28242.

When building blocks, the miner only creates the blocks and waits for the consensus node to retrieve them. In an ideal scenario, the consensus client will retrieve the latest, after which it will feed it back to us to import it. This creates a bit of a wasted latency as we're given back the same block we've just made a few seconds ago.

This PR is a small optimisation where each block produced by the mined is also immediately imported into the chain. Even more so, each version of the produced block is imported. This is fine, because we can have arbitrary branchings on top of the chain and they will just get pruned when the chain moves forward anyway. Ideally, this reduces the consensus API hot path a bit for networks with faster blocks.

CC @protolambda: does something like this make things simpler for you a bit? Any idea how to properly test this?