### PR TITLE
eth/tracers: support debug_traceCall on transaction

### DIFF
--- a/eth/tracers/api.go
+++ b/eth/tracers/api.go
@@ -864,6 +864,10 @@ func (api *API) TraceTransaction(ctx context.Context, hash common.Hash, config *
 // TraceCall lets you trace a given eth_call. It collects the structured logs
 // created during the execution of EVM if the given transaction was added on
 // top of the provided block and returns them as a JSON object.
+// If no transaction index is specified, the trace will be conducted on the state
+// after executing the specified block. However, if a transaction index is provided,
+// the trace will be conducted on the state after executing the specified transaction
+// within the specified block.
 func (api *API) TraceCall(ctx context.Context, args ethapi.TransactionArgs, blockNrOrHash rpc.BlockNumberOrHash, config *TraceCallConfig) (interface{}, error) {
 	// Try to retrieve the specified block
 	var (
@@ -896,14 +900,6 @@ func (api *API) TraceCall(ctx context.Context, args ethapi.TransactionArgs, bloc
 		reexec = *config.Reexec
 	}
 
-	// If no transaction index is specified, the trace will be conducted on the state
-	// after executing the specified block. However, if a transaction index is provided,
-	// the trace will be conducted on the state after executing the specified transaction
-	// within the specified block.
-	// When "latest" is used without a transaction index, it means that the simulation is
-	// done on the state after the latest block execution. Conversely, when "latest" is used
-	// with a transaction index, it indicates simulating on the intermediate state after a
-	// specific transaction within the most recent block.
 	if config != nil && config.TxIndex != nil {
 		_, _, statedb, release, err = api.backend.StateAtTransaction(ctx, block, int(*config.TxIndex), reexec)
 	} else {

--- a/eth/tracers/api.go
+++ b/eth/tracers/api.go
@@ -895,6 +895,15 @@ func (api *API) TraceCall(ctx context.Context, args ethapi.TransactionArgs, bloc
 	if config != nil && config.Reexec != nil {
 		reexec = *config.Reexec
 	}
+
+	// If no transaction index is specified, the trace will be conducted on the state
+	// after executing the specified block. However, if a transaction index is provided,
+	// the trace will be conducted on the state after executing the specified transaction
+	// within the specified block.
+	// When "latest" is used without a transaction index, it means that the simulation is
+	// done on the state after the latest block execution. Conversely, when "latest" is used
+	// with a transaction index, it indicates simulating on the intermediate state after a
+	// specific transaction within the most recent block.
 	if config != nil && config.TxIndex != nil {
 		_, _, statedb, release, err = api.backend.StateAtTransaction(ctx, block, int(*config.TxIndex), reexec)
 	} else {

--- a/eth/tracers/api_test.go
+++ b/eth/tracers/api_test.go
@@ -205,18 +205,39 @@ func TestTraceCall(t *testing.T) {
 		// Transfer from account[0] to account[1]
 		//    value: 1000 wei
 		//    fee:   0 wei
-		tx, _ := types.SignTx(types.NewTransaction(nonce, accounts[1].addr, big.NewInt(1000), params.TxGas, b.BaseFee(), nil), signer, accounts[0].key)
+		tx, _ := types.SignTx(types.NewTx(&types.LegacyTx{
+			Nonce:    nonce,
+			To:       &accounts[1].addr,
+			Value:    big.NewInt(1000),
+			Gas:      params.TxGas,
+			GasPrice: b.BaseFee(),
+			Data:     nil}),
+			signer, accounts[0].key)
 		b.AddTx(tx)
 		nonce++
 
 		if i == genBlocks-2 {
 			// Transfer from account[0] to account[2]
-			tx, _ = types.SignTx(types.NewTransaction(nonce, accounts[2].addr, big.NewInt(1000), params.TxGas, b.BaseFee(), nil), signer, accounts[0].key)
+			tx, _ = types.SignTx(types.NewTx(&types.LegacyTx{
+				Nonce:    nonce,
+				To:       &accounts[2].addr,
+				Value:    big.NewInt(1000),
+				Gas:      params.TxGas,
+				GasPrice: b.BaseFee(),
+				Data:     nil}),
+				signer, accounts[0].key)
 			b.AddTx(tx)
 			nonce++
 
 			// Transfer from account[0] to account[1] again
-			tx, _ = types.SignTx(types.NewTransaction(nonce, accounts[1].addr, big.NewInt(1000), params.TxGas, b.BaseFee(), nil), signer, accounts[0].key)
+			tx, _ = types.SignTx(types.NewTx(&types.LegacyTx{
+				Nonce:    nonce,
+				To:       &accounts[1].addr,
+				Value:    big.NewInt(1000),
+				Gas:      params.TxGas,
+				GasPrice: b.BaseFee(),
+				Data:     nil}),
+				signer, accounts[0].key)
 			b.AddTx(tx)
 			nonce++
 		}

--- a/eth/tracers/api_test.go
+++ b/eth/tracers/api_test.go
@@ -421,7 +421,14 @@ func TestTraceTransaction(t *testing.T) {
 		// Transfer from account[0] to account[1]
 		//    value: 1000 wei
 		//    fee:   0 wei
-		tx, _ := types.SignTx(types.NewTransaction(uint64(i), accounts[1].addr, big.NewInt(1000), params.TxGas, b.BaseFee(), nil), signer, accounts[0].key)
+		tx, _ := types.SignTx(types.NewTx(&types.LegacyTx{
+			Nonce:    uint64(i),
+			To:       &accounts[1].addr,
+			Value:    big.NewInt(1000),
+			Gas:      params.TxGas,
+			GasPrice: b.BaseFee(),
+			Data:     nil}),
+			signer, accounts[0].key)
 		b.AddTx(tx)
 		target = tx.Hash()
 	})
@@ -471,7 +478,14 @@ func TestTraceBlock(t *testing.T) {
 		// Transfer from account[0] to account[1]
 		//    value: 1000 wei
 		//    fee:   0 wei
-		tx, _ := types.SignTx(types.NewTransaction(uint64(i), accounts[1].addr, big.NewInt(1000), params.TxGas, b.BaseFee(), nil), signer, accounts[0].key)
+		tx, _ := types.SignTx(types.NewTx(&types.LegacyTx{
+			Nonce:    uint64(i),
+			To:       &accounts[1].addr,
+			Value:    big.NewInt(1000),
+			Gas:      params.TxGas,
+			GasPrice: b.BaseFee(),
+			Data:     nil}),
+			signer, accounts[0].key)
 		b.AddTx(tx)
 		txHash = tx.Hash()
 	})
@@ -561,7 +575,14 @@ func TestTracingWithOverrides(t *testing.T) {
 		// Transfer from account[0] to account[1]
 		//    value: 1000 wei
 		//    fee:   0 wei
-		tx, _ := types.SignTx(types.NewTransaction(uint64(i), accounts[1].addr, big.NewInt(1000), params.TxGas, b.BaseFee(), nil), signer, accounts[0].key)
+		tx, _ := types.SignTx(types.NewTx(&types.LegacyTx{
+			Nonce:    uint64(i),
+			To:       &accounts[1].addr,
+			Value:    big.NewInt(1000),
+			Gas:      params.TxGas,
+			GasPrice: b.BaseFee(),
+			Data:     nil}),
+			signer, accounts[0].key)
 		b.AddTx(tx)
 	})
 	defer backend.chain.Stop()


### PR DESCRIPTION
Currently, `debug_traceCall` only supports invoking the post-state based on a specific block. 

However, in some cases, we may want to simulate the transaction based on the state of a specific intermediate index within a block. For example, when analyzing a scenario involving a malicious transaction, we may want to simulate the execution of that malicious transaction based on the state before its execution to observe the impact it would have caused.

So I added the field `txIndex` in the `TraceCallConfig`