### PR TITLE
README.md: fix travis badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Golang execution layer implementation of the Ethereum protocol.
 https://pkg.go.dev/badge/github.com/ethereum/go-ethereum
 )](https://pkg.go.dev/github.com/ethereum/go-ethereum?tab=doc)
 [![Go Report Card](https://goreportcard.com/badge/github.com/ethereum/go-ethereum)](https://goreportcard.com/report/github.com/ethereum/go-ethereum)
-[![Travis](https://travis-ci.com/ethereum/go-ethereum.svg?branch=master)](https://travis-ci.com/ethereum/go-ethereum)
+[![Travis](https://app.travis-ci.com/ethereum/go-ethereum.svg?branch=master)](https://app.travis-ci.com/github/ethereum/go-ethereum)
 [![Discord](https://img.shields.io/badge/discord-join%20chat-blue.svg)](https://discord.gg/nthXNEv)
 
 Automated builds are available for stable releases and the unstable master branch. Binary


### PR DESCRIPTION
The hyperlink in the README file that directs to the Travis CI build was broken. This commit updates the link to point to the correct Travis CI build page for the Ethereum code repository.