### PR TITLE
tests: more verbosity if block decoding fails

### DIFF
--- a/tests/block_test_util.go
+++ b/tests/block_test_util.go
@@ -36,6 +36,7 @@ import (
 	"github.com/ethereum/go-ethereum/core/state"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/core/vm"
+	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/params"
 	"github.com/ethereum/go-ethereum/rlp"
 	"github.com/ethereum/go-ethereum/trie"
@@ -224,6 +225,7 @@ func (t *BlockTest) insertBlocks(blockchain *core.BlockChain) ([]btBlock, error)
 		cb, err := b.decode()
 		if err != nil {
 			if b.BlockHeader == nil {
+				log.Info("Block decoding failed", "index", bi, "err", err)
 				continue // OK - block is supposed to be invalid, continue with next block
 			} else {
 				return nil, fmt.Errorf("block RLP decoding failed when expected to succeed: %v", err)


### PR DESCRIPTION
This prints some more info in case a block in a blockchain test fails decoding. 
```
$ go run ./cmd/evm/ blocktest ~/Downloads/invalid_blob_tx_contract_creation.json  2>&1 | tail -n 5
INFO [01-15|13:32:38.195] ---------------------------------------------------------------------------------------------------------------------------------------------------------
INFO [01-15|13:32:38.195] 
INFO [01-15|13:32:38.196] Loaded most recent local block           number=0 hash=93a8f6..9578db td=0 age=54y9mo3w
INFO [01-15|13:32:38.196] Block decoding failed                    index=0 err="rlp: input string too short for common.Address, decoding into (types.Block)(types.extblock).Txs[0](types.BlobTx).To"
INFO [01-15|13:32:38.196] Blockchain stopped
```
This was requested by testing-team (@danceratopz ) , who wanted to experiment with blob-txs without `to`.

Example testcase: 
```
{
    "tests/cancun/eip4844_blobs/test_blob_txs.py::test_invalid_blob_tx_contract_creation[fork_Cancun-blockchain_test-]": {
        "_info": {
            "filling-transition-tool": "evm version 1.13.9-unstable-6313a9df",
            "reference-spec": "https://github.com/ethereum/EIPs/blob/master/EIPS/eip-4844.md",
            "reference-spec-version": "f0eb6a364aaf5ccb43516fa2c269a54fb881ecfd"
        },
        "network": "Cancun",
        "genesisRLP": "0xf90243f9023da00000000000000000000000000000000000000000000000000000000000000000a01dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347940000000000000000000000000000000000000000a0300a057c652cb1e1c221ce8ad52e18d155520093291cefda9b6a4a3a7c2c5e13a056e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421a056e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421b9010000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000808088016345785d8a0000808000a0000000000000000000000000000000000000000000000000000000000000000088000000000000000007a056e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b4218083140000a00000000000000000000000000000000000000000000000000000000000000000c0c0c0",
        "genesisBlockHeader": {
            "parentHash": "0x0000000000000000000000000000000000000000000000000000000000000000",
            "uncleHash": "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
            "coinbase": "0x0000000000000000000000000000000000000000",
            "stateRoot": "0x300a057c652cb1e1c221ce8ad52e18d155520093291cefda9b6a4a3a7c2c5e13",
            "transactionsTrie": "0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421",
            "receiptTrie": "0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421",
            "bloom": "0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
            "difficulty": "0x00",
            "number": "0x00",
            "gasLimit": "0x016345785d8a0000",
            "gasUsed": "0x00",
            "timestamp": "0x00",
            "extraData": "0x00",
            "mixHash": "0x0000000000000000000000000000000000000000000000000000000000000000",
            "nonce": "0x0000000000000000",
            "baseFeePerGas": "0x07",
            "withdrawalsRoot": "0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421",
            "blobGasUsed": "0x00",
            "excessBlobGas": "0x140000",
            "parentBeaconBlockRoot": "0x0000000000000000000000000000000000000000000000000000000000000000",
            "hash": "0x93a8f642e7619d3fbfe682dfdeaa06b70582703e21b8d94f85f13e9a8b9578db"
        },
        "blocks": [
            {
                "rlp": "0xf902c0f90242a093a8f642e7619d3fbfe682dfdeaa06b70582703e21b8d94f85f13e9a8b9578dba01dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347942adc25665018aa1fe0e6bc666dac8fc2697ff9baa0cc7b88d58927ebfd44f66b63ec5a29eb8661cedeaf8a9d563f6f7408b3c42fcea0d7d1670440b906eca746fb1b344ad2d3843bfaaf82324d0b4e7cdab67c3e753ea0eaa8c40899a61ae59615cf9985f5e2194f8fd2b57d273be63bde6733e89b12abb9010000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000800188016345785d8a00008252080c80a0000000000000000000000000000000000000000000000000000000000000000088000000000000000007a056e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b42183020000830e0000a00000000000000000000000000000000000000000000000000000000000000000f877b87503f872018080078307a120800180c001e1a0010000000000000000000000000000000000000000000000000000000000000001a0990fd9e8068282f2f657fda1fc17ba168b6ccb064a796796a04647268efdc0baa05497398a0d1bfe95930e450561b2a88ece16b0212a4784e92b0a7cd3921852c4c0c0",
                "expectException": "no_contract_creating_blob_txs",
                "rlp_decoded": {
                    "blockHeader": {
                        "parentHash": "0x93a8f642e7619d3fbfe682dfdeaa06b70582703e21b8d94f85f13e9a8b9578db",
                        "uncleHash": "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
                        "coinbase": "0x2adc25665018aa1fe0e6bc666dac8fc2697ff9ba",
                        "stateRoot": "0xcc7b88d58927ebfd44f66b63ec5a29eb8661cedeaf8a9d563f6f7408b3c42fce",
                        "transactionsTrie": "0xd7d1670440b906eca746fb1b344ad2d3843bfaaf82324d0b4e7cdab67c3e753e",
                        "receiptTrie": "0xeaa8c40899a61ae59615cf9985f5e2194f8fd2b57d273be63bde6733e89b12ab",
                        "bloom": "0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
                        "difficulty": "0x00",
                        "number": "0x01",
                        "gasLimit": "0x016345785d8a0000",
                        "gasUsed": "0x5208",
                        "timestamp": "0x0c",
                        "extraData": "0x",
                        "mixHash": "0x0000000000000000000000000000000000000000000000000000000000000000",
                        "nonce": "0x0000000000000000",
                        "baseFeePerGas": "0x07",
                        "withdrawalsRoot": "0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421",
                        "blobGasUsed": "0x020000",
                        "excessBlobGas": "0x0e0000",
                        "parentBeaconBlockRoot": "0x0000000000000000000000000000000000000000000000000000000000000000",
                        "hash": "0x9b5af5a719ed59157d3f4436e9033d68b36029b1bbdb43a25ddf76fe1cd8b627"
                    },
                    "transactions": [
                        {
                            "type": "0x03",
                            "chainId": "0x01",
                            "nonce": "0x00",
                            "maxPriorityFeePerGas": "0x00",
                            "maxFeePerGas": "0x07",
                            "gasLimit": "0x07a120",
                            "to": "0x0000000000000000000000000000000000000100",
                            "value": "0x01",
                            "data": "0x",
                            "accessList": [],
                            "maxFeePerBlobGas": "0x01",
                            "blobVersionedHashes": [
                                "0x0100000000000000000000000000000000000000000000000000000000000000"
                            ],
                            "v": "0x01",
                            "r": "0x8633745d9ccae895b1cd9b35473bf2c2f19230b32ebecf93fcf6e98e08868a7f",
                            "s": "0x2df5e81e127ad763e99e70e134ea214d74d47e80787950b1959551c7b61f68ea",
                            "sender": "0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b"
                        }
                    ],
                    "uncleHeaders": [],
                    "withdrawals": []
                }
            }
        ],
        "lastblockhash": "0x93a8f642e7619d3fbfe682dfdeaa06b70582703e21b8d94f85f13e9a8b9578db",
        "pre": {
            "0x000f3df6d732807ef1319fb7b8bb8522d0beac02": {
                "nonce": "0x01",
                "balance": "0x00",
                "code": "0x3373fffffffffffffffffffffffffffffffffffffffe14604d57602036146024575f5ffd5b5f35801560495762001fff810690815414603c575f5ffd5b62001fff01545f5260205ff35b5f5ffd5b62001fff42064281555f359062001fff015500",
                "storage": {}
            },
            "0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b": {
                "nonce": "0x00",
                "balance": "0x3767e1",
                "code": "0x",
                "storage": {}
            }
        },
        "postState": {
            "0x000f3df6d732807ef1319fb7b8bb8522d0beac02": {
                "nonce": "0x01",
                "balance": "0x00",
                "code": "0x3373fffffffffffffffffffffffffffffffffffffffe14604d57602036146024575f5ffd5b5f35801560495762001fff810690815414603c575f5ffd5b62001fff01545f5260205ff35b5f5ffd5b62001fff42064281555f359062001fff015500",
                "storage": {}
            },
            "0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b": {
                "nonce": "0x00",
                "balance": "0x3767e1",
                "code": "0x",
                "storage": {}
            }
        },
        "sealEngine": "NoProof"
    }
}
```