### PR TITLE
eth/catalyst: encode logs for invalid new payload params error so it's more readable

### DIFF
--- a/eth/catalyst/api.go
+++ b/eth/catalyst/api.go
@@ -23,6 +23,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/davecgh/go-spew/spew"
 	"github.com/ethereum/go-ethereum/beacon/engine"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
@@ -550,7 +551,7 @@ func (api *ConsensusAPI) newPayload(params engine.ExecutableData, versionedHashe
 	log.Trace("Engine API request received", "method", "NewPayload", "number", params.Number, "hash", params.BlockHash)
 	block, err := engine.ExecutableDataToBlock(params, versionedHashes, beaconRoot)
 	if err != nil {
-		log.Warn("Invalid NewPayload params", "params", params, "error", err)
+		log.Warn("Invalid NewPayload params", "params", spew.Sdump(params), "error", err)
 		return api.invalid(err, nil), nil
 	}
 	// Stash away the last update to warn the user if the beacon client goes offline


### PR DESCRIPTION
This is an idea. Here is the log currently:

`
Invalid NewPayload params                params="{ParentHash:0x05f8d8dc22c9c0073d9226ef778f11f7453eed0a073a81313cfc89bb96edf411 FeeRecipient:0x77777A6C097a1cE65C61A96a49bd1100F
660eC94 StateRoot:0x3abbda0df2aacb7081e69ba944a7215b00e27245a50455ab66861031809851a5 ReceiptsRoot: 0x86af7ae966f0b0d39c88027ce0dda44008fe06f8fa097af70b94972859e93356 LogsBloom:[35 247 145 111 101 246 43 92 222 137 99 14 146 93 155 218 55 235 137 74 117 135 21 43 221 27 27 56 244 189 143 118 243 187 189 211 168 120 49 40 98 51 95 235 52 0 145 81 135 81 193 178 158 198 63 4 8 55 207 206 27 59 233 171 194 12 101 9 98 30 91 57 237 179 118 77 146 168 67 56 161 31 116 111 181 109 156 121 252 31 221 117 183 255 159 188 171 80 222 12 235 246 180 151 116 60 93 32 244 53 189 219 200 60 137 97 160 93 109 187 146 27 116 252 25 154 28 120 50 0 119 117 12 96 79 199 80 229 151 116 171 170 106 134 151 35 212 179 69 201 195 187 101 118 128 116 120 216 182 34 6 67 248 220 157 130 174 49 222 213 112 245 125 42 148 227 231 87 203 208 10 245 64 107 63 249 166 238 87 248 43 34 31 223 33 2 149 2 205 253 44 193 33 238 152 251 116 253 100 255 49 102 55 200 226 93 9 2 117 199 18 7 224 92 189 246 60 126 187 148 208 21 222 135 116 175 135 120 213 234 143 22 216 59 253 185 96 202 129 172 186 23 95 160 54 25] Random:0xd51cc9df0ba97bc8cae5e6f24346d8bd0f6465615aef9114d7f6c9a49b0846e3 Number:19169429 GasLimit:30000000 GasUsed:16928838 Timestamp:1707225287 ExtraData:[114 115 121 110 99 45 98 117 105 108 100 101 114 46 120 121 122], ...
}"
`

now will look more like

```
(engine.ExecutableData) {
 ParentHash: (common.Hash) (len=32 cap=32) 0x0000000000000000000000000000000000000000000000000000000000000000,
 FeeRecipient: (common.Address) (len=20 cap=20) 0x0000000000000000000000000000000000000000,
 StateRoot: (common.Hash) (len=32 cap=32) 0x0000000000000000000000000000000000000000000000000000000000000000,
 ReceiptsRoot: (common.Hash) (len=32 cap=32) 0x0000000000000000000000000000000000000000000000000000000000000000,
 LogsBloom: ([]uint8) <nil>,
 Random: (common.Hash) (len=32 cap=32) 0x0000000000000000000000000000000000000000000000000000000000000000,
 Number: (uint64) 0,
 GasLimit: (uint64) 0,
 GasUsed: (uint64) 0,
 Timestamp: (uint64) 0,
 ExtraData: ([]uint8) (len=17 cap=17) {
  00000000  72 73 79 6e 63 2d 62 75  69 6c 64 65 72 2e 78 79  |rsync-builder.xy|
  00000010  7a                                                |z|
 },
 BaseFeePerGas: (*big.Int)(<nil>),
 BlockHash: (common.Hash) (len=32 cap=32) 0x0000000000000000000000000000000000000000000000000000000000000000,
 Transactions: ([][]uint8) <nil>,
 Withdrawals: ([]*types.Withdrawal) <nil>,
 BlobGasUsed: (*uint64)(<nil>),
 ExcessBlobGas: (*uint64)(<nil>)
}
```