### PR TITLE
log: remove custom json and logfmt handlers

### DIFF
--- a/cmd/geth/logging_test.go
+++ b/cmd/geth/logging_test.go
@@ -62,7 +62,7 @@ func censor(input string, start, end int) string {
 func TestLogging(t *testing.T) {
 	t.Parallel()
 	testConsoleLogging(t, "terminal", 6, 24)
-	testConsoleLogging(t, "logfmt", 2, 26)
+	testConsoleLogging(t, "logfmt", 5, 34)
 }
 
 func testConsoleLogging(t *testing.T, format string, tStart, tEnd int) {

--- a/cmd/geth/testdata/logging/logtest-json.txt
+++ b/cmd/geth/testdata/logging/logtest-json.txt
@@ -48,5 +48,5 @@
 {"time":"2023-11-22T15:42:00.40835+08:00","level":"INFO","msg":"raw nil","res":null}
 {"time":"2023-11-22T15:42:00.408354+08:00","level":"INFO","msg":"(*uint64)(nil)","res":null}
 {"time":"2023-11-22T15:42:00.408361+08:00","level":"INFO","msg":"Using keys 't', 'level', 'time', 'level' and 'msg'","time":"time","t":"t","level":"level","lvl":"lvl","msg":"msg"}
-{"time":"2023-11-29T15:13:00.195655931+01:00","level":"INFO","msg":"Odd pair (1 attr)","key":null,"LOG_ERROR":"Normalized odd number of arguments by adding nil"}
-{"time":"2023-11-29T15:13:00.195681832+01:00","level":"INFO","msg":"Odd pair (3 attr)","key":"value","key2":null,"LOG_ERROR":"Normalized odd number of arguments by adding nil"}
+{"time":"2023-11-29T15:13:00.195655931+01:00","level":"INFO","msg":"Odd pair (1 attr)","!BADKEY":"key"}
+{"time":"2023-11-29T15:13:00.195681832+01:00","level":"INFO","msg":"Odd pair (3 attr)","key":"value","!BADKEY":"key2"}

--- a/cmd/geth/testdata/logging/logtest-json.txt
+++ b/cmd/geth/testdata/logging/logtest-json.txt
@@ -1,52 +1,52 @@
-{"t":"2023-11-22T15:42:00.407963+08:00","lvl":"info","msg":"big.Int","111,222,333,444,555,678,999":"111222333444555678999"}
-{"t":"2023-11-22T15:42:00.408084+08:00","lvl":"info","msg":"-big.Int","-111,222,333,444,555,678,999":"-111222333444555678999"}
-{"t":"2023-11-22T15:42:00.408092+08:00","lvl":"info","msg":"big.Int","11,122,233,344,455,567,899,900":"11122233344455567899900"}
-{"t":"2023-11-22T15:42:00.408097+08:00","lvl":"info","msg":"-big.Int","-11,122,233,344,455,567,899,900":"-11122233344455567899900"}
-{"t":"2023-11-22T15:42:00.408127+08:00","lvl":"info","msg":"uint256","111,222,333,444,555,678,999":"111222333444555678999"}
-{"t":"2023-11-22T15:42:00.408133+08:00","lvl":"info","msg":"uint256","11,122,233,344,455,567,899,900":"11122233344455567899900"}
-{"t":"2023-11-22T15:42:00.408137+08:00","lvl":"info","msg":"int64","1,000,000":1000000}
-{"t":"2023-11-22T15:42:00.408145+08:00","lvl":"info","msg":"int64","-1,000,000":-1000000}
-{"t":"2023-11-22T15:42:00.408149+08:00","lvl":"info","msg":"int64","9,223,372,036,854,775,807":9223372036854775807}
-{"t":"2023-11-22T15:42:00.408153+08:00","lvl":"info","msg":"int64","-9,223,372,036,854,775,808":-9223372036854775808}
-{"t":"2023-11-22T15:42:00.408156+08:00","lvl":"info","msg":"uint64","1,000,000":1000000}
-{"t":"2023-11-22T15:42:00.40816+08:00","lvl":"info","msg":"uint64","18,446,744,073,709,551,615":18446744073709551615}
-{"t":"2023-11-22T15:42:00.408164+08:00","lvl":"info","msg":"Special chars in value","key":"special \r\n\t chars"}
-{"t":"2023-11-22T15:42:00.408167+08:00","lvl":"info","msg":"Special chars in key","special \n\t chars":"value"}
-{"t":"2023-11-22T15:42:00.408171+08:00","lvl":"info","msg":"nospace","nospace":"nospace"}
-{"t":"2023-11-22T15:42:00.408174+08:00","lvl":"info","msg":"with space","with nospace":"with nospace"}
-{"t":"2023-11-22T15:42:00.408178+08:00","lvl":"info","msg":"Bash escapes in value","key":"\u001b[1G\u001b[K\u001b[1A"}
-{"t":"2023-11-22T15:42:00.408182+08:00","lvl":"info","msg":"Bash escapes in key","\u001b[1G\u001b[K\u001b[1A":"value"}
-{"t":"2023-11-22T15:42:00.408186+08:00","lvl":"info","msg":"Bash escapes in message  \u001b[1G\u001b[K\u001b[1A end","key":"value"}
-{"t":"2023-11-22T15:42:00.408194+08:00","lvl":"info","msg":"\u001b[35mColored\u001b[0m[","\u001b[35mColored\u001b[0m[":"\u001b[35mColored\u001b[0m["}
-{"t":"2023-11-22T15:42:00.408197+08:00","lvl":"info","msg":"an error message with quotes","error":"this is an 'error'"}
-{"t":"2023-11-22T15:42:00.408202+08:00","lvl":"info","msg":"Custom Stringer value","2562047h47m16.854s":"2562047h47m16.854s"}
-{"t":"2023-11-22T15:42:00.408208+08:00","lvl":"info","msg":"a custom stringer that emits quoted text","output":"output with 'quotes'"}
-{"t":"2023-11-22T15:42:00.408219+08:00","lvl":"info","msg":"A message with wonky 💩 characters"}
-{"t":"2023-11-22T15:42:00.408222+08:00","lvl":"info","msg":"A multiline message \nINFO [10-18|14:11:31.106] with wonky characters 💩"}
-{"t":"2023-11-22T15:42:00.408226+08:00","lvl":"info","msg":"A multiline message \nLALA [ZZZZZZZZZZZZZZZZZZ] Actually part of message above"}
-{"t":"2023-11-22T15:42:00.408229+08:00","lvl":"info","msg":"boolean","true":true,"false":false}
-{"t":"2023-11-22T15:42:00.408234+08:00","lvl":"info","msg":"repeated-key 1","foo":"alpha","foo":"beta"}
-{"t":"2023-11-22T15:42:00.408237+08:00","lvl":"info","msg":"repeated-key 2","xx":"short","xx":"longer"}
-{"t":"2023-11-22T15:42:00.408241+08:00","lvl":"info","msg":"log at level info"}
-{"t":"2023-11-22T15:42:00.408244+08:00","lvl":"warn","msg":"log at level warn"}
-{"t":"2023-11-22T15:42:00.408247+08:00","lvl":"eror","msg":"log at level error"}
-{"t":"2023-11-22T15:42:00.408251+08:00","lvl":"info","msg":"test","bar":"short","a":"aligned left"}
-{"t":"2023-11-22T15:42:00.408254+08:00","lvl":"info","msg":"test","bar":"a long message","a":1}
-{"t":"2023-11-22T15:42:00.408258+08:00","lvl":"info","msg":"test","bar":"short","a":"aligned right"}
-{"t":"2023-11-22T15:42:00.408261+08:00","lvl":"info","msg":"The following logs should align so that the key-fields make 5 columns"}
-{"t":"2023-11-22T15:42:00.408275+08:00","lvl":"info","msg":"Inserted known block","number":1012,"hash":"0x0000000000000000000000000000000000000000000000000000000000001234","txs":200,"gas":1123123,"other":"first"}
-{"t":"2023-11-22T15:42:00.408281+08:00","lvl":"info","msg":"Inserted new block","number":1,"hash":"0x0000000000000000000000000000000000000000000000000000000000001235","txs":2,"gas":1123,"other":"second"}
-{"t":"2023-11-22T15:42:00.408287+08:00","lvl":"info","msg":"Inserted known block","number":99,"hash":"0x0000000000000000000000000000000000000000000000000000000000012322","txs":10,"gas":1,"other":"third"}
-{"t":"2023-11-22T15:42:00.408296+08:00","lvl":"warn","msg":"Inserted known block","number":1012,"hash":"0x0000000000000000000000000000000000000000000000000000000000001234","txs":200,"gas":99,"other":"fourth"}
-{"t":"2023-11-22T15:42:00.4083+08:00","lvl":"info","msg":"(*big.Int)(nil)","<nil>":"<nil>"}
-{"t":"2023-11-22T15:42:00.408303+08:00","lvl":"info","msg":"(*uint256.Int)(nil)","<nil>":"<nil>"}
-{"t":"2023-11-22T15:42:00.408311+08:00","lvl":"info","msg":"(fmt.Stringer)(nil)","res":null}
-{"t":"2023-11-22T15:42:00.408318+08:00","lvl":"info","msg":"nil-concrete-stringer","res":"<nil>"}
-{"t":"2023-11-22T15:42:00.408322+08:00","lvl":"info","msg":"error(nil) ","res":null}
-{"t":"2023-11-22T15:42:00.408326+08:00","lvl":"info","msg":"nil-concrete-error","res":""}
-{"t":"2023-11-22T15:42:00.408334+08:00","lvl":"info","msg":"nil-custom-struct","res":null}
-{"t":"2023-11-22T15:42:00.40835+08:00","lvl":"info","msg":"raw nil","res":null}
-{"t":"2023-11-22T15:42:00.408354+08:00","lvl":"info","msg":"(*uint64)(nil)","res":null}
-{"t":"2023-11-22T15:42:00.408361+08:00","lvl":"info","msg":"Using keys 't', 'lvl', 'time', 'level' and 'msg'","t":"t","time":"time","lvl":"lvl","level":"level","msg":"msg"}
-{"t":"2023-11-29T15:13:00.195655931+01:00","lvl":"info","msg":"Odd pair (1 attr)","key":null,"LOG_ERROR":"Normalized odd number of arguments by adding nil"}
-{"t":"2023-11-29T15:13:00.195681832+01:00","lvl":"info","msg":"Odd pair (3 attr)","key":"value","key2":null,"LOG_ERROR":"Normalized odd number of arguments by adding nil"}
+{"time":"2023-11-22T15:42:00.407963+08:00","level":"INFO","msg":"big.Int","111,222,333,444,555,678,999":"111222333444555678999"}
+{"time":"2023-11-22T15:42:00.408084+08:00","level":"INFO","msg":"-big.Int","-111,222,333,444,555,678,999":"-111222333444555678999"}
+{"time":"2023-11-22T15:42:00.408092+08:00","level":"INFO","msg":"big.Int","11,122,233,344,455,567,899,900":"11122233344455567899900"}
+{"time":"2023-11-22T15:42:00.408097+08:00","level":"INFO","msg":"-big.Int","-11,122,233,344,455,567,899,900":"-11122233344455567899900"}
+{"time":"2023-11-22T15:42:00.408127+08:00","level":"INFO","msg":"uint256","111,222,333,444,555,678,999":"111222333444555678999"}
+{"time":"2023-11-22T15:42:00.408133+08:00","level":"INFO","msg":"uint256","11,122,233,344,455,567,899,900":"11122233344455567899900"}
+{"time":"2023-11-22T15:42:00.408137+08:00","level":"INFO","msg":"int64","1,000,000":1000000}
+{"time":"2023-11-22T15:42:00.408145+08:00","level":"INFO","msg":"int64","-1,000,000":-1000000}
+{"time":"2023-11-22T15:42:00.408149+08:00","level":"INFO","msg":"int64","9,223,372,036,854,775,807":9223372036854775807}
+{"time":"2023-11-22T15:42:00.408153+08:00","level":"INFO","msg":"int64","-9,223,372,036,854,775,808":-9223372036854775808}
+{"time":"2023-11-22T15:42:00.408156+08:00","level":"INFO","msg":"uint64","1,000,000":1000000}
+{"time":"2023-11-22T15:42:00.40816+08:00","level":"INFO","msg":"uint64","18,446,744,073,709,551,615":18446744073709551615}
+{"time":"2023-11-22T15:42:00.408164+08:00","level":"INFO","msg":"Special chars in value","key":"special \r\n\t chars"}
+{"time":"2023-11-22T15:42:00.408167+08:00","level":"INFO","msg":"Special chars in key","special \n\t chars":"value"}
+{"time":"2023-11-22T15:42:00.408171+08:00","level":"INFO","msg":"nospace","nospace":"nospace"}
+{"time":"2023-11-22T15:42:00.408174+08:00","level":"INFO","msg":"with space","with nospace":"with nospace"}
+{"time":"2023-11-22T15:42:00.408178+08:00","level":"INFO","msg":"Bash escapes in value","key":"\u001b[1G\u001b[K\u001b[1A"}
+{"time":"2023-11-22T15:42:00.408182+08:00","level":"INFO","msg":"Bash escapes in key","\u001b[1G\u001b[K\u001b[1A":"value"}
+{"time":"2023-11-22T15:42:00.408186+08:00","level":"INFO","msg":"Bash escapes in message  \u001b[1G\u001b[K\u001b[1A end","key":"value"}
+{"time":"2023-11-22T15:42:00.408194+08:00","level":"INFO","msg":"\u001b[35mColored\u001b[0m[","\u001b[35mColored\u001b[0m[":"\u001b[35mColored\u001b[0m["}
+{"time":"2023-11-22T15:42:00.408197+08:00","level":"INFO","msg":"an error message with quotes","error":"this is an 'error'"}
+{"time":"2023-11-22T15:42:00.408202+08:00","level":"INFO","msg":"Custom Stringer value","2562047h47m16.854s":9223372036854776000}
+{"time":"2023-11-22T15:42:00.408208+08:00","level":"INFO","msg":"a custom stringer that emits quoted text","output":{}}
+{"time":"2023-11-22T15:42:00.408219+08:00","level":"INFO","msg":"A message with wonky 💩 characters"}
+{"time":"2023-11-22T15:42:00.408222+08:00","level":"INFO","msg":"A multiline message \nINFO [10-18|14:11:31.106] with wonky characters 💩"}
+{"time":"2023-11-22T15:42:00.408226+08:00","level":"INFO","msg":"A multiline message \nLALA [ZZZZZZZZZZZZZZZZZZ] Actually part of message above"}
+{"time":"2023-11-22T15:42:00.408229+08:00","level":"INFO","msg":"boolean","true":true,"false":false}
+{"time":"2023-11-22T15:42:00.408234+08:00","level":"INFO","msg":"repeated-key 1","foo":"alpha","foo":"beta"}
+{"time":"2023-11-22T15:42:00.408237+08:00","level":"INFO","msg":"repeated-key 2","xx":"short","xx":"longer"}
+{"time":"2023-11-22T15:42:00.408241+08:00","level":"INFO","msg":"log at level info"}
+{"time":"2023-11-22T15:42:00.408244+08:00","level":"WARN","msg":"log at level warn"}
+{"time":"2023-11-22T15:42:00.408247+08:00","level":"ERROR","msg":"log at level error"}
+{"time":"2023-11-22T15:42:00.408251+08:00","level":"INFO","msg":"test","bar":"short","a":"aligned left"}
+{"time":"2023-11-22T15:42:00.408254+08:00","level":"INFO","msg":"test","bar":"a long message","a":1}
+{"time":"2023-11-22T15:42:00.408258+08:00","level":"INFO","msg":"test","bar":"short","a":"aligned right"}
+{"time":"2023-11-22T15:42:00.408261+08:00","level":"INFO","msg":"The following logs should align so that the key-fields make 5 columns"}
+{"time":"2023-11-22T15:42:00.408275+08:00","level":"INFO","msg":"Inserted known block","number":1012,"hash":"0x0000000000000000000000000000000000000000000000000000000000001234","txs":200,"gas":1123123,"other":"first"}
+{"time":"2023-11-22T15:42:00.408281+08:00","level":"INFO","msg":"Inserted new block","number":1,"hash":"0x0000000000000000000000000000000000000000000000000000000000001235","txs":2,"gas":1123,"other":"second"}
+{"time":"2023-11-22T15:42:00.408287+08:00","level":"INFO","msg":"Inserted known block","number":99,"hash":"0x0000000000000000000000000000000000000000000000000000000000012322","txs":10,"gas":1,"other":"third"}
+{"time":"2023-11-22T15:42:00.408296+08:00","level":"WARN","msg":"Inserted known block","number":1012,"hash":"0x0000000000000000000000000000000000000000000000000000000000001234","txs":200,"gas":99,"other":"fourth"}
+{"time":"2023-11-22T15:42:00.4083+08:00","level":"INFO","msg":"(*big.Int)(nil)","<nil>":null}
+{"time":"2023-11-22T15:42:00.408303+08:00","level":"INFO","msg":"(*uint256.Int)(nil)","<nil>":null}
+{"time":"2023-11-22T15:42:00.408311+08:00","level":"INFO","msg":"(fmt.Stringer)(nil)","res":null}
+{"time":"2023-11-22T15:42:00.408318+08:00","level":"INFO","msg":"nil-concrete-stringer","res":null}
+{"time":"2023-11-22T15:42:00.408322+08:00","level":"INFO","msg":"error(nil) ","res":null}
+{"time":"2023-11-22T15:42:00.408326+08:00","level":"INFO","msg":"nil-concrete-error","res":""}
+{"time":"2023-11-22T15:42:00.408334+08:00","level":"INFO","msg":"nil-custom-struct","res":null}
+{"time":"2023-11-22T15:42:00.40835+08:00","level":"INFO","msg":"raw nil","res":null}
+{"time":"2023-11-22T15:42:00.408354+08:00","level":"INFO","msg":"(*uint64)(nil)","res":null}
+{"time":"2023-11-22T15:42:00.408361+08:00","level":"INFO","msg":"Using keys 't', 'level', 'time', 'level' and 'msg'","time":"time","t":"t","level":"level","lvl":"lvl","msg":"msg"}
+{"time":"2023-11-29T15:13:00.195655931+01:00","level":"INFO","msg":"Odd pair (1 attr)","key":null,"LOG_ERROR":"Normalized odd number of arguments by adding nil"}
+{"time":"2023-11-29T15:13:00.195681832+01:00","level":"INFO","msg":"Odd pair (3 attr)","key":"value","key2":null,"LOG_ERROR":"Normalized odd number of arguments by adding nil"}

--- a/cmd/geth/testdata/logging/logtest-logfmt.txt
+++ b/cmd/geth/testdata/logging/logtest-logfmt.txt
@@ -48,5 +48,5 @@ time=xxxxxxxxxxxxxxxxxxxxxxxxxxxxx level=INFO msg=nil-custom-struct res=<nil>
 time=xxxxxxxxxxxxxxxxxxxxxxxxxxxxx level=INFO msg="raw nil" res=<nil>
 time=xxxxxxxxxxxxxxxxxxxxxxxxxxxxx level=INFO msg=(*uint64)(nil) res=<nil>
 time=xxxxxxxxxxxxxxxxxxxxxxxxxxxxx level=INFO msg="Using keys 't', 'lvl', 'time', 'level' and 'msg'" t=t time=time lvl=lvl level=level msg=msg
-time=xxxxxxxxxxxxxxxxxxxxxxxxxxxxx level=INFO msg="Odd pair (1 attr)" key=<nil> LOG_ERROR="Normalized odd number of arguments by adding nil"
-time=xxxxxxxxxxxxxxxxxxxxxxxxxxxxx level=INFO msg="Odd pair (3 attr)" key=value key2=<nil> LOG_ERROR="Normalized odd number of arguments by adding nil"
+time=xxxxxxxxxxxxxxxxxxxxxxxxxxxxx level=INFO msg="Odd pair (1 attr)" !BADKEY=key
+time=xxxxxxxxxxxxxxxxxxxxxxxxxxxxx level=INFO msg="Odd pair (3 attr)" key=value !BADKEY=key2

--- a/cmd/geth/testdata/logging/logtest-logfmt.txt
+++ b/cmd/geth/testdata/logging/logtest-logfmt.txt
@@ -1,52 +1,52 @@
-t=xxxx-xx-xxTxx:xx:xx+xxxx lvl=info msg=big.Int 111,222,333,444,555,678,999=111222333444555678999
-t=xxxx-xx-xxTxx:xx:xx+xxxx lvl=info msg=-big.Int -111,222,333,444,555,678,999=-111222333444555678999
-t=xxxx-xx-xxTxx:xx:xx+xxxx lvl=info msg=big.Int 11,122,233,344,455,567,899,900=11122233344455567899900
-t=xxxx-xx-xxTxx:xx:xx+xxxx lvl=info msg=-big.Int -11,122,233,344,455,567,899,900=-11122233344455567899900
-t=xxxx-xx-xxTxx:xx:xx+xxxx lvl=info msg=uint256 111,222,333,444,555,678,999=111222333444555678999
-t=xxxx-xx-xxTxx:xx:xx+xxxx lvl=info msg=uint256 11,122,233,344,455,567,899,900=11122233344455567899900
-t=xxxx-xx-xxTxx:xx:xx+xxxx lvl=info msg=int64 1,000,000=1000000
-t=xxxx-xx-xxTxx:xx:xx+xxxx lvl=info msg=int64 -1,000,000=-1000000
-t=xxxx-xx-xxTxx:xx:xx+xxxx lvl=info msg=int64 9,223,372,036,854,775,807=9223372036854775807
-t=xxxx-xx-xxTxx:xx:xx+xxxx lvl=info msg=int64 -9,223,372,036,854,775,808=-9223372036854775808
-t=xxxx-xx-xxTxx:xx:xx+xxxx lvl=info msg=uint64 1,000,000=1000000
-t=xxxx-xx-xxTxx:xx:xx+xxxx lvl=info msg=uint64 18,446,744,073,709,551,615=18446744073709551615
-t=xxxx-xx-xxTxx:xx:xx+xxxx lvl=info msg="Special chars in value" key="special \r\n\t chars"
-t=xxxx-xx-xxTxx:xx:xx+xxxx lvl=info msg="Special chars in key" "special \n\t chars"=value
-t=xxxx-xx-xxTxx:xx:xx+xxxx lvl=info msg=nospace nospace=nospace
-t=xxxx-xx-xxTxx:xx:xx+xxxx lvl=info msg="with space" "with nospace"="with nospace"
-t=xxxx-xx-xxTxx:xx:xx+xxxx lvl=info msg="Bash escapes in value" key="\x1b[1G\x1b[K\x1b[1A"
-t=xxxx-xx-xxTxx:xx:xx+xxxx lvl=info msg="Bash escapes in key" "\x1b[1G\x1b[K\x1b[1A"=value
-t=xxxx-xx-xxTxx:xx:xx+xxxx lvl=info msg="Bash escapes in message  \x1b[1G\x1b[K\x1b[1A end" key=value
-t=xxxx-xx-xxTxx:xx:xx+xxxx lvl=info msg="\x1b[35mColored\x1b[0m[" "\x1b[35mColored\x1b[0m["="\x1b[35mColored\x1b[0m["
-t=xxxx-xx-xxTxx:xx:xx+xxxx lvl=info msg="an error message with quotes" error="this is an 'error'"
-t=xxxx-xx-xxTxx:xx:xx+xxxx lvl=info msg="Custom Stringer value" 2562047h47m16.854s=2562047h47m16.854s
-t=xxxx-xx-xxTxx:xx:xx+xxxx lvl=info msg="a custom stringer that emits quoted text" output="output with 'quotes'"
-t=xxxx-xx-xxTxx:xx:xx+xxxx lvl=info msg="A message with wonky 💩 characters"
-t=xxxx-xx-xxTxx:xx:xx+xxxx lvl=info msg="A multiline message \nINFO [10-18|14:11:31.106] with wonky characters 💩"
-t=xxxx-xx-xxTxx:xx:xx+xxxx lvl=info msg="A multiline message \nLALA [ZZZZZZZZZZZZZZZZZZ] Actually part of message above"
-t=xxxx-xx-xxTxx:xx:xx+xxxx lvl=info msg=boolean true=true false=false
-t=xxxx-xx-xxTxx:xx:xx+xxxx lvl=info msg="repeated-key 1" foo=alpha foo=beta
-t=xxxx-xx-xxTxx:xx:xx+xxxx lvl=info msg="repeated-key 2" xx=short xx=longer
-t=xxxx-xx-xxTxx:xx:xx+xxxx lvl=info msg="log at level info"
-t=xxxx-xx-xxTxx:xx:xx+xxxx lvl=warn msg="log at level warn"
-t=xxxx-xx-xxTxx:xx:xx+xxxx lvl=eror msg="log at level error"
-t=xxxx-xx-xxTxx:xx:xx+xxxx lvl=info msg=test bar=short a="aligned left"
-t=xxxx-xx-xxTxx:xx:xx+xxxx lvl=info msg=test bar="a long message" a=1
-t=xxxx-xx-xxTxx:xx:xx+xxxx lvl=info msg=test bar=short a="aligned right"
-t=xxxx-xx-xxTxx:xx:xx+xxxx lvl=info msg="The following logs should align so that the key-fields make 5 columns"
-t=xxxx-xx-xxTxx:xx:xx+xxxx lvl=info msg="Inserted known block" number=1012 hash=0x0000000000000000000000000000000000000000000000000000000000001234 txs=200 gas=1123123 other=first
-t=xxxx-xx-xxTxx:xx:xx+xxxx lvl=info msg="Inserted new block" number=1 hash=0x0000000000000000000000000000000000000000000000000000000000001235 txs=2 gas=1123 other=second
-t=xxxx-xx-xxTxx:xx:xx+xxxx lvl=info msg="Inserted known block" number=99 hash=0x0000000000000000000000000000000000000000000000000000000000012322 txs=10 gas=1 other=third
-t=xxxx-xx-xxTxx:xx:xx+xxxx lvl=warn msg="Inserted known block" number=1012 hash=0x0000000000000000000000000000000000000000000000000000000000001234 txs=200 gas=99 other=fourth
-t=xxxx-xx-xxTxx:xx:xx+xxxx lvl=info msg=(*big.Int)(nil) <nil>=<nil>
-t=xxxx-xx-xxTxx:xx:xx+xxxx lvl=info msg=(*uint256.Int)(nil) <nil>=<nil>
-t=xxxx-xx-xxTxx:xx:xx+xxxx lvl=info msg=(fmt.Stringer)(nil) res=<nil>
-t=xxxx-xx-xxTxx:xx:xx+xxxx lvl=info msg=nil-concrete-stringer res=<nil>
-t=xxxx-xx-xxTxx:xx:xx+xxxx lvl=info msg="error(nil) " res=<nil>
-t=xxxx-xx-xxTxx:xx:xx+xxxx lvl=info msg=nil-concrete-error res=""
-t=xxxx-xx-xxTxx:xx:xx+xxxx lvl=info msg=nil-custom-struct res=<nil>
-t=xxxx-xx-xxTxx:xx:xx+xxxx lvl=info msg="raw nil" res=<nil>
-t=xxxx-xx-xxTxx:xx:xx+xxxx lvl=info msg=(*uint64)(nil) res=<nil>
-t=xxxx-xx-xxTxx:xx:xx+xxxx lvl=info msg="Using keys 't', 'lvl', 'time', 'level' and 'msg'" t=t time=time lvl=lvl level=level msg=msg
-t=xxxx-xx-xxTxx:xx:xx+xxxx lvl=info msg="Odd pair (1 attr)" key=<nil> LOG_ERROR="Normalized odd number of arguments by adding nil"
-t=xxxx-xx-xxTxx:xx:xx+xxxx lvl=info msg="Odd pair (3 attr)" key=value key2=<nil> LOG_ERROR="Normalized odd number of arguments by adding nil"
+time=xxxxxxxxxxxxxxxxxxxxxxxxxxxxx level=INFO msg=big.Int 111,222,333,444,555,678,999=111222333444555678999
+time=xxxxxxxxxxxxxxxxxxxxxxxxxxxxx level=INFO msg=-big.Int -111,222,333,444,555,678,999=-111222333444555678999
+time=xxxxxxxxxxxxxxxxxxxxxxxxxxxxx level=INFO msg=big.Int 11,122,233,344,455,567,899,900=11122233344455567899900
+time=xxxxxxxxxxxxxxxxxxxxxxxxxxxxx level=INFO msg=-big.Int -11,122,233,344,455,567,899,900=-11122233344455567899900
+time=xxxxxxxxxxxxxxxxxxxxxxxxxxxxx level=INFO msg=uint256 111,222,333,444,555,678,999=111222333444555678999
+time=xxxxxxxxxxxxxxxxxxxxxxxxxxxxx level=INFO msg=uint256 11,122,233,344,455,567,899,900=11122233344455567899900
+time=xxxxxxxxxxxxxxxxxxxxxxxxxxxxx level=INFO msg=int64 1,000,000=1000000
+time=xxxxxxxxxxxxxxxxxxxxxxxxxxxxx level=INFO msg=int64 -1,000,000=-1000000
+time=xxxxxxxxxxxxxxxxxxxxxxxxxxxxx level=INFO msg=int64 9,223,372,036,854,775,807=9223372036854775807
+time=xxxxxxxxxxxxxxxxxxxxxxxxxxxxx level=INFO msg=int64 -9,223,372,036,854,775,808=-9223372036854775808
+time=xxxxxxxxxxxxxxxxxxxxxxxxxxxxx level=INFO msg=uint64 1,000,000=1000000
+time=xxxxxxxxxxxxxxxxxxxxxxxxxxxxx level=INFO msg=uint64 18,446,744,073,709,551,615=18446744073709551615
+time=xxxxxxxxxxxxxxxxxxxxxxxxxxxxx level=INFO msg="Special chars in value" key="special \r\n\t chars"
+time=xxxxxxxxxxxxxxxxxxxxxxxxxxxxx level=INFO msg="Special chars in key" "special \n\t chars"=value
+time=xxxxxxxxxxxxxxxxxxxxxxxxxxxxx level=INFO msg=nospace nospace=nospace
+time=xxxxxxxxxxxxxxxxxxxxxxxxxxxxx level=INFO msg="with space" "with nospace"="with nospace"
+time=xxxxxxxxxxxxxxxxxxxxxxxxxxxxx level=INFO msg="Bash escapes in value" key="\x1b[1G\x1b[K\x1b[1A"
+time=xxxxxxxxxxxxxxxxxxxxxxxxxxxxx level=INFO msg="Bash escapes in key" "\x1b[1G\x1b[K\x1b[1A"=value
+time=xxxxxxxxxxxxxxxxxxxxxxxxxxxxx level=INFO msg="Bash escapes in message  \x1b[1G\x1b[K\x1b[1A end" key=value
+time=xxxxxxxxxxxxxxxxxxxxxxxxxxxxx level=INFO msg="\x1b[35mColored\x1b[0m[" "\x1b[35mColored\x1b[0m["="\x1b[35mColored\x1b[0m["
+time=xxxxxxxxxxxxxxxxxxxxxxxxxxxxx level=INFO msg="an error message with quotes" error="this is an 'error'"
+time=xxxxxxxxxxxxxxxxxxxxxxxxxxxxx level=INFO msg="Custom Stringer value" 2562047h47m16.854s=2562047h47m16.854s
+time=xxxxxxxxxxxxxxxxxxxxxxxxxxxxx level=INFO msg="a custom stringer that emits quoted text" output="output with 'quotes'"
+time=xxxxxxxxxxxxxxxxxxxxxxxxxxxxx level=INFO msg="A message with wonky 💩 characters"
+time=xxxxxxxxxxxxxxxxxxxxxxxxxxxxx level=INFO msg="A multiline message \nINFO [10-18|14:11:31.106] with wonky characters 💩"
+time=xxxxxxxxxxxxxxxxxxxxxxxxxxxxx level=INFO msg="A multiline message \nLALA [ZZZZZZZZZZZZZZZZZZ] Actually part of message above"
+time=xxxxxxxxxxxxxxxxxxxxxxxxxxxxx level=INFO msg=boolean true=true false=false
+time=xxxxxxxxxxxxxxxxxxxxxxxxxxxxx level=INFO msg="repeated-key 1" foo=alpha foo=beta
+time=xxxxxxxxxxxxxxxxxxxxxxxxxxxxx level=INFO msg="repeated-key 2" xx=short xx=longer
+time=xxxxxxxxxxxxxxxxxxxxxxxxxxxxx level=INFO msg="log at level info"
+time=xxxxxxxxxxxxxxxxxxxxxxxxxxxxx level=WARN msg="log at level warn"
+time=xxxxxxxxxxxxxxxxxxxxxxxxxxxxx level=ERROR msg="log at level error"
+time=xxxxxxxxxxxxxxxxxxxxxxxxxxxxx level=INFO msg=test bar=short a="aligned left"
+time=xxxxxxxxxxxxxxxxxxxxxxxxxxxxx level=INFO msg=test bar="a long message" a=1
+time=xxxxxxxxxxxxxxxxxxxxxxxxxxxxx level=INFO msg=test bar=short a="aligned right"
+time=xxxxxxxxxxxxxxxxxxxxxxxxxxxxx level=INFO msg="The following logs should align so that the key-fields make 5 columns"
+time=xxxxxxxxxxxxxxxxxxxxxxxxxxxxx level=INFO msg="Inserted known block" number=1012 hash=0x0000000000000000000000000000000000000000000000000000000000001234 txs=200 gas=1123123 other=first
+time=xxxxxxxxxxxxxxxxxxxxxxxxxxxxx level=INFO msg="Inserted new block" number=1 hash=0x0000000000000000000000000000000000000000000000000000000000001235 txs=2 gas=1123 other=second
+time=xxxxxxxxxxxxxxxxxxxxxxxxxxxxx level=INFO msg="Inserted known block" number=99 hash=0x0000000000000000000000000000000000000000000000000000000000012322 txs=10 gas=1 other=third
+time=xxxxxxxxxxxxxxxxxxxxxxxxxxxxx level=WARN msg="Inserted known block" number=1012 hash=0x0000000000000000000000000000000000000000000000000000000000001234 txs=200 gas=99 other=fourth
+time=xxxxxxxxxxxxxxxxxxxxxxxxxxxxx level=INFO msg=(*big.Int)(nil) <nil>=<nil>
+time=xxxxxxxxxxxxxxxxxxxxxxxxxxxxx level=INFO msg=(*uint256.Int)(nil) <nil>=<nil>
+time=xxxxxxxxxxxxxxxxxxxxxxxxxxxxx level=INFO msg=(fmt.Stringer)(nil) res=<nil>
+time=xxxxxxxxxxxxxxxxxxxxxxxxxxxxx level=INFO msg=nil-concrete-stringer res=<nil>
+time=xxxxxxxxxxxxxxxxxxxxxxxxxxxxx level=INFO msg="error(nil) " res=<nil>
+time=xxxxxxxxxxxxxxxxxxxxxxxxxxxxx level=INFO msg=nil-concrete-error res=""
+time=xxxxxxxxxxxxxxxxxxxxxxxxxxxxx level=INFO msg=nil-custom-struct res=<nil>
+time=xxxxxxxxxxxxxxxxxxxxxxxxxxxxx level=INFO msg="raw nil" res=<nil>
+time=xxxxxxxxxxxxxxxxxxxxxxxxxxxxx level=INFO msg=(*uint64)(nil) res=<nil>
+time=xxxxxxxxxxxxxxxxxxxxxxxxxxxxx level=INFO msg="Using keys 't', 'lvl', 'time', 'level' and 'msg'" t=t time=time lvl=lvl level=level msg=msg
+time=xxxxxxxxxxxxxxxxxxxxxxxxxxxxx level=INFO msg="Odd pair (1 attr)" key=<nil> LOG_ERROR="Normalized odd number of arguments by adding nil"
+time=xxxxxxxxxxxxxxxxxxxxxxxxxxxxx level=INFO msg="Odd pair (3 attr)" key=value key2=<nil> LOG_ERROR="Normalized odd number of arguments by adding nil"

--- a/cmd/geth/testdata/logging/logtest-terminal.txt
+++ b/cmd/geth/testdata/logging/logtest-terminal.txt
@@ -49,5 +49,5 @@ INFO [xx-xx|xx:xx:xx.xxx] nil-custom-struct                        res=<nil>
 INFO [xx-xx|xx:xx:xx.xxx] raw nil                                  res=<nil>
 INFO [xx-xx|xx:xx:xx.xxx] (*uint64)(nil)                           res=<nil>
 INFO [xx-xx|xx:xx:xx.xxx] Using keys 't', 'lvl', 'time', 'level' and 'msg' t=t time=time lvl=lvl level=level msg=msg
-INFO [xx-xx|xx:xx:xx.xxx] Odd pair (1 attr)                        key=<nil>                  LOG_ERROR="Normalized odd number of arguments by adding nil"
-INFO [xx-xx|xx:xx:xx.xxx] Odd pair (3 attr)                        key=value                  key2=<nil> LOG_ERROR="Normalized odd number of arguments by adding nil"
+INFO [xx-xx|xx:xx:xx.xxx] Odd pair (1 attr)                        "!BADKEY"=key
+INFO [xx-xx|xx:xx:xx.xxx] Odd pair (3 attr)                        key=value                  "!BADKEY"=key2

--- a/log/handler.go
+++ b/log/handler.go
@@ -123,9 +123,7 @@ func JSONHandler(wr io.Writer) slog.Handler {
 //
 // For more details see: http://godoc.org/github.com/kr/logfmt
 func LogfmtHandler(wr io.Writer) slog.Handler {
-	return slog.NewTextHandler(wr, &slog.HandlerOptions{
-		ReplaceAttr: builtinReplaceLogfmt,
-	})
+	return slog.NewTextHandler(wr, nil)
 }
 
 // LogfmtHandlerWithLevel returns the same handler as LogfmtHandler but it only outputs

--- a/log/handler.go
+++ b/log/handler.go
@@ -115,9 +115,7 @@ func (l *leveler) Level() slog.Level {
 
 // JSONHandler returns a handler which prints records in JSON format.
 func JSONHandler(wr io.Writer) slog.Handler {
-	return slog.NewJSONHandler(wr, &slog.HandlerOptions{
-		ReplaceAttr: builtinReplaceJSON,
-	})
+	return slog.NewJSONHandler(wr, nil)
 }
 
 // LogfmtHandler returns a handler which prints records in logfmt format, an easy machine-parseable but human-readable

--- a/log/logger.go
+++ b/log/logger.go
@@ -159,9 +159,6 @@ func (l *logger) Write(level slog.Level, msg string, attrs ...any) {
 	var pcs [1]uintptr
 	runtime.Callers(3, pcs[:])
 
-	if len(attrs)%2 != 0 {
-		attrs = append(attrs, nil, errorKey, "Normalized odd number of arguments by adding nil")
-	}
 	r := slog.NewRecord(time.Now(), level, msg, pcs[0])
 	r.Add(attrs...)
 	l.inner.Handler().Handle(context.Background(), r)


### PR DESCRIPTION
Potential follow-up to https://github.com/ethereum/go-ethereum/pull/28622 

This PR removes our custom `json` and `logfmt` implementations, to instead use the ones built into `slog`. Ours does some transformations under the hood, mainly renaming `time` to `t` and `level` to `lvl`, and de-capitalizing the levels. 

It also does away with the custom key-value pair "filling". Instead of 
`key=<nil> LOG_ERROR="Normalized odd number of arguments by adding nil"` slog simply says `BADKEY=key`

The one other thing worth mentioning is that this makes the json output spit out `*big.Int` types as json-native numeric format, e.g `111222333444555678999` instead of `"111222333444555678999"`. When trying to read that back into `any`, the unmarshaller selects `float64`, which cannot read it fully correct on the way back. 

I think it would be better to switch over to `slog`, if we believe that slog is some kind of go-idiomatic future of logging. A few of our users may potentially have to switch over their parsing, but all in all it's probably not a great amount of work, and probably something that's better done sooner rather than later. 

