### PR TITLE
website: fix `debug.stopGoTrace()` param docs

### DIFF
--- a/docs/interacting-with-geth/rpc/ns-debug.md
+++ b/docs/interacting-with-geth/rpc/ns-debug.md
@@ -455,8 +455,8 @@ Stops writing the Go runtime trace.
 
 | Client  | Method invocation                               |
 | :------ | ----------------------------------------------- |
-| Console | `debug.stopGoTrace(file)`                      |
-| RPC     | `{"method": "debug_stopGoTrace", "params": [string]}` |
+| Console | `debug.stopGoTrace()`                      |
+| RPC     | `{"method": "debug_stopGoTrace", "params": []}` |
 
 ### debug_storageRangeAt
 


### PR DESCRIPTION
The `debug_stopGoTrace` API does not accept any parameters but is documented as accepting a file name.
https://github.com/ethereum/go-ethereum/blob/daa2e5d6a66833b9834b60a3a46835610bbde99a/internal/web3ext/web3ext.go#L340-L344