### PR TITLE
rpc: fix nanoseconds/microseconds mismatch in rpc metrics

### DIFF
--- a/metrics/timer.go
+++ b/metrics/timer.go
@@ -106,20 +106,18 @@ func (t *StandardTimer) Time(f func()) {
 	t.Update(time.Since(ts))
 }
 
-// Record the duration of an event.
+// Record the duration of an event, in nanoseconds.
 func (t *StandardTimer) Update(d time.Duration) {
 	t.mutex.Lock()
 	defer t.mutex.Unlock()
-	t.histogram.Update(int64(d))
+	t.histogram.Update(d.Nanoseconds())
 	t.meter.Mark(1)
 }
 
 // Record the duration of an event that started at a time and ends now.
+// The record uses nanoseconds.
 func (t *StandardTimer) UpdateSince(ts time.Time) {
-	t.mutex.Lock()
-	defer t.mutex.Unlock()
-	t.histogram.Update(int64(time.Since(ts)))
-	t.meter.Mark(1)
+	t.Update(time.Since(ts))
 }
 
 // timerSnapshot is a read-only copy of another Timer.

--- a/rpc/metrics.go
+++ b/rpc/metrics.go
@@ -46,5 +46,5 @@ func updateServeTimeHistogram(method string, success bool, elapsed time.Duration
 			metrics.NewExpDecaySample(1028, 0.015),
 		)
 	}
-	metrics.GetOrRegisterHistogramLazy(h, nil, sampler).Update(elapsed.Microseconds())
+	metrics.GetOrRegisterHistogramLazy(h, nil, sampler).Update(elapsed.Nanoseconds())
 }


### PR DESCRIPTION
Fixes https://github.com/ethereum/go-ethereum/issues/28619 

The `rpc/duration/all` meter metered in nanoseconds, the individual meter metered in microseconds. 

```golang
		rpcServingTimer.UpdateSince(start) // <-- Would use nanoseconds (default) 
		updateServeTimeHistogram(msg.Method, answer.Error == nil, time.Since(start)) // <-- Would use microseconds
```

