### PR TITLE
eth/protocols/eth: fix typos in comments

### DIFF
--- a/eth/protocols/eth/dispatcher.go
+++ b/eth/protocols/eth/dispatcher.go
@@ -41,7 +41,7 @@ var (
 // Request is a pending request to allow tracking it and delivering a response
 // back to the requester on their chosen channel.
 type Request struct {
-	peer *Peer  // Peer to which this request belogs for untracking
+	peer *Peer  // Peer to which this request belongs for untracking
 	id   uint64 // Request ID to match up replies to
 
 	sink   chan *Response // Channel to deliver the response on
@@ -224,7 +224,7 @@ func (p *Peer) dispatcher() {
 			switch {
 			case res.Req == nil:
 				// Response arrived with an untracked ID. Since even cancelled
-				// requests are tracked until fulfilment, a dangling response
+				// requests are tracked until fulfillment, a dangling response
 				// means the remote peer implements the protocol badly.
 				resOp.fail <- errDanglingResponse
 

--- a/eth/protocols/eth/peer.go
+++ b/eth/protocols/eth/peer.go
@@ -84,7 +84,7 @@ type Peer struct {
 	txBroadcast chan []common.Hash // Channel used to queue transaction propagation requests
 	txAnnounce  chan []common.Hash // Channel used to queue transaction announcement requests
 
-	reqDispatch chan *request  // Dispatch channel to send requests and track then until fulfilment
+	reqDispatch chan *request  // Dispatch channel to send requests and track then until fulfillment
 	reqCancel   chan *cancel   // Dispatch channel to cancel pending requests and untrack them
 	resDispatch chan *response // Dispatch channel to fulfil pending requests and untrack them
 

--- a/log/logger.go
+++ b/log/logger.go
@@ -95,7 +95,7 @@ func LevelString(l slog.Level) string {
 	case slog.LevelWarn:
 		return "warn"
 	case slog.LevelError:
-		return "error"
+		return "eror"
 	case LevelCrit:
 		return "crit"
 	default:

--- a/log/logger.go
+++ b/log/logger.go
@@ -95,7 +95,7 @@ func LevelString(l slog.Level) string {
 	case slog.LevelWarn:
 		return "warn"
 	case slog.LevelError:
-		return "eror"
+		return "error"
 	case LevelCrit:
 		return "crit"
 	default:


### PR DESCRIPTION
minor typo fix

two comments, one returned message