### PR TITLE
core/types: make 'v' optional for DynamicFeeTx and BlobTx

### DIFF
--- a/core/types/transaction.go
+++ b/core/types/transaction.go
@@ -37,6 +37,9 @@ var (
 	ErrTxTypeNotSupported   = errors.New("transaction type not supported")
 	ErrGasFeeCapTooLow      = errors.New("fee cap less than base fee")
 	errShortTypedTx         = errors.New("typed transaction too short")
+	errInvalidYParity       = errors.New("'yParity' field must be 0 or 1")
+	errVYParityMismatch     = errors.New("'v' and 'yParity' fields do not match")
+	errVYParityMissing      = errors.New("missing 'yParity' or 'v' field in transaction")
 )
 
 // Transaction types.

--- a/core/types/transaction_marshalling.go
+++ b/core/types/transaction_marshalling.go
@@ -294,9 +294,6 @@ func (tx *Transaction) UnmarshalJSON(input []byte) error {
 			return errors.New("missing required field 'input' in transaction")
 		}
 		itx.Data = *dec.Input
-		if dec.V == nil {
-			return errors.New("missing required field 'v' in transaction")
-		}
 		if dec.AccessList != nil {
 			itx.AccessList = *dec.AccessList
 		}
@@ -361,9 +358,6 @@ func (tx *Transaction) UnmarshalJSON(input []byte) error {
 			return errors.New("missing required field 'input' in transaction")
 		}
 		itx.Data = *dec.Input
-		if dec.V == nil {
-			return errors.New("missing required field 'v' in transaction")
-		}
 		if dec.AccessList != nil {
 			itx.AccessList = *dec.AccessList
 		}

--- a/core/types/transaction_marshalling.go
+++ b/core/types/transaction_marshalling.go
@@ -57,18 +57,18 @@ func (tx *txJSON) yParityValue() (*big.Int, error) {
 	if tx.YParity != nil {
 		val := uint64(*tx.YParity)
 		if val != 0 && val != 1 {
-			return nil, errors.New("'yParity' field must be 0 or 1")
+			return nil, errInvalidYParity
 		}
 		bigval := new(big.Int).SetUint64(val)
 		if tx.V != nil && tx.V.ToInt().Cmp(bigval) != 0 {
-			return nil, errors.New("'v' and 'yParity' fields do not match")
+			return nil, errVYParityMismatch
 		}
 		return bigval, nil
 	}
 	if tx.V != nil {
 		return tx.V.ToInt(), nil
 	}
-	return nil, errors.New("missing 'yParity' or 'v' field in transaction")
+	return nil, errVYParityMissing
 }
 
 // MarshalJSON marshals as JSON with a hash.


### PR DESCRIPTION
Removes a redundant check for `dec.V == nil` on transaction types that accept either `V` or `yParity`.

The check is performed by `yParityValue`, so the extra check at `UnmarshalJSON` resulted in the unmarshal failing when the `V` field was missing, but `yParity` was present.

Currently the redundant check was present only in `DynamicFeeTxType` and `BlobTxType`, and was caught during hive testing because besu was returning only `yParity` on `eth_getBlockByNumber` in its blob type transactions, and this is correct as specified by the [API](https://ethereum.github.io/execution-apis/api-documentation/).

Added unit test `TestYParityJSONUnmarshalling`.