### PR TITLE
accounts/abi/bind/backend: use requested header for gas prices and gas limits

### DIFF
--- a/accounts/abi/bind/backends/simulated.go
+++ b/accounts/abi/bind/backends/simulated.go
@@ -606,8 +606,7 @@ func (b *SimulatedBackend) callContract(ctx context.Context, call ethereum.CallM
 	if call.GasPrice != nil && (call.GasFeeCap != nil || call.GasTipCap != nil) {
 		return nil, errors.New("both gasPrice and (maxFeePerGas or maxPriorityFeePerGas) specified")
 	}
-	head := b.blockchain.CurrentHeader()
-	if !b.blockchain.Config().IsLondon(head.Number) {
+	if !b.blockchain.Config().IsLondon(header.Number) {
 		// If there's no basefee, then it must be a non-1559 execution
 		if call.GasPrice == nil {
 			call.GasPrice = new(big.Int)
@@ -629,13 +628,13 @@ func (b *SimulatedBackend) callContract(ctx context.Context, call ethereum.CallM
 			// Backfill the legacy gasPrice for EVM execution, unless we're all zeroes
 			call.GasPrice = new(big.Int)
 			if call.GasFeeCap.BitLen() > 0 || call.GasTipCap.BitLen() > 0 {
-				call.GasPrice = math.BigMin(new(big.Int).Add(call.GasTipCap, head.BaseFee), call.GasFeeCap)
+				call.GasPrice = math.BigMin(new(big.Int).Add(call.GasTipCap, header.BaseFee), call.GasFeeCap)
 			}
 		}
 	}
 	// Ensure message is initialized properly.
 	if call.Gas == 0 {
-		call.Gas = 50000000
+		call.Gas = 10 * header.GasLimit
 	}
 	if call.Value == nil {
 		call.Value = new(big.Int)


### PR DESCRIPTION
The simulated backend had two quirks that PR addresses:

- When doing a Call, we could specify the header to use as the call context. However, when the gas price was auto calculated for 1559, the target header was the chain HEAD, not the header we used as context. I don't expect people to specify gas prices for calls, but if they do, this is more accurate that the old code.
- If no gas limit is given for a Call (e.g. the abigen generated stuff does not -and cannot - specify a gas limit), the simulated backend defaults to a 50M gas cap. The PR suggests making this dynamic at 10X the block gas limit for the header being ran at. This is consistent with what [Infura for example runs their APIs with](https://docs.infura.io/networks/ethereum/json-rpc-methods/eth_call) and would allow going a bit above the 50M cap. I'd also suggest raising the default cap in Geth, but that's a different story and PR.