### PR TITLE
accounts, ethclient: minor tweaks on the new simulated backend

### DIFF
--- a/accounts/abi/bind/backends/simulated.go
+++ b/accounts/abi/bind/backends/simulated.go
@@ -44,7 +44,7 @@ func (b *SimulatedBackend) Fork(ctx context.Context, parentHash common.Hash) err
 // Deprecated: please use simulated.Backend from package
 // github.com/ethereum/go-ethereum/ethclient/simulated instead.
 func NewSimulatedBackend(alloc core.GenesisAlloc, gasLimit uint64) *SimulatedBackend {
-	b := simulated.NewBackend(alloc, simulated.WithGasLimit(gasLimit))
+	b := simulated.NewBackend(alloc, simulated.WithBlockGasLimit(gasLimit))
 	return &SimulatedBackend{
 		Backend: b,
 		Client:  b.Client(),

--- a/accounts/abi/bind/backends/simulated.go
+++ b/accounts/abi/bind/backends/simulated.go
@@ -44,7 +44,7 @@ func (b *SimulatedBackend) Fork(ctx context.Context, parentHash common.Hash) err
 // Deprecated: please use simulated.Backend from package
 // github.com/ethereum/go-ethereum/ethclient/simulated instead.
 func NewSimulatedBackend(alloc core.GenesisAlloc, gasLimit uint64) *SimulatedBackend {
-	b := simulated.NewBackend(alloc, gasLimit)
+	b := simulated.NewBackend(alloc, simulated.WithGasLimit(gasLimit))
 	return &SimulatedBackend{
 		Backend: b,
 		Client:  b.Client(),

--- a/accounts/abi/bind/backends/simulated.go
+++ b/accounts/abi/bind/backends/simulated.go
@@ -44,7 +44,7 @@ func (b *SimulatedBackend) Fork(ctx context.Context, parentHash common.Hash) err
 // Deprecated: please use simulated.Backend from package
 // github.com/ethereum/go-ethereum/ethclient/simulated instead.
 func NewSimulatedBackend(alloc core.GenesisAlloc, gasLimit uint64) *SimulatedBackend {
-	b := simulated.New(alloc, gasLimit)
+	b := simulated.NewBackend(alloc, gasLimit)
 	return &SimulatedBackend{
 		Backend: b,
 		Client:  b.Client(),

--- a/accounts/abi/bind/util_test.go
+++ b/accounts/abi/bind/util_test.go
@@ -60,7 +60,6 @@ func TestWaitDeployed(t *testing.T) {
 			core.GenesisAlloc{
 				crypto.PubkeyToAddress(testKey.PublicKey): {Balance: big.NewInt(10000000000000000)},
 			},
-			10000000,
 		)
 		defer backend.Close()
 
@@ -106,7 +105,6 @@ func TestWaitDeployedCornerCases(t *testing.T) {
 		core.GenesisAlloc{
 			crypto.PubkeyToAddress(testKey.PublicKey): {Balance: big.NewInt(10000000000000000)},
 		},
-		10000000,
 	)
 	defer backend.Close()
 

--- a/accounts/abi/bind/util_test.go
+++ b/accounts/abi/bind/util_test.go
@@ -56,7 +56,7 @@ var waitDeployedTests = map[string]struct {
 func TestWaitDeployed(t *testing.T) {
 	t.Parallel()
 	for name, test := range waitDeployedTests {
-		backend := simulated.New(
+		backend := simulated.NewBackend(
 			core.GenesisAlloc{
 				crypto.PubkeyToAddress(testKey.PublicKey): {Balance: big.NewInt(10000000000000000)},
 			},
@@ -102,7 +102,7 @@ func TestWaitDeployed(t *testing.T) {
 }
 
 func TestWaitDeployedCornerCases(t *testing.T) {
-	backend := simulated.New(
+	backend := simulated.NewBackend(
 		core.GenesisAlloc{
 			crypto.PubkeyToAddress(testKey.PublicKey): {Balance: big.NewInt(10000000000000000)},
 		},

--- a/ethclient/simulated/backend.go
+++ b/ethclient/simulated/backend.go
@@ -70,7 +70,7 @@ type Backend struct {
 // contract bindings in unit tests.
 //
 // A simulated backend always uses chainID 1337.
-func NewBackend(alloc core.GenesisAlloc, gasLimit uint64, options ...func(nodeConf *node.Config, ethConf *ethconfig.Config)) *Backend {
+func NewBackend(alloc core.GenesisAlloc, options ...func(nodeConf *node.Config, ethConf *ethconfig.Config)) *Backend {
 	// Create the default configurations for the outer node shell and the Ethereum
 	// service to mutate with the options afterwards
 	nodeConf := node.DefaultConfig
@@ -80,11 +80,9 @@ func NewBackend(alloc core.GenesisAlloc, gasLimit uint64, options ...func(nodeCo
 	ethConf := ethconfig.Defaults
 	ethConf.Genesis = &core.Genesis{
 		Config:   params.AllDevChainProtocolChanges,
-		GasLimit: gasLimit,
+		GasLimit: ethconfig.Defaults.Miner.GasCeil,
 		Alloc:    alloc,
 	}
-	ethConf.Miner.GasCeil = gasLimit
-	ethConf.RPCGasCap = 10 * gasLimit
 	ethConf.SyncMode = downloader.FullSync
 	ethConf.TxPool.NoLocals = true
 

--- a/ethclient/simulated/backend_test.go
+++ b/ethclient/simulated/backend_test.go
@@ -43,7 +43,7 @@ func simTestBackend(testAddr common.Address) *Backend {
 	return NewBackend(
 		core.GenesisAlloc{
 			testAddr: {Balance: big.NewInt(10000000000000000)},
-		}, 10000000,
+		},
 	)
 }
 
@@ -71,7 +71,7 @@ func newTx(sim *Backend, key *ecdsa.PrivateKey) (*types.Transaction, error) {
 }
 
 func TestNewBackend(t *testing.T) {
-	sim := NewBackend(core.GenesisAlloc{}, 30_000_000)
+	sim := NewBackend(core.GenesisAlloc{})
 	defer sim.Close()
 
 	client := sim.Client()
@@ -94,7 +94,7 @@ func TestNewBackend(t *testing.T) {
 }
 
 func TestAdjustTime(t *testing.T) {
-	sim := NewBackend(core.GenesisAlloc{}, 10_000_000)
+	sim := NewBackend(core.GenesisAlloc{})
 	defer sim.Close()
 
 	client := sim.Client()

--- a/ethclient/simulated/backend_test.go
+++ b/ethclient/simulated/backend_test.go
@@ -40,7 +40,7 @@ var (
 )
 
 func simTestBackend(testAddr common.Address) *Backend {
-	return New(
+	return NewBackend(
 		core.GenesisAlloc{
 			testAddr: {Balance: big.NewInt(10000000000000000)},
 		}, 10000000,
@@ -70,8 +70,8 @@ func newTx(sim *Backend, key *ecdsa.PrivateKey) (*types.Transaction, error) {
 	return types.SignTx(tx, types.LatestSignerForChainID(chainid), key)
 }
 
-func TestNewSim(t *testing.T) {
-	sim := New(core.GenesisAlloc{}, 30_000_000)
+func TestNewBackend(t *testing.T) {
+	sim := NewBackend(core.GenesisAlloc{}, 30_000_000)
 	defer sim.Close()
 
 	client := sim.Client()
@@ -94,7 +94,7 @@ func TestNewSim(t *testing.T) {
 }
 
 func TestAdjustTime(t *testing.T) {
-	sim := New(core.GenesisAlloc{}, 10_000_000)
+	sim := NewBackend(core.GenesisAlloc{}, 10_000_000)
 	defer sim.Close()
 
 	client := sim.Client()

--- a/ethclient/simulated/options.go
+++ b/ethclient/simulated/options.go
@@ -25,6 +25,7 @@ import (
 // when producing blocks.
 func WithGasLimit(gaslimit uint64) func(nodeConf *node.Config, ethConf *ethconfig.Config) {
 	return func(nodeConf *node.Config, ethConf *ethconfig.Config) {
+		ethConf.Genesis.GasLimit = gaslimit
 		ethConf.Miner.GasCeil = gaslimit
 	}
 }

--- a/ethclient/simulated/options.go
+++ b/ethclient/simulated/options.go
@@ -1,0 +1,38 @@
+// Copyright 2024 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+
+package simulated
+
+import (
+	"github.com/ethereum/go-ethereum/eth/ethconfig"
+	"github.com/ethereum/go-ethereum/node"
+)
+
+// WithGasLimit configures the simulated backend to target a specific gas limit
+// when producing blocks.
+func WithGasLimit(gaslimit uint64) func(nodeConf *node.Config, ethConf *ethconfig.Config) {
+	return func(nodeConf *node.Config, ethConf *ethconfig.Config) {
+		ethConf.Miner.GasCeil = gaslimit
+	}
+}
+
+// WithCallGasCap configures the simulated backend to cap eth_calls to a specific
+// gas limit when running client operations.
+func WithCallGasCap(gascap uint64) func(nodeConf *node.Config, ethConf *ethconfig.Config) {
+	return func(nodeConf *node.Config, ethConf *ethconfig.Config) {
+		ethConf.RPCGasCap = gascap
+	}
+}

--- a/ethclient/simulated/options.go
+++ b/ethclient/simulated/options.go
@@ -21,19 +21,19 @@ import (
 	"github.com/ethereum/go-ethereum/node"
 )
 
-// WithGasLimit configures the simulated backend to target a specific gas limit
+// WithBlockGasLimit configures the simulated backend to target a specific gas limit
 // when producing blocks.
-func WithGasLimit(gaslimit uint64) func(nodeConf *node.Config, ethConf *ethconfig.Config) {
+func WithBlockGasLimit(gaslimit uint64) func(nodeConf *node.Config, ethConf *ethconfig.Config) {
 	return func(nodeConf *node.Config, ethConf *ethconfig.Config) {
 		ethConf.Genesis.GasLimit = gaslimit
 		ethConf.Miner.GasCeil = gaslimit
 	}
 }
 
-// WithCallGasCap configures the simulated backend to cap eth_calls to a specific
+// WithCallGasLimit configures the simulated backend to cap eth_calls to a specific
 // gas limit when running client operations.
-func WithCallGasCap(gascap uint64) func(nodeConf *node.Config, ethConf *ethconfig.Config) {
+func WithCallGasLimit(gaslimit uint64) func(nodeConf *node.Config, ethConf *ethconfig.Config) {
 	return func(nodeConf *node.Config, ethConf *ethconfig.Config) {
-		ethConf.RPCGasCap = gascap
+		ethConf.RPCGasCap = gaslimit
 	}
 }

--- a/ethclient/simulated/options_test.go
+++ b/ethclient/simulated/options_test.go
@@ -28,10 +28,10 @@ import (
 )
 
 // Tests that the simulator starts with the initial gas limit in the genesis block,
-// but that it can target a different value.
+// and that it keeps the same target value.
 func TestWithGasLimitOption(t *testing.T) {
 	// Construct a simulator, targeting a different gas limit
-	sim := NewBackend(core.GenesisAlloc{}, 30_000_000, WithGasLimit(29_940_000))
+	sim := NewBackend(core.GenesisAlloc{}, WithGasLimit(12_345_678))
 	defer sim.Close()
 
 	client := sim.Client()
@@ -39,8 +39,8 @@ func TestWithGasLimitOption(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to retrieve genesis block: %v", err)
 	}
-	if genesis.GasLimit() != 30_000_000 {
-		t.Errorf("genesis gas limit mismatch: have %v, want %v", genesis.GasLimit(), 30_000_000)
+	if genesis.GasLimit() != 12_345_678 {
+		t.Errorf("genesis gas limit mismatch: have %v, want %v", genesis.GasLimit(), 12_345_678)
 	}
 	// Produce a number of blocks and verify the locked in gas target
 	sim.Commit()
@@ -48,24 +48,8 @@ func TestWithGasLimitOption(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to retrieve head block: %v", err)
 	}
-	if head.GasLimit() != 29_970_705 {
-		t.Errorf("head gas limit mismatch: have %v, want %v", head.GasLimit(), 29_970_705)
-	}
-	sim.Commit()
-	head, err = client.BlockByNumber(context.Background(), big.NewInt(2))
-	if err != nil {
-		t.Fatalf("failed to retrieve head block: %v", err)
-	}
-	if head.GasLimit() != 29_941_438 {
-		t.Errorf("head gas limit mismatch: have %v, want %v", head.GasLimit(), 29_941_438)
-	}
-	sim.Commit()
-	head, err = client.BlockByNumber(context.Background(), big.NewInt(3))
-	if err != nil {
-		t.Fatalf("failed to retrieve head block: %v", err)
-	}
-	if head.GasLimit() != 29_940_000 {
-		t.Errorf("head gas limit mismatch: have %v, want %v", head.GasLimit(), 29_940_000)
+	if head.GasLimit() != 12_345_678 {
+		t.Errorf("head gas limit mismatch: have %v, want %v", head.GasLimit(), 12_345_678)
 	}
 }
 
@@ -74,7 +58,7 @@ func TestWithCallGasCapOption(t *testing.T) {
 	// Construct a simulator, targeting a different gas limit
 	sim := NewBackend(core.GenesisAlloc{
 		testAddr: {Balance: big.NewInt(10000000000000000)},
-	}, 30_000_000, WithCallGasCap(params.TxGas-1))
+	}, WithCallGasCap(params.TxGas-1))
 	defer sim.Close()
 
 	client := sim.Client()

--- a/ethclient/simulated/options_test.go
+++ b/ethclient/simulated/options_test.go
@@ -1,0 +1,89 @@
+// Copyright 2024 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+
+package simulated
+
+import (
+	"context"
+	"math/big"
+	"strings"
+	"testing"
+
+	"github.com/ethereum/go-ethereum"
+	"github.com/ethereum/go-ethereum/core"
+	"github.com/ethereum/go-ethereum/params"
+)
+
+// Tests that the simulator starts with the initial gas limit in the genesis block,
+// but that it can target a different value.
+func TestWithGasLimitOption(t *testing.T) {
+	// Construct a simulator, targeting a different gas limit
+	sim := NewBackend(core.GenesisAlloc{}, 30_000_000, WithGasLimit(29_940_000))
+	defer sim.Close()
+
+	client := sim.Client()
+	genesis, err := client.BlockByNumber(context.Background(), big.NewInt(0))
+	if err != nil {
+		t.Fatalf("failed to retrieve genesis block: %v", err)
+	}
+	if genesis.GasLimit() != 30_000_000 {
+		t.Errorf("genesis gas limit mismatch: have %v, want %v", genesis.GasLimit(), 30_000_000)
+	}
+	// Produce a number of blocks and verify the locked in gas target
+	sim.Commit()
+	head, err := client.BlockByNumber(context.Background(), big.NewInt(1))
+	if err != nil {
+		t.Fatalf("failed to retrieve head block: %v", err)
+	}
+	if head.GasLimit() != 29_970_705 {
+		t.Errorf("head gas limit mismatch: have %v, want %v", head.GasLimit(), 29_970_705)
+	}
+	sim.Commit()
+	head, err = client.BlockByNumber(context.Background(), big.NewInt(2))
+	if err != nil {
+		t.Fatalf("failed to retrieve head block: %v", err)
+	}
+	if head.GasLimit() != 29_941_438 {
+		t.Errorf("head gas limit mismatch: have %v, want %v", head.GasLimit(), 29_941_438)
+	}
+	sim.Commit()
+	head, err = client.BlockByNumber(context.Background(), big.NewInt(3))
+	if err != nil {
+		t.Fatalf("failed to retrieve head block: %v", err)
+	}
+	if head.GasLimit() != 29_940_000 {
+		t.Errorf("head gas limit mismatch: have %v, want %v", head.GasLimit(), 29_940_000)
+	}
+}
+
+// Tests that the simulator honors the RPC call caps set by the options.
+func TestWithCallGasCapOption(t *testing.T) {
+	// Construct a simulator, targeting a different gas limit
+	sim := NewBackend(core.GenesisAlloc{
+		testAddr: {Balance: big.NewInt(10000000000000000)},
+	}, 30_000_000, WithCallGasCap(params.TxGas-1))
+	defer sim.Close()
+
+	client := sim.Client()
+	_, err := client.CallContract(context.Background(), ethereum.CallMsg{
+		From: testAddr,
+		To:   &testAddr,
+		Gas:  21000,
+	}, nil)
+	if !strings.Contains(err.Error(), core.ErrIntrinsicGas.Error()) {
+		t.Fatalf("error mismatch: have %v, want %v", err, core.ErrIntrinsicGas)
+	}
+}

--- a/ethclient/simulated/options_test.go
+++ b/ethclient/simulated/options_test.go
@@ -29,9 +29,9 @@ import (
 
 // Tests that the simulator starts with the initial gas limit in the genesis block,
 // and that it keeps the same target value.
-func TestWithGasLimitOption(t *testing.T) {
+func TestWithBlockGasLimitOption(t *testing.T) {
 	// Construct a simulator, targeting a different gas limit
-	sim := NewBackend(core.GenesisAlloc{}, WithGasLimit(12_345_678))
+	sim := NewBackend(core.GenesisAlloc{}, WithBlockGasLimit(12_345_678))
 	defer sim.Close()
 
 	client := sim.Client()
@@ -54,11 +54,11 @@ func TestWithGasLimitOption(t *testing.T) {
 }
 
 // Tests that the simulator honors the RPC call caps set by the options.
-func TestWithCallGasCapOption(t *testing.T) {
+func TestWithCallGasLimitOption(t *testing.T) {
 	// Construct a simulator, targeting a different gas limit
 	sim := NewBackend(core.GenesisAlloc{
 		testAddr: {Balance: big.NewInt(10000000000000000)},
-	}, WithCallGasCap(params.TxGas-1))
+	}, WithCallGasLimit(params.TxGas-1))
 	defer sim.Close()
 
 	client := sim.Client()


### PR DESCRIPTION
This PR does a minor renaming of the simulated constructor and fixes some gas limit bugs introduced by the rework.

It also adds an initial batch of fine tuning options.