### PR TITLE
ethclient: add tests for TransactionInBlock

### DIFF
--- a/ethclient/ethclient_test.go
+++ b/ethclient/ethclient_test.go
@@ -396,7 +396,7 @@ func testTransactionInBlock(t *testing.T, client *rpc.Client) {
 	}
 
 	// Test tx in block found.
-	tx, err = ec.TransactionInBlock(context.Background(), block.Hash(), 0)
+	tx, err := ec.TransactionInBlock(context.Background(), block.Hash(), 0)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}

--- a/ethclient/ethclient_test.go
+++ b/ethclient/ethclient_test.go
@@ -423,7 +423,6 @@ func testTransactionInBlock(t *testing.T, client *rpc.Client) {
 	if tx.Hash() != testTx2.Hash() {
 		t.Fatalf("unexpected transaction: %v", tx)
 	}
-	t.Error("test")
 }
 
 func testChainID(t *testing.T, client *rpc.Client) {

--- a/ethclient/ethclient_test.go
+++ b/ethclient/ethclient_test.go
@@ -390,18 +390,6 @@ func testTransactionInBlock(t *testing.T, client *rpc.Client) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	// Test tx in block interrupted.
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
-	<-ctx.Done() // Ensure the close of the Done channel
-	tx, err := ec.TransactionInBlock(ctx, block.Hash(), 0)
-	if tx != nil {
-		t.Fatal("transaction should be nil")
-	}
-	if !errors.Is(err, context.Canceled) {
-		t.Fatalf("error should be context.Canceled, got %v", err)
-	}
-
 	// Test tx in block not found.
 	if _, err := ec.TransactionInBlock(context.Background(), block.Hash(), 20); err != ethereum.NotFound {
 		t.Fatal("error should be ethereum.NotFound")


### PR DESCRIPTION
This commit also asserts context.Cancel error upon canceling, and removes unnecessary newlines in logs messages.