### PR TITLE
crypto: change the comment variable order

### DIFF
--- a/crypto/crypto.go
+++ b/crypto/crypto.go
@@ -109,8 +109,8 @@ func CreateAddress(b common.Address, nonce uint64) common.Address {
 	return common.BytesToAddress(Keccak256(data)[12:])
 }
 
-// CreateAddress2 creates an ethereum address given the address bytes, initial
-// contract code hash and a salt.
+// CreateAddress2 creates an ethereum address given the address bytes, a salt
+// and contract code hash.
 func CreateAddress2(b common.Address, salt [32]byte, inithash []byte) common.Address {
 	return common.BytesToAddress(Keccak256([]byte{0xff}, b.Bytes(), salt[:], inithash)[12:])
 }

--- a/crypto/crypto.go
+++ b/crypto/crypto.go
@@ -110,7 +110,7 @@ func CreateAddress(b common.Address, nonce uint64) common.Address {
 }
 
 // CreateAddress2 creates an ethereum address given the address bytes, a salt
-// and contract code hash.
+// and inital contract code hash.
 func CreateAddress2(b common.Address, salt [32]byte, inithash []byte) common.Address {
 	return common.BytesToAddress(Keccak256([]byte{0xff}, b.Bytes(), salt[:], inithash)[12:])
 }


### PR DESCRIPTION
I found that some comments' positions do not match the corresponding code in the repository.

 So I submitted a pull request to fix this issue by adjusting the comments position, hoping to make a basic contribution. Thanks.