### PR TITLE
tests/fuzzers/bls12381: deactivate fuzzer when CGO_ENABLED=0

### DIFF
--- a/tests/fuzzers/bls12381/bls12381_fuzz.go
+++ b/tests/fuzzers/bls12381/bls12381_fuzz.go
@@ -14,6 +14,9 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
 
+//go:build cgo
+// +build cgo
+
 package bls
 
 import (

--- a/tests/fuzzers/bls12381/bls12381_test.go
+++ b/tests/fuzzers/bls12381/bls12381_test.go
@@ -14,6 +14,9 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
 
+//go:build cgo
+// +build cgo
+
 package bls
 
 import "testing"


### PR DESCRIPTION
Blast needs cgo (it is a C library) and won't compile in an environment where cgo is disabled. This is the reason for the 32-bit build to fail as cgo isn't enabled by default. The CI 32 bit build needs some specific, wip environment for cgo to be enabled. Regardless, not having cgo available for a given platform should not break tests.

This PR won't build the one package that requires blast so that the 32-bit build is fixed.