### PR TITLE
miner: only fill the pending block pre-merge

### DIFF
--- a/ethclient/ethclient_test.go
+++ b/ethclient/ethclient_test.go
@@ -598,8 +598,9 @@ func testAtFunctions(t *testing.T, client *rpc.Client) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if pending != 1 {
-		t.Fatalf("unexpected pending, wanted 1 got: %v", pending)
+	// After nerfing the pending block, pending transaction count will be 0
+	if pending != 0 {
+		t.Fatalf("unexpected pending, wanted 0 got: %v", pending)
 	}
 	// Query balance
 	balance, err := ec.BalanceAt(context.Background(), testAddr, nil)
@@ -617,7 +618,8 @@ func testAtFunctions(t *testing.T, client *rpc.Client) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if balance.Cmp(penBalance) == 0 {
+	// After nerfing the pending block, pending balance will be equal to balance
+	if balance.Cmp(penBalance) != 0 {
 		t.Fatalf("unexpected balance: %v %v", balance, penBalance)
 	}
 	// NonceAt

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -533,7 +533,7 @@ func (w *worker) mainLoop() {
 			// Note all transactions received may not be continuous with transactions
 			// already included in the current sealing block. These transactions will
 			// be automatically eliminated.
-			if !w.isRunning() && w.current != nil {
+			if !w.chainConfig.TerminalTotalDifficultyPassed && !w.isRunning() && w.current != nil {
 				// If block is already full, abort
 				if gp := w.current.gasPool; gp != nil && gp.Gas() < params.TxGas {
 					continue


### PR DESCRIPTION
This PR changes the way the pending block is constructed.
It will leave the pending block empty after the merge.

The pending block still behaves correctly (e.g. increased block number etc), but it is just constructed as if the node has no transactions available.

The only issue I see with this approach is that some people might rely on the pending state for nonce tracking. However you can track the pending nonces via eth_getTransactionCount which uses the pendingNoncer in the txpool instead of the pending state.