### PR TITLE
internal/build: fix crash in MustRunCommandWithOutput

### DIFF
--- a/internal/build/util.go
+++ b/internal/build/util.go
@@ -68,23 +68,18 @@ func MustRunCommand(cmd string, args ...string) {
 	MustRun(exec.Command(cmd, args...))
 }
 
+// MustRunCommandWithOutput runs the given command, and ensures that some output will be
+// printed while it runs. This is useful for CI builds where the process will be stopped
+// when there is no output.
 func MustRunCommandWithOutput(cmd string, args ...string) {
-	var done chan bool
-	// This is a little loop to generate some output, so CI does not tear down the
-	// process after 300 seconds.
+	interval := time.NewTicker(time.Minute)
+	defer interval.Stop()
 	go func() {
-		for i := 0; i < 15; i++ {
+		for range interval.C {
 			fmt.Printf("Waiting for command %q\n", cmd)
-			select {
-			case <-time.After(time.Minute):
-				break
-			case <-done:
-				return
-			}
 		}
 	}()
 	MustRun(exec.Command(cmd, args...))
-	close(done)
 }
 
 var warnedAboutGit bool


### PR DESCRIPTION
Fixes the crash below, which happens because the `done` channel was not initialized.

```
Waiting for command "build/cache/golangci-lint-1.51.1-linux-amd64/golangci-lint"
panic: close of nil channel
goroutine 1 [running]:
github.com/ethereum/go-ethereum/internal/build.MustRunCommandWithOutput({0xc0002d1500, 0x3a}, {0xc000296060, 0x4, 0x6})
	/home/appveyor/projects/go-ethereum/internal/build/util.go:87 +0xac
main.doLint({0xc0000ae000, 0x0, 0x0})
	/home/appveyor/projects/go-ethereum/build/ci.go:369 +0x237
main.main()
	/home/appveyor/projects/go-ethereum/build/ci.go:167 +0x1b3
```