### PR TITLE
eth/gasestimator: allow slight estimation error in favor of less iterations

### DIFF
--- a/core/state_transition.go
+++ b/core/state_transition.go
@@ -32,9 +32,10 @@ import (
 // ExecutionResult includes all output after executing given evm
 // message no matter the execution itself is successful or not.
 type ExecutionResult struct {
-	UsedGas    uint64 // Total used gas but include the refunded gas
-	Err        error  // Any error encountered during the execution(listed in core/vm/errors.go)
-	ReturnData []byte // Returned data from evm(function result or data supplied with revert opcode)
+	UsedGas     uint64 // Total used gas, not including the refunded gas
+	RefundedGas uint64 // Total gas refunded after execution
+	Err         error  // Any error encountered during the execution(listed in core/vm/errors.go)
+	ReturnData  []byte // Returned data from evm(function result or data supplied with revert opcode)
 }
 
 // Unwrap returns the internal evm error which allows us for further
@@ -419,12 +420,13 @@ func (st *StateTransition) TransitionDb() (*ExecutionResult, error) {
 		ret, st.gasRemaining, vmerr = st.evm.Call(sender, st.to(), msg.Data, st.gasRemaining, msg.Value)
 	}
 
+	var gasRefund uint64
 	if !rules.IsLondon {
 		// Before EIP-3529: refunds were capped to gasUsed / 2
-		st.refundGas(params.RefundQuotient)
+		gasRefund = st.refundGas(params.RefundQuotient)
 	} else {
 		// After EIP-3529: refunds are capped to gasUsed / 5
-		st.refundGas(params.RefundQuotientEIP3529)
+		gasRefund = st.refundGas(params.RefundQuotientEIP3529)
 	}
 	effectiveTip := msg.GasPrice
 	if rules.IsLondon {
@@ -442,13 +444,14 @@ func (st *StateTransition) TransitionDb() (*ExecutionResult, error) {
 	}
 
 	return &ExecutionResult{
-		UsedGas:    st.gasUsed(),
-		Err:        vmerr,
-		ReturnData: ret,
+		UsedGas:     st.gasUsed(),
+		RefundedGas: gasRefund,
+		Err:         vmerr,
+		ReturnData:  ret,
 	}, nil
 }
 
-func (st *StateTransition) refundGas(refundQuotient uint64) {
+func (st *StateTransition) refundGas(refundQuotient uint64) uint64 {
 	// Apply refund counter, capped to a refund quotient
 	refund := st.gasUsed() / refundQuotient
 	if refund > st.state.GetRefund() {
@@ -463,6 +466,8 @@ func (st *StateTransition) refundGas(refundQuotient uint64) {
 	// Also return remaining gas to the block gas counter so it is
 	// available for the next transaction.
 	st.gp.AddGas(st.gasRemaining)
+
+	return refund
 }
 
 // gasUsed returns the amount of gas used up by the state transition.

--- a/eth/gasestimator/gasestimator.go
+++ b/eth/gasestimator/gasestimator.go
@@ -52,8 +52,8 @@ type Options struct {
 func Estimate(ctx context.Context, call *core.Message, opts *Options, gasCap uint64) (uint64, []byte, error) {
 	// Binary search the gas limit, as it may need to be higher than the amount used
 	var (
-		lo = params.TxGas - 1 // lowest-known gas limit where tx execution fails
-		hi uint64             // lowest-known gas limit where tx execution succeeds
+		lo uint64 // lowest-known gas limit where tx execution fails
+		hi uint64 // lowest-known gas limit where tx execution succeeds
 	)
 	// Determine the highest gas limit can be used during the estimation.
 	hi = opts.Header.GasLimit

--- a/graphql/graphql_test.go
+++ b/graphql/graphql_test.go
@@ -139,7 +139,7 @@ func TestGraphQLBlockSerialization(t *testing.T) {
 		// should return `estimateGas` as decimal
 		{
 			body: `{"query": "{block{ estimateGas(data:{}) }}"}`,
-			want: `{"data":{"block":{"estimateGas":"0xcf08"}}}`,
+			want: `{"data":{"block":{"estimateGas":"0xd221"}}}`,
 			code: 200,
 		},
 		// should return `status` as decimal

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -51,6 +51,10 @@ import (
 	"github.com/tyler-smith/go-bip39"
 )
 
+// estimateGasErrorRatio is the amount of overestimation eth_estimateGas is
+// allowed to produce in order to speed up calculations.
+const estimateGasErrorRatio = 0.015
+
 // EthereumAPI provides an API to access Ethereum related information.
 type EthereumAPI struct {
 	b Backend
@@ -1193,7 +1197,7 @@ func DoEstimateGas(ctx context.Context, b Backend, args TransactionArgs, blockNr
 		Chain:      NewChainContext(ctx, b),
 		Header:     header,
 		State:      state,
-		ErrorRatio: 0.015,
+		ErrorRatio: estimateGasErrorRatio,
 	}
 	// Run the gas estimation andwrap any revertals into a custom return
 	call, err := args.ToMessage(gasCap, header.BaseFee)

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -1189,10 +1189,11 @@ func DoEstimateGas(ctx context.Context, b Backend, args TransactionArgs, blockNr
 	}
 	// Construct the gas estimator option from the user input
 	opts := &gasestimator.Options{
-		Config: b.ChainConfig(),
-		Chain:  NewChainContext(ctx, b),
-		Header: header,
-		State:  state,
+		Config:     b.ChainConfig(),
+		Chain:      NewChainContext(ctx, b),
+		Header:     header,
+		State:      state,
+		ErrorRatio: 0.015,
 	}
 	// Run the gas estimation andwrap any revertals into a custom return
 	call, err := args.ToMessage(gasCap, header.BaseFee)

--- a/internal/ethapi/api_test.go
+++ b/internal/ethapi/api_test.go
@@ -735,7 +735,7 @@ func TestEstimateGas(t *testing.T) {
 			t.Errorf("test %d: want no error, have %v", i, err)
 			continue
 		}
-		if uint64(result) != tc.want {
+		if float64(result) > float64(tc.want)*(1+estimateGasErrorRatio) {
 			t.Errorf("test %d, result mismatch, have\n%v\n, want\n%v\n", i, uint64(result), tc.want)
 		}
 	}


### PR DESCRIPTION
This PR adds three optimisations to gas estimation:

- A precise optimization is trying to return 21000 gas for plain transfers. It does it if there's no contract code at the receiver side and no input data. The call is still simulated before returning 21000 to catch any potential future unaccounted tx cost (like access lists currently). This results in a total iteration count of 1 for plain transfers.
- Introduces an error ratio (currently set to 1.5%) to allow short circuiting the binary search faster by returning a slight overestimate. This reduces the number of needed estimation calls from 18-20 to 7-8 at the cost of overshooting the perfect estimate by 1.5% gas max. Maybe this could be made configurable in the future, but I think it's useful to be more agressive by default than perfect.
- Introduces an optimization from @orenyomtov that tries to "guesstimate" the needed gas as `gasUsed + gasRefund` (I've added a call stipend on top + a 64/63 multiplier to account for gas forwarding rules). Most of the time this estimate will be enough to cover the execution. The original proposal did an early return, but that has a variance of 1-11% error ratio, which is a bit unpredictable, so this PR doens't do an early return, rather uses the result as a `lo` or `hi` cap for the binary search, cutting the iteration count in half most f the time whilst preserving the 1.5% precision.

FWIW, it would most definitely be possible to make the error ratio configurable, but I'm unsure if that's a desirable aspect. If it's configurable via a CLI flag, node operators are incentivised to bump it all the way up as it saves them CPU. This might get weird if different operators run with different limits. On the other hand, if it's configurable via a RPC param to eth_estimateGas, then callers could just yolo it down to 0 error, because why not, they are paying the same, so might as well max out precision. As such, this PR for now picks a percentage that seems small enough to be irrelevant as an overestimate, but forces it upon everyone equally.