### PR TITLE
eth/filters: exit early if topics-filter has more than 4 topics

### DIFF
--- a/eth/filters/api.go
+++ b/eth/filters/api.go
@@ -29,6 +29,7 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/core/vm"
 	"github.com/ethereum/go-ethereum/internal/ethapi"
 	"github.com/ethereum/go-ethereum/rpc"
 )
@@ -38,6 +39,9 @@ var (
 	errFilterNotFound    = errors.New("filter not found")
 	errInvalidBlockRange = errors.New("invalid block range params")
 )
+
+// The maximum number of topic criteria allowed
+const maxTopics = int(vm.LOG4 - vm.LOG0)
 
 // filter is a helper struct that holds meta information over the filter type
 // and associated subscription in the event system.
@@ -334,6 +338,9 @@ func (api *FilterAPI) NewFilter(crit FilterCriteria) (rpc.ID, error) {
 
 // GetLogs returns logs matching the given argument that are stored within the state.
 func (api *FilterAPI) GetLogs(ctx context.Context, crit FilterCriteria) ([]*types.Log, error) {
+	if len(crit.Topics) > maxTopics {
+		return nil, errInvalidTopic
+	}
 	var filter *Filter
 	if crit.BlockHash != nil {
 		// Block filter requested, construct a single-shot filter

--- a/eth/filters/api.go
+++ b/eth/filters/api.go
@@ -29,7 +29,6 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/core/types"
-	"github.com/ethereum/go-ethereum/core/vm"
 	"github.com/ethereum/go-ethereum/internal/ethapi"
 	"github.com/ethereum/go-ethereum/rpc"
 )
@@ -38,10 +37,11 @@ var (
 	errInvalidTopic      = errors.New("invalid topic(s)")
 	errFilterNotFound    = errors.New("filter not found")
 	errInvalidBlockRange = errors.New("invalid block range params")
+	errExceedMaxTopics   = errors.New("exceed max topics")
 )
 
-// The maximum number of topic criteria allowed
-const maxTopics = int(vm.LOG4 - vm.LOG0)
+// The maximum number of topic criteria allowed, vm.LOG4 - vm.LOG0
+const maxTopics = 4
 
 // filter is a helper struct that holds meta information over the filter type
 // and associated subscription in the event system.
@@ -339,7 +339,7 @@ func (api *FilterAPI) NewFilter(crit FilterCriteria) (rpc.ID, error) {
 // GetLogs returns logs matching the given argument that are stored within the state.
 func (api *FilterAPI) GetLogs(ctx context.Context, crit FilterCriteria) ([]*types.Log, error) {
 	if len(crit.Topics) > maxTopics {
-		return nil, errInvalidTopic
+		return nil, errExceedMaxTopics
 	}
 	var filter *Filter
 	if crit.BlockHash != nil {

--- a/eth/filters/filter_system.go
+++ b/eth/filters/filter_system.go
@@ -300,7 +300,7 @@ func (es *EventSystem) subscribe(sub *subscription) *Subscription {
 // block is "latest". If the fromBlock > toBlock an error is returned.
 func (es *EventSystem) SubscribeLogs(crit ethereum.FilterQuery, logs chan []*types.Log) (*Subscription, error) {
 	if len(crit.Topics) > maxTopics {
-		return nil, errInvalidTopic
+		return nil, errExceedMaxTopics
 	}
 	var from, to rpc.BlockNumber
 	if crit.FromBlock == nil {

--- a/eth/filters/filter_system.go
+++ b/eth/filters/filter_system.go
@@ -299,6 +299,9 @@ func (es *EventSystem) subscribe(sub *subscription) *Subscription {
 // given criteria to the given logs channel. Default value for the from and to
 // block is "latest". If the fromBlock > toBlock an error is returned.
 func (es *EventSystem) SubscribeLogs(crit ethereum.FilterQuery, logs chan []*types.Log) (*Subscription, error) {
+	if len(crit.Topics) > maxTopics {
+		return nil, errInvalidTopic
+	}
 	var from, to rpc.BlockNumber
 	if crit.FromBlock == nil {
 		from = rpc.LatestBlockNumber

--- a/eth/filters/filter_system_test.go
+++ b/eth/filters/filter_system_test.go
@@ -386,6 +386,8 @@ func TestLogFilterCreation(t *testing.T) {
 			{FilterCriteria{FromBlock: big.NewInt(rpc.PendingBlockNumber.Int64()), ToBlock: big.NewInt(100)}, false},
 			// from block "higher" than to block
 			{FilterCriteria{FromBlock: big.NewInt(rpc.PendingBlockNumber.Int64()), ToBlock: big.NewInt(rpc.LatestBlockNumber.Int64())}, false},
+			// topics more then 4
+			{FilterCriteria{Topics: [][]common.Hash{{}, {}, {}, {}, {}}}, false},
 		}
 	)
 
@@ -420,6 +422,7 @@ func TestInvalidLogFilterCreation(t *testing.T) {
 		0: {FromBlock: big.NewInt(rpc.PendingBlockNumber.Int64()), ToBlock: big.NewInt(rpc.LatestBlockNumber.Int64())},
 		1: {FromBlock: big.NewInt(rpc.PendingBlockNumber.Int64()), ToBlock: big.NewInt(100)},
 		2: {FromBlock: big.NewInt(rpc.LatestBlockNumber.Int64()), ToBlock: big.NewInt(100)},
+		3: {Topics: [][]common.Hash{{}, {}, {}, {}, {}}},
 	}
 
 	for i, test := range testCases {
@@ -445,6 +448,7 @@ func TestInvalidGetLogsRequest(t *testing.T) {
 		0: {BlockHash: &blockHash, FromBlock: big.NewInt(100)},
 		1: {BlockHash: &blockHash, ToBlock: big.NewInt(500)},
 		2: {BlockHash: &blockHash, FromBlock: big.NewInt(rpc.LatestBlockNumber.Int64())},
+		3: {BlockHash: &blockHash, Topics: [][]common.Hash{{}, {}, {}, {}, {}}},
 	}
 
 	for i, test := range testCases {


### PR DESCRIPTION
Currently, geth's will return `[]` for any `len(topics) > 4` log filter. If user request a large range of blocks, this will only make geth to do useless works. So maybe we can fast exit if the query topics is invalid at the beginning.

FYI, here is some responses for different client. 

> request

```json
{
  "jsonrpc": "2.0",
  "method": "eth_getLogs",
  "id": 74,
  "params": [
    {
      "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
      "toBlock": "0x11AC43D",
      "fromBlock": "0x11AC43D",
      "topics": [[], [], [], [], []]
    }
  ]
}
```

> reth's response

```json
{
  "error": {
    "code": -32602,
    "data": "exceeded maximum topics len at line 7 column 5",
    "message": "Invalid params"
  },
  "id": 74,
  "jsonrpc": "2.0"
}
```

> erigon's response

```json
{
  "id": 74,
  "jsonrpc": "2.0",
  "result": []
}
```

> and here is the response of geth for this PR

```json
{
  "error": {
    "code": -32000,
    "message": "invalid topic(s)"
  },
  "id": 74,
  "jsonrpc": "2.0"
}
```