### PR TITLE
cmd/evm: validate blockchain tests poststate account storage

### DIFF
--- a/tests/block_test_util.go
+++ b/tests/block_test_util.go
@@ -330,6 +330,12 @@ func (t *BlockTest) validatePostState(statedb *state.StateDB) error {
 		if nonce2 != acct.Nonce {
 			return fmt.Errorf("account nonce mismatch for addr: %s want: %d have: %d", addr, acct.Nonce, nonce2)
 		}
+		for k, v := range acct.Storage {
+			v2 := statedb.GetState(addr, k)
+			if v2 != v {
+				return fmt.Errorf("account storage mismatch for addr: %s, slot: %x, want: %x, have: %x", addr, k, v, v2)
+			}
+		}
 	}
 	return nil
 }


### PR DESCRIPTION
This PR additionally verifies the accounts' storage as specified in a blockchain test's `postState` field (as described in the "Expect" section [here](https://ethereum-tests.readthedocs.io/en/latest/test_filler/blockchain_filler.html#expect)).
