### PR TITLE
tests: Add `currentExcessBlobGas` to state tests

### DIFF
--- a/tests/gen_stenv.go
+++ b/tests/gen_stenv.go
@@ -16,13 +16,14 @@ var _ = (*stEnvMarshaling)(nil)
 // MarshalJSON marshals as JSON.
 func (s stEnv) MarshalJSON() ([]byte, error) {
 	type stEnv struct {
-		Coinbase   common.UnprefixedAddress `json:"currentCoinbase"   gencodec:"required"`
-		Difficulty *math.HexOrDecimal256    `json:"currentDifficulty" gencodec:"optional"`
-		Random     *math.HexOrDecimal256    `json:"currentRandom"     gencodec:"optional"`
-		GasLimit   math.HexOrDecimal64      `json:"currentGasLimit"   gencodec:"required"`
-		Number     math.HexOrDecimal64      `json:"currentNumber"     gencodec:"required"`
-		Timestamp  math.HexOrDecimal64      `json:"currentTimestamp"  gencodec:"required"`
-		BaseFee    *math.HexOrDecimal256    `json:"currentBaseFee"    gencodec:"optional"`
+		Coinbase      common.UnprefixedAddress `json:"currentCoinbase"      gencodec:"required"`
+		Difficulty    *math.HexOrDecimal256    `json:"currentDifficulty"    gencodec:"optional"`
+		Random        *math.HexOrDecimal256    `json:"currentRandom"        gencodec:"optional"`
+		GasLimit      math.HexOrDecimal64      `json:"currentGasLimit"      gencodec:"required"`
+		Number        math.HexOrDecimal64      `json:"currentNumber"        gencodec:"required"`
+		Timestamp     math.HexOrDecimal64      `json:"currentTimestamp"     gencodec:"required"`
+		BaseFee       *math.HexOrDecimal256    `json:"currentBaseFee"       gencodec:"optional"`
+		ExcessBlobGas *math.HexOrDecimal64     `json:"currentExcessBlobGas" gencodec:"optional"`
 	}
 	var enc stEnv
 	enc.Coinbase = common.UnprefixedAddress(s.Coinbase)
@@ -32,19 +33,21 @@ func (s stEnv) MarshalJSON() ([]byte, error) {
 	enc.Number = math.HexOrDecimal64(s.Number)
 	enc.Timestamp = math.HexOrDecimal64(s.Timestamp)
 	enc.BaseFee = (*math.HexOrDecimal256)(s.BaseFee)
+	enc.ExcessBlobGas = (*math.HexOrDecimal64)(s.ExcessBlobGas)
 	return json.Marshal(&enc)
 }
 
 // UnmarshalJSON unmarshals from JSON.
 func (s *stEnv) UnmarshalJSON(input []byte) error {
 	type stEnv struct {
-		Coinbase   *common.UnprefixedAddress `json:"currentCoinbase"   gencodec:"required"`
-		Difficulty *math.HexOrDecimal256     `json:"currentDifficulty" gencodec:"optional"`
-		Random     *math.HexOrDecimal256     `json:"currentRandom"     gencodec:"optional"`
-		GasLimit   *math.HexOrDecimal64      `json:"currentGasLimit"   gencodec:"required"`
-		Number     *math.HexOrDecimal64      `json:"currentNumber"     gencodec:"required"`
-		Timestamp  *math.HexOrDecimal64      `json:"currentTimestamp"  gencodec:"required"`
-		BaseFee    *math.HexOrDecimal256     `json:"currentBaseFee"    gencodec:"optional"`
+		Coinbase      *common.UnprefixedAddress `json:"currentCoinbase"      gencodec:"required"`
+		Difficulty    *math.HexOrDecimal256     `json:"currentDifficulty"    gencodec:"optional"`
+		Random        *math.HexOrDecimal256     `json:"currentRandom"        gencodec:"optional"`
+		GasLimit      *math.HexOrDecimal64      `json:"currentGasLimit"      gencodec:"required"`
+		Number        *math.HexOrDecimal64      `json:"currentNumber"        gencodec:"required"`
+		Timestamp     *math.HexOrDecimal64      `json:"currentTimestamp"     gencodec:"required"`
+		BaseFee       *math.HexOrDecimal256     `json:"currentBaseFee"       gencodec:"optional"`
+		ExcessBlobGas *math.HexOrDecimal64      `json:"currentExcessBlobGas" gencodec:"optional"`
 	}
 	var dec stEnv
 	if err := json.Unmarshal(input, &dec); err != nil {
@@ -74,6 +77,9 @@ func (s *stEnv) UnmarshalJSON(input []byte) error {
 	s.Timestamp = uint64(*dec.Timestamp)
 	if dec.BaseFee != nil {
 		s.BaseFee = (*big.Int)(dec.BaseFee)
+	}
+	if dec.ExcessBlobGas != nil {
+		s.ExcessBlobGas = (*uint64)(dec.ExcessBlobGas)
 	}
 	return nil
 }


### PR DESCRIPTION
Adds `currentExcessBlobGas` to the state test parser, to be able to read tests generated by the following PR:

https://github.com/ethereum/execution-spec-tests/pull/356

The value is interpreted as the current context's ExcessBlobGas, as the value that would been read from the block's header, and assuming the value was correctly calculated by using the parent's ExcessBlobGas and BlobGasUsed.