### PR TITLE
miner: fixed default gasPriceOracle min price for private networks

### DIFF
--- a/miner/miner.go
+++ b/miner/miner.go
@@ -58,7 +58,7 @@ type Config struct {
 // DefaultConfig contains default settings for miner.
 var DefaultConfig = Config{
 	GasCeil:  30000000,
-	GasPrice: big.NewInt(params.GWei),
+	GasPrice: big.NewInt(2 * params.Wei),
 
 	// The default recommit time is chosen as two seconds since
 	// consensus-layer usually will wait a half slot of time(6s)


### PR DESCRIPTION
Should fix #27517 and any possibly related gasPrice issues with private networks.

Currently, the default settings for the merge chains allow using the default baseFeePerGas from block header for maxPriorityFeePerGas value for transactions

Example that a tx with 12 wei is mined on Goerli testnet

https://goerli.etherscan.io/tx/0xd3aca9687bdee8ae0e1b2a6ea9c0acb950ed2f1912a4724b7064872cea708ab6

However, with non-merge private networks spawned through Geth ( Clique ) doesn't allow transactions less than 1 gwei to be confirmed by miners which causes problem since many libraries like ethers.js or hardhat uses block.baseFeePerGas value by default which causes unconfirmation of transactions generated by those libraries

https://github.com/ethers-io/ethers.js/blob/main/src.ts/providers/abstract-provider.ts#L915

Therefore, this PR will fix the potential bug and will allow EIP-1559 functionality to be recovered.

( The value 2 wei matches with the default params here https://github.com/ethereum/go-ethereum/blob/master/eth/gasprice/gasprice.go#L39 )