### PR TITLE
build: use scratch as runtime base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,10 +16,11 @@ RUN cd /go-ethereum && go mod download
 ADD . /go-ethereum
 RUN cd /go-ethereum && go run build/ci.go install -static ./cmd/geth
 
-# Pull Geth into a second stage deploy alpine container
-FROM alpine:latest
+# Pull Geth into a second stage deploy container
+FROM scratch
 
-RUN apk add --no-cache ca-certificates
+# Add certificates for HTTPS
+COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 COPY --from=builder /go-ethereum/build/bin/geth /usr/local/bin/
 
 EXPOSE 8545 8546 30303 30303/udp

--- a/Dockerfile.alltools
+++ b/Dockerfile.alltools
@@ -16,10 +16,11 @@ RUN cd /go-ethereum && go mod download
 ADD . /go-ethereum
 RUN cd /go-ethereum && go run build/ci.go install -static
 
-# Pull all binaries into a second stage deploy alpine container
-FROM alpine:latest
+# Pull all binaries into a second stage deploy container
+FROM scratch
 
-RUN apk add --no-cache ca-certificates
+# Add certificates for HTTPS
+COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 COPY --from=builder /go-ethereum/build/bin/* /usr/local/bin/
 
 EXPOSE 8545 8546 30303 30303/udp

--- a/README.md
+++ b/README.md
@@ -154,8 +154,7 @@ docker run -d --name ethereum-node -v /Users/alice/ethereum:/root \
 
 This will start `geth` in snap-sync mode with a DB memory allowance of 1GB, as the
 above command does.  It will also create a persistent volume in your home directory for
-saving your blockchain as well as map the default ports. There is also an `alpine` tag
-available for a slim version of the image.
+saving your blockchain as well as map the default ports.
 
 Do not forget `--http.addr 0.0.0.0`, if you want to access RPC from other containers
 and/or hosts. By default, `geth` binds to the local interface and RPC endpoints are not


### PR DESCRIPTION
Since the compilation is static we can use scratch as a runtime base image. It's a tiny bit smaller and we can copy the certificates from the builder image instead of installing them. Also there are no tools installed anymore.

```
<none>                                  <none>            76593f71afed   3 hours ago     60.3MB
<none>                                  <none>            0451bb08ef59   3 hours ago     67.9MB
```