### PR TITLE
core/rawdb: resolving code redundancy

### DIFF
--- a/core/rawdb/accessors_chain.go
+++ b/core/rawdb/accessors_chain.go
@@ -681,25 +681,16 @@ func DeleteReceipts(db ethdb.KeyValueWriter, hash common.Hash, number uint64) {
 	}
 }
 
-// storedReceiptRLP is the storage encoding of a receipt.
-// Re-definition in core/types/receipt.go.
-// TODO: Re-use the existing definition.
-type storedReceiptRLP struct {
-	PostStateOrStatus []byte
-	CumulativeGasUsed uint64
-	Logs              []*types.Log
-}
-
 // ReceiptLogs is a barebone version of ReceiptForStorage which only keeps
 // the list of logs. When decoding a stored receipt into this object we
 // avoid creating the bloom filter.
 type receiptLogs struct {
-	Logs []*types.Log
+	Logs []*types.Log 
 }
 
 // DecodeRLP implements rlp.Decoder.
 func (r *receiptLogs) DecodeRLP(s *rlp.Stream) error {
-	var stored storedReceiptRLP
+	var stored types.StoredReceiptRLP
 	if err := s.Decode(&stored); err != nil {
 		return err
 	}

--- a/core/types/receipt.go
+++ b/core/types/receipt.go
@@ -95,7 +95,7 @@ type receiptRLP struct {
 }
 
 // storedReceiptRLP is the storage encoding of a receipt.
-type storedReceiptRLP struct {
+type StoredReceiptRLP struct {
 	PostStateOrStatus []byte
 	CumulativeGasUsed uint64
 	Logs              []*Log
@@ -282,7 +282,7 @@ func (r *ReceiptForStorage) EncodeRLP(_w io.Writer) error {
 // DecodeRLP implements rlp.Decoder, and loads both consensus and implementation
 // fields of a receipt from an RLP stream.
 func (r *ReceiptForStorage) DecodeRLP(s *rlp.Stream) error {
-	var stored storedReceiptRLP
+	var stored StoredReceiptRLP
 	if err := s.Decode(&stored); err != nil {
 		return err
 	}


### PR DESCRIPTION
resolving some old code redundancy in `core/rawdb`

```
// TODO: Re-use the existing definition.
type storedReceiptRLP struct {
	PostStateOrStatus []byte
	CumulativeGasUsed uint64
	Logs              []*types.Log
}

```