### PR TITLE
tests/fuzzers/les: fix crasher

### DIFF
--- a/tests/fuzzers/les/les-fuzzer.go
+++ b/tests/fuzzers/les/les-fuzzer.go
@@ -70,7 +70,7 @@ func makechain() (bc *core.BlockChain, addresses []common.Address, txHashes []co
 			)
 			nonce := uint64(i)
 			if i%4 == 0 {
-				tx, _ = types.SignTx(types.NewContractCreation(nonce, big.NewInt(0), 200000, big.NewInt(0), testContractCode), signer, bankKey)
+				tx, _ = types.SignTx(types.NewContractCreation(nonce, big.NewInt(0), 200000, big.NewInt(params.GWei), testContractCode), signer, bankKey)
 				addr = crypto.CreateAddress(bankAddr, nonce)
 			} else {
 				addr = common.BigToAddress(big.NewInt(int64(i)))


### PR DESCRIPTION
This PR fixes a crash in the LES fuzzer. We included transactions that payed less gas than the block base fee

```
INFO: -max_len is not provided; libFuzzer will not generate inputs larger than 4096 bytes
INFO [10-17|09:42:05.569] Persisted trie from memory database      nodes=1 size=149.00B time="10.63µs" gcnodes=0 gcsize=0.00B gctime=0s livenodes=0 livesize=0.00B
panic: max fee per gas less than block base fee: address 0x71562b71999873DB5b286dF957af199Ec94617F7, maxFeePerGas: 0 baseFee: 875000000

goroutine 1 [running]:
github.com/ethereum/go-ethereum/core.(*BlockGen).addTx(0x10c0006ce240, 0xf71746c9?, {{0x0, 0x0}, 0x0, 0x0, {0x0, 0x0, 0x0}}, 0x10c000700900)
    github.com/ethereum/go-ethereum/core/chain_makers.go:105 +0x4ba
github.com/ethereum/go-ethereum/core.(*BlockGen).AddTx(...)
    github.com/ethereum/go-ethereum/core/chain_makers.go:123
github.com/ethereum/go-ethereum/tests/fuzzers/les.makechain.func1(0x0, 0x10c000370ad0?)
    github.com/ethereum/go-ethereum/tests/fuzzers/les/les-fuzzer.go:79 +0x857
github.com/ethereum/go-ethereum/core.GenerateChain.func1(0x0, 0x10c0006c4460, 0xc2d83ed049652476?, 0x10c000038f00)
    github.com/ethereum/go-ethereum/core/chain_makers.go:320 +0x910
github.com/ethereum/go-ethereum/core.GenerateChain(0x10c00068e000?, 0x10c0006c4460, {0x1b4b820, 0x10c00036e7c8}, {0x1b50eb0, 0x10c0006dc020}, 0x100, 0x10c00090fd90)
    github.com/ethereum/go-ethereum/core/chain_makers.go:349 +0x38c
github.com/ethereum/go-ethereum/core.GenerateChainWithGenesis(0x10c00068e000, {0x1b4b820, 0x10c00036e7c8}, 0x0?, 0x198?)
    github.com/ethereum/go-ethereum/core/chain_makers.go:368 +0x1ef
github.com/ethereum/go-ethereum/tests/fuzzers/les.makechain()
    github.com/ethereum/go-ethereum/tests/fuzzers/les/les-fuzzer.go:65 +0x1f9
github.com/ethereum/go-ethereum/tests/fuzzers/les.init.0()
    github.com/ethereum/go-ethereum/tests/fuzzers/les/les-fuzzer.go:110 +0x2f
AddressSanitizer:DEADLYSIGNAL
```