### PR TITLE
eth/fetcher, eth/gasestimator: fix typos in comments

### DIFF
--- a/eth/fetcher/tx_fetcher_test.go
+++ b/eth/fetcher/tx_fetcher_test.go
@@ -1030,7 +1030,7 @@ func TestTransactionFetcherRateLimiting(t *testing.T) {
 }
 
 // Tests that if huge transactions are announced, only a small number of them will
-// be requested at a time, to keep the responses below a resonable level.
+// be requested at a time, to keep the responses below a reasonable level.
 func TestTransactionFetcherBandwidthLimiting(t *testing.T) {
 	testTransactionFetcherParallel(t, txFetcherTest{
 		init: func() *TxFetcher {

--- a/eth/fetcher/tx_fetcher_test.go
+++ b/eth/fetcher/tx_fetcher_test.go
@@ -186,7 +186,7 @@ func TestTransactionFetcherWaiting(t *testing.T) {
 // waitlist, and none of them are scheduled for retrieval until the wait expires.
 //
 // This test is an extended version of TestTransactionFetcherWaiting. It's mostly
-// to cover the metadata checkes without bloating up the basic behavioral tests
+// to cover the metadata checks without bloating up the basic behavioral tests
 // with all the useless extra fields.
 func TestTransactionFetcherWaitingWithMeta(t *testing.T) {
 	testTransactionFetcherParallel(t, txFetcherTest{

--- a/eth/gasestimator/gasestimator.go
+++ b/eth/gasestimator/gasestimator.go
@@ -47,7 +47,7 @@ type Options struct {
 }
 
 // Estimate returns the lowest possible gas limit that allows the transaction to
-// run successfully with the provided context optons. It returns an error if the
+// run successfully with the provided context options. It returns an error if the
 // transaction would always revert, or if there are unexpected failures.
 func Estimate(ctx context.Context, call *core.Message, opts *Options, gasCap uint64) (uint64, []byte, error) {
 	// Binary search the gas limit, as it may need to be higher than the amount used


### PR DESCRIPTION
hey, few typos i found in comments, this is a minor change.
have a nice afternoon.