### PR TITLE
core/state: semantic journalling (part 1)

### DIFF
--- a/core/state/journal.go
+++ b/core/state/journal.go
@@ -63,9 +63,9 @@ func newJournal() *journal {
 	}
 }
 
-// reset clears the journal, after this operation the journal can be used
-// as new. It is semantically similar to calling 'newJournal', but the underlying
-// slices can be reused.
+// reset clears the journal, after this operation the journal can be used anew.
+// It is semantically similar to calling 'newJournal', but the underlying slices
+// can be reused.
 func (j *journal) reset() {
 	j.entries = j.entries[:0]
 	j.validRevisions = j.validRevisions[:0]
@@ -192,7 +192,7 @@ func (j *journal) balanceChange(addr common.Address, previous *uint256.Int) {
 	})
 }
 
-func (j *journal) codeChange(address common.Address) {
+func (j *journal) setCode(address common.Address) {
 	j.append(codeChange{account: &address})
 }
 

--- a/core/state/journal.go
+++ b/core/state/journal.go
@@ -160,10 +160,6 @@ func (j *journal) JournalLog(txHash common.Hash) {
 	j.append(addLogChange{txhash: txHash})
 }
 
-func (j *journal) JournalAddPreimage(hash common.Hash) {
-	j.append(addPreimageChange{hash: hash})
-}
-
 func (j *journal) JournalCreate(addr common.Address) {
 	j.append(createObjectChange{account: &addr})
 }
@@ -264,9 +260,6 @@ type (
 	}
 	addLogChange struct {
 		txhash common.Hash
-	}
-	addPreimageChange struct {
-		hash common.Hash
 	}
 	touchChange struct {
 		account *common.Address
@@ -453,20 +446,6 @@ func (ch addLogChange) dirtied() *common.Address {
 func (ch addLogChange) copy() journalEntry {
 	return addLogChange{
 		txhash: ch.txhash,
-	}
-}
-
-func (ch addPreimageChange) revert(s *StateDB) {
-	delete(s.preimages, ch.hash)
-}
-
-func (ch addPreimageChange) dirtied() *common.Address {
-	return nil
-}
-
-func (ch addPreimageChange) copy() journalEntry {
-	return addPreimageChange{
-		hash: ch.hash,
 	}
 }
 

--- a/core/state/journal.go
+++ b/core/state/journal.go
@@ -148,30 +148,30 @@ func (j *journal) copy() *journal {
 	}
 }
 
-func (j *journal) JournalAccessListAddAccount(addr common.Address) {
+func (j *journal) AccessListAddAccount(addr common.Address) {
 	j.append(accessListAddAccountChange{&addr})
 }
 
-func (j *journal) JournalAccessListAddSlot(addr common.Address, slot common.Hash) {
+func (j *journal) AccessListAddSlot(addr common.Address, slot common.Hash) {
 	j.append(accessListAddSlotChange{
 		address: &addr,
 		slot:    &slot,
 	})
 }
 
-func (j *journal) JournalLog(txHash common.Hash) {
+func (j *journal) Log(txHash common.Hash) {
 	j.append(addLogChange{txhash: txHash})
 }
 
-func (j *journal) JournalCreate(addr common.Address) {
+func (j *journal) Create(addr common.Address) {
 	j.append(createObjectChange{account: &addr})
 }
 
-func (j *journal) JournalDestruct(addr common.Address) {
+func (j *journal) Destruct(addr common.Address) {
 	j.append(selfDestructChange{account: &addr})
 }
 
-func (j *journal) JournalSetState(addr common.Address, key, prev, origin common.Hash) {
+func (j *journal) SetStorage(addr common.Address, key, prev, origin common.Hash) {
 	j.append(storageChange{
 		account:   &addr,
 		key:       key,
@@ -180,7 +180,7 @@ func (j *journal) JournalSetState(addr common.Address, key, prev, origin common.
 	})
 }
 
-func (j *journal) JournalSetTransientState(addr common.Address, key, prev common.Hash) {
+func (j *journal) SetTransientState(addr common.Address, key, prev common.Hash) {
 	j.append(transientStorageChange{
 		account:  &addr,
 		key:      key,
@@ -188,29 +188,29 @@ func (j *journal) JournalSetTransientState(addr common.Address, key, prev common
 	})
 }
 
-func (j *journal) JournalRefundChange(previous uint64) {
+func (j *journal) RefundChange(previous uint64) {
 	j.append(refundChange{prev: previous})
 }
 
-func (j *journal) JournalBalanceChange(addr common.Address, previous *uint256.Int) {
+func (j *journal) BalanceChange(addr common.Address, previous *uint256.Int) {
 	j.append(balanceChange{
 		account: &addr,
 		prev:    previous.Clone(),
 	})
 }
 
-func (j *journal) JournalSetCode(address common.Address) {
+func (j *journal) SetCode(address common.Address) {
 	j.append(codeChange{account: &address})
 }
 
-func (j *journal) JournalNonceChange(address common.Address, prev uint64) {
+func (j *journal) NonceChange(address common.Address, prev uint64) {
 	j.append(nonceChange{
 		account: &address,
 		prev:    prev,
 	})
 }
 
-func (j *journal) JournalTouch(address common.Address) {
+func (j *journal) Touch(address common.Address) {
 	j.append(touchChange{
 		account: &address,
 	})

--- a/core/state/journal.go
+++ b/core/state/journal.go
@@ -100,6 +100,91 @@ func (j *journal) copy() *journal {
 	}
 }
 
+func (j *journal) JournalAccessListAddAccount(addr common.Address) {
+	j.append(accessListAddAccountChange{&addr})
+}
+
+func (j *journal) JournalAccessListAddSlot(addr common.Address, slot common.Hash) {
+	j.append(accessListAddSlotChange{
+		address: &addr,
+		slot:    &slot,
+	})
+}
+
+func (j *journal) JournalLog(txHash common.Hash) {
+	j.append(addLogChange{txhash: txHash})
+}
+
+func (j *journal) JournalAddPreimage(hash common.Hash) {
+	j.append(addPreimageChange{hash: hash})
+}
+
+func (j *journal) JournalCreate(addr common.Address) {
+	j.append(createObjectChange{account: &addr})
+}
+
+func (j *journal) JournalDestruct(addr common.Address, previouslyDestructed bool, prevBalance *uint256.Int) {
+	j.append(selfDestructChange{
+		account:     &addr,
+		prev:        previouslyDestructed,
+		prevbalance: prevBalance.Clone(),
+	})
+}
+
+func (j *journal) JournalSetState(addr common.Address, key, prev, origin common.Hash) {
+	j.append(storageChange{
+		account:   &addr,
+		key:       key,
+		prevvalue: prev,
+		origvalue: origin,
+	})
+}
+
+func (j *journal) JournalSetTransientState(addr common.Address, key, prev common.Hash) {
+	j.append(transientStorageChange{
+		account:  &addr,
+		key:      key,
+		prevalue: prev,
+	})
+}
+
+func (j *journal) JournalRefundChange(previous uint64) {
+	j.append(refundChange{prev: previous})
+}
+
+func (j *journal) JournalBalanceChange(addr common.Address, previous *uint256.Int) {
+	j.append(balanceChange{
+		account: &addr,
+		prev:    previous.Clone(),
+	})
+}
+
+func (j *journal) JournalSetCode(address common.Address, prevcode, prevHash []byte) {
+	j.append(codeChange{
+		account:  &address,
+		prevhash: prevHash,
+		prevcode: prevcode,
+	})
+}
+
+func (j *journal) JournalNonceChange(address common.Address, prev uint64) {
+	j.append(nonceChange{
+		account: &address,
+		prev:    prev,
+	})
+}
+
+func (j *journal) JournalTouch(address common.Address) {
+	j.append(touchChange{
+		account: &address,
+	})
+	if address == ripemd {
+		// Explicitly put it in the dirty-cache, which is otherwise generated from
+		// flattened journals.
+		j.dirty(address)
+	}
+}
+
 type (
 	// Changes to the account trie.
 	createObjectChange struct {

--- a/core/state/journal.go
+++ b/core/state/journal.go
@@ -19,6 +19,7 @@ package state
 import (
 	"fmt"
 	"maps"
+	"slices"
 	"sort"
 
 	"github.com/ethereum/go-ethereum/common"
@@ -68,7 +69,7 @@ func newJournal() *journal {
 func (j *journal) Reset() {
 	j.entries = j.entries[:0]
 	j.validRevisions = j.validRevisions[:0]
-	j.dirties = make(map[common.Address]int)
+	clear(j.dirties)
 	j.nextRevisionId = 0
 }
 
@@ -140,8 +141,10 @@ func (j *journal) copy() *journal {
 		entries = append(entries, j.entries[i].copy())
 	}
 	return &journal{
-		entries: entries,
-		dirties: maps.Clone(j.dirties),
+		entries:        entries,
+		dirties:        maps.Clone(j.dirties),
+		validRevisions: slices.Clone(j.validRevisions),
+		nextRevisionId: j.nextRevisionId,
 	}
 }
 

--- a/core/state/journal.go
+++ b/core/state/journal.go
@@ -168,12 +168,8 @@ func (j *journal) JournalCreate(addr common.Address) {
 	j.append(createObjectChange{account: &addr})
 }
 
-func (j *journal) JournalDestruct(addr common.Address, previouslyDestructed bool, prevBalance *uint256.Int) {
-	j.append(selfDestructChange{
-		account:     &addr,
-		prev:        previouslyDestructed,
-		prevbalance: prevBalance.Clone(),
-	})
+func (j *journal) JournalDestruct(addr common.Address) {
+	j.append(selfDestructChange{account: &addr})
 }
 
 func (j *journal) JournalSetState(addr common.Address, key, prev, origin common.Hash) {
@@ -240,9 +236,7 @@ type (
 	}
 
 	selfDestructChange struct {
-		account     *common.Address
-		prev        bool // whether account had already self-destructed
-		prevbalance *uint256.Int
+		account *common.Address
 	}
 
 	// Changes to individual accounts.
@@ -325,8 +319,7 @@ func (ch createContractChange) copy() journalEntry {
 func (ch selfDestructChange) revert(s *StateDB) {
 	obj := s.getStateObject(*ch.account)
 	if obj != nil {
-		obj.selfDestructed = ch.prev
-		obj.setBalance(ch.prevbalance)
+		obj.selfDestructed = false
 	}
 }
 
@@ -336,9 +329,7 @@ func (ch selfDestructChange) dirtied() *common.Address {
 
 func (ch selfDestructChange) copy() journalEntry {
 	return selfDestructChange{
-		account:     ch.account,
-		prev:        ch.prev,
-		prevbalance: new(uint256.Int).Set(ch.prevbalance),
+		account: ch.account,
 	}
 }
 

--- a/core/state/state_object.go
+++ b/core/state/state_object.go
@@ -114,7 +114,7 @@ func (s *stateObject) markSelfdestructed() {
 }
 
 func (s *stateObject) touch() {
-	s.db.journal.Touch(s.address)
+	s.db.journal.touchChange(s.address)
 }
 
 // getTrie returns the associated storage trie. The trie will be opened if it's
@@ -244,7 +244,7 @@ func (s *stateObject) SetState(key, value common.Hash) {
 		return
 	}
 	// New value is different, update and journal the change
-	s.db.journal.SetStorage(s.address, key, prev, origin)
+	s.db.journal.storageChange(s.address, key, prev, origin)
 	s.setState(key, value, origin)
 	if s.db.logger != nil && s.db.logger.OnStorageChange != nil {
 		s.db.logger.OnStorageChange(s.address, key, prev, value)
@@ -498,7 +498,7 @@ func (s *stateObject) SubBalance(amount *uint256.Int, reason tracing.BalanceChan
 }
 
 func (s *stateObject) SetBalance(amount *uint256.Int, reason tracing.BalanceChangeReason) {
-	s.db.journal.BalanceChange(s.address, s.data.Balance)
+	s.db.journal.balanceChange(s.address, s.data.Balance)
 	if s.db.logger != nil && s.db.logger.OnBalanceChange != nil {
 		s.db.logger.OnBalanceChange(s.address, s.Balance().ToBig(), amount.ToBig(), reason)
 	}
@@ -574,7 +574,7 @@ func (s *stateObject) CodeSize() int {
 }
 
 func (s *stateObject) SetCode(codeHash common.Hash, code []byte) {
-	s.db.journal.SetCode(s.address)
+	s.db.journal.codeChange(s.address)
 	if s.db.logger != nil && s.db.logger.OnCodeChange != nil {
 		// TODO remove prevcode from this callback
 		s.db.logger.OnCodeChange(s.address, common.BytesToHash(s.CodeHash()), nil, codeHash, code)
@@ -589,7 +589,7 @@ func (s *stateObject) setCode(codeHash common.Hash, code []byte) {
 }
 
 func (s *stateObject) SetNonce(nonce uint64) {
-	s.db.journal.NonceChange(s.address, s.data.Nonce)
+	s.db.journal.nonceChange(s.address, s.data.Nonce)
 	if s.db.logger != nil && s.db.logger.OnNonceChange != nil {
 		s.db.logger.OnNonceChange(s.address, s.data.Nonce, nonce)
 	}

--- a/core/state/state_object.go
+++ b/core/state/state_object.go
@@ -574,7 +574,7 @@ func (s *stateObject) CodeSize() int {
 }
 
 func (s *stateObject) SetCode(codeHash common.Hash, code []byte) {
-	s.db.journal.codeChange(s.address)
+	s.db.journal.setCode(s.address)
 	if s.db.logger != nil && s.db.logger.OnCodeChange != nil {
 		// TODO remove prevcode from this callback
 		s.db.logger.OnCodeChange(s.address, common.BytesToHash(s.CodeHash()), nil, codeHash, code)

--- a/core/state/state_object.go
+++ b/core/state/state_object.go
@@ -574,7 +574,7 @@ func (s *stateObject) CodeSize() int {
 }
 
 func (s *stateObject) SetCode(codeHash common.Hash, code []byte) {
-	s.db.journal.JournalSetCode(s.address, s.Code(), s.CodeHash())
+	s.db.journal.JournalSetCode(s.address)
 	if s.db.logger != nil && s.db.logger.OnCodeChange != nil {
 		// TODO remove prevcode from this callback
 		s.db.logger.OnCodeChange(s.address, common.BytesToHash(s.CodeHash()), nil, codeHash, code)

--- a/core/state/state_object.go
+++ b/core/state/state_object.go
@@ -114,7 +114,7 @@ func (s *stateObject) markSelfdestructed() {
 }
 
 func (s *stateObject) touch() {
-	s.db.journal.JournalTouch(s.address)
+	s.db.journal.Touch(s.address)
 }
 
 // getTrie returns the associated storage trie. The trie will be opened if it's
@@ -244,7 +244,7 @@ func (s *stateObject) SetState(key, value common.Hash) {
 		return
 	}
 	// New value is different, update and journal the change
-	s.db.journal.JournalSetState(s.address, key, prev, origin)
+	s.db.journal.SetStorage(s.address, key, prev, origin)
 	s.setState(key, value, origin)
 	if s.db.logger != nil && s.db.logger.OnStorageChange != nil {
 		s.db.logger.OnStorageChange(s.address, key, prev, value)
@@ -498,7 +498,7 @@ func (s *stateObject) SubBalance(amount *uint256.Int, reason tracing.BalanceChan
 }
 
 func (s *stateObject) SetBalance(amount *uint256.Int, reason tracing.BalanceChangeReason) {
-	s.db.journal.JournalBalanceChange(s.address, s.data.Balance)
+	s.db.journal.BalanceChange(s.address, s.data.Balance)
 	if s.db.logger != nil && s.db.logger.OnBalanceChange != nil {
 		s.db.logger.OnBalanceChange(s.address, s.Balance().ToBig(), amount.ToBig(), reason)
 	}
@@ -574,7 +574,7 @@ func (s *stateObject) CodeSize() int {
 }
 
 func (s *stateObject) SetCode(codeHash common.Hash, code []byte) {
-	s.db.journal.JournalSetCode(s.address)
+	s.db.journal.SetCode(s.address)
 	if s.db.logger != nil && s.db.logger.OnCodeChange != nil {
 		// TODO remove prevcode from this callback
 		s.db.logger.OnCodeChange(s.address, common.BytesToHash(s.CodeHash()), nil, codeHash, code)
@@ -589,7 +589,7 @@ func (s *stateObject) setCode(codeHash common.Hash, code []byte) {
 }
 
 func (s *stateObject) SetNonce(nonce uint64) {
-	s.db.journal.JournalNonceChange(s.address, s.data.Nonce)
+	s.db.journal.NonceChange(s.address, s.data.Nonce)
 	if s.db.logger != nil && s.db.logger.OnNonceChange != nil {
 		s.db.logger.OnNonceChange(s.address, s.data.Nonce, nonce)
 	}

--- a/core/state/statedb.go
+++ b/core/state/statedb.go
@@ -500,9 +500,6 @@ func (s *StateDB) SelfDestruct(addr common.Address) {
 	// Regardless of whether it is already destructed or not, we do have to
 	// journal the balance-change, if we set it to zero here.
 	if !stateObject.Balance().IsZero() {
-		if s.logger != nil && s.logger.OnBalanceChange != nil {
-			s.logger.OnBalanceChange(addr, stateObject.Balance().ToBig(), new(big.Int), tracing.BalanceDecreaseSelfdestruct)
-		}
 		stateObject.SetBalance(new(uint256.Int), tracing.BalanceDecreaseSelfdestruct)
 	}
 	// If it is already marked as self-destructed, we do not need to add it

--- a/core/state/statedb.go
+++ b/core/state/statedb.go
@@ -248,7 +248,7 @@ func (s *StateDB) Error() error {
 }
 
 func (s *StateDB) AddLog(log *types.Log) {
-	s.journal.JournalLog(s.thash)
+	s.journal.Log(s.thash)
 
 	log.TxHash = s.thash
 	log.TxIndex = uint(s.txIndex)
@@ -293,14 +293,14 @@ func (s *StateDB) Preimages() map[common.Hash][]byte {
 
 // AddRefund adds gas to the refund counter
 func (s *StateDB) AddRefund(gas uint64) {
-	s.journal.JournalRefundChange(s.refund)
+	s.journal.RefundChange(s.refund)
 	s.refund += gas
 }
 
 // SubRefund removes gas from the refund counter.
 // This method will panic if the refund counter goes below zero
 func (s *StateDB) SubRefund(gas uint64) {
-	s.journal.JournalRefundChange(s.refund)
+	s.journal.RefundChange(s.refund)
 	if gas > s.refund {
 		panic(fmt.Sprintf("Refund counter below zero (gas: %d > refund: %d)", gas, s.refund))
 	}
@@ -508,7 +508,7 @@ func (s *StateDB) SelfDestruct(addr common.Address) {
 	// If it is already marked as self-destructed, we do not need to add it
 	// for journalling a second time.
 	if !stateObject.selfDestructed {
-		s.journal.JournalDestruct(addr)
+		s.journal.Destruct(addr)
 		stateObject.markSelfdestructed()
 	}
 }
@@ -531,7 +531,7 @@ func (s *StateDB) SetTransientState(addr common.Address, key, value common.Hash)
 	if prev == value {
 		return
 	}
-	s.journal.JournalSetTransientState(addr, key, prev)
+	s.journal.SetTransientState(addr, key, prev)
 	s.setTransientState(addr, key, value)
 }
 
@@ -650,7 +650,7 @@ func (s *StateDB) getOrNewStateObject(addr common.Address) *stateObject {
 // existing account with the given address, otherwise it will be silently overwritten.
 func (s *StateDB) createObject(addr common.Address) *stateObject {
 	obj := newObject(s, addr, nil)
-	s.journal.JournalCreate(addr)
+	s.journal.Create(addr)
 	s.setStateObject(obj)
 	return obj
 }
@@ -1387,7 +1387,7 @@ func (s *StateDB) Prepare(rules params.Rules, sender, coinbase common.Address, d
 // AddAddressToAccessList adds the given address to the access list
 func (s *StateDB) AddAddressToAccessList(addr common.Address) {
 	if s.accessList.AddAddress(addr) {
-		s.journal.JournalAccessListAddAccount(addr)
+		s.journal.AccessListAddAccount(addr)
 	}
 }
 
@@ -1399,10 +1399,10 @@ func (s *StateDB) AddSlotToAccessList(addr common.Address, slot common.Hash) {
 		// scope of 'address' without having the 'address' become already added
 		// to the access list (via call-variant, create, etc).
 		// Better safe than sorry, though
-		s.journal.JournalAccessListAddAccount(addr)
+		s.journal.AccessListAddAccount(addr)
 	}
 	if slotMod {
-		s.journal.JournalAccessListAddSlot(addr, slot)
+		s.journal.AccessListAddSlot(addr, slot)
 	}
 }
 

--- a/core/state/statedb.go
+++ b/core/state/statedb.go
@@ -500,10 +500,10 @@ func (s *StateDB) SelfDestruct(addr common.Address) {
 	// Regardless of whether it is already destructed or not, we do have to
 	// journal the balance-change, if we set it to zero here.
 	if !stateObject.Balance().IsZero() {
-		stateObject.SetBalance(new(uint256.Int), tracing.BalanceDecreaseSelfdestruct)
 		if s.logger != nil && s.logger.OnBalanceChange != nil {
 			s.logger.OnBalanceChange(addr, stateObject.Balance().ToBig(), new(big.Int), tracing.BalanceDecreaseSelfdestruct)
 		}
+		stateObject.SetBalance(new(uint256.Int), tracing.BalanceDecreaseSelfdestruct)
 	}
 	// If it is already marked as self-destructed, we do not need to add it
 	// for journalling a second time.

--- a/core/state/statedb.go
+++ b/core/state/statedb.go
@@ -282,7 +282,6 @@ func (s *StateDB) Logs() []*types.Log {
 // AddPreimage records a SHA3 preimage seen by the VM.
 func (s *StateDB) AddPreimage(hash common.Hash, preimage []byte) {
 	if _, ok := s.preimages[hash]; !ok {
-		s.journal.JournalAddPreimage(hash)
 		s.preimages[hash] = slices.Clone(preimage)
 	}
 }

--- a/core/state/statedb_fuzz_test.go
+++ b/core/state/statedb_fuzz_test.go
@@ -73,7 +73,7 @@ func newStateTestAction(addr common.Address, r *rand.Rand, index int) testAction
 			args: make([]int64, 1),
 		},
 		{
-			name: "SetState",
+			name: "SetStorage",
 			fn: func(a testAction, s *StateDB) {
 				var key, val common.Hash
 				binary.BigEndian.PutUint16(key[:], uint16(a.args[0]))

--- a/core/state/statedb_test.go
+++ b/core/state/statedb_test.go
@@ -372,6 +372,12 @@ func newTestAction(addr common.Address, r *rand.Rand) testAction {
 		{
 			name: "SetCode",
 			fn: func(a testAction, s *StateDB) {
+				// SetCode can only be performed in case the addr does
+				// not already hold code
+				if c := s.GetCode(addr); len(c) > 0 {
+					// no-op
+					return
+				}
 				code := make([]byte, 16)
 				binary.BigEndian.PutUint64(code, uint64(a.args[0]))
 				binary.BigEndian.PutUint64(code[8:], uint64(a.args[1]))

--- a/core/state/statedb_test.go
+++ b/core/state/statedb_test.go
@@ -360,7 +360,7 @@ func newTestAction(addr common.Address, r *rand.Rand) testAction {
 			args: make([]int64, 1),
 		},
 		{
-			name: "SetState",
+			name: "SetStorage",
 			fn: func(a testAction, s *StateDB) {
 				var key, val common.Hash
 				binary.BigEndian.PutUint16(key[:], uint16(a.args[0]))


### PR DESCRIPTION
This is a follow-up to #29520, and a preparatory PR to a more thorough change in the journalling system.

### API methods instead of `append` operations

This PR hides the journal-implementation details away, so that the statedb invokes methods like `JournalCreate`, instead of explicitly appending journal-events in a list. This means that it's up to the journal whether to implement it as a sequence of events or aggregate/merge events. 

### Snapshot-management inside the journal 

This PR also makes it so that management of valid snapshots is moved inside the journal, exposed via the methods `Snapshot() int` and `RevertToSnapshot(revid int, s *StateDB)`. 


### SetCode

JournalSetCode journals the setting of code: it is implicit that the previous values were "no code" and emptyCodeHash. Therefore, we can simplify the setCode journal.

### Selfdestruct

The self-destruct journalling is a bit strange: we allow the selfdestruct operation to be journalled several times. This makes it so that we also are forced to store whether the account was already destructed.

What we can do instead, is to only journal the first destruction, and after that only journal balance-changes, but not journal the selfdestruct itself.

This simplifies the journalling, so that internals about state management does not leak into the journal-API.

### Preimages

Preimages were, for some reason, integrated into the journal management, despite not being a consensus-critical data structure. This PR undoes that.