### PR TITLE
.github: use github actions to run 32-bit linux tests

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -1,0 +1,23 @@
+name: i386 linux tests
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: self-hosted
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: 1.21.4
+      - name: Run tests
+        run: go test ./...
+        env:
+          GOOS: linux
+          GOARCH: 386


### PR DESCRIPTION
This is a 2nd attempt in running 32-bit tests outside of appveryor's 32 bit windows. The previous attempt in #28523 ran into the same problem described in #28378.

As an intermediate approach, this PR will build a  i386, 32-bit linux binary and run it. This works because linux is still able to run i386 binaries without an emulation layer since intel/amd processors are still backwards-compatible.