### PR TITLE
common: Let Hex2Bytes and Hex2BytesFixed panic for invalid hex strings

### DIFF
--- a/common/bytes.go
+++ b/common/bytes.go
@@ -76,14 +76,24 @@ func Bytes2Hex(d []byte) string {
 }
 
 // Hex2Bytes returns the bytes represented by the hexadecimal string str.
+// The string must not be prefixed with `0x`.
+// It panics if str contains a non-hex char.
 func Hex2Bytes(str string) []byte {
-	h, _ := hex.DecodeString(str)
+	h, err := hex.DecodeString(str)
+	if err != nil {
+		panic("error decoding string: " + err.Error())
+	}
 	return h
 }
 
 // Hex2BytesFixed returns bytes of a specified fixed length flen.
+// The string must not be prefixed with `0x`.
+// It panics if str contains a non-hex char.
 func Hex2BytesFixed(str string, flen int) []byte {
-	h, _ := hex.DecodeString(str)
+	h, err := hex.DecodeString(str)
+	if err != nil {
+		panic("error decoding string: " + err.Error())
+	}
 	if len(h) == flen {
 		return h
 	}

--- a/core/state/snapshot/generate_test.go
+++ b/core/state/snapshot/generate_test.go
@@ -374,7 +374,7 @@ func testGenerateExistentStateWithWrongAccounts(t *testing.T, scheme string) {
 	// Wrong accounts
 	{
 		helper.addTrieAccount("acc-2", &types.StateAccount{Balance: uint256.NewInt(1), Root: stRoot, CodeHash: types.EmptyCodeHash.Bytes()})
-		helper.addSnapAccount("acc-2", &types.StateAccount{Balance: uint256.NewInt(1), Root: stRoot, CodeHash: common.Hex2Bytes("0x1234")})
+		helper.addSnapAccount("acc-2", &types.StateAccount{Balance: uint256.NewInt(1), Root: stRoot, CodeHash: common.Hex2Bytes("1234")})
 
 		helper.addTrieAccount("acc-3", &types.StateAccount{Balance: uint256.NewInt(1), Root: stRoot, CodeHash: types.EmptyCodeHash.Bytes()})
 		helper.addSnapAccount("acc-3", &types.StateAccount{Balance: uint256.NewInt(1), Root: types.EmptyRootHash, CodeHash: types.EmptyCodeHash.Bytes()})
@@ -383,7 +383,7 @@ func testGenerateExistentStateWithWrongAccounts(t *testing.T, scheme string) {
 	// Extra accounts, only in the snap
 	{
 		helper.addSnapAccount("acc-0", &types.StateAccount{Balance: uint256.NewInt(1), Root: stRoot, CodeHash: types.EmptyCodeHash.Bytes()})              // before the beginning
-		helper.addSnapAccount("acc-5", &types.StateAccount{Balance: uint256.NewInt(1), Root: types.EmptyRootHash, CodeHash: common.Hex2Bytes("0x1234")})  // Middle
+		helper.addSnapAccount("acc-5", &types.StateAccount{Balance: uint256.NewInt(1), Root: types.EmptyRootHash, CodeHash: common.Hex2Bytes("1234")})    // Middle
 		helper.addSnapAccount("acc-7", &types.StateAccount{Balance: uint256.NewInt(1), Root: types.EmptyRootHash, CodeHash: types.EmptyCodeHash.Bytes()}) // after the end
 	}
 


### PR DESCRIPTION
**Description**

The functions `Hex2Bytes` and `Hex2BytesFixed` silently return an empty bytes slice if the input string is invalid. Proposing to let it panic instead on invalid input.

The PR also fixes two usages of `Hex2Bytes` with a `0x` prefixed string in tests.

**Context**

We hit this in our tests where we accidentally decoded `0x` prefixed hex strings into empty byte slices.

Is there a specific use case where it is explicitly desired that `Hex2Bytes` silently returns an empty bytes slice on invalid input?

Also seeing that there's the safer `FromHex` function. But given that `Hex2Bytes` is an exported function, it might still make sense to panic instead of silently failing.
