### PR TITLE
trie: remove inconsistent trie nodes during sync in path mode

### DIFF
--- a/ethdb/dbtest/testsuite.go
+++ b/ethdb/dbtest/testsuite.go
@@ -273,8 +273,12 @@ func TestDatabaseSuite(t *testing.T, New func() ethdb.KeyValueStore) {
 		b.Put([]byte("5"), nil)
 		b.Delete([]byte("1"))
 		b.Put([]byte("6"), nil)
-		b.Delete([]byte("3"))
+
+		b.Delete([]byte("3")) // delete then put
 		b.Put([]byte("3"), nil)
+
+		b.Put([]byte("7"), nil) // put then delete
+		b.Delete([]byte("7"))
 
 		if err := b.Write(); err != nil {
 			t.Fatal(err)

--- a/trie/sync.go
+++ b/trie/sync.go
@@ -256,7 +256,6 @@ func NewSync(root common.Hash, database ethdb.KeyValueReader, callback LeafCallb
 // parent for completion tracking. The given path is a unique node path in
 // hex format and contain all the parent path if it's layered trie node.
 func (s *Sync) AddSubTrie(root common.Hash, path []byte, parent common.Hash, parentPath []byte, callback LeafCallback) {
-	// Short circuit if the trie is empty.
 	if root == types.EmptyRootHash {
 		return
 	}	

--- a/trie/sync.go
+++ b/trie/sync.go
@@ -258,7 +258,7 @@ func NewSync(root common.Hash, database ethdb.KeyValueReader, callback LeafCallb
 func (s *Sync) AddSubTrie(root common.Hash, path []byte, parent common.Hash, parentPath []byte, callback LeafCallback) {
 	if root == types.EmptyRootHash {
 		return
-	}	
+	}
 	owner, inner := ResolvePath(path)
 	exist, inconsistent := s.hasNode(owner, inner, root)
 	if exist {
@@ -601,7 +601,7 @@ func (s *Sync) children(req *nodeRequest, object node) ([]*nodeRequest, error) {
 				defer pending.Done()
 				owner, inner := ResolvePath(path)
 				exist, inconsistent := s.hasNode(owner, inner, hash)
-				if exist {					
+				if exist {
 					return
 				} else if inconsistent {
 					// There is a pre-existing node with the wrong hash in DB, remove it.

--- a/trie/sync.go
+++ b/trie/sync.go
@@ -428,7 +428,7 @@ func (s *Sync) Commit(dbw ethdb.Batch) error {
 	)
 	for _, op := range s.membatch.nodes {
 		if op.isDelete() {
-			// node deletion is not supported in path mode.
+			// node deletion is only supported in path mode.
 			if op.owner == (common.Hash{}) {
 				rawdb.DeleteAccountTrieNode(dbw, op.path)
 			} else {

--- a/trie/sync.go
+++ b/trie/sync.go
@@ -116,10 +116,9 @@ type LeafCallback func(keys [][]byte, path []byte, leaf []byte, parent common.Ha
 
 // nodeRequest represents a scheduled or already in-flight trie node retrieval request.
 type nodeRequest struct {
-	hash    common.Hash // Hash of the trie node to retrieve
-	path    []byte      // Merkle path leading to this node for prioritization
-	data    []byte      // Data content of the node, cached until all subtrees complete
-	deletes [][]byte    // List of internal path segments for trie nodes to delete
+	hash common.Hash // Hash of the trie node to retrieve
+	path []byte      // Merkle path leading to this node for prioritization
+	data []byte      // Data content of the node, cached until all subtrees complete
 
 	parent   *nodeRequest // Parent state node referencing this entry
 	deps     int          // Number of dependencies before allowed to commit this node
@@ -146,36 +145,83 @@ type CodeSyncResult struct {
 	Data []byte      // Data content of the retrieved bytecode
 }
 
+// nodeOp represents an operation upon the trie node. It can either represent a
+// deletion to the specific node or a node write for persisting retrieved node.
+type nodeOp struct {
+	owner common.Hash // identifier of the trie (empty for account trie)
+	path  []byte      // path from the root to the specified node.
+	blob  []byte      // the content of the node, nil means it's deletion
+	hash  common.Hash // hash of the node content (empty for node deletion)
+}
+
+// isDelete indicates if the operation is a database deletion.
+func (op *nodeOp) isDelete() bool {
+	return len(op.blob) == 0
+}
+
 // syncMemBatch is an in-memory buffer of successfully downloaded but not yet
 // persisted data items.
 type syncMemBatch struct {
-	nodes   map[string][]byte      // In-memory membatch of recently completed nodes
-	hashes  map[string]common.Hash // Hashes of recently completed nodes
-	deletes map[string]struct{}    // List of paths for trie node to delete
-	codes   map[common.Hash][]byte // In-memory membatch of recently completed codes
-	size    uint64                 // Estimated batch-size of in-memory data.
+	scheme string                 // State scheme identifier
+	codes  map[common.Hash][]byte // In-memory batch of recently completed codes
+	nodes  []nodeOp               // In-memory batch of recently completed/deleted nodes
+	size   uint64                 // Estimated batch-size of in-memory data.
 }
 
 // newSyncMemBatch allocates a new memory-buffer for not-yet persisted trie nodes.
-func newSyncMemBatch() *syncMemBatch {
+func newSyncMemBatch(scheme string) *syncMemBatch {
 	return &syncMemBatch{
-		nodes:   make(map[string][]byte),
-		hashes:  make(map[string]common.Hash),
-		deletes: make(map[string]struct{}),
-		codes:   make(map[common.Hash][]byte),
+		scheme: scheme,
+		codes:  make(map[common.Hash][]byte),
 	}
-}
-
-// hasNode reports the trie node with specific path is already cached.
-func (batch *syncMemBatch) hasNode(path []byte) bool {
-	_, ok := batch.nodes[string(path)]
-	return ok
 }
 
 // hasCode reports the contract code with specific hash is already cached.
 func (batch *syncMemBatch) hasCode(hash common.Hash) bool {
 	_, ok := batch.codes[hash]
 	return ok
+}
+
+// addCode caches a contract code database write operation.
+func (batch *syncMemBatch) addCode(hash common.Hash, code []byte) {
+	batch.codes[hash] = code
+	batch.size += common.HashLength + uint64(len(code))
+}
+
+// addNode caches a node database write operation.
+func (batch *syncMemBatch) addNode(owner common.Hash, path []byte, blob []byte, hash common.Hash) {
+	if batch.scheme == rawdb.PathScheme {
+		if owner == (common.Hash{}) {
+			batch.size += uint64(len(path) + len(blob))
+		} else {
+			batch.size += common.HashLength + uint64(len(path)+len(blob))
+		}
+	} else {
+		batch.size += common.HashLength + uint64(len(blob))
+	}
+	batch.nodes = append(batch.nodes, nodeOp{
+		owner: owner,
+		path:  path,
+		blob:  blob,
+		hash:  hash,
+	})
+}
+
+// delNode caches a node database delete operation.
+func (batch *syncMemBatch) delNode(owner common.Hash, path []byte) {
+	if batch.scheme != rawdb.PathScheme {
+		log.Error("Unexpected node deletion", "owner", owner, "path", path, "scheme", batch.scheme)
+		return // deletion is not supported in hash mode.
+	}
+	if owner == (common.Hash{}) {
+		batch.size += uint64(len(path))
+	} else {
+		batch.size += common.HashLength + uint64(len(path))
+	}
+	batch.nodes = append(batch.nodes, nodeOp{
+		owner: owner,
+		path:  path,
+	})
 }
 
 // Sync is the main state trie synchronisation scheduler, which provides yet
@@ -196,7 +242,7 @@ func NewSync(root common.Hash, database ethdb.KeyValueReader, callback LeafCallb
 	ts := &Sync{
 		scheme:   scheme,
 		database: database,
-		membatch: newSyncMemBatch(),
+		membatch: newSyncMemBatch(scheme),
 		nodeReqs: make(map[string]*nodeRequest),
 		codeReqs: make(map[common.Hash]*codeRequest),
 		queue:    prque.New[int64, any](nil), // Ugh, can contain both string and hash, whyyy
@@ -214,11 +260,8 @@ func (s *Sync) AddSubTrie(root common.Hash, path []byte, parent common.Hash, par
 	if root == types.EmptyRootHash {
 		return
 	}
-	if s.membatch.hasNode(path) {
-		return
-	}
 	owner, inner := ResolvePath(path)
-	if rawdb.HasTrieNode(s.database, owner, inner, root, s.scheme) {
+	if s.hasNode(owner, inner, root) {
 		return
 	}
 	// Assemble the new sub-trie sync request
@@ -371,39 +414,39 @@ func (s *Sync) ProcessNode(result NodeSyncResult) error {
 }
 
 // Commit flushes the data stored in the internal membatch out to persistent
-// storage, returning any occurred error.
+// storage, returning any occurred error. The whole data set will be flushed
+// in an atomic database batch.
 func (s *Sync) Commit(dbw ethdb.Batch) error {
 	// Flush the pending node writes into database batch.
 	var (
 		account int
 		storage int
 	)
-	for path, value := range s.membatch.nodes {
-		owner, inner := ResolvePath([]byte(path))
-		if owner == (common.Hash{}) {
-			account += 1
+	for _, op := range s.membatch.nodes {
+		if op.isDelete() {
+			// node deletion is only supported in path mode for which
+			// node hash is not required.
+			rawdb.DeleteTrieNode(dbw, op.owner, op.path, common.Hash{} /* unused */, s.scheme)
+			deletionGauge.Inc(1)
 		} else {
-			storage += 1
+			if op.owner == (common.Hash{}) {
+				account += 1
+			} else {
+				storage += 1
+			}
+			rawdb.WriteTrieNode(dbw, op.owner, op.path, op.hash, op.blob, s.scheme)
 		}
-		rawdb.WriteTrieNode(dbw, owner, inner, s.membatch.hashes[path], value, s.scheme)
 	}
 	accountNodeSyncedGauge.Inc(int64(account))
 	storageNodeSyncedGauge.Inc(int64(storage))
 
-	// Flush the pending node deletes into the database batch.
-	// Please note that each written and deleted node has a
-	// unique path, ensuring no duplication occurs.
-	for path := range s.membatch.deletes {
-		owner, inner := ResolvePath([]byte(path))
-		rawdb.DeleteTrieNode(dbw, owner, inner, common.Hash{} /* unused */, s.scheme)
-	}
 	// Flush the pending code writes into database batch.
 	for hash, value := range s.membatch.codes {
 		rawdb.WriteCode(dbw, hash, value)
 	}
 	codeSyncedGauge.Inc(int64(len(s.membatch.codes)))
 
-	s.membatch = newSyncMemBatch() // reset the batch
+	s.membatch = newSyncMemBatch(s.scheme) // reset the batch
 	return nil
 }
 
@@ -476,12 +519,15 @@ func (s *Sync) children(req *nodeRequest, object node) ([]*nodeRequest, error) {
 		// child as invalid. This is essential in the case of path mode
 		// scheme; otherwise, state healing might overwrite existing child
 		// nodes silently while leaving a dangling parent node within the
-		// range of this internal path on disk. This would break the
-		// guarantee for state healing.
+		// range of this internal path on disk and the persistent state
+		// ends up with a very weird situation that nodes on the same path
+		// are not inconsistent while they all present in disk. This property
+		// would break the guarantee for state healing.
 		//
 		// While it's possible for this shortNode to overwrite a previously
 		// existing full node, the other branches of the fullNode can be
-		// retained as they remain untouched and complete.
+		// retained as they are not accessible with the new shortNode, and
+		// also the whole sub-trie is still untouched and complete.
 		//
 		// This step is only necessary for path mode, as there is no deletion
 		// in hash mode at all.
@@ -498,8 +544,7 @@ func (s *Sync) children(req *nodeRequest, object node) ([]*nodeRequest, error) {
 					exists = rawdb.ExistsStorageTrieNode(s.database, owner, append(inner, key[:i]...))
 				}
 				if exists {
-					req.deletes = append(req.deletes, key[:i])
-					deletionGauge.Inc(1)
+					s.membatch.delNode(owner, append(inner, key[:i]...))
 					log.Debug("Detected dangling node", "owner", owner, "path", append(inner, key[:i]...))
 				}
 			}
@@ -540,32 +585,25 @@ func (s *Sync) children(req *nodeRequest, object node) ([]*nodeRequest, error) {
 		}
 		// If the child references another node, resolve or schedule
 		if node, ok := (child.node).(hashNode); ok {
-			// Try to resolve the node from the local database
-			if s.membatch.hasNode(child.path) {
-				continue
-			}
 			// Check the presence of children concurrently
 			pending.Add(1)
-			go func(child childNode) {
+			go func(path []byte, hash common.Hash) {
 				defer pending.Done()
 
 				// If database says duplicate, then at least the trie node is present
 				// and we hold the assumption that it's NOT legacy contract code.
-				var (
-					chash        = common.BytesToHash(node)
-					owner, inner = ResolvePath(child.path)
-				)
-				if rawdb.HasTrieNode(s.database, owner, inner, chash, s.scheme) {
+				owner, inner := ResolvePath(path)
+				if s.hasNode(owner, inner, hash) {
 					return
 				}
 				// Locally unknown node, schedule for retrieval
 				missing <- &nodeRequest{
-					path:     child.path,
-					hash:     chash,
+					path:     path,
+					hash:     hash,
 					parent:   req,
 					callback: req.callback,
 				}
-			}(child)
+			}(child.path, common.BytesToHash(node))
 		}
 	}
 	pending.Wait()
@@ -587,21 +625,10 @@ func (s *Sync) children(req *nodeRequest, object node) ([]*nodeRequest, error) {
 // committed themselves.
 func (s *Sync) commitNodeRequest(req *nodeRequest) error {
 	// Write the node content to the membatch
-	s.membatch.nodes[string(req.path)] = req.data
-	s.membatch.hashes[string(req.path)] = req.hash
+	owner, path := ResolvePath(req.path)
+	s.membatch.addNode(owner, path, req.data, req.hash)
 
-	// The size tracking refers to the db-batch, not the in-memory data.
-	if s.scheme == rawdb.PathScheme {
-		s.membatch.size += uint64(len(req.path) + len(req.data))
-	} else {
-		s.membatch.size += common.HashLength + uint64(len(req.data))
-	}
-	// Delete the internal nodes which are marked as invalid
-	for _, segment := range req.deletes {
-		path := append(req.path, segment...)
-		s.membatch.deletes[string(path)] = struct{}{}
-		s.membatch.size += uint64(len(path))
-	}
+	// Removed the completed node request
 	delete(s.nodeReqs, string(req.path))
 	s.fetches[len(req.path)]--
 
@@ -622,8 +649,9 @@ func (s *Sync) commitNodeRequest(req *nodeRequest) error {
 // committed themselves.
 func (s *Sync) commitCodeRequest(req *codeRequest) error {
 	// Write the node content to the membatch
-	s.membatch.codes[req.hash] = req.data
-	s.membatch.size += common.HashLength + uint64(len(req.data))
+	s.membatch.addCode(req.hash, req.data)
+
+	// Removed the completed code request
 	delete(s.codeReqs, req.hash)
 	s.fetches[len(req.path)]--
 
@@ -637,6 +665,40 @@ func (s *Sync) commitCodeRequest(req *codeRequest) error {
 		}
 	}
 	return nil
+}
+
+// hasNode reports if the specified trie node is present in database or not.
+//
+// Notably, the existent node should be wiped in path scheme if it's not matched
+// with the requested one, otherwise the persistent state will end up with a
+// weird situation that parent node is inconsistent with children while they
+// are all present in database.
+func (s *Sync) hasNode(owner common.Hash, path []byte, root common.Hash) bool {
+	// If node is run with hash scheme, check the presence with node hash.
+	if s.scheme == rawdb.HashScheme {
+		return rawdb.HasLegacyTrieNode(s.database, root)
+	}
+	// If node is run with path scheme, check the presence with node path.
+	if owner == (common.Hash{}) {
+		blob, hash := rawdb.ReadAccountTrieNode(s.database, path)
+		if hash == root {
+			return true
+		}
+		// Remove the inconsistent node before expanding the path.
+		if len(blob) != 0 {
+			s.membatch.delNode(common.Hash{}, path)
+		}
+		return false
+	}
+	blob, hash := rawdb.ReadStorageTrieNode(s.database, owner, path)
+	if hash == root {
+		return true
+	}
+	// Remove the inconsistent node before expanding the path.
+	if len(blob) != 0 {
+		s.membatch.delNode(owner, path)
+	}
+	return false
 }
 
 // ResolvePath resolves the provided composite node path by separating the


### PR DESCRIPTION
This pull request fixes #28587 

--- 

**State sync recap**

In Geth state sync mechanism, there are two steps: (1) snap sync (2) state healing. In the first stage, Geth will request a batch of states(accounts and storage slots), verify the correctness via range proof and construct the internal merkle tree nodes locally. 

However due to the fact that the retrieved states may be incomplete, lacking either the head or the tail, the locally constructed merkle trie nodes may be inconsistent with the correct one. In order to avoid committing inconsistent trie nodes, the boundary trie nodes are filtered out and this logic is implemented in https://github.com/ethereum/go-ethereum/pull/28327.

After retrieving the states of the entire keyspace, the persistent states, along with their Merkle tree nodes, can still be inconsistent with each other due to differences in sync targets between different sync cycles. To fix this inconsistency, state healing is necessary.

State healing essentially traverses the entire Merkle trie from root to bottom, retrieving any inconsistent nodes and continuously expanding the trie until the entire trie aligns with the provided root node.

---

**What's the issue this pull request trying to fix?**


Originally, in the state healing stage, the inconsistent trie nodes would be left in the database, awaiting overwriting. However, one corner case is not handled: What if the children of this inconsistent node are committed, and the sync cycle is aborted without overwriting this inconsistent one? The persistent state ends up in a weird situation where nodes on the same path are inconsistent with each other.

And, even worse, what if the target of the next sync cycle switches to one that matches the leftover inconsistent node? The entire subtrie won't be expanded because the state healer believes the subtrie must exist and be consistent with the sub-root node.


<img width="892" alt="截屏2023-11-27 下午2 54 48" src="https://github.com/ethereum/go-ethereum/assets/5959481/0bd9262e-5086-43ef-86da-326b43a0f1fe">

Here is an example to demonstrate the situation.

- The original state root is 1
- The current state root is 1'
- State healer detects the inconsistency and expands the node path from 1 to 6
- State healer commits the 6' into database
- Healing is aborted
- The next state root is switched to 1 again
- The original root node 1 is present in database, healing finished

However, the `6'` is left in database, causing the state as corrupted.

Although this corner case is pretty hard to occur, but it's totally possible and #28587 is the example.


---

**How to fix the state healer to address this it?**


This fix is specifically for path mode and not relevant with hash based at all. 

In path mode, whenever the inconsistent nodes are met by state healer, these nodes must be marked as deleted, **from top to bottom**, consistent with the order of traverse.

- If a few nodes are bypassed by a shortNode, should these node be marked as deleted?

Yes. in the picture above, node 3 is bypassed by node 2'. In this case, the node 3 should also be deleted otherwise the leftover 3 will be inconsistent with bottom nodes.

- If a fullNode is replaced by a shortNode and do we need to delete the other branches?

No. These branches are not linked with the trie anymore, and also they are complete. It's totally safe to leave them in disk and they can be re-linked if state switches.

- It might be possible that a node is deleted because of inconsistency and re-written. The delete and write can happen in the same database batch, does leveldb and pebble support it?

Yes, both database engine support mixing delete and write in same batch and there is a test case to prove that in codebase.

