### PR TITLE
ethclient: fix invalid params in eth_call, made ethclient support other EVMs network

### DIFF
--- a/ethclient/ethclient.go
+++ b/ethclient/ethclient.go
@@ -647,7 +647,7 @@ func toCallArg(msg ethereum.CallMsg) interface{} {
 		"to":   msg.To,
 	}
 	if len(msg.Data) > 0 {
-		arg["input"] = hexutil.Bytes(msg.Data)
+		arg["data"] = hexutil.Bytes(msg.Data)
 	}
 	if msg.Value != nil {
 		arg["value"] = (*hexutil.Big)(msg.Value)


### PR DESCRIPTION
I was using ethclient to query contract in other EVMs, but mostly only support `data` field instead `input`, while ethereum support both.

Replacement `input` with `data` for eth_call in ethclient: 
```json
{
    "jsonrpc": "2.0",
    "method": "eth_call",
    "params": [
        {
            "to": "0xdAC17F958D2ee523a2206206994597C13D831xxx",
            "input": "0x06fddxxx"
        },
        "latest"
    ],
    "id": 1
}
```
to 
```json
{
    "jsonrpc": "2.0",
    "method": "eth_call",
    "params": [
        {
            "to": "0xdAC17F958D2ee523a2206206994597C13D831xxx",
            "data": "0x06fddxxx"
        },
        "latest"
    ],
    "id": 1
}
```