### PR TITLE
graphql: set content-type as json

### DIFF
--- a/graphql/graphql_test.go
+++ b/graphql/graphql_test.go
@@ -164,6 +164,9 @@ func TestGraphQLBlockSerialization(t *testing.T) {
 		if tt.code != resp.StatusCode {
 			t.Errorf("testcase %d %s,\nwrong statuscode, have: %v, want: %v", i, tt.body, resp.StatusCode, tt.code)
 		}
+		if ctype := resp.Header.Get("Content-Type"); ctype != "application/json" {
+			t.Errorf("testcase %d \nwrong Content-Type, have: %v, want: %v", i, ctype, "application/json")
+		}
 	}
 }
 

--- a/graphql/service.go
+++ b/graphql/service.go
@@ -73,12 +73,12 @@ func (h handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 				}
 
 				// Setting this disables gzip compression in package node.
-				w.Header().Set("transfer-encoding", "identity")
+				w.Header().Set("Transfer-Encoding", "identity")
 
 				// Flush the response. Since we are writing close to the response timeout,
 				// chunked transfer encoding must be disabled by setting content-length.
-				w.Header().Set("content-type", "application/json")
-				w.Header().Set("content-length", strconv.Itoa(len(responseJSON)))
+				w.Header().Set("Content-Type", "application/json")
+				w.Header().Set("Content-Length", strconv.Itoa(len(responseJSON)))
 				w.Write(responseJSON)
 				if flush, ok := w.(http.Flusher); ok {
 					flush.Flush()
@@ -97,10 +97,10 @@ func (h handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 			return
 		}
+		w.Header().Set("Content-Type", "application/json")
 		if len(response.Errors) > 0 {
 			w.WriteHeader(http.StatusBadRequest)
 		}
-		w.Header().Set("Content-Type", "application/json")
 		w.Write(responseJSON)
 	})
 }


### PR DESCRIPTION
Fix an issue of wrong Content-Type

```
$ curl -XPOST 127.0.0.1:8545/graphql -d '{"query": "{block(number: 1  hash: \"0xc1d1224983a2b43f2ea1b847337eda55e316e94603386e346abe3f6e08121027\") {number hash }}"}' -v
Note: Unnecessary use of -X or --request, POST is already inferred.
* Connected to 127.0.0.1 (127.0.0.1) port 8545 (#0)
> POST /graphql HTTP/1.1
> Host: 127.0.0.1:8545
> User-Agent: curl/8.1.2
> Accept: */*
> Content-Length: 124
> Content-Type: application/x-www-form-urlencoded
>
< HTTP/1.1 400 Bad Request
< Date: Thu, 26 Oct 2023 00:29:18 GMT
< Content-Length: 110
< Content-Type: text/plain; charset=utf-8
<
* Connection #0 to host 127.0.0.1 left intact
{"errors":[{"message":"only one of number or hash must be specified","path":["block"]}],"data":{"block":null}}

```

@s1na PTAL