### PR TITLE
docs: remove reference to being official

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ## Go Ethereum
 
-Official Golang execution layer implementation of the Ethereum protocol.
+Golang execution layer implementation of the Ethereum protocol.
 
 [![API Reference](
 https://pkg.go.dev/badge/github.com/ethereum/go-ethereum

--- a/cmd/geth/main.go
+++ b/cmd/geth/main.go
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with go-ethereum. If not, see <http://www.gnu.org/licenses/>.
 
-// geth is the official command-line client for Ethereum.
+// geth is a command-line client for Ethereum.
 package main
 
 import (


### PR DESCRIPTION
Geth is described as "the official golang" ethereum implementation, which is not proper. Geth does not have any more 'official' status than any other client. This PR removes the usage of this phrase. 