### PR TITLE
core/rawdb: fsync the index file after each freezer write

### DIFF
--- a/core/rawdb/ancient_utils.go
+++ b/core/rawdb/ancient_utils.go
@@ -18,6 +18,7 @@ package rawdb
 
 import (
 	"fmt"
+	"path/filepath"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/ethdb"
@@ -126,6 +127,8 @@ func InspectFreezerTable(ancient string, freezerName string, tableName string, s
 	switch freezerName {
 	case chainFreezerName:
 		path, tables = resolveChainFreezerDir(ancient), chainFreezerNoSnappy
+	case stateFreezerName:
+		path, tables = filepath.Join(ancient, freezerName), stateFreezerNoSnappy
 	default:
 		return fmt.Errorf("unknown freezer, supported ones: %v", freezers)
 	}

--- a/core/rawdb/freezer_batch.go
+++ b/core/rawdb/freezer_batch.go
@@ -182,10 +182,13 @@ func (batch *freezerTableBatch) maybeCommit() error {
 
 // commit writes the batched items to the backing freezerTable.
 func (batch *freezerTableBatch) commit() error {
-	// Write data. The head file is not fsync'd after write to avoid
-	// expensive overhead.
+	// Write data. The head file is fsync'd after write to ensure the
+	// data is truly transferred to disk.
 	_, err := batch.t.head.Write(batch.dataBuffer)
 	if err != nil {
+		return err
+	}
+	if err := batch.t.head.Sync(); err != nil {
 		return err
 	}
 	dataSize := int64(len(batch.dataBuffer))

--- a/core/rawdb/freezer_batch.go
+++ b/core/rawdb/freezer_batch.go
@@ -182,7 +182,8 @@ func (batch *freezerTableBatch) maybeCommit() error {
 
 // commit writes the batched items to the backing freezerTable.
 func (batch *freezerTableBatch) commit() error {
-	// Write data.
+	// Write data. The head file is not fsync'd after write to avoid
+	// expensive overhead.
 	_, err := batch.t.head.Write(batch.dataBuffer)
 	if err != nil {
 		return err
@@ -190,9 +191,13 @@ func (batch *freezerTableBatch) commit() error {
 	dataSize := int64(len(batch.dataBuffer))
 	batch.dataBuffer = batch.dataBuffer[:0]
 
-	// Write indices.
+	// Write indices. The index file is fsync'd after write to ensure the
+	// data indexes are truly transferred to disk.
 	_, err = batch.t.index.Write(batch.indexBuffer)
 	if err != nil {
+		return err
+	}
+	if err := batch.t.index.Sync(); err != nil {
 		return err
 	}
 	indexSize := int64(len(batch.indexBuffer))

--- a/core/rawdb/freezer_table.go
+++ b/core/rawdb/freezer_table.go
@@ -215,7 +215,9 @@ func (t *freezerTable) repair() error {
 		if t.readonly {
 			return fmt.Errorf("index file(path: %s, name: %s) size is not a multiple of %d", t.path, t.name, indexEntrySize)
 		}
-		truncateFreezerFile(t.index, stat.Size()-overflow) // New file can't trigger this path
+		if err := truncateFreezerFile(t.index, stat.Size()-overflow); err != nil {
+			return err
+		} // New file can't trigger this path
 	}
 	// Retrieve the file sizes and prepare for truncation
 	if stat, err = t.index.Stat(); err != nil {
@@ -260,8 +262,8 @@ func (t *freezerTable) repair() error {
 	// Print an error log if the index is corrupted due to an incorrect
 	// last index item. While it is theoretically possible to have a zero offset
 	// by storing all zero-size items, it is highly unlikely to occur in practice.
-	if lastIndex.offset == 0 && offsetsSize%indexEntrySize > 1 {
-		log.Error("Corrupted index file detected", "lastOffset", lastIndex.offset, "items", offsetsSize%indexEntrySize-1)
+	if lastIndex.offset == 0 && offsetsSize/indexEntrySize > 1 {
+		log.Error("Corrupted index file detected", "lastOffset", lastIndex.offset, "indexes", offsetsSize/indexEntrySize)
 	}
 	if t.readonly {
 		t.head, err = t.openFile(lastIndex.filenum, openFreezerFileForReadOnly)
@@ -416,6 +418,9 @@ func (t *freezerTable) truncateHead(items uint64) error {
 	if err := truncateFreezerFile(t.index, int64(length+1)*indexEntrySize); err != nil {
 		return err
 	}
+	if err := t.index.Sync(); err != nil {
+		return err
+	}
 	// Calculate the new expected size of the data file and truncate it
 	var expected indexEntry
 	if length == 0 {
@@ -438,11 +443,15 @@ func (t *freezerTable) truncateHead(items uint64) error {
 		// Release any files _after the current head -- both the previous head
 		// and any files which may have been opened for reading
 		t.releaseFilesAfter(expected.filenum, true)
+
 		// Set back the historic head
 		t.head = newHead
 		t.headId = expected.filenum
 	}
 	if err := truncateFreezerFile(t.head, int64(expected.offset)); err != nil {
+		return err
+	}
+	if err := t.head.Sync(); err != nil {
 		return err
 	}
 	// All data files truncated, set internal counters and return
@@ -589,10 +598,12 @@ func (t *freezerTable) Close() error {
 	// error on Windows.
 	doClose(t.index, true, true)
 	doClose(t.meta, true, true)
+
 	// The preopened non-head data-files are all opened in readonly.
 	// The head is opened in rw-mode, so we sync it here - but since it's also
 	// part of t.files, it will be closed in the loop below.
 	doClose(t.head, true, false) // sync but do not close
+
 	for _, f := range t.files {
 		doClose(f, false, true) // close but do not sync
 	}

--- a/core/rawdb/freezer_utils.go
+++ b/core/rawdb/freezer_utils.go
@@ -73,11 +73,7 @@ func copyFrom(srcPath, destPath string, offset uint64, before func(f *os.File) e
 		return err
 	}
 	f = nil
-
-	if err := os.Rename(fname, destPath); err != nil {
-		return err
-	}
-	return nil
+	return os.Rename(fname, destPath)
 }
 
 // openFreezerFileForAppend opens a freezer table file and seeks to the end


### PR DESCRIPTION
This pull request tries to fix an issue in freezer, raised by #28105 

--- 

Let's briefly recap the issue: If a power failure occurs during the execution in path model, Geth may not be able to recover in the subsequent restart.

After investigating a bit further, I discovered that the underlying state freezer is corrupted. Specifically, the freezer has experienced corruption in its index files, which now contain indexes with the values {file_num = 0; offset = 0} at the end.

Upon accessing the freezer table, it will initiate a repair process by truncating the excess bytes in the data file. However, due to the "zero" index at the end, the freezer table truncates the entire data file while retaining the complete index file.

Therefore, freezer table enters a very weird status that items indexes are present but their corresponding data is missing.

--- 

The root cause is why index file will contain zero indexes at the end after the power failure? It turns out it's relevant with OS file management.

According to Linux [manual][(https://man7.org/linux/man-pages/man2/write.2.html), it said that the file size is expanded when we try to write some items at the end of the file. In another word, the file offset will be moved even without flushing the associated data from OS cache from underlying disk.

```
If the file was [open(2)](https://man7.org/linux/man-pages/man2/open.2.html)ed with O_APPEND, the
file offset is first set to the end of the file before writing.
The adjustment of the file offset and the write operation are
performed as an atomic step.
```

This feature is used to ensure concurrent file writers won't overwrite with each other by atomically increasing the file offset.

```
Among the APIs subsequently listed are write() and [writev(2)](https://man7.org/linux/man-pages/man2/writev.2.html).
And among the effects that should be atomic across threads (and
processes) are updates of the file offset.  However, before Linux
3.14, this was not the case: if two processes that share an open
file description (see [open(2)](https://man7.org/linux/man-pages/man2/open.2.html)) perform a write() (or [writev(2)](https://man7.org/linux/man-pages/man2/writev.2.html))
at the same time, then the I/O operations were not atomic with
respect to updating the file offset, with the result that the
blocks of data output by the two processes might (incorrectly)
overlap.  This problem was fixed in Linux 3.14.
```

Also from the [documentation of sqlite](https://www.sqlite.org/draft/atomiccommit.html), it also points out this issue at 6.2

```
When data is appended to the end of the rollback journal, SQLite normally makes the pessimistic assumption
that the file is first extended with invalid "garbage" data and that afterwards the correct data replaces the garbage.

In other words, SQLite assumes that the file size is increased first and then afterwards the content is written 
into the file. If a power failure occurs after the file size has been increased but before the file content has been
written, the rollback journal can be left containing garbage data. If after power is restored, another SQLite process 
sees the rollback journal containing the garbage data and tries to roll it back into the original database file, 
it might copy some of the garbage into the database file and thus corrupt the database file.
``` 

We can conclude that the issue is relevant with the async file write.


---

How to fix the issue in order to survive the power failure?

**Detect the garbage index data and truncate them in the repair stage**

It's a straightforward idea that we can blindly truncate the index items with {0,0} values at the end of the file. However, due to the fact that freezer might store 0-size items, {0, 0} might be a valid index if all previous items + itself are all zero size.

So the opening question is left here how can we avoid this special scenario and correctly detect the garbage data?


**Sync the file after each freezer write**

We can minimize the possibility of having "garbage" zero value index items by SYNC index file after each write.
Once the index file is sync'd, it will ensure the stored index item is complete. But what if the power failure occurs
between the file.Write() and file.Sync()?

Apparently, sqlite uses another marker to track the item number in the index file, and use a two step SYNC approach
to address it. Essentially, it flushes the index file as the first step and then update this marker as the second step. 
In this approach, the marker will be the indicator how many index items we expect and truncate all other above.

This approach is a bit over-complicated and might degrade the performance.
