### PR TITLE
.travis: set lower GOGC value

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ jobs:
       git:
         submodules: false # avoid cloning ethereum/tests
       script:
-        - go run build/ci.go lint
+        - GOGC=10 go run build/ci.go lint
 
     # These builders create the Docker sub-images for multi-arch push and each
     # will attempt to push the multi-arch image if they are the last builder


### PR DESCRIPTION
As documented on https://golangci-lint.run/usage/performance/ , a lower GOGC value causes less peak mem consumption when running the linter.

Exceeding 3Gb is a common cause for build failures, according to https://docs.travis-ci.com/user/common-build-problems/#my-build-script-is-killed-without-any-error