### PR TITLE
chore(cmd/evm):fix link jump in cmd/evm/README.md

### DIFF
--- a/cmd/evm/README.md
+++ b/cmd/evm/README.md
@@ -214,7 +214,7 @@ exitcode:3 OK
 
 The chain configuration to be used for a transition is specified via the
 `--state.fork` CLI flag. A list of possible values and configurations can be
-found in [`tests/init.go`](tests/init.go).
+found in [`tests/init.go`](../../tests/init.go).
 
 #### Examples
 ##### Basic usage


### PR DESCRIPTION
fix the relative path in  cmd/evm/README.md

before that:
<img width="1319" alt="image" src="https://github.com/ethereum/go-ethereum/assets/24953789/cb026cff-878e-4bbe-946d-9cf1c6c10af4">
