### PR TITLE
Why is the write performance of PebbleDB so low

### DIFF
--- a/ethdb/leveldb/leveldb_test.go
+++ b/ethdb/leveldb/leveldb_test.go
@@ -17,6 +17,7 @@
 package leveldb
 
 import (
+	"os"
 	"testing"
 
 	"github.com/ethereum/go-ethereum/ethdb"
@@ -49,4 +50,29 @@ func BenchmarkLevelDB(b *testing.B) {
 			db: db,
 		}
 	})
+}
+
+func BenchmarkIOLevelDB(b *testing.B) {
+	dir, err := os.MkdirTemp("", "leveldb_*")
+	if err != nil {
+		b.Fatal(err)
+	}
+	var stor storage.Storage
+	stor, err = storage.OpenFile(dir, false)
+	if err != nil {
+		b.Fatal(err)
+	}
+	dbtest.BenchDatabaseSuite2(b, func() ethdb.KeyValueStore {
+		db, err := leveldb.Open(stor, nil)
+		if err != nil {
+			b.Fatal(err)
+		}
+		return &Database{
+			db: db,
+		}
+	})
+	err = os.RemoveAll(dir)
+	if err != nil {
+		b.Fatal(err)
+	}
 }

--- a/ethdb/pebble/pebble_test.go
+++ b/ethdb/pebble/pebble_test.go
@@ -19,6 +19,7 @@
 package pebble
 
 import (
+	"os"
 	"testing"
 
 	"github.com/cockroachdb/pebble"
@@ -55,4 +56,24 @@ func BenchmarkPebbleDB(b *testing.B) {
 			db: db,
 		}
 	})
+}
+
+func BenchmarkIOPebbleDB(b *testing.B) {
+	dir, err := os.MkdirTemp("", "pebble_*")
+	if err != nil {
+		b.Fatal(err)
+	}
+	dbtest.BenchDatabaseSuite2(b, func() ethdb.KeyValueStore {
+		db, err := pebble.Open(dir, &pebble.Options{})
+		if err != nil {
+			b.Fatal(err)
+		}
+		return &Database{
+			db: db,
+		}
+	})
+	err = os.RemoveAll(dir)
+	if err != nil {
+		b.Fatal(err)
+	}
 }


### PR DESCRIPTION
I found that using PebbleDB for block synchronization would be very slow, so I wrote this benchmark. Because I found that the original benchmark used memory as data storage, which did not truly reflect the storage performance of the database.

```
goos: linux
goarch: amd64
pkg: github.com/ethereum/go-ethereum/ethdb/leveldb
cpu: 13th Gen Intel(R) Core(TM) i9-13900HX
BenchmarkIOLevelDB
BenchmarkIOLevelDB/Write
BenchmarkIOLevelDB/Write/WriteSorted
BenchmarkIOLevelDB/Write/WriteSorted-32                 1000000000 0.002453 ns/op
BenchmarkIOLevelDB/Write/WriteRandom
BenchmarkIOLevelDB/Write/WriteRandom-32                 1000000000 0.001432 ns/op
BenchmarkIOLevelDB/Read
BenchmarkIOLevelDB/Read/ReadSorted
BenchmarkIOLevelDB/Read/ReadSorted-32                   1000000000 0.0003110 ns/op
BenchmarkIOLevelDB/Read/ReadRandom
BenchmarkIOLevelDB/Read/ReadRandom-32                   1000000000 0.002103 ns/op
BenchmarkIOLevelDB/Iteration
BenchmarkIOLevelDB/Iteration/IterationSorted
BenchmarkIOLevelDB/Iteration/IterationSorted-32         1000000000 0.001583 ns/op
BenchmarkIOLevelDB/Iteration/IterationRandom
BenchmarkIOLevelDB/Iteration/IterationRandom-32         1000000000 0.0009521 ns/op
BenchmarkIOLevelDB/BatchWrite
BenchmarkIOLevelDB/BatchWrite/BenchWriteSorted
BenchmarkIOLevelDB/BatchWrite/BenchWriteSorted-32               1000000000        0.005066 ns/op
BenchmarkIOLevelDB/BatchWrite/BenchWriteRandom
BenchmarkIOLevelDB/BatchWrite/BenchWriteRandom-32               1000000000        0.005044 ns/op
PASS
```


```
goos: linux
goarch: amd64
pkg: github.com/ethereum/go-ethereum/ethdb/pebble
cpu: 13th Gen Intel(R) Core(TM) i9-13900HX
BenchmarkIOPebbleDB
BenchmarkIOPebbleDB/Write
BenchmarkIOPebbleDB/Write/WriteSorted
BenchmarkIOPebbleDB/Write/WriteSorted-32                       1        2681966887 ns/op
BenchmarkIOPebbleDB/Write/WriteRandom
BenchmarkIOPebbleDB/Write/WriteRandom-32                       1        2299213713 ns/op
BenchmarkIOPebbleDB/Read
BenchmarkIOPebbleDB/Read/ReadSorted
BenchmarkIOPebbleDB/Read/ReadSorted-32                  1000000000 0.004273 ns/op
BenchmarkIOPebbleDB/Read/ReadRandom
BenchmarkIOPebbleDB/Read/ReadRandom-32                  1000000000 0.003380 ns/op
BenchmarkIOPebbleDB/Iteration
BenchmarkIOPebbleDB/Iteration/IterationSorted
BenchmarkIOPebbleDB/Iteration/IterationSorted-32        1000000000 0.004186 ns/op
BenchmarkIOPebbleDB/Iteration/IterationRandom
BenchmarkIOPebbleDB/Iteration/IterationRandom-32        1000000000 0.004321 ns/op
BenchmarkIOPebbleDB/BatchWrite
BenchmarkIOPebbleDB/BatchWrite/BenchWriteSorted
BenchmarkIOPebbleDB/BatchWrite/BenchWriteSorted-32              1000000000        0.005306 ns/op
BenchmarkIOPebbleDB/BatchWrite/BenchWriteRandom
BenchmarkIOPebbleDB/BatchWrite/BenchWriteRandom-32              1000000000        0.003691 ns/op
PASS
```
I found that the write operation of PebbleDB is much slower than that of LevelDB, and logically it shouldn't be so much different. I don't know where the problem is