### PR TITLE
ethdb/pebble: add `Errorf` function to panicLogger

### DIFF
--- a/ethdb/pebble/pebble.go
+++ b/ethdb/pebble/pebble.go
@@ -127,6 +127,9 @@ type panicLogger struct{}
 func (l panicLogger) Infof(format string, args ...interface{}) {
 }
 
+func (l panicLogger) Errorf(format string, args ...interface{}) {
+}
+
 func (l panicLogger) Fatalf(format string, args ...interface{}) {
 	panic(errors.Errorf("fatal: "+format, args...))
 }


### PR DESCRIPTION
https://github.com/cockroachdb/pebble/commit/422dce9100554605cb60f1b29e77287d70f540ae added `Errorf` to the Logger interface; add this to `panicLogger` to allow compilation with latest version.