### PR TITLE
accounts/manager: properly close account manager and usb wallets

### DIFF
--- a/accounts/manager.go
+++ b/accounts/manager.go
@@ -98,6 +98,9 @@ func NewManager(config *Config, backends ...Backend) *Manager {
 
 // Close terminates the account manager's internal notification processes.
 func (am *Manager) Close() error {
+	for _, w := range am.wallets {
+		w.Close()
+	}
 	errc := make(chan error)
 	am.quit <- errc
 	return <-errc

--- a/accounts/usbwallet/wallet.go
+++ b/accounts/usbwallet/wallet.go
@@ -483,6 +483,10 @@ func (w *wallet) Derive(path accounts.DerivationPath, pin bool) (accounts.Accoun
 	w.stateLock.Lock()
 	defer w.stateLock.Unlock()
 
+	if w.device == nil {
+		return accounts.Account{}, accounts.ErrWalletClosed
+	}
+
 	if _, ok := w.paths[address]; !ok {
 		w.accounts = append(w.accounts, account)
 		w.paths[address] = make(accounts.DerivationPath, len(path))

--- a/cmd/clef/main.go
+++ b/cmd/clef/main.go
@@ -704,6 +704,7 @@ func signer(c *cli.Context) error {
 	log.Info("Starting signer", "chainid", chainId, "keystore", ksLoc,
 		"light-kdf", lightKdf, "advanced", advanced)
 	am := core.StartClefAccountManager(ksLoc, nousb, lightKdf, scpath)
+	defer am.Close()
 	apiImpl := core.NewSignerAPI(am, chainId, nousb, ui, db, advanced, pwStorage)
 
 	// Establish the bidirectional communication, by creating a new UI backend and registering


### PR DESCRIPTION
I noticed, when interacting both via `geth` and `clef`, that shutting down the process and trying to work with usb hardware wallets again, most often failed. I had to unplug the device and plug it back again for it to work. 

It turns out that the account manager did not call `Close` on the wallets that it was managing. 
Further, `clef` did not even bother to close the account manager. 

This PR fixes both problems. 