### PR TITLE
.github: add mips-32 test

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -1,0 +1,22 @@
+name: mips32 tests
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: self-hosted
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: 1.21.1
+      - name: Build core tests
+        run: go test -c ./core
+      - name: Run tests
+        run: qemu-mips-static ./core.test


### PR DESCRIPTION
This is an attempt at replacing the Windows 32 appveyor build with something else. mips32 is a prime target as some rollups compile geth to mips in order to build their proofs.

The current version only runs the `core` package. For it to work, devops needs to prepare the self-hosted machine, which should be done next week.