### PR TITLE
eth/filters: reset filter.begin in BenchmarkFilters

### DIFF
--- a/eth/filters/filter_test.go
+++ b/eth/filters/filter_test.go
@@ -99,6 +99,7 @@ func BenchmarkFilters(b *testing.B) {
 	filter := sys.NewRangeFilter(0, -1, []common.Address{addr1, addr2, addr3, addr4}, nil)
 
 	for i := 0; i < b.N; i++ {
+		filter.begin = 0
 		logs, _ := filter.Logs(context.Background())
 		if len(logs) != 4 {
 			b.Fatal("expected 4 logs, got", len(logs))


### PR DESCRIPTION
This PR resets `filter.begin` to 0 between benchmark iterations, otherwise the filter backend will update `begin` after the call to `Logs` and the 2nd call will return no logs.
Alternatively, can move:
```go
	filter := sys.NewRangeFilter(0, -1, []common.Address{addr1, addr2, addr3, addr4}, nil)
``` 
to the loop if you prefer.