### PR TITLE
graphql: change the type of yParity from Long to BigInt

### DIFF
--- a/graphql/graphql.go
+++ b/graphql/graphql.go
@@ -615,13 +615,13 @@ func (t *Transaction) V(ctx context.Context) hexutil.Big {
 	return hexutil.Big(*v)
 }
 
-func (t *Transaction) YParity(ctx context.Context) (*hexutil.Uint64, error) {
+func (t *Transaction) YParity(ctx context.Context) (*hexutil.Big, error) {
 	tx, _ := t.resolve(ctx)
 	if tx == nil || tx.Type() == types.LegacyTxType {
 		return nil, nil
 	}
 	v, _, _ := tx.RawSignatureValues()
-	ret := hexutil.Uint64(v.Int64())
+	ret := hexutil.Big(*v)
 	return &ret, nil
 }
 

--- a/graphql/schema.go
+++ b/graphql/schema.go
@@ -157,7 +157,7 @@ const schema string = `
         r: BigInt!
         s: BigInt!
         v: BigInt!
-        yParity: Long
+        yParity: BigInt
         # Envelope transaction support
         type: Long
         accessList: [AccessTuple!]


### PR DESCRIPTION
Discussed in https://github.com/ethereum/execution-apis/pull/471

as `r`, `s`, `v` are bigints, so yParity should also be the same. 

