### PR TITLE
eth: minor change of config-accessor

### DIFF
--- a/eth/api_backend.go
+++ b/eth/api_backend.go
@@ -260,7 +260,7 @@ func (b *EthAPIBackend) GetEVM(ctx context.Context, msg *core.Message, state *st
 	} else {
 		context = core.NewEVMBlockContext(header, b.eth.BlockChain(), nil)
 	}
-	return vm.NewEVM(context, txContext, state, b.eth.blockchain.Config(), *vmConfig)
+	return vm.NewEVM(context, txContext, state, b.ChainConfig(), *vmConfig)
 }
 
 func (b *EthAPIBackend) SubscribeRemovedLogsEvent(ch chan<- core.RemovedLogsEvent) event.Subscription {


### PR DESCRIPTION
we already have `func (b *EthAPIBackend) ChainConfig() *params.ChainConfig` and we can reuse it