### PR TITLE
fix: fix build devtools

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,6 +33,6 @@ devtools:
 	env GOBIN= go install golang.org/x/tools/cmd/stringer@latest
 	env GOBIN= go install github.com/fjl/gencodec@latest
 	env GOBIN= go install github.com/golang/protobuf/protoc-gen-go@latest
-	env GOBIN= go install ./cmd/abigen
+	$(GORUN) build/ci.go install ./cmd/abigen
 	@type "solc" 2> /dev/null || echo 'Please install solc'
 	@type "protoc" 2> /dev/null || echo 'Please install protoc'


### PR DESCRIPTION
fix: fix build devtools 

When I run 
```shell
make devtools
```
It seems that the output directory is empty and I guess it might be better if use file `build/ci.go` to build abigen. 


