### PR TITLE
website: fix broken redirect

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -42,7 +42,7 @@
 
 [[redirects]]
   from = "/docs/interface/consensus-clients"
-  to = "/docs/getting-started/consensus-client"
+  to = "/docs/getting-started/consensus-clients"
   force = true
 
 [[redirects]]

--- a/redirects.js
+++ b/redirects.js
@@ -33,7 +33,7 @@ const redirects = [
   },
   {
     source: '/docs/interface/consensus-clients',
-    destination: '/docs/getting-started/consensus-client',
+    destination: '/docs/getting-started/consensus-clients',
     permanent: true
   },
   {


### PR DESCRIPTION
This PR updates the redirect destination from

https://geth.ethereum.org/docs/getting-started/consensus-client (404)

to

https://geth.ethereum.org/docs/getting-started/consensus-clients (works)