### PR TITLE
cmd/geth: make it possible to autopilot removedb

### DIFF
--- a/cmd/geth/dbcmd.go
+++ b/cmd/geth/dbcmd.go
@@ -43,12 +43,23 @@ import (
 )
 
 var (
+	removeStateDataFlag = &cli.BoolFlag{
+		Name:  "remove.state",
+		Usage: "If set, selects the state data for removal",
+	}
+	removeChainDataFlag = &cli.BoolFlag{
+		Name:  "remove.chain",
+		Usage: "If set, selects the state data for removal",
+	}
+
 	removedbCommand = &cli.Command{
-		Action:    removeDB,
-		Name:      "removedb",
-		Usage:     "Remove blockchain and state databases",
+		Action: removeDB,
+		Name:   "removedb",
+		Usage: "Remove blockchain and state databases. If arguments are provided, " +
+			"they are interpreted as comma-separated answers to questions.",
 		ArgsUsage: "",
-		Flags:     utils.DatabaseFlags,
+		Flags: flags.Merge(utils.DatabaseFlags,
+			[]cli.Flag{removeStateDataFlag, removeChainDataFlag}),
 		Description: `
 Remove blockchain and state databases`,
 	}
@@ -211,11 +222,11 @@ func removeDB(ctx *cli.Context) error {
 	}
 	// Delete state data
 	statePaths := []string{rootDir, filepath.Join(ancientDir, rawdb.StateFreezerName)}
-	confirmAndRemoveDB(statePaths, "state data")
+	confirmAndRemoveDB(statePaths, "state data", ctx, removeStateDataFlag.Name)
 
 	// Delete ancient chain
 	chainPaths := []string{filepath.Join(ancientDir, rawdb.ChainFreezerName)}
-	confirmAndRemoveDB(chainPaths, "ancient chain")
+	confirmAndRemoveDB(chainPaths, "ancient chain", ctx, removeChainDataFlag.Name)
 	return nil
 }
 
@@ -238,14 +249,26 @@ func removeFolder(dir string) {
 
 // confirmAndRemoveDB prompts the user for a last confirmation and removes the
 // list of folders if accepted.
-func confirmAndRemoveDB(paths []string, kind string) {
+func confirmAndRemoveDB(paths []string, kind string, ctx *cli.Context, removeFlagName string) {
+	var (
+		confirm bool
+		err     error
+	)
 	msg := fmt.Sprintf("Location(s) of '%s': \n", kind)
 	for _, path := range paths {
 		msg += fmt.Sprintf("\t- %s\n", path)
 	}
 	fmt.Println(msg)
-
-	confirm, err := prompt.Stdin.PromptConfirm(fmt.Sprintf("Remove '%s'?", kind))
+	if ctx.IsSet(removeFlagName) {
+		confirm = ctx.Bool(removeFlagName)
+		if confirm {
+			fmt.Printf("Remove '%s'? [y/n] y\n", kind)
+		} else {
+			fmt.Printf("Remove '%s'? [y/n] n\n", kind)
+		}
+	} else {
+		confirm, err = prompt.Stdin.PromptConfirm(fmt.Sprintf("Remove '%s'?", kind))
+	}
 	switch {
 	case err != nil:
 		utils.Fatalf("%v", err)

--- a/cmd/geth/dbcmd.go
+++ b/cmd/geth/dbcmd.go
@@ -53,10 +53,9 @@ var (
 	}
 
 	removedbCommand = &cli.Command{
-		Action: removeDB,
-		Name:   "removedb",
-		Usage: "Remove blockchain and state databases. If arguments are provided, " +
-			"they are interpreted as comma-separated answers to questions.",
+		Action:    removeDB,
+		Name:      "removedb",
+		Usage:     "Remove blockchain and state databases",
 		ArgsUsage: "",
 		Flags: flags.Merge(utils.DatabaseFlags,
 			[]cli.Flag{removeStateDataFlag, removeChainDataFlag}),


### PR DESCRIPTION
Supersedes #28721

When managing geth over docker, sometimes it's desirable to do a partial wipe: delete state but retain freezer data. This can be a bit tricky: the ansible scripts to delete files individually are _slow_, a faster way to do it is to 
- move the freezer-data somewhere else, 
- delete the chaindata
- create the chaindata
- move back the freezer-data

This "works" but it's clumsy, and now that we have both block-data and state-data in freezer, it's a bit incomplete, the correct thing to do would be to save only the block-data, not the state-data. 

This PR implements an alternative way to achieve the same thing, by making it possible to run `geth removedb` non-interactive, using boolean options instead. 

------------

Explicitly removing chain (it asks about state, no question about chain):
```
[user@work go-ethereum]$ go run ./cmd/geth removedb --remove.chain
INFO [12-22|08:12:19.779] Maximum peer count                       ETH=50 total=50
INFO [12-22|08:12:19.837] Set global gas cap                       cap=50,000,000
INFO [12-22|08:12:19.838] Initializing the KZG library             backend=gokzg
Location(s) of 'state data': 
	- /home/user/.ethereum/geth/chaindata
	- /home/user/.ethereum/geth/chaindata/ancient/state

Remove 'state data'? [y/n] n 
Remove 'state data'? [y/n] n
INFO [12-22|08:12:31.010] Database deletion skipped                kind="state data" paths="[/home/user/.ethereum/geth/chaindata /home/user/.ethereum/geth/chaindata/ancient/state]"
Location(s) of 'ancient chain': 
	- /home/user/.ethereum/geth/chaindata/ancient/chain

Remove 'ancient chain'? [y/n] y
INFO [12-22|08:12:31.012] Folder is not existent                   path=/home/user/.ethereum/geth/chaindata/ancient/chain
INFO [12-22|08:12:31.012] Database successfully deleted            kind="ancient chain" paths=[] elapsed=1.797ms
```
Both specified, so no question asked (but it's still printed):
```
[user@work go-ethereum]$ go run ./cmd/geth removedb --remove.chain=false --remove.state=false
INFO [12-22|08:12:45.883] Maximum peer count                       ETH=50 total=50
INFO [12-22|08:12:45.899] Set global gas cap                       cap=50,000,000
INFO [12-22|08:12:45.900] Initializing the KZG library             backend=gokzg
Location(s) of 'state data': 
	- /home/user/.ethereum/geth/chaindata
	- /home/user/.ethereum/geth/chaindata/ancient/state

Remove 'state data'? [y/n] n
INFO [12-22|08:12:45.950] Database deletion skipped                kind="state data" paths="[/home/user/.ethereum/geth/chaindata /home/user/.ethereum/geth/chaindata/ancient/state]"
Location(s) of 'ancient chain': 
	- /home/user/.ethereum/geth/chaindata/ancient/chain

Remove 'ancient chain'? [y/n] n
INFO [12-22|08:12:45.951] Database deletion skipped                kind="ancient chain" paths=[/home/user/.ethereum/geth/chaindata/ancient/chain]
```

Both specified for deletion:
```
[user@work go-ethereum]$ go run ./cmd/geth removedb --remove.chain=true --remove.state=true
INFO [12-22|08:12:57.571] Maximum peer count                       ETH=50 total=50
INFO [12-22|08:12:57.584] Set global gas cap                       cap=50,000,000
INFO [12-22|08:12:57.584] Initializing the KZG library             backend=gokzg
Location(s) of 'state data': 
	- /home/user/.ethereum/geth/chaindata
	- /home/user/.ethereum/geth/chaindata/ancient/state

Remove 'state data'? [y/n] y
INFO [12-22|08:12:57.633] Folder is not existent                   path=/home/user/.ethereum/geth/chaindata/ancient/state
INFO [12-22|08:12:57.633] Database successfully deleted            kind="state data" paths=[/home/user/.ethereum/geth/chaindata] elapsed="218.429µs"
Location(s) of 'ancient chain': 
	- /home/user/.ethereum/geth/chaindata/ancient/chain

Remove 'ancient chain'? [y/n] y
INFO [12-22|08:12:57.634] Folder is not existent                   path=/home/user/.ethereum/geth/chaindata/ancient/chain
INFO [12-22|08:12:57.634] Database successfully deleted            kind="ancient chain" paths=[]                                    elapsed="31.8µs"
```
Nothing specified: 
```
[user@work go-ethereum]$ go run ./cmd/geth removedb 
INFO [12-22|08:13:13.461] Maximum peer count                       ETH=50 total=50
INFO [12-22|08:13:13.471] Set global gas cap                       cap=50,000,000
INFO [12-22|08:13:13.471] Initializing the KZG library             backend=gokzg
Location(s) of 'state data': 
	- /home/user/.ethereum/geth/chaindata
	- /home/user/.ethereum/geth/chaindata/ancient/state

Remove 'state data'? [y/n] ^C^C
^C
Fatal: prompt aborted
```