### PR TITLE
cmd/evm/internal/t8ntool, core, core/vm, miner, params: implement eip 2935: save historical block hash in state

### DIFF
--- a/cmd/evm/internal/t8ntool/execution.go
+++ b/cmd/evm/internal/t8ntool/execution.go
@@ -89,6 +89,7 @@ type stEnv struct {
 	ParentExcessBlobGas   *uint64                             `json:"parentExcessBlobGas,omitempty"`
 	ParentBlobGasUsed     *uint64                             `json:"parentBlobGasUsed,omitempty"`
 	ParentBeaconBlockRoot *common.Hash                        `json:"parentBeaconBlockRoot"`
+	ParentHash            *common.Hash                        `json:"parentHash,omitempty"`
 }
 
 type stEnvMarshaling struct {
@@ -189,6 +190,9 @@ func (pre *Prestate) Apply(vmConfig vm.Config, chainConfig *params.ChainConfig,
 	if beaconRoot := pre.Env.ParentBeaconBlockRoot; beaconRoot != nil {
 		evm := vm.NewEVM(vmContext, vm.TxContext{}, statedb, chainConfig, vmConfig)
 		core.ProcessBeaconBlockRoot(*beaconRoot, evm, statedb)
+	}
+	if chainConfig.IsPrague(big.NewInt(int64(pre.Env.Number)), pre.Env.Timestamp) {
+		core.ProcessParentBlockHash(statedb, pre.Env.Number-1, *pre.Env.ParentHash)
 	}
 
 	for i := 0; txIt.Next(); i++ {

--- a/cmd/evm/internal/t8ntool/gen_stenv.go
+++ b/cmd/evm/internal/t8ntool/gen_stenv.go
@@ -37,6 +37,7 @@ func (s stEnv) MarshalJSON() ([]byte, error) {
 		ParentExcessBlobGas   *math.HexOrDecimal64                `json:"parentExcessBlobGas,omitempty"`
 		ParentBlobGasUsed     *math.HexOrDecimal64                `json:"parentBlobGasUsed,omitempty"`
 		ParentBeaconBlockRoot *common.Hash                        `json:"parentBeaconBlockRoot"`
+		ParentHash            *common.Hash                        `json:"parentHash,omitempty"`
 	}
 	var enc stEnv
 	enc.Coinbase = common.UnprefixedAddress(s.Coinbase)
@@ -59,6 +60,7 @@ func (s stEnv) MarshalJSON() ([]byte, error) {
 	enc.ParentExcessBlobGas = (*math.HexOrDecimal64)(s.ParentExcessBlobGas)
 	enc.ParentBlobGasUsed = (*math.HexOrDecimal64)(s.ParentBlobGasUsed)
 	enc.ParentBeaconBlockRoot = s.ParentBeaconBlockRoot
+	enc.ParentHash = s.ParentHash
 	return json.Marshal(&enc)
 }
 
@@ -85,6 +87,7 @@ func (s *stEnv) UnmarshalJSON(input []byte) error {
 		ParentExcessBlobGas   *math.HexOrDecimal64                `json:"parentExcessBlobGas,omitempty"`
 		ParentBlobGasUsed     *math.HexOrDecimal64                `json:"parentBlobGasUsed,omitempty"`
 		ParentBeaconBlockRoot *common.Hash                        `json:"parentBeaconBlockRoot"`
+		ParentHash            *common.Hash                        `json:"parentHash,omitempty"`
 	}
 	var dec stEnv
 	if err := json.Unmarshal(input, &dec); err != nil {
@@ -153,6 +156,9 @@ func (s *stEnv) UnmarshalJSON(input []byte) error {
 	}
 	if dec.ParentBeaconBlockRoot != nil {
 		s.ParentBeaconBlockRoot = dec.ParentBeaconBlockRoot
+	}
+	if dec.ParentHash != nil {
+		s.ParentHash = dec.ParentHash
 	}
 	return nil
 }

--- a/core/vm/instructions.go
+++ b/core/vm/instructions.go
@@ -17,6 +17,8 @@
 package vm
 
 import (
+	"encoding/binary"
+
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/crypto"
@@ -432,6 +434,12 @@ func opGasprice(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([
 	return nil, nil
 }
 
+func getBlockHashFromContract(number uint64, statedb StateDB) common.Hash {
+	var pnum common.Hash
+	binary.BigEndian.PutUint64(pnum[24:], number)
+	return statedb.GetState(params.HistoryStorageAddress, pnum)
+}
+
 func opBlockhash(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([]byte, error) {
 	num := scope.Stack.peek()
 	num64, overflow := num.Uint64WithOverflow()
@@ -439,6 +447,26 @@ func opBlockhash(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) (
 		num.Clear()
 		return nil, nil
 	}
+
+	evm := interpreter.evm
+	bnum := evm.Context.BlockNumber.Uint64()
+	// if Prague is active, check if we are past the 256th block so that
+	// reading from the contract can be activated (EIP 2935).
+	if interpreter.evm.chainRules.IsPrague && bnum > 256 {
+		if getBlockHashFromContract(bnum-256, evm.StateDB) != (common.Hash{}) {
+			// EIP-2935 case: get the block number from the fork, as we are 256 blocks
+			// after the fork activation.
+
+			num.SetBytes(getBlockHashFromContract(num64, evm.StateDB).Bytes())
+			return nil, nil
+		}
+
+		// if the 256th ancestor didn't have its hash stored in the
+		// history contract, then we are within 256 blocks of the
+		// fork activation, and the former behavior should be retained.
+		// Fall through the legacy use case.
+	}
+
 	var upper, lower uint64
 	upper = interpreter.evm.Context.BlockNumber.Uint64()
 	if upper < 257 {

--- a/core/vm/instructions.go
+++ b/core/vm/instructions.go
@@ -449,22 +449,9 @@ func opBlockhash(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) (
 	}
 
 	evm := interpreter.evm
-	bnum := evm.Context.BlockNumber.Uint64()
-	// if Prague is active, check if we are past the 256th block so that
-	// reading from the contract can be activated (EIP 2935).
-	if interpreter.evm.chainRules.IsPrague && bnum > 256 {
-		if getBlockHashFromContract(bnum-256, evm.StateDB) != (common.Hash{}) {
-			// EIP-2935 case: get the block number from the fork, as we are 256 blocks
-			// after the fork activation.
-
-			num.SetBytes(getBlockHashFromContract(num64, evm.StateDB).Bytes())
-			return nil, nil
-		}
-
-		// if the 256th ancestor didn't have its hash stored in the
-		// history contract, then we are within 256 blocks of the
-		// fork activation, and the former behavior should be retained.
-		// Fall through the legacy use case.
+	if evm.chainRules.IsPrague {
+		num.SetBytes(getBlockHashFromContract(num64, evm.StateDB).Bytes())
+		return nil, nil
 	}
 
 	var upper, lower uint64

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -978,6 +978,9 @@ func (w *worker) prepareWork(genParams *generateParams) (*environment, error) {
 		vmenv := vm.NewEVM(context, vm.TxContext{}, env.state, w.chainConfig, vm.Config{})
 		core.ProcessBeaconBlockRoot(*header.ParentBeaconRoot, vmenv, env.state)
 	}
+	if w.chainConfig.IsPrague(header.Number, header.Time) {
+		core.ProcessParentBlockHash(env.state, header.Number.Uint64()-1, header.ParentHash)
+	}
 	return env, nil
 }
 

--- a/params/protocol_params.go
+++ b/params/protocol_params.go
@@ -188,4 +188,6 @@ var (
 	BeaconRootsStorageAddress = common.HexToAddress("0x000F3df6D732807Ef1319fB7B8bB8522d0Beac02")
 	// SystemAddress is where the system-transaction is sent from as per EIP-4788
 	SystemAddress common.Address = common.HexToAddress("0xfffffffffffffffffffffffffffffffffffffffe")
+	// HistoryStorageAddress is where the historical block hashes are stored.
+	HistoryStorageAddress common.Address = common.HexToAddress("0xfffffffffffffffffffffffffffffffffffffffe")
 )


### PR DESCRIPTION
This is a rewrite building on my previous attempt.

~~Because the EIP is only activated 256 blocks after the fork, and that timestamp-based fork makes things really tricky, this approach checks the contract to see if the blockhash of its 256th ancestor is non-zero. If that is the case, then it means that the EIP has been active since at least 256 blocks, and therefore it is safe to activate the new behavior. Otherwise, it will default to the older behavior.~~ Rewrote the branch to conform to the latest version of the EIP, in which all previous 256 ancestor hashes are written to the contract at the fork. The EIP is rooted at Prague because this is the fork that is being targeted.