### PR TITLE
accounts/abi: distinguish 'Unpack' error

### DIFF
--- a/accounts/abi/error.go
+++ b/accounts/abi/error.go
@@ -84,10 +84,10 @@ func (e Error) String() string {
 
 func (e *Error) Unpack(data []byte) (interface{}, error) {
 	if len(data) < 4 {
-		return "", errors.New("invalid data for unpacking")
+		return "", errors.New("invalid data for unpacking, length is less than 4")
 	}
 	if !bytes.Equal(data[:4], e.ID[:4]) {
-		return "", errors.New("invalid data for unpacking")
+		return "", errors.New("invalid data for unpacking, first four bytes are not equal with error's signature")
 	}
 	return e.Inputs.Unpack(data[4:])
 }

--- a/accounts/abi/error.go
+++ b/accounts/abi/error.go
@@ -87,7 +87,7 @@ func (e *Error) Unpack(data []byte) (interface{}, error) {
 		return "", fmt.Errorf("invalid data length for unpacking: got %v, want 4", len(data))
 	}
 	if !bytes.Equal(data[:4], e.ID[:4]) {
-		return "", errors.New("invalid data for unpacking, first four bytes are not equal with error's signature")
+		return "", fmt.Errorf("invalid event ID, got %v want %v", data[:4], e.ID[:4])
 	}
 	return e.Inputs.Unpack(data[4:])
 }

--- a/accounts/abi/error.go
+++ b/accounts/abi/error.go
@@ -18,7 +18,6 @@ package abi
 
 import (
 	"bytes"
-	"errors"
 	"fmt"
 	"strings"
 

--- a/accounts/abi/error.go
+++ b/accounts/abi/error.go
@@ -83,7 +83,7 @@ func (e Error) String() string {
 
 func (e *Error) Unpack(data []byte) (interface{}, error) {
 	if len(data) < 4 {
-		return "", fmt.Errorf("invalid data length for unpacking: got %v, want 4", len(data))
+		return "", fmt.Errorf("insufficient data for unpacking: have %d, want at least 4", len(data))
 	}
 	if !bytes.Equal(data[:4], e.ID[:4]) {
 		return "", fmt.Errorf("invalid event ID, got %v want %v", data[:4], e.ID[:4])

--- a/accounts/abi/error.go
+++ b/accounts/abi/error.go
@@ -84,7 +84,7 @@ func (e Error) String() string {
 
 func (e *Error) Unpack(data []byte) (interface{}, error) {
 	if len(data) < 4 {
-		return "", errors.New("invalid data for unpacking, length is less than 4")
+		return "", fmt.Errorf("invalid data length for unpacking: got %v, want 4", len(data))
 	}
 	if !bytes.Equal(data[:4], e.ID[:4]) {
 		return "", errors.New("invalid data for unpacking, first four bytes are not equal with error's signature")

--- a/accounts/abi/error.go
+++ b/accounts/abi/error.go
@@ -86,7 +86,7 @@ func (e *Error) Unpack(data []byte) (interface{}, error) {
 		return "", fmt.Errorf("insufficient data for unpacking: have %d, want at least 4", len(data))
 	}
 	if !bytes.Equal(data[:4], e.ID[:4]) {
-		return "", fmt.Errorf("invalid event ID, got %v want %v", data[:4], e.ID[:4])
+		return "", fmt.Errorf("invalid identifier, have %#x want %#x", data[:4], e.ID[:4])
 	}
 	return e.Inputs.Unpack(data[4:])
 }


### PR DESCRIPTION
In my opinion, if we need to return different errors for different parameter check, we should split them, otherwise we should put them together 
```go
if len(data) < 4 || !bytes.Equal(data[:4], e.ID[:4]) {
	return "", errors.New("invalid data for unpacking")
}
```