### PR TITLE
trie: fix random test generator early terminate

### DIFF
--- a/trie/trie_test.go
+++ b/trie/trie_test.go
@@ -372,6 +372,9 @@ func TestRandomCases(t *testing.T) {
 // Instances of this test are created by Generate.
 type randTest []randTestStep
 
+// compile-time interface check
+var _ quick.Generator = (randTest)(nil)
+
 type randTestStep struct {
 	op    int
 	key   []byte // for opUpdate, opDelete, opGet

--- a/trie/trie_test.go
+++ b/trie/trie_test.go
@@ -394,7 +394,7 @@ const (
 func (randTest) Generate(r *rand.Rand, size int) reflect.Value {
 	var finishedFn = func() bool {
 		size--
-		return size > 0
+		return size == 0
 	}
 	return reflect.ValueOf(generateSteps(finishedFn, r))
 }


### PR DESCRIPTION
This PR is a one-liner change to fix the minor bug in the `randTest.Generate` function.

When generating random tests for the Trie, the Generate function should terminate only when the size reaches 0. However, the current code does the opposite, effectively causing the random Trie tests to be redundant since there are no test cases at all.