### PR TITLE
les/vflux: run tests in parallel

### DIFF
--- a/les/vflux/client/fillset_test.go
+++ b/les/vflux/client/fillset_test.go
@@ -65,6 +65,8 @@ func (i *testIter) waiting(timeout time.Duration) bool {
 }
 
 func TestFillSet(t *testing.T) {
+	t.Parallel()
+
 	ns := nodestate.NewNodeStateMachine(nil, nil, &mclock.Simulated{}, testSetup)
 	iter := &testIter{
 		waitCh: make(chan struct{}),

--- a/les/vflux/client/queueiterator_test.go
+++ b/les/vflux/client/queueiterator_test.go
@@ -31,10 +31,14 @@ func testNode(i int) *enode.Node {
 }
 
 func TestQueueIteratorFIFO(t *testing.T) {
+	t.Parallel()
+
 	testQueueIterator(t, true)
 }
 
 func TestQueueIteratorLIFO(t *testing.T) {
+	t.Parallel()
+
 	testQueueIterator(t, false)
 }
 

--- a/les/vflux/client/requestbasket_test.go
+++ b/les/vflux/client/requestbasket_test.go
@@ -36,6 +36,8 @@ func checkF64(t *testing.T, name string, value, exp, tol float64) {
 }
 
 func TestServerBasket(t *testing.T) {
+	t.Parallel()
+
 	var s serverBasket
 	s.init(2)
 	// add some requests with different request value factors
@@ -70,6 +72,8 @@ func TestServerBasket(t *testing.T) {
 }
 
 func TestConvertMapping(t *testing.T) {
+	t.Parallel()
+
 	b := requestBasket{items: []basketItem{{3, 3}, {1, 1}, {2, 2}}}
 	oldMap := []string{"req3", "req1", "req2"}
 	newMap := []string{"req1", "req2", "req3", "req4"}
@@ -82,6 +86,8 @@ func TestConvertMapping(t *testing.T) {
 }
 
 func TestReqValueFactor(t *testing.T) {
+	t.Parallel()
+
 	var ref referenceBasket
 	ref.basket = requestBasket{items: make([]basketItem, 4)}
 	for i := range ref.basket.items {
@@ -95,6 +101,8 @@ func TestReqValueFactor(t *testing.T) {
 }
 
 func TestNormalize(t *testing.T) {
+	t.Parallel()
+
 	for cycle := 0; cycle < 100; cycle += 1 {
 		// Initialize data for testing
 		valueRange, lower := 1000000, 1000000
@@ -119,6 +127,8 @@ func TestNormalize(t *testing.T) {
 }
 
 func TestReqValueAdjustment(t *testing.T) {
+	t.Parallel()
+
 	var s1, s2 serverBasket
 	s1.init(3)
 	s2.init(3)

--- a/les/vflux/client/serverpool_test.go
+++ b/les/vflux/client/serverpool_test.go
@@ -326,9 +326,21 @@ func (s *ServerPoolTest) checkNodes(t *testing.T, nodes []int) {
 	}
 }
 
-func TestServerPool(t *testing.T)               { testServerPool(t, false, false) }
-func TestServerPoolWithPreNeg(t *testing.T)     { testServerPool(t, true, false) }
-func TestServerPoolWithPreNegFail(t *testing.T) { testServerPool(t, true, true) }
+func TestServerPool(t *testing.T) {
+	t.Parallel()
+
+	testServerPool(t, false, false)
+}
+func TestServerPoolWithPreNeg(t *testing.T) {
+	t.Parallel()
+
+	testServerPool(t, true, false)
+}
+func TestServerPoolWithPreNegFail(t *testing.T) {
+	t.Parallel()
+
+	testServerPool(t, true, true)
+}
 func testServerPool(t *testing.T, preNeg, fail bool) {
 	s := newServerPoolTest(preNeg, fail)
 	nodes := s.setNodes(100, 200, 200, true, false)
@@ -339,8 +351,16 @@ func testServerPool(t *testing.T, preNeg, fail bool) {
 	s.checkNodes(t, nodes)
 }
 
-func TestServerPoolChangedNodes(t *testing.T)           { testServerPoolChangedNodes(t, false) }
-func TestServerPoolChangedNodesWithPreNeg(t *testing.T) { testServerPoolChangedNodes(t, true) }
+func TestServerPoolChangedNodes(t *testing.T) {
+	t.Parallel()
+
+	testServerPoolChangedNodes(t, false)
+}
+func TestServerPoolChangedNodesWithPreNeg(t *testing.T) {
+	t.Parallel()
+
+	testServerPoolChangedNodes(t, true)
+}
 func testServerPoolChangedNodes(t *testing.T, preNeg bool) {
 	s := newServerPoolTest(preNeg, false)
 	nodes := s.setNodes(100, 200, 200, true, false)
@@ -358,8 +378,14 @@ func testServerPoolChangedNodes(t *testing.T, preNeg bool) {
 	s.stop()
 }
 
-func TestServerPoolRestartNoDiscovery(t *testing.T) { testServerPoolRestartNoDiscovery(t, false) }
+func TestServerPoolRestartNoDiscovery(t *testing.T) {
+	t.Parallel()
+
+	testServerPoolRestartNoDiscovery(t, false)
+}
 func TestServerPoolRestartNoDiscoveryWithPreNeg(t *testing.T) {
+	t.Parallel()
+
 	testServerPoolRestartNoDiscovery(t, true)
 }
 func testServerPoolRestartNoDiscovery(t *testing.T, preNeg bool) {
@@ -377,8 +403,14 @@ func testServerPoolRestartNoDiscovery(t *testing.T, preNeg bool) {
 	s.checkNodes(t, nodes)
 }
 
-func TestServerPoolTrustedNoDiscovery(t *testing.T) { testServerPoolTrustedNoDiscovery(t, false) }
+func TestServerPoolTrustedNoDiscovery(t *testing.T) {
+	t.Parallel()
+
+	testServerPoolTrustedNoDiscovery(t, false)
+}
 func TestServerPoolTrustedNoDiscoveryWithPreNeg(t *testing.T) {
+	t.Parallel()
+
 	testServerPoolTrustedNoDiscovery(t, true)
 }
 func testServerPoolTrustedNoDiscovery(t *testing.T, preNeg bool) {

--- a/les/vflux/client/timestats_test.go
+++ b/les/vflux/client/timestats_test.go
@@ -26,6 +26,8 @@ import (
 )
 
 func TestTransition(t *testing.T) {
+	t.Parallel()
+
 	var epsilon = 0.01
 	var cases = []time.Duration{
 		time.Millisecond, minResponseTime,
@@ -47,6 +49,8 @@ func TestTransition(t *testing.T) {
 var maxResponseWeights = TimeoutWeights(maxResponseTime)
 
 func TestValue(t *testing.T) {
+	t.Parallel()
+
 	noexp := utils.ExpirationFactor{Factor: 1}
 	for i := 0; i < 1000; i++ {
 		max := minResponseTime + time.Duration(rand.Int63n(int64(maxResponseTime-minResponseTime)))
@@ -70,6 +74,8 @@ func TestValue(t *testing.T) {
 }
 
 func TestAddSubExpire(t *testing.T) {
+	t.Parallel()
+
 	var (
 		sum1, sum2                 ResponseTimeStats
 		sum1ValueExp, sum2ValueExp float64
@@ -110,6 +116,8 @@ func TestAddSubExpire(t *testing.T) {
 }
 
 func TestTimeout(t *testing.T) {
+	t.Parallel()
+
 	testTimeoutRange(t, 0, time.Second)
 	testTimeoutRange(t, time.Second, time.Second*2)
 	testTimeoutRange(t, time.Second, maxResponseTime)

--- a/les/vflux/client/valuetracker_test.go
+++ b/les/vflux/client/valuetracker_test.go
@@ -38,6 +38,8 @@ const (
 )
 
 func TestValueTracker(t *testing.T) {
+	t.Parallel()
+
 	db := memorydb.New()
 	clock := &mclock.Simulated{}
 	requestList := make([]RequestInfo, testReqTypes)

--- a/les/vflux/client/wrsiterator_test.go
+++ b/les/vflux/client/wrsiterator_test.go
@@ -37,6 +37,8 @@ var (
 const iterTestNodeCount = 6
 
 func TestWrsIterator(t *testing.T) {
+	t.Parallel()
+
 	ns := nodestate.NewNodeStateMachine(nil, nil, &mclock.Simulated{}, testSetup)
 	w := NewWrsIterator(ns, sfTest2, sfTest3.Or(sfTest4), sfiTestWeight)
 	ns.Start()

--- a/les/vflux/server/balance_test.go
+++ b/les/vflux/server/balance_test.go
@@ -107,6 +107,8 @@ func (b *balanceTestSetup) stop() {
 }
 
 func TestAddBalance(t *testing.T) {
+	t.Parallel()
+
 	b := newBalanceTestSetup(nil, nil, nil)
 	defer b.stop()
 
@@ -143,6 +145,8 @@ func TestAddBalance(t *testing.T) {
 }
 
 func TestSetBalance(t *testing.T) {
+	t.Parallel()
+
 	b := newBalanceTestSetup(nil, nil, nil)
 	defer b.stop()
 	node := b.newNode(1000)
@@ -167,6 +171,8 @@ func TestSetBalance(t *testing.T) {
 }
 
 func TestBalanceTimeCost(t *testing.T) {
+	t.Parallel()
+
 	b := newBalanceTestSetup(nil, nil, nil)
 	defer b.stop()
 	node := b.newNode(1000)
@@ -207,6 +213,8 @@ func TestBalanceTimeCost(t *testing.T) {
 }
 
 func TestBalanceReqCost(t *testing.T) {
+	t.Parallel()
+
 	b := newBalanceTestSetup(nil, nil, nil)
 	defer b.stop()
 	node := b.newNode(1000)
@@ -235,6 +243,8 @@ func TestBalanceReqCost(t *testing.T) {
 }
 
 func TestBalanceToPriority(t *testing.T) {
+	t.Parallel()
+
 	b := newBalanceTestSetup(nil, nil, nil)
 	defer b.stop()
 	node := b.newNode(1000)
@@ -260,6 +270,8 @@ func TestBalanceToPriority(t *testing.T) {
 }
 
 func TestEstimatedPriority(t *testing.T) {
+	t.Parallel()
+
 	b := newBalanceTestSetup(nil, nil, nil)
 	defer b.stop()
 	node := b.newNode(1000000000)
@@ -299,6 +311,8 @@ func TestEstimatedPriority(t *testing.T) {
 }
 
 func TestPositiveBalanceCounting(t *testing.T) {
+	t.Parallel()
+
 	b := newBalanceTestSetup(nil, nil, nil)
 	defer b.stop()
 
@@ -340,6 +354,8 @@ func TestPositiveBalanceCounting(t *testing.T) {
 }
 
 func TestCallbackChecking(t *testing.T) {
+	t.Parallel()
+
 	b := newBalanceTestSetup(nil, nil, nil)
 	defer b.stop()
 	node := b.newNode(1000000)
@@ -363,6 +379,8 @@ func TestCallbackChecking(t *testing.T) {
 }
 
 func TestCallback(t *testing.T) {
+	t.Parallel()
+
 	b := newBalanceTestSetup(nil, nil, nil)
 	defer b.stop()
 	node := b.newNode(1000)
@@ -392,6 +410,8 @@ func TestCallback(t *testing.T) {
 }
 
 func TestBalancePersistence(t *testing.T) {
+	t.Parallel()
+
 	posExp := &utils.Expirer{}
 	negExp := &utils.Expirer{}
 	posExp.SetRate(0, math.Log(2)/float64(time.Hour*2)) // halves every two hours

--- a/les/vflux/server/clientdb_test.go
+++ b/les/vflux/server/clientdb_test.go
@@ -32,6 +32,8 @@ func expval(v uint64) utils.ExpiredValue {
 }
 
 func TestNodeDB(t *testing.T) {
+	t.Parallel()
+
 	ndb := newNodeDB(rawdb.NewMemoryDatabase(), mclock.System{})
 	defer ndb.close()
 
@@ -85,6 +87,8 @@ func TestNodeDB(t *testing.T) {
 }
 
 func TestNodeDBExpiration(t *testing.T) {
+	t.Parallel()
+
 	var (
 		iterated int
 		done     = make(chan struct{}, 1)

--- a/les/vflux/server/clientpool_test.go
+++ b/les/vflux/server/clientpool_test.go
@@ -32,26 +32,38 @@ import (
 const defaultConnectedBias = time.Minute * 3
 
 func TestClientPoolL10C100Free(t *testing.T) {
+	t.Parallel()
+
 	testClientPool(t, 10, 100, 0, true)
 }
 
 func TestClientPoolL40C200Free(t *testing.T) {
+	t.Parallel()
+
 	testClientPool(t, 40, 200, 0, true)
 }
 
 func TestClientPoolL100C300Free(t *testing.T) {
+	t.Parallel()
+
 	testClientPool(t, 100, 300, 0, true)
 }
 
 func TestClientPoolL10C100P4(t *testing.T) {
+	t.Parallel()
+
 	testClientPool(t, 10, 100, 4, false)
 }
 
 func TestClientPoolL40C200P30(t *testing.T) {
+	t.Parallel()
+
 	testClientPool(t, 40, 200, 30, false)
 }
 
 func TestClientPoolL100C300P20(t *testing.T) {
+	t.Parallel()
+
 	testClientPool(t, 100, 300, 20, false)
 }
 
@@ -244,6 +256,8 @@ func testPriorityConnect(t *testing.T, pool *ClientPool, p *poolTestPeer, cap ui
 }
 
 func TestConnectPaidClient(t *testing.T) {
+	t.Parallel()
+
 	var (
 		clock mclock.Simulated
 		db    = rawdb.NewMemoryDatabase()
@@ -260,6 +274,8 @@ func TestConnectPaidClient(t *testing.T) {
 }
 
 func TestConnectPaidClientToSmallPool(t *testing.T) {
+	t.Parallel()
+
 	var (
 		clock mclock.Simulated
 		db    = rawdb.NewMemoryDatabase()
@@ -278,6 +294,8 @@ func TestConnectPaidClientToSmallPool(t *testing.T) {
 }
 
 func TestConnectPaidClientToFullPool(t *testing.T) {
+	t.Parallel()
+
 	var (
 		clock mclock.Simulated
 		db    = rawdb.NewMemoryDatabase()
@@ -304,6 +322,8 @@ func TestConnectPaidClientToFullPool(t *testing.T) {
 }
 
 func TestPaidClientKickedOut(t *testing.T) {
+	t.Parallel()
+
 	var (
 		clock    mclock.Simulated
 		db       = rawdb.NewMemoryDatabase()
@@ -337,6 +357,8 @@ func TestPaidClientKickedOut(t *testing.T) {
 }
 
 func TestConnectFreeClient(t *testing.T) {
+	t.Parallel()
+
 	var (
 		clock mclock.Simulated
 		db    = rawdb.NewMemoryDatabase()
@@ -353,6 +375,8 @@ func TestConnectFreeClient(t *testing.T) {
 }
 
 func TestConnectFreeClientToFullPool(t *testing.T) {
+	t.Parallel()
+
 	var (
 		clock mclock.Simulated
 		db    = rawdb.NewMemoryDatabase()
@@ -381,6 +405,8 @@ func TestConnectFreeClientToFullPool(t *testing.T) {
 }
 
 func TestFreeClientKickedOut(t *testing.T) {
+	t.Parallel()
+
 	var (
 		clock  mclock.Simulated
 		db     = rawdb.NewMemoryDatabase()
@@ -425,6 +451,8 @@ func TestFreeClientKickedOut(t *testing.T) {
 }
 
 func TestPositiveBalanceCalculation(t *testing.T) {
+	t.Parallel()
+
 	var (
 		clock  mclock.Simulated
 		db     = rawdb.NewMemoryDatabase()
@@ -448,6 +476,8 @@ func TestPositiveBalanceCalculation(t *testing.T) {
 }
 
 func TestDowngradePriorityClient(t *testing.T) {
+	t.Parallel()
+
 	var (
 		clock  mclock.Simulated
 		db     = rawdb.NewMemoryDatabase()
@@ -484,6 +514,8 @@ func TestDowngradePriorityClient(t *testing.T) {
 }
 
 func TestNegativeBalanceCalculation(t *testing.T) {
+	t.Parallel()
+
 	var (
 		clock mclock.Simulated
 		db    = rawdb.NewMemoryDatabase()
@@ -523,6 +555,8 @@ func TestNegativeBalanceCalculation(t *testing.T) {
 }
 
 func TestInactiveClient(t *testing.T) {
+	t.Parallel()
+
 	var (
 		clock mclock.Simulated
 		db    = rawdb.NewMemoryDatabase()

--- a/les/vflux/server/prioritypool_test.go
+++ b/les/vflux/server/prioritypool_test.go
@@ -48,6 +48,8 @@ func (c *ppTestClient) estimatePriority(cap uint64, addBalance int64, future, bi
 }
 
 func TestPriorityPool(t *testing.T) {
+	t.Parallel()
+
 	clock := &mclock.Simulated{}
 	setup := newServerSetup()
 	setup.balanceField = setup.setup.NewField("ppTestClient", reflect.TypeOf(&ppTestClient{}))
@@ -160,6 +162,8 @@ func TestPriorityPool(t *testing.T) {
 }
 
 func TestCapacityCurve(t *testing.T) {
+	t.Parallel()
+
 	clock := &mclock.Simulated{}
 	setup := newServerSetup()
 	setup.balanceField = setup.setup.NewField("ppTestClient", reflect.TypeOf(&ppTestClient{}))


### PR DESCRIPTION
Continuation of https://github.com/ethereum/go-ethereum/pull/28506
Run more tests in parallel. I'm currently running on a 2019 intel Mac, so it's a bit slow...
There are more tests that can be parallelized in the `les` package, but I thought it would be nice to split it up into multiple PRs.

```
➜  go-ethereum git:(estensen/parallel-tests-les) ✗ go test ./les/vflux/client -race -count=1
➜  go-ethereum git:(estensen/parallel-tests-les) ✗ go test ./les/vflux/server -race -count=1
// Before
ok  	github.com/ethereum/go-ethereum/les/vflux/client	5.536s
ok  	github.com/ethereum/go-ethereum/les/vflux/server	132.992s
// After 
ok  	github.com/ethereum/go-ethereum/les/vflux/client	2.509s
ok  	github.com/ethereum/go-ethereum/les/vflux/server	32.019s
```