### PR TITLE
cmd/evm: set default chain config to post-merge

### DIFF
--- a/cmd/evm/runner.go
+++ b/cmd/evm/runner.go
@@ -144,7 +144,7 @@ func runCmd(ctx *cli.Context) error {
 			initialGas = genesisConfig.GasLimit
 		}
 	} else {
-		genesisConfig.Config = params.AllEthashProtocolChanges
+		genesisConfig.Config = params.AllDevChainProtocolChanges
 	}
 
 	db := rawdb.NewMemoryDatabase()


### PR DESCRIPTION
closes https://github.com/ethereum/go-ethereum/issues/28690

This will enable the post-merge opcodes in the evm (such as PUSH0).
It might break users that expect the evm binary to default to London. Since the genesis can be overwritten, I think it is reasonable to switch the default