### PR TITLE
miner: only notify when `payload.full` is updated

### DIFF
--- a/miner/payload_building.go
+++ b/miner/payload_building.go
@@ -120,7 +120,6 @@ func (payload *Payload) update(r *newPayloadResult, elapsed time.Duration) {
 		)
 		payload.cond.Broadcast() // fire signal for notifying full block
 	}
-	
 }
 
 // Resolve returns the latest built payload and also terminates the background

--- a/miner/payload_building.go
+++ b/miner/payload_building.go
@@ -118,8 +118,9 @@ func (payload *Payload) update(r *newPayloadResult, elapsed time.Duration) {
 			"root", r.block.Root(),
 			"elapsed", common.PrettyDuration(elapsed),
 		)
+		payload.cond.Broadcast() // fire signal for notifying full block
 	}
-	payload.cond.Broadcast() // fire signal for notifying full block
+	
 }
 
 // Resolve returns the latest built payload and also terminates the background


### PR DESCRIPTION
If `Broadcast` is called when `payload.full` is not updated, the [waiting side](https://github.com/ethereum/go-ethereum/blob/566754c74a74c8175ec2f1ee5cc10a8caced6015/miner/payload_building.go#L166) will be waken and panic inside `BlockToExecutableData` since the [`payload.full`](https://github.com/ethereum/go-ethereum/blob/566754c74a74c8175ec2f1ee5cc10a8caced6015/miner/payload_building.go#L174) is `nil`.