### PR TITLE
geth: add staticpeers option to specify staticNodes from the command …

### DIFF
--- a/cmd/geth/main.go
+++ b/cmd/geth/main.go
@@ -59,6 +59,7 @@ var (
 		utils.UnlockedAccountFlag,
 		utils.PasswordFileFlag,
 		utils.BootnodesFlag,
+		utils.StaticPeers,
 		utils.MinFreeDiskSpaceFlag,
 		utils.KeyStoreDirFlag,
 		utils.ExternalSignerFlag,


### PR DESCRIPTION
No Option was given to specify static peers from the command line even if it was possible to manually edit the config file to add some.

Added the option `--staticpeers` where you can specify a list of enode being added as static peers at startup.
You can now specify a staticpeers from the command line 
`geth --staticpeers $enode ....`.

Useful when running small testing/private network.