### PR TITLE
signer: run tests in parallel

### DIFF
--- a/signer/core/api_test.go
+++ b/signer/core/api_test.go
@@ -169,6 +169,7 @@ func list(ui *headlessUi, api *core.SignerAPI, t *testing.T) ([]common.Address, 
 }
 
 func TestNewAcc(t *testing.T) {
+	t.Parallel()
 	api, control := setup(t)
 	verifyNum := func(num int) {
 		list, err := list(control, api, t)
@@ -235,6 +236,7 @@ func mkTestTx(from common.MixedcaseAddress) apitypes.SendTxArgs {
 }
 
 func TestSignTx(t *testing.T) {
+	t.Parallel()
 	var (
 		list      []common.Address
 		res, res2 *ethapi.SignTransactionResult

--- a/signer/core/apitypes/signed_data_internal_test.go
+++ b/signer/core/apitypes/signed_data_internal_test.go
@@ -27,6 +27,7 @@ import (
 )
 
 func TestBytesPadding(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		Type   string
 		Input  []byte
@@ -87,6 +88,7 @@ func TestBytesPadding(t *testing.T) {
 }
 
 func TestParseAddress(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		Input  interface{}
 		Output []byte // nil => error
@@ -136,6 +138,7 @@ func TestParseAddress(t *testing.T) {
 }
 
 func TestParseBytes(t *testing.T) {
+	t.Parallel()
 	for i, tt := range []struct {
 		v   interface{}
 		exp []byte
@@ -170,6 +173,7 @@ func TestParseBytes(t *testing.T) {
 }
 
 func TestParseInteger(t *testing.T) {
+	t.Parallel()
 	for i, tt := range []struct {
 		t   string
 		v   interface{}
@@ -200,6 +204,7 @@ func TestParseInteger(t *testing.T) {
 }
 
 func TestConvertStringDataToSlice(t *testing.T) {
+	t.Parallel()
 	slice := []string{"a", "b", "c"}
 	var it interface{} = slice
 	_, err := convertDataToSlice(it)
@@ -209,6 +214,7 @@ func TestConvertStringDataToSlice(t *testing.T) {
 }
 
 func TestConvertUint256DataToSlice(t *testing.T) {
+	t.Parallel()
 	slice := []*math.HexOrDecimal256{
 		math.NewHexOrDecimal256(1),
 		math.NewHexOrDecimal256(2),
@@ -222,6 +228,7 @@ func TestConvertUint256DataToSlice(t *testing.T) {
 }
 
 func TestConvertAddressDataToSlice(t *testing.T) {
+	t.Parallel()
 	slice := []common.Address{
 		common.HexToAddress("0x0000000000000000000000000000000000000001"),
 		common.HexToAddress("0x0000000000000000000000000000000000000002"),

--- a/signer/core/apitypes/types_test.go
+++ b/signer/core/apitypes/types_test.go
@@ -19,6 +19,7 @@ package apitypes
 import "testing"
 
 func TestIsPrimitive(t *testing.T) {
+	t.Parallel()
 	// Expected positives
 	for i, tc := range []string{
 		"int24", "int24[]", "uint88", "uint88[]", "uint", "uint[]", "int256", "int256[]",

--- a/signer/core/signed_data_test.go
+++ b/signer/core/signed_data_test.go
@@ -183,6 +183,7 @@ var typedData = apitypes.TypedData{
 }
 
 func TestSignData(t *testing.T) {
+	t.Parallel()
 	api, control := setup(t)
 	//Create two accounts
 	createAccount(control, api, t)
@@ -248,6 +249,7 @@ func TestSignData(t *testing.T) {
 }
 
 func TestDomainChainId(t *testing.T) {
+	t.Parallel()
 	withoutChainID := apitypes.TypedData{
 		Types: apitypes.Types{
 			"EIP712Domain": []apitypes.Type{
@@ -289,6 +291,7 @@ func TestDomainChainId(t *testing.T) {
 }
 
 func TestHashStruct(t *testing.T) {
+	t.Parallel()
 	hash, err := typedData.HashStruct(typedData.PrimaryType, typedData.Message)
 	if err != nil {
 		t.Fatal(err)
@@ -309,6 +312,7 @@ func TestHashStruct(t *testing.T) {
 }
 
 func TestEncodeType(t *testing.T) {
+	t.Parallel()
 	domainTypeEncoding := string(typedData.EncodeType("EIP712Domain"))
 	if domainTypeEncoding != "EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)" {
 		t.Errorf("Expected different encodeType result (got %s)", domainTypeEncoding)
@@ -321,6 +325,7 @@ func TestEncodeType(t *testing.T) {
 }
 
 func TestTypeHash(t *testing.T) {
+	t.Parallel()
 	mailTypeHash := fmt.Sprintf("0x%s", common.Bytes2Hex(typedData.TypeHash(typedData.PrimaryType)))
 	if mailTypeHash != "0xa0cedeb2dc280ba39b857546d74f5549c3a1d7bdc2dd96bf881f76108e23dac2" {
 		t.Errorf("Expected different typeHash result (got %s)", mailTypeHash)
@@ -328,6 +333,7 @@ func TestTypeHash(t *testing.T) {
 }
 
 func TestEncodeData(t *testing.T) {
+	t.Parallel()
 	hash, err := typedData.EncodeData(typedData.PrimaryType, typedData.Message, 0)
 	if err != nil {
 		t.Fatal(err)
@@ -339,6 +345,7 @@ func TestEncodeData(t *testing.T) {
 }
 
 func TestFormatter(t *testing.T) {
+	t.Parallel()
 	var d apitypes.TypedData
 	err := json.Unmarshal([]byte(jsonTypedData), &d)
 	if err != nil {
@@ -368,6 +375,7 @@ func sign(typedData apitypes.TypedData) ([]byte, []byte, error) {
 }
 
 func TestJsonFiles(t *testing.T) {
+	t.Parallel()
 	testfiles, err := os.ReadDir("testdata/")
 	if err != nil {
 		t.Fatalf("failed reading files: %v", err)
@@ -402,6 +410,7 @@ func TestJsonFiles(t *testing.T) {
 // TestFuzzerFiles tests some files that have been found by fuzzing to cause
 // crashes or hangs.
 func TestFuzzerFiles(t *testing.T) {
+	t.Parallel()
 	corpusdir := path.Join("testdata", "fuzzing")
 	testfiles, err := os.ReadDir(corpusdir)
 	if err != nil {
@@ -514,6 +523,7 @@ var gnosisTx = `
 // TestGnosisTypedData tests the scenario where a user submits a full EIP-712
 // struct without using the gnosis-specific endpoint
 func TestGnosisTypedData(t *testing.T) {
+	t.Parallel()
 	var td apitypes.TypedData
 	err := json.Unmarshal([]byte(gnosisTypedData), &td)
 	if err != nil {
@@ -532,6 +542,7 @@ func TestGnosisTypedData(t *testing.T) {
 // TestGnosisCustomData tests the scenario where a user submits only the gnosis-safe
 // specific data, and we fill the TypedData struct on our side
 func TestGnosisCustomData(t *testing.T) {
+	t.Parallel()
 	var tx core.GnosisSafeTx
 	err := json.Unmarshal([]byte(gnosisTx), &tx)
 	if err != nil {
@@ -644,6 +655,7 @@ var gnosisTxWithChainId = `
 `
 
 func TestGnosisTypedDataWithChainId(t *testing.T) {
+	t.Parallel()
 	var td apitypes.TypedData
 	err := json.Unmarshal([]byte(gnosisTypedDataWithChainId), &td)
 	if err != nil {
@@ -662,6 +674,7 @@ func TestGnosisTypedDataWithChainId(t *testing.T) {
 // TestGnosisCustomData tests the scenario where a user submits only the gnosis-safe
 // specific data, and we fill the TypedData struct on our side
 func TestGnosisCustomDataWithChainId(t *testing.T) {
+	t.Parallel()
 	var tx core.GnosisSafeTx
 	err := json.Unmarshal([]byte(gnosisTxWithChainId), &tx)
 	if err != nil {
@@ -813,6 +826,7 @@ var complexTypedData = `
 `
 
 func TestComplexTypedData(t *testing.T) {
+	t.Parallel()
 	var td apitypes.TypedData
 	err := json.Unmarshal([]byte(complexTypedData), &td)
 	if err != nil {
@@ -829,6 +843,7 @@ func TestComplexTypedData(t *testing.T) {
 }
 
 func TestGnosisSafe(t *testing.T) {
+	t.Parallel()
 	// json missing chain id
 	js := "{\n  \"safe\": \"0x899FcB1437DE65DC6315f5a69C017dd3F2837557\",\n  \"to\": \"0x899FcB1437DE65DC6315f5a69C017dd3F2837557\",\n  \"value\": \"0\",\n  \"data\": \"0x0d582f13000000000000000000000000d3ed2b8756b942c98c851722f3bd507a17b4745f0000000000000000000000000000000000000000000000000000000000000005\",\n  \"operation\": 0,\n  \"gasToken\": \"0x0000000000000000000000000000000000000000\",\n  \"safeTxGas\": 0,\n  \"baseGas\": 0,\n  \"gasPrice\": \"0\",\n  \"refundReceiver\": \"0x0000000000000000000000000000000000000000\",\n  \"nonce\": 0,\n  \"executionDate\": null,\n  \"submissionDate\": \"2022-02-23T14:09:00.018475Z\",\n  \"modified\": \"2022-12-01T15:52:21.214357Z\",\n  \"blockNumber\": null,\n  \"transactionHash\": null,\n  \"safeTxHash\": \"0x6f0f5cffee69087c9d2471e477a63cab2ae171cf433e754315d558d8836274f4\",\n  \"executor\": null,\n  \"isExecuted\": false,\n  \"isSuccessful\": null,\n  \"ethGasPrice\": null,\n  \"maxFeePerGas\": null,\n  \"maxPriorityFeePerGas\": null,\n  \"gasUsed\": null,\n  \"fee\": null,\n  \"origin\": \"https://gnosis-safe.io\",\n  \"dataDecoded\": {\n    \"method\": \"addOwnerWithThreshold\",\n    \"parameters\": [\n      {\n        \"name\": \"owner\",\n        \"type\": \"address\",\n        \"value\": \"0xD3Ed2b8756b942c98c851722F3bd507a17B4745F\"\n      },\n      {\n        \"name\": \"_threshold\",\n        \"type\": \"uint256\",\n        \"value\": \"5\"\n      }\n    ]\n  },\n  \"confirmationsRequired\": 4,\n  \"confirmations\": [\n    {\n      \"owner\": \"0x30B714E065B879F5c042A75Bb40a220A0BE27966\",\n      \"submissionDate\": \"2022-03-01T14:56:22Z\",\n      \"transactionHash\": \"0x6d0a9c83ac7578ef3be1f2afce089fb83b619583dfa779b82f4422fd64ff3ee9\",\n      \"signature\": \"0x00000000000000000000000030b714e065b879f5c042a75bb40a220a0be27966000000000000000000000000000000000000000000000000000000000000000001\",\n      \"signatureType\": \"APPROVED_HASH\"\n    },\n    {\n      \"owner\": \"0x8300dFEa25Da0eb744fC0D98c23283F86AB8c10C\",\n      \"submissionDate\": \"2022-12-01T15:52:21.214357Z\",\n      \"transactionHash\": null,\n      \"signature\": \"0xbce73de4cc6ee208e933a93c794dcb8ba1810f9848d1eec416b7be4dae9854c07dbf1720e60bbd310d2159197a380c941cfdb55b3ce58f9dd69efd395d7bef881b\",\n      \"signatureType\": \"EOA\"\n    }\n  ],\n  \"trusted\": true,\n  \"signatures\": null\n}\n"
 	var gnosisTx core.GnosisSafeTx
@@ -984,6 +999,7 @@ var complexTypedDataLCRefType = `
 `
 
 func TestComplexTypedDataWithLowercaseReftype(t *testing.T) {
+	t.Parallel()
 	var td apitypes.TypedData
 	err := json.Unmarshal([]byte(complexTypedDataLCRefType), &td)
 	if err != nil {

--- a/signer/core/validation_test.go
+++ b/signer/core/validation_test.go
@@ -19,6 +19,7 @@ package core
 import "testing"
 
 func TestPasswordValidation(t *testing.T) {
+	t.Parallel()
 	testcases := []struct {
 		pw         string
 		shouldFail bool

--- a/signer/fourbyte/abi_test.go
+++ b/signer/fourbyte/abi_test.go
@@ -52,6 +52,7 @@ func verify(t *testing.T, jsondata, calldata string, exp []interface{}) {
 }
 
 func TestNewUnpacker(t *testing.T) {
+	t.Parallel()
 	type unpackTest struct {
 		jsondata string
 		calldata string
@@ -97,6 +98,7 @@ func TestNewUnpacker(t *testing.T) {
 }
 
 func TestCalldataDecoding(t *testing.T) {
+	t.Parallel()
 	// send(uint256)                              : a52c101e
 	// compareAndApprove(address,uint256,uint256) : 751e1079
 	// issue(address[],uint256)                   : 42958b54
@@ -159,6 +161,7 @@ func TestCalldataDecoding(t *testing.T) {
 }
 
 func TestMaliciousABIStrings(t *testing.T) {
+	t.Parallel()
 	tests := []string{
 		"func(uint256,uint256,[]uint256)",
 		"func(uint256,uint256,uint256,)",

--- a/signer/fourbyte/fourbyte_test.go
+++ b/signer/fourbyte/fourbyte_test.go
@@ -27,6 +27,7 @@ import (
 
 // Tests that all the selectors contained in the 4byte database are valid.
 func TestEmbeddedDatabase(t *testing.T) {
+	t.Parallel()
 	db, err := New()
 	if err != nil {
 		t.Fatal(err)
@@ -55,6 +56,7 @@ func TestEmbeddedDatabase(t *testing.T) {
 
 // Tests that custom 4byte datasets can be handled too.
 func TestCustomDatabase(t *testing.T) {
+	t.Parallel()
 	// Create a new custom 4byte database with no embedded component
 	tmpdir := t.TempDir()
 	filename := fmt.Sprintf("%s/4byte_custom.json", tmpdir)

--- a/signer/fourbyte/fourbyte_test.go
+++ b/signer/fourbyte/fourbyte_test.go
@@ -17,8 +17,8 @@
 package fourbyte
 
 import (
+	"encoding/json"
 	"fmt"
-	"strings"
 	"testing"
 
 	"github.com/ethereum/go-ethereum/accounts/abi"
@@ -32,14 +32,14 @@ func TestEmbeddedDatabase(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	var abistruct abi.ABI
 	for id, selector := range db.embedded {
 		abistring, err := parseSelector(selector)
 		if err != nil {
 			t.Errorf("Failed to convert selector to ABI: %v", err)
 			continue
 		}
-		abistruct, err := abi.JSON(strings.NewReader(string(abistring)))
-		if err != nil {
+		if err := json.Unmarshal(abistring, &abistruct); err != nil {
 			t.Errorf("Failed to parse ABI: %v", err)
 			continue
 		}

--- a/signer/fourbyte/validation_test.go
+++ b/signer/fourbyte/validation_test.go
@@ -73,6 +73,7 @@ type txtestcase struct {
 }
 
 func TestTransactionValidation(t *testing.T) {
+	t.Parallel()
 	var (
 		// use empty db, there are other tests for the abi-specific stuff
 		db = newEmpty()

--- a/signer/rules/rules_test.go
+++ b/signer/rules/rules_test.go
@@ -124,6 +124,7 @@ func initRuleEngine(js string) (*rulesetUI, error) {
 }
 
 func TestListRequest(t *testing.T) {
+	t.Parallel()
 	accs := make([]accounts.Account, 5)
 
 	for i := range accs {
@@ -152,6 +153,7 @@ func TestListRequest(t *testing.T) {
 }
 
 func TestSignTxRequest(t *testing.T) {
+	t.Parallel()
 	js := `
 	function ApproveTx(r){
 		console.log("transaction.from", r.transaction.from);
@@ -244,6 +246,7 @@ func (d *dummyUI) OnSignerStartup(info core.StartupInfo) {
 
 // TestForwarding tests that the rule-engine correctly dispatches requests to the next caller
 func TestForwarding(t *testing.T) {
+	t.Parallel()
 	js := ""
 	ui := &dummyUI{make([]string, 0)}
 	jsBackend := storage.NewEphemeralStorage()
@@ -271,6 +274,7 @@ func TestForwarding(t *testing.T) {
 }
 
 func TestMissingFunc(t *testing.T) {
+	t.Parallel()
 	r, err := initRuleEngine(JS)
 	if err != nil {
 		t.Errorf("Couldn't create evaluator %v", err)
@@ -293,6 +297,7 @@ func TestMissingFunc(t *testing.T) {
 	t.Logf("Err %v", err)
 }
 func TestStorage(t *testing.T) {
+	t.Parallel()
 	js := `
 	function testStorage(){
 		storage.put("mykey", "myvalue")
@@ -455,6 +460,7 @@ func dummySigned(value *big.Int) *types.Transaction {
 }
 
 func TestLimitWindow(t *testing.T) {
+	t.Parallel()
 	r, err := initRuleEngine(ExampleTxWindow)
 	if err != nil {
 		t.Errorf("Couldn't create evaluator %v", err)
@@ -540,6 +546,7 @@ func (d *dontCallMe) OnApprovedTx(tx ethapi.SignTransactionResult) {
 // if it does, that would be bad since developers may rely on that to store data,
 // instead of using the disk-based data storage
 func TestContextIsCleared(t *testing.T) {
+	t.Parallel()
 	js := `
 	function ApproveTx(){
 		if (typeof foobar == 'undefined') {
@@ -571,6 +578,7 @@ func TestContextIsCleared(t *testing.T) {
 }
 
 func TestSignData(t *testing.T) {
+	t.Parallel()
 	js := `function ApproveListing(){
     return "Approve"
 }

--- a/signer/storage/aes_gcm_storage_test.go
+++ b/signer/storage/aes_gcm_storage_test.go
@@ -29,6 +29,7 @@ import (
 )
 
 func TestEncryption(t *testing.T) {
+	t.Parallel()
 	//	key := []byte("AES256Key-32Characters1234567890")
 	//	plaintext := []byte(value)
 	key := []byte("AES256Key-32Characters1234567890")
@@ -51,6 +52,7 @@ func TestEncryption(t *testing.T) {
 }
 
 func TestFileStorage(t *testing.T) {
+	t.Parallel()
 	a := map[string]storedCredential{
 		"secret": {
 			Iv:         common.Hex2Bytes("cdb30036279601aeee60f16b"),
@@ -89,6 +91,7 @@ func TestFileStorage(t *testing.T) {
 	}
 }
 func TestEnd2End(t *testing.T) {
+	t.Parallel()
 	log.Root().SetHandler(log.LvlFilterHandler(log.Lvl(3), log.StreamHandler(colorable.NewColorableStderr(), log.TerminalFormat(true))))
 
 	d := t.TempDir()
@@ -109,6 +112,7 @@ func TestEnd2End(t *testing.T) {
 }
 
 func TestSwappedKeys(t *testing.T) {
+	t.Parallel()
 	// It should not be possible to swap the keys/values, so that
 	// K1:V1, K2:V2 can be swapped into K1:V2, K2:V1
 	log.Root().SetHandler(log.LvlFilterHandler(log.Lvl(3), log.StreamHandler(colorable.NewColorableStderr(), log.TerminalFormat(true))))


### PR DESCRIPTION
Continuation of https://github.com/ethereum/go-ethereum/pull/28506
Run more tests in parallel.

```
go test ./signer/... -race -count=1
// Before
ok  	github.com/ethereum/go-ethereum/signer/core	16.925s
ok  	github.com/ethereum/go-ethereum/signer/core/apitypes	1.487s
ok  	github.com/ethereum/go-ethereum/signer/fourbyte	39.548s
ok  	github.com/ethereum/go-ethereum/signer/rules	3.115s
ok  	github.com/ethereum/go-ethereum/signer/storage	2.306s
// After
ok  	github.com/ethereum/go-ethereum/signer/core	9.835s
ok  	github.com/ethereum/go-ethereum/signer/core/apitypes	1.515s
ok  	github.com/ethereum/go-ethereum/signer/fourbyte	43.597s
ok  	github.com/ethereum/go-ethereum/signer/rules	3.537s
ok  	github.com/ethereum/go-ethereum/signer/storage	2.758s
```