### PR TITLE
cmd/devp2p: fix modulo in makeBlobTxs

### DIFF
--- a/cmd/devp2p/internal/ethtest/suite.go
+++ b/cmd/devp2p/internal/ethtest/suite.go
@@ -762,7 +762,7 @@ func (s *Suite) makeBlobTxs(count, blobs int, discriminator byte) (txs types.Tra
 	from, nonce := s.chain.GetSender(5)
 	for i := 0; i < count; i++ {
 		// Make blob data, max of 2 blobs per tx.
-		blobdata := make([]byte, blobs%2)
+		blobdata := make([]byte, blobs%3)
 		for i := range blobdata {
 			blobdata[i] = discriminator
 			blobs -= 1


### PR DESCRIPTION
Finding a small inconsistency when playing with blob transactions (using this code snippet as a reference). Changing the module from 2 to 3 can make it consistent with the comments, and by the way, it can consume all blobs when calling makeBlobTxs in the tests (first tx with 2 blobs, second with 1 blob):
```
	var (
		t1 = s.makeBlobTxs(2, 3, 0x1)
		t2 = s.makeBlobTxs(2, 3, 0x2)
	)
```
Previously, the first tx only had 1 blob, and the second 1, strictly less than 3 blobs bandwidth provided.