### PR TITLE
core/txpool: don't inject lazy resolved transactions into the container

### DIFF
--- a/core/txpool/subpool.go
+++ b/core/txpool/subpool.go
@@ -46,8 +46,8 @@ type LazyTransaction struct {
 // maintained by the transaction pool.
 //
 // Note, the method will *not* cache the retrieved transaction if the original
-// pool has not cached it. The idea being that if the tx was too big to insert
-// originally, silently saving it will cause more toruble down the line (and
+// pool has not cached it. The idea being, that if the tx was too big to insert
+// originally, silently saving it will cause more trouble down the line (and
 // indeed seems to have caused a memory bloat in the original implementation
 // which did just that).
 func (ltx *LazyTransaction) Resolve() *types.Transaction {

--- a/core/txpool/subpool.go
+++ b/core/txpool/subpool.go
@@ -44,11 +44,17 @@ type LazyTransaction struct {
 
 // Resolve retrieves the full transaction belonging to a lazy handle if it is still
 // maintained by the transaction pool.
+//
+// Note, the method will *not* cache the retrieved transaction if the original
+// pool has not cached it. The idea being that if the tx was too big to insert
+// originally, silently saving it will cause more toruble down the line (and
+// indeed seems to have caused a memory bloat in the original implementation
+// which did just that).
 func (ltx *LazyTransaction) Resolve() *types.Transaction {
-	if ltx.Tx == nil {
-		ltx.Tx = ltx.Pool.Get(ltx.Hash)
+	if ltx.Tx != nil {
+		return ltx.Tx
 	}
-	return ltx.Tx
+	return ltx.Pool.Get(ltx.Hash)
 }
 
 // LazyResolver is a minimal interface needed for a transaction pool to satisfy


### PR DESCRIPTION
When retrieving transactions for mining, we return lazy wrappers. The purpose is to delay loading blobs from disk until they are absolutely necessary and seem to really really really go into a next block.

The original wrapper however when "Resolved", pulled in the full transaction and stored it in the lazy wrapper. This seems like a good idea as it avoids loading the transaction a second time, but:

- We never ever want to load a transaction a second time. We load it when we want to insert into a block, and then we either push it into the block or discard it. We never need it again (until the next block when we remake the lazy list). Storing it is thus pointless.
- However, storing it means that our original light list starts to get heavy. And for every transaction that the miner resolves, the full blobs remain in memory until the entire list gets dereferenced. Depending on how the miner's implemented, this might be 12s until the block is retrieved.

With recommits, this work gets repeated multiple times, worsening the effect.