### PR TITLE
core/state, trie/triedb/pathdb: remove storage incomplete flag

### DIFF
--- a/core/state/metrics.go
+++ b/core/state/metrics.go
@@ -33,5 +33,4 @@ var (
 	slotDeletionTimer    = metrics.NewRegisteredResettingTimer("state/delete/storage/timer", nil)
 	slotDeletionCount    = metrics.NewRegisteredMeter("state/delete/storage/slot", nil)
 	slotDeletionSize     = metrics.NewRegisteredMeter("state/delete/storage/size", nil)
-	slotDeletionSkip     = metrics.NewRegisteredGauge("state/delete/storage/skip", nil)
 )

--- a/core/state/statedb_test.go
+++ b/core/state/statedb_test.go
@@ -1161,12 +1161,12 @@ func TestDeleteStorage(t *testing.T) {
 	obj := fastState.getOrNewStateObject(addr)
 	storageRoot := obj.data.Root
 
-	_, _, fastNodes, err := fastState.deleteStorage(addr, crypto.Keccak256Hash(addr[:]), storageRoot)
+	_, fastNodes, err := fastState.deleteStorage(addr, crypto.Keccak256Hash(addr[:]), storageRoot)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	_, _, slowNodes, err := slowState.deleteStorage(addr, crypto.Keccak256Hash(addr[:]), storageRoot)
+	_, slowNodes, err := slowState.deleteStorage(addr, crypto.Keccak256Hash(addr[:]), storageRoot)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/trie/triestate/state.go
+++ b/trie/triestate/state.go
@@ -59,18 +59,16 @@ type TrieLoader interface {
 // The value refers to the original content of state before the transition
 // is made. Nil means that the state was not present previously.
 type Set struct {
-	Accounts   map[common.Address][]byte                 // Mutated account set, nil means the account was not present
-	Storages   map[common.Address]map[common.Hash][]byte // Mutated storage set, nil means the slot was not present
-	Incomplete map[common.Address]struct{}               // Indicator whether the storage is incomplete due to large deletion
-	size       common.StorageSize                        // Approximate size of set
+	Accounts map[common.Address][]byte                 // Mutated account set, nil means the account was not present
+	Storages map[common.Address]map[common.Hash][]byte // Mutated storage set, nil means the slot was not present
+	size     common.StorageSize                        // Approximate size of set
 }
 
 // New constructs the state set with provided data.
-func New(accounts map[common.Address][]byte, storages map[common.Address]map[common.Hash][]byte, incomplete map[common.Address]struct{}) *Set {
+func New(accounts map[common.Address][]byte, storages map[common.Address]map[common.Hash][]byte) *Set {
 	return &Set{
-		Accounts:   accounts,
-		Storages:   storages,
-		Incomplete: incomplete,
+		Accounts: accounts,
+		Storages: storages,
 	}
 }
 
@@ -88,7 +86,6 @@ func (s *Set) Size() common.StorageSize {
 		}
 		s.size += common.StorageSize(common.AddressLength)
 	}
-	s.size += common.StorageSize(common.AddressLength * len(s.Incomplete))
 	return s.size
 }
 

--- a/triedb/pathdb/database.go
+++ b/triedb/pathdb/database.go
@@ -403,9 +403,6 @@ func (db *Database) Recoverable(root common.Hash) bool {
 		if m.parent != root {
 			return errors.New("unexpected state history")
 		}
-		if len(m.incomplete) > 0 {
-			return errors.New("incomplete state history")
-		}
 		root = m.root
 		return nil
 	}) == nil

--- a/triedb/pathdb/database_test.go
+++ b/triedb/pathdb/database_test.go
@@ -299,7 +299,7 @@ func (t *tester) generate(parent common.Hash) (common.Hash, *trienode.MergedNode
 			}
 		}
 	}
-	return root, ctx.nodes, triestate.New(ctx.accountOrigin, ctx.storageOrigin, nil)
+	return root, ctx.nodes, triestate.New(ctx.accountOrigin, ctx.storageOrigin)
 }
 
 // lastRoot returns the latest root hash, or empty if nothing is cached.
@@ -543,7 +543,7 @@ func TestCorruptedJournal(t *testing.T) {
 
 	// Mutate the journal in disk, it should be regarded as invalid
 	blob := rawdb.ReadTrieJournal(tester.db.diskdb)
-	blob[0] = 1
+	blob[0] = 0xa
 	rawdb.WriteTrieJournal(tester.db.diskdb, blob)
 
 	// Verify states, all not-yet-written states should be discarded

--- a/triedb/pathdb/disklayer.go
+++ b/triedb/pathdb/disklayer.go
@@ -17,7 +17,6 @@
 package pathdb
 
 import (
-	"errors"
 	"fmt"
 	"sync"
 
@@ -238,12 +237,6 @@ func (dl *diskLayer) commit(bottom *diffLayer, force bool) (*diskLayer, error) {
 func (dl *diskLayer) revert(h *history, loader triestate.TrieLoader) (*diskLayer, error) {
 	if h.meta.root != dl.rootHash() {
 		return nil, errUnexpectedHistory
-	}
-	// Reject if the provided state history is incomplete. It's due to
-	// a large construct SELF-DESTRUCT which can't be handled because
-	// of memory limitation.
-	if len(h.meta.incomplete) > 0 {
-		return nil, errors.New("incomplete state history")
 	}
 	if dl.id == 0 {
 		return nil, fmt.Errorf("%w: zero state id", errStateUnrecoverable)

--- a/triedb/pathdb/history_test.go
+++ b/triedb/pathdb/history_test.go
@@ -47,7 +47,7 @@ func randomStateSet(n int) *triestate.Set {
 		account := generateAccount(types.EmptyRootHash)
 		accounts[addr] = types.SlimAccountRLP(account)
 	}
-	return triestate.New(accounts, storages, nil)
+	return triestate.New(accounts, storages)
 }
 
 func makeHistory() *history {

--- a/triedb/pathdb/journal.go
+++ b/triedb/pathdb/journal.go
@@ -41,7 +41,13 @@ var (
 	errUnmatchedJournal  = errors.New("unmatched journal")
 )
 
-const journalVersion uint64 = 0
+// journalVersion ensures that an incompatible journal is detected and discarded.
+//
+// Changelog:
+//
+// - Version 0: initial version
+// - Version 1: storage.Incomplete field is removed
+const journalVersion uint64 = 1
 
 // journalNode represents a trie node persisted in the journal.
 type journalNode struct {
@@ -64,10 +70,9 @@ type journalAccounts struct {
 
 // journalStorage represents a list of storage slots belong to an account.
 type journalStorage struct {
-	Incomplete bool
-	Account    common.Address
-	Hashes     []common.Hash
-	Slots      [][]byte
+	Account common.Address
+	Hashes  []common.Hash
+	Slots   [][]byte
 }
 
 // loadJournal tries to parse the layer journal from the disk.
@@ -209,11 +214,10 @@ func (db *Database) loadDiffLayer(parent layer, r *rlp.Stream) (layer, error) {
 	}
 	// Read state changes from journal
 	var (
-		jaccounts  journalAccounts
-		jstorages  []journalStorage
-		accounts   = make(map[common.Address][]byte)
-		storages   = make(map[common.Address]map[common.Hash][]byte)
-		incomplete = make(map[common.Address]struct{})
+		jaccounts journalAccounts
+		jstorages []journalStorage
+		accounts  = make(map[common.Address][]byte)
+		storages  = make(map[common.Address]map[common.Hash][]byte)
 	)
 	if err := r.Decode(&jaccounts); err != nil {
 		return nil, fmt.Errorf("load diff accounts: %v", err)
@@ -233,12 +237,9 @@ func (db *Database) loadDiffLayer(parent layer, r *rlp.Stream) (layer, error) {
 				set[h] = nil
 			}
 		}
-		if entry.Incomplete {
-			incomplete[entry.Account] = struct{}{}
-		}
 		storages[entry.Account] = set
 	}
-	return db.loadDiffLayer(newDiffLayer(parent, root, parent.stateID()+1, block, nodes, triestate.New(accounts, storages, incomplete)), r)
+	return db.loadDiffLayer(newDiffLayer(parent, root, parent.stateID()+1, block, nodes, triestate.New(accounts, storages)), r)
 }
 
 // journal implements the layer interface, marshaling the un-flushed trie nodes
@@ -316,9 +317,6 @@ func (dl *diffLayer) journal(w io.Writer) error {
 	storage := make([]journalStorage, 0, len(dl.states.Storages))
 	for addr, slots := range dl.states.Storages {
 		entry := journalStorage{Account: addr}
-		if _, ok := dl.states.Incomplete[addr]; ok {
-			entry.Incomplete = true
-		}
 		for slotHash, slot := range slots {
 			entry.Hashes = append(entry.Hashes, slotHash)
 			entry.Slots = append(entry.Slots, slot)


### PR DESCRIPTION
As SELF-DESTRUCT opcode is disabled in the cancun fork(unless the account is created within the same transaction, nothing to delete in this case). The account will only be deleted in the following cases:

- The account is created within the same transaction. In this case the original storage was empty.

- The account is empty(zero nonce, zero balance, zero code) and is touched within the transaction. Fortunately this kind of accounts are not-existent on ethereum-mainnet.

All in all, after cancun, we are pretty sure there is no large contract deletion and we don't need this mechanism for oom protection.