### PR TITLE
log: add Handler getter to Logger interface

### DIFF
--- a/internal/testlog/testlog.go
+++ b/internal/testlog/testlog.go
@@ -98,6 +98,10 @@ func LoggerWithHandler(t *testing.T, handler slog.Handler) log.Logger {
 	}
 }
 
+func (l *logger) Handler() slog.Handler {
+	return l.l.Handler()
+}
+
 func (l *logger) Write(level slog.Level, msg string, ctx ...interface{}) {}
 
 func (l *logger) Enabled(ctx context.Context, level slog.Level) bool {

--- a/log/logger.go
+++ b/log/logger.go
@@ -137,6 +137,9 @@ type Logger interface {
 
 	// Enabled reports whether l emits log records at the given context and level.
 	Enabled(ctx context.Context, level slog.Level) bool
+
+	// Handler returns the underlying handler of the inner logger.
+	Handler() slog.Handler
 }
 
 type logger struct {
@@ -148,6 +151,10 @@ func NewLogger(h slog.Handler) Logger {
 	return &logger{
 		slog.New(h),
 	}
+}
+
+func (l *logger) Handler() slog.Handler {
+	return l.inner.Handler()
 }
 
 // write logs a message at the specified level:


### PR DESCRIPTION
It is sometimes useful to access the underlying handler of a logger. The `slog.Logger` exposes its handler, so this PR simply adds the `Handler` getter to geth's `log.Logger` interface and forwards it in the `logger` implementations to the inner logger.