### PR TITLE
ethereum, ethclient: add blob transaction fields in CallMsg

### DIFF
--- a/ethclient/ethclient.go
+++ b/ethclient/ethclient.go
@@ -665,6 +665,12 @@ func toCallArg(msg ethereum.CallMsg) interface{} {
 	if msg.AccessList != nil {
 		arg["accessList"] = msg.AccessList
 	}
+	if msg.BlobGasFeeCap != nil {
+		arg["maxFeePerBlobGas"] = msg.BlobGasFeeCap
+	}
+	if msg.BlobHashes != nil {
+		arg["blobVersionedHashes"] = msg.BlobHashes
+	}
 	return arg
 }
 

--- a/ethclient/ethclient.go
+++ b/ethclient/ethclient.go
@@ -666,7 +666,7 @@ func toCallArg(msg ethereum.CallMsg) interface{} {
 		arg["accessList"] = msg.AccessList
 	}
 	if msg.BlobGasFeeCap != nil {
-		arg["maxFeePerBlobGas"] = msg.BlobGasFeeCap
+		arg["maxFeePerBlobGas"] = (*hexutil.Big)(msg.BlobGasFeeCap)
 	}
 	if msg.BlobHashes != nil {
 		arg["blobVersionedHashes"] = msg.BlobHashes

--- a/interfaces.go
+++ b/interfaces.go
@@ -152,6 +152,10 @@ type CallMsg struct {
 	Data      []byte          // input data, usually an ABI-encoded contract method invocation
 
 	AccessList types.AccessList // EIP-2930 access list.
+
+	// For BlobTxType
+	BlobGasFeeCap *big.Int
+	BlobHashes    []common.Hash
 }
 
 // A ContractCaller provides contract calls, essentially transactions that are executed by


### PR DESCRIPTION
Add blob transaction fields in the eth client.