### PR TITLE
core/vm: fix misleading comment

### DIFF
--- a/core/vm/jump_table.go
+++ b/core/vm/jump_table.go
@@ -122,7 +122,7 @@ func newLondonInstructionSet() JumpTable {
 // constantinople, istanbul, petersburg and berlin instructions.
 func newBerlinInstructionSet() JumpTable {
 	instructionSet := newIstanbulInstructionSet()
-	enable2929(&instructionSet) // Access lists for trie accesses https://eips.ethereum.org/EIPS/eip-2929
+	enable2929(&instructionSet) // Gas cost increases for state access opcodes https://eips.ethereum.org/EIPS/eip-2929
 	return validate(instructionSet)
 }
 


### PR DESCRIPTION
PR's title is pretty explanatory, the comment was probably referring to EIP-2930 instead of EIP-2929