### PR TITLE
ethclient: ensure the close of canceled context

### DIFF
--- a/ethclient/ethclient_test.go
+++ b/ethclient/ethclient_test.go
@@ -393,6 +393,7 @@ func testTransactionInBlockInterrupted(t *testing.T, client *rpc.Client) {
 	// Test tx in block interrupted.
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
+	<-ctx.Done() // Ensure the close of the Done channel
 	tx, err := ec.TransactionInBlock(ctx, block.Hash(), 0)
 	if tx != nil {
 		t.Fatal("transaction should be nil")
@@ -666,6 +667,7 @@ func testTransactionSender(t *testing.T, client *rpc.Client) {
 	// TransactionSender. Ensure the server is not asked by canceling the context here.
 	canceledCtx, cancel := context.WithCancel(context.Background())
 	cancel()
+	<-canceledCtx.Done() // Ensure the close of the Done channel
 	sender1, err := ec.TransactionSender(canceledCtx, tx1, block2.Hash(), 0)
 	if err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
Case `TestEthClient/TxInBlockInterrupted` checks whether the interface `eth_getTransactionByBlockHashAndIndex` works correctly with a canceled context. Therefore, it passes a cancelled context to the interface and expects a `nil` transaction is returned.

However, as the close of the `Done` channel may happen asynchronously after the cancel function returns, this test case may occasionally return a non-nil transaction.

This PR adds `<-ctx.Done()` to ensure the close of the `Done` channel.

---

The test case has failed several times on free GitHub Actions CI runners.