### PR TITLE
internal/flags: add missing flag types for auto-env-var generation

### DIFF
--- a/internal/flags/helpers.go
+++ b/internal/flags/helpers.go
@@ -105,7 +105,7 @@ func MigrateGlobalFlags(ctx *cli.Context) {
 func doMigrateFlags(ctx *cli.Context) {
 	// Figure out if there are any aliases of commands. If there are, we want
 	// to ignore them when iterating over the flags.
-	var aliases = make(map[string]bool)
+	aliases := make(map[string]bool)
 	for _, fl := range ctx.Command.Flags {
 		for _, alias := range fl.Names()[1:] {
 			aliases[alias] = true
@@ -239,13 +239,22 @@ func AutoEnvVars(flags []cli.Flag, prefix string) {
 		case *cli.StringFlag:
 			flag.EnvVars = append(flag.EnvVars, envvar)
 
+		case *cli.StringSliceFlag:
+			flag.EnvVars = append(flag.EnvVars, envvar)
+
 		case *cli.BoolFlag:
 			flag.EnvVars = append(flag.EnvVars, envvar)
 
 		case *cli.IntFlag:
 			flag.EnvVars = append(flag.EnvVars, envvar)
 
+		case *cli.Int64Flag:
+			flag.EnvVars = append(flag.EnvVars, envvar)
+
 		case *cli.Uint64Flag:
+			flag.EnvVars = append(flag.EnvVars, envvar)
+
+		case *cli.Float64Flag:
 			flag.EnvVars = append(flag.EnvVars, envvar)
 
 		case *cli.DurationFlag:


### PR DESCRIPTION
Flags like `--rpc.txfeecap` currently don't have an env var auto-generated for them. This PR adds three missing cli flag types to the auto env-var helper function to fix this.

This was probably missed in the original work that added auto env-vars: https://github.com/ethereum/go-ethereum/pull/28103

Would be great if we can still get this into [`1.13.6`](https://github.com/ethereum/go-ethereum/milestone/154) 🙏🏻 
