### PR TITLE
fix: update outdated link to trezor docs

### DIFF
--- a/accounts/usbwallet/trezor/trezor.go
+++ b/accounts/usbwallet/trezor/trezor.go
@@ -16,7 +16,7 @@
 
 // This file contains the implementation for interacting with the Trezor hardware
 // wallets. The wire protocol spec can be found on the SatoshiLabs website:
-// https://wiki.trezor.io/Developers_guide-Message_Workflows
+// https://docs.trezor.io/trezor-firmware/common/message-workflows.html
 
 // !!! STAHP !!!
 //


### PR DESCRIPTION
Hello, I've found outdated link to trezor docs, this PR fix the issue.