### PR TITLE
docs: fix example to avoid  "gas required exceeds allowance"-error

### DIFF
--- a/docs/fundamentals/private-network.md
+++ b/docs/fundamentals/private-network.md
@@ -260,7 +260,7 @@ In each data directory save a copy of the following `genesis.json` to the top le
 ```json
 {
   "config": {
-    "chainId": 12345,
+    "chainId": 123454321,
     "homesteadBlock": 0,
     "eip150Block": 0,
     "eip155Block": 0,
@@ -283,8 +283,8 @@ In each data directory save a copy of the following `genesis.json` to the top le
   "gasLimit": "800000000",
   "extradata": "0x0000000000000000000000000000000000000000000000000000000000000000C1B2c0dFD381e6aC08f34816172d6343Decbb12b0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
   "alloc": {
-    "C1B2c0dFD381e6aC08f34816172d6343Decbb12b": { "balance": "500000" },
-    "c94d95a5106270775351eecfe43f97e8e75e59e8": { "balance": "500000" }
+    "C1B2c0dFD381e6aC08f34816172d6343Decbb12b": { "balance": "1000000000000000000" },
+    "c94d95a5106270775351eecfe43f97e8e75e59e8": { "balance": "1000000000000000000" }
   }
 }
 ```


### PR DESCRIPTION
This bug was already reported by [28450](https://github.com/ethereum/go-ethereum/issues/28450) on nov 1 and fixed in the same date by [28451](https://github.com/ethereum/go-ethereum/pull/28451,) but due to "Deploy Preview for geth-website failed" by netlify bot, was not deployed. 

On nov 7, the last comment of [28433](https://github.com/ethereum/go-ethereum/issues/28433#issuecomment-1800042790)  (the solution was pointed out in the same comment) reported the persistence of the bug, I tried by myself and found the bug still occurs:

![gasExceeds](https://github.com/ethereum/go-ethereum/assets/154467290/849f1beb-41c9-4db3-9d04-ddf71c0f5507)


This alternative PR fix this issue