### PR TITLE
accounts/keystore: KDFParams unmarshalling chore

### DIFF
--- a/accounts/keystore/key.go
+++ b/accounts/keystore/key.go
@@ -78,12 +78,22 @@ type encryptedKeyJSONV1 struct {
 }
 
 type CryptoJSON struct {
-	Cipher       string                 `json:"cipher"`
-	CipherText   string                 `json:"ciphertext"`
-	CipherParams cipherparamsJSON       `json:"cipherparams"`
-	KDF          string                 `json:"kdf"`
-	KDFParams    map[string]interface{} `json:"kdfparams"`
-	MAC          string                 `json:"mac"`
+	Cipher       string           `json:"cipher"`
+	CipherText   string           `json:"ciphertext"`
+	CipherParams cipherparamsJSON `json:"cipherparams"`
+	KDF          string           `json:"kdf"`
+	KDFParams    kdfParamsJSON    `json:"kdfparams"`
+	MAC          string           `json:"mac"`
+}
+
+type kdfParamsJSON struct {
+	Salt  string `json:"salt"`
+	DKlen int    `json:"dklen"`
+	N     int    `json:"n"`
+	R     int    `json:"r"`
+	P     int    `json:"p"`
+	C     int    `json:"c"`
+	PRF   string `json:"prf"`
 }
 
 type cipherparamsJSON struct {


### PR DESCRIPTION
Created a new struct for KDFParams as `KDFParams`. 
Updated the affected code for the same.

go documentation does mention.
```
To unmarshal JSON into an interface value, Unmarshal stores one of these in the interface value: 

bool, for JSON booleans
float64, for JSON numbers
```
figured it won't be necessary for us here to use
```
func ensureInt(x interface{}) int {
	res, ok := x.(int)
	if !ok {
		res = int(x.(float64))
	}
	return res
}
```
since the values are int anyways