### PR TITLE
ethclient: Fix eth_getBlockReceipts call when using block numbers or labels

### DIFF
--- a/rpc/types.go
+++ b/rpc/types.go
@@ -21,7 +21,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"math"
-	"strconv"
 	"strings"
 
 	"github.com/ethereum/go-ethereum/common"
@@ -221,7 +220,7 @@ func (bnh *BlockNumberOrHash) Number() (BlockNumber, bool) {
 
 func (bnh *BlockNumberOrHash) String() string {
 	if bnh.BlockNumber != nil {
-		return strconv.Itoa(int(*bnh.BlockNumber))
+		return bnh.BlockNumber.String()
 	}
 	if bnh.BlockHash != nil {
 		return bnh.BlockHash.String()

--- a/rpc/types_test.go
+++ b/rpc/types_test.go
@@ -153,3 +153,33 @@ func TestBlockNumberOrHash_WithNumber_MarshalAndUnmarshal(t *testing.T) {
 		})
 	}
 }
+
+func TestBlockNumberOrHash_WithNumber_StringAndUnmarshal(t *testing.T) {
+	tests := []struct {
+		name  string
+		value BlockNumberOrHash
+	}{
+		{"max", BlockNumberOrHashWithNumber(math.MaxInt64)},
+		{"pending", BlockNumberOrHashWithNumber(PendingBlockNumber)},
+		{"latest", BlockNumberOrHashWithNumber(LatestBlockNumber)},
+		{"earliest", BlockNumberOrHashWithNumber(EarliestBlockNumber)},
+		{"0x20", BlockNumberOrHashWithNumber(32)},
+		{"hash", BlockNumberOrHashWithHash(common.Hash{0xaa}, false)},
+	}
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			bnh := test.value
+			// Wrap the string value in quotes to make it a JSON string.
+			marshalled := []byte("\"" + bnh.String() + "\"")
+			var unmarshalled BlockNumberOrHash
+			err := json.Unmarshal(marshalled, &unmarshalled)
+			if err != nil {
+				t.Fatalf("cannot unmarshal (%v): %v", string(marshalled), err)
+			}
+			if !reflect.DeepEqual(bnh, unmarshalled) {
+				t.Fatalf("wrong result: expected %v, got %v", bnh, unmarshalled)
+			}
+		})
+	}
+}

--- a/rpc/types_test.go
+++ b/rpc/types_test.go
@@ -154,32 +154,23 @@ func TestBlockNumberOrHash_WithNumber_MarshalAndUnmarshal(t *testing.T) {
 	}
 }
 
-func TestBlockNumberOrHash_WithNumber_StringAndUnmarshal(t *testing.T) {
-	tests := []struct {
-		name  string
-		value BlockNumberOrHash
-	}{
-		{"max", BlockNumberOrHashWithNumber(math.MaxInt64)},
-		{"pending", BlockNumberOrHashWithNumber(PendingBlockNumber)},
-		{"latest", BlockNumberOrHashWithNumber(LatestBlockNumber)},
-		{"earliest", BlockNumberOrHashWithNumber(EarliestBlockNumber)},
-		{"0x20", BlockNumberOrHashWithNumber(32)},
-		{"hash", BlockNumberOrHashWithHash(common.Hash{0xaa}, false)},
+func TestBlockNumberOrHash_StringAndUnmarshal(t *testing.T) {
+	tests := []BlockNumberOrHash{
+		BlockNumberOrHashWithNumber(math.MaxInt64),
+		BlockNumberOrHashWithNumber(PendingBlockNumber),
+		BlockNumberOrHashWithNumber(LatestBlockNumber),
+		BlockNumberOrHashWithNumber(EarliestBlockNumber),
+		BlockNumberOrHashWithNumber(32),
+		BlockNumberOrHashWithHash(common.Hash{0xaa}, false),
 	}
-	for _, test := range tests {
-		test := test
-		t.Run(test.name, func(t *testing.T) {
-			bnh := test.value
-			// Wrap the string value in quotes to make it a JSON string.
-			marshalled := []byte("\"" + bnh.String() + "\"")
-			var unmarshalled BlockNumberOrHash
-			err := json.Unmarshal(marshalled, &unmarshalled)
-			if err != nil {
-				t.Fatalf("cannot unmarshal (%v): %v", string(marshalled), err)
-			}
-			if !reflect.DeepEqual(bnh, unmarshalled) {
-				t.Fatalf("wrong result: expected %v, got %v", bnh, unmarshalled)
-			}
-		})
+	for _, want := range tests {
+		marshalled, _ := json.Marshal(want.String())
+		var have BlockNumberOrHash
+		if err := json.Unmarshal(marshalled, &have); err != nil {
+			t.Fatalf("cannot unmarshal (%v): %v", string(marshalled), err)
+		}
+		if !reflect.DeepEqual(want, have) {
+			t.Fatalf("wrong result: have %v, want %v", have, want)
+		}
 	}
 }


### PR DESCRIPTION
The String() version of BlockNumberOrHash uses decimal for all block numbers, including negative ones used to indicate labels. Switch to using BlockNumber.String() which encodes it correctly for use in the JSON-RPC API.

The incorrect encoding was introduced in https://github.com/ethereum/go-ethereum/pull/28087 when switching from the working but non-standard object encoding (e.g. `{"blockNumber":"0x7fffffffffffffff"}`) that comes from JSON serialising `BlockNumberOrHash` to using `String()` to return a single value.  With this implementation of `String()` it matches the execution-apis spec for block hash, block number and block labels.