### PR TITLE
accounts/keystore : First replacement failed test fix

### DIFF
--- a/accounts/keystore/account_cache_test.go
+++ b/accounts/keystore/account_cache_test.go
@@ -68,7 +68,7 @@ func waitWatcherStart(ks *KeyStore) bool {
 
 func waitForAccounts(wantAccounts []accounts.Account, ks *KeyStore) error {
 	var list []accounts.Account
-	for t0 := time.Now(); time.Since(t0) < 5*time.Second; time.Sleep(100 * time.Millisecond) {
+	for t0 := time.Now(); time.Since(t0) < 5*time.Second; time.Sleep(200 * time.Millisecond) {
 		list = ks.Accounts()
 		if reflect.DeepEqual(list, wantAccounts) {
 			// ks should have also received change notifications

--- a/accounts/keystore/account_cache_test.go
+++ b/accounts/keystore/account_cache_test.go
@@ -350,7 +350,7 @@ func TestUpdatedKeyfileContents(t *testing.T) {
 		return
 	}
 	// needed so that modTime of `file` is different to its current value after forceCopyFile
-	os.Chtimes(file, time.Now().Add(-time.Second), time.Now().Add(-time.Second))
+	time.Sleep(time.Second)
 
 	// Now replace file contents
 	if err := forceCopyFile(file, cachetestAccounts[1].URL.Path); err != nil {
@@ -366,7 +366,7 @@ func TestUpdatedKeyfileContents(t *testing.T) {
 	}
 
 	// needed so that modTime of `file` is different to its current value after forceCopyFile
-	os.Chtimes(file, time.Now().Add(-time.Second), time.Now().Add(-time.Second))
+	time.Sleep(time.Second)
 
 	// Now replace file contents again
 	if err := forceCopyFile(file, cachetestAccounts[2].URL.Path); err != nil {
@@ -382,7 +382,7 @@ func TestUpdatedKeyfileContents(t *testing.T) {
 	}
 
 	// needed so that modTime of `file` is different to its current value after os.WriteFile
-	os.Chtimes(file, time.Now().Add(-time.Second), time.Now().Add(-time.Second))
+	time.Sleep(time.Second)
 
 	// Now replace file contents with crap
 	if err := os.WriteFile(file, []byte("foo"), 0600); err != nil {


### PR DESCRIPTION
Fix https://github.com/ethereum/go-ethereum/issues/28603
```
--- FAIL: TestUpdatedKeyfileContents (7.13s)
    account_cache_test.go:363: First replacement failed
    account_cache_test.go:364: 
        got  [{0x7EF5A6135f1FD6a02593eEdC869c6D41D934aef8 keystore:///tmp/eth-keystore-updatedkeyfilecontents-test-10585-343632243341291513/aaa}]
        want [{0xf466859eAD1932D743d622CB74FC058882E8648A keystore:///tmp/eth-keystore-updatedkeyfilecontents-test-10585-343632243341291513/aaa}]
FAIL
FAIL	github.com/ethereum/go-ethereum/accounts/keystore	9.953s
FAIL
```
<img width="910" alt="image" src="https://github.com/ethereum/go-ethereum/assets/22344498/f2621398-668c-4b05-8688-f251e29a4403">
