### PR TITLE
core, cmd/evm/internal/t8ntool, miner, params: Implement eip-2935

### DIFF
--- a/cmd/evm/internal/t8ntool/execution.go
+++ b/cmd/evm/internal/t8ntool/execution.go
@@ -122,7 +122,7 @@ func (pre *Prestate) Apply(vmConfig vm.Config, chainConfig *params.ChainConfig,
 	// Capture errors for BLOCKHASH operation, if we haven't been supplied the
 	// required blockhashes
 	var hashError error
-	getHash := func(num uint64) common.Hash {
+	getHash := func(num uint64, _ vm.StateDB, _ bool) common.Hash {
 		if pre.Env.BlockHashes == nil {
 			hashError = fmt.Errorf("getHash(%d) invoked, no blockhashes provided", num)
 			return common.Hash{}

--- a/cmd/evm/internal/t8ntool/execution.go
+++ b/cmd/evm/internal/t8ntool/execution.go
@@ -89,6 +89,7 @@ type stEnv struct {
 	ParentExcessBlobGas   *uint64                             `json:"parentExcessBlobGas,omitempty"`
 	ParentBlobGasUsed     *uint64                             `json:"parentBlobGasUsed,omitempty"`
 	ParentBeaconBlockRoot *common.Hash                        `json:"parentBeaconBlockRoot"`
+	ParentHash            *common.Hash                        `json:"parentHash,omitempty"`
 }
 
 type stEnvMarshaling struct {
@@ -189,6 +190,9 @@ func (pre *Prestate) Apply(vmConfig vm.Config, chainConfig *params.ChainConfig,
 	if beaconRoot := pre.Env.ParentBeaconBlockRoot; beaconRoot != nil {
 		evm := vm.NewEVM(vmContext, vm.TxContext{}, statedb, chainConfig, vmConfig)
 		core.ProcessBeaconBlockRoot(*beaconRoot, evm, statedb)
+	}
+	if chainConfig.IsPrague(big.NewInt(int64(pre.Env.Number)), pre.Env.Timestamp) {
+		core.ProcessParentBlockHash(statedb, pre.Env.Number-1, *pre.Env.ParentHash)
 	}
 
 	for i := 0; txIt.Next(); i++ {

--- a/cmd/evm/internal/t8ntool/gen_stenv.go
+++ b/cmd/evm/internal/t8ntool/gen_stenv.go
@@ -37,6 +37,7 @@ func (s stEnv) MarshalJSON() ([]byte, error) {
 		ParentExcessBlobGas   *math.HexOrDecimal64                `json:"parentExcessBlobGas,omitempty"`
 		ParentBlobGasUsed     *math.HexOrDecimal64                `json:"parentBlobGasUsed,omitempty"`
 		ParentBeaconBlockRoot *common.Hash                        `json:"parentBeaconBlockRoot"`
+		ParentHash            *common.Hash                        `json:"parentHash,omitempty"`
 	}
 	var enc stEnv
 	enc.Coinbase = common.UnprefixedAddress(s.Coinbase)
@@ -59,6 +60,7 @@ func (s stEnv) MarshalJSON() ([]byte, error) {
 	enc.ParentExcessBlobGas = (*math.HexOrDecimal64)(s.ParentExcessBlobGas)
 	enc.ParentBlobGasUsed = (*math.HexOrDecimal64)(s.ParentBlobGasUsed)
 	enc.ParentBeaconBlockRoot = s.ParentBeaconBlockRoot
+	enc.ParentHash = s.ParentHash
 	return json.Marshal(&enc)
 }
 
@@ -85,6 +87,7 @@ func (s *stEnv) UnmarshalJSON(input []byte) error {
 		ParentExcessBlobGas   *math.HexOrDecimal64                `json:"parentExcessBlobGas,omitempty"`
 		ParentBlobGasUsed     *math.HexOrDecimal64                `json:"parentBlobGasUsed,omitempty"`
 		ParentBeaconBlockRoot *common.Hash                        `json:"parentBeaconBlockRoot"`
+		ParentHash            *common.Hash                        `json:"parentHash,omitempty"`
 	}
 	var dec stEnv
 	if err := json.Unmarshal(input, &dec); err != nil {
@@ -153,6 +156,9 @@ func (s *stEnv) UnmarshalJSON(input []byte) error {
 	}
 	if dec.ParentBeaconBlockRoot != nil {
 		s.ParentBeaconBlockRoot = dec.ParentBeaconBlockRoot
+	}
+	if dec.ParentHash != nil {
+		s.ParentHash = dec.ParentHash
 	}
 	return nil
 }

--- a/core/vm/evm.go
+++ b/core/vm/evm.go
@@ -34,7 +34,7 @@ type (
 	TransferFunc func(StateDB, common.Address, common.Address, *big.Int)
 	// GetHashFunc returns the n'th block hash in the blockchain
 	// and is used by the BLOCKHASH EVM op code.
-	GetHashFunc func(uint64) common.Hash
+	GetHashFunc func(uint64, StateDB, bool) common.Hash
 )
 
 func (evm *EVM) precompile(addr common.Address) (PrecompiledContract, bool) {

--- a/core/vm/instructions.go
+++ b/core/vm/instructions.go
@@ -441,13 +441,17 @@ func opBlockhash(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) (
 	}
 	var upper, lower uint64
 	upper = interpreter.evm.Context.BlockNumber.Uint64()
-	if upper < 257 {
-		lower = 0
-	} else {
+	evm := interpreter.evm
+
+	// After Prague, the values preceding FORKNUM will be 0,
+	// as requested in EIP-2935. So it's fine to allow 0 as
+	// the lower bound.
+	if !evm.chainRules.IsPrague && upper >= 257 {
 		lower = upper - 256
 	}
+
 	if num64 >= lower && num64 < upper {
-		num.SetBytes(interpreter.evm.Context.GetHash(num64).Bytes())
+		num.SetBytes(evm.Context.GetHash(num64, evm.StateDB, evm.chainRules.IsPrague).Bytes())
 	} else {
 		num.Clear()
 	}

--- a/core/vm/runtime/runtime.go
+++ b/core/vm/runtime/runtime.go
@@ -50,7 +50,7 @@ type Config struct {
 	Random      *common.Hash
 
 	State     *state.StateDB
-	GetHashFn func(n uint64) common.Hash
+	GetHashFn vm.GetHashFunc
 }
 
 // sets defaults on the config
@@ -90,7 +90,7 @@ func setDefaults(cfg *Config) {
 		cfg.BlockNumber = new(big.Int)
 	}
 	if cfg.GetHashFn == nil {
-		cfg.GetHashFn = func(n uint64) common.Hash {
+		cfg.GetHashFn = func(n uint64, _ vm.StateDB, _ bool) common.Hash {
 			return common.BytesToHash(crypto.Keccak256([]byte(new(big.Int).SetUint64(n).String())))
 		}
 	}

--- a/core/vm/runtime/runtime_test.go
+++ b/core/vm/runtime/runtime_test.go
@@ -247,6 +247,14 @@ func (d *dummyChain) GetHeader(h common.Hash, n uint64) *types.Header {
 	return fakeHeader(n, parentHash)
 }
 
+func (d *dummyChain) Config() *params.ChainConfig {
+	return nil
+}
+
+func (d *dummyChain) GetHeaderByNumber(n uint64) *types.Header {
+	return d.GetHeader(common.Hash{}, n)
+}
+
 // TestBlockhash tests the blockhash operation. It's a bit special, since it internally
 // requires access to a chain reader.
 func TestBlockhash(t *testing.T) {

--- a/core/vm/runtime/runtime_test.go
+++ b/core/vm/runtime/runtime_test.go
@@ -248,11 +248,7 @@ func (d *dummyChain) GetHeader(h common.Hash, n uint64) *types.Header {
 }
 
 func (d *dummyChain) Config() *params.ChainConfig {
-	return nil
-}
-
-func (d *dummyChain) GetHeaderByNumber(n uint64) *types.Header {
-	return d.GetHeader(common.Hash{}, n)
+	return &params.ChainConfig{}
 }
 
 // TestBlockhash tests the blockhash operation. It's a bit special, since it internally
@@ -325,8 +321,8 @@ func TestBlockhash(t *testing.T) {
 	if last.Uint64() != 744 {
 		t.Fatalf("last block should be 744, got %d (%x)", last, ret[64:96])
 	}
-	if exp, got := 255, chain.counter; exp != got {
-		t.Errorf("suboptimal; too much chain iteration, expected %d, got %d", exp, got)
+	if exp, got := 256, chain.counter; exp != got {
+		t.Errorf("suboptimal; too many chain iteration, expected %d, got %d", exp, got)
 	}
 }
 

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -1043,6 +1043,7 @@ func (diff *BlockOverrides) Apply(blockCtx *vm.BlockContext) {
 type ChainContextBackend interface {
 	Engine() consensus.Engine
 	HeaderByNumber(context.Context, rpc.BlockNumber) (*types.Header, error)
+	ChainConfig() *params.ChainConfig
 }
 
 // ChainContext is an implementation of core.ChainContext. It's main use-case
@@ -1069,6 +1070,10 @@ func (context *ChainContext) GetHeader(hash common.Hash, number uint64) *types.H
 		return nil
 	}
 	return header
+}
+
+func (context *ChainContext) Config() *params.ChainConfig {
+	return context.b.ChainConfig()
 }
 
 func doCall(ctx context.Context, b Backend, args TransactionArgs, state *state.StateDB, header *types.Header, overrides *StateOverride, blockOverrides *BlockOverrides, timeout time.Duration, globalGasCap uint64) (*core.ExecutionResult, error) {

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -978,6 +978,9 @@ func (w *worker) prepareWork(genParams *generateParams) (*environment, error) {
 		vmenv := vm.NewEVM(context, vm.TxContext{}, env.state, w.chainConfig, vm.Config{})
 		core.ProcessBeaconBlockRoot(*header.ParentBeaconRoot, vmenv, env.state)
 	}
+	if w.chainConfig.IsPrague(header.Number, header.Time) {
+		core.ProcessParentBlockHash(env.state, header.Number.Uint64()-1, header.ParentHash)
+	}
 	return env, nil
 }
 

--- a/params/protocol_params.go
+++ b/params/protocol_params.go
@@ -188,4 +188,6 @@ var (
 	BeaconRootsStorageAddress = common.HexToAddress("0x000F3df6D732807Ef1319fB7B8bB8522d0Beac02")
 	// SystemAddress is where the system-transaction is sent from as per EIP-4788
 	SystemAddress common.Address = common.HexToAddress("0xfffffffffffffffffffffffffffffffffffffffe")
+	// HistoryStorageAddress is where the historical block hashes are stored.
+	HistoryStorageAddress common.Address = common.HexToAddress("0xfffffffffffffffffffffffffffffffffffffffe")
 )

--- a/tests/state_test_util.go
+++ b/tests/state_test_util.go
@@ -474,6 +474,6 @@ func rlpHash(x interface{}) (h common.Hash) {
 	return h
 }
 
-func vmTestBlockHash(n uint64) common.Hash {
+func vmTestBlockHash(n uint64, _ vm.StateDB, _ bool) common.Hash {
 	return common.BytesToHash(crypto.Keccak256([]byte(big.NewInt(int64(n)).String())))
 }


### PR DESCRIPTION
Implement the storage of block hashes older than 256 blocks into a special system contract.

The behavior of the function is slightly changed: the cache of 256 ancestors will be built on the first call to `BLOCKHASH`, so that it is possible to check if the 256th ancestor has passed shanghai. This is the signal for the activation of the new method of reading block hashes from the contract storage.

This is activated in Prague since this is a preqrequisite for verkle trees.