### PR TITLE
trie: use explicit errors in stacktrie (instead of panic)

### DIFF
--- a/core/state/snapshot/generate.go
+++ b/core/state/snapshot/generate.go
@@ -230,7 +230,9 @@ func (dl *diskLayer) proveRange(ctx *generatorContext, trieId *trie.ID, prefix [
 	if origin == nil && !diskMore {
 		stackTr := trie.NewStackTrie(nil)
 		for i, key := range keys {
-			stackTr.Update(key, vals[i])
+			if err := stackTr.Update(key, vals[i]); err != nil {
+				return nil, err
+			}
 		}
 		if gotRoot := stackTr.Hash(); gotRoot != root {
 			return &proofResult{

--- a/trie/stacktrie.go
+++ b/trie/stacktrie.go
@@ -98,20 +98,20 @@ func (t *StackTrie) Update(key, value []byte) error {
 	}
 	k := keybytesToHex(key)
 	k = k[:len(k)-1] // chop the termination flag
+	if bytes.Compare(t.last, k) >= 0 {
+		return errors.New("non-ascending key order")
+	}
+	if err := t.insert(t.root, k, value, nil); err != nil {
+		return err
+	}
 	// track the first and last inserted entries.
 	if t.first == nil {
 		t.first = append([]byte{}, k...)
-	}
-	if bytes.Compare(t.last, k) >= 0 {
-		return errors.New("non-ascending key order")
 	}
 	if t.last == nil {
 		t.last = append([]byte{}, k...) // allocate key slice
 	} else {
 		t.last = append(t.last[:0], k...) // reuse key slice
-	}
-	if err := t.insert(t.root, k, value, nil); err != nil {
-		return err
 	}
 	return nil
 }

--- a/trie/stacktrie.go
+++ b/trie/stacktrie.go
@@ -101,9 +101,6 @@ func (t *StackTrie) Update(key, value []byte) error {
 	if bytes.Compare(t.last, k) >= 0 {
 		return errors.New("non-ascending key order")
 	}
-	if err := t.insert(t.root, k, value, nil); err != nil {
-		return err
-	}
 	// track the first and last inserted entries.
 	if t.first == nil {
 		t.first = append([]byte{}, k...)
@@ -112,6 +109,9 @@ func (t *StackTrie) Update(key, value []byte) error {
 		t.last = append([]byte{}, k...) // allocate key slice
 	} else {
 		t.last = append(t.last[:0], k...) // reuse key slice
+	}
+	if err := t.insert(t.root, k, value, nil); err != nil {
+		return err
 	}
 	return nil
 }

--- a/trie/stacktrie_test.go
+++ b/trie/stacktrie_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/ethereum/go-ethereum/core/rawdb"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/trie/testutil"
+	"github.com/stretchr/testify/assert"
 	"golang.org/x/exp/slices"
 )
 
@@ -462,4 +463,25 @@ func TestPartialStackTrie(t *testing.T) {
 			}
 		}
 	}
+}
+
+func TestStacstaturieErrors(t *testing.T) {
+	s := NewStackTrie(nil)
+	// Deletion
+	if err := s.Update(nil, nil); err == nil {
+		t.Fatal("expected error")
+	}
+	if err := s.Update(nil, []byte{}); err == nil {
+		t.Fatal("expected error")
+	}
+	if err := s.Update([]byte{0xa}, []byte{}); err == nil {
+		t.Fatal("expected error")
+	}
+	// Non-ascending keys (going backwards or repeating)
+	assert.Nil(t, s.Update([]byte{0xaa}, []byte{0xa}))
+	assert.NotNil(t, s.Update([]byte{0xaa}, []byte{0xa}), "repeat insert same key")
+	assert.NotNil(t, s.Update([]byte{0xaa}, []byte{0xb}), "repeat insert same key")
+	assert.Nil(t, s.Update([]byte{0xab}, []byte{0xa}))
+	assert.NotNil(t, s.Update([]byte{0x10}, []byte{0xb}), "out of order insert")
+	assert.NotNil(t, s.Update([]byte{0xaa}, []byte{0xb}), "repeat insert same key")
 }

--- a/trie/stacktrie_test.go
+++ b/trie/stacktrie_test.go
@@ -465,7 +465,7 @@ func TestPartialStackTrie(t *testing.T) {
 	}
 }
 
-func TestStacstaturieErrors(t *testing.T) {
+func TestStackTrieErrors(t *testing.T) {
 	s := NewStackTrie(nil)
 	// Deletion
 	if err := s.Update(nil, nil); err == nil {


### PR DESCRIPTION
Follow-up to https://github.com/ethereum/go-ethereum/pull/28350 . 
This PR removes `panic`s from stacktrie (mostly), and makes the `Update` return errors instead. While adding tests for this, I also found that one case of possible corruption was not caught. 

If we inserted into an existing node, we noticed and panic:ed. However, it was possible to insert into an "empty slot" further back, so inserting at `0xaa` followed by `0x10` did not panic. To handle that, I now added a `lastPath` to the stacktrie, to keep record of the path of the last inserted item. 

This can also be useful for keeping track of the right hand boundary. 
