### PR TITLE
core/state/snapshot: use AddHash/ContainHash instead of Hasher interface

### DIFF
--- a/core/state/pruner/bloom.go
+++ b/core/state/pruner/bloom.go
@@ -27,9 +27,7 @@ import (
 	bloomfilter "github.com/holiman/bloomfilter/v2"
 )
 
-// stateBloomHasher is a wrapper around a byte blob to satisfy the interface API
-// requirements of the bloom library used. It's used to convert a trie hash or
-// contract code hash into a 64 bit mini hash.
+// stateBloomHasher is used to convert a trie hash or contract code hash into a 64 bit mini hash.
 func stateBloomHasher(f []byte) uint64 {
 	return binary.BigEndian.Uint64(f)
 }

--- a/core/state/pruner/bloom.go
+++ b/core/state/pruner/bloom.go
@@ -27,8 +27,8 @@ import (
 	bloomfilter "github.com/holiman/bloomfilter/v2"
 )
 
-// stateBloomHasher is used to convert a trie hash or contract code hash into a 64 bit mini hash.
-func stateBloomHasher(f []byte) uint64 {
+// stateBloomHash is used to convert a trie hash or contract code hash into a 64 bit mini hash.
+func stateBloomHash(f []byte) uint64 {
 	return binary.BigEndian.Uint64(f)
 }
 
@@ -106,10 +106,10 @@ func (bloom *stateBloom) Put(key []byte, value []byte) error {
 		if !isCode {
 			return errors.New("invalid entry")
 		}
-		bloom.bloom.AddHash(stateBloomHasher(codeKey))
+		bloom.bloom.AddHash(stateBloomHash(codeKey))
 		return nil
 	}
-	bloom.bloom.AddHash(stateBloomHasher(key))
+	bloom.bloom.AddHash(stateBloomHash(key))
 	return nil
 }
 
@@ -121,5 +121,5 @@ func (bloom *stateBloom) Delete(key []byte) error { panic("not supported") }
 // - If it says yes, the key may be contained
 // - If it says no, the key is definitely not contained.
 func (bloom *stateBloom) Contain(key []byte) bool {
-	return bloom.bloom.ContainsHash(stateBloomHasher(key))
+	return bloom.bloom.ContainsHash(stateBloomHash(key))
 }

--- a/core/state/pruner/bloom.go
+++ b/core/state/pruner/bloom.go
@@ -30,14 +30,9 @@ import (
 // stateBloomHasher is a wrapper around a byte blob to satisfy the interface API
 // requirements of the bloom library used. It's used to convert a trie hash or
 // contract code hash into a 64 bit mini hash.
-type stateBloomHasher []byte
-
-func (f stateBloomHasher) Write(p []byte) (n int, err error) { panic("not implemented") }
-func (f stateBloomHasher) Sum(b []byte) []byte               { panic("not implemented") }
-func (f stateBloomHasher) Reset()                            { panic("not implemented") }
-func (f stateBloomHasher) BlockSize() int                    { panic("not implemented") }
-func (f stateBloomHasher) Size() int                         { return 8 }
-func (f stateBloomHasher) Sum64() uint64                     { return binary.BigEndian.Uint64(f) }
+func stateBloomHasher(f []byte) uint64 {
+	return binary.BigEndian.Uint64(f)
+}
 
 // stateBloom is a bloom filter used during the state conversion(snapshot->state).
 // The keys of all generated entries will be recorded here so that in the pruning
@@ -113,10 +108,10 @@ func (bloom *stateBloom) Put(key []byte, value []byte) error {
 		if !isCode {
 			return errors.New("invalid entry")
 		}
-		bloom.bloom.Add(stateBloomHasher(codeKey))
+		bloom.bloom.AddHash(stateBloomHasher(codeKey))
 		return nil
 	}
-	bloom.bloom.Add(stateBloomHasher(key))
+	bloom.bloom.AddHash(stateBloomHasher(key))
 	return nil
 }
 
@@ -128,5 +123,5 @@ func (bloom *stateBloom) Delete(key []byte) error { panic("not supported") }
 // - If it says yes, the key may be contained
 // - If it says no, the key is definitely not contained.
 func (bloom *stateBloom) Contain(key []byte) bool {
-	return bloom.bloom.Contains(stateBloomHasher(key))
+	return bloom.bloom.ContainsHash(stateBloomHasher(key))
 }

--- a/core/state/snapshot/difflayer.go
+++ b/core/state/snapshot/difflayer.go
@@ -124,17 +124,17 @@ type diffLayer struct {
 	lock sync.RWMutex
 }
 
+// destructBloomHasher is used to convert a destruct event into a 64 bit mini hash.
 func destructBloomHasher(h common.Hash) uint64 {
 	return binary.BigEndian.Uint64(h[bloomDestructHasherOffset : bloomDestructHasherOffset+8])
 }
 
-// accountBloomHasher is a wrapper around a common.Hash to satisfy the interface
-// API requirements of the bloom library used. It's used to convert an account
-// hash into a 64 bit mini hash.
+// accountBloomHasher is used to convert an account hash into a 64 bit mini hash.
 func accountBloomHasher(h common.Hash) uint64 {
 	return binary.BigEndian.Uint64(h[bloomAccountHasherOffset : bloomAccountHasherOffset+8])
 }
 
+// storageBloomHasher is used to convert an account hash and a storage hash into a 64 bit mini hash.
 func storageBloomHasher(h0, h1 common.Hash) uint64 {
 	return binary.BigEndian.Uint64(h0[bloomStorageHasherOffset:bloomStorageHasherOffset+8]) ^
 		binary.BigEndian.Uint64(h1[bloomStorageHasherOffset:bloomStorageHasherOffset+8])


### PR DESCRIPTION
This PR switches from using the Hasher interface to add/query the bloomfilter to implementing it as methods.
This significantly reduces the allocations for Search and Rebloom.
The allocations for the storageBloom alone was ~7% of all allocations (in a quite contrived scenario)
`  26666581   26666581    243:			dl.diffed.Add(storageBloomHasher{accountHash, storageHash})`
`  14812039   14812039    375:	hit := dl.diffed.Contains(storageBloomHasher{accountHash, storageHash})`
`14828423   14849723 (flat, cum)  2.50% of Total`
`26666581   26672121 (flat, cum)  4.49% of Total`

The added benefit of reduced allocations also surfaces in the benchmark:
```
Master:
BenchmarkSearchSlot-8   	 4042929	       341.6 ns/op	     160 B/op	       3 allocs/op
PR:
BenchmarkSearchSlot-8   	 6573976	       180.8 ns/op	      64 B/op	       1 allocs/op
``` 