### PR TITLE
core, trie/triedb/pathdb: adjust pathdb for verkle

### DIFF
--- a/cmd/geth/dbcmd.go
+++ b/cmd/geth/dbcmd.go
@@ -220,11 +220,18 @@ func removeDB(ctx *cli.Context) error {
 		ancientDir = config.Node.ResolvePath(ancientDir)
 	}
 	// Delete state data
-	statePaths := []string{rootDir, filepath.Join(ancientDir, rawdb.StateFreezerName)}
+	statePaths := []string{
+		rootDir,
+		filepath.Join(ancientDir, rawdb.MerkleStateFreezerName),
+		filepath.Join(ancientDir, rawdb.VerkleStateFreezerName),
+	}
 	confirmAndRemoveDB(statePaths, "state data", ctx, removeStateDataFlag.Name)
 
 	// Delete ancient chain
-	chainPaths := []string{filepath.Join(ancientDir, rawdb.ChainFreezerName)}
+	chainPaths := []string{filepath.Join(
+		ancientDir,
+		rawdb.ChainFreezerName,
+	)}
 	confirmAndRemoveDB(chainPaths, "ancient chain", ctx, removeChainDataFlag.Name)
 	return nil
 }

--- a/core/rawdb/accessors_trie.go
+++ b/core/rawdb/accessors_trie.go
@@ -65,16 +65,10 @@ func (h *hasher) release() {
 	hasherPool.Put(h)
 }
 
-// ReadAccountTrieNode retrieves the account trie node and the associated node
-// hash with the specified node path.
-func ReadAccountTrieNode(db ethdb.KeyValueReader, path []byte) ([]byte, common.Hash) {
-	data, err := db.Get(accountTrieNodeKey(path))
-	if err != nil {
-		return nil, common.Hash{}
-	}
-	h := newHasher()
-	defer h.release()
-	return data, h.hash(data)
+// ReadAccountTrieNode retrieves the account trie node with the specified node path.
+func ReadAccountTrieNode(db ethdb.KeyValueReader, path []byte) []byte {
+	data, _ := db.Get(accountTrieNodeKey(path))
+	return data
 }
 
 // HasAccountTrieNode checks the account trie node presence with the specified
@@ -113,16 +107,10 @@ func DeleteAccountTrieNode(db ethdb.KeyValueWriter, path []byte) {
 	}
 }
 
-// ReadStorageTrieNode retrieves the storage trie node and the associated node
-// hash with the specified node path.
-func ReadStorageTrieNode(db ethdb.KeyValueReader, accountHash common.Hash, path []byte) ([]byte, common.Hash) {
-	data, err := db.Get(storageTrieNodeKey(accountHash, path))
-	if err != nil {
-		return nil, common.Hash{}
-	}
-	h := newHasher()
-	defer h.release()
-	return data, h.hash(data)
+// ReadStorageTrieNode retrieves the storage trie node with the specified node path.
+func ReadStorageTrieNode(db ethdb.KeyValueReader, accountHash common.Hash, path []byte) []byte {
+	data, _ := db.Get(storageTrieNodeKey(accountHash, path))
+	return data
 }
 
 // HasStorageTrieNode checks the storage trie node presence with the provided
@@ -220,16 +208,15 @@ func ReadTrieNode(db ethdb.KeyValueReader, owner common.Hash, path []byte, hash 
 	case HashScheme:
 		return ReadLegacyTrieNode(db, hash)
 	case PathScheme:
-		var (
-			blob  []byte
-			nHash common.Hash
-		)
+		var blob []byte
 		if owner == (common.Hash{}) {
-			blob, nHash = ReadAccountTrieNode(db, path)
+			blob = ReadAccountTrieNode(db, path)
 		} else {
-			blob, nHash = ReadStorageTrieNode(db, owner, path)
+			blob = ReadStorageTrieNode(db, owner, path)
 		}
-		if nHash != hash {
+		h := newHasher()
+		defer h.release()
+		if h.hash(blob) != hash {
 			return nil
 		}
 		return blob
@@ -287,8 +274,12 @@ func DeleteTrieNode(db ethdb.KeyValueWriter, owner common.Hash, path []byte, has
 // ReadStateScheme reads the state scheme of persistent state, or none
 // if the state is not present in database.
 func ReadStateScheme(db ethdb.Reader) string {
-	// Check if state in path-based scheme is present
-	blob, _ := ReadAccountTrieNode(db, nil)
+	// Check if state in path-based scheme is present, it can be either
+	// merkle tree or verkle tree.
+	blob := ReadAccountTrieNode(db, nil)
+	if len(blob) == 0 {
+		blob, _ = db.Get(verkleTrieNodeKey(nil)) // FIX HACK(rjl493456442)
+	}
 	if len(blob) != 0 {
 		return PathScheme
 	}

--- a/core/rawdb/ancient_scheme.go
+++ b/core/rawdb/ancient_scheme.go
@@ -68,14 +68,21 @@ var stateFreezerNoSnappy = map[string]bool{
 
 // The list of identifiers of ancient stores.
 var (
-	ChainFreezerName = "chain" // the folder name of chain segment ancient store.
-	StateFreezerName = "state" // the folder name of reverse diff ancient store.
+	ChainFreezerName       = "chain"        // the folder name of chain segment ancient store.
+	MerkleStateFreezerName = "state"        // the folder name of reverse diff ancient store.
+	VerkleStateFreezerName = "state_verkle" // the folder name of reverse diff ancient store.
 )
 
 // freezers the collections of all builtin freezers.
-var freezers = []string{ChainFreezerName, StateFreezerName}
+var freezers = []string{ChainFreezerName, MerkleStateFreezerName, VerkleStateFreezerName}
 
 // NewStateFreezer initializes the freezer for state history.
-func NewStateFreezer(ancientDir string, readOnly bool) (*ResettableFreezer, error) {
-	return NewResettableFreezer(filepath.Join(ancientDir, StateFreezerName), "eth/db/state", readOnly, stateHistoryTableSize, stateFreezerNoSnappy)
+func NewStateFreezer(ancientDir string, verkle bool, readOnly bool) (*ResettableFreezer, error) {
+	var name string
+	if verkle {
+		name = filepath.Join(ancientDir, VerkleStateFreezerName)
+	} else {
+		name = filepath.Join(ancientDir, MerkleStateFreezerName)
+	}
+	return NewResettableFreezer(name, "eth/db/state", readOnly, stateHistoryTableSize, stateFreezerNoSnappy)
 }

--- a/core/rawdb/ancient_utils.go
+++ b/core/rawdb/ancient_utils.go
@@ -88,21 +88,18 @@ func inspectFreezers(db ethdb.Database) ([]freezerInfo, error) {
 			}
 			infos = append(infos, info)
 
-		case StateFreezerName:
-			if ReadStateScheme(db) != PathScheme {
-				continue
-			}
+		case MerkleStateFreezerName, VerkleStateFreezerName:
 			datadir, err := db.AncientDatadir()
 			if err != nil {
 				return nil, err
 			}
-			f, err := NewStateFreezer(datadir, true)
+			f, err := NewStateFreezer(datadir, freezer == VerkleStateFreezerName, true)
 			if err != nil {
-				return nil, err
+				continue // might be possible the state freezer is not existent
 			}
 			defer f.Close()
 
-			info, err := inspect(StateFreezerName, stateFreezerNoSnappy, f)
+			info, err := inspect(freezer, stateFreezerNoSnappy, f)
 			if err != nil {
 				return nil, err
 			}
@@ -127,7 +124,7 @@ func InspectFreezerTable(ancient string, freezerName string, tableName string, s
 	switch freezerName {
 	case ChainFreezerName:
 		path, tables = resolveChainFreezerDir(ancient), chainFreezerNoSnappy
-	case StateFreezerName:
+	case MerkleStateFreezerName, VerkleStateFreezerName:
 		path, tables = filepath.Join(ancient, freezerName), stateFreezerNoSnappy
 	default:
 		return fmt.Errorf("unknown freezer, supported ones: %v", freezers)

--- a/core/rawdb/schema.go
+++ b/core/rawdb/schema.go
@@ -117,6 +117,10 @@ var (
 	trieNodeStoragePrefix = []byte("O") // trieNodeStoragePrefix + accountHash + hexPath -> trie node
 	stateIDPrefix         = []byte("L") // stateIDPrefix + state root -> state id
 
+	// VerklePrefix is the prefix of verkle states(verkle trie nodes,
+	// trie journal, persistent state id, state id lookups).
+	VerklePrefix = []byte("v")
+
 	PreimagePrefix = []byte("secure-key-")       // PreimagePrefix + hash -> preimage
 	configPrefix   = []byte("ethereum-config-")  // config prefix for the db
 	genesisPrefix  = []byte("ethereum-genesis-") // genesis state prefix for the db
@@ -268,6 +272,11 @@ func stateIDKey(root common.Hash) []byte {
 // accountTrieNodeKey = trieNodeAccountPrefix + nodePath.
 func accountTrieNodeKey(path []byte) []byte {
 	return append(trieNodeAccountPrefix, path...)
+}
+
+// verkleTrieNodeKey = verklePrefix + trieNodeAccountPrefix + nodePath.
+func verkleTrieNodeKey(path []byte) []byte {
+	return append(VerklePrefix, append(trieNodeAccountPrefix, path...)...)
 }
 
 // storageTrieNodeKey = trieNodeStoragePrefix + accountHash + nodePath.

--- a/trie/sync.go
+++ b/trie/sync.go
@@ -19,6 +19,7 @@ package trie
 import (
 	"errors"
 	"fmt"
+	"github.com/ethereum/go-ethereum/crypto"
 	"sync"
 
 	"github.com/ethereum/go-ethereum/common"
@@ -691,13 +692,12 @@ func (s *Sync) hasNode(owner common.Hash, path []byte, hash common.Hash) (exists
 	}
 	// If node is running with path scheme, check the presence with node path.
 	var blob []byte
-	var dbHash common.Hash
 	if owner == (common.Hash{}) {
-		blob, dbHash = rawdb.ReadAccountTrieNode(s.database, path)
+		blob = rawdb.ReadAccountTrieNode(s.database, path)
 	} else {
-		blob, dbHash = rawdb.ReadStorageTrieNode(s.database, owner, path)
+		blob = rawdb.ReadStorageTrieNode(s.database, owner, path)
 	}
-	exists = hash == dbHash
+	exists = hash == crypto.Keccak256Hash(blob)
 	inconsistent = !exists && len(blob) != 0
 	return exists, inconsistent
 }

--- a/trie/trie_reader.go
+++ b/trie/trie_reader.go
@@ -23,19 +23,6 @@ import (
 	"github.com/ethereum/go-ethereum/trie/triestate"
 )
 
-// Reader wraps the Node method of a backing trie store.
-type Reader interface {
-	// Node retrieves the trie node blob with the provided trie identifier, node path and
-	// the corresponding node hash. No error will be returned if the node is not found.
-	//
-	// When looking up nodes in the account trie, 'owner' is the zero hash. For contract
-	// storage trie nodes, 'owner' is the hash of the account address that containing the
-	// storage.
-	//
-	// TODO(rjl493456442): remove the 'hash' parameter, it's redundant in PBSS.
-	Node(owner common.Hash, path []byte, hash common.Hash) ([]byte, error)
-}
-
 // trieReader is a wrapper of the underlying node reader. It's not safe
 // for concurrent usage.
 type trieReader struct {

--- a/trie/triedb/hashdb/database.go
+++ b/trie/triedb/hashdb/database.go
@@ -624,11 +624,6 @@ func (db *Database) Close() error {
 	return nil
 }
 
-// Scheme returns the node scheme used in the database.
-func (db *Database) Scheme() string {
-	return rawdb.HashScheme
-}
-
 // Reader retrieves a node reader belonging to the given state root.
 // An error will be returned if the requested state is not available.
 func (db *Database) Reader(root common.Hash) (*reader, error) {

--- a/trie/triedb/pathdb/database.go
+++ b/trie/triedb/pathdb/database.go
@@ -54,14 +54,34 @@ const (
 	DefaultBufferSize = 64 * 1024 * 1024
 )
 
+const (
+	locDirtyCache = "dirty"
+	locCleanCache = "clean"
+	locDisk       = "disk"
+	locDiffLayer  = "diff"
+)
+
+// nodeLoc is a helpful structure that contains the location where the node
+// is found, as it's useful for debugging purposes.
+type nodeLoc struct {
+	loc   string
+	depth int
+}
+
+// string returns the string representation of node location.
+func (loc *nodeLoc) string() string {
+	return fmt.Sprintf("loc: %s, depth: %d", loc.loc, loc.depth)
+}
+
 // layer is the interface implemented by all state layers which includes some
 // public methods and some additional methods for internal usage.
 type layer interface {
 	// Node retrieves the trie node with the node info. An error will be returned
-	// if the read operation exits abnormally. For example, if the layer is already
-	// stale, or the associated state is regarded as corrupted. Notably, no error
-	// will be returned if the requested node is not found in database.
-	Node(owner common.Hash, path []byte, hash common.Hash) ([]byte, error)
+	// if the read operation exits abnormally. Specifically, if the layer is
+	// already stale.
+	//
+	// Note, no error will be returned if the requested node is not found in database.
+	node(owner common.Hash, path []byte, depth int) ([]byte, *nodeLoc, error)
 
 	// rootHash returns the root hash for which this layer was made.
 	rootHash() common.Hash
@@ -76,7 +96,7 @@ type layer interface {
 	// the provided dirty trie nodes along with the state change set.
 	//
 	// Note, the maps are retained by the method to avoid copying everything.
-	update(root common.Hash, id uint64, block uint64, nodes map[common.Hash]map[string]*trienode.Node, states *triestate.Set) *diffLayer
+	update(root common.Hash, id uint64, block uint64, nodes map[common.Hash]map[string][]byte, states *triestate.Set) *diffLayer
 
 	// journal commits an entire diff hierarchy to disk into a single journal entry.
 	// This is meant to be used during shutdown to persist the layer without
@@ -86,10 +106,11 @@ type layer interface {
 
 // Config contains the settings for database.
 type Config struct {
-	StateHistory   uint64 // Number of recent blocks to maintain state history for
-	CleanCacheSize int    // Maximum memory allowance (in bytes) for caching clean nodes
-	DirtyCacheSize int    // Maximum memory allowance (in bytes) for caching dirty nodes
-	ReadOnly       bool   // Flag whether the database is opened in read only mode.
+	StateHistory   uint64                   // Number of recent blocks to maintain state history for
+	CleanCacheSize int                      // Maximum memory allowance (in bytes) for caching clean nodes
+	DirtyCacheSize int                      // Maximum memory allowance (in bytes) for caching dirty nodes
+	ReadOnly       bool                     // Flag whether the database is opened in read only mode.
+	Hasher         func([]byte) common.Hash // Function to compute the hash of node
 }
 
 // sanitize checks the provided user configurations and changes anything that's
@@ -99,6 +120,9 @@ func (c *Config) sanitize() *Config {
 	if conf.DirtyCacheSize > maxBufferSize {
 		log.Warn("Sanitizing invalid node buffer size", "provided", common.StorageSize(conf.DirtyCacheSize), "updated", common.StorageSize(maxBufferSize))
 		conf.DirtyCacheSize = maxBufferSize
+	}
+	if conf.Hasher == nil {
+		conf.Hasher = hashNode
 	}
 	return &conf
 }
@@ -112,6 +136,12 @@ var Defaults = &Config{
 
 // ReadOnly is the config in order to open database in read only mode.
 var ReadOnly = &Config{ReadOnly: true}
+
+// readOption contains the configurations for reader.
+type readOption struct {
+	checkHash bool
+	hasher    func([]byte) common.Hash
+}
 
 // Database is a multiple-layered structure for maintaining in-memory trie nodes.
 // It consists of one persistent base layer backed by a key-value store, on top
@@ -135,23 +165,33 @@ type Database struct {
 	diskdb     ethdb.Database           // Persistent storage for matured trie nodes
 	tree       *layerTree               // The group for all known layers
 	freezer    *rawdb.ResettableFreezer // Freezer for storing trie histories, nil possible in tests
+	readOption *readOption              // Options for constructing reader.
 	lock       sync.RWMutex             // Lock to prevent mutations from happening at the same time
 }
 
 // New attempts to load an already existing layer from a persistent key-value
 // store (with a number of memory layers from a journal). If the journal is not
 // matched with the base persistent layer, all the recorded diff layers are discarded.
-func New(diskdb ethdb.Database, config *Config) *Database {
+func New(diskdb ethdb.Database, config *Config, verkle bool) *Database {
 	if config == nil {
 		config = Defaults
 	}
 	config = config.sanitize()
 
+	// Establish a dedicated database namespace tailored for verkle-specific
+	// data, ensuring the isolation of both verkle and mpt tree data. It's
+	// important to note that the introduction of a prefix won't lead to
+	// substantial storage overhead, as the underlying database will efficiently
+	// compress the shared key prefix.
+	if verkle {
+		diskdb = rawdb.NewTable(diskdb, string(rawdb.VerklePrefix))
+	}
 	db := &Database{
 		readOnly:   config.ReadOnly,
 		bufferSize: config.DirtyCacheSize,
 		config:     config,
 		diskdb:     diskdb,
+		readOption: &readOption{checkHash: !verkle, hasher: config.Hasher},
 	}
 	// Construct the layer tree by resolving the in-disk singleton state
 	// and in-memory layer journal.
@@ -164,7 +204,7 @@ func New(diskdb ethdb.Database, config *Config) *Database {
 	// mechanism also ensures that at most one **non-readOnly** database
 	// is opened at the same time to prevent accidental mutation.
 	if ancient, err := diskdb.AncientDatadir(); err == nil && ancient != "" && !db.readOnly {
-		freezer, err := rawdb.NewStateFreezer(ancient, false)
+		freezer, err := rawdb.NewStateFreezer(ancient, verkle, false)
 		if err != nil {
 			log.Crit("Failed to open state history freezer", "err", err)
 		}
@@ -207,13 +247,50 @@ func New(diskdb ethdb.Database, config *Config) *Database {
 	return db
 }
 
+// reader implements the Reader interface, providing the functionalities to
+// retrieve trie nodes by wrapping the internal state layer.
+type reader struct {
+	layer  layer
+	option *readOption
+}
+
+// Node implements trie.Reader interface, retrieving the node with specified
+// node info. Don't modify the returned byte slice since it's not deep-copied
+// and still be referenced by database.
+func (r *reader) Node(owner common.Hash, path []byte, hash common.Hash) ([]byte, error) {
+	blob, loc, err := r.layer.node(owner, path, 0)
+	if err != nil {
+		return nil, err
+	}
+	// Skip the hash comparison if it's disabled. Normally it will be configured
+	// in the verkle context because slim format is used in verkle which doesn't
+	// store the node hash at all to reduce read/write amplification.
+	if !r.option.checkHash {
+		return blob, nil
+	}
+	if got := r.option.hasher(blob); got != hash {
+		switch loc.loc {
+		case locCleanCache:
+			cleanFalseMeter.Mark(1)
+		case locDirtyCache:
+			dirtyFalseMeter.Mark(1)
+		case locDiffLayer:
+			diffFalseMeter.Mark(1)
+		case locDisk:
+			diskFalseMeter.Mark(1)
+		}
+		return nil, fmt.Errorf("unexpected node: (%x %v), %x!=%x, %s", owner, path, hash, got, loc.string())
+	}
+	return blob, nil
+}
+
 // Reader retrieves a layer belonging to the given state root.
-func (db *Database) Reader(root common.Hash) (layer, error) {
-	l := db.tree.get(root)
-	if l == nil {
+func (db *Database) Reader(root common.Hash) (*reader, error) {
+	layer := db.tree.get(root)
+	if layer == nil {
 		return nil, fmt.Errorf("state %#x is not available", root)
 	}
-	return l, nil
+	return &reader{layer: layer, option: db.readOption}, nil
 }
 
 // Update adds a new layer into the tree, if that can be linked to an existing
@@ -297,7 +374,7 @@ func (db *Database) Enable(root common.Hash) error {
 	}
 	// Ensure the provided state root matches the stored one.
 	root = types.TrieRootHash(root)
-	_, stored := rawdb.ReadAccountTrieNode(db.diskdb, nil)
+	stored := db.config.Hasher(rawdb.ReadAccountTrieNode(db.diskdb, nil))
 	if stored != root {
 		return fmt.Errorf("state root mismatch: stored %x, synced %x", stored, root)
 	}
@@ -465,11 +542,6 @@ func (db *Database) SetBufferSize(size int) error {
 	}
 	db.bufferSize = size
 	return db.tree.bottom().setBufferSize(db.bufferSize)
-}
-
-// Scheme returns the node scheme used in the database.
-func (db *Database) Scheme() string {
-	return rawdb.PathScheme
 }
 
 // modifyAllowed returns the indicator if mutation is allowed. This function

--- a/trie/triedb/pathdb/database_test.go
+++ b/trie/triedb/pathdb/database_test.go
@@ -103,7 +103,7 @@ func newTester(t *testing.T, historyLimit uint64) *tester {
 			StateHistory:   historyLimit,
 			CleanCacheSize: 256 * 1024,
 			DirtyCacheSize: 256 * 1024,
-		})
+		}, false)
 		obj = &tester{
 			db:           db,
 			preimages:    make(map[common.Hash]common.Address),
@@ -447,7 +447,7 @@ func TestDisable(t *testing.T) {
 	tester := newTester(t, 0)
 	defer tester.release()
 
-	_, stored := rawdb.ReadAccountTrieNode(tester.db.diskdb, nil)
+	stored := crypto.Keccak256Hash(rawdb.ReadAccountTrieNode(tester.db.diskdb, nil))
 	if err := tester.db.Disable(); err != nil {
 		t.Fatal("Failed to deactivate database")
 	}
@@ -511,7 +511,7 @@ func TestJournal(t *testing.T) {
 		t.Errorf("Failed to journal, err: %v", err)
 	}
 	tester.db.Close()
-	tester.db = New(tester.db.diskdb, nil)
+	tester.db = New(tester.db.diskdb, nil, false)
 
 	// Verify states including disk layer and all diff on top.
 	for i := 0; i < len(tester.roots); i++ {
@@ -535,7 +535,9 @@ func TestCorruptedJournal(t *testing.T) {
 		t.Errorf("Failed to journal, err: %v", err)
 	}
 	tester.db.Close()
-	_, root := rawdb.ReadAccountTrieNode(tester.db.diskdb, nil)
+
+	rootBlob := rawdb.ReadAccountTrieNode(tester.db.diskdb, nil)
+	root := crypto.Keccak256Hash(rootBlob)
 
 	// Mutate the journal in disk, it should be regarded as invalid
 	blob := rawdb.ReadTrieJournal(tester.db.diskdb)
@@ -543,7 +545,7 @@ func TestCorruptedJournal(t *testing.T) {
 	rawdb.WriteTrieJournal(tester.db.diskdb, blob)
 
 	// Verify states, all not-yet-written states should be discarded
-	tester.db = New(tester.db.diskdb, nil)
+	tester.db = New(tester.db.diskdb, nil, false)
 	for i := 0; i < len(tester.roots); i++ {
 		if tester.roots[i] == root {
 			if err := tester.verifyState(root); err != nil {
@@ -574,7 +576,7 @@ func TestTailTruncateHistory(t *testing.T) {
 	defer tester.release()
 
 	tester.db.Close()
-	tester.db = New(tester.db.diskdb, &Config{StateHistory: 10})
+	tester.db = New(tester.db.diskdb, &Config{StateHistory: 10}, false)
 
 	head, err := tester.db.freezer.Ancients()
 	if err != nil {

--- a/trie/triedb/pathdb/disklayer.go
+++ b/trie/triedb/pathdb/disklayer.go
@@ -24,11 +24,8 @@ import (
 	"github.com/VictoriaMetrics/fastcache"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/rawdb"
-	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/log"
-	"github.com/ethereum/go-ethereum/trie/trienode"
 	"github.com/ethereum/go-ethereum/trie/triestate"
-	"golang.org/x/crypto/sha3"
 )
 
 // diskLayer is a low level persistent layer built on top of a key-value store.
@@ -95,27 +92,25 @@ func (dl *diskLayer) markStale() {
 	dl.stale = true
 }
 
-// Node implements the layer interface, retrieving the trie node with the
+// node implements the layer interface, retrieving the trie node with the
 // provided node info. No error will be returned if the node is not found.
-func (dl *diskLayer) Node(owner common.Hash, path []byte, hash common.Hash) ([]byte, error) {
+func (dl *diskLayer) node(owner common.Hash, path []byte, depth int) ([]byte, *nodeLoc, error) {
 	dl.lock.RLock()
 	defer dl.lock.RUnlock()
 
 	if dl.stale {
-		return nil, errSnapshotStale
+		return nil, nil, errSnapshotStale
 	}
 	// Try to retrieve the trie node from the not-yet-written
 	// node buffer first. Note the buffer is lock free since
 	// it's impossible to mutate the buffer before tagging the
 	// layer as stale.
-	n, err := dl.buffer.node(owner, path, hash)
-	if err != nil {
-		return nil, err
-	}
-	if n != nil {
+	n, found := dl.buffer.node(owner, path)
+	if found {
 		dirtyHitMeter.Mark(1)
-		dirtyReadMeter.Mark(int64(len(n.Blob)))
-		return n.Blob, nil
+		dirtyReadMeter.Mark(int64(len(n)))
+		dirtyNodeHitDepthHist.Update(int64(depth))
+		return n, &nodeLoc{loc: locDirtyCache, depth: depth}, nil
 	}
 	dirtyMissMeter.Mark(1)
 
@@ -123,45 +118,31 @@ func (dl *diskLayer) Node(owner common.Hash, path []byte, hash common.Hash) ([]b
 	key := cacheKey(owner, path)
 	if dl.cleans != nil {
 		if blob := dl.cleans.Get(nil, key); len(blob) > 0 {
-			h := newHasher()
-			defer h.release()
-
-			got := h.hash(blob)
-			if got == hash {
-				cleanHitMeter.Mark(1)
-				cleanReadMeter.Mark(int64(len(blob)))
-				return blob, nil
-			}
-			cleanFalseMeter.Mark(1)
-			log.Error("Unexpected trie node in clean cache", "owner", owner, "path", path, "expect", hash, "got", got)
+			cleanHitMeter.Mark(1)
+			cleanReadMeter.Mark(int64(len(blob)))
+			dirtyNodeHitDepthHist.Update(int64(depth))
+			return blob, &nodeLoc{loc: locCleanCache, depth: depth}, nil
 		}
 		cleanMissMeter.Mark(1)
 	}
 	// Try to retrieve the trie node from the disk.
-	var (
-		nBlob []byte
-		nHash common.Hash
-	)
+	var blob []byte
 	if owner == (common.Hash{}) {
-		nBlob, nHash = rawdb.ReadAccountTrieNode(dl.db.diskdb, path)
+		blob = rawdb.ReadAccountTrieNode(dl.db.diskdb, path)
 	} else {
-		nBlob, nHash = rawdb.ReadStorageTrieNode(dl.db.diskdb, owner, path)
+		blob = rawdb.ReadStorageTrieNode(dl.db.diskdb, owner, path)
 	}
-	if nHash != hash {
-		diskFalseMeter.Mark(1)
-		log.Error("Unexpected trie node in disk", "owner", owner, "path", path, "expect", hash, "got", nHash)
-		return nil, newUnexpectedNodeError("disk", hash, nHash, owner, path, nBlob)
+	if dl.cleans != nil && len(blob) > 0 {
+		dl.cleans.Set(key, blob)
+		cleanWriteMeter.Mark(int64(len(blob)))
+		dirtyNodeHitDepthHist.Update(int64(depth))
 	}
-	if dl.cleans != nil && len(nBlob) > 0 {
-		dl.cleans.Set(key, nBlob)
-		cleanWriteMeter.Mark(int64(len(nBlob)))
-	}
-	return nBlob, nil
+	return blob, &nodeLoc{loc: locDisk, depth: depth}, nil
 }
 
 // update implements the layer interface, returning a new diff layer on top
 // with the given state set.
-func (dl *diskLayer) update(root common.Hash, id uint64, block uint64, nodes map[common.Hash]map[string]*trienode.Node, states *triestate.Set) *diffLayer {
+func (dl *diskLayer) update(root common.Hash, id uint64, block uint64, nodes map[common.Hash]map[string][]byte, states *triestate.Set) *diffLayer {
 	return newDiffLayer(dl, root, id, block, nodes, states)
 }
 
@@ -316,23 +297,4 @@ func (dl *diskLayer) resetCache() {
 	if dl.cleans != nil {
 		dl.cleans.Reset()
 	}
-}
-
-// hasher is used to compute the sha256 hash of the provided data.
-type hasher struct{ sha crypto.KeccakState }
-
-var hasherPool = sync.Pool{
-	New: func() interface{} { return &hasher{sha: sha3.NewLegacyKeccak256().(crypto.KeccakState)} },
-}
-
-func newHasher() *hasher {
-	return hasherPool.Get().(*hasher)
-}
-
-func (h *hasher) hash(data []byte) common.Hash {
-	return crypto.HashData(h.sha, data)
-}
-
-func (h *hasher) release() {
-	hasherPool.Put(h)
 }

--- a/trie/triedb/pathdb/errors.go
+++ b/trie/triedb/pathdb/errors.go
@@ -18,10 +18,6 @@ package pathdb
 
 import (
 	"errors"
-	"fmt"
-
-	"github.com/ethereum/go-ethereum/common"
-	"github.com/ethereum/go-ethereum/common/hexutil"
 )
 
 var (
@@ -45,16 +41,4 @@ var (
 	// errStateUnrecoverable is returned if state is required to be reverted to
 	// a destination without associated state history available.
 	errStateUnrecoverable = errors.New("state is unrecoverable")
-
-	// errUnexpectedNode is returned if the requested node with specified path is
-	// not hash matched with expectation.
-	errUnexpectedNode = errors.New("unexpected node")
 )
-
-func newUnexpectedNodeError(loc string, expHash common.Hash, gotHash common.Hash, owner common.Hash, path []byte, blob []byte) error {
-	blobHex := "nil"
-	if len(blob) > 0 {
-		blobHex = hexutil.Encode(blob)
-	}
-	return fmt.Errorf("%w, loc: %s, node: (%x %v), %x!=%x, blob: %s", errUnexpectedNode, loc, owner, path, expHash, gotHash, blobHex)
-}

--- a/trie/triedb/pathdb/hasher.go
+++ b/trie/triedb/pathdb/hasher.go
@@ -1,0 +1,51 @@
+// Copyright 2023 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+
+package pathdb
+
+import (
+	"sync"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/crypto"
+	"golang.org/x/crypto/sha3"
+)
+
+// hasher is used to compute the sha256 hash of the provided data.
+type hasher struct{ sha crypto.KeccakState }
+
+var hasherPool = sync.Pool{
+	New: func() interface{} { return &hasher{sha: sha3.NewLegacyKeccak256().(crypto.KeccakState)} },
+}
+
+func newHasher() *hasher {
+	return hasherPool.Get().(*hasher)
+}
+
+func (h *hasher) hash(data []byte) common.Hash {
+	return crypto.HashData(h.sha, data)
+}
+
+func (h *hasher) release() {
+	hasherPool.Put(h)
+}
+
+func hashNode(node []byte) common.Hash {
+	h := newHasher()
+	defer h.release()
+
+	return h.hash(node)
+}

--- a/trie/triedb/pathdb/history_test.go
+++ b/trie/triedb/pathdb/history_test.go
@@ -270,7 +270,7 @@ func TestTruncateOutOfRange(t *testing.T) {
 
 // openFreezer initializes the freezer instance for storing state histories.
 func openFreezer(datadir string, readOnly bool) (*rawdb.ResettableFreezer, error) {
-	return rawdb.NewStateFreezer(datadir, readOnly)
+	return rawdb.NewStateFreezer(datadir, false, readOnly)
 }
 
 func compareSet[k comparable](a, b map[k][]byte) bool {

--- a/trie/triedb/pathdb/layertree.go
+++ b/trie/triedb/pathdb/layertree.go
@@ -101,7 +101,7 @@ func (tree *layerTree) add(root common.Hash, parentRoot common.Hash, block uint6
 	if parent == nil {
 		return fmt.Errorf("triedb parent [%#x] layer missing", parentRoot)
 	}
-	l := parent.update(root, parent.stateID()+1, block, nodes.Flatten(), states)
+	l := parent.update(root, parent.stateID()+1, block, nodes.Slim(), states)
 
 	tree.lock.Lock()
 	tree.layers[l.rootHash()] = l

--- a/trie/triedb/pathdb/metrics.go
+++ b/trie/triedb/pathdb/metrics.go
@@ -33,6 +33,7 @@ var (
 	cleanFalseMeter = metrics.NewRegisteredMeter("pathdb/clean/false", nil)
 	dirtyFalseMeter = metrics.NewRegisteredMeter("pathdb/dirty/false", nil)
 	diskFalseMeter  = metrics.NewRegisteredMeter("pathdb/disk/false", nil)
+	diffFalseMeter  = metrics.NewRegisteredMeter("pathdb/diff/false", nil)
 
 	commitTimeTimer  = metrics.NewRegisteredTimer("pathdb/commit/time", nil)
 	commitNodesMeter = metrics.NewRegisteredMeter("pathdb/commit/nodes", nil)

--- a/trie/triestate/state.go
+++ b/trie/triestate/state.go
@@ -105,7 +105,7 @@ type context struct {
 // Apply traverses the provided state diffs, apply them in the associated
 // post-state and return the generated dirty trie nodes. The state can be
 // loaded via the provided trie loader.
-func Apply(prevRoot common.Hash, postRoot common.Hash, accounts map[common.Address][]byte, storages map[common.Address]map[common.Hash][]byte, loader TrieLoader) (map[common.Hash]map[string]*trienode.Node, error) {
+func Apply(prevRoot common.Hash, postRoot common.Hash, accounts map[common.Address][]byte, storages map[common.Address]map[common.Hash][]byte, loader TrieLoader) (map[common.Hash]map[string][]byte, error) {
 	tr, err := loader.OpenTrie(postRoot)
 	if err != nil {
 		return nil, err
@@ -139,7 +139,7 @@ func Apply(prevRoot common.Hash, postRoot common.Hash, accounts map[common.Addre
 	if err := ctx.nodes.Merge(result); err != nil {
 		return nil, err
 	}
-	return ctx.nodes.Flatten(), nil
+	return ctx.nodes.Slim(), nil
 }
 
 // updateAccount the account was present in prev-state, and may or may not


### PR DESCRIPTION
This pull request is a prerequisite for landing verkle.

Specifically, verkle and merkle are two independent trees which may be existent at the same time. In order to store tree data separately, we need to explicitly make the isolation in database level, for both key-value store and state freezer.

Besides, verkle uses a slim format which doesn't store the node hash in the parent node. This slim format can significantly reduce the read and write amplification, but in the same time loses some robustness. However, we think it's still worthwhile to at least experiment it to see the performance difference. In order to support it, pathdb will no longer maintain the node hash which is also beneficial by maintaining less stuff in memory.
 
**But one thing is noteworthy**, pathdb will return the node blindly where ever it's found without hash comparison(clean cache, dirty cache, diff layer, disk). Originally we have this tiny trick to compare the hash if the node is found in clean cache, and fallback to disk if it's not matched, just in case the clean cache is not properly maintained, but this mechanism is lost in this pull request.


Update: this pull request can snap/full sync the mainnet, we have more confidence that the clean cache is properly maintained and safe to have this change.