### PR TITLE
core/blockchain: warn on error messages

### DIFF
--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -409,7 +409,10 @@ func NewBlockChain(db ethdb.Database, cacheConfig *CacheConfig, genesis *Genesis
 	// The first thing the node will do is reconstruct the verification data for
 	// the head block (ethash cache or clique voting snapshot). Might as well do
 	// it in advance.
-	bc.engine.VerifyHeader(bc, bc.CurrentHeader())
+	err = bc.engine.VerifyHeader(bc, bc.CurrentHeader())
+	if err != nil {
+		log.Warn("Failed to verify the chain's head block", "err", err)
+	}
 
 	// Check the current state of the block hashes and make sure that we do not have any of the bad blocks in our chain
 	for hash := range BadHashes {


### PR DESCRIPTION
This commit prints warning on error message returned while verifying the block header.

Frankly, I'm not sure why this line is here without returning the error.
To be careful editing core file, I've decided to let it in and log at the very least.

Returning the error seems to break many tests, and that was just over my head at the moment.
I can investigate further if that's advised, but I'm guessing it's there for a reason that I'm just not aware of.
