### PR TITLE
core: implement auth and authcall

### DIFF
--- a/core/vm/errors.go
+++ b/core/vm/errors.go
@@ -38,6 +38,7 @@ var (
 	ErrGasUintOverflow          = errors.New("gas uint64 overflow")
 	ErrInvalidCode              = errors.New("invalid code: must not begin with 0xef")
 	ErrNonceUintOverflow        = errors.New("nonce uint64 overflow")
+	ErrAuthorizedNotSet         = errors.New("authcall without setting authorized")
 
 	// errStopToken is an internal token indicating interpreter loop termination,
 	// never returned to outside callers.

--- a/core/vm/gas.go
+++ b/core/vm/gas.go
@@ -51,3 +51,18 @@ func callGas(isEip150 bool, availableGas, base uint64, callCost *uint256.Int) (u
 
 	return callCost.Uint64(), nil
 }
+
+func authCallGas(availableGas, base uint64, callCost *uint256.Int) (uint64, error) {
+	availableGas = availableGas - base
+	gas := availableGas - availableGas/64
+	// If the bit length exceeds 64 bit we know that the newly calculated "gas" for EIP150
+	// is smaller than the requested amount. Therefore we return the new gas instead
+	// of returning an error.
+	if !callCost.IsUint64() || gas < callCost.Uint64() {
+		return gas, nil
+	}
+	if !callCost.IsUint64() {
+		return 0, ErrGasUintOverflow
+	}
+	return callCost.Uint64(), nil
+}

--- a/core/vm/gas_table.go
+++ b/core/vm/gas_table.go
@@ -480,6 +480,41 @@ func gasStaticCall(evm *EVM, contract *Contract, stack *Stack, mem *Memory, memo
 	return gas, nil
 }
 
+func gasAuthCall(evm *EVM, contract *Contract, stack *Stack, mem *Memory, memorySize uint64) (uint64, error) {
+	var (
+		gas            uint64
+		transfersValue = !stack.Back(2).IsZero()
+		address        = common.Address(stack.Back(1).Bytes20())
+	)
+	if transfersValue {
+		if evm.StateDB.Empty(address) {
+			gas += params.CallNewAccountGas
+		} else {
+			gas += params.CallValueTransferGas - params.CallStipend
+		}
+	}
+	memoryGas, err := memoryGasCost(mem, memorySize)
+	if err != nil {
+		return 0, err
+	}
+	var overflow bool
+	if gas, overflow = math.SafeAdd(gas, memoryGas); overflow {
+		return 0, ErrGasUintOverflow
+	}
+
+	evm.callGasTemp, err = callGas(evm.chainRules.IsEIP150, contract.Gas, gas, stack.Back(0))
+	if err != nil {
+		return 0, err
+	}
+	if gas == 0 {
+		evm.callGasTemp = contract.Gas
+	}
+	if gas, overflow = math.SafeAdd(gas, evm.callGasTemp); overflow {
+		return 0, ErrGasUintOverflow
+	}
+	return gas, nil
+}
+
 func gasSelfdestruct(evm *EVM, contract *Contract, stack *Stack, mem *Memory, memorySize uint64) (uint64, error) {
 	var gas uint64
 	// EIP150 homestead gas reprice fork:

--- a/core/vm/interpreter.go
+++ b/core/vm/interpreter.go
@@ -38,9 +38,10 @@ type Config struct {
 // ScopeContext contains the things that are per-call, such as stack and memory,
 // but not transients like pc and gas
 type ScopeContext struct {
-	Memory   *Memory
-	Stack    *Stack
-	Contract *Contract
+	Memory     *Memory
+	Stack      *Stack
+	Contract   *Contract
+	Authorized *common.Address
 }
 
 // MemoryData returns the underlying memory slice. Callers must not modify the contents
@@ -102,6 +103,8 @@ func NewEVMInterpreter(evm *EVM) *EVMInterpreter {
 	case evm.chainRules.IsVerkle:
 		// TODO replace with proper instruction set when fork is specified
 		table = &verkleInstructionSet
+	case evm.chainRules.IsPrague:
+		table = &pragueInstructionSet
 	case evm.chainRules.IsCancun:
 		table = &cancunInstructionSet
 	case evm.chainRules.IsShanghai:

--- a/core/vm/jump_table.go
+++ b/core/vm/jump_table.go
@@ -57,6 +57,7 @@ var (
 	mergeInstructionSet            = newMergeInstructionSet()
 	shanghaiInstructionSet         = newShanghaiInstructionSet()
 	cancunInstructionSet           = newCancunInstructionSet()
+	pragueInstructionSet           = newPraugeInstructionSet()
 	verkleInstructionSet           = newVerkleInstructionSet()
 )
 
@@ -84,6 +85,12 @@ func validate(jt JumpTable) JumpTable {
 func newVerkleInstructionSet() JumpTable {
 	instructionSet := newCancunInstructionSet()
 	enable4762(&instructionSet)
+	return validate(instructionSet)
+}
+
+func newPraugeInstructionSet() JumpTable {
+	instructionSet := newCancunInstructionSet()
+	enable3074(&instructionSet) // EIP-3074 AUTH & AUTHCALL
 	return validate(instructionSet)
 }
 

--- a/core/vm/memory_table.go
+++ b/core/vm/memory_table.go
@@ -56,6 +56,10 @@ func memoryMcopy(stack *Stack) (uint64, bool) {
 	return calcMemSize64(mStart, stack.Back(2)) // stack[2]: length
 }
 
+func memoryAuth(stack *Stack) (uint64, bool) {
+	return calcMemSize64(stack.Back(1), stack.Back(2))
+}
+
 func memoryCreate(stack *Stack) (uint64, bool) {
 	return calcMemSize64(stack.Back(1), stack.Back(2))
 }

--- a/core/vm/opcodes.go
+++ b/core/vm/opcodes.go
@@ -218,6 +218,9 @@ const (
 	DELEGATECALL OpCode = 0xf4
 	CREATE2      OpCode = 0xf5
 
+	AUTH     OpCode = 0xf6
+	AUTHCALL OpCode = 0xf7
+
 	STATICCALL   OpCode = 0xfa
 	REVERT       OpCode = 0xfd
 	INVALID      OpCode = 0xfe
@@ -391,6 +394,8 @@ var opCodeToString = [256]string{
 	CALLCODE:     "CALLCODE",
 	DELEGATECALL: "DELEGATECALL",
 	CREATE2:      "CREATE2",
+	AUTH:         "AUTH",
+	AUTHCALL:     "AUTHCALL",
 	STATICCALL:   "STATICCALL",
 	REVERT:       "REVERT",
 	INVALID:      "INVALID",
@@ -548,6 +553,8 @@ var stringToOp = map[string]OpCode{
 	"LOG4":           LOG4,
 	"CREATE":         CREATE,
 	"CREATE2":        CREATE2,
+	"AUTH":           AUTH,
+	"AUTHCALL":       AUTHCALL,
 	"CALL":           CALL,
 	"RETURN":         RETURN,
 	"CALLCODE":       CALLCODE,

--- a/params/config.go
+++ b/params/config.go
@@ -184,6 +184,7 @@ var (
 		GrayGlacierBlock:              big.NewInt(0),
 		ShanghaiTime:                  newUint64(0),
 		CancunTime:                    newUint64(0),
+		PragueTime:                    newUint64(0),
 		TerminalTotalDifficulty:       big.NewInt(0),
 		TerminalTotalDifficultyPassed: true,
 	}

--- a/params/protocol_params.go
+++ b/params/protocol_params.go
@@ -189,4 +189,7 @@ var (
 	BeaconRootsAddress = common.HexToAddress("0x000F3df6D732807Ef1319fB7B8bB8522d0Beac02")
 	// SystemAddress is where the system-transaction is sent from as per EIP-4788
 	SystemAddress = common.HexToAddress("0xfffffffffffffffffffffffffffffffffffffffe")
+
+	// Magic prefix for EIP-3074 AUTH messages.
+	AuthMagic = byte(0x04)
 )


### PR DESCRIPTION
This is an implementation of [EIP-3074: AUTH and AUTHCALL](https://eips.ethereum.org/EIPS/eip-3074). Still a WIP, I think there may be some bugs in the gas calculations and some edge cases which are not correctly dealt with. But it should be good enough for people wanting to experiment with the `AUTH` and `AUTHCALL` opcodes!

To use, you'll have to be sure the chain is configured to be post-Prague.