### PR TITLE
core/state: auto-finalise state objects during copy

### DIFF
--- a/core/state/statedb.go
+++ b/core/state/statedb.go
@@ -723,6 +723,7 @@ func (s *StateDB) Copy() *StateDB {
 			// so we need to make sure that any side-effect the journal would have caused
 			// during a commit (or similar op) is already applied to the copy.
 			state.stateObjects[addr] = object.deepCopy(state)
+			state.stateObjects[addr].finalise(true)
 
 			state.stateObjectsDirty[addr] = struct{}{}   // Mark the copy dirty to force internal (code/state) commits
 			state.stateObjectsPending[addr] = struct{}{} // Mark the copy pending to force external (account) commits


### PR DESCRIPTION
Fixes https://github.com/ethereum/go-ethereum/issues/20119.

When we copy a statedb, we auto-flatten the journal into the dirty objects map. The Copy method did not call finalize on the individual objects, rather deep copied the dirtyness too. That's nice and all, but the statedb.Finalize has an optimization to only finalize "touched" objects (i.e. in the journal), so that would omit finalizing just-flattened stuff from commit.

This is a bit of a pickle:

- Most importantly, this does not affect us. We never copy a non-finalized statedb.
- Originally copy was meant to be able to copy kind of all the dirtyness too, but some finality is leaking into it already if we flatten the journal (and not flattening the journal leaks the previous execution stack, which is again weird). It's unclear at this point whether we should just force-finalize before copy, should perhaps error if non-finalized is copied; should try to make it work by copying dirtyness and have statedb.Finalize somehow detect it, etc.