### PR TITLE
cmd/evm: capitalize evm commands

### DIFF
--- a/cmd/evm/blockrunner.go
+++ b/cmd/evm/blockrunner.go
@@ -40,7 +40,7 @@ var RunFlag = &cli.StringFlag{
 var blockTestCommand = &cli.Command{
 	Action:    blockTestCmd,
 	Name:      "blocktest",
-	Usage:     "executes the given blockchain tests",
+	Usage:     "Executes the given blockchain tests",
 	ArgsUsage: "<file>",
 	Flags:     []cli.Flag{RunFlag},
 }

--- a/cmd/evm/compiler.go
+++ b/cmd/evm/compiler.go
@@ -29,7 +29,7 @@ import (
 var compileCommand = &cli.Command{
 	Action:    compileCmd,
 	Name:      "compile",
-	Usage:     "compiles easm source to evm binary",
+	Usage:     "Compiles easm source to evm binary",
 	ArgsUsage: "<file>",
 }
 

--- a/cmd/evm/disasm.go
+++ b/cmd/evm/disasm.go
@@ -29,7 +29,7 @@ import (
 var disasmCommand = &cli.Command{
 	Action:    disasmCmd,
 	Name:      "disasm",
-	Usage:     "disassembles evm binary",
+	Usage:     "Disassembles evm binary",
 	ArgsUsage: "<file>",
 }
 

--- a/cmd/evm/main.go
+++ b/cmd/evm/main.go
@@ -139,7 +139,7 @@ var (
 var stateTransitionCommand = &cli.Command{
 	Name:    "transition",
 	Aliases: []string{"t8n"},
-	Usage:   "executes a full state transition",
+	Usage:   "Executes a full state transition",
 	Action:  t8ntool.Transition,
 	Flags: []cli.Flag{
 		t8ntool.TraceFlag,
@@ -165,7 +165,7 @@ var stateTransitionCommand = &cli.Command{
 var transactionCommand = &cli.Command{
 	Name:    "transaction",
 	Aliases: []string{"t9n"},
-	Usage:   "performs transaction validation",
+	Usage:   "Performs transaction validation",
 	Action:  t8ntool.Transaction,
 	Flags: []cli.Flag{
 		t8ntool.InputTxsFlag,
@@ -178,7 +178,7 @@ var transactionCommand = &cli.Command{
 var blockBuilderCommand = &cli.Command{
 	Name:    "block-builder",
 	Aliases: []string{"b11r"},
-	Usage:   "builds a block",
+	Usage:   "Builds a block",
 	Action:  t8ntool.BuildBlock,
 	Flags: []cli.Flag{
 		t8ntool.OutputBasedir,

--- a/cmd/evm/runner.go
+++ b/cmd/evm/runner.go
@@ -46,7 +46,7 @@ import (
 var runCommand = &cli.Command{
 	Action:      runCmd,
 	Name:        "run",
-	Usage:       "run arbitrary evm binary",
+	Usage:       "Run arbitrary evm binary",
 	ArgsUsage:   "<code>",
 	Description: `The run command runs arbitrary EVM code.`,
 	Flags:       flags.Merge(vmFlags, traceFlags),


### PR DESCRIPTION
When I used the “evm --help” command, the output displayed the content in the figure below. I noticed that the capitalization was inconsistent.

I standardized the capitalization to make it more consistent and readable.

![WechatIMG24](https://github.com/ethereum/go-ethereum/assets/51777534/3ba5e20f-d149-4031-98ec-5b7fd3027290)

