### PR TITLE
internal/ethapi: support unlimited rpc gas cap in eth_createAccessList

### DIFF
--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -1513,8 +1513,13 @@ func AccessList(ctx context.Context, b Backend, blockNrOrHash rpc.BlockNumberOrH
 	}
 	// If the gas amount is not set, default to RPC gas cap.
 	if args.Gas == nil {
-		tmp := hexutil.Uint64(b.RPCGasCap())
-		args.Gas = &tmp
+		if b.RPCGasCap() != 0 {
+			tmp := hexutil.Uint64(b.RPCGasCap())
+			args.Gas = &tmp
+		} else {
+			tmp := hexutil.Uint64(b.CurrentBlock().GasLimit)
+			args.Gas = &tmp
+		}
 	}
 
 	// Ensure any missing fields are filled, extract the recipient and input data

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -451,7 +451,7 @@ func (s *PersonalAccountAPI) signTransaction(ctx context.Context, args *Transact
 		return nil, err
 	}
 	// Set some sanity defaults and terminate on failure
-	if err := args.setDefaults(ctx, s.b); err != nil {
+	if err := args.setDefaults(ctx, s.b, false); err != nil {
 		return nil, err
 	}
 	// Assemble the transaction and sign with the wallet
@@ -1511,19 +1511,9 @@ func AccessList(ctx context.Context, b Backend, blockNrOrHash rpc.BlockNumberOrH
 	if db == nil || err != nil {
 		return nil, 0, nil, err
 	}
-	// If the gas amount is not set, default to RPC gas cap.
-	if args.Gas == nil {
-		if b.RPCGasCap() != 0 {
-			tmp := hexutil.Uint64(b.RPCGasCap())
-			args.Gas = &tmp
-		} else {
-			tmp := hexutil.Uint64(math.MaxUint64 / 2)
-			args.Gas = &tmp
-		}
-	}
 
 	// Ensure any missing fields are filled, extract the recipient and input data
-	if err := args.setDefaults(ctx, b); err != nil {
+	if err := args.setDefaults(ctx, b, true); err != nil {
 		return nil, 0, nil, err
 	}
 	var to common.Address
@@ -1828,7 +1818,7 @@ func (s *TransactionAPI) SendTransaction(ctx context.Context, args TransactionAr
 	}
 
 	// Set some sanity defaults and terminate on failure
-	if err := args.setDefaults(ctx, s.b); err != nil {
+	if err := args.setDefaults(ctx, s.b, false); err != nil {
 		return common.Hash{}, err
 	}
 	// Assemble the transaction and sign with the wallet
@@ -1846,7 +1836,7 @@ func (s *TransactionAPI) SendTransaction(ctx context.Context, args TransactionAr
 // processing (signing + broadcast).
 func (s *TransactionAPI) FillTransaction(ctx context.Context, args TransactionArgs) (*SignTransactionResult, error) {
 	// Set some sanity defaults and terminate on failure
-	if err := args.setDefaults(ctx, s.b); err != nil {
+	if err := args.setDefaults(ctx, s.b, false); err != nil {
 		return nil, err
 	}
 	// Assemble the transaction and obtain rlp
@@ -1916,7 +1906,7 @@ func (s *TransactionAPI) SignTransaction(ctx context.Context, args TransactionAr
 	if args.Nonce == nil {
 		return nil, errors.New("nonce not specified")
 	}
-	if err := args.setDefaults(ctx, s.b); err != nil {
+	if err := args.setDefaults(ctx, s.b, false); err != nil {
 		return nil, err
 	}
 	// Before actually sign the transaction, ensure the transaction fee is reasonable.
@@ -1965,7 +1955,7 @@ func (s *TransactionAPI) Resend(ctx context.Context, sendArgs TransactionArgs, g
 	if sendArgs.Nonce == nil {
 		return common.Hash{}, errors.New("missing transaction nonce in transaction spec")
 	}
-	if err := sendArgs.setDefaults(ctx, s.b); err != nil {
+	if err := sendArgs.setDefaults(ctx, s.b, false); err != nil {
 		return common.Hash{}, err
 	}
 	matchTx := sendArgs.toTransaction()

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -1517,7 +1517,7 @@ func AccessList(ctx context.Context, b Backend, blockNrOrHash rpc.BlockNumberOrH
 			tmp := hexutil.Uint64(b.RPCGasCap())
 			args.Gas = &tmp
 		} else {
-			tmp := hexutil.Uint64(b.CurrentBlock().GasLimit)
+			tmp := hexutil.Uint64(math.MaxUint64 / 2)
 			args.Gas = &tmp
 		}
 	}

--- a/internal/ethapi/transaction_args.go
+++ b/internal/ethapi/transaction_args.go
@@ -96,7 +96,7 @@ func (args *TransactionArgs) data() []byte {
 }
 
 // setDefaults fills in default values for unspecified tx fields.
-func (args *TransactionArgs) setDefaults(ctx context.Context, b Backend, infiniteGas bool) error {
+func (args *TransactionArgs) setDefaults(ctx context.Context, b Backend, skipGasEstimation bool) error {
 	if err := args.setBlobTxSidecar(ctx, b); err != nil {
 		return err
 	}
@@ -135,37 +135,36 @@ func (args *TransactionArgs) setDefaults(ctx context.Context, b Backend, infinit
 			return errors.New(`contract creation without any data provided`)
 		}
 	}
-	// Assign a very high gas limit for cases where an accurate gas limit is not critical,
-	// but need to ensure that gas is sufficient.
-	if infiniteGas {
-		tmp := hexutil.Uint64(math.MaxUint64 / 2)
-		args.Gas = &tmp
-	}
 
-	// Estimate the gas usage if necessary.
 	if args.Gas == nil {
-		// These fields are immutable during the estimation, safe to
-		// pass the pointer directly.
-		data := args.data()
-		callArgs := TransactionArgs{
-			From:                 args.From,
-			To:                   args.To,
-			GasPrice:             args.GasPrice,
-			MaxFeePerGas:         args.MaxFeePerGas,
-			MaxPriorityFeePerGas: args.MaxPriorityFeePerGas,
-			Value:                args.Value,
-			Data:                 (*hexutil.Bytes)(&data),
-			AccessList:           args.AccessList,
-			BlobFeeCap:           args.BlobFeeCap,
-			BlobHashes:           args.BlobHashes,
+		if skipGasEstimation { // Skip gas usage estimation if a precise gas limit is not critical, e.g., in non-transaction calls.
+			gas := hexutil.Uint64(b.RPCGasCap())
+			if gas == 0 {
+				gas = hexutil.Uint64(math.MaxUint64 / 2)
+			}
+			args.Gas = &gas
+		} else { // Estimate the gas usage otherwise.
+			// These fields are immutable during the estimation, safe to
+			// pass the pointer directly.
+			data := args.data()
+			callArgs := TransactionArgs{
+				From:                 args.From,
+				To:                   args.To,
+				GasPrice:             args.GasPrice,
+				MaxFeePerGas:         args.MaxFeePerGas,
+				MaxPriorityFeePerGas: args.MaxPriorityFeePerGas,
+				Value:                args.Value,
+				Data:                 (*hexutil.Bytes)(&data),
+				AccessList:           args.AccessList,
+			}
+			latestBlockNr := rpc.BlockNumberOrHashWithNumber(rpc.LatestBlockNumber)
+			estimated, err := DoEstimateGas(ctx, b, callArgs, latestBlockNr, nil, b.RPCGasCap())
+			if err != nil {
+				return err
+			}
+			args.Gas = &estimated
+			log.Trace("Estimate gas usage automatically", "gas", args.Gas)
 		}
-		latestBlockNr := rpc.BlockNumberOrHashWithNumber(rpc.LatestBlockNumber)
-		estimated, err := DoEstimateGas(ctx, b, callArgs, latestBlockNr, nil, b.RPCGasCap())
-		if err != nil {
-			return err
-		}
-		args.Gas = &estimated
-		log.Trace("Estimate gas usage automatically", "gas", args.Gas)
 	}
 
 	// If chain id is provided, ensure it matches the local chain id. Otherwise, set the local

--- a/internal/ethapi/transaction_args.go
+++ b/internal/ethapi/transaction_args.go
@@ -81,7 +81,7 @@ func (args *TransactionArgs) data() []byte {
 }
 
 // setDefaults fills in default values for unspecified tx fields.
-func (args *TransactionArgs) setDefaults(ctx context.Context, b Backend) error {
+func (args *TransactionArgs) setDefaults(ctx context.Context, b Backend, infiniteGas bool) error {
 	if err := args.setFeeDefaults(ctx, b); err != nil {
 		return err
 	}
@@ -106,6 +106,12 @@ func (args *TransactionArgs) setDefaults(ctx context.Context, b Backend) error {
 	}
 	if args.To == nil && len(args.data()) == 0 {
 		return errors.New(`contract creation without any data provided`)
+	}
+	// Assign a very high gas limit for cases where an accurate gas limit is not critical,
+	// but need to ensure that gas is sufficient.
+	if infiniteGas {
+		tmp := hexutil.Uint64(math.MaxUint64 / 2)
+		args.Gas = &tmp
 	}
 	// Estimate the gas usage if necessary.
 	if args.Gas == nil {


### PR DESCRIPTION
This PR enhances `eth_createAccessList` RPC call to support scenarios where the node is launched with an unlimited gas cap (`--rpc.gascap 0`). The `eth_createAccessList` RPC call returns failure if the `ethereum.CallMsg` doesn't explicitly set a gas limit.

An error message example (the unexpected `err: intrinsic gas too low: have 0`):
```
failed to apply transaction: 0x7073334f34b8882d79023837f726926522cf796da1ea4354bbb132497feb0331 err: intrinsic gas too low: have 0, want 22624
```