### PR TITLE
cmd/evm: fix dump after state-test exec

### DIFF
--- a/cmd/evm/staterunner.go
+++ b/cmd/evm/staterunner.go
@@ -100,18 +100,19 @@ func runStateTest(fname string, cfg vm.Config, jsonOut, dump bool) error {
 		for _, st := range test.Subtests() {
 			// Run the test and aggregate the result
 			result := &StatetestResult{Name: key, Fork: st.Fork, Pass: true}
-			test.Run(st, cfg, false, rawdb.HashScheme, func(err error, snaps *snapshot.Tree, state *state.StateDB) {
-				if state != nil {
-					root := state.IntermediateRoot(false)
+			test.Run(st, cfg, false, rawdb.HashScheme, func(err error, snaps *snapshot.Tree, statedb *state.StateDB) {
+				var root common.Hash
+				if statedb != nil {
+					root = statedb.IntermediateRoot(false)
 					result.Root = &root
 					if jsonOut {
 						fmt.Fprintf(os.Stderr, "{\"stateRoot\": \"%#x\"}\n", root)
 					}
-				}
-				// Dump any state to aid debugging
-				if dump {
-					dump := state.RawDump(nil)
-					result.State = &dump
+					if dump { // Dump any state to aid debugging
+						cpy, _ := state.New(root, statedb.Database(), nil)
+						dump := cpy.RawDump(nil)
+						result.State = &dump
+					}
 				}
 				if err != nil {
 					// Test failed, mark as so

--- a/core/state/dump.go
+++ b/core/state/dump.go
@@ -129,6 +129,7 @@ func (s *StateDB) DumpToCollector(c DumpCollector, conf *DumpConfig) (nextKey []
 
 	trieIt, err := s.trie.NodeIterator(conf.Start)
 	if err != nil {
+		log.Error("Trie dumping error", "err", err)
 		return nil
 	}
 	it := trie.NewIterator(trieIt)


### PR DESCRIPTION
When investigating https://github.com/ethereum/evmone/issues/740, I noticed that the dump after state-test didn't seem to work. 

Can be tested by storing that statetest as `foo.json` and running: 
```
 go run ./cmd/evm --json --dump  statetest   ./foo.json
```
With this PR , it works. The problem was an error, "Already committed", which was silently ignored. The state needs to be re-initialized for the dumping to work. 