### PR TITLE
cmd, eth: Add txpool.disabled flag

### DIFF
--- a/cmd/geth/config.go
+++ b/cmd/geth/config.go
@@ -164,6 +164,10 @@ func makeConfigNode(ctx *cli.Context) (*node.Node, gethConfig) {
 	}
 	applyMetricConfig(ctx, &cfg)
 
+	if cfg.Eth.TxPoolDisabled && cfg.Node.P2P.NetRestrict == nil {
+		utils.Fatalf("Transaction pool can only be disabled when network is restricted")
+	}
+
 	return stack, cfg
 }
 

--- a/cmd/geth/main.go
+++ b/cmd/geth/main.go
@@ -68,6 +68,7 @@ var (
 		utils.OverrideCancun,
 		utils.OverrideVerkle,
 		utils.EnablePersonal,
+		utils.TxPoolDisabledFlag,
 		utils.TxPoolLocalsFlag,
 		utils.TxPoolNoLocalsFlag,
 		utils.TxPoolJournalFlag,

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -318,6 +318,11 @@ var (
 		Category: flags.LightCategory,
 	}
 	// Transaction pool settings
+	TxPoolDisabledFlag = &cli.BoolFlag{
+		Name:     "txpool.disabled",
+		Usage:    "Run node without a transaction pool",
+		Category: flags.TxPoolCategory,
+	}
 	TxPoolLocalsFlag = &cli.StringFlag{
 		Name:     "txpool.locals",
 		Usage:    "Comma separated accounts to treat as locals (no flush, priority inclusion)",
@@ -1656,10 +1661,15 @@ func SetEthConfig(ctx *cli.Context, stack *node.Node, cfg *ethconfig.Config) {
 	// Set configurations from CLI flags
 	setEtherbase(ctx, cfg)
 	setGPO(ctx, &cfg.GPO, ctx.String(SyncModeFlag.Name) == "light")
-	setTxPool(ctx, &cfg.TxPool)
 	setMiner(ctx, &cfg.Miner)
 	setRequiredBlocks(ctx, cfg)
 	setLes(ctx, cfg)
+
+	if ctx.IsSet(TxPoolDisabledFlag.Name) {
+		cfg.TxPoolDisabled = ctx.Bool(TxPoolDisabledFlag.Name)
+	} else {
+		setTxPool(ctx, &cfg.TxPool)
+	}
 
 	// Cap the cache allowance and tune the garbage collector
 	mem, err := gopsutil.VirtualMemory()

--- a/eth/ethconfig/config.go
+++ b/eth/ethconfig/config.go
@@ -71,6 +71,7 @@ var Defaults = Config{
 	SnapshotCache:      102,
 	FilterLogCacheSize: 32,
 	Miner:              miner.DefaultConfig,
+	TxPoolDisabled:     false,
 	TxPool:             legacypool.DefaultConfig,
 	BlobPool:           blobpool.DefaultConfig,
 	RPCGasCap:          50000000,
@@ -141,8 +142,9 @@ type Config struct {
 	Miner miner.Config
 
 	// Transaction pool options
-	TxPool   legacypool.Config
-	BlobPool blobpool.Config
+	TxPoolDisabled bool
+	TxPool         legacypool.Config
+	BlobPool       blobpool.Config
 
 	// Gas Price Oracle options
 	GPO gasprice.Config

--- a/eth/ethconfig/gen_config.go
+++ b/eth/ethconfig/gen_config.go
@@ -46,6 +46,7 @@ func (c Config) MarshalTOML() (interface{}, error) {
 		Preimages               bool
 		FilterLogCacheSize      int
 		Miner                   miner.Config
+		TxPoolDisabled          bool
 		TxPool                  legacypool.Config
 		BlobPool                blobpool.Config
 		GPO                     gasprice.Config
@@ -87,6 +88,7 @@ func (c Config) MarshalTOML() (interface{}, error) {
 	enc.Preimages = c.Preimages
 	enc.FilterLogCacheSize = c.FilterLogCacheSize
 	enc.Miner = c.Miner
+	enc.TxPoolDisabled = c.TxPoolDisabled
 	enc.TxPool = c.TxPool
 	enc.BlobPool = c.BlobPool
 	enc.GPO = c.GPO
@@ -132,6 +134,7 @@ func (c *Config) UnmarshalTOML(unmarshal func(interface{}) error) error {
 		Preimages               *bool
 		FilterLogCacheSize      *int
 		Miner                   *miner.Config
+		TxPoolDisabled          *bool
 		TxPool                  *legacypool.Config
 		BlobPool                *blobpool.Config
 		GPO                     *gasprice.Config
@@ -233,6 +236,9 @@ func (c *Config) UnmarshalTOML(unmarshal func(interface{}) error) error {
 	}
 	if dec.Miner != nil {
 		c.Miner = *dec.Miner
+	}
+	if dec.TxPoolDisabled != nil {
+		c.TxPoolDisabled = *dec.TxPoolDisabled
 	}
 	if dec.TxPool != nil {
 		c.TxPool = *dec.TxPool


### PR DESCRIPTION
The PR adds the `--txpool.disabled` flag:

```
    --txpool.disabled                   (default: false)                   ($GETH_TXPOOL_DISABLED)
          Run node without a transaction pool
```

### Why would I want this?

We've been running _some_ of our nodes w/ a similar patch applied for quite some time now, and it significantly reduces the CPU required for "keeping up w/ the network" thereby keeping more CPU available for importing blocks quickly and handling RPC load.

In our topology, we run a small number of normally networked "peering" nodes, then most of our RPC nodes run w/ `--txpool.disabled --nodiscover --netrestrict 10.0.0.0/8` to prevent them from connecting directly to the larger devp2p network.  Finally, we use a daemon like https://github.com/vipnode/vipnode to rendezvous the "normal" and "net restricted" nodes.

To give you an idea of the CPU savings, the otherwise idle "peering" nodes hover around 60% CPU usage on an `i3.xlarge` instance type, while the netrestricted/txpool-disabled nodes hover around 30% CPU even while handling a fair amount of RPC traffic. 

A quick pprof of the "peering" nodes shows that about half the CPU cycles are spend in tx-related methods:

<img width="876" alt="image" src="https://github.com/ethereum/go-ethereum/assets/53520/78b9b83d-72a2-464d-ac40-0cf124feb412">

And after Dencun, I expect this difference to be even higher.

### Behavioral Changes

When this flag is set, `txpool.New` is passed an empty subpools slice, which in turn means that no transactions are handled, including blob txs.

Note that a side effect of this disabling is that `eth_sendRawTransaction` no longer works, which IMO is the correct behavior:

```
> eth.sendRawTransaction("0xf86f80850500cf6e0083015f9094c149be1bcdfa69a94384b46a1f91350e5f81c1ab880d2f13f7789f0000808284f3a029301d659d790c0bb993e3b6075ce7a4d4ea5744c91651cf9387e963a4762d7da02d0d678d4cce2735475693afc12895416ccaca7ac8015cd09c0af3730864d5cf")
Error: transaction type not supported
	at web3.js:6365:9(39)
	at send (web3.js:5099:62(29))
	at <eval>:1:23(3)

> txpool.status
{
  pending: 0,
  queued: 0
}
```

### Why _require_ `--netrestrict`?

I think it's important that geth is a "good citizen" and propagates txs to its peers whenever it makes sense to do so.  In fact, the main reason I haven't submitted this PR in the past was because I don't want to encourage bad behavior.  As such, I think `--txpool.disable` should only be usable in situations where the user is running in a non-standard networking setup.  I'd be happy to include a check for `--nodiscover` as well, and am open to cleaner suggestions on how to restrict the use of this option.

### Why `Config.TxPoolDisabled` vs. `Config.TxPoolEnabled`?

In an ideal world, I think `txpool.enabled` and `Config.TxPoolEnabled` makes more sense, but I was afraid that changing the _default_ behavior or `Config{}` could break downstream projects or spots in the codebase I might've missed, so I decided to err on the side of caution and name the flag `Config.TxPoolDisabled`.
