### PR TITLE
graphql: fix an issue of nil pointer panic

### DIFF
--- a/graphql/graphql.go
+++ b/graphql/graphql.go
@@ -1325,6 +1325,9 @@ func (r *Resolver) Blocks(ctx context.Context, args struct {
 	From *Long
 	To   *Long
 }) ([]*Block, error) {
+	if args.From == nil {
+		return nil, errors.New("from block number must be specified")
+	}
 	from := rpc.BlockNumber(*args.From)
 
 	var to rpc.BlockNumber

--- a/graphql/graphql_test.go
+++ b/graphql/graphql_test.go
@@ -148,6 +148,11 @@ func TestGraphQLBlockSerialization(t *testing.T) {
 			want: `{"data":{"block":{"number":"0xa","call":{"data":"0x","status":"0x1"}}}}`,
 			code: 200,
 		},
+		{
+			body: `{"query": "{blocks {number}}"}`,
+			want: `{"errors":[{"message":"from block number must be specified","path":["blocks"]}],"data":null}`,
+			code: 400,
+		},
 	} {
 		resp, err := http.Post(fmt.Sprintf("%s/graphql", stack.HTTPEndpoint()), "application/json", strings.NewReader(tt.body))
 		if err != nil {


### PR DESCRIPTION
Fix as issue of nil pointer panic


> query

```graphql
{blocks { number }}
```


> response

```json
{
  "errors": [
    {
      "message": "panic occurred: runtime error: invalid memory address or nil pointer dereference",
      "path": [
        "blocks"
      ]
    }
  ],
  "data": null
}
```

and the stack:

```
> 2023/10/26 08:25:36 graphql: panic occurred: runtime error: invalid memory address or nil pointer dereference
goroutine 4252 [running]:
github.com/graph-gophers/graphql-go/log.(*DefaultLogger).LogPanic(0x28?, {0x104254960?, 0x140014805a0}, {0x103fdb9a0, 0x104d31bf0})
        github.com/graph-gophers/graphql-go@v1.3.0/log/log.go:21 +0x58
github.com/graph-gophers/graphql-go/internal/exec.execFieldSelection.func2.1()
        github.com/graph-gophers/graphql-go@v1.3.0/internal/exec/exec.go:187 +0x80
panic({0x103fdb9a0?, 0x104d31bf0?})
        runtime/panic.go:914 +0x218
github.com/ethereum/go-ethereum/graphql.(*Resolver).Blocks(0x140014a6210, {0x104254960, 0x14001480630}, {0x0?, 0x0?})
        github.com/ethereum/go-ethereum/graphql/graphql.go:1327 +0x30
reflect.Value.call({0x104159a60?, 0x140014a6210?, 0x1400075ac68?}, {0x10386365d, 0x4}, {0x14001480660, 0x2, 0x103391400?})
        reflect/value.go:596 +0x994
reflect.Value.Call({0x104159a60?, 0x140014a6210?, 0x104253590?}, {0x14001480660?, 0x10422b220?, 0x1b?})
        reflect/value.go:380 +0x94
github.com/graph-gophers/graphql-go/internal/exec.execFieldSelection.func2(0x1400064c638?, {0x104254960?, 0x140014805a0?}, 0x14000b760c0, 0x14001490140, 0x140009a3eb0, {0x104254960?, 0x14001480630})
        github.com/graph-gophers/graphql-go@v1.3.0/internal/exec/exec.go:211 +0x380
github.com/graph-gophers/graphql-go/internal/exec.execFieldSelection({0x104254960, 0x140014805a0}, 0x1400101c100, 0x0?, 0x14001490140, 0x0?, 0x1)
        github.com/graph-gophers/graphql-go@v1.3.0/internal/exec/exec.go:231 +0x118
github.com/graph-gophers/graphql-go/internal/exec.(*Request).execSelections.func1(0x14001490140)
        github.com/graph-gophers/graphql-go@v1.3.0/internal/exec/exec.go:81 +0x178
created by github.com/graph-gophers/graphql-go/internal/exec.(*Request).execSelections in goroutine 4250
        github.com/graph-gophers/graphql-go@v1.3.0/internal/exec/exec.go:77 +0x140

context: context.Background.WithValue(type *http.contextKey, val <not Stringer>).WithValue(type *http.contextKey, val 127.0.0.1:8545).WithCancel.WithCancel.WithCancel.WithValue(type opentracing.contextKey, val <not Stringer>)
```

@s1na PTAL