### PR TITLE
core/txpool/blobpool: rename variables in comments

### DIFF
--- a/core/txpool/blobpool/blobpool.go
+++ b/core/txpool/blobpool/blobpool.go
@@ -268,7 +268,7 @@ func newBlobTxMeta(id uint64, size uint32, tx *types.Transaction) *blobTxMeta {
 //     going up, crossing the smaller positive jump counter). As such, the pool
 //     cares only about the min of the two delta values for eviction priority.
 //
-//     priority = min(delta_basefee, delta_blobfee)
+//     priority = min(deltaBasefee, deltaBlobfee)
 //
 //   - The above very aggressive dimensionality and noise reduction should result
 //     in transaction being grouped into a small number of buckets, the further
@@ -280,7 +280,7 @@ func newBlobTxMeta(id uint64, size uint32, tx *types.Transaction) *blobTxMeta {
 //     with high fee caps since it could enable pool wars. As such, any positive
 //     priority will be grouped together.
 //
-//     priority = min(delta_basefee, delta_blobfee, 0)
+//     priority = min(deltaBasefee, deltaBlobfee, 0)
 //
 // Optimisation tradeoffs:
 //

--- a/core/txpool/blobpool/blobpool.go
+++ b/core/txpool/blobpool/blobpool.go
@@ -268,7 +268,7 @@ func newBlobTxMeta(id uint64, size uint32, tx *types.Transaction) *blobTxMeta {
 //     going up, crossing the smaller positive jump counter). As such, the pool
 //     cares only about the min of the two delta values for eviction priority.
 //
-//     priority = min(delta-basefee, delta-blobfee)
+//     priority = min(delta_basefee, delta_blobfee)
 //
 //   - The above very aggressive dimensionality and noise reduction should result
 //     in transaction being grouped into a small number of buckets, the further
@@ -280,7 +280,7 @@ func newBlobTxMeta(id uint64, size uint32, tx *types.Transaction) *blobTxMeta {
 //     with high fee caps since it could enable pool wars. As such, any positive
 //     priority will be grouped together.
 //
-//     priority = min(delta-basefee, delta-blobfee, 0)
+//     priority = min(delta_basefee, delta_blobfee, 0)
 //
 // Optimisation tradeoffs:
 //


### PR DESCRIPTION
use underscores so they are not confused for subtraction