### PR TITLE
cmd/devp2p/internal/ethtest: skip large tx test on github build

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -17,7 +17,7 @@ jobs:
         with:
           go-version: 1.21.4
       - name: Run tests
-        run: go test ./...
+        run: go test -short ./...
         env:
           GOOS: linux
           GOARCH: 386

--- a/cmd/devp2p/internal/ethtest/suite.go
+++ b/cmd/devp2p/internal/ethtest/suite.go
@@ -19,6 +19,7 @@ package ethtest
 import (
 	"crypto/rand"
 	"math/big"
+	"math/bits"
 	"reflect"
 
 	"github.com/ethereum/go-ethereum/common"
@@ -62,7 +63,7 @@ func NewSuite(dest *enode.Node, chainDir, engineURL, jwt string) (*Suite, error)
 }
 
 func (s *Suite) EthTests() []utesting.Test {
-	return []utesting.Test{
+	tests := []utesting.Test{
 		// status
 		{Name: "TestStatus", Fn: s.TestStatus},
 		// get block headers
@@ -78,10 +79,15 @@ func (s *Suite) EthTests() []utesting.Test {
 		// test transactions
 		{Name: "TestTransaction", Fn: s.TestTransaction},
 		{Name: "TestInvalidTxs", Fn: s.TestInvalidTxs},
-		{Name: "TestLargeTxRequest", Fn: s.TestLargeTxRequest},
 		{Name: "TestNewPooledTxs", Fn: s.TestNewPooledTxs},
 		{Name: "TestBlobViolations", Fn: s.TestBlobViolations},
 	}
+	// This test is often failing on 32-bit CI.
+	if bits.UintSize > 32 {
+		tests = append(tests, utesting.Test{Name: "TestLargeTxRequest", Fn: s.TestLargeTxRequest})
+	}
+	return tests
+
 }
 
 func (s *Suite) SnapTests() []utesting.Test {

--- a/cmd/devp2p/internal/ethtest/suite.go
+++ b/cmd/devp2p/internal/ethtest/suite.go
@@ -87,7 +87,6 @@ func (s *Suite) EthTests() []utesting.Test {
 		tests = append(tests, utesting.Test{Name: "TestLargeTxRequest", Fn: s.TestLargeTxRequest})
 	}
 	return tests
-
 }
 
 func (s *Suite) SnapTests() []utesting.Test {

--- a/cmd/devp2p/internal/ethtest/suite.go
+++ b/cmd/devp2p/internal/ethtest/suite.go
@@ -105,6 +105,7 @@ func (s *Suite) TestStatus(t *utesting.T) {
 	if err := conn.peer(s.chain, nil); err != nil {
 		t.Fatalf("peering failed: %v", err)
 	}
+}
 
 // headersMatch returns whether the received headers match the given request
 func headersMatch(expected []*types.Header, headers []*types.Header) bool {

--- a/cmd/devp2p/internal/ethtest/suite.go
+++ b/cmd/devp2p/internal/ethtest/suite.go
@@ -19,7 +19,6 @@ package ethtest
 import (
 	"crypto/rand"
 	"math/big"
-	"math/bits"
 	"reflect"
 
 	"github.com/ethereum/go-ethereum/common"
@@ -63,7 +62,7 @@ func NewSuite(dest *enode.Node, chainDir, engineURL, jwt string) (*Suite, error)
 }
 
 func (s *Suite) EthTests() []utesting.Test {
-	tests := []utesting.Test{
+	return []utesting.Test{
 		// status
 		{Name: "TestStatus", Fn: s.TestStatus},
 		// get block headers
@@ -77,16 +76,12 @@ func (s *Suite) EthTests() []utesting.Test {
 		{Name: "TestMaliciousHandshake", Fn: s.TestMaliciousHandshake},
 		{Name: "TestMaliciousStatus", Fn: s.TestMaliciousStatus},
 		// test transactions
+		{Name: "TestLargeTxRequest", Fn: s.TestLargeTxRequest, Slow: true},
 		{Name: "TestTransaction", Fn: s.TestTransaction},
 		{Name: "TestInvalidTxs", Fn: s.TestInvalidTxs},
 		{Name: "TestNewPooledTxs", Fn: s.TestNewPooledTxs},
 		{Name: "TestBlobViolations", Fn: s.TestBlobViolations},
 	}
-	// This test is often failing on 32-bit CI.
-	if bits.UintSize > 32 {
-		tests = append(tests, utesting.Test{Name: "TestLargeTxRequest", Fn: s.TestLargeTxRequest})
-	}
-	return tests
 }
 
 func (s *Suite) SnapTests() []utesting.Test {

--- a/cmd/devp2p/internal/ethtest/suite.go
+++ b/cmd/devp2p/internal/ethtest/suite.go
@@ -105,7 +105,6 @@ func (s *Suite) TestStatus(t *utesting.T) {
 	if err := conn.peer(s.chain, nil); err != nil {
 		t.Fatalf("peering failed: %v", err)
 	}
-}
 
 // headersMatch returns whether the received headers match the given request
 func headersMatch(expected []*types.Header, headers []*types.Header) bool {

--- a/cmd/devp2p/internal/ethtest/suite_test.go
+++ b/cmd/devp2p/internal/ethtest/suite_test.go
@@ -62,10 +62,11 @@ func TestEthSuite(t *testing.T) {
 	if err != nil {
 		t.Fatalf("could not create new test suite: %v", err)
 	}
+	skipReason, skip := skipSlow()
 	for _, test := range suite.EthTests() {
 		t.Run(test.Name, func(t *testing.T) {
-			if test.Slow && skipSlow() {
-				t.Skipf("skipped slow test %s", test.Name)
+			if test.Slow && skip {
+				t.Skipf("%s: %s", test.Name, skipReason)
 			}
 			result := utesting.RunTests([]utesting.Test{{Name: test.Name, Fn: test.Fn}}, os.Stdout)
 			if result[0].Failed {
@@ -153,6 +154,12 @@ func setupGeth(stack *node.Node, dir string) error {
 	return err
 }
 
-func skipSlow() bool {
-	return testing.Short() || runtime.GOARCH == "386"
+func skipSlow() (string, bool) {
+	if testing.Short() {
+		return "skipped in -short mode", true
+	}
+	if runtime.GOARCH == "386" {
+		return "skipped on 386 arch", true
+	}
+	return "", false
 }

--- a/cmd/devp2p/internal/ethtest/suite_test.go
+++ b/cmd/devp2p/internal/ethtest/suite_test.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"os"
 	"path"
+	"runtime"
 	"testing"
 	"time"
 
@@ -63,6 +64,9 @@ func TestEthSuite(t *testing.T) {
 	}
 	for _, test := range suite.EthTests() {
 		t.Run(test.Name, func(t *testing.T) {
+			if test.Slow && skipSlow() {
+				t.Skipf("skipped slow test %s", test.Name)
+			}
 			result := utesting.RunTests([]utesting.Test{{Name: test.Name, Fn: test.Fn}}, os.Stdout)
 			if result[0].Failed {
 				t.Fatal()
@@ -147,4 +151,8 @@ func setupGeth(stack *node.Node, dir string) error {
 	}
 	_, err = backend.BlockChain().InsertChain(chain.blocks[1:])
 	return err
+}
+
+func skipSlow() bool {
+	return testing.Short() || runtime.GOARCH == "386"
 }

--- a/cmd/devp2p/internal/ethtest/suite_test.go
+++ b/cmd/devp2p/internal/ethtest/suite_test.go
@@ -21,7 +21,6 @@ import (
 	"fmt"
 	"os"
 	"path"
-	"runtime"
 	"testing"
 	"time"
 
@@ -62,11 +61,10 @@ func TestEthSuite(t *testing.T) {
 	if err != nil {
 		t.Fatalf("could not create new test suite: %v", err)
 	}
-	skipReason, skip := skipSlow()
 	for _, test := range suite.EthTests() {
 		t.Run(test.Name, func(t *testing.T) {
-			if test.Slow && skip {
-				t.Skipf("%s: %s", test.Name, skipReason)
+			if test.Slow && testing.Short() {
+				t.Skipf("%s: skipping in -short mode", test.Name)
 			}
 			result := utesting.RunTests([]utesting.Test{{Name: test.Name, Fn: test.Fn}}, os.Stdout)
 			if result[0].Failed {
@@ -152,14 +150,4 @@ func setupGeth(stack *node.Node, dir string) error {
 	}
 	_, err = backend.BlockChain().InsertChain(chain.blocks[1:])
 	return err
-}
-
-func skipSlow() (string, bool) {
-	if testing.Short() {
-		return "skipped in -short mode", true
-	}
-	if runtime.GOARCH == "386" {
-		return "skipped on 386 arch", true
-	}
-	return "", false
 }

--- a/internal/utesting/utesting.go
+++ b/internal/utesting/utesting.go
@@ -35,6 +35,7 @@ import (
 type Test struct {
 	Name string
 	Fn   func(*T)
+	Slow bool
 }
 
 // Result is the result of a test execution.


### PR DESCRIPTION
This test was failling consistently on the github 32-bit build probably due to slow IO. Skipping it for that green check.