### PR TITLE
cmd/evm: allow state dump regardless if test passes in statetest

### DIFF
--- a/cmd/evm/staterunner.go
+++ b/cmd/evm/staterunner.go
@@ -116,7 +116,6 @@ func runStateTest(fname string, cfg vm.Config, jsonOut, dump bool) error {
 				if err != nil {
 					// Test failed, mark as so
 					result.Pass, result.Error = false, err.Error()
-
 				}
 			})
 			results = append(results, *result)

--- a/cmd/evm/staterunner.go
+++ b/cmd/evm/staterunner.go
@@ -108,13 +108,15 @@ func runStateTest(fname string, cfg vm.Config, jsonOut, dump bool) error {
 						fmt.Fprintf(os.Stderr, "{\"stateRoot\": \"%#x\"}\n", root)
 					}
 				}
+				// Dump any state to aid debugging
+				if dump {
+					dump := state.RawDump(nil)
+					result.State = &dump
+				}
 				if err != nil {
-					// Test failed, mark as so and dump any state to aid debugging
+					// Test failed, mark as so
 					result.Pass, result.Error = false, err.Error()
-					if dump {
-						dump := state.RawDump(nil)
-						result.State = &dump
-					}
+
 				}
 			})
 			results = append(results, *result)


### PR DESCRIPTION
This just makes it simpler for other `evm` implementations testing against `geth`.