### PR TITLE
eth/downloader: fix skeleton cleanup

### DIFF
--- a/eth/downloader/beaconsync.go
+++ b/eth/downloader/beaconsync.go
@@ -50,7 +50,8 @@ func newBeaconBackfiller(dl *Downloader, success func()) backfiller {
 }
 
 // suspend cancels any background downloader threads and returns the last header
-// that has been successfully backfilled.
+// that has been successfully backfilled (potentially in a previous run), or the
+// genesis.
 func (b *beaconBackfiller) suspend() *types.Header {
 	// If no filling is running, don't waste cycles
 	b.lock.Lock()

--- a/eth/downloader/downloader.go
+++ b/eth/downloader/downloader.go
@@ -611,6 +611,7 @@ func (d *Downloader) syncWithPeer(p *peerConnection, hash common.Hash, td, ttd *
 			if err := d.lightchain.SetHead(origin); err != nil {
 				return err
 			}
+			log.Info("Truncated excess ancient chain segment", "oldhead", frozen-1, "newhead", origin)
 		}
 	}
 	// Initiate the sync using a concurrent header and content retrieval algorithm

--- a/eth/downloader/skeleton.go
+++ b/eth/downloader/skeleton.go
@@ -1120,52 +1120,46 @@ func (s *skeleton) cleanStales(filled *types.Header) error {
 	number := filled.Number.Uint64()
 	log.Trace("Cleaning stale beacon headers", "filled", number, "hash", filled.Hash())
 
-	// If the filled header is below and discontinuous with the linked subchain,
-	// something's corrupted internally. Report and error and refuse to do anything.
+	// If the filled header is below the linked subchain, something's corrupted
+	// internally. Report and error and refuse to do anything.
 	if number+1 < s.progress.Subchains[0].Tail {
 		return fmt.Errorf("filled header below beacon header tail: %d < %d", number, s.progress.Subchains[0].Tail)
 	}
-	// If nothing is filled, don't bother to do cleanup.
+	// If nothing in subchain is filled, don't bother to do cleanup.
 	if number+1 == s.progress.Subchains[0].Tail {
 		return nil
 	}
-	// Determine the new tail based on the given filled header. If it's still
-	// in the range of skeleton chain, use the next header adjacent to the
-	// filled one (it's expected to link with the filled one, otherwise
-	// something corrupted); otherwise use the filled one if the whole skeleton
-	// chain is consumed.
-	newTail := filled
-	if number < s.progress.Subchains[0].Head {
-		newTail = rawdb.ReadSkeletonHeader(s.db, number+1)
-		if newTail.ParentHash != filled.Hash() {
-			return fmt.Errorf("filled header is discontinuous with subchain: %d %s", number, filled.Hash())
-		}
-	}
-	// Subchain seems trimmable, push the tail forward up to the last
-	// filled header and delete everything before it - if available. In
-	// case we filled past the head, recreate the subchain with a new
-	// head to keep it consistent with the data on disk.
 	var (
-		start = s.progress.Subchains[0].Tail // start deleting from the first known header
-		end   = newTail.Number.Uint64()      // delete skeleton headers before the new tail
+		start uint64
+		end   uint64
 		batch = s.db.NewBatch()
 	)
-	s.progress.Subchains[0].Tail = newTail.Number.Uint64()
-	s.progress.Subchains[0].Next = newTail.ParentHash
+	if number < s.progress.Subchains[0].Head {
+		// The skeleton chain is partially consumed, set the new tail as filled+1.
+		tail := rawdb.ReadSkeletonHeader(s.db, number+1)
+		if tail.ParentHash != filled.Hash() {
+			return fmt.Errorf("filled header is discontinuous with subchain: %d %s", number, filled.Hash())
+		}
+		start, end = s.progress.Subchains[0].Tail, number+1 // remove headers in [tail, filled]
+		s.progress.Subchains[0].Tail = tail.Number.Uint64()
+		s.progress.Subchains[0].Next = tail.ParentHash
+	} else {
+		// The skeleton chain is fully consumed, set both head and tail as filled.
+		start, end = s.progress.Subchains[0].Tail, filled.Number.Uint64() // remove headers in [tail, filled)
+		s.progress.Subchains[0].Tail = filled.Number.Uint64()
+		s.progress.Subchains[0].Next = filled.ParentHash
 
-	// If more headers were filled than available, push the entire subchain
-	// forward to keep tracking the node's block imports.
-	//
-	// Note that the new tail will be the filled one in this case, which is
-	// unexpected, but we cannot do anything else to improve the situation.
-	if s.progress.Subchains[0].Head < number {
-		end = s.progress.Subchains[0].Head + 1 // delete the entire original range, including the head
-		s.progress.Subchains[0].Head = number  // assign a new head (tail is already assigned to this)
+		// If more headers were filled than available, push the entire subchain
+		// forward to keep tracking the node's block imports.
+		if number > s.progress.Subchains[0].Head {
+			end = s.progress.Subchains[0].Head + 1 // delete the entire original range, including the head
+			s.progress.Subchains[0].Head = number  // assign a new head (tail is already assigned to this)
 
-		// The entire original skeleton chain was deleted and a new one
-		// defined. Make sure the new single-header chain gets pushed to
-		// disk to keep internal state consistent.
-		rawdb.WriteSkeletonHeader(batch, filled)
+			// The entire original skeleton chain was deleted and a new one
+			// defined. Make sure the new single-header chain gets pushed to
+			// disk to keep internal state consistent.
+			rawdb.WriteSkeletonHeader(batch, filled)
+		}
 	}
 	// Execute the trimming and the potential rewiring of the progress
 	s.saveSyncStatus(batch)

--- a/eth/downloader/skeleton.go
+++ b/eth/downloader/skeleton.go
@@ -1125,6 +1125,10 @@ func (s *skeleton) cleanStales(filled *types.Header) error {
 	if number+1 < s.progress.Subchains[0].Tail {
 		return fmt.Errorf("filled header below beacon header tail: %d < %d", number, s.progress.Subchains[0].Tail)
 	}
+	// If nothing is filled, don't bother to do cleanup.
+	if number+1 == s.progress.Subchains[0].Tail {
+		return nil
+	}
 	// Determine the new tail based on the given filled header. If it's still
 	// in the range of skeleton chain, use the next header adjacent to the
 	// filled one (it's expected to link with the filled one, otherwise


### PR DESCRIPTION
This pull request fixes a corner case in skeleton header deletion.

The background is Geth uses a backward-sync mechanism to fetch and assemble the skeleton header chain locally (guided by consensus client) and then extend block chain by consuming the skeleton headers. The consumed skeleton headers will be deleted from database to avoid accumulating junks.

The assumption is always held that a complete skeleton header chain is linked with local blockchain, specifically `skeleton.tail.parent == blockchain.head`. However the originally deletion logic always sets the `blockchain.head` as the new tail and delete headers beforehand.

In this fix, the next header of filled block will be regarded as the new tail, to keep the guarantee skeleton chain is linked with blockchain, instead of overlapping with it.

It's not a really critical issue because we just leave one more skeleton header in database, but it will result in some weird behaviors which we really want to avoid. 


---

A: Avoid unexpected chain truncation

Before spinning up a new sync cycle, downloader needs to figure out the common ancestor of local chain and skeleton header chain by function `findBeaconAncestor`.

Due the fact that originally deletion logic sets the tail with the local chain head, the common ancestor will be `chain.head-1`.

Therefore, the excess block along with its other data(e.g. receipts) will be truncated from the ancient store by this logic

```go
	        // Rewind the ancient store and blockchain if reorg happens.
		if origin+1 < frozen {
			if err := d.lightchain.SetHead(origin); err != nil {
				return err
			}
			log.Info("Truncated excess ancient chain segment", "oldhead", frozen-1, "newhead", origin)
		}
```

This behavior is really unexpected in normal cases, should only occur if the network reorg is deeper than our local chain.
Unfortunately It occurs a lot, e.g.

```
Nov 15 18:21:30 ip-10-0-0-11.ec2.internal geth[18425]: INFO [11-15|18:21:30.426] Syncing beacon headers                   downloaded=18,579,869 left=3,223,551  eta=5m40.255s
Nov 15 18:21:30 ip-10-0-0-11.ec2.internal geth[18425]: ERROR[11-15|18:21:30.428] Reject duplicated disable operation
Nov 15 18:21:30 ip-10-0-0-11.ec2.internal geth[18425]: WARN [11-15|18:21:30.430] Rewinding blockchain to block            target=3,223,551
Nov 15 18:21:33 ip-10-0-0-11.ec2.internal geth[18425]: INFO [11-15|18:21:33.424] Loaded most recent local header          number=3,223,551  hash=a0aaff..914938 td=146,234,259,464,463,532,817 age=6y9mo4w
Nov 15 18:21:33 ip-10-0-0-11.ec2.internal geth[18425]: INFO [11-15|18:21:33.424] Loaded most recent local block           number=0          hash=d4e567..cb8fa3 td=17,179,869,184              age=54y7mo3w
Nov 15 18:21:33 ip-10-0-0-11.ec2.internal geth[18425]: INFO [11-15|18:21:33.424] Loaded most recent local snap block      number=3,223,551  hash=a0aaff..914938 td=146,234,259,464,463,532,817 age=6y9mo4w
Nov 15 18:21:33 ip-10-0-0-11.ec2.internal geth[18425]: INFO [11-15|18:21:33.424] Loaded last snap-sync pivot marker       number=18,578,974
Nov 15 18:21:33 ip-10-0-0-11.ec2.internal geth[18425]: ERROR[11-15|18:21:33.424] Failed to reset txpool state             err="missing trie node d7f8974fb5ac78d9ac099b9ad5018bedc2ce0a72dad1827a1709da30580f0544 (path ) layer stale"
Nov 15 18:21:33 ip-10-0-0-11.ec2.internal geth[18425]: ERROR[11-15|18:21:33.424] Failed to reset blobpool state           err="missing trie node d7f8974fb5ac78d9ac099b9ad5018bedc2ce0a72dad1827a1709da30580f0544 (path ) layer stale"
```

I think we can avoid it by applying this fix.

--- 

B: Annoying error log for deleting skeleton headers

`Failed to clean stale beacon headers     err="filled header below beacon header tail: 16554016 < 16554017"` 

This kind of log is pretty common and I realized that the filled header is just one block before the tail. My hunch is we spin up the backfiller but terminate it without extending any blocks into the local chain. It can be avoid with this fix.




