### PR TITLE
chore: add `make help` to display the usage for project `Makefile`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,21 +7,27 @@
 GOBIN = ./build/bin
 GO ?= latest
 GORUN = go run
+PROJECT_NAME = $(shell git remote get-url origin | xargs basename -s .git)
 
+#? geth: Build geth
 geth:
 	$(GORUN) build/ci.go install ./cmd/geth
 	@echo "Done building."
 	@echo "Run \"$(GOBIN)/geth\" to launch geth."
 
+#? all: Build all packages and executables, include abidump, abigen, bootnode, clef, devp2p, ethkey, evm, geth, p2psim, rlpdump
 all:
 	$(GORUN) build/ci.go install
 
+#? test: Run the tests
 test: all
 	$(GORUN) build/ci.go test
 
+#? lint: Run certain pre-selected linters
 lint: ## Run linters.
 	$(GORUN) build/ci.go lint
 
+#? clean: Clean go cache and built excutebles, and the auto generated folder
 clean:
 	go clean -cache
 	rm -fr build/_workspace/pkg/ $(GOBIN)/*
@@ -29,6 +35,7 @@ clean:
 # The devtools target installs tools required for 'go generate'.
 # You need to put $GOBIN (or $GOPATH/bin) in your PATH to use 'go generate'.
 
+#? devtools: Install pre-requirement developer tools
 devtools:
 	env GOBIN= go install golang.org/x/tools/cmd/stringer@latest
 	env GOBIN= go install github.com/fjl/gencodec@latest
@@ -36,3 +43,9 @@ devtools:
 	env GOBIN= go install ./cmd/abigen
 	@type "solc" 2> /dev/null || echo 'Please install solc'
 	@type "protoc" 2> /dev/null || echo 'Please install protoc'
+
+#? help: Get more info on make commands.
+help: Makefile
+	@echo " Choose a command run in "$(PROJECT_NAME)":"
+	@sed -n 's/^#?//p' $< | column -t -s ':' |  sort | sed -e 's/^/ /'
+.PHONY: help


### PR DESCRIPTION
# Description

This pr added a new `make help` function for displaying which commonly used commands that the Makefile supported. This is useful when a new developer goes to find a helpful tool for testing or building etc.

![image](https://github.com/ethereum/go-ethereum/assets/25278203/76eda6c9-ea8b-4ee6-8fb2-ef759e10325e)
