### PR TITLE
cmd/evm:fix Env struct json tag

### DIFF
--- a/cmd/evm/README.md
+++ b/cmd/evm/README.md
@@ -88,7 +88,7 @@ type Env struct {
     CurrentTimestamp uint64              `json:"currentTimestamp"`
     Withdrawals      []*Withdrawal       `json:"withdrawals"`
     // optional
-    CurrentDifficulty *big.Int           `json:"currentDifficuly"`
+    CurrentDifficulty *big.Int           `json:"currentDifficulty"`
     CurrentRandom     *big.Int           `json:"currentRandom"`
     CurrentBaseFee    *big.Int           `json:"currentBaseFee"`
     ParentDifficulty  *big.Int           `json:"parentDifficulty"`


### PR DESCRIPTION
Followed the evm/cmd documentation, found that the actual returned json field **currentDifficulty** are not consistent with the description of the documentation.