### PR TITLE
ethclient/simulated: add timeout to fix flaky test

### DIFF
--- a/ethclient/simulated/backend_test.go
+++ b/ethclient/simulated/backend_test.go
@@ -230,6 +230,9 @@ func TestForkResendTx(t *testing.T) {
 
 	// 5.
 	sim.Commit()
+	// The new-head-event needs to trickle out to the tx pool(s), so they reset
+	// their internal state.
+	time.Sleep(1 * time.Second)
 	if err := client.SendTransaction(ctx, tx); err != nil {
 		t.Fatalf("sending transaction: %v", err)
 	}


### PR DESCRIPTION
We have a flaky test: 
```
--- FAIL: TestForkResendTx (0.02s)
    backend_test.go:234: sending transaction: nonce too low: next nonce 1, tx nonce 0
```
The reason the test fails is that after rolling back a block (reorging out a transaction), the head-event which should trigger the txpool to reset the internal state is not handled fast enough, and when we try to re-submit the tx, the pool uses the old data, saying the nonce should be `1`. 

This is a crappy fix, but I don't see how to properly make sure the head-event was processed by subpools, when all we have is a backend and an ethclient. 