### PR TITLE
crypto/secp256k1: fix 32-bit tests when CGO_ENABLED=0

### DIFF
--- a/crypto/secp256k1/secp256_test.go
+++ b/crypto/secp256k1/secp256_test.go
@@ -2,6 +2,9 @@
 // Use of this source code is governed by a BSD-style license that can be found in
 // the LICENSE file.
 
+//go:build !gofuzz && cgo
+// +build !gofuzz,cgo
+
 package secp256k1
 
 import (


### PR DESCRIPTION
The 32-bit tests are broken because a test file builds regardless of the `CGO_ENABLED` context, when the functions it uses are only availanle when `CGO_ENABLED=1`. This PR makes the two file be both included (or not) depending on the value of `CGO_ENABLED`.