### PR TITLE
core/state: logic equivalence for GetCodeHash

### DIFF
--- a/core/state/statedb.go
+++ b/core/state/statedb.go
@@ -331,10 +331,10 @@ func (s *StateDB) GetCodeSize(addr common.Address) int {
 
 func (s *StateDB) GetCodeHash(addr common.Address) common.Hash {
 	stateObject := s.getStateObject(addr)
-	if stateObject == nil {
-		return common.Hash{}
+	if stateObject != nil {
+		return common.BytesToHash(stateObject.CodeHash())
 	}
-	return common.BytesToHash(stateObject.CodeHash())
+	return common.Hash{}
 }
 
 // GetState retrieves a value from the given account's storage trie.


### PR DESCRIPTION
Every other getter in statedb follows the pattern of:
```
if stateObject != nil {
    return value
}
return defaultValue
```
I changed GetCodeHash to match this pattern