### PR TITLE
core, eth, trie: filter out boundary nodes and remove dangling nodes in stacktrie

### DIFF
--- a/eth/protocols/snap/metrics.go
+++ b/eth/protocols/snap/metrics.go
@@ -26,4 +26,15 @@ var (
 
 	IngressRegistrationErrorMeter = metrics.NewRegisteredMeter(ingressRegistrationErrorName, nil)
 	EgressRegistrationErrorMeter  = metrics.NewRegisteredMeter(egressRegistrationErrorName, nil)
+
+	// deletionGauge is the metric to track how many trie node deletions
+	// are performed in total during the sync process.
+	deletionGauge = metrics.NewRegisteredGauge("eth/protocols/snap/sync/delete", nil)
+
+	// lookupGauge is the metric to track how many trie node lookups are
+	// performed to determine if node needs to be deleted.
+	lookupGauge = metrics.NewRegisteredGauge("eth/protocols/snap/sync/lookup", nil)
+
+	// boundaryNodesGauge is the metric to track how many boundary trie node are met.
+	boundaryNodesGauge = metrics.NewRegisteredGauge("eth/protocols/snap/sync/boundary", nil)
 )

--- a/eth/protocols/snap/metrics.go
+++ b/eth/protocols/snap/metrics.go
@@ -50,4 +50,8 @@ var (
 	// largeStorageGauge is the metric to track how many storages are large enough
 	// to retrieved concurrently.
 	largeStorageGauge = metrics.NewRegisteredGauge("eth/protocols/snap/sync/storage/large", nil)
+
+	// skipStorageHealingGauge is the metric to track how many storages are retrieved
+	// in multiple requests but healing is not necessary.
+	skipStorageHealingGauge = metrics.NewRegisteredGauge("eth/protocols/snap/sync/storage/noheal", nil)
 )

--- a/eth/protocols/snap/metrics.go
+++ b/eth/protocols/snap/metrics.go
@@ -35,6 +35,11 @@ var (
 	// performed to determine if node needs to be deleted.
 	lookupGauge = metrics.NewRegisteredGauge("eth/protocols/snap/sync/lookup", nil)
 
-	// boundaryNodesGauge is the metric to track how many boundary trie node are met.
-	boundaryNodesGauge = metrics.NewRegisteredGauge("eth/protocols/snap/sync/boundary", nil)
+	// boundaryAccountNodesGauge is the metric to track how many boundary trie
+	// nodes in account trie are met.
+	boundaryAccountNodesGauge = metrics.NewRegisteredGauge("eth/protocols/snap/sync/boundary/account", nil)
+
+	// boundaryAccountNodesGauge is the metric to track how many boundary trie
+	// nodes in storage tries are met.
+	boundaryStorageNodesGauge = metrics.NewRegisteredGauge("eth/protocols/snap/sync/boundary/storage", nil)
 )

--- a/eth/protocols/snap/metrics.go
+++ b/eth/protocols/snap/metrics.go
@@ -42,4 +42,12 @@ var (
 	// boundaryAccountNodesGauge is the metric to track how many boundary trie
 	// nodes in storage tries are met.
 	boundaryStorageNodesGauge = metrics.NewRegisteredGauge("eth/protocols/snap/sync/boundary/storage", nil)
+
+	// smallStorageGauge is the metric to track how many storages are retrieved
+	// in a single request.
+	smallStorageGauge = metrics.NewRegisteredGauge("eth/protocols/snap/sync/storage/small", nil)
+
+	// largeStorageGauge is the metric to track how many storages are large enough
+	// to retrieved concurrently.
+	largeStorageGauge = metrics.NewRegisteredGauge("eth/protocols/snap/sync/storage/large", nil)
 )

--- a/eth/protocols/snap/metrics.go
+++ b/eth/protocols/snap/metrics.go
@@ -43,8 +43,8 @@ var (
 	// nodes in storage tries are met.
 	boundaryStorageNodesGauge = metrics.NewRegisteredGauge("eth/protocols/snap/sync/boundary/storage", nil)
 
-	// smallStorageGauge is the metric to track how many storages are retrieved
-	// in a single request.
+	// smallStorageGauge is the metric to track how many storages are small enough
+	// to retrieved in one or two request.
 	smallStorageGauge = metrics.NewRegisteredGauge("eth/protocols/snap/sync/storage/small", nil)
 
 	// largeStorageGauge is the metric to track how many storages are large enough

--- a/eth/protocols/snap/sync.go
+++ b/eth/protocols/snap/sync.go
@@ -756,6 +756,9 @@ func (s *Syncer) loadSyncStatus() {
 					rawdb.WriteTrieNode(task.genBatch, common.Hash{}, path, hash, blob, s.scheme)
 				})
 				if s.scheme == rawdb.PathScheme {
+					// Configure the dangling node cleaner and also filter out boundary nodes
+					// only in the context of the path scheme. Deletion is forbidden in the
+					// hash scheme, as it can disrupt state completeness.
 					options = options.WithCleaner(func(path []byte) {
 						s.cleanPath(task.genBatch, common.Hash{}, path)
 					})
@@ -780,6 +783,9 @@ func (s *Syncer) loadSyncStatus() {
 							rawdb.WriteTrieNode(subtask.genBatch, owner, path, hash, blob, s.scheme)
 						})
 						if s.scheme == rawdb.PathScheme {
+							// Configure the dangling node cleaner and also filter out boundary nodes
+							// only in the context of the path scheme. Deletion is forbidden in the
+							// hash scheme, as it can disrupt state completeness.
 							options = options.WithCleaner(func(path []byte) {
 								s.cleanPath(subtask.genBatch, owner, path)
 							})
@@ -844,6 +850,9 @@ func (s *Syncer) loadSyncStatus() {
 			rawdb.WriteTrieNode(batch, common.Hash{}, path, hash, blob, s.scheme)
 		})
 		if s.scheme == rawdb.PathScheme {
+			// Configure the dangling node cleaner and also filter out boundary nodes
+			// only in the context of the path scheme. Deletion is forbidden in the
+			// hash scheme, as it can disrupt state completeness.
 			options = options.WithCleaner(func(path []byte) {
 				s.cleanPath(batch, common.Hash{}, path)
 			})
@@ -2080,6 +2089,9 @@ func (s *Syncer) processStorageResponse(res *storageResponse) {
 							rawdb.WriteTrieNode(batch, owner, path, hash, blob, s.scheme)
 						})
 						if s.scheme == rawdb.PathScheme {
+							// Configure the dangling node cleaner and also filter out boundary nodes
+							// only in the context of the path scheme. Deletion is forbidden in the
+							// hash scheme, as it can disrupt state completeness.
 							options = options.WithCleaner(func(path []byte) {
 								s.cleanPath(batch, owner, path)
 							})
@@ -2143,6 +2155,12 @@ func (s *Syncer) processStorageResponse(res *storageResponse) {
 				rawdb.WriteTrieNode(batch, account, path, hash, blob, s.scheme)
 			})
 			if s.scheme == rawdb.PathScheme {
+				// Configure the dangling node cleaner only in the context of the
+				// path scheme. Deletion is forbidden in the hash scheme, as it can
+				// disrupt state completeness.
+				//
+				// Notably, boundary nodes can be also kept because the whole storage
+				// trie is complete.
 				options = options.WithCleaner(func(path []byte) {
 					s.cleanPath(batch, account, path)
 				})

--- a/eth/protocols/snap/sync.go
+++ b/eth/protocols/snap/sync.go
@@ -762,9 +762,7 @@ func (s *Syncer) loadSyncStatus() {
 					options = options.WithCleaner(func(path []byte) {
 						s.cleanPath(task.genBatch, common.Hash{}, path)
 					})
-					options = options.SkipBoundary(true, true, func(path []byte, hash common.Hash, blob []byte) {
-						boundaryNodesGauge.Inc(1)
-					})
+					options = options.SkipBoundary(true, true, boundaryAccountNodesGauge)
 				}
 				task.genTrie = trie.NewStackTrie(options)
 				for accountHash, subtasks := range task.SubTasks {
@@ -789,9 +787,7 @@ func (s *Syncer) loadSyncStatus() {
 							options = options.WithCleaner(func(path []byte) {
 								s.cleanPath(subtask.genBatch, owner, path)
 							})
-							options = options.SkipBoundary(true, true, func(path []byte, hash common.Hash, blob []byte) {
-								boundaryNodesGauge.Inc(1)
-							})
+							options = options.SkipBoundary(true, true, boundaryStorageNodesGauge)
 						}
 						subtask.genTrie = trie.NewStackTrie(options)
 					}
@@ -856,9 +852,7 @@ func (s *Syncer) loadSyncStatus() {
 			options = options.WithCleaner(func(path []byte) {
 				s.cleanPath(batch, common.Hash{}, path)
 			})
-			options = options.SkipBoundary(true, true, func(path []byte, hash common.Hash, blob []byte) {
-				boundaryNodesGauge.Inc(1)
-			})
+			options = options.SkipBoundary(true, true, boundaryAccountNodesGauge)
 		}
 		s.tasks = append(s.tasks, &accountTask{
 			Next:     next,
@@ -2066,9 +2060,7 @@ func (s *Syncer) processStorageResponse(res *storageResponse) {
 						options = options.WithCleaner(func(path []byte) {
 							s.cleanPath(batch, owner, path)
 						})
-						options.SkipBoundary(true, true, func(path []byte, hash common.Hash, blob []byte) {
-							boundaryNodesGauge.Inc(1)
-						})
+						options.SkipBoundary(true, true, boundaryStorageNodesGauge)
 					}
 					tasks = append(tasks, &storageTask{
 						Next:     common.Hash{},
@@ -2095,9 +2087,7 @@ func (s *Syncer) processStorageResponse(res *storageResponse) {
 							options = options.WithCleaner(func(path []byte) {
 								s.cleanPath(batch, owner, path)
 							})
-							options.SkipBoundary(true, true, func(path []byte, hash common.Hash, blob []byte) {
-								boundaryNodesGauge.Inc(1)
-							})
+							options.SkipBoundary(true, true, boundaryStorageNodesGauge)
 						}
 						tasks = append(tasks, &storageTask{
 							Next:     r.Start(),

--- a/eth/protocols/snap/sync_test.go
+++ b/eth/protocols/snap/sync_test.go
@@ -1871,7 +1871,7 @@ func verifyTrie(scheme string, db ethdb.KeyValueStore, root common.Hash, t *test
 // TestSyncAccountPerformance tests how efficient the snap algo is at minimizing
 // state healing
 func TestSyncAccountPerformance(t *testing.T) {
-	t.SkipNow()
+	t.Parallel()
 
 	testSyncAccountPerformance(t, rawdb.HashScheme)
 	testSyncAccountPerformance(t, rawdb.PathScheme)

--- a/eth/protocols/snap/sync_test.go
+++ b/eth/protocols/snap/sync_test.go
@@ -1871,7 +1871,7 @@ func verifyTrie(scheme string, db ethdb.KeyValueStore, root common.Hash, t *test
 // TestSyncAccountPerformance tests how efficient the snap algo is at minimizing
 // state healing
 func TestSyncAccountPerformance(t *testing.T) {
-	t.Parallel()
+	t.SkipNow()
 
 	testSyncAccountPerformance(t, rawdb.HashScheme)
 	testSyncAccountPerformance(t, rawdb.PathScheme)

--- a/trie/stacktrie.go
+++ b/trie/stacktrie.go
@@ -49,7 +49,7 @@ func (o *StackTrieOptions) WithWriter(writer func(path []byte, hash common.Hash,
 	return o
 }
 
-// WithCleaner configures path cleaner within the options.
+// WithCleaner configures the cleaner in the option for removing dangling nodes.
 func (o *StackTrieOptions) WithCleaner(cleaner func(path []byte)) *StackTrieOptions {
 	o.Cleaner = cleaner
 	return o
@@ -74,7 +74,7 @@ type StackTrie struct {
 	h       *hasher
 
 	first []byte // The key of first inserted entry, tracked as left boundary.
-	last  []byte // The key of last inserted entry, tracked as left boundary.
+	last  []byte // The key of last inserted entry, tracked as right boundary.
 }
 
 // NewStackTrie allocates and initializes an empty trie.
@@ -102,9 +102,9 @@ func (t *StackTrie) Update(key, value []byte) error {
 		t.first = append([]byte{}, k...)
 	}
 	if t.last == nil {
-		t.last = append([]byte{}, k...)
+		t.last = append([]byte{}, k...) // allocate key slice
 	} else {
-		t.last = append(t.last[:0], k...)
+		t.last = append(t.last[:0], k...) // reuse key slice
 	}
 	t.insert(t.root, k, value, nil)
 	return nil

--- a/trie/stacktrie.go
+++ b/trie/stacktrie.go
@@ -73,8 +73,8 @@ type StackTrie struct {
 	root    *stNode
 	h       *hasher
 
-	first []byte // The key of first inserted entry, tracked as left boundary.
-	last  []byte // The key of last inserted entry, tracked as right boundary.
+	first []byte // The (hex-encoded without terminator) key of first inserted entry, tracked as left boundary.
+	last  []byte // The (hex-encoded without terminator) key of last inserted entry, tracked as right boundary.
 }
 
 // NewStackTrie allocates and initializes an empty trie.

--- a/trie/stacktrie.go
+++ b/trie/stacktrie.go
@@ -17,6 +17,7 @@
 package trie
 
 import (
+	"bytes"
 	"sync"
 
 	"github.com/ethereum/go-ethereum/common"
@@ -31,7 +32,12 @@ var (
 
 // StackTrieOptions contains the configured options for manipulating the stackTrie.
 type StackTrieOptions struct {
-	Writer func(path []byte, hash common.Hash, blob []byte) // The function to commit the dirty nodes
+	Writer  func(path []byte, hash common.Hash, blob []byte) // The function to commit the dirty nodes
+	Cleaner func(path []byte)                                // The function to clean up dangling nodes
+
+	SkipLeftBoundary  bool                                             // Flag whether the nodes on the left boundary are skipped for committing
+	SkipRightBoundary bool                                             // Flag whether the nodes on the right boundary are skipped for committing
+	OnBoundary        func(path []byte, hash common.Hash, blob []byte) // Callback invoked when the node is skipped committing
 }
 
 // NewStackTrieOptions initializes an empty options for stackTrie.
@@ -43,6 +49,22 @@ func (o *StackTrieOptions) WithWriter(writer func(path []byte, hash common.Hash,
 	return o
 }
 
+// WithCleaner configures path cleaner within the options.
+func (o *StackTrieOptions) WithCleaner(cleaner func(path []byte)) *StackTrieOptions {
+	o.Cleaner = cleaner
+	return o
+}
+
+// SkipBoundary configures whether the left and right boundary nodes are filtered
+// for committing, along with a onBoundary callback invoked whenever the boundary
+// nodes are met.
+func (o *StackTrieOptions) SkipBoundary(skipLeft, skipRight bool, onBoundary func(path []byte, hash common.Hash, blob []byte)) *StackTrieOptions {
+	o.SkipLeftBoundary = skipLeft
+	o.SkipRightBoundary = skipRight
+	o.OnBoundary = onBoundary
+	return o
+}
+
 // StackTrie is a trie implementation that expects keys to be inserted
 // in order. Once it determines that a subtree will no longer be inserted
 // into, it will hash it and free up the memory it uses.
@@ -50,6 +72,9 @@ type StackTrie struct {
 	options *StackTrieOptions
 	root    *stNode
 	h       *hasher
+
+	first []byte // The key of first inserted entry, tracked as left boundary.
+	last  []byte // The key of last inserted entry, tracked as left boundary.
 }
 
 // NewStackTrie allocates and initializes an empty trie.
@@ -72,6 +97,15 @@ func (t *StackTrie) Update(key, value []byte) error {
 	}
 	k = k[:len(k)-1] // chop the termination flag
 
+	// track the first and last inserted entries.
+	if t.first == nil {
+		t.first = append([]byte{}, k...)
+	}
+	if t.last == nil {
+		t.last = append([]byte{}, k...)
+	} else {
+		t.last = append(t.last[:0], k...)
+	}
 	t.insert(t.root, k, value, nil)
 	return nil
 }
@@ -88,6 +122,8 @@ func (t *StackTrie) MustUpdate(key, value []byte) {
 func (t *StackTrie) Reset() {
 	t.options = NewStackTrieOptions()
 	t.root = stPool.Get().(*stNode)
+	t.first = nil
+	t.last = nil
 }
 
 // stNode represents a node within a StackTrie
@@ -306,8 +342,10 @@ func (t *StackTrie) insert(st *stNode, key, value []byte, path []byte) {
 //
 // This method also sets 'st.type' to hashedNode, and clears 'st.key'.
 func (t *StackTrie) hash(st *stNode, path []byte) {
-	var blob []byte // RLP-encoded node blob
-
+	var (
+		blob     []byte   // RLP-encoded node blob
+		internal [][]byte // List of node paths covered by the extension node
+	)
 	switch st.typ {
 	case hashedNode:
 		return
@@ -342,6 +380,15 @@ func (t *StackTrie) hash(st *stNode, path []byte) {
 		// recursively hash and commit child as the first step
 		t.hash(st.children[0], append(path, st.key...))
 
+		// Collect the path of internal nodes between shortNode and its **in disk**
+		// child. This is essential in the case of path mode scheme to avoid leaving
+		// danging nodes within the range of this internal path on disk, which would
+		// break the guarantee for state healing.
+		if len(st.children[0].val) >= 32 && t.options.Cleaner != nil {
+			for i := 1; i < len(st.key); i++ {
+				internal = append(internal, append(path, st.key[:i]...))
+			}
+		}
 		// encode the extension node
 		n := shortNode{Key: hexToCompactInPlace(st.key)}
 		if len(st.children[0].val) < 32 {
@@ -378,10 +425,35 @@ func (t *StackTrie) hash(st *stNode, path []byte) {
 	// input values.
 	st.val = t.h.hashData(blob)
 
-	// Commit the trie node if the writer is configured.
-	if t.options.Writer != nil {
-		t.options.Writer(path, common.BytesToHash(st.val), blob)
+	// Short circuit if the stack trie is not configured for writing.
+	if t.options.Writer == nil {
+		return
 	}
+	hash := common.BytesToHash(st.val)
+
+	// Skip committing if the node is on the left boundary and stackTrie is
+	// configured to filter the boundary.
+	if t.options.SkipLeftBoundary && bytes.HasPrefix(t.first, path) {
+		if t.options.OnBoundary != nil {
+			t.options.OnBoundary(path, hash, blob)
+		}
+		return
+	}
+	// Skip committing if the node is on the right boundary and stackTrie is
+	// configured to filter the boundary.
+	if t.options.SkipRightBoundary && bytes.HasPrefix(t.last, path) {
+		if t.options.OnBoundary != nil {
+			t.options.OnBoundary(path, hash, blob)
+		}
+		return
+	}
+	// Clean up the internal dangling nodes covered by the extension node.
+	// This should be done before writing the node to adhere to the committing
+	// order from bottom to top.
+	for _, path := range internal {
+		t.options.Cleaner(path)
+	}
+	t.options.Writer(path, common.BytesToHash(st.val), blob)
 }
 
 // Hash will firstly hash the entire trie if it's still not hashed and then commit

--- a/trie/stacktrie.go
+++ b/trie/stacktrie.go
@@ -56,10 +56,10 @@ func (o *StackTrieOptions) WithCleaner(cleaner func(path []byte)) *StackTrieOpti
 	return o
 }
 
-// SkipBoundary configures whether the left and right boundary nodes are filtered
-// for committing, along with a onBoundary callback invoked whenever the boundary
-// nodes are met.
-func (o *StackTrieOptions) SkipBoundary(skipLeft, skipRight bool, gauge metrics.Gauge) *StackTrieOptions {
+// WithSkipBoundary configures whether the left and right boundary nodes are
+// filtered for committing, along with a gauge metrics to track how many
+// boundary nodes are met.
+func (o *StackTrieOptions) WithSkipBoundary(skipLeft, skipRight bool, gauge metrics.Gauge) *StackTrieOptions {
 	o.SkipLeftBoundary = skipLeft
 	o.SkipRightBoundary = skipRight
 	o.boundaryGauge = gauge

--- a/trie/stacktrie_test.go
+++ b/trie/stacktrie_test.go
@@ -408,7 +408,7 @@ func buildPartialTree(entries []*kv, t *testing.T) map[string]common.Hash {
 			noRight = true
 		}
 	}
-	options = options.SkipBoundary(noLeft, noRight, nil)
+	options = options.WithSkipBoundary(noLeft, noRight, nil)
 	options = options.WithWriter(func(path []byte, hash common.Hash, blob []byte) {
 		nodes[string(path)] = hash
 	})

--- a/trie/stacktrie_test.go
+++ b/trie/stacktrie_test.go
@@ -382,9 +382,8 @@ func TestStacktrieNotModifyValues(t *testing.T) {
 
 func buildPartialTree(entries []*kv, t *testing.T) map[string]common.Hash {
 	var (
-		options  = NewStackTrieOptions()
-		nodes    = make(map[string]common.Hash)
-		boundary = make(map[string]common.Hash)
+		options = NewStackTrieOptions()
+		nodes   = make(map[string]common.Hash)
 	)
 	var (
 		first int
@@ -409,9 +408,7 @@ func buildPartialTree(entries []*kv, t *testing.T) map[string]common.Hash {
 			noRight = true
 		}
 	}
-	options = options.SkipBoundary(noLeft, noRight, func(path []byte, hash common.Hash, blob []byte) {
-		boundary[string(path)] = hash
-	})
+	options = options.SkipBoundary(noLeft, noRight, nil)
 	options = options.WithWriter(func(path []byte, hash common.Hash, blob []byte) {
 		nodes[string(path)] = hash
 	})
@@ -421,19 +418,6 @@ func buildPartialTree(entries []*kv, t *testing.T) map[string]common.Hash {
 		tr.MustUpdate(entries[i].k, entries[i].v)
 	}
 	tr.Commit()
-
-	for path := range boundary {
-		var expect bool
-		if noLeft && bytes.HasPrefix(keybytesToHex(entries[first].k), []byte(path)) {
-			expect = true
-		}
-		if noRight && bytes.HasPrefix(keybytesToHex(entries[last].k), []byte(path)) {
-			expect = true
-		}
-		if !expect {
-			t.Fatalf("Unexpected boundary node, %v", []byte(path))
-		}
-	}
 	return nodes
 }
 

--- a/trie/stacktrie_test.go
+++ b/trie/stacktrie_test.go
@@ -19,11 +19,14 @@ package trie
 import (
 	"bytes"
 	"math/big"
+	"math/rand"
 	"testing"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/rawdb"
 	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/ethereum/go-ethereum/trie/testutil"
+	"golang.org/x/exp/slices"
 )
 
 func TestStackTrieInsertAndHash(t *testing.T) {
@@ -373,6 +376,106 @@ func TestStacktrieNotModifyValues(t *testing.T) {
 		have := vals[i]
 		if !bytes.Equal(have, want) {
 			t.Fatalf("item %d, have %#x want %#x", i, have, want)
+		}
+	}
+}
+
+func buildPartialTree(entries []*kv, t *testing.T) map[string]common.Hash {
+	var (
+		options  = NewStackTrieOptions()
+		nodes    = make(map[string]common.Hash)
+		boundary = make(map[string]common.Hash)
+	)
+	var (
+		first int
+		last  = len(entries) - 1
+
+		noLeft  bool
+		noRight bool
+	)
+	// Enter split mode if there are at least two elements
+	if rand.Intn(5) != 0 {
+		for {
+			first = rand.Intn(len(entries))
+			last = rand.Intn(len(entries))
+			if first <= last {
+				break
+			}
+		}
+		if first != 0 {
+			noLeft = true
+		}
+		if last != len(entries)-1 {
+			noRight = true
+		}
+	}
+	options = options.SkipBoundary(noLeft, noRight, func(path []byte, hash common.Hash, blob []byte) {
+		boundary[string(path)] = hash
+	})
+	options = options.WithWriter(func(path []byte, hash common.Hash, blob []byte) {
+		nodes[string(path)] = hash
+	})
+	tr := NewStackTrie(options)
+
+	for i := first; i <= last; i++ {
+		tr.MustUpdate(entries[i].k, entries[i].v)
+	}
+	tr.Commit()
+
+	for path := range boundary {
+		var expect bool
+		if noLeft && bytes.HasPrefix(keybytesToHex(entries[first].k), []byte(path)) {
+			expect = true
+		}
+		if noRight && bytes.HasPrefix(keybytesToHex(entries[last].k), []byte(path)) {
+			expect = true
+		}
+		if !expect {
+			t.Fatalf("Unexpected boundary node, %v", []byte(path))
+		}
+	}
+	return nodes
+}
+
+func TestPartialStackTrie(t *testing.T) {
+	for round := 0; round < 100; round++ {
+		var (
+			n       = rand.Intn(100) + 1
+			entries []*kv
+		)
+		for i := 0; i < n; i++ {
+			var val []byte
+			if rand.Intn(3) == 0 {
+				val = testutil.RandBytes(3)
+			} else {
+				val = testutil.RandBytes(32)
+			}
+			entries = append(entries, &kv{
+				k: testutil.RandBytes(32),
+				v: val,
+			})
+		}
+		slices.SortFunc(entries, (*kv).cmp)
+
+		var (
+			nodes   = make(map[string]common.Hash)
+			options = NewStackTrieOptions().WithWriter(func(path []byte, hash common.Hash, blob []byte) {
+				nodes[string(path)] = hash
+			})
+		)
+		tr := NewStackTrie(options)
+
+		for i := 0; i < len(entries); i++ {
+			tr.MustUpdate(entries[i].k, entries[i].v)
+		}
+		tr.Commit()
+
+		for j := 0; j < 100; j++ {
+			for path, hash := range buildPartialTree(entries, t) {
+				if nodes[path] != hash {
+					t.Errorf("%v, want %x, got %x", []byte(path), nodes[path], hash)
+				}
+			}
 		}
 	}
 }


### PR DESCRIPTION
This pull request implements two optional features for stacktrie:

- Filtering out the boundary nodes to avoid committing "incomplete" ones
- Detecting dangling nodes fall within the path covered by an extension node

These two features can be used to enhance the snap sync in the case of path mode.

---

**Why to filter out boundary nodes?**

In the snap sync, a large trie is separated into several chunks(usually 16) to sync concurrently. For single chunk, there is a corresponding stack trie to accept the states within this range and build the merkle trie nodes on top.

However, the lack of states ahead and behind, the generated merkle trie nodes on boundary are incomplete. They do not match the nodes in the full trie.

<img width="548" alt="截屏2023-10-17 下午12 14 05" src="https://github.com/ethereum/go-ethereum/assets/5959481/69c6139a-6ef0-42a0-b751-98c7d385e59c">

In this example above, the trie is divided into three ranges. The partial trie of these ranges will generate incorrect boundary nodes. e.g. node A was in a deeper position, but now moved to a higher level. The root node is also incorrect due to missing children.

**How to detect boundary nodes?**

All nodes along the path of the 'first-inserted-state' node key are considered left-boundary nodes.
All nodes along the path of the 'last-inserted-state' node key are considered right-boundary nodes.

**How can we guarantee that nodes except the left and right boundaries are all correct?**

Because these states fall within the range are complete. The first and last states can uniquely determine the position of the subtrie which contains all the states in the middle. In another word, the subtrie of the internal states(except first and last) is completely consistent with the one in the full trie, and the position of this subtrie can be uniquely determined by the boundary states. 

Therefore, we can conclude that the nodes  except the left and right boundaries are all correct.

--- 

**Why to remove the dangling nodes fall within the range covered by extension node?**

Since the snap syncer might sync the storage trie multiple times due to sync cycle termination and resumption, and the sync target can change because of pivot movement. This scenario can occur which disrupts state healing.

In cycle 1, the storage trie appears as follows. The snap syncer successfully retrieved the entire storage trie and stored the nodes in the database.

However, cycle 1 was terminated due to a pivot movement at that time, with an incomplete storage trie of another account ahead. Consequently, this account range will need to be reprocessed in the next cycle, and, if the storage trie has changed, it will be resynced.

<img width="708" alt="截屏2023-10-17 上午11 50 24" src="https://github.com/ethereum/go-ethereum/assets/5959481/2d20a37d-1066-424b-9b7e-eb4ed6425fcc">


In cycle 2, the shape of the storage trie changes. Specifically, the short node at [0, 1, 2, 3, 5] is modified, and a few node branches are removed, causing nodes M-3 and M-4 to become dangling.


<img width="674" alt="截屏2023-10-17 上午11 57 03" src="https://github.com/ethereum/go-ethereum/assets/5959481/63295ae4-8544-4970-914a-5befddce3f38">

When the snap sync is completed, the state healer begins filling in the missing nodes. If, at that time, the storage reverts to the state it was in during cycle 1, the state healer will stop at M-3. This is because the state healer operates under the assumption that if a node exists, the entire sub-trie should also be present. However, in this case, M-3 is merely a dangling node, and the corresponding sub-trie is incomplete. For instance, the node at the path [0, 1, 2, 3, 5] is N-4, does not matching with M-3.

Thus, we can conclude that whenever we commit nodes into the database, we must ensure that the entire path space is uniquely occupied and remove all the dangling nodes within that path space.


**Overhead analysis**

In order to detect the dangling nodes, a lot of database reads will be conducted. The statistics from a live sync show that 950K database reads are performed in total(and nothing detected, kind of expected, very rare to occur).

Although the overhead is not trivial, but also not significant. We have to live with it to avoid corruption that can happen in a very low possibility.


