### PR TITLE
event: fix Resubscribe deadlock when unsubscribing after inner sub ends

### DIFF
--- a/event/subscription.go
+++ b/event/subscription.go
@@ -153,8 +153,8 @@ func (s *resubscribeSub) Err() <-chan error {
 }
 
 func (s *resubscribeSub) loop() {
-	var done bool
 	defer close(s.err)
+	var done bool
 	for !done {
 		sub := s.subscribe()
 		if sub == nil {


### PR DESCRIPTION
A goroutine oversees the lifetime of subscriptions handled by resubscriptions. This goroutine terminates when the subscription ends without any errors.  However, the resub goroutine needs to live long enough to read from the unsub channel. Otherwise, an Unsubscribe call deadlocks when writing to the unsub channel.