### PR TITLE
internal/flags: fix --miner.gasprice default listing

### DIFF
--- a/internal/flags/flags.go
+++ b/internal/flags/flags.go
@@ -256,7 +256,8 @@ type BigFlag struct {
 	Hidden     bool
 	HasBeenSet bool
 
-	Value *big.Int
+	Value        *big.Int
+	defaultValue *big.Int
 
 	Aliases []string
 	EnvVars []string
@@ -269,6 +270,10 @@ func (f *BigFlag) IsSet() bool     { return f.HasBeenSet }
 func (f *BigFlag) String() string  { return cli.FlagStringer(f) }
 
 func (f *BigFlag) Apply(set *flag.FlagSet) error {
+	// Set default value so that environment wont be able to overwrite it
+	if f.Value != nil {
+		f.defaultValue = new(big.Int).Set(f.Value)
+	}
 	for _, envVar := range f.EnvVars {
 		envVar = strings.TrimSpace(envVar)
 		if value, found := syscall.Getenv(envVar); found {
@@ -283,7 +288,6 @@ func (f *BigFlag) Apply(set *flag.FlagSet) error {
 		f.Value = new(big.Int)
 		set.Var((*bigValue)(f.Value), f.Name, f.Usage)
 	})
-
 	return nil
 }
 
@@ -310,7 +314,7 @@ func (f *BigFlag) GetDefaultText() string {
 	if f.DefaultText != "" {
 		return f.DefaultText
 	}
-	return f.GetValue()
+	return f.defaultValue.String()
 }
 
 // bigValue turns *big.Int into a flag.Value


### PR DESCRIPTION
Seems the CLI package did some internal crap, which caused our default formatter for big.Int flags to stop working. I just copy pasted the default handling from the cli.Uint64 flag.

$ geth --help

master:

```
    --miner.gasprice value              (default: 0)              ($GETH_MINER_GASPRICE)
          Minimum gas price for mining a transaction
```

vs PR:

```
    --miner.gasprice value              (default: 1000000000)              ($GETH_MINER_GASPRICE)
          Minimum gas price for mining a transaction
```