### PR TITLE
feat(ci): introduce PR title linting with GitHub Actions

### DIFF
--- a/.github/workflows/check-pr-title.yml
+++ b/.github/workflows/check-pr-title.yml
@@ -1,0 +1,18 @@
+name: Check PR title
+on:
+  pull_request_target:
+    types:
+      - opened
+      - reopened
+      - edited
+      - synchronize
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    permissions:
+      statuses: write
+    steps:
+      - uses: aslafy-z/conventional-pr-title-action@v3
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This PR integrates a GitHub Actions workflow for linting PR titles against the Conventional Commits standard, significantly enhancing our project's consistency and readability. This automated check streamlines the review process, ensures clear and descriptive PR titles, and facilitates easier generation of change logs, ultimately improving our development workflow and documentation quality.