### PR TITLE
core, trie, rpc: speed up tests

### DIFF
--- a/accounts/keystore/account_cache_test.go
+++ b/accounts/keystore/account_cache_test.go
@@ -68,7 +68,7 @@ func waitWatcherStart(ks *KeyStore) bool {
 
 func waitForAccounts(wantAccounts []accounts.Account, ks *KeyStore) error {
 	var list []accounts.Account
-	for t0 := time.Now(); time.Since(t0) < 5*time.Second; time.Sleep(200 * time.Millisecond) {
+	for t0 := time.Now(); time.Since(t0) < 5*time.Second; time.Sleep(100 * time.Millisecond) {
 		list = ks.Accounts()
 		if reflect.DeepEqual(list, wantAccounts) {
 			// ks should have also received change notifications
@@ -350,7 +350,7 @@ func TestUpdatedKeyfileContents(t *testing.T) {
 		return
 	}
 	// needed so that modTime of `file` is different to its current value after forceCopyFile
-	time.Sleep(time.Second)
+	os.Chtimes(file, time.Now().Add(-time.Second), time.Now().Add(-time.Second))
 
 	// Now replace file contents
 	if err := forceCopyFile(file, cachetestAccounts[1].URL.Path); err != nil {
@@ -366,7 +366,7 @@ func TestUpdatedKeyfileContents(t *testing.T) {
 	}
 
 	// needed so that modTime of `file` is different to its current value after forceCopyFile
-	time.Sleep(time.Second)
+	os.Chtimes(file, time.Now().Add(-time.Second), time.Now().Add(-time.Second))
 
 	// Now replace file contents again
 	if err := forceCopyFile(file, cachetestAccounts[2].URL.Path); err != nil {
@@ -382,7 +382,7 @@ func TestUpdatedKeyfileContents(t *testing.T) {
 	}
 
 	// needed so that modTime of `file` is different to its current value after os.WriteFile
-	time.Sleep(time.Second)
+	os.Chtimes(file, time.Now().Add(-time.Second), time.Now().Add(-time.Second))
 
 	// Now replace file contents with crap
 	if err := os.WriteFile(file, []byte("foo"), 0600); err != nil {

--- a/core/forkid/forkid_test.go
+++ b/core/forkid/forkid_test.go
@@ -366,8 +366,9 @@ func TestValidation(t *testing.T) {
 		// TODO(karalabe): Enable this when Cancun is specced
 		//{params.MainnetChainConfig, 20999999, 1677999999, ID{Hash: checksumToBytes(0x71147644), Next: 1678000000}, ErrLocalIncompatibleOrStale},
 	}
+	genesis := core.DefaultGenesisBlock().ToBlock()
 	for i, tt := range tests {
-		filter := newFilter(tt.config, core.DefaultGenesisBlock().ToBlock(), func() (uint64, uint64) { return tt.head, tt.time })
+		filter := newFilter(tt.config, genesis, func() (uint64, uint64) { return tt.head, tt.time })
 		if err := filter(tt.id); err != tt.err {
 			t.Errorf("test %d: validation error mismatch: have %v, want %v", i, err, tt.err)
 		}

--- a/core/state/statedb_test.go
+++ b/core/state/statedb_test.go
@@ -426,10 +426,12 @@ func (test *snapshotTest) run() bool {
 		state, _     = New(types.EmptyRootHash, NewDatabase(rawdb.NewMemoryDatabase()), nil)
 		snapshotRevs = make([]int, len(test.snapshots))
 		sindex       = 0
+		checkstates  = make([]*StateDB, len(test.snapshots))
 	)
 	for i, action := range test.actions {
 		if len(test.snapshots) > sindex && i == test.snapshots[sindex] {
 			snapshotRevs[sindex] = state.Snapshot()
+			checkstates[sindex] = state.Copy()
 			sindex++
 		}
 		action.fn(action, state)
@@ -437,12 +439,8 @@ func (test *snapshotTest) run() bool {
 	// Revert all snapshots in reverse order. Each revert must yield a state
 	// that is equivalent to fresh state with all actions up the snapshot applied.
 	for sindex--; sindex >= 0; sindex-- {
-		checkstate, _ := New(types.EmptyRootHash, state.Database(), nil)
-		for _, action := range test.actions[:test.snapshots[sindex]] {
-			action.fn(action, checkstate)
-		}
 		state.RevertToSnapshot(snapshotRevs[sindex])
-		if err := test.checkEqual(state, checkstate); err != nil {
+		if err := test.checkEqual(state, checkstates[sindex]); err != nil {
 			test.err = fmt.Errorf("state mismatch after revert to snapshot %d\n%v", sindex, err)
 			return false
 		}

--- a/rpc/client_test.go
+++ b/rpc/client_test.go
@@ -595,7 +595,7 @@ func TestClientSubscriptionChannelClose(t *testing.T) {
 
 	for i := 0; i < 100; i++ {
 		ch := make(chan int, 100)
-		sub, err := client.Subscribe(context.Background(), "nftest", ch, "someSubscription", maxClientSubscriptionBuffer-1, 1)
+		sub, err := client.Subscribe(context.Background(), "nftest", ch, "someSubscription", 100, 1)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/trie/sync_test.go
+++ b/trie/sync_test.go
@@ -73,7 +73,7 @@ func makeTestTrie(scheme string) (ethdb.Database, *Database, *StateTrie, map[str
 func checkTrieContents(t *testing.T, db ethdb.Database, scheme string, root []byte, content map[string][]byte, rawTrie bool) {
 	// Check root availability and trie contents
 	ndb := newTestDatabase(db, scheme)
-	if err := checkTrieConsistency(db, scheme, common.BytesToHash(root), rawTrie, nil); err != nil {
+	if err := checkTrieConsistency(db, scheme, common.BytesToHash(root), rawTrie); err != nil {
 		t.Fatalf("inconsistent trie at %x: %v", root, err)
 	}
 	type reader interface {
@@ -101,7 +101,7 @@ func checkTrieContents(t *testing.T, db ethdb.Database, scheme string, root []by
 }
 
 // checkTrieConsistency checks that all nodes in a trie are indeed present.
-func checkTrieConsistency(db ethdb.Database, scheme string, root common.Hash, rawTrie bool, resolver NodeResolver) error {
+func checkTrieConsistency(db ethdb.Database, scheme string, root common.Hash, rawTrie bool) error {
 	ndb := newTestDatabase(db, scheme)
 	var it NodeIterator
 	if rawTrie {
@@ -116,9 +116,6 @@ func checkTrieConsistency(db ethdb.Database, scheme string, root common.Hash, ra
 			return nil // Consider a non existent state consistent
 		}
 		it = trie.MustNodeIterator(nil)
-	}
-	if resolver != nil {
-		it.AddResolver(resolver)
 	}
 	for it.Next(true) {
 	}
@@ -515,8 +512,8 @@ func testDuplicateAvoidanceSync(t *testing.T, scheme string) {
 // Tests that at any point in time during a sync, only complete sub-tries are in
 // the database.
 func TestIncompleteSyncHash(t *testing.T) {
-	testIncompleteSync(t, rawdb.HashScheme) // 9.585s
-	testIncompleteSync(t, rawdb.PathScheme) // 19.522
+	testIncompleteSync(t, rawdb.HashScheme)
+	testIncompleteSync(t, rawdb.PathScheme)
 }
 
 func testIncompleteSync(t *testing.T, scheme string) {
@@ -589,31 +586,16 @@ func testIncompleteSync(t *testing.T, scheme string) {
 		}
 	}
 
-	// Cache trie nodes for faster verification
-	nodesCache := make(map[string][]byte)
-	resolver := func(owner common.Hash, path []byte, hash common.Hash) []byte {
-		if scheme == rawdb.HashScheme {
-			return nodesCache[string(hash[:])]
-		}
-		return nodesCache[string(path)]
-	}
-
 	// Sanity check that removing any node from the database is detected
 	for i, path := range addedKeys {
 		owner, inner := ResolvePath([]byte(path))
 		nodeHash := addedHashes[i]
 		value := rawdb.ReadTrieNode(diskdb, owner, inner, nodeHash, scheme)
 		rawdb.DeleteTrieNode(diskdb, owner, inner, nodeHash, scheme)
-		if err := checkTrieConsistency(diskdb, srcDb.Scheme(), root, false, resolver); err == nil {
+		if err := checkTrieConsistency(diskdb, srcDb.Scheme(), root, false); err == nil {
 			t.Fatalf("trie inconsistency not caught, missing: %x", path)
 		}
 		rawdb.WriteTrieNode(diskdb, owner, inner, nodeHash, value, scheme)
-		// We only add nodes to the cache that we already visited
-		if scheme == rawdb.HashScheme {
-			nodesCache[string(nodeHash[:])] = value
-		} else {
-			nodesCache[string(inner[:])] = value
-		}
 	}
 }
 

--- a/trie/sync_test.go
+++ b/trie/sync_test.go
@@ -19,6 +19,7 @@ package trie
 import (
 	"bytes"
 	"fmt"
+	"math/rand"
 	"testing"
 
 	"github.com/ethereum/go-ethereum/common"
@@ -585,9 +586,12 @@ func testIncompleteSync(t *testing.T, scheme string) {
 			})
 		}
 	}
-
 	// Sanity check that removing any node from the database is detected
 	for i, path := range addedKeys {
+		if rand.Int31n(100) > 5 {
+			// Only check 5 percent of added keys as a sanity check
+			continue
+		}
 		owner, inner := ResolvePath([]byte(path))
 		nodeHash := addedHashes[i]
 		value := rawdb.ReadTrieNode(diskdb, owner, inner, nodeHash, scheme)


### PR DESCRIPTION
This PR makes a few of our tests faster, the changes are in separate commits which makes it easier to review and shows their advantages. 
All in all these fixes take our whole pipeline (including ethereum/tests) from 96s to 88s on my machine.