### PR TITLE
core: fix genesis setup in benchReadChain

### DIFF
--- a/core/bench_test.go
+++ b/core/bench_test.go
@@ -243,7 +243,7 @@ func BenchmarkChainWrite_full_500k(b *testing.B) {
 
 // makeChainForBench writes a given number of headers or empty blocks/receipts
 // into a database.
-func makeChainForBench(db ethdb.Database, full bool, count uint64) {
+func makeChainForBench(db ethdb.Database, genesis *Genesis, full bool, count uint64) {
 	var hash common.Hash
 	for n := uint64(0); n < count; n++ {
 		header := &types.Header{
@@ -255,6 +255,9 @@ func makeChainForBench(db ethdb.Database, full bool, count uint64) {
 			TxHash:      types.EmptyTxsHash,
 			ReceiptHash: types.EmptyReceiptsHash,
 		}
+		if n == 0 {
+			header = genesis.ToBlock().Header()
+		}
 		hash = header.Hash()
 
 		rawdb.WriteHeader(db, header)
@@ -262,7 +265,7 @@ func makeChainForBench(db ethdb.Database, full bool, count uint64) {
 		rawdb.WriteTd(db, hash, n, big.NewInt(int64(n+1)))
 
 		if n == 0 {
-			rawdb.WriteChainConfig(db, hash, params.AllEthashProtocolChanges)
+			rawdb.WriteChainConfig(db, hash, genesis.Config)
 		}
 		rawdb.WriteHeadHeaderHash(db, hash)
 
@@ -276,13 +279,14 @@ func makeChainForBench(db ethdb.Database, full bool, count uint64) {
 }
 
 func benchWriteChain(b *testing.B, full bool, count uint64) {
+	genesis := &Genesis{Config: params.AllEthashProtocolChanges}
 	for i := 0; i < b.N; i++ {
 		dir := b.TempDir()
 		db, err := rawdb.NewLevelDBDatabase(dir, 128, 1024, "", false)
 		if err != nil {
 			b.Fatalf("error opening database at %v: %v", dir, err)
 		}
-		makeChainForBench(db, full, count)
+		makeChainForBench(db, genesis, full, count)
 		db.Close()
 	}
 }
@@ -294,7 +298,8 @@ func benchReadChain(b *testing.B, full bool, count uint64) {
 	if err != nil {
 		b.Fatalf("error opening database at %v: %v", dir, err)
 	}
-	makeChainForBench(db, full, count)
+	genesis := &Genesis{Config: params.AllEthashProtocolChanges}
+	makeChainForBench(db, genesis, full, count)
 	db.Close()
 	cacheConfig := *defaultCacheConfig
 	cacheConfig.TrieDirtyDisabled = true
@@ -307,7 +312,7 @@ func benchReadChain(b *testing.B, full bool, count uint64) {
 		if err != nil {
 			b.Fatalf("error opening database at %v: %v", dir, err)
 		}
-		chain, err := NewBlockChain(db, &cacheConfig, nil, nil, ethash.NewFaker(), vm.Config{}, nil, nil)
+		chain, err := NewBlockChain(db, &cacheConfig, genesis, nil, ethash.NewFaker(), vm.Config{}, nil, nil)
 		if err != nil {
 			b.Fatalf("error creating chain: %v", err)
 		}


### PR DESCRIPTION
Hi, currently the benchmarks `BenchmarkChainRead_header_10k` etc are failing with:

`error creating chain: database contains incompatible genesis (have c27db71b33e259aa7357e6d44f8f1c78adbae50d5ac59d61103ec0f1ad109a3f, new d4e56740f876aef8c010b86a40d5f56745a118d0906a34e69aec8c0db1cb8fa3`

I made this change to call `&core.Genesis{}.ToBlock().Header()` to set-up the genesis header, since the amount of setup in the test is not sufficient to pass through the checks in `SetupGenesisBlock`
Alternatively, we could set the loop to start at 1 [here](https://github.com/ethereum/go-ethereum/pull/28856/files#diff-d05251a221cde2fe44cf0b3a5f53f9d3a7317508308801a02568404e0779cf1eL248) for a less invasive change and similar effect, if you prefer.