### PR TITLE
ethdb/memorydb, trie: reduced allocations

### DIFF
--- a/ethdb/memorydb/memorydb_test.go
+++ b/ethdb/memorydb/memorydb_test.go
@@ -17,9 +17,9 @@
 package memorydb
 
 import (
+	"encoding/binary"
 	"testing"
 
-	"encoding/binary"
 	"github.com/ethereum/go-ethereum/ethdb"
 	"github.com/ethereum/go-ethereum/ethdb/dbtest"
 )

--- a/ethdb/memorydb/memorydb_test.go
+++ b/ethdb/memorydb/memorydb_test.go
@@ -19,6 +19,7 @@ package memorydb
 import (
 	"testing"
 
+	"encoding/binary"
 	"github.com/ethereum/go-ethereum/ethdb"
 	"github.com/ethereum/go-ethereum/ethdb/dbtest"
 )
@@ -29,4 +30,21 @@ func TestMemoryDB(t *testing.T) {
 			return New()
 		})
 	})
+}
+
+// BenchmarkBatchAllocs measures the time/allocs for storing 120 kB of data
+func BenchmarkBatchAllocs(b *testing.B) {
+	b.ReportAllocs()
+	var key = make([]byte, 20)
+	var val = make([]byte, 100)
+	// 120 * 1_000 -> 120_000 == 120kB
+	for i := 0; i < b.N; i++ {
+		batch := New().NewBatch()
+		for j := uint64(0); j < 1000; j++ {
+			binary.BigEndian.PutUint64(key, j)
+			binary.BigEndian.PutUint64(val, j)
+			batch.Put(key, val)
+		}
+		batch.Write()
+	}
 }

--- a/trie/iterator.go
+++ b/trie/iterator.go
@@ -144,7 +144,8 @@ type nodeIterator struct {
 	path  []byte               // Path to the current node
 	err   error                // Failure set in case of an internal error in the iterator
 
-	resolver NodeResolver // optional node resolver for avoiding disk hits
+	resolver NodeResolver         // optional node resolver for avoiding disk hits
+	pool     []*nodeIteratorState // local pool for iteratorstates
 }
 
 // errIteratorEnd is stored in nodeIterator.err when iteration is done.
@@ -170,6 +171,24 @@ func newNodeIterator(trie *Trie, start []byte) NodeIterator {
 	it := &nodeIterator{trie: trie}
 	it.err = it.seek(start)
 	return it
+}
+
+func (it *nodeIterator) putInPool(item *nodeIteratorState) {
+	if len(it.pool) < 40 {
+		item.node = nil
+		it.pool = append(it.pool, item)
+	}
+}
+
+func (it *nodeIterator) getFromPool() *nodeIteratorState {
+	idx := len(it.pool) - 1
+	if idx < 0 {
+		return new(nodeIteratorState)
+	}
+	el := it.pool[idx]
+	it.pool[idx] = nil
+	it.pool = it.pool[:idx]
+	return el
 }
 
 func (it *nodeIterator) AddResolver(resolver NodeResolver) {
@@ -423,8 +442,9 @@ func (st *nodeIteratorState) resolve(it *nodeIterator, path []byte) error {
 	return nil
 }
 
-func findChild(n *fullNode, index int, path []byte, ancestor common.Hash) (node, *nodeIteratorState, []byte, int) {
+func (it *nodeIterator) findChild(n *fullNode, index int, ancestor common.Hash) (node, *nodeIteratorState, []byte, int) {
 	var (
+		path      = it.path
 		child     node
 		state     *nodeIteratorState
 		childPath []byte
@@ -433,13 +453,12 @@ func findChild(n *fullNode, index int, path []byte, ancestor common.Hash) (node,
 		if n.Children[index] != nil {
 			child = n.Children[index]
 			hash, _ := child.cache()
-			state = &nodeIteratorState{
-				hash:    common.BytesToHash(hash),
-				node:    child,
-				parent:  ancestor,
-				index:   -1,
-				pathlen: len(path),
-			}
+			state = it.getFromPool()
+			state.hash = common.BytesToHash(hash)
+			state.node = child
+			state.parent = ancestor
+			state.index = -1
+			state.pathlen = len(path)
 			childPath = append(childPath, path...)
 			childPath = append(childPath, byte(index))
 			return child, state, childPath, index
@@ -452,7 +471,7 @@ func (it *nodeIterator) nextChild(parent *nodeIteratorState, ancestor common.Has
 	switch node := parent.node.(type) {
 	case *fullNode:
 		// Full node, move to the first non-nil child.
-		if child, state, path, index := findChild(node, parent.index+1, it.path, ancestor); child != nil {
+		if child, state, path, index := it.findChild(node, parent.index+1, ancestor); child != nil {
 			parent.index = index - 1
 			return state, path, true
 		}
@@ -460,13 +479,12 @@ func (it *nodeIterator) nextChild(parent *nodeIteratorState, ancestor common.Has
 		// Short node, return the pointer singleton child
 		if parent.index < 0 {
 			hash, _ := node.Val.cache()
-			state := &nodeIteratorState{
-				hash:    common.BytesToHash(hash),
-				node:    node.Val,
-				parent:  ancestor,
-				index:   -1,
-				pathlen: len(it.path),
-			}
+			state := it.getFromPool()
+			state.hash = common.BytesToHash(hash)
+			state.node = node.Val
+			state.parent = ancestor
+			state.index = -1
+			state.pathlen = len(it.path)
 			path := append(it.path, node.Key...)
 			return state, path, true
 		}
@@ -480,7 +498,7 @@ func (it *nodeIterator) nextChildAt(parent *nodeIteratorState, ancestor common.H
 	switch n := parent.node.(type) {
 	case *fullNode:
 		// Full node, move to the first non-nil child before the desired key position
-		child, state, path, index := findChild(n, parent.index+1, it.path, ancestor)
+		child, state, path, index := it.findChild(n, parent.index+1, ancestor)
 		if child == nil {
 			// No more children in this fullnode
 			return parent, it.path, false
@@ -492,7 +510,7 @@ func (it *nodeIterator) nextChildAt(parent *nodeIteratorState, ancestor common.H
 		}
 		// The child is before the seek position. Try advancing
 		for {
-			nextChild, nextState, nextPath, nextIndex := findChild(n, index+1, it.path, ancestor)
+			nextChild, nextState, nextPath, nextIndex := it.findChild(n, index+1, ancestor)
 			// If we run out of children, or skipped past the target, return the
 			// previous one
 			if nextChild == nil || bytes.Compare(nextPath, key) >= 0 {
@@ -506,13 +524,12 @@ func (it *nodeIterator) nextChildAt(parent *nodeIteratorState, ancestor common.H
 		// Short node, return the pointer singleton child
 		if parent.index < 0 {
 			hash, _ := n.Val.cache()
-			state := &nodeIteratorState{
-				hash:    common.BytesToHash(hash),
-				node:    n.Val,
-				parent:  ancestor,
-				index:   -1,
-				pathlen: len(it.path),
-			}
+			state := it.getFromPool()
+			state.hash = common.BytesToHash(hash)
+			state.node = n.Val
+			state.parent = ancestor
+			state.index = -1
+			state.pathlen = len(it.path)
 			path := append(it.path, n.Key...)
 			return state, path, true
 		}
@@ -533,6 +550,8 @@ func (it *nodeIterator) pop() {
 	it.path = it.path[:last.pathlen]
 	it.stack[len(it.stack)-1] = nil
 	it.stack = it.stack[:len(it.stack)-1]
+	// last is now unused
+	it.putInPool(last)
 }
 
 func compareNodes(a, b NodeIterator) int {

--- a/trie/iterator_test.go
+++ b/trie/iterator_test.go
@@ -616,3 +616,15 @@ func isTrieNode(scheme string, key, val []byte) (bool, []byte, common.Hash) {
 	}
 	return true, path, hash
 }
+
+func BenchmarkIterator(b *testing.B) {
+	diskDb, srcDb, tr, _ := makeTestTrie(rawdb.HashScheme)
+	root := tr.Hash()
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if err := checkTrieConsistency(diskDb, srcDb.Scheme(), root, false); err != nil {
+			b.Fatal(err)
+		}
+	}
+}

--- a/trie/sync_test.go
+++ b/trie/sync_test.go
@@ -571,7 +571,7 @@ func testIncompleteSync(t *testing.T, scheme string) {
 			hash := crypto.Keccak256Hash(result.Data)
 			if hash != root {
 				addedKeys = append(addedKeys, result.Path)
-				addedHashes = append(addedHashes, crypto.Keccak256Hash(result.Data))
+				addedHashes = append(addedHashes, hash)
 			}
 		}
 		// Fetch the next batch to retrieve


### PR DESCRIPTION
The changes in https://github.com/ethereum/go-ethereum/pull/28461 regarding the `sync_test` showed that by adding a resolver, the node iterator sped up considerably. This is really kind of strange, since a memorydb is in essence a map of `string->[]byte`, exactly the same thing as the resolver used instead. 

While investigating, I found that one big reason for the test being slow is that a lot of time is spent on gc. And the upside of using a naive slice instead of memorydb is that memorydb copies on write, and copies again on read. This PR removes one unnecessary copy of the key though. 

```

name           old time/op    new time/op    delta
BatchAllocs-8     412µs ± 6%     382µs ± 2%   -7.18%  (p=0.016 n=5+4)

name           old alloc/op   new alloc/op   delta
BatchAllocs-8     480kB ± 0%     490kB ± 0%   +1.93%  (p=0.008 n=5+5)

name           old allocs/op  new allocs/op  delta
BatchAllocs-8     3.03k ± 0%     2.03k ± 0%  -32.98%  (p=0.008 n=5+5)
```

I also found that the node iterator burns through a lot of memory, which can be remedied by using a local pool. 


```
name        old time/op    new time/op    delta
Iterator-8    6.22ms ± 3%    5.40ms ± 6%  -13.18%  (p=0.008 n=5+5)

name        old alloc/op   new alloc/op   delta
Iterator-8    2.36MB ± 0%    1.67MB ± 0%  -29.23%  (p=0.008 n=5+5)

name        old allocs/op  new allocs/op  delta
Iterator-8     37.0k ± 0%     29.8k ± 0%     ~     (p=0.079 n=4+5)
````

---

There's one remaining source of memory-burn in the node iterator, which comes from the use of `path` separate from node iterator state. This `it.path` is re-allocated on every step, and the node-iterator-state only knows how long their path is, not what the actual path is. I assume this was a decision made to make the node-iterator-state smaller in memory, however, when using a bit of pooling, it would be nicer to move the path into the node-iterator-state, and be able to reuse the `path`-bytes also. Left as a potential future exercise. 