### PR TITLE
ethdb/pebble: don't double-close iterator inside pebbleIterator

### DIFF
--- a/ethdb/pebble/pebble.go
+++ b/ethdb/pebble/pebble.go
@@ -609,6 +609,8 @@ func (b *batch) Replay(w ethdb.KeyValueWriter) error {
 
 // pebbleIterator is a wrapper of underlying iterator in storage engine.
 // The purpose of this structure is to implement the missing APIs.
+//
+// The pebble iterator is not thread-safe.
 type pebbleIterator struct {
 	iter     *pebble.Iterator
 	moved    bool

--- a/ethdb/pebble/pebble.go
+++ b/ethdb/pebble/pebble.go
@@ -610,8 +610,9 @@ func (b *batch) Replay(w ethdb.KeyValueWriter) error {
 // pebbleIterator is a wrapper of underlying iterator in storage engine.
 // The purpose of this structure is to implement the missing APIs.
 type pebbleIterator struct {
-	iter  *pebble.Iterator
-	moved bool
+	iter     *pebble.Iterator
+	moved    bool
+	released bool
 }
 
 // NewIterator creates a binary-alphabetical iterator over a subset
@@ -623,7 +624,7 @@ func (d *Database) NewIterator(prefix []byte, start []byte) ethdb.Iterator {
 		UpperBound: upperBound(prefix),
 	})
 	iter.First()
-	return &pebbleIterator{iter: iter, moved: true}
+	return &pebbleIterator{iter: iter, moved: true, released: false}
 }
 
 // Next moves the iterator to the next key/value pair. It returns whether the
@@ -658,4 +659,9 @@ func (iter *pebbleIterator) Value() []byte {
 
 // Release releases associated resources. Release should always succeed and can
 // be called multiple times without causing error.
-func (iter *pebbleIterator) Release() { iter.iter.Close() }
+func (iter *pebbleIterator) Release() {
+	if !iter.released {
+		iter.iter.Close()
+		iter.released = true
+	}
+}


### PR DESCRIPTION
Adds `released` flag to `pebbleIterator` to avoid double closing `cockroachdb/pebble.Iterator` as it is an invalid operation.

Fixes #28565