### PR TITLE
account/usbwallet: make ledger x discoverable on macos14

### DIFF
--- a/accounts/usbwallet/hub.go
+++ b/accounts/usbwallet/hub.go
@@ -23,6 +23,8 @@ import (
 	"sync/atomic"
 	"time"
 
+	"golang.org/x/exp/slices"
+
 	"github.com/ethereum/go-ethereum/accounts"
 	"github.com/ethereum/go-ethereum/event"
 	"github.com/ethereum/go-ethereum/log"
@@ -48,7 +50,7 @@ type Hub struct {
 	scheme     string                  // Protocol scheme prefixing account and wallet URLs.
 	vendorID   uint16                  // USB vendor identifier used for device discovery
 	productIDs []uint16                // USB product identifiers used for device discovery
-	usageID    uint16                  // USB usage page identifier used for macOS device discovery
+	usageIDs   []uint16                // USB usage page identifier used for macOS device discovery
 	endpointID int                     // USB endpoint identifier used for non-macOS device discovery
 	makeDriver func(log.Logger) driver // Factory method to construct a vendor specific driver
 
@@ -93,22 +95,22 @@ func NewLedgerHub() (*Hub, error) {
 		0x4011, /* HID + WebUSB Ledger Nano X */
 		0x5011, /* HID + WebUSB Ledger Nano S Plus */
 		0x6011, /* HID + WebUSB Ledger Nano FTS */
-	}, 0xffa0, 0, newLedgerDriver)
+	}, []uint16{0xffa0, 0}, 2, newLedgerDriver)
 }
 
 // NewTrezorHubWithHID creates a new hardware wallet manager for Trezor devices.
 func NewTrezorHubWithHID() (*Hub, error) {
-	return newHub(TrezorScheme, 0x534c, []uint16{0x0001 /* Trezor HID */}, 0xff00, 0, newTrezorDriver)
+	return newHub(TrezorScheme, 0x534c, []uint16{0x0001 /* Trezor HID */}, []uint16{0xff00}, 0, newTrezorDriver)
 }
 
 // NewTrezorHubWithWebUSB creates a new hardware wallet manager for Trezor devices with
 // firmware version > 1.8.0
 func NewTrezorHubWithWebUSB() (*Hub, error) {
-	return newHub(TrezorScheme, 0x1209, []uint16{0x53c1 /* Trezor WebUSB */}, 0xffff /* No usage id on webusb, don't match unset (0) */, 0, newTrezorDriver)
+	return newHub(TrezorScheme, 0x1209, []uint16{0x53c1 /* Trezor WebUSB */}, []uint16{0xffff} /* No usage id on webusb, don't match unset (0) */, 0, newTrezorDriver)
 }
 
 // newHub creates a new hardware wallet manager for generic USB devices.
-func newHub(scheme string, vendorID uint16, productIDs []uint16, usageID uint16, endpointID int, makeDriver func(log.Logger) driver) (*Hub, error) {
+func newHub(scheme string, vendorID uint16, productIDs []uint16, usageIDs []uint16, endpointID int, makeDriver func(log.Logger) driver) (*Hub, error) {
 	if !usb.Supported() {
 		return nil, errors.New("unsupported platform")
 	}
@@ -116,7 +118,7 @@ func newHub(scheme string, vendorID uint16, productIDs []uint16, usageID uint16,
 		scheme:     scheme,
 		vendorID:   vendorID,
 		productIDs: productIDs,
-		usageID:    usageID,
+		usageIDs:   usageIDs,
 		endpointID: endpointID,
 		makeDriver: makeDriver,
 		quit:       make(chan chan error),
@@ -186,7 +188,9 @@ func (hub *Hub) refreshWallets() {
 	for _, info := range infos {
 		for _, id := range hub.productIDs {
 			// Windows and Macos use UsageID matching, Linux uses Interface matching
-			if info.ProductID == id && (info.UsagePage == hub.usageID || info.Interface == hub.endpointID) {
+			if info.ProductID == id &&
+				info.Path != "" &&
+				(slices.Contains(hub.usageIDs, info.UsagePage) || info.Interface == hub.endpointID) {
 				devices = append(devices, info)
 				break
 			}

--- a/accounts/usbwallet/hub.go
+++ b/accounts/usbwallet/hub.go
@@ -23,12 +23,11 @@ import (
 	"sync/atomic"
 	"time"
 
-	"golang.org/x/exp/slices"
-
 	"github.com/ethereum/go-ethereum/accounts"
 	"github.com/ethereum/go-ethereum/event"
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/karalabe/usb"
+	"golang.org/x/exp/slices"
 )
 
 // LedgerScheme is the protocol scheme prefixing account and wallet URLs.

--- a/accounts/usbwallet/hub.go
+++ b/accounts/usbwallet/hub.go
@@ -188,9 +188,7 @@ func (hub *Hub) refreshWallets() {
 	for _, info := range infos {
 		for _, id := range hub.productIDs {
 			// Windows and Macos use UsageID matching, Linux uses Interface matching
-			if info.ProductID == id &&
-				info.Path != "" &&
-				(slices.Contains(hub.usageIDs, info.UsagePage) || info.Interface == hub.endpointID) {
+			if info.ProductID == id && info.Path != "" && (slices.Contains(hub.usageIDs, info.UsagePage) || info.Interface == hub.endpointID) {
 				devices = append(devices, info)
 				break
 			}

--- a/accounts/usbwallet/hub.go
+++ b/accounts/usbwallet/hub.go
@@ -185,12 +185,8 @@ func (hub *Hub) refreshWallets() {
 	hub.enumFails.Store(0)
 
 	for _, info := range infos {
-		for _, id := range hub.productIDs {
-			// Windows and Macos use UsageID matching, Linux uses Interface matching
-			if info.ProductID == id && info.Path != "" && (slices.Contains(hub.usageIDs, info.UsagePage) || info.Interface == hub.endpointID) {
-				devices = append(devices, info)
-				break
-			}
+		if hub.matchDevice(info) {
+			devices = append(devices, info)
 		}
 	}
 	if runtime.GOOS == "linux" {
@@ -247,6 +243,13 @@ func (hub *Hub) refreshWallets() {
 	for _, event := range events {
 		hub.updateFeed.Send(event)
 	}
+}
+
+func (hub *Hub) matchDevice(info usb.DeviceInfo) bool {
+	// Windows and Macos use UsageID matching, Linux uses Interface matching
+	return slices.Contains(hub.productIDs, info.ProductID) &&
+		info.Path != "" &&
+		(slices.Contains(hub.usageIDs, info.UsagePage) || info.Interface == hub.endpointID)
 }
 
 // Subscribe implements accounts.Backend, creating an async subscription to


### PR DESCRIPTION
Hi,

I tried using this code to interface with a Ledger X device and I bumped into this error:

``` 
hidapi: failed to open device
``` 

This started happened in my Mac M2 with macos 14 (sonoma). Debugging it I noticed the usb.DeviceInfo path got an empty string, which then failed when Open is called.

Debugging it I found it actually enumerate 3 interfaces, but go-ethereum usbwallet hub arbitrarily picks one based on the `usageID`.  So I decided to change to pick the other two. It eventually worked.

To match additional usageIDs, I converted the field into a slice and ignored matches with empty `Path` as seems like they can't be opened anyways.

Here are the three enumerated devices printed with a simple ` fmt.Printf("enumerate: %#v", infos)` 

``` 
enumerate: []usb.DeviceInfo{

usb.DeviceInfo{Path:"2c97:4015:01", VendorID:0x2c97, ProductID:0x4015, Release:0x0,   Serial:"",     Manufacturer:"",       Product:"",       UsagePage:0x0,    Usage:0x0, Interface:2,  rawDevice:(*usb._Ctype_struct_libusb_device)(0x6000003cc3c0), rawPort:(*uint8)(0x140002e84a8), rawReader:(*uint8)(0x140002e8498), rawWriter:(*uint8)(0x140002e8499)}, 

usb.DeviceInfo{Path:"",             VendorID:0x2c97, ProductID:0x4015, Release:0x201, Serial:"0001", Manufacturer:"Ledger", Product:"Nano X", UsagePage:0xffa0, Usage:0x1, Interface:-1, rawDevice:interface {}(nil), rawPort:(*uint8)(nil), rawReader:(*uint8)(nil), rawWriter:(*uint8)(nil)}, 

usb.DeviceInfo{Path:"",             VendorID:0x2c97, ProductID:0x4015, Release:0x201, Serial:"0001", Manufacturer:"Ledger", Product:"Nano X", UsagePage:0xf1d0, Usage:0x1, Interface:-1, rawDevice:interface {}(nil), rawPort:(*uint8)(nil), rawReader:(*uint8)(nil), rawWriter:(*uint8)(nil)}

}
``` 

### Test

Tested only on macos 14 with a Ledger X. 
Would be interesting if someone can validate this is not breaking other OS and devices before merging. i.e. not sure how Linux and Windows would handle the empty usb.DeviceInfo Path.
