### PR TITLE
Optimize gas estimation

### DIFF
--- a/core/state_transition.go
+++ b/core/state_transition.go
@@ -447,7 +447,7 @@ func (st *StateTransition) TransitionDb() (*ExecutionResult, error) {
 		UsedGas:    st.gasUsed(),
 		Err:        vmerr,
 		ReturnData: ret,
-		GasRefund:	gasRefund,
+		GasRefund:  gasRefund,
 	}, nil
 }
 

--- a/core/state_transition.go
+++ b/core/state_transition.go
@@ -35,6 +35,7 @@ type ExecutionResult struct {
 	UsedGas    uint64 // Total used gas but include the refunded gas
 	Err        error  // Any error encountered during the execution(listed in core/vm/errors.go)
 	ReturnData []byte // Returned data from evm(function result or data supplied with revert opcode)
+	GasRefund  uint64 // Total gas refunded
 }
 
 // Unwrap returns the internal evm error which allows us for further
@@ -445,6 +446,7 @@ func (st *StateTransition) TransitionDb() (*ExecutionResult, error) {
 		UsedGas:    st.gasUsed(),
 		Err:        vmerr,
 		ReturnData: ret,
+		GasRefund:	st.state.GetRefund(),
 	}, nil
 }
 

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -1282,9 +1282,10 @@ func DoEstimateGas(ctx context.Context, b Backend, args TransactionArgs, blockNr
 
 	// Optimization: if the transaction succeeded with gasLimit set to the first execution's 
 	// usedGas + gasRefund, then return that value immediately. Else, continue with the binary search.
-	_, _, err = executeEstimate(ctx, b, args, state.Copy(), header, gasCap, result.UsedGas + result.GasRefund)
-	if err == nil {
-		return hexutil.Uint64(result.UsedGas + result.GasRefund), nil
+	optimisticGasLimit := result.UsedGas + result.GasRefund
+	failed, _, err = executeEstimate(ctx, b, args, state.Copy(), header, gasCap, optimisticGasLimit)
+	if !failed && err == nil {
+		return hexutil.Uint64(optimisticGasLimit), nil
 	}
 
 	// For almost any transaction, the gas consumed by the unconstrained execution above

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -1280,7 +1280,7 @@ func DoEstimateGas(ctx context.Context, b Backend, args TransactionArgs, blockNr
 		return 0, fmt.Errorf("gas required exceeds allowance (%d)", hi)
 	}
 
-	// Optimization: if the transaction succeeded with gasLimit set to the first execution's 
+	// Optimization: if the transaction succeeded with gasLimit set to the first execution's
 	// usedGas + gasRefund, then return that value immediately. Else, continue with the binary search.
 	optimisticGasLimit := result.UsedGas + result.GasRefund
 	failed, _, err = executeEstimate(ctx, b, args, state.Copy(), header, gasCap, optimisticGasLimit)


### PR DESCRIPTION
From my tests, it reduces the number of tx simulations for each gas estimation down from 16-18 to just 2 for most transactions (actually for all the transactions that I've tried).

The gist is that after the first simulation, it optimistically tries a second simulation with `gasLimit` set to `usedGas + gasRefund` and if it succeeds, it returns that value.

This change was inspired by @karalabe's tweet:
https://twitter.com/peter_szilagyi/status/1726884606492999754