### PR TITLE
trie/triedb/pathdb: fix initialization flaws

### DIFF
--- a/trie/triedb/pathdb/database.go
+++ b/trie/triedb/pathdb/database.go
@@ -431,6 +431,9 @@ func (db *Database) Initialized(genesisRoot common.Hash) bool {
 			inited = true
 		}
 	})
+	if !inited {
+		inited = rawdb.ReadSnapSyncStatusFlag(db.diskdb) != rawdb.StateSyncUnknown
+	}
 	return inited
 }
 

--- a/trie/triedb/pathdb/history.go
+++ b/trie/triedb/pathdb/history.go
@@ -576,8 +576,10 @@ func truncateFromHead(db ethdb.Batcher, freezer *rawdb.ResettableFreezer, nhead 
 		return 0, err
 	}
 	// Ensure that the truncation target falls within the specified range.
-	if ohead < nhead || nhead < otail {
-		return 0, fmt.Errorf("out of range, tail: %d, head: %d, target: %d", otail, ohead, nhead)
+	if nhead != 0 { // truncating to zero is always possible
+		if ohead < nhead || nhead < otail {
+			return 0, fmt.Errorf("out of range, tail: %d, head: %d, target: %d", otail, ohead, nhead)
+		}
 	}
 	// Short circuit if nothing to truncate.
 	if ohead == nhead {


### PR DESCRIPTION
Fix for https://github.com/ethereum/go-ethereum/issues/28713 


**Original problem** was caused by https://github.com/ethereum/go-ethereum/pull/28595 . In this PR, we made it so that as soon as we start to sync, we delete the root of the disk layer. That is not wrong per se, but, another part of the code uses the "presence of the root" as an init-check for the pathdb. And, since the init-check now failed, it tried to initialize it, which failed since a sync was already ongoing.

**Impact:** after a state-sync has begun, if the node is restarted, it will refuse to restart, with the error message: `Fatal: Failed to register the Ethereum service: waiting for sync`. 


Fix courtesy of @rjl493456442 : we now extend the init-check, so that detect that "yes, it's already initalized, and a sync is ongoing". 

There's an additional fix also, which I ran into when doing a guerilla partial-wipe by keeping the ancient folder but deleting chaindata. It would not allow pruning the state histories back to zero. 
