### PR TITLE
eth, miner: fix enforcing the minimum miner tip

### DIFF
--- a/accounts/abi/bind/util_test.go
+++ b/accounts/abi/bind/util_test.go
@@ -65,7 +65,7 @@ func TestWaitDeployed(t *testing.T) {
 
 		// Create the transaction
 		head, _ := backend.Client().HeaderByNumber(context.Background(), nil) // Should be child's, good enough
-		gasPrice := new(big.Int).Add(head.BaseFee, big.NewInt(1))
+		gasPrice := new(big.Int).Add(head.BaseFee, big.NewInt(params.GWei))
 
 		tx := types.NewContractCreation(0, big.NewInt(0), test.gas, gasPrice, common.FromHex(test.code))
 		tx, _ = types.SignTx(tx, types.LatestSignerForChainID(big.NewInt(1337)), testKey)

--- a/eth/api_miner.go
+++ b/eth/api_miner.go
@@ -64,6 +64,7 @@ func (api *MinerAPI) SetGasPrice(gasPrice hexutil.Big) bool {
 	api.e.lock.Unlock()
 
 	api.e.txPool.SetGasTip((*big.Int)(&gasPrice))
+	api.e.Miner().SetGasTip((*big.Int)(&gasPrice))
 	return true
 }
 

--- a/ethclient/simulated/backend_test.go
+++ b/ethclient/simulated/backend_test.go
@@ -52,7 +52,7 @@ func newTx(sim *Backend, key *ecdsa.PrivateKey) (*types.Transaction, error) {
 
 	// create a signed transaction to send
 	head, _ := client.HeaderByNumber(context.Background(), nil) // Should be child's, good enough
-	gasPrice := new(big.Int).Add(head.BaseFee, big.NewInt(1))
+	gasPrice := new(big.Int).Add(head.BaseFee, big.NewInt(params.GWei))
 	addr := crypto.PubkeyToAddress(key.PublicKey)
 	chainid, _ := client.ChainID(context.Background())
 	nonce, err := client.PendingNonceAt(context.Background(), addr)
@@ -62,7 +62,7 @@ func newTx(sim *Backend, key *ecdsa.PrivateKey) (*types.Transaction, error) {
 	tx := types.NewTx(&types.DynamicFeeTx{
 		ChainID:   chainid,
 		Nonce:     nonce,
-		GasTipCap: big.NewInt(1),
+		GasTipCap: big.NewInt(params.GWei),
 		GasFeeCap: gasPrice,
 		Gas:       21000,
 		To:        &addr,

--- a/ethclient/simulated/options.go
+++ b/ethclient/simulated/options.go
@@ -17,6 +17,8 @@
 package simulated
 
 import (
+	"math/big"
+
 	"github.com/ethereum/go-ethereum/eth/ethconfig"
 	"github.com/ethereum/go-ethereum/node"
 )
@@ -35,5 +37,19 @@ func WithBlockGasLimit(gaslimit uint64) func(nodeConf *node.Config, ethConf *eth
 func WithCallGasLimit(gaslimit uint64) func(nodeConf *node.Config, ethConf *ethconfig.Config) {
 	return func(nodeConf *node.Config, ethConf *ethconfig.Config) {
 		ethConf.RPCGasCap = gaslimit
+	}
+}
+
+// WithMinerMinTip configures the simulated backend to require a specific minimum
+// gas tip for a transaction to be included.
+//
+// 0 is not possible as a live Geth node would reject that due to DoS protection,
+// so the simulated backend will replicate that behavior for consisntency.
+func WithMinerMinTip(tip *big.Int) func(nodeConf *node.Config, ethConf *ethconfig.Config) {
+	if tip == nil || tip.Cmp(new(big.Int)) <= 0 {
+		panic("invalid miner minimum tip")
+	}
+	return func(nodeConf *node.Config, ethConf *ethconfig.Config) {
+		ethConf.Miner.GasPrice = tip
 	}
 }

--- a/miner/miner.go
+++ b/miner/miner.go
@@ -197,6 +197,11 @@ func (miner *Miner) SetExtra(extra []byte) error {
 	return nil
 }
 
+func (miner *Miner) SetGasTip(tip *big.Int) error {
+	miner.worker.setGasTip(tip)
+	return nil
+}
+
 // SetRecommitInterval sets the interval for sealing work resubmitting.
 func (miner *Miner) SetRecommitInterval(interval time.Duration) {
 	miner.worker.setRecommitInterval(interval)

--- a/miner/ordering.go
+++ b/miner/ordering.go
@@ -119,11 +119,11 @@ func newTransactionsByPriceAndNonce(signer types.Signer, txs map[common.Address]
 }
 
 // Peek returns the next transaction by price.
-func (t *transactionsByPriceAndNonce) Peek() *txpool.LazyTransaction {
+func (t *transactionsByPriceAndNonce) Peek() (*txpool.LazyTransaction, *big.Int) {
 	if len(t.heads) == 0 {
-		return nil
+		return nil, nil
 	}
-	return t.heads[0].tx
+	return t.heads[0].tx, t.heads[0].fees
 }
 
 // Shift replaces the current best head with the next one from the same account.

--- a/miner/ordering_test.go
+++ b/miner/ordering_test.go
@@ -104,7 +104,7 @@ func testTransactionPriceNonceSort(t *testing.T, baseFee *big.Int) {
 	txset := newTransactionsByPriceAndNonce(signer, groups, baseFee)
 
 	txs := types.Transactions{}
-	for tx := txset.Peek(); tx != nil; tx = txset.Peek() {
+	for tx, _ := txset.Peek(); tx != nil; tx, _ = txset.Peek() {
 		txs = append(txs, tx.Tx)
 		txset.Shift()
 	}
@@ -170,7 +170,7 @@ func TestTransactionTimeSort(t *testing.T) {
 	txset := newTransactionsByPriceAndNonce(signer, groups, nil)
 
 	txs := types.Transactions{}
-	for tx := txset.Peek(); tx != nil; tx = txset.Peek() {
+	for tx, _ := txset.Peek(); tx != nil; tx, _ = txset.Peek() {
 		txs = append(txs, tx.Tx)
 		txset.Shift()
 	}


### PR DESCRIPTION
Geth originally enforced transaction gas prices and tips in the transaction pool. This seemed like an elegant way to avoid having to check the same thing in two different places. By default the pool (and hence miner) admitted 1 wei tip transactions, and when mining was started, that was increased to whatever the user set, or 1gwei by default.

Unfortunately, the merge kind of broke this mechanism. Since post-merge mining is not requested to be "turned on" in Geth, rather blocks are sometimes produced on demand via the beacon client, the mechanism that flipped the pool from non-mining-node mode to mining-node mode never got triggered. The effect is that all validating Geth nodes accept 1 wei tip transactions into the pool currently, and because the miner doens't do a follow-up enforcement, those will get included in a block blindly...

Now, in practice, the transactions are still sorted in highest-tip order, so the effect isn't really relevant on mainnet, or anywhere really where the pool has enough proper transactions to fill up a block. The issue is mostly relevant in testnets, private nets, or Geth forks where the network might not be completely saturated. In those cases, even though Geth supports a `--miner.gasprice` flag, that gets elegantly ignored (tho you could still use `txpool.gasprice` to have the desired side effect).

The fix for this issue is not so obvious. Restoring the previous mechanism of the pool enforcing the tip is problematic, since there's no startup marker in Geth that would signal that the machine will be mining, so start enforcing stricter limits. Sure, we could require users to pass in `--mine`, but it seems like an arbitrary useless thing to need. We could also start enforcing gas tips the first time a block is requested from us, but it feels wrong to all of a sudden do a big txpool filtering exactly when we need to build a block and can't afford to waste time.

The solution proposed in this PR is to go back to a less simple way, that of having a second filtering step within a miner that can enforce tips independent of the pool. Cost wise this doesn't add anything to the current "faulty" behavior. What this would mean is that by default even block producing nodes accept and propagate txs down to 1 wei tip (as long as it fits into the 4/6K limit); but anything below the needed limit would get filtered out in the miner itself now.

Side note: if the user calls `miner.setGasPrice` API method, that will enforce the price on *both* the miner and the txpool. Whilst we could drop the enforcement from the pool, I felt that we should aim to keep as much behavior as we can unchanged.