### PR TITLE
ethclient: add empty/nonexist account testcase for eth_getProof RPC

### DIFF
--- a/ethclient/gethclient/gethclient_test.go
+++ b/ethclient/gethclient/gethclient_test.go
@@ -111,6 +111,9 @@ func TestGethClient(t *testing.T) {
 			"TestGetProof2",
 			func(t *testing.T) { testGetProof(t, client, testContract) },
 		}, {
+			"TestGetProofNonExistent",
+			func(t *testing.T) { testGetProof(t, client, common.HexToAddress("0x0001")) },
+		}, {
 			"TestGetProofCanonicalizeKeys",
 			func(t *testing.T) { testGetProofCanonicalizeKeys(t, client) },
 		}, {

--- a/ethclient/gethclient/gethclient_test.go
+++ b/ethclient/gethclient/gethclient_test.go
@@ -42,6 +42,7 @@ var (
 	testKey, _   = crypto.HexToECDSA("b71c71a67e1177ad4e901695e1b4b9ee17ae16c6668d313eac2f96dbcda3f291")
 	testAddr     = crypto.PubkeyToAddress(testKey.PublicKey)
 	testContract = common.HexToAddress("0xbeef")
+	testEmpty    = common.HexToAddress("0xeeee")
 	testSlot     = common.HexToHash("0xdeadbeef")
 	testValue    = crypto.Keccak256Hash(testSlot[:])
 	testBalance  = big.NewInt(2e15)
@@ -80,8 +81,11 @@ func newTestBackend(t *testing.T) (*node.Node, []*types.Block) {
 func generateTestChain() (*core.Genesis, []*types.Block) {
 	genesis := &core.Genesis{
 		Config: params.AllEthashProtocolChanges,
-		Alloc: core.GenesisAlloc{testAddr: {Balance: testBalance, Storage: map[common.Hash]common.Hash{testSlot: testValue}},
-			testContract: {Nonce: 1, Code: []byte{0x13, 0x37}}},
+		Alloc: core.GenesisAlloc{
+			testAddr:     {Balance: testBalance, Storage: map[common.Hash]common.Hash{testSlot: testValue}},
+			testContract: {Nonce: 1, Code: []byte{0x13, 0x37}},
+			testEmpty:    {Balance: big.NewInt(1)},
+		},
 		ExtraData: []byte("test genesis"),
 		Timestamp: 9000,
 	}
@@ -110,6 +114,9 @@ func TestGethClient(t *testing.T) {
 		}, {
 			"TestGetProof2",
 			func(t *testing.T) { testGetProof(t, client, testContract) },
+		}, {
+			"TestGetProofEmpty",
+			func(t *testing.T) { testGetProof(t, client, testEmpty) },
 		}, {
 			"TestGetProofNonExistent",
 			func(t *testing.T) { testGetProofNonExistent(t, client) },
@@ -280,7 +287,7 @@ func testGetProofCanonicalizeKeys(t *testing.T, client *rpc.Client) {
 func testGetProofNonExistent(t *testing.T, client *rpc.Client) {
 	addr := common.HexToAddress("0x0001")
 	ec := New(client)
-	result, err := ec.GetProof(context.Background(), addr, []string{testSlot.String()}, nil)
+	result, err := ec.GetProof(context.Background(), addr, nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -296,16 +303,16 @@ func testGetProofNonExistent(t *testing.T, client *rpc.Client) {
 		t.Fatalf("invalid balance, want: %v got: %v", 0, result.Balance)
 	}
 	// test storage
-	if len(result.StorageProof) != 1 {
-		t.Fatalf("invalid storage proof, want 1 proof, got %v proof(s)", len(result.StorageProof))
+	if have := len(result.StorageProof); have != 0 {
+		t.Fatalf("invalid storage proof, want 0 proof, got %v proof(s)", have)
 	}
 	// test codeHash
-	if result.CodeHash != types.EmptyCodeHash {
-		t.Fatalf("codehash wrong, have %v want %v ", result.CodeHash, types.EmptyCodeHash)
+	if have, want := result.CodeHash, (common.Hash{}); have != want {
+		t.Fatalf("codehash wrong, have %v want %v ", have, want)
 	}
 	// test codeHash
-	if result.StorageHash != types.EmptyRootHash {
-		t.Fatalf("storagehash wrong, have %v want %v ", result.StorageHash, types.EmptyRootHash)
+	if have, want := result.StorageHash, (common.Hash{}); have != want {
+		t.Fatalf("storagehash wrong, have %v want %v ", have, want)
 	}
 }
 

--- a/ethclient/gethclient/gethclient_test.go
+++ b/ethclient/gethclient/gethclient_test.go
@@ -112,7 +112,7 @@ func TestGethClient(t *testing.T) {
 			func(t *testing.T) { testGetProof(t, client, testContract) },
 		}, {
 			"TestGetProofNonExistent",
-			func(t *testing.T) { testGetProof(t, client, common.HexToAddress("0x0001")) },
+			func(t *testing.T) { testGetProofNonExistent(t, client) },
 		}, {
 			"TestGetProofCanonicalizeKeys",
 			func(t *testing.T) { testGetProofCanonicalizeKeys(t, client) },
@@ -274,6 +274,38 @@ func testGetProofCanonicalizeKeys(t *testing.T, client *rpc.Client) {
 	}
 	if result.StorageProof[0].Key != hashSizedKey {
 		t.Fatalf("wrong storage key encoding in proof: %q", result.StorageProof[0].Key)
+	}
+}
+
+func testGetProofNonExistent(t *testing.T, client *rpc.Client) {
+	addr := common.HexToAddress("0x0001")
+	ec := New(client)
+	result, err := ec.GetProof(context.Background(), addr, []string{testSlot.String()}, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Address != addr {
+		t.Fatalf("unexpected address, have: %v want: %v", result.Address, addr)
+	}
+	// test nonce
+	if result.Nonce != 0 {
+		t.Fatalf("invalid nonce, want: %v got: %v", 0, result.Nonce)
+	}
+	// test balance
+	if result.Balance.Cmp(big.NewInt(0)) != 0 {
+		t.Fatalf("invalid balance, want: %v got: %v", 0, result.Balance)
+	}
+	// test storage
+	if len(result.StorageProof) != 1 {
+		t.Fatalf("invalid storage proof, want 1 proof, got %v proof(s)", len(result.StorageProof))
+	}
+	// test codeHash
+	if result.CodeHash != types.EmptyCodeHash {
+		t.Fatalf("codehash wrong, have %v want %v ", result.CodeHash, types.EmptyCodeHash)
+	}
+	// test codeHash
+	if result.StorageHash != types.EmptyRootHash {
+		t.Fatalf("storagehash wrong, have %v want %v ", result.StorageHash, types.EmptyRootHash)
 	}
 }
 


### PR DESCRIPTION
I apologize for the inappropriate fix for the issue https://github.com/ethereum/go-ethereum/issues/28441. Here, I have added two new test cases to differentiate between the scenarios:

1. the account/contract does not exists;
2. the account/contract exists but is empty.