### PR TITLE
core/rawdb: improve state scheme checking

### DIFF
--- a/core/rawdb/accessors_trie.go
+++ b/core/rawdb/accessors_trie.go
@@ -292,6 +292,11 @@ func ReadStateScheme(db ethdb.Reader) string {
 	if len(blob) != 0 {
 		return PathScheme
 	}
+	// The root node might be deleted during the initial snap sync, check
+	// the persistent state id then.
+	if id := ReadPersistentStateID(db); id != 0 {
+		return PathScheme
+	}
 	// In a hash-based scheme, the genesis state is consistently stored
 	// on the disk. To assess the scheme of the persistent state, it
 	// suffices to inspect the scheme of the genesis state.


### PR DESCRIPTION
This pull request improves the condition to check if path state scheme is ever used.

Originally root node presence is used as the indicator if path scheme is used or not. However due to fact that root node will be deleted during the initial snap sync, this condition is no longer useful.

Therefore, one more condition is added if the root node is not present => The presence of `PersistentStateID` is also checked, reasons:

- PersistentStateID is only available in path scheme
- PersistentStateID is only committed once we successfully update the persistent state, e.g. Initialize genesis state
- PersistentStateID entry won't be deleted ever.

If PersistentStateID is present, it can prove we did write state in path scheme before and it's a good indicator for path scheme.