### PR TITLE
go.mod: retract 1.13.9

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -141,3 +141,5 @@ require (
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	rsc.io/tmplfunc v0.0.3 // indirect
 )
+
+retract v1.13.9 // wrong commit was tagged


### PR DESCRIPTION
This PR proposes adding a [retract directive](https://go.dev/ref/mod#go-mod-file-retract) for `v1.13.9`, based on the `v1.13.10` [release notes](https://github.com/ethereum/go-ethereum/releases/tag/v1.13.10).

> When a module version is retracted, users will not upgrade to it automatically using [go get](https://go.dev/ref/mod#go-get), [go mod tidy](https://go.dev/ref/mod#go-mod-tidy), or other commands. Builds that depend on retracted versions should continue to work, but users will be notified of retractions when they check for updates with [go list -m -u](https://go.dev/ref/mod#go-list-m) or update a related module with [go get](https://go.dev/ref/mod#go-get).