### PR TITLE
eth/filters: fix flaky test

### DIFF
--- a/eth/filters/filter_system_test.go
+++ b/eth/filters/filter_system_test.go
@@ -941,7 +941,7 @@ func TestPendingTxFilterDeadlock(t *testing.T) {
 		select {
 		case <-sub.Err():
 		case <-time.After(1 * time.Second):
-			t.Fatalf("Filter %s should have been uninstalled\n", sub.ID)
+			t.Fatalf("Filter timeout is hanging")
 		}
 	}
 }

--- a/eth/filters/filter_system_test.go
+++ b/eth/filters/filter_system_test.go
@@ -933,7 +933,7 @@ func TestPendingTxFilterDeadlock(t *testing.T) {
 	}
 
 	// Wait until filters have timed out
-	time.Sleep(3 * timeout)
+	time.Sleep(6 * timeout)
 
 	// If tx loop doesn't consume `done` after a second
 	// it's hanging.

--- a/eth/filters/filter_system_test.go
+++ b/eth/filters/filter_system_test.go
@@ -915,10 +915,14 @@ func TestPendingTxFilterDeadlock(t *testing.T) {
 
 	// Create a bunch of filters that will
 	// timeout either in 100ms or 200ms
-	fids := make([]rpc.ID, 20)
-	for i := 0; i < len(fids); i++ {
+	subs := make([]*Subscription, 20)
+	for i := 0; i < len(subs); i++ {
 		fid := api.NewPendingTransactionFilter(nil)
-		fids[i] = fid
+		f, ok := api.filters[fid]
+		if !ok {
+			t.Fatalf("Filter %s should exist", fid)
+		}
+		subs[i] = f.s
 		// Wait for at least one tx to arrive in filter
 		for {
 			hashes, err := api.GetFilterChanges(fid)
@@ -932,21 +936,13 @@ func TestPendingTxFilterDeadlock(t *testing.T) {
 		}
 	}
 
-	// Wait until filters have timed out
-	time.Sleep(6 * timeout)
-
-	// If tx loop doesn't consume `done` after a second
-	// it's hanging.
-	select {
-	case done <- struct{}{}:
-		// Check that all filters have been uninstalled
-		for _, fid := range fids {
-			if _, err := api.GetFilterChanges(fid); err == nil {
-				t.Errorf("Filter %s should have been uninstalled\n", fid)
-			}
+	// Wait until filters have timed out and have been uninstalled.
+	for _, sub := range subs {
+		select {
+		case <-sub.Err():
+		case <-time.After(1 * time.Second):
+			t.Fatalf("Filter %s should have been uninstalled\n", sub.ID)
 		}
-	case <-time.After(1 * time.Second):
-		t.Error("Tx sending loop hangs")
 	}
 }
 


### PR DESCRIPTION
I used a private field in the test which is ugly but the test isn't using a constant timeout which should be more reliable.

```terminal
--- FAIL: TestPendingTxFilterDeadlock (0.43s)
    filter_system_test.go:945: Filter 0xb8eae786b9803d3d609b2c821eb1063b should have been uninstalled
    filter_system_test.go:945: Filter 0x9c29340950cc32a5d529614bc7eebba6 should have been uninstalled
    filter_system_test.go:945: Filter 0xee2adcbcb566863626d022fd9a7cf25d should have been uninstalled
    filter_system_test.go:945: Filter 0x9787a8ad2029820e12ec76c42834669b should have been uninstalled
    filter_system_test.go:945: Filter 0x4ed8bcb649c19fb643819d1a0a4c7d5 should have been uninstalled
    filter_system_test.go:945: Filter 0x63649cc3a9ff47d4fae0f9c288b03e57 should have been uninstalled
    filter_system_test.go:945: Filter 0xc70de5b5187afa7c319b1dfb2af863a should have been uninstalled
    filter_system_test.go:945: Filter 0x5c29489f19b2a13ef169381abc725d0 should have been uninstalled
    filter_system_test.go:945: Filter 0x8d45e09c46026e74d867a233c8cdba1c should have been uninstalled
FAIL
FAIL	github.com/ethereum/go-ethereum/eth/filters	4.506s
```

For context this test was added to cover the deadlock reported here: https://github.com/ethereum/go-ethereum/issues/22131