### PR TITLE
core/state: make stateobject.create selfcontain

### DIFF
--- a/core/state/state_object.go
+++ b/core/state/state_object.go
@@ -98,7 +98,10 @@ func (s *stateObject) empty() bool {
 
 // newObject creates a state object.
 func newObject(db *StateDB, address common.Address, acct *types.StateAccount) *stateObject {
-	origin := acct
+	var (
+		origin  = acct
+		created = acct == nil // true if the account was not existent
+	)
 	if acct == nil {
 		acct = types.NewEmptyStateAccount()
 	}
@@ -111,6 +114,7 @@ func newObject(db *StateDB, address common.Address, acct *types.StateAccount) *s
 		originStorage:  make(Storage),
 		pendingStorage: make(Storage),
 		dirtyStorage:   make(Storage),
+		created:        created,
 	}
 }
 

--- a/core/state/statedb.go
+++ b/core/state/statedb.go
@@ -658,9 +658,6 @@ func (s *StateDB) createObject(addr common.Address) (newobj, prev *stateObject) 
 		delete(s.accountsOrigin, prev.address)
 		delete(s.storagesOrigin, prev.address)
 	}
-
-	newobj.created = true
-
 	s.setStateObject(newobj)
 	if prev != nil && !prev.deleted {
 		return newobj, prev


### PR DESCRIPTION
The stateObject.created flag is currently assigned outside of the constructor and revoked in the finalise function. I realized a better way to manage this flag and make it very self-contained.

In the constructor, we can simplify the logic by setting `created` to True when the account does not exist and False otherwise. This will make the flag assignment more robust and self-contained within the constructor.