### PR TITLE
core/vm: performance tweak of `OpCode.String()`

### DIFF
--- a/core/vm/opcodes.go
+++ b/core/vm/opcodes.go
@@ -224,8 +224,7 @@ const (
 	SELFDESTRUCT OpCode = 0xff
 )
 
-// Since the opcodes aren't all in order we can't use a regular slice.
-var opCodeToString = map[OpCode]string{
+var opCodeToString = [256]string{
 	// 0x0 range - arithmetic ops.
 	STOP:       "STOP",
 	ADD:        "ADD",
@@ -399,12 +398,10 @@ var opCodeToString = map[OpCode]string{
 }
 
 func (op OpCode) String() string {
-	str := opCodeToString[op]
-	if len(str) == 0 {
-		return fmt.Sprintf("opcode %#x not defined", int(op))
+	if s := opCodeToString[op]; s != "" {
+		return s
 	}
-
-	return str
+	return fmt.Sprintf("opcode %#x not defined", int(op))
 }
 
 var stringToOp = map[string]OpCode{


### PR DESCRIPTION
Small change that improves the performance of `OpCode.String()` by changing:
```diff
- var opCodeToString = map[OpCode]string{
+ var opCodeToString = [256]string{
```

> `// Since the opcodes aren't all in order we can't use a regular slice.`

Yes, but we can use an array and define opcodes using a key-value-pair as one would do in a map (so order still does not matter).