### PR TITLE
internal/ethapi: fix codehash lookup in eth_getProof

### DIFF
--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -675,9 +675,6 @@ func (s *BlockChainAPI) GetProof(ctx context.Context, address common.Address, st
 		keys         = make([]common.Hash, len(storageKeys))
 		keyLengths   = make([]int, len(storageKeys))
 		storageProof = make([]StorageResult, len(storageKeys))
-
-		storageRoot = types.EmptyRootHash
-		codeHash    = types.EmptyCodeHash
 	)
 	// Deserialize all keys. This prevents state access on invalid input.
 	for i, hexKey := range storageKeys {
@@ -687,18 +684,22 @@ func (s *BlockChainAPI) GetProof(ctx context.Context, address common.Address, st
 			return nil, err
 		}
 	}
-	state, header, err := s.b.StateAndHeaderByNumberOrHash(ctx, blockNrOrHash)
-	if state == nil || err != nil {
+	statedb, header, err := s.b.StateAndHeaderByNumberOrHash(ctx, blockNrOrHash)
+	if statedb == nil || err != nil {
 		return nil, err
 	}
-	codeHash = state.GetCodeHash(address)
-	storageRoot = state.GetStorageRoot(address)
+	codeHash := statedb.GetCodeHash(address)
+	storageRoot := statedb.GetStorageRoot(address)
 
-	if len(keys) > 0 && storageRoot != types.EmptyRootHash && storageRoot != (common.Hash{}) { // Create storage proof
-		id := trie.StorageTrieID(header.Root, crypto.Keccak256Hash(address.Bytes()), storageRoot)
-		storageTrie, err := trie.NewStateTrie(id, state.Database().TrieDB())
-		if err != nil {
-			return nil, err
+	if len(keys) > 0 {
+		var storageTrie state.Trie
+		if storageRoot != types.EmptyRootHash && storageRoot != (common.Hash{}) {
+			id := trie.StorageTrieID(header.Root, crypto.Keccak256Hash(address.Bytes()), storageRoot)
+			st, err := trie.NewStateTrie(id, statedb.Database().TrieDB())
+			if err != nil {
+				return nil, err
+			}
+			storageTrie = st
 		}
 		// Create the proofs for the storageKeys.
 		for i, key := range keys {
@@ -712,7 +713,6 @@ func (s *BlockChainAPI) GetProof(ctx context.Context, address common.Address, st
 			} else {
 				outputKey = hexutil.Encode(key[:])
 			}
-
 			if storageTrie == nil {
 				storageProof[i] = StorageResult{outputKey, &hexutil.Big{}, []string{}}
 				continue
@@ -721,12 +721,12 @@ func (s *BlockChainAPI) GetProof(ctx context.Context, address common.Address, st
 			if err := storageTrie.Prove(crypto.Keccak256(key.Bytes()), &proof); err != nil {
 				return nil, err
 			}
-			value := (*hexutil.Big)(state.GetState(address, key).Big())
+			value := (*hexutil.Big)(statedb.GetState(address, key).Big())
 			storageProof[i] = StorageResult{outputKey, value, proof}
 		}
 	}
 	// Create the accountProof.
-	tr, err := trie.NewStateTrie(trie.StateTrieID(header.Root), state.Database().TrieDB())
+	tr, err := trie.NewStateTrie(trie.StateTrieID(header.Root), statedb.Database().TrieDB())
 	if err != nil {
 		return nil, err
 	}
@@ -737,12 +737,12 @@ func (s *BlockChainAPI) GetProof(ctx context.Context, address common.Address, st
 	return &AccountResult{
 		Address:      address,
 		AccountProof: accountProof,
-		Balance:      (*hexutil.Big)(state.GetBalance(address)),
+		Balance:      (*hexutil.Big)(statedb.GetBalance(address)),
 		CodeHash:     codeHash,
-		Nonce:        hexutil.Uint64(state.GetNonce(address)),
+		Nonce:        hexutil.Uint64(statedb.GetNonce(address)),
 		StorageHash:  storageRoot,
 		StorageProof: storageProof,
-	}, state.Error()
+	}, statedb.Error()
 }
 
 // decodeHash parses a hex-encoded 32-byte hash. The input may optionally


### PR DESCRIPTION
Fixes https://github.com/ethereum/go-ethereum/issues/28355 (I think), unconditionally looks up the codehash. Also refactors a bit.