### PR TITLE
core: cache transaction indexing tail in memory

### DIFF
--- a/core/txindexer.go
+++ b/core/txindexer.go
@@ -127,9 +127,10 @@ func (indexer *txIndexer) loop(chain *BlockChain) {
 
 	// Listening to chain events and manipulate the transaction indexes.
 	var (
-		stop     chan struct{} // Non-nil if background routine is active.
-		done     chan struct{} // Non-nil if background routine is active.
-		lastHead uint64        // The latest announced chain head (whose tx indexes are assumed created)
+		stop     chan struct{}                       // Non-nil if background routine is active.
+		done     chan struct{}                       // Non-nil if background routine is active.
+		lastHead uint64                              // The latest announced chain head (whose tx indexes are assumed created)
+		lastTail = rawdb.ReadTxIndexTail(indexer.db) // The oldest indexed block, nil means nothing indexed
 
 		headCh = make(chan ChainHeadEvent)
 		sub    = chain.SubscribeChainHeadEvent(headCh)
@@ -156,8 +157,9 @@ func (indexer *txIndexer) loop(chain *BlockChain) {
 		case <-done:
 			stop = nil
 			done = nil
+			lastTail = rawdb.ReadTxIndexTail(indexer.db)
 		case ch := <-indexer.progress:
-			ch <- indexer.report(lastHead)
+			ch <- indexer.report(lastHead, lastTail)
 		case ch := <-indexer.term:
 			if stop != nil {
 				close(stop)
@@ -173,11 +175,7 @@ func (indexer *txIndexer) loop(chain *BlockChain) {
 }
 
 // report returns the tx indexing progress.
-func (indexer *txIndexer) report(head uint64) TxIndexProgress {
-	var (
-		remaining uint64
-		tail      = rawdb.ReadTxIndexTail(indexer.db)
-	)
+func (indexer *txIndexer) report(head uint64, tail *uint64) TxIndexProgress {
 	total := indexer.limit
 	if indexer.limit == 0 || total > head {
 		total = head + 1 // genesis included
@@ -188,6 +186,7 @@ func (indexer *txIndexer) report(head uint64) TxIndexProgress {
 	}
 	// The value of indexed might be larger than total if some blocks need
 	// to be unindexed, avoiding a negative remaining.
+	var remaining uint64
 	if indexed < total {
 		remaining = total - indexed
 	}

--- a/core/txindexer_test.go
+++ b/core/txindexer_test.go
@@ -85,7 +85,7 @@ func TestTxIndexer(t *testing.T) {
 		for number := *tail; number <= chainHead; number += 1 {
 			verifyIndexes(db, number, true)
 		}
-		progress := indexer.report(chainHead)
+		progress := indexer.report(chainHead, tail)
 		if !progress.Done() {
 			t.Fatalf("Expect fully indexed")
 		}


### PR DESCRIPTION
This pull request tries to address issue #28907

From the ticket we can see the `txindexer.report` dominates the CPU usage. Inside of this function, only a single database read is involved. Therefore the first attempt to mitigate the situation is caching the `tail` data in memory instead of retrieving it from db.

**Note, with this change, the indexing progress reported will have a big delay as tail is only updated at the end**. It might have bad UX for reporting tx indexing progress, but should be fine.