### PR TITLE
cmd/evm: fix typo in test script

### DIFF
--- a/cmd/evm/transition-test.sh
+++ b/cmd/evm/transition-test.sh
@@ -103,7 +103,7 @@ type Env struct {
     CurrentTimestamp uint64              `json:"currentTimestamp"`
     Withdrawals      []*Withdrawal       `json:"withdrawals"`
     // optional
-    CurrentDifficulty *big.Int           `json:"currentDifficuly"`
+    CurrentDifficulty *big.Int           `json:"currentDifficulty"`
     CurrentRandom     *big.Int           `json:"currentRandom"`
     CurrentBaseFee    *big.Int           `json:"currentBaseFee"`
     ParentDifficulty  *big.Int           `json:"parentDifficulty"`


### PR DESCRIPTION
json tag keep consistency with  struct's field