### PR TITLE
internal/ethapi: eth_getRequiredBlockState endpoint addition

### DIFF
--- a/cmd/evm/internal/t8ntool/execution.go
+++ b/cmd/evm/internal/t8ntool/execution.go
@@ -304,7 +304,7 @@ func (pre *Prestate) Apply(vmConfig vm.Config, chainConfig *params.ChainConfig,
 		statedb.AddBalance(w.Address, amount)
 	}
 	// Commit block
-	root, err := statedb.Commit(vmContext.BlockNumber.Uint64(), chainConfig.IsEIP158(vmContext.BlockNumber))
+	root, _, err := statedb.Commit(vmContext.BlockNumber.Uint64(), chainConfig.IsEIP158(vmContext.BlockNumber))
 	if err != nil {
 		return nil, nil, NewError(ErrorEVM, fmt.Errorf("could not commit state: %v", err))
 	}
@@ -349,7 +349,7 @@ func MakePreState(db ethdb.Database, accounts core.GenesisAlloc) *state.StateDB 
 		}
 	}
 	// Commit and re-open to start with a clean state.
-	root, _ := statedb.Commit(0, false)
+	root, _, _ := statedb.Commit(0, false)
 	statedb, _ = state.New(root, sdb, nil)
 	return statedb
 }

--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -1407,7 +1407,7 @@ func (bc *BlockChain) writeBlockWithState(block *types.Block, receipts []*types.
 		log.Crit("Failed to write block into disk", "err", err)
 	}
 	// Commit all cached state changes into underlying memory database.
-	root, err := state.Commit(block.NumberU64(), bc.chainConfig.IsEIP158(block.Number()))
+	root, _, err := state.Commit(block.NumberU64(), bc.chainConfig.IsEIP158(block.Number()))
 	if err != nil {
 		return err
 	}

--- a/core/chain_makers.go
+++ b/core/chain_makers.go
@@ -326,7 +326,7 @@ func GenerateChain(config *params.ChainConfig, parent *types.Block, engine conse
 			}
 
 			// Write state changes to db
-			root, err := statedb.Commit(b.header.Number.Uint64(), config.IsEIP158(b.header.Number))
+			root, _, err := statedb.Commit(b.header.Number.Uint64(), config.IsEIP158(b.header.Number))
 			if err != nil {
 				panic(fmt.Sprintf("state write error: %v", err))
 			}

--- a/core/genesis.go
+++ b/core/genesis.go
@@ -139,7 +139,8 @@ func (ga *GenesisAlloc) deriveHash() (common.Hash, error) {
 			statedb.SetState(addr, key, value)
 		}
 	}
-	return statedb.Commit(0, false)
+	root, _, err := statedb.Commit(0, false)
+	return root, err
 }
 
 // flush is very similar with deriveHash, but the main difference is
@@ -160,7 +161,7 @@ func (ga *GenesisAlloc) flush(db ethdb.Database, triedb *trie.Database, blockhas
 			statedb.SetState(addr, key, value)
 		}
 	}
-	root, err := statedb.Commit(0, false)
+	root, _, err := statedb.Commit(0, false)
 	if err != nil {
 		return err
 	}

--- a/core/state/database.go
+++ b/core/state/database.go
@@ -115,7 +115,7 @@ type Trie interface {
 	// The returned nodeset can be nil if the trie is clean(nothing to commit).
 	// Once the trie is committed, it's not usable anymore. A new trie must
 	// be created with new root and updated trie database for following usage
-	Commit(collectLeaf bool) (common.Hash, *trienode.NodeSet, error)
+	Commit(collectLeaf bool) (common.Hash, *trienode.NodeSet, *trienode.Witness, error)
 
 	// NodeIterator returns an iterator that returns nodes of the trie. Iteration
 	// starts at the key after the given start key. And error will be returned

--- a/core/state/database.go
+++ b/core/state/database.go
@@ -75,6 +75,8 @@ type Trie interface {
 	// a trie.MissingNodeError is returned.
 	GetStorage(addr common.Address, key []byte) ([]byte, error)
 
+	GetWitness() *trienode.Witness
+
 	// GetAccount abstracts an account read from the trie. It retrieves the
 	// account blob from the trie with provided account address and decodes it
 	// with associated decoding algorithm. If the specified account is not in

--- a/core/state/database.go
+++ b/core/state/database.go
@@ -75,8 +75,6 @@ type Trie interface {
 	// a trie.MissingNodeError is returned.
 	GetStorage(addr common.Address, key []byte) ([]byte, error)
 
-	GetWitness() *trienode.Witness
-
 	// GetAccount abstracts an account read from the trie. It retrieves the
 	// account blob from the trie with provided account address and decodes it
 	// with associated decoding algorithm. If the specified account is not in

--- a/core/state/snapshot/generate.go
+++ b/core/state/snapshot/generate.go
@@ -362,7 +362,7 @@ func (dl *diskLayer) generateRange(ctx *generatorContext, trieId *trie.ID, prefi
 		for i, key := range result.keys {
 			snapTrie.Update(key, result.vals[i])
 		}
-		root, nodes, err := snapTrie.Commit(false)
+		root, nodes, _, err := snapTrie.Commit(false)
 		if err != nil {
 			return false, nil, err
 		}

--- a/core/state/snapshot/generate_test.go
+++ b/core/state/snapshot/generate_test.go
@@ -209,7 +209,7 @@ func (t *testHelper) makeStorageTrie(owner common.Hash, keys []string, vals []st
 	if !commit {
 		return stTrie.Hash()
 	}
-	root, nodes, _ := stTrie.Commit(false)
+	root, nodes, _, _ := stTrie.Commit(false)
 	if nodes != nil {
 		t.nodes.Merge(nodes)
 	}
@@ -217,7 +217,7 @@ func (t *testHelper) makeStorageTrie(owner common.Hash, keys []string, vals []st
 }
 
 func (t *testHelper) Commit() common.Hash {
-	root, nodes, _ := t.accTrie.Commit(true)
+	root, nodes, _, _ := t.accTrie.Commit(true)
 	if nodes != nil {
 		t.nodes.Merge(nodes)
 	}

--- a/core/state/state_object.go
+++ b/core/state/state_object.go
@@ -375,11 +375,11 @@ func (s *stateObject) updateRoot() {
 // commit obtains a set of dirty storage trie nodes and updates the account data.
 // The returned set can be nil if nothing to commit. This function assumes all
 // storage mutations have already been flushed into trie by updateRoot.
-func (s *stateObject) commit() (*trienode.NodeSet, error) {
+func (s *stateObject) commit() (*trienode.NodeSet, *trienode.Witness, error) {
 	// Short circuit if trie is not even loaded, don't bother with committing anything
 	if s.trie == nil {
 		s.origin = s.data.Copy()
-		return nil, nil
+		return nil, nil, nil
 	}
 	// Track the amount of time wasted on committing the storage trie
 	if metrics.EnabledExpensive {
@@ -388,15 +388,15 @@ func (s *stateObject) commit() (*trienode.NodeSet, error) {
 	// The trie is currently in an open state and could potentially contain
 	// cached mutations. Call commit to acquire a set of nodes that have been
 	// modified, the set can be nil if nothing to commit.
-	root, nodes, _, err := s.trie.Commit(false)
+	root, nodes, witness, err := s.trie.Commit(false)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	s.data.Root = root
 
 	// Update original account data after commit
 	s.origin = s.data.Copy()
-	return nodes, nil
+	return nodes, witness, nil
 }
 
 // AddBalance adds amount to s's balance.

--- a/core/state/state_object.go
+++ b/core/state/state_object.go
@@ -388,7 +388,7 @@ func (s *stateObject) commit() (*trienode.NodeSet, error) {
 	// The trie is currently in an open state and could potentially contain
 	// cached mutations. Call commit to acquire a set of nodes that have been
 	// modified, the set can be nil if nothing to commit.
-	root, nodes, err := s.trie.Commit(false)
+	root, nodes, _, err := s.trie.Commit(false)
 	if err != nil {
 		return nil, err
 	}

--- a/core/state/state_test.go
+++ b/core/state/state_test.go
@@ -58,7 +58,7 @@ func TestDump(t *testing.T) {
 	// write some of them to the trie
 	s.state.updateStateObject(obj1)
 	s.state.updateStateObject(obj2)
-	root, _ := s.state.Commit(0, false)
+	root, _, _ := s.state.Commit(0, false)
 
 	// check that DumpToCollector contains the state objects that are in trie
 	s.state, _ = New(root, tdb, nil)
@@ -114,7 +114,7 @@ func TestIterativeDump(t *testing.T) {
 	// write some of them to the trie
 	s.state.updateStateObject(obj1)
 	s.state.updateStateObject(obj2)
-	root, _ := s.state.Commit(0, false)
+	root, _, _ := s.state.Commit(0, false)
 	s.state, _ = New(root, tdb, nil)
 
 	b := &bytes.Buffer{}
@@ -212,7 +212,7 @@ func TestSnapshot2(t *testing.T) {
 	so0.deleted = false
 	state.setStateObject(so0)
 
-	root, _ := state.Commit(0, false)
+	root, _, _ := state.Commit(0, false)
 	state, _ = New(root, state.db, state.snaps)
 
 	// and one with deleted == true

--- a/core/state/statedb.go
+++ b/core/state/statedb.go
@@ -180,6 +180,11 @@ func (s *StateDB) GetWitness()  *trienode.Witness {
 	return s.trie.GetWitness()
 }
 
+func (s *StateDB) CleanSnaps() {
+	s.snaps = nil
+	s.snap = nil
+}
+
 // StartPrefetcher initializes a new trie prefetcher to pull in nodes from the
 // state trie concurrently while the state is mutated so that when we reach the
 // commit phase, most of the needed data is already hot.

--- a/core/state/statedb.go
+++ b/core/state/statedb.go
@@ -1222,7 +1222,7 @@ func (s *StateDB) Commit(block uint64, deleteEmptyObjects bool) (common.Hash, er
 	if metrics.EnabledExpensive {
 		start = time.Now()
 	}
-	root, set, err := s.trie.Commit(true)
+	root, set, _, err := s.trie.Commit(true)
 	if err != nil {
 		return common.Hash{}, err
 	}

--- a/core/state/statedb.go
+++ b/core/state/statedb.go
@@ -172,6 +172,14 @@ func New(root common.Hash, db Database, snaps *snapshot.Tree) (*StateDB, error) 
 	return sdb, nil
 }
 
+
+// StartPrefetcher initializes a new trie prefetcher to pull in nodes from the
+// state trie concurrently while the state is mutated so that when we reach the
+// commit phase, most of the needed data is already hot.
+func (s *StateDB) GetWitness()  *trienode.Witness {
+	return s.trie.GetWitness()
+}
+
 // StartPrefetcher initializes a new trie prefetcher to pull in nodes from the
 // state trie concurrently while the state is mutated so that when we reach the
 // commit phase, most of the needed data is already hot.

--- a/core/state/statedb_fuzz_test.go
+++ b/core/state/statedb_fuzz_test.go
@@ -223,7 +223,7 @@ func (test *stateTest) run() bool {
 		} else {
 			state.IntermediateRoot(true) // call intermediateRoot at the transaction boundary
 		}
-		nroot, err := state.Commit(0, true) // call commit at the block boundary
+		nroot, _, err := state.Commit(0, true) // call commit at the block boundary
 		if err != nil {
 			panic(err)
 		}

--- a/core/state/statedb_test.go
+++ b/core/state/statedb_test.go
@@ -116,7 +116,7 @@ func TestIntermediateLeaks(t *testing.T) {
 	}
 
 	// Commit and cross check the databases.
-	transRoot, err := transState.Commit(0, false)
+	transRoot, _, err := transState.Commit(0, false)
 	if err != nil {
 		t.Fatalf("failed to commit transition state: %v", err)
 	}
@@ -124,7 +124,7 @@ func TestIntermediateLeaks(t *testing.T) {
 		t.Errorf("can not commit trie %v to persistent database", transRoot.Hex())
 	}
 
-	finalRoot, err := finalState.Commit(0, false)
+	finalRoot, _, err := finalState.Commit(0, false)
 	if err != nil {
 		t.Fatalf("failed to commit final state: %v", err)
 	}
@@ -534,7 +534,7 @@ func (test *snapshotTest) checkEqual(state, checkstate *StateDB) error {
 func TestTouchDelete(t *testing.T) {
 	s := newStateEnv()
 	s.state.GetOrNewStateObject(common.Address{})
-	root, _ := s.state.Commit(0, false)
+	root, _, _ := s.state.Commit(0, false)
 	s.state, _ = New(root, s.state.db, s.state.snaps)
 
 	snapshot := s.state.Snapshot()
@@ -622,7 +622,7 @@ func TestCopyCommitCopy(t *testing.T) {
 		t.Fatalf("second copy committed storage slot mismatch: have %x, want %x", val, sval)
 	}
 	// Commit state, ensure states can be loaded from disk
-	root, _ := state.Commit(0, false)
+	root, _, _ := state.Commit(0, false)
 	state, _ = New(root, tdb, nil)
 	if balance := state.GetBalance(addr); balance.Cmp(big.NewInt(42)) != 0 {
 		t.Fatalf("state post-commit balance mismatch: have %v, want %v", balance, 42)
@@ -770,7 +770,7 @@ func TestDeleteCreateRevert(t *testing.T) {
 	addr := common.BytesToAddress([]byte("so"))
 	state.SetBalance(addr, big.NewInt(1))
 
-	root, _ := state.Commit(0, false)
+	root, _, _ := state.Commit(0, false)
 	state, _ = New(root, state.db, state.snaps)
 
 	// Simulate self-destructing in one transaction, then create-reverting in another
@@ -782,7 +782,7 @@ func TestDeleteCreateRevert(t *testing.T) {
 	state.RevertToSnapshot(id)
 
 	// Commit the entire state and make sure we don't crash and have the correct state
-	root, _ = state.Commit(0, true)
+	root, _, _ = state.Commit(0, true)
 	state, _ = New(root, state.db, state.snaps)
 
 	if state.getStateObject(addr) != nil {
@@ -825,7 +825,7 @@ func testMissingTrieNodes(t *testing.T, scheme string) {
 		a2 := common.BytesToAddress([]byte("another"))
 		state.SetBalance(a2, big.NewInt(100))
 		state.SetCode(a2, []byte{1, 2, 4})
-		root, _ = state.Commit(0, false)
+		root, _, _ = state.Commit(0, false)
 		t.Logf("root: %x", root)
 		// force-flush
 		triedb.Commit(root, false)
@@ -849,7 +849,7 @@ func testMissingTrieNodes(t *testing.T, scheme string) {
 	}
 	// Modify the state
 	state.SetBalance(addr, big.NewInt(2))
-	root, err := state.Commit(0, false)
+	root, _, err := state.Commit(0, false)
 	if err == nil {
 		t.Fatalf("expected error, got root :%x", root)
 	}
@@ -1045,7 +1045,7 @@ func TestFlushOrderDataLoss(t *testing.T) {
 			state.SetState(common.Address{a}, common.Hash{a, s}, common.Hash{a, s})
 		}
 	}
-	root, err := state.Commit(0, false)
+	root, _, err := state.Commit(0, false)
 	if err != nil {
 		t.Fatalf("failed to commit state trie: %v", err)
 	}
@@ -1124,7 +1124,7 @@ func TestResetObject(t *testing.T) {
 	state.CreateAccount(addr)
 	state.SetBalance(addr, big.NewInt(2))
 	state.SetState(addr, slotB, common.BytesToHash([]byte{0x2}))
-	root, _ := state.Commit(0, true)
+	root, _, _ := state.Commit(0, true)
 
 	// Ensure the original account is wiped properly
 	snap := snaps.Snapshot(root)
@@ -1155,7 +1155,7 @@ func TestDeleteStorage(t *testing.T) {
 		value := common.Hash(uint256.NewInt(uint64(10 * i)).Bytes32())
 		state.SetState(addr, slot, value)
 	}
-	root, _ := state.Commit(0, true)
+	root, _, _ := state.Commit(0, true)
 	// Init phase done, create two states, one with snap and one without
 	fastState, _ := New(root, db, snaps)
 	slowState, _ := New(root, db, nil)

--- a/core/state/sync_test.go
+++ b/core/state/sync_test.go
@@ -78,7 +78,7 @@ func makeTestState(scheme string) (ethdb.Database, Database, *trie.Database, com
 		}
 		accounts = append(accounts, acc)
 	}
-	root, _ := state.Commit(0, false)
+	root, _, _ := state.Commit(0, false)
 
 	// Return the generated state
 	return db, sdb, nodeDb, root, accounts

--- a/eth/api_debug_test.go
+++ b/eth/api_debug_test.go
@@ -79,7 +79,7 @@ func TestAccountRange(t *testing.T) {
 			m[addr] = true
 		}
 	}
-	root, _ := sdb.Commit(0, true)
+	root, _, _ := sdb.Commit(0, true)
 	sdb, _ = state.New(root, statedb, nil)
 
 	trie, err := statedb.OpenTrie(root)
@@ -178,7 +178,7 @@ func TestStorageRangeAt(t *testing.T) {
 	for _, entry := range storage {
 		sdb.SetState(addr, *entry.Key, entry.Value)
 	}
-	root, _ := sdb.Commit(0, false)
+	root, _, _ := sdb.Commit(0, false)
 	sdb, _ = state.New(root, db, nil)
 
 	// Check a few combinations of limit and start/end.

--- a/eth/protocols/snap/sync_test.go
+++ b/eth/protocols/snap/sync_test.go
@@ -1482,7 +1482,7 @@ func makeAccountTrieNoStorage(n int, scheme string) (string, *trie.Trie, []*kv) 
 
 	// Commit the state changes into db and re-create the trie
 	// for accessing later.
-	root, nodes, _ := accTrie.Commit(false)
+	root, nodes, _, _ := accTrie.Commit(false)
 	db.Update(root, types.EmptyRootHash, 0, trienode.NewWithNodeSet(nodes), nil)
 
 	accTrie, _ = trie.New(trie.StateTrieID(root), db)
@@ -1544,7 +1544,7 @@ func makeBoundaryAccountTrie(scheme string, n int) (string, *trie.Trie, []*kv) {
 
 	// Commit the state changes into db and re-create the trie
 	// for accessing later.
-	root, nodes, _ := accTrie.Commit(false)
+	root, nodes, _, _ := accTrie.Commit(false)
 	db.Update(root, types.EmptyRootHash, 0, trienode.NewWithNodeSet(nodes), nil)
 
 	accTrie, _ = trie.New(trie.StateTrieID(root), db)
@@ -1590,7 +1590,7 @@ func makeAccountTrieWithStorageWithUniqueStorage(scheme string, accounts, slots 
 	slices.SortFunc(entries, (*kv).cmp)
 
 	// Commit account trie
-	root, set, _ := accTrie.Commit(true)
+	root, set, _, _ := accTrie.Commit(true)
 	nodes.Merge(set)
 
 	// Commit gathered dirty nodes into database
@@ -1655,7 +1655,7 @@ func makeAccountTrieWithStorage(scheme string, accounts, slots int, code, bounda
 	slices.SortFunc(entries, (*kv).cmp)
 
 	// Commit account trie
-	root, set, _ := accTrie.Commit(true)
+	root, set, _, _ := accTrie.Commit(true)
 	nodes.Merge(set)
 
 	// Commit gathered dirty nodes into database
@@ -1697,7 +1697,7 @@ func makeStorageTrieWithSeed(owner common.Hash, n, seed uint64, db *trie.Databas
 		entries = append(entries, elem)
 	}
 	slices.SortFunc(entries, (*kv).cmp)
-	root, nodes, _ := trie.Commit(false)
+	root, nodes, _, _ := trie.Commit(false)
 	return root, nodes, entries
 }
 
@@ -1748,7 +1748,7 @@ func makeBoundaryStorageTrie(owner common.Hash, n int, db *trie.Database) (commo
 		entries = append(entries, elem)
 	}
 	slices.SortFunc(entries, (*kv).cmp)
-	root, nodes, _ := trie.Commit(false)
+	root, nodes, _, _ := trie.Commit(false)
 	return root, nodes, entries
 }
 

--- a/eth/state_accessor.go
+++ b/eth/state_accessor.go
@@ -150,7 +150,7 @@ func (eth *Ethereum) hashState(ctx context.Context, block *types.Block, reexec u
 			return nil, nil, fmt.Errorf("processing block %d failed: %v", current.NumberU64(), err)
 		}
 		// Finalize the state so any modifications are written to the trie
-		root, err := statedb.Commit(current.NumberU64(), eth.blockchain.Config().IsEIP158(current.Number()))
+		root, _, err := statedb.Commit(current.NumberU64(), eth.blockchain.Config().IsEIP158(current.Number()))
 		if err != nil {
 			return nil, nil, fmt.Errorf("stateAtBlock commit failed, number %d root %v: %w",
 				current.NumberU64(), current.Root().Hex(), err)

--- a/ethclient/gethclient/gethclient.go
+++ b/ethclient/gethclient/gethclient.go
@@ -125,6 +125,15 @@ func (ec *Client) GetProof(ctx context.Context, account common.Address, keys []s
 	return &result, err
 }
 
+type RequiredBlockState struct {
+}
+
+// GetRequiredBlockState returns all state required to execute a single historical block.
+func (ec *Client) GetRequiredBlockState(ctx context.Context, blockNumber *big.Int) (*RequiredBlockState, error) {
+	result := RequiredBlockState{}
+	return &result, nil
+}
+
 // CallContract executes a message call transaction, which is directly executed in the VM
 // of the node, but never mined into the blockchain.
 //

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -936,7 +936,7 @@ func (s *BlockChainAPI) GetBlockReceipts(ctx context.Context, blockNrOrHash rpc.
 
 type RequiredBlockState struct {
 	CompactEip1186Proofs []CompactEip1186Proof `json:"compact_eip1186_proofs"` // sorted by address
-	Contracts            []Contract            `json:"sorted"`                 // sorted by address
+	Contracts            []Contract            `json:"contracts"`              // sorted by address
 	AccountNodes         []TrieNode            `json:"account_nodes"`          // sorted by address
 	StorageNodes         []TrieNode            `json:"storage_nodes"`          // sorted by address
 	BlockHashes          []RecentBlockHash     `json:"block_hashes"`           // sorted by address

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -48,6 +48,7 @@ import (
 	"github.com/ethereum/go-ethereum/rlp"
 	"github.com/ethereum/go-ethereum/rpc"
 	"github.com/ethereum/go-ethereum/trie"
+	"github.com/ethereum/go-ethereum/trie/trienode"
 	"github.com/tyler-smith/go-bip39"
 )
 
@@ -961,7 +962,7 @@ type RecentBlockHash struct {
 }
 
 // GetRequiredBlockState returns all state required to execute a single historical block.
-func (s *BlockChainAPI) GetRequiredBlockState(ctx context.Context, blockNrOrHash rpc.BlockNumberOrHash) ([]*txTraceResult, error) {
+func (s *BlockChainAPI) GetRequiredBlockState(ctx context.Context, blockNrOrHash rpc.BlockNumberOrHash) (*trienode.Witness, error) {
 	block, err := s.b.BlockByNumberOrHash(ctx, blockNrOrHash)
 	if block == nil || err != nil {
 		// When the block doesn't exist, the RPC method should return JSON null
@@ -972,7 +973,8 @@ func (s *BlockChainAPI) GetRequiredBlockState(ctx context.Context, blockNrOrHash
 		return nil, nil
 	}
 	s.ProcessBlock(ctx, block, state, vm.Config{})
-	return s.traceBlock(ctx, block)
+	return state.GetWitness(), nil
+	// return s.traceBlock(ctx, block)
 }
 
 // txTraceResult is the result of a single transaction trace.

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -972,6 +972,7 @@ func (s *BlockChainAPI) GetRequiredBlockState(ctx context.Context, blockNrOrHash
 	if err != nil {
 		return nil, nil
 	}
+	state.CleanSnaps()
 	s.ProcessBlock(ctx, block, state, vm.Config{})
 	return state.GetWitness(), nil
 	// return s.traceBlock(ctx, block)

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -934,6 +934,32 @@ func (s *BlockChainAPI) GetBlockReceipts(ctx context.Context, blockNrOrHash rpc.
 	return result, nil
 }
 
+type RequiredBlockState struct {
+	CompactEip1186Proofs []CompactEip1186Proof `json:"compact_eip1186_proofs"` // sorted by address
+	Contracts            []Contract            `json:"sorted"`                 // sorted by address
+	AccountNodes         []TrieNode            `json:"account_nodes"`          // sorted by address
+	StorageNodes         []TrieNode            `json:"storage_nodes"`          // sorted by address
+	BlockHashes          []RecentBlockHash     `json:"block_hashes"`           // sorted by address
+}
+
+type CompactEip1186Proof struct {
+	Address       common.Address  `json:"address"`
+	Balance       big.Int         `json:"balance"`
+	CodeHash      common.Hash     `json:"code_hash"`
+	Nonce         uint64          `json:"nonce"`
+	StorageHash   common.Hash     `json:"storage_hash"`
+	AccountProof  []string        `json:"account_proof"`  // sorted: node nearest to root first
+	StorageProofs []StorageResult `json:"storage_proofs"` // sorted
+}
+
+type Contract []byte
+type TrieNode []byte
+
+type RecentBlockHash struct {
+	BlockNumber big.Int     `json:"block_number"`
+	BlockHash   common.Hash `json:"block_hash"`
+}
+
 // GetRequiredBlockState returns all state required to execute a single historical block.
 func (s *BlockChainAPI) GetRequiredBlockState(ctx context.Context, blockNrOrHash rpc.BlockNumberOrHash) ([]*txTraceResult, error) {
 	block, err := s.b.BlockByNumberOrHash(ctx, blockNrOrHash)

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -933,6 +933,18 @@ func (s *BlockChainAPI) GetBlockReceipts(ctx context.Context, blockNrOrHash rpc.
 	return result, nil
 }
 
+// GetRequiredBlockState returns all state required to execute a single historical block.
+func (s *BlockChainAPI) GetRequiredBlockState(ctx context.Context, blockNrOrHash rpc.BlockNumberOrHash) ([]map[string]interface{}, error) {
+	block, err := s.b.BlockByNumberOrHash(ctx, blockNrOrHash)
+	if block == nil || err != nil {
+		// When the block doesn't exist, the RPC method should return JSON null
+		return nil, nil
+	}
+
+	result := make([]map[string]interface{}, 1)
+	return result, nil
+}
+
 // OverrideAccount indicates the overriding fields of account during the execution
 // of a message call.
 // Note, state and stateDiff can't be specified at the same time. If state is

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -967,6 +967,11 @@ func (s *BlockChainAPI) GetRequiredBlockState(ctx context.Context, blockNrOrHash
 		// When the block doesn't exist, the RPC method should return JSON null
 		return nil, nil
 	}
+	state, _, err := s.b.StateAndHeaderByNumberOrHash(ctx, blockNrOrHash)
+	if err != nil {
+		return nil, nil
+	}
+	s.ProcessBlock(ctx, block, state, vm.Config{})
 	return s.traceBlock(ctx, block)
 }
 

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -1056,34 +1056,8 @@ func applyTransaction(msg *core.Message, config *params.ChainConfig, gp *core.Ga
 	}
 	*usedGas += result.UsedGas
 
-	// Create a new receipt for the transaction, storing the intermediate root and gas used
-	// by the tx.
-	receipt := &types.Receipt{Type: tx.Type(), PostState: root, CumulativeGasUsed: *usedGas}
-	if result.Failed() {
-		receipt.Status = types.ReceiptStatusFailed
-	} else {
-		receipt.Status = types.ReceiptStatusSuccessful
-	}
-	receipt.TxHash = tx.Hash()
-	receipt.GasUsed = result.UsedGas
-
-	if tx.Type() == types.BlobTxType {
-		receipt.BlobGasUsed = uint64(len(tx.BlobHashes()) * params.BlobTxBlobGasPerBlob)
-		receipt.BlobGasPrice = evm.Context.BlobBaseFee
-	}
-
-	// If the transaction created a contract, store the creation address in the receipt.
-	if msg.To == nil {
-		receipt.ContractAddress = crypto.CreateAddress(evm.TxContext.Origin, tx.Nonce())
-	}
-
-	// Set the receipt logs and create the bloom filter.
-	receipt.Logs = statedb.GetLogs(tx.Hash(), blockNumber.Uint64(), blockHash)
-	receipt.Bloom = types.CreateBloom(types.Receipts{receipt})
-	receipt.BlockHash = blockHash
-	receipt.BlockNumber = blockNumber
-	receipt.TransactionIndex = uint(statedb.TxIndex())
-	return receipt, err
+	_ = root
+	return nil, err
 }
 
 // traceBlock configures a new tracer according to the provided configuration, and

--- a/internal/ethapi/api_test.go
+++ b/internal/ethapi/api_test.go
@@ -1619,6 +1619,10 @@ func TestRPCGetBlockReceipts(t *testing.T) {
 	}
 }
 
+func TestRPCGetRequiredBlockState(t *testing.T) {
+	//
+}
+
 func testRPCResponseWithFile(t *testing.T, testid int, result interface{}, rpc string, file string) {
 	data, err := json.MarshalIndent(result, "", "  ")
 	if err != nil {

--- a/internal/ethapi/api_test.go
+++ b/internal/ethapi/api_test.go
@@ -1620,7 +1620,86 @@ func TestRPCGetBlockReceipts(t *testing.T) {
 }
 
 func TestRPCGetRequiredBlockState(t *testing.T) {
-	//
+	t.Parallel()
+
+	var (
+		genBlocks  = 6
+		backend, _ = setupReceiptBackend(t, genBlocks)
+		api        = NewBlockChainAPI(backend)
+	)
+	blockHashes := make([]common.Hash, genBlocks+1)
+	ctx := context.Background()
+	for i := 0; i <= genBlocks; i++ {
+		header, err := backend.HeaderByNumber(ctx, rpc.BlockNumber(i))
+		if err != nil {
+			t.Errorf("failed to get block: %d err: %v", i, err)
+		}
+		blockHashes[i] = header.Hash()
+	}
+
+	var testSuite = []struct {
+		test rpc.BlockNumberOrHash
+		file string
+	}{
+		// 3. latest tag
+		{
+			test: rpc.BlockNumberOrHashWithNumber(rpc.LatestBlockNumber),
+			file: "tag-latest",
+		},
+		// // 4. block with legacy transfer tx(hash)
+		// {
+		// 	test: rpc.BlockNumberOrHashWithHash(blockHashes[1], false),
+		// 	file: "block-with-legacy-transfer-tx",
+		// },
+		// // 5. block with contract create tx(number)
+		// {
+		// 	test: rpc.BlockNumberOrHashWithNumber(rpc.BlockNumber(2)),
+		// 	file: "block-with-contract-create-tx",
+		// },
+		// // 6. block with legacy contract call tx(hash)
+		// {
+		// 	test: rpc.BlockNumberOrHashWithHash(blockHashes[3], false),
+		// 	file: "block-with-legacy-contract-call-tx",
+		// },
+		// // 7. block with dynamic fee tx(number)
+		// {
+		// 	test: rpc.BlockNumberOrHashWithNumber(rpc.BlockNumber(4)),
+		// 	file: "block-with-dynamic-fee-tx",
+		// },
+		// // 8. block is empty
+		// {
+		// 	test: rpc.BlockNumberOrHashWithHash(common.Hash{}, false),
+		// 	file: "hash-empty",
+		// },
+		// // 9. block is not found
+		// {
+		// 	test: rpc.BlockNumberOrHashWithHash(common.HexToHash("deadbeef"), false),
+		// 	file: "hash-notfound",
+		// },
+		// // 10. block is not found
+		// {
+		// 	test: rpc.BlockNumberOrHashWithNumber(rpc.BlockNumber(genBlocks + 1)),
+		// 	file: "block-notfound",
+		// },
+		// // 11. block with blob tx
+		// {
+		// 	test: rpc.BlockNumberOrHashWithNumber(rpc.BlockNumber(6)),
+		// 	file: "block-with-blob-tx",
+		// },
+	}
+
+	for i, tt := range testSuite {
+		var (
+			result interface{}
+			err    error
+		)
+		result, err = api.GetRequiredBlockState(context.Background(), tt.test)
+		if err != nil {
+			t.Errorf("test %d: want no error, have %v", i, err)
+			continue
+		}
+		testRPCResponseWithFile(t, i, result, "eth_getRequiredBlockState", tt.file)
+	}
 }
 
 func testRPCResponseWithFile(t *testing.T, testid int, result interface{}, rpc string, file string) {

--- a/internal/ethapi/testdata/eth_getRequiredBlockState-tag-latest.json
+++ b/internal/ethapi/testdata/eth_getRequiredBlockState-tag-latest.json
@@ -1,0 +1,11 @@
+[
+  {
+    "txHash": "0xb51ee3d2a89ba5d5623c73133c8d7a6ba9fb41194c17f4302c21b30994a1180f",
+    "result": {
+      "gas": 21001,
+      "failed": false,
+      "returnValue": "",
+      "structLogs": []
+    }
+  }
+]

--- a/internal/web3ext/web3ext.go
+++ b/internal/web3ext/web3ext.go
@@ -595,6 +595,12 @@ web3._extend({
 			inputFormatter: [web3._extend.formatters.inputAddressFormatter, null, web3._extend.formatters.inputBlockNumberFormatter]
 		}),
 		new web3._extend.Method({
+			name: 'getRequiredBlockState',
+			call: 'eth_getRequiredBlockState',
+			params: 1,
+			inputFormatter: [web3._extend.formatters.inputBlockNumberFormatter]
+		}),
+		new web3._extend.Method({
 			name: 'createAccessList',
 			call: 'eth_createAccessList',
 			params: 2,

--- a/light/postprocess.go
+++ b/light/postprocess.go
@@ -214,7 +214,7 @@ func (c *ChtIndexerBackend) Process(ctx context.Context, header *types.Header) e
 
 // Commit implements core.ChainIndexerBackend
 func (c *ChtIndexerBackend) Commit() error {
-	root, nodes, err := c.trie.Commit(false)
+	root, nodes, _, err := c.trie.Commit(false)
 	if err != nil {
 		return err
 	}
@@ -467,7 +467,7 @@ func (b *BloomTrieIndexerBackend) Commit() error {
 			return terr
 		}
 	}
-	root, nodes, err := b.trie.Commit(false)
+	root, nodes, _, err := b.trie.Commit(false)
 	if err != nil {
 		return err
 	}

--- a/light/trie.go
+++ b/light/trie.go
@@ -177,9 +177,9 @@ func (t *odrTrie) DeleteAccount(address common.Address) error {
 	})
 }
 
-func (t *odrTrie) Commit(collectLeaf bool) (common.Hash, *trienode.NodeSet, error) {
+func (t *odrTrie) Commit(collectLeaf bool) (common.Hash, *trienode.NodeSet, *trienode.Witness, error) {
 	if t.trie == nil {
-		return t.id.Root, nil, nil
+		return t.id.Root, nil, nil, nil
 	}
 	return t.trie.Commit(collectLeaf)
 }

--- a/light/trie.go
+++ b/light/trie.go
@@ -106,6 +106,10 @@ type odrTrie struct {
 	trie *trie.Trie
 }
 
+func (t *odrTrie) GetWitness() *trienode.Witness {
+	return t.trie.GetWitness()
+}
+
 func (t *odrTrie) GetStorage(_ common.Address, key []byte) ([]byte, error) {
 	key = crypto.Keccak256(key)
 	var enc []byte

--- a/light/trie.go
+++ b/light/trie.go
@@ -106,10 +106,6 @@ type odrTrie struct {
 	trie *trie.Trie
 }
 
-func (t *odrTrie) GetWitness() *trienode.Witness {
-	return t.trie.GetWitness()
-}
-
 func (t *odrTrie) GetStorage(_ common.Address, key []byte) ([]byte, error) {
 	key = crypto.Keccak256(key)
 	var enc []byte

--- a/tests/fuzzers/stacktrie/trie_fuzzer.go
+++ b/tests/fuzzers/stacktrie/trie_fuzzer.go
@@ -171,7 +171,7 @@ func (f *fuzzer) fuzz() int {
 		return 0
 	}
 	// Flush trie -> database
-	rootA, nodes, err := trieA.Commit(false)
+	rootA, nodes, _, err := trieA.Commit(false)
 	if err != nil {
 		panic(err)
 	}

--- a/tests/fuzzers/trie/trie-fuzzer.go
+++ b/tests/fuzzers/trie/trie-fuzzer.go
@@ -165,7 +165,7 @@ func runRandTest(rt randTest) error {
 		case opHash:
 			tr.Hash()
 		case opCommit:
-			hash, nodes, err := tr.Commit(false)
+			hash, nodes, _, err := tr.Commit(false)
 			if err != nil {
 				return err
 			}

--- a/tests/state_test_util.go
+++ b/tests/state_test_util.go
@@ -298,7 +298,7 @@ func (t *StateTest) RunNoVerify(subtest StateSubtest, vmconfig vm.Config, snapsh
 	statedb.AddBalance(block.Coinbase(), new(big.Int))
 
 	// Commit state mutations into database.
-	root, _ := statedb.Commit(block.NumberU64(), config.IsEIP158(block.Number()))
+	root, _, _ := statedb.Commit(block.NumberU64(), config.IsEIP158(block.Number()))
 	return triedb, snaps, statedb, root, err
 }
 
@@ -325,7 +325,7 @@ func MakePreState(db ethdb.Database, accounts core.GenesisAlloc, snapshotter boo
 		}
 	}
 	// Commit and re-open to start with a clean state.
-	root, _ := statedb.Commit(0, false)
+	root, _, _ := statedb.Commit(0, false)
 
 	var snaps *snapshot.Tree
 	if snapshotter {

--- a/trie/committer.go
+++ b/trie/committer.go
@@ -28,15 +28,15 @@ import (
 // insertion order.
 type committer struct {
 	nodes       *trienode.NodeSet
-	tracer      *tracer
+	witness     *trienode.Witness
 	collectLeaf bool
 }
 
 // newCommitter creates a new committer or picks one from the pool.
-func newCommitter(nodeset *trienode.NodeSet, tracer *tracer, collectLeaf bool) *committer {
+func newCommitter(nodeset *trienode.NodeSet, witness *trienode.Witness, collectLeaf bool) *committer {
 	return &committer{
 		nodes:       nodeset,
-		tracer:      tracer,
+		witness:     witness,
 		collectLeaf: collectLeaf,
 	}
 }
@@ -131,8 +131,7 @@ func (c *committer) store(path []byte, n node) node {
 		// The node is embedded in its parent, in other words, this node
 		// will not be stored in the database independently, mark it as
 		// deleted only if the node was existent in database before.
-		_, ok := c.tracer.accessList[string(path)]
-		if ok {
+		if c.witness.Has(string(path)) {
 			c.nodes.AddNode(path, trienode.NewDeleted())
 		}
 		return n

--- a/trie/iterator_test.go
+++ b/trie/iterator_test.go
@@ -59,7 +59,7 @@ func TestIterator(t *testing.T) {
 		all[val.k] = val.v
 		trie.MustUpdate([]byte(val.k), []byte(val.v))
 	}
-	root, nodes, _ := trie.Commit(false)
+	root, nodes, _, _ := trie.Commit(false)
 	db.Update(root, types.EmptyRootHash, 0, trienode.NewWithNodeSet(nodes), nil)
 
 	trie, _ = New(TrieID(root), db)
@@ -251,7 +251,7 @@ func TestDifferenceIterator(t *testing.T) {
 	for _, val := range testdata1 {
 		triea.MustUpdate([]byte(val.k), []byte(val.v))
 	}
-	rootA, nodesA, _ := triea.Commit(false)
+	rootA, nodesA, _, _ := triea.Commit(false)
 	dba.Update(rootA, types.EmptyRootHash, 0, trienode.NewWithNodeSet(nodesA), nil)
 	triea, _ = New(TrieID(rootA), dba)
 
@@ -260,7 +260,7 @@ func TestDifferenceIterator(t *testing.T) {
 	for _, val := range testdata2 {
 		trieb.MustUpdate([]byte(val.k), []byte(val.v))
 	}
-	rootB, nodesB, _ := trieb.Commit(false)
+	rootB, nodesB, _, _ := trieb.Commit(false)
 	dbb.Update(rootB, types.EmptyRootHash, 0, trienode.NewWithNodeSet(nodesB), nil)
 	trieb, _ = New(TrieID(rootB), dbb)
 
@@ -293,7 +293,7 @@ func TestUnionIterator(t *testing.T) {
 	for _, val := range testdata1 {
 		triea.MustUpdate([]byte(val.k), []byte(val.v))
 	}
-	rootA, nodesA, _ := triea.Commit(false)
+	rootA, nodesA, _, _ := triea.Commit(false)
 	dba.Update(rootA, types.EmptyRootHash, 0, trienode.NewWithNodeSet(nodesA), nil)
 	triea, _ = New(TrieID(rootA), dba)
 
@@ -302,7 +302,7 @@ func TestUnionIterator(t *testing.T) {
 	for _, val := range testdata2 {
 		trieb.MustUpdate([]byte(val.k), []byte(val.v))
 	}
-	rootB, nodesB, _ := trieb.Commit(false)
+	rootB, nodesB, _, _ := trieb.Commit(false)
 	dbb.Update(rootB, types.EmptyRootHash, 0, trienode.NewWithNodeSet(nodesB), nil)
 	trieb, _ = New(TrieID(rootB), dbb)
 
@@ -364,7 +364,7 @@ func testIteratorContinueAfterError(t *testing.T, memonly bool, scheme string) {
 	for _, val := range testdata1 {
 		tr.MustUpdate([]byte(val.k), []byte(val.v))
 	}
-	root, nodes, _ := tr.Commit(false)
+	root, nodes, _, _ := tr.Commit(false)
 	tdb.Update(root, types.EmptyRootHash, 0, trienode.NewWithNodeSet(nodes), nil)
 	if !memonly {
 		tdb.Commit(root, false)
@@ -474,7 +474,7 @@ func testIteratorContinueAfterSeekError(t *testing.T, memonly bool, scheme strin
 	for _, val := range testdata1 {
 		ctr.MustUpdate([]byte(val.k), []byte(val.v))
 	}
-	root, nodes, _ := ctr.Commit(false)
+	root, nodes, _, _ := ctr.Commit(false)
 	for path, n := range nodes.Nodes {
 		if n.Hash == barNodeHash {
 			barNodePath = []byte(path)
@@ -554,7 +554,7 @@ func testIteratorNodeBlob(t *testing.T, scheme string) {
 		all[val.k] = val.v
 		trie.MustUpdate([]byte(val.k), []byte(val.v))
 	}
-	root, nodes, _ := trie.Commit(false)
+	root, nodes, _, _ := trie.Commit(false)
 	triedb.Update(root, types.EmptyRootHash, 0, trienode.NewWithNodeSet(nodes), nil)
 	triedb.Commit(root, false)
 

--- a/trie/secure_trie.go
+++ b/trie/secure_trie.go
@@ -223,7 +223,7 @@ func (t *StateTrie) GetKey(shaKey []byte) []byte {
 // All cached preimages will be also flushed if preimages recording is enabled.
 // Once the trie is committed, it's not usable anymore. A new trie must
 // be created with new root and updated trie database for following usage
-func (t *StateTrie) Commit(collectLeaf bool) (common.Hash, *trienode.NodeSet, error) {
+func (t *StateTrie) Commit(collectLeaf bool) (common.Hash, *trienode.NodeSet, *trienode.Witness, error) {
 	// Write all the pre-images to the actual disk database
 	if len(t.getSecKeyCache()) > 0 {
 		if t.preimages != nil {

--- a/trie/secure_trie.go
+++ b/trie/secure_trie.go
@@ -81,10 +81,6 @@ func (t *StateTrie) MustGet(key []byte) []byte {
 	return t.trie.MustGet(t.hashKey(key))
 }
 
-func (t *StateTrie) GetWitness() *trienode.Witness {
-	return t.trie.GetWitness()
-}
-
 // GetStorage attempts to retrieve a storage slot with provided account address
 // and slot key. The value bytes must not be modified by the caller.
 // If the specified storage slot is not in the trie, nil will be returned.

--- a/trie/secure_trie.go
+++ b/trie/secure_trie.go
@@ -81,6 +81,10 @@ func (t *StateTrie) MustGet(key []byte) []byte {
 	return t.trie.MustGet(t.hashKey(key))
 }
 
+func (t *StateTrie) GetWitness() *trienode.Witness {
+	return t.trie.GetWitness()
+}
+
 // GetStorage attempts to retrieve a storage slot with provided account address
 // and slot key. The value bytes must not be modified by the caller.
 // If the specified storage slot is not in the trie, nil will be returned.

--- a/trie/secure_trie_test.go
+++ b/trie/secure_trie_test.go
@@ -60,7 +60,7 @@ func makeTestStateTrie() (*Database, *StateTrie, map[string][]byte) {
 			trie.MustUpdate(key, val)
 		}
 	}
-	root, nodes, _ := trie.Commit(false)
+	root, nodes, _, _ := trie.Commit(false)
 	if err := triedb.Update(root, types.EmptyRootHash, 0, trienode.NewWithNodeSet(nodes), nil); err != nil {
 		panic(fmt.Errorf("failed to commit db %v", err))
 	}

--- a/trie/sync_test.go
+++ b/trie/sync_test.go
@@ -56,7 +56,7 @@ func makeTestTrie(scheme string) (ethdb.Database, *Database, *StateTrie, map[str
 			trie.MustUpdate(key, val)
 		}
 	}
-	root, nodes, _ := trie.Commit(false)
+	root, nodes, _, _ := trie.Commit(false)
 	if err := triedb.Update(root, types.EmptyRootHash, 0, trienode.NewWithNodeSet(nodes), nil); err != nil {
 		panic(fmt.Errorf("failed to commit db %v", err))
 	}
@@ -759,7 +759,7 @@ func testSyncMovingTarget(t *testing.T, scheme string) {
 		srcTrie.MustUpdate(key, val)
 		diff[string(key)] = val
 	}
-	root, nodes, _ := srcTrie.Commit(false)
+	root, nodes, _, _ := srcTrie.Commit(false)
 	if err := srcDb.Update(root, preRoot, 0, trienode.NewWithNodeSet(nodes), nil); err != nil {
 		panic(err)
 	}
@@ -784,7 +784,7 @@ func testSyncMovingTarget(t *testing.T, scheme string) {
 		srcTrie.MustUpdate([]byte(k), val)
 		reverted[k] = val
 	}
-	root, nodes, _ = srcTrie.Commit(false)
+	root, nodes, _, _ = srcTrie.Commit(false)
 	if err := srcDb.Update(root, preRoot, 0, trienode.NewWithNodeSet(nodes), nil); err != nil {
 		panic(err)
 	}
@@ -842,7 +842,7 @@ func testPivotMove(t *testing.T, scheme string, tiny bool) {
 	writeFn([]byte{0x02, 0x34}, nil, srcTrie, stateA)
 	writeFn([]byte{0x13, 0x44}, nil, srcTrie, stateA)
 
-	rootA, nodesA, _ := srcTrie.Commit(false)
+	rootA, nodesA, _, _ := srcTrie.Commit(false)
 	if err := srcTrieDB.Update(rootA, types.EmptyRootHash, 0, trienode.NewWithNodeSet(nodesA), nil); err != nil {
 		panic(err)
 	}
@@ -861,7 +861,7 @@ func testPivotMove(t *testing.T, scheme string, tiny bool) {
 	deleteFn([]byte{0x13, 0x44}, srcTrie, stateB)
 	writeFn([]byte{0x01, 0x24}, nil, srcTrie, stateB)
 
-	rootB, nodesB, _ := srcTrie.Commit(false)
+	rootB, nodesB, _, _ := srcTrie.Commit(false)
 	if err := srcTrieDB.Update(rootB, rootA, 0, trienode.NewWithNodeSet(nodesB), nil); err != nil {
 		panic(err)
 	}
@@ -879,7 +879,7 @@ func testPivotMove(t *testing.T, scheme string, tiny bool) {
 	writeFn([]byte{0x02, 0x34}, nil, srcTrie, stateC)
 	writeFn([]byte{0x13, 0x44}, nil, srcTrie, stateC)
 
-	rootC, nodesC, _ := srcTrie.Commit(false)
+	rootC, nodesC, _, _ := srcTrie.Commit(false)
 	if err := srcTrieDB.Update(rootC, rootB, 0, trienode.NewWithNodeSet(nodesC), nil); err != nil {
 		panic(err)
 	}

--- a/trie/tracer_test.go
+++ b/trie/tracer_test.go
@@ -70,7 +70,7 @@ func testTrieTracer(t *testing.T, vals []struct{ k, v string }) {
 	}
 	insertSet := copySet(trie.tracer.inserts) // copy before commit
 	deleteSet := copySet(trie.tracer.deletes) // copy before commit
-	root, nodes, _ := trie.Commit(false)
+	root, nodes, _, _ := trie.Commit(false)
 	db.Update(root, types.EmptyRootHash, 0, trienode.NewWithNodeSet(nodes), nil)
 
 	seen := setKeys(iterNodes(db, root))
@@ -136,7 +136,7 @@ func testAccessList(t *testing.T, vals []struct{ k, v string }) {
 	for _, val := range vals {
 		trie.MustUpdate([]byte(val.k), []byte(val.v))
 	}
-	root, nodes, _ := trie.Commit(false)
+	root, nodes, _, _ := trie.Commit(false)
 	db.Update(root, types.EmptyRootHash, 0, trienode.NewWithNodeSet(nodes), nil)
 
 	trie, _ = New(TrieID(root), db)
@@ -151,7 +151,7 @@ func testAccessList(t *testing.T, vals []struct{ k, v string }) {
 	for _, val := range vals {
 		trie.MustUpdate([]byte(val.k), randBytes(32))
 	}
-	root, nodes, _ = trie.Commit(false)
+	root, nodes, _, _ = trie.Commit(false)
 	db.Update(root, parent, 0, trienode.NewWithNodeSet(nodes), nil)
 
 	trie, _ = New(TrieID(root), db)
@@ -169,7 +169,7 @@ func testAccessList(t *testing.T, vals []struct{ k, v string }) {
 		keys = append(keys, string(key))
 		trie.MustUpdate(key, randBytes(32))
 	}
-	root, nodes, _ = trie.Commit(false)
+	root, nodes, _, _ = trie.Commit(false)
 	db.Update(root, parent, 0, trienode.NewWithNodeSet(nodes), nil)
 
 	trie, _ = New(TrieID(root), db)
@@ -184,7 +184,7 @@ func testAccessList(t *testing.T, vals []struct{ k, v string }) {
 	for _, key := range keys {
 		trie.MustUpdate([]byte(key), nil)
 	}
-	root, nodes, _ = trie.Commit(false)
+	root, nodes, _, _ = trie.Commit(false)
 	db.Update(root, parent, 0, trienode.NewWithNodeSet(nodes), nil)
 
 	trie, _ = New(TrieID(root), db)
@@ -199,7 +199,7 @@ func testAccessList(t *testing.T, vals []struct{ k, v string }) {
 	for _, val := range vals {
 		trie.MustUpdate([]byte(val.k), nil)
 	}
-	root, nodes, _ = trie.Commit(false)
+	root, nodes, _, _ = trie.Commit(false)
 	db.Update(root, parent, 0, trienode.NewWithNodeSet(nodes), nil)
 
 	trie, _ = New(TrieID(root), db)
@@ -218,7 +218,7 @@ func TestAccessListLeak(t *testing.T) {
 	for _, val := range standard {
 		trie.MustUpdate([]byte(val.k), []byte(val.v))
 	}
-	root, nodes, _ := trie.Commit(false)
+	root, nodes, _, _ := trie.Commit(false)
 	db.Update(root, types.EmptyRootHash, 0, trienode.NewWithNodeSet(nodes), nil)
 
 	var cases = []struct {
@@ -248,9 +248,9 @@ func TestAccessListLeak(t *testing.T) {
 	}
 	for _, c := range cases {
 		trie, _ = New(TrieID(root), db)
-		n1 := len(trie.tracer.accessList)
+		n1 := trie.witness.Len()
 		c.op(trie)
-		n2 := len(trie.tracer.accessList)
+		n2 := trie.witness.Len()
 
 		if n1 != n2 {
 			t.Fatalf("AccessList is leaked, prev %d after %d", n1, n2)
@@ -268,7 +268,7 @@ func TestTinyTree(t *testing.T) {
 	for _, val := range tiny {
 		trie.MustUpdate([]byte(val.k), randBytes(32))
 	}
-	root, set, _ := trie.Commit(false)
+	root, set, _, _ := trie.Commit(false)
 	db.Update(root, types.EmptyRootHash, 0, trienode.NewWithNodeSet(set), nil)
 
 	parent := root
@@ -277,7 +277,7 @@ func TestTinyTree(t *testing.T) {
 	for _, val := range tiny {
 		trie.MustUpdate([]byte(val.k), []byte(val.v))
 	}
-	root, set, _ = trie.Commit(false)
+	root, set, _, _ = trie.Commit(false)
 	db.Update(root, parent, 0, trienode.NewWithNodeSet(set), nil)
 
 	trie, _ = New(TrieID(root), db)

--- a/trie/trie.go
+++ b/trie/trie.go
@@ -688,7 +688,3 @@ func (t *Trie) Reset() {
 	t.witness = trienode.NewWitness(common.Hash{})
 	t.committed = false
 }
-
-func (t *Trie) GetWitness() *trienode.Witness {
-	return t.witness
-}

--- a/trie/trie.go
+++ b/trie/trie.go
@@ -688,3 +688,7 @@ func (t *Trie) Reset() {
 	t.witness = trienode.NewWitness(common.Hash{})
 	t.committed = false
 }
+
+func (t *Trie) GetWitness() *trienode.Witness {
+	return t.witness
+}

--- a/trie/trie_test.go
+++ b/trie/trie_test.go
@@ -93,7 +93,7 @@ func testMissingNode(t *testing.T, memonly bool, scheme string) {
 	trie := NewEmpty(triedb)
 	updateString(trie, "120000", "qwerqwerqwerqwerqwerqwerqwerqwer")
 	updateString(trie, "123456", "asdfasdfasdfasdfasdfasdfasdfasdf")
-	root, nodes, _ := trie.Commit(false)
+	root, nodes, _, _ := trie.Commit(false)
 	triedb.Update(root, types.EmptyRootHash, 0, trienode.NewWithNodeSet(nodes), nil)
 
 	if !memonly {
@@ -182,7 +182,7 @@ func TestInsert(t *testing.T) {
 	updateString(trie, "A", "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
 
 	exp = common.HexToHash("d23786fb4a010da3ce639d66d5e904a11dbc02746d1ce25029e53290cabf28ab")
-	root, _, _ = trie.Commit(false)
+	root, _, _, _ = trie.Commit(false)
 	if root != exp {
 		t.Errorf("case 2: exp %x got %x", exp, root)
 	}
@@ -207,7 +207,7 @@ func TestGet(t *testing.T) {
 		if i == 1 {
 			return
 		}
-		root, nodes, _ := trie.Commit(false)
+		root, nodes, _, _ := trie.Commit(false)
 		db.Update(root, types.EmptyRootHash, 0, trienode.NewWithNodeSet(nodes), nil)
 		trie, _ = New(TrieID(root), db)
 	}
@@ -279,7 +279,7 @@ func TestReplication(t *testing.T) {
 	for _, val := range vals {
 		updateString(trie, val.k, val.v)
 	}
-	root, nodes, _ := trie.Commit(false)
+	root, nodes, _, _ := trie.Commit(false)
 	db.Update(root, types.EmptyRootHash, 0, trienode.NewWithNodeSet(nodes), nil)
 
 	// create a new trie on top of the database and check that lookups work.
@@ -292,7 +292,7 @@ func TestReplication(t *testing.T) {
 			t.Errorf("trie2 doesn't have %q => %q", kv.k, kv.v)
 		}
 	}
-	hash, nodes, _ := trie2.Commit(false)
+	hash, nodes, _, _ := trie2.Commit(false)
 	if hash != root {
 		t.Errorf("root failure. expected %x got %x", root, hash)
 	}
@@ -506,7 +506,7 @@ func runRandTest(rt randTest) bool {
 		case opHash:
 			tr.Hash()
 		case opCommit:
-			root, nodes, _ := tr.Commit(true)
+			root, nodes, _, _ := tr.Commit(true)
 			if nodes != nil {
 				triedb.Update(root, origin, 0, trienode.NewWithNodeSet(nodes), nil)
 			}
@@ -743,7 +743,7 @@ func TestCommitAfterHash(t *testing.T) {
 	if exp != root {
 		t.Errorf("got %x, exp %x", root, exp)
 	}
-	root, _, _ = trie.Commit(false)
+	root, _, _, _ = trie.Commit(false)
 	if exp != root {
 		t.Errorf("got %x, exp %x", root, exp)
 	}
@@ -852,7 +852,7 @@ func TestCommitSequence(t *testing.T) {
 			trie.MustUpdate(crypto.Keccak256(addresses[i][:]), accounts[i])
 		}
 		// Flush trie -> database
-		root, nodes, _ := trie.Commit(false)
+		root, nodes, _, _ := trie.Commit(false)
 		db.Update(root, types.EmptyRootHash, 0, trienode.NewWithNodeSet(nodes), nil)
 		// Flush memdb -> disk (sponge)
 		db.Commit(root, false)
@@ -893,7 +893,7 @@ func TestCommitSequenceRandomBlobs(t *testing.T) {
 			trie.MustUpdate(key, val)
 		}
 		// Flush trie -> database
-		root, nodes, _ := trie.Commit(false)
+		root, nodes, _, _ := trie.Commit(false)
 		db.Update(root, types.EmptyRootHash, 0, trienode.NewWithNodeSet(nodes), nil)
 		// Flush memdb -> disk (sponge)
 		db.Commit(root, false)
@@ -932,7 +932,7 @@ func TestCommitSequenceStackTrie(t *testing.T) {
 			stTrie.Update(key, val)
 		}
 		// Flush trie -> database
-		root, nodes, _ := trie.Commit(false)
+		root, nodes, _, _ := trie.Commit(false)
 		// Flush memdb -> disk (sponge)
 		db.Update(root, types.EmptyRootHash, 0, trienode.NewWithNodeSet(nodes), nil)
 		db.Commit(root, false)
@@ -980,7 +980,7 @@ func TestCommitSequenceSmallRoot(t *testing.T) {
 	trie.Update(key, []byte{0x1})
 	stTrie.Update(key, []byte{0x1})
 	// Flush trie -> database
-	root, nodes, _ := trie.Commit(false)
+	root, nodes, _, _ := trie.Commit(false)
 	// Flush memdb -> disk (sponge)
 	db.Update(root, types.EmptyRootHash, 0, trienode.NewWithNodeSet(nodes), nil)
 	db.Commit(root, false)
@@ -1153,7 +1153,7 @@ func benchmarkDerefRootFixedSize(b *testing.B, addresses [][20]byte, accounts []
 		trie.MustUpdate(crypto.Keccak256(addresses[i][:]), accounts[i])
 	}
 	h := trie.Hash()
-	root, nodes, _ := trie.Commit(false)
+	root, nodes, _, _ := trie.Commit(false)
 	triedb.Update(root, types.EmptyRootHash, 0, trienode.NewWithNodeSet(nodes), nil)
 	b.StartTimer()
 	triedb.Dereference(h)

--- a/trie/triedb/pathdb/database_test.go
+++ b/trie/triedb/pathdb/database_test.go
@@ -46,7 +46,7 @@ func updateTrie(addrHash common.Hash, root common.Hash, dirties, cleans map[comm
 			h.Update(key.Bytes(), val)
 		}
 	}
-	root, nodes, _ := h.Commit(false)
+	root, nodes, _, _ := h.Commit(false)
 	return root, nodes
 }
 

--- a/trie/triedb/pathdb/testutils.go
+++ b/trie/triedb/pathdb/testutils.go
@@ -80,7 +80,7 @@ func (h *testHasher) Delete(key []byte) error {
 
 // Commit computes the new hash of the states and returns the set with all
 // state changes.
-func (h *testHasher) Commit(collectLeaf bool) (common.Hash, *trienode.NodeSet, error) {
+func (h *testHasher) Commit(collectLeaf bool) (common.Hash, *trienode.NodeSet, *trienode.Witness, error) {
 	var (
 		nodes = make(map[common.Hash][]byte)
 		set   = trienode.NewNodeSet(h.owner)
@@ -108,7 +108,7 @@ func (h *testHasher) Commit(collectLeaf bool) (common.Hash, *trienode.NodeSet, e
 	if root == types.EmptyRootHash && h.root != types.EmptyRootHash {
 		set.AddNode(nil, trienode.NewDeleted())
 	}
-	return root, set, nil
+	return root, set, nil, nil
 }
 
 // hash performs the hash computation upon the provided states.

--- a/trie/trienode/witness.go
+++ b/trie/trienode/witness.go
@@ -32,13 +32,20 @@ type Witness struct {
 }
 
 func (u *Witness) MarshalJSON() ([]byte, error) {
-	nodes := make(map[string]string)
+	type Node struct {
+		Key   string
+		Value string
+	}
+	nodes := []Node{}
 	for key, node := range u.Nodes {
-		nodes[key] = hex.EncodeToString(node)
+		nodes = append(nodes, Node{
+			Key:   hex.EncodeToString([]byte(key)),
+			Value: hex.EncodeToString(node),
+		})
 	}
 	return json.Marshal(&struct {
 		Owner common.Hash
-		Nodes map[string]string
+		Nodes []Node
 	}{
 		Owner: u.Owner,
 		Nodes: nodes,

--- a/trie/trienode/witness.go
+++ b/trie/trienode/witness.go
@@ -59,3 +59,24 @@ func (w *Witness) Copy() *Witness {
 	}
 	return cpy
 }
+
+// Witnesses represents a set of witness for a group of tries.
+type Witnesses struct {
+	witness map[common.Hash]*Witness
+}
+
+// NewWitnesses initializes an empty witness set.
+func NewWitnesses() *Witnesses {
+	return &Witnesses{witness: make(map[common.Hash]*Witness)}
+}
+
+// Merge merges the provided dirty nodes of a trie into the set. The assumption
+// is held that no duplicated set belonging to the same trie will be merged twice.
+func (set *Witnesses) Merge(other *Witness) error {
+	_, present := set.witness[other.Owner]
+	if present {
+		//return subset.Merge(other.Owner, other.Nodes)
+	}
+	set.witness[other.Owner] = other
+	return nil
+}

--- a/trie/trienode/witness.go
+++ b/trie/trienode/witness.go
@@ -16,7 +16,12 @@
 
 package trienode
 
-import "github.com/ethereum/go-ethereum/common"
+import (
+	"encoding/hex"
+	"encoding/json"
+
+	"github.com/ethereum/go-ethereum/common"
+)
 
 // Witness is the set of nodes retrieved from the database for executing a state
 // transition. It can be considered as the previous state for the state transition,
@@ -24,6 +29,20 @@ import "github.com/ethereum/go-ethereum/common"
 type Witness struct {
 	Owner common.Hash
 	Nodes map[string][]byte
+}
+
+func (u *Witness) MarshalJSON() ([]byte, error) {
+	nodes := make(map[string]string)
+	for key, node := range u.Nodes {
+		nodes[key] = hex.EncodeToString(node)
+	}
+	return json.Marshal(&struct {
+		Owner common.Hash
+		Nodes map[string]string
+	}{
+		Owner: u.Owner,
+		Nodes: nodes,
+	})
 }
 
 // NewWitness constructs a witness structure.

--- a/trie/trienode/witness.go
+++ b/trie/trienode/witness.go
@@ -1,0 +1,61 @@
+// Copyright 2023 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/
+
+package trienode
+
+import "github.com/ethereum/go-ethereum/common"
+
+// Witness is the set of nodes retrieved from the database for executing a state
+// transition. It can be considered as the previous state for the state transition,
+// effectively serving as the witness for that transition.
+type Witness struct {
+	Owner common.Hash
+	Nodes map[string][]byte
+}
+
+// NewWitness constructs a witness structure.
+func NewWitness(owner common.Hash) *Witness {
+	return &Witness{Owner: owner, Nodes: make(map[string][]byte)}
+}
+
+// Add tracks the node resolved from database. Don't change the blob outside of
+// function since it's not deep-copied.
+func (w *Witness) Add(path string, blob []byte) {
+	w.Nodes[path] = common.CopyBytes(blob)
+}
+
+// Has returns the indicator whether the specified node is in witness.
+func (w *Witness) Has(path string) bool {
+	_, ok := w.Nodes[path]
+	return ok
+}
+
+// Len returns the number of nodes resolved in the witness.
+func (w *Witness) Len() int {
+	return len(w.Nodes)
+}
+
+// Copy returns a deep copied witness structure.
+func (w *Witness) Copy() *Witness {
+	cpy := &Witness{
+		Owner: w.Owner,
+		Nodes: make(map[string][]byte),
+	}
+	for p, n := range w.Nodes {
+		cpy.Nodes[p] = n // it's not deep-copied
+	}
+	return cpy
+}

--- a/trie/trienode/witness.go
+++ b/trie/trienode/witness.go
@@ -101,8 +101,13 @@ func NewWitnesses() *Witnesses {
 func (set *Witnesses) Merge(other *Witness) error {
 	_, present := set.witness[other.Owner]
 	if present {
+		return nil
 		//return subset.Merge(other.Owner, other.Nodes)
 	}
 	set.witness[other.Owner] = other
 	return nil
+}
+
+func (set *Witnesses) Witnesses() map[common.Hash]*Witness {
+	return set.witness
 }

--- a/trie/triestate/state.go
+++ b/trie/triestate/state.go
@@ -43,7 +43,7 @@ type Trie interface {
 
 	// Commit the trie and returns a set of dirty nodes generated along with
 	// the new root hash.
-	Commit(collectLeaf bool) (common.Hash, *trienode.NodeSet, error)
+	Commit(collectLeaf bool) (common.Hash, *trienode.NodeSet, *trienode.Witness, error)
 }
 
 // TrieLoader wraps functions to load tries.
@@ -129,7 +129,7 @@ func Apply(prevRoot common.Hash, postRoot common.Hash, accounts map[common.Addre
 			return nil, fmt.Errorf("failed to revert state, err: %w", err)
 		}
 	}
-	root, result, err := tr.Commit(false)
+	root, result, _, err := tr.Commit(false)
 	if err != nil {
 		return nil, err
 	}
@@ -184,7 +184,7 @@ func updateAccount(ctx *context, loader TrieLoader, addr common.Address) error {
 			return err
 		}
 	}
-	root, result, err := st.Commit(false)
+	root, result, _, err := st.Commit(false)
 	if err != nil {
 		return err
 	}
@@ -238,7 +238,7 @@ func deleteAccount(ctx *context, loader TrieLoader, addr common.Address) error {
 			return err
 		}
 	}
-	root, result, err := st.Commit(false)
+	root, result, _, err := st.Commit(false)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
This feature can be utilized on zkevms and other projects that need the full witness of a block.

Spec: https://github.com/ethereum/execution-apis/pull/455/files

This is built on top of https://github.com/rjl493456442/go-ethereum/tree/trie-witness