### PR TITLE
cmd/utils:  if dev-mode is enabled and db is pre-existing, validate that genesis configuration is compatible

### DIFF
--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -1646,38 +1646,40 @@ func CheckExclusive(ctx *cli.Context, args ...interface{}) {
 	}
 }
 
+// validateDeveloperGenesis asserts that a provided genesis can be used with dev mode:
+// it requires pre-merge hard-forks and proof-of-stake to be activated at block 0
 func validateDeveloperGenesis(genesis *core.Genesis) error {
-	checkHFIsZero := func(forkName string, hfBlockNumber *big.Int) error {
+	checkForkIsBlock0 := func(forkName string, hfBlockNumber *big.Int) error {
 		if hfBlockNumber == nil {
-			return errors.New(fmt.Sprintf("%s: hard-fork not enabled", forkName))
+			return fmt.Errorf("%s: hard-fork not enabled", forkName)
 		} else if hfBlockNumber.Cmp(big.NewInt(0)) != 0 {
-			return errors.New(fmt.Sprintf("%s: hard-fork not activated in block 0", forkName))
+			return fmt.Errorf("%s: hard-fork not activated in block 0", forkName)
 		}
 		return nil
 	}
 
 	config := genesis.Config
-	if err := checkHFIsZero("Homestead", config.HomesteadBlock); err != nil {
+	if err := checkForkIsBlock0("Homestead", config.HomesteadBlock); err != nil {
 		return err
 	} else if config.DAOForkBlock != nil {
 		return errors.New("DAO hardfork cannot be enabled")
-	} else if err := checkHFIsZero("EIP150", config.EIP150Block); err != nil {
+	} else if err := checkForkIsBlock0("EIP150", config.EIP150Block); err != nil {
 		return err
-	} else if err := checkHFIsZero("EIP155", config.EIP155Block); err != nil {
+	} else if err := checkForkIsBlock0("EIP155", config.EIP155Block); err != nil {
 		return err
-	} else if err := checkHFIsZero("EIP158", config.EIP158Block); err != nil {
+	} else if err := checkForkIsBlock0("EIP158", config.EIP158Block); err != nil {
 		return err
-	} else if err := checkHFIsZero("Byzantium", config.ByzantiumBlock); err != nil {
+	} else if err := checkForkIsBlock0("Byzantium", config.ByzantiumBlock); err != nil {
 		return err
-	} else if err := checkHFIsZero("Constantinople", config.ConstantinopleBlock); err != nil {
+	} else if err := checkForkIsBlock0("Constantinople", config.ConstantinopleBlock); err != nil {
 		return err
-	} else if err := checkHFIsZero("Istanbul", config.IstanbulBlock); err != nil {
+	} else if err := checkForkIsBlock0("Istanbul", config.IstanbulBlock); err != nil {
 		return err
-	} else if err := checkHFIsZero("Berlin", config.BerlinBlock); err != nil {
+	} else if err := checkForkIsBlock0("Berlin", config.BerlinBlock); err != nil {
 		return err
-	} else if err := checkHFIsZero("London", config.LondonBlock); err != nil {
+	} else if err := checkForkIsBlock0("London", config.LondonBlock); err != nil {
 		return err
-	} else if config.TerminalTotalDifficultyPassed != true {
+	} else if !config.TerminalTotalDifficultyPassed {
 		return errors.New("terminal total difficulty must be passed")
 	}
 	return nil

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -1877,7 +1877,13 @@ func SetEthConfig(ctx *cli.Context, stack *node.Node, cfg *ethconfig.Config) {
 					Fatalf("Could not read genesis from database: %v", err)
 				}
 				if !genesis.Config.TerminalTotalDifficultyPassed {
-					Fatalf("Bad genesis configuration: ttd must be passed in block 0 in developer mode")
+					Fatalf("Bad developer-mode genesis configuration: terminal total difficulty must be passed in block 0 in developer mode")
+				}
+				if genesis.Config.TerminalTotalDifficulty == nil {
+					Fatalf("Bad developer-mode genesis configuration:  terminal total difficulty must be specified.")
+				}
+				if genesis.Difficulty.Cmp(genesis.Config.TerminalTotalDifficulty) != 1 {
+					Fatalf("Bad developer-mode genesis configuration:  genesis block difficulty must be greater than ttd")
 				}
 			}
 			chaindb.Close()

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -1877,13 +1877,13 @@ func SetEthConfig(ctx *cli.Context, stack *node.Node, cfg *ethconfig.Config) {
 					Fatalf("Could not read genesis from database: %v", err)
 				}
 				if !genesis.Config.TerminalTotalDifficultyPassed {
-					Fatalf("Bad developer-mode genesis configuration: terminal total difficulty must be passed in block 0 in developer mode")
+					Fatalf("Bad developer-mode genesis configuration: terminalTotalDifficultyPassed must be true in developer mode")
 				}
 				if genesis.Config.TerminalTotalDifficulty == nil {
-					Fatalf("Bad developer-mode genesis configuration:  terminal total difficulty must be specified.")
+					Fatalf("Bad developer-mode genesis configuration: terminalTotalDifficulty must be specified.")
 				}
 				if genesis.Difficulty.Cmp(genesis.Config.TerminalTotalDifficulty) != 1 {
-					Fatalf("Bad developer-mode genesis configuration:  genesis block difficulty must be greater than ttd")
+					Fatalf("Bad developer-mode genesis configuration: genesis block difficulty must be > terminalTotalDifficulty")
 				}
 			}
 			chaindb.Close()

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -1646,45 +1646,6 @@ func CheckExclusive(ctx *cli.Context, args ...interface{}) {
 	}
 }
 
-// validateDeveloperGenesis asserts that a provided genesis can be used with dev mode:
-// it requires pre-merge hard-forks and proof-of-stake to be activated at block 0
-func validateDeveloperGenesis(genesis *core.Genesis) error {
-	checkForkIsBlock0 := func(forkName string, hfBlockNumber *big.Int) error {
-		if hfBlockNumber == nil {
-			return fmt.Errorf("%s: hard-fork not enabled", forkName)
-		} else if hfBlockNumber.Cmp(big.NewInt(0)) != 0 {
-			return fmt.Errorf("%s: hard-fork not activated in block 0", forkName)
-		}
-		return nil
-	}
-
-	config := genesis.Config
-	if err := checkForkIsBlock0("Homestead", config.HomesteadBlock); err != nil {
-		return err
-	} else if config.DAOForkBlock != nil {
-		return errors.New("DAO hardfork cannot be enabled")
-	} else if err := checkForkIsBlock0("EIP150", config.EIP150Block); err != nil {
-		return err
-	} else if err := checkForkIsBlock0("EIP155", config.EIP155Block); err != nil {
-		return err
-	} else if err := checkForkIsBlock0("EIP158", config.EIP158Block); err != nil {
-		return err
-	} else if err := checkForkIsBlock0("Byzantium", config.ByzantiumBlock); err != nil {
-		return err
-	} else if err := checkForkIsBlock0("Constantinople", config.ConstantinopleBlock); err != nil {
-		return err
-	} else if err := checkForkIsBlock0("Istanbul", config.IstanbulBlock); err != nil {
-		return err
-	} else if err := checkForkIsBlock0("Berlin", config.BerlinBlock); err != nil {
-		return err
-	} else if err := checkForkIsBlock0("London", config.LondonBlock); err != nil {
-		return err
-	} else if !config.TerminalTotalDifficultyPassed {
-		return errors.New("terminal total difficulty must be passed")
-	}
-	return nil
-}
-
 // SetEthConfig applies eth-related command line flags to the config.
 func SetEthConfig(ctx *cli.Context, stack *node.Node, cfg *ethconfig.Config) {
 	// Avoid conflicting network flags
@@ -1913,10 +1874,10 @@ func SetEthConfig(ctx *cli.Context, stack *node.Node, cfg *ethconfig.Config) {
 				var genesis *core.Genesis
 				var err error
 				if genesis, err = core.ReadGenesis(chaindb); err != nil {
-					Fatalf("could not read genesis from database: %v", err)
+					Fatalf("Could not read genesis from database: %v", err)
 				}
-				if err = validateDeveloperGenesis(genesis); err != nil {
-					Fatalf("genesis configuration incompatible with development mode: %v", err)
+				if !genesis.Config.TerminalTotalDifficultyPassed {
+					Fatalf("Bad genesis configuration: ttd must be passed in block 0 in developer mode")
 				}
 			}
 			chaindb.Close()

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -1871,9 +1871,9 @@ func SetEthConfig(ctx *cli.Context, stack *node.Node, cfg *ethconfig.Config) {
 			if rawdb.ReadCanonicalHash(chaindb, 0) != (common.Hash{}) {
 				cfg.Genesis = nil // fallback to db content
 
-				var genesis *core.Genesis
-				var err error
-				if genesis, err = core.ReadGenesis(chaindb); err != nil {
+				//validate genesis has PoS enabled in block 0
+				genesis, err := core.ReadGenesis(chaindb)
+				if err != nil {
 					Fatalf("Could not read genesis from database: %v", err)
 				}
 				if !genesis.Config.TerminalTotalDifficultyPassed {

--- a/core/genesis.go
+++ b/core/genesis.go
@@ -572,7 +572,7 @@ func DeveloperGenesisBlock(gasLimit uint64, faucet common.Address) *Genesis {
 		Config:     &config,
 		GasLimit:   gasLimit,
 		BaseFee:    big.NewInt(params.InitialBaseFee),
-		Difficulty: big.NewInt(0),
+		Difficulty: big.NewInt(1),
 		Alloc: map[common.Address]GenesisAccount{
 			common.BytesToAddress([]byte{1}): {Balance: big.NewInt(1)}, // ECRecover
 			common.BytesToAddress([]byte{2}): {Balance: big.NewInt(1)}, // SHA256

--- a/eth/catalyst/simulated_beacon.go
+++ b/eth/catalyst/simulated_beacon.go
@@ -82,10 +82,6 @@ type SimulatedBeacon struct {
 }
 
 func NewSimulatedBeacon(period uint64, eth *eth.Ethereum) (*SimulatedBeacon, error) {
-	chainConfig := eth.APIBackend.ChainConfig()
-	if !chainConfig.IsDevMode {
-		return nil, errors.New("incompatible pre-existing chain configuration")
-	}
 	block := eth.BlockChain().CurrentBlock()
 	current := engine.ForkchoiceStateV1{
 		HeadBlockHash:      block.Hash(),

--- a/params/config.go
+++ b/params/config.go
@@ -328,8 +328,8 @@ type ChainConfig struct {
 	TerminalTotalDifficultyPassed bool `json:"terminalTotalDifficultyPassed,omitempty"`
 
 	// Various consensus engines
-	Ethash    *EthashConfig `json:"ethash,omitempty"`
-	Clique    *CliqueConfig `json:"clique,omitempty"`
+	Ethash *EthashConfig `json:"ethash,omitempty"`
+	Clique *CliqueConfig `json:"clique,omitempty"`
 }
 
 // EthashConfig is the consensus engine configs for proof-of-work based sealing.

--- a/params/config.go
+++ b/params/config.go
@@ -180,7 +180,6 @@ var (
 		ShanghaiTime:                  newUint64(0),
 		TerminalTotalDifficulty:       big.NewInt(0),
 		TerminalTotalDifficultyPassed: true,
-		IsDevMode:                     true,
 	}
 
 	// AllCliqueProtocolChanges contains every protocol change (EIPs) introduced
@@ -331,7 +330,6 @@ type ChainConfig struct {
 	// Various consensus engines
 	Ethash    *EthashConfig `json:"ethash,omitempty"`
 	Clique    *CliqueConfig `json:"clique,omitempty"`
-	IsDevMode bool          `json:"isDev,omitempty"`
 }
 
 // EthashConfig is the consensus engine configs for proof-of-work based sealing.


### PR DESCRIPTION
Dev mode should expect TTD to be passed at genesis.  With these changes, it also asserts that pre-merge non-DAO, non-difficulty bomb delay HFs are activated at block 0 (not strictly necessary for all of them but why not 🤷‍♂️ )

This aims to help prevent users from foot-gunning themselves if they misconfigure a custom genesis.