### PR TITLE
graphql: add error code and message

### DIFF
--- a/graphql/errors.go
+++ b/graphql/errors.go
@@ -22,6 +22,7 @@ import (
 )
 
 var (
+	errOnlyNumberOrHash  = invalidParamsError("only one of number or hash must be specified")
 	errBlockInvariant    = invalidParamsError("block objects must be instantiated with at least one of num or hash")
 	errInvalidBlockRange = invalidParamsError("invalid from and to block combination: from > to")
 )

--- a/graphql/errors.go
+++ b/graphql/errors.go
@@ -1,0 +1,54 @@
+// Copyright 2023 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+
+// Package graphql provides a GraphQL interface to Ethereum node data.
+package graphql
+
+import (
+	"errors"
+	"fmt"
+)
+
+var (
+	errBlockInvariant    = errors.New("block objects must be instantiated with at least one of num or hash")
+	errInvalidBlockRange = errors.New("invalid from and to block combination: from > to")
+)
+
+type graphQLError struct {
+	Code    string `json:"code"`
+	Message string `json:"message"`
+}
+
+// Error implements the github.com/graph-gophers/graphql-go.ResolverError interface.
+func (e *graphQLError) Error() string {
+	return fmt.Sprintf("error [%s]: %s", e.Code, e.Message)
+}
+
+// Extensions implements the github.com/graph-gophers/graphql-go.ResolverError interface.
+func (e *graphQLError) Extensions() map[string]interface{} {
+	return map[string]interface{}{
+		"code":    e.Code,
+		"message": e.Message,
+	}
+}
+
+// asGraphQLError wraps an error into graphQLError
+func asGraphQLError(err error) error {
+	if err == nil {
+		return nil
+	}
+	return &graphQLError{Code: "-32602", Message: err.Error()}
+}

--- a/graphql/errors.go
+++ b/graphql/errors.go
@@ -25,6 +25,7 @@ var (
 	errOnlyNumberOrHash  = invalidParamsError("only one of number or hash must be specified")
 	errBlockInvariant    = invalidParamsError("block objects must be instantiated with at least one of num or hash")
 	errInvalidBlockRange = invalidParamsError("invalid from and to block combination: from > to")
+	errFromBlockRequired = invalidParamsError("from block number must be specified")
 )
 
 const (

--- a/graphql/errors.go
+++ b/graphql/errors.go
@@ -18,30 +18,34 @@
 package graphql
 
 import (
-	"errors"
 	"fmt"
 )
 
 var (
-	errBlockInvariant    = errors.New("block objects must be instantiated with at least one of num or hash")
-	errInvalidBlockRange = errors.New("invalid from and to block combination: from > to")
+	errBlockInvariant    = invalidParamsError("block objects must be instantiated with at least one of num or hash")
+	errInvalidBlockRange = invalidParamsError("invalid from and to block combination: from > to")
+)
+
+const (
+	errcodeDefault       = -32600
+	errcodeInvalidParams = -32602
 )
 
 type graphQLError struct {
-	Code    string `json:"code"`
-	Message string `json:"message"`
+	Code    int
+	Message string
 }
 
 // Error implements the github.com/graph-gophers/graphql-go.ResolverError interface.
 func (e *graphQLError) Error() string {
-	return fmt.Sprintf("error [%s]: %s", e.Code, e.Message)
+	return fmt.Sprintf("error [%d]: %s", e.Code, e.Message)
 }
 
 // Extensions implements the github.com/graph-gophers/graphql-go.ResolverError interface.
 func (e *graphQLError) Extensions() map[string]interface{} {
 	return map[string]interface{}{
-		"code":    e.Code,
-		"message": e.Message,
+		"errorCode":    e.Code,
+		"errorMessage": e.Message,
 	}
 }
 
@@ -50,5 +54,9 @@ func asGraphQLError(err error) error {
 	if err == nil {
 		return nil
 	}
-	return &graphQLError{Code: "-32602", Message: err.Error()}
+	return &graphQLError{Code: errcodeDefault, Message: err.Error()}
+}
+
+func invalidParamsError(msg string) error {
+	return &graphQLError{Code: errcodeInvalidParams, Message: msg}
 }

--- a/graphql/graphql.go
+++ b/graphql/graphql.go
@@ -40,11 +40,6 @@ import (
 	"github.com/ethereum/go-ethereum/rpc"
 )
 
-var (
-	errBlockInvariant    = errors.New("block objects must be instantiated with at least one of num or hash")
-	errInvalidBlockRange = errors.New("invalid from and to block combination: from > to")
-)
-
 type Long int64
 
 // ImplementsGraphQLType returns true if Long implements the provided GraphQL type.

--- a/graphql/graphql.go
+++ b/graphql/graphql.go
@@ -1320,7 +1320,7 @@ func (r *Resolver) Blocks(ctx context.Context, args struct {
 	To   *Long
 }) ([]*Block, error) {
 	if args.From == nil {
-		return nil, errors.New("from block number must be specified")
+		return nil, errFromBlockRequired
 	}
 	from := rpc.BlockNumber(*args.From)
 

--- a/graphql/graphql_test.go
+++ b/graphql/graphql_test.go
@@ -153,6 +153,18 @@ func TestGraphQLBlockSerialization(t *testing.T) {
 			want: `{"errors":[{"message":"from block number must be specified","path":["blocks"]}],"data":null}`,
 			code: 400,
 		},
+		// invalid block range
+		{
+			body: `{"query": "{blocks(from: 5 to: 1 ){number}}"}`,
+			want: `{"errors":[{"message":"error [-32602]: invalid from and to block combination: from \u003e to","path":["blocks"],"extensions":{"errorCode":-32602,"errorMessage":"invalid from and to block combination: from \u003e to"}}],"data":null}`,
+			code: 400,
+		},
+		// both hash and number
+		{
+			body: `{"query": "{block(number: 1 hash: \"0xd864c9d7d37fade6b70164740540c06dd58bb9c3f6b46101908d6339db6a6a7b\"){number}}"}`,
+			want: `{"errors":[{"message":"error [-32602]: only one of number or hash must be specified","path":["block"],"extensions":{"errorCode":-32602,"errorMessage":"only one of number or hash must be specified"}}],"data":{"block":null}}`,
+			code: 400,
+		},
 	} {
 		resp, err := http.Post(fmt.Sprintf("%s/graphql", stack.HTTPEndpoint()), "application/json", strings.NewReader(tt.body))
 		if err != nil {

--- a/graphql/graphql_test.go
+++ b/graphql/graphql_test.go
@@ -150,7 +150,7 @@ func TestGraphQLBlockSerialization(t *testing.T) {
 		},
 		{
 			body: `{"query": "{blocks {number}}"}`,
-			want: `{"errors":[{"message":"from block number must be specified","path":["blocks"]}],"data":null}`,
+			want: `{"errors":[{"message":"error [-32602]: from block number must be specified","path":["blocks"],"extensions":{"errorCode":-32602,"errorMessage":"from block number must be specified"}}],"data":null}`,
 			code: 400,
 		},
 		// invalid block range


### PR DESCRIPTION
I'm introduing https://github.com/graph-gophers/graphql-go#custom-errors to add `errorCode` and `errorMessage` for the incorrect GraphQL requests. 

It will return something like this, eg:

```graphql
{blocks(from: 2 to: 0) { number }}
```


```json
{
  "errors": [
    {
      "message": "error [-32602]: invalid from and to block combination: from > to",
      "path": [
        "blocks"
      ],
      "extensions": {
        "errorCode": -32602,
        "errorMessage": "invalid from and to block combination: from > to"
      }
    }
  ],
  "data": null
}
```
Two error codes were defined in this PR:

- `-32602`: for any invalid request parameters
- `-32600`: for any other unknown errors

But the `graphql.ResolverError` can only be used for errors returned by graphql implementation body functions, for these errors that have not yet entered the function cannot be applied. 

eg:

```graphql
{ block(number: "") { number } }
```

> geth's response(after this PR)

```json
{"errors":[{"message":"strconv.ParseInt: parsing \"\": invalid syntax"}],"data":{}}
```

> besu's response

```json
{
  "errors" : [ {
    "message" : "Validation error (WrongType@[block]) : argument 'number' with value 'StringValue{value=''}' is not a valid 'Long' - Value is not any Long : 'StringValue{value=''}'",
    "locations" : [ {
      "line" : 1,
      "column" : 9
    } ],
    "extensions" : {
      "classification" : "ValidationError"
    }
  } ]
}
```

Or another case

```graphql
{ block(hash: "0x1001") { number } }
```

> geth's response(after this PR)

```json
{"errors":[{"message":"hex string has length 4, want 64 for Hash"}],"data":{}}
```

> besu's response

```json
{
  "errors" : [ {
    "message" : "Exception while fetching data (/block) : Block hash 0x0000000000000000000000000000000000000000000000000000000000001001 was not found",
    "locations" : [ {
      "line" : 1,
      "column" : 3
    } ],
    "path" : [ "block" ],
    "extensions" : {
      "classification" : "DataFetchingException"
    }
  } ],
  "data" : {
    "block" : null
  }
}
```

@s1na please take a look, and give some advice. thanks.
