### PR TITLE
ethdb/pebble: cap memory table size as maxMemTableSize-1

### DIFF
--- a/ethdb/pebble/pebble.go
+++ b/ethdb/pebble/pebble.go
@@ -160,8 +160,15 @@ func New(file string, cache int, handles int, namespace string, readonly bool, e
 	// including a frozen memory table and another live one.
 	memTableLimit := 2
 	memTableSize := cache * 1024 * 1024 / 2 / memTableLimit
-	if memTableSize > maxMemTableSize {
-		memTableSize = maxMemTableSize
+
+	// The memory table size is currently capped at maxMemTableSize-1 due to a
+	// known bug in the pebble where maxMemTableSize is not recognized as a
+	// valid size.
+	//
+	// TODO use the maxMemTableSize as the maximum table size once the issue
+	// in pebble is fixed.
+	if memTableSize >= maxMemTableSize {
+		memTableSize = maxMemTableSize - 1
 	}
 	db := &Database{
 		fn:           file,


### PR DESCRIPTION
Fixes https://github.com/ethereum/go-ethereum/issues/28384

Wait the upstream [fix](https://github.com/cockroachdb/pebble/pull/3008/files) to revert this "temporary" fix.