### PR TITLE
eth/filters: fix early Unsubscribe of log events

### DIFF
--- a/eth/filters/api.go
+++ b/eth/filters/api.go
@@ -266,9 +266,9 @@ func (api *FilterAPI) Logs(ctx context.Context, crit FilterCriteria) (*rpc.Subsc
 	if err != nil {
 		return nil, err
 	}
-	defer logsSub.Unsubscribe()
 
 	go func() {
+		defer logsSub.Unsubscribe()
 		for {
 			select {
 			case logs := <-matchedLogs:


### PR DESCRIPTION
FIx https://github.com/ethereum/go-ethereum/pull/28762 the logsub should not be unsubscribed earlier than the go func
