### PR TITLE
core/txpool, eth, miner: pre-filter dynamic fees during pending tx retrieval

### DIFF
--- a/core/txpool/blobpool/blobpool.go
+++ b/core/txpool/blobpool/blobpool.go
@@ -436,8 +436,10 @@ func (p *BlobPool) Init(gasTip uint64, head *types.Header, reserve txpool.Addres
 // Close closes down the underlying persistent store.
 func (p *BlobPool) Close() error {
 	var errs []error
-	if err := p.limbo.Close(); err != nil {
-		errs = append(errs, err)
+	if p.limbo != nil { // Close might be invoked due to error in constructor, before p,limbo is set
+		if err := p.limbo.Close(); err != nil {
+			errs = append(errs, err)
+		}
 	}
 	if err := p.store.Close(); err != nil {
 		errs = append(errs, err)

--- a/core/txpool/blobpool/blobpool.go
+++ b/core/txpool/blobpool/blobpool.go
@@ -1441,7 +1441,10 @@ func (p *BlobPool) drop() {
 
 // Pending retrieves all currently processable transactions, grouped by origin
 // account and sorted by nonce.
-func (p *BlobPool) Pending(enforceTips bool) map[common.Address][]*txpool.LazyTransaction {
+//
+// The transactions can also be pre-filtered by the dynamic fee components to
+// reduce allocations and load on downstream subsystems.
+func (p *BlobPool) Pending(minTip *uint256.Int, baseFee *uint256.Int, blobFee *uint256.Int) map[common.Address][]*txpool.LazyTransaction {
 	// Track the amount of time waiting to retrieve the list of pending blob txs
 	// from the pool and the amount of time actually spent on assembling the data.
 	// The latter will be pretty much moot, but we've kept it to have symmetric
@@ -1459,6 +1462,25 @@ func (p *BlobPool) Pending(enforceTips bool) map[common.Address][]*txpool.LazyTr
 	for addr, txs := range p.index {
 		var lazies []*txpool.LazyTransaction
 		for _, tx := range txs {
+			// If transaction filtering was requested, discard badly priced ones
+			if minTip != nil && baseFee != nil {
+				if tx.execFeeCap.Lt(baseFee) {
+					break // basefee too low, cannot be included, discard rest of txs from the account
+				}
+				tip := new(uint256.Int).Sub(tx.execFeeCap, baseFee)
+				if tip.Gt(tx.execTipCap) {
+					tip = tx.execTipCap
+				}
+				if tip.Lt(minTip) {
+					break // allowed or remaining tip too low, cannot be included, discard rest of txs from the account
+				}
+			}
+			if blobFee != nil {
+				if tx.blobFeeCap.Lt(blobFee) {
+					break // blobfee too low, cannot be included, discard rest of txs from the account
+				}
+			}
+			// Transaction was accepted according to the filter, append to the pending list
 			lazies = append(lazies, &txpool.LazyTransaction{
 				Pool:      p,
 				Hash:      tx.hash,

--- a/core/txpool/subpool.go
+++ b/core/txpool/subpool.go
@@ -24,6 +24,7 @@ import (
 	"github.com/ethereum/go-ethereum/core"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/event"
+	"github.com/holiman/uint256"
 )
 
 // LazyTransaction contains a small subset of the transaction properties that is
@@ -114,7 +115,10 @@ type SubPool interface {
 
 	// Pending retrieves all currently processable transactions, grouped by origin
 	// account and sorted by nonce.
-	Pending(enforceTips bool) map[common.Address][]*LazyTransaction
+	//
+	// The transactions can also be pre-filtered by the dynamic fee components to
+	// reduce allocations and load on downstream subsystems.
+	Pending(minTip *uint256.Int, baseFee *uint256.Int, blobFee *uint256.Int) map[common.Address][]*LazyTransaction
 
 	// SubscribeTransactions subscribes to new transaction events. The subscriber
 	// can decide whether to receive notifications only for newly seen transactions

--- a/core/txpool/txpool.go
+++ b/core/txpool/txpool.go
@@ -28,6 +28,7 @@ import (
 	"github.com/ethereum/go-ethereum/event"
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/metrics"
+	"github.com/holiman/uint256"
 )
 
 // TxStatus is the current status of a transaction as seen by the pool.
@@ -353,10 +354,13 @@ func (p *TxPool) Add(txs []*types.Transaction, local bool, sync bool) []error {
 
 // Pending retrieves all currently processable transactions, grouped by origin
 // account and sorted by nonce.
-func (p *TxPool) Pending(enforceTips bool) map[common.Address][]*LazyTransaction {
+//
+// The transactions can also be pre-filtered by the dynamic fee components to
+// reduce allocations and load on downstream subsystems.
+func (p *TxPool) Pending(minTip *uint256.Int, baseFee *uint256.Int, blobFee *uint256.Int) map[common.Address][]*LazyTransaction {
 	txs := make(map[common.Address][]*LazyTransaction)
 	for _, subpool := range p.subpools {
-		for addr, set := range subpool.Pending(enforceTips) {
+		for addr, set := range subpool.Pending(minTip, baseFee, blobFee) {
 			txs[addr] = set
 		}
 	}

--- a/eth/api_backend.go
+++ b/eth/api_backend.go
@@ -292,7 +292,7 @@ func (b *EthAPIBackend) SendTx(ctx context.Context, signedTx *types.Transaction)
 }
 
 func (b *EthAPIBackend) GetPoolTransactions() (types.Transactions, error) {
-	pending := b.eth.txPool.Pending(false)
+	pending := b.eth.txPool.Pending(nil, nil, nil)
 	var txs types.Transactions
 	for _, batch := range pending {
 		for _, lazy := range batch {

--- a/eth/catalyst/simulated_beacon.go
+++ b/eth/catalyst/simulated_beacon.go
@@ -263,7 +263,7 @@ func (c *SimulatedBeacon) Rollback() {
 
 // Fork sets the head to the provided hash.
 func (c *SimulatedBeacon) Fork(parentHash common.Hash) error {
-	if len(c.eth.TxPool().Pending(false)) != 0 {
+	if len(c.eth.TxPool().Pending(nil, nil, nil)) != 0 {
 		return errors.New("pending block dirty")
 	}
 	parent := c.eth.BlockChain().GetBlockByHash(parentHash)
@@ -275,7 +275,7 @@ func (c *SimulatedBeacon) Fork(parentHash common.Hash) error {
 
 // AdjustTime creates a new block with an adjusted timestamp.
 func (c *SimulatedBeacon) AdjustTime(adjustment time.Duration) error {
-	if len(c.eth.TxPool().Pending(false)) != 0 {
+	if len(c.eth.TxPool().Pending(nil, nil, nil)) != 0 {
 		return errors.New("could not adjust time on non-empty block")
 	}
 	parent := c.eth.BlockChain().CurrentBlock()

--- a/eth/handler.go
+++ b/eth/handler.go
@@ -42,6 +42,7 @@ import (
 	"github.com/ethereum/go-ethereum/metrics"
 	"github.com/ethereum/go-ethereum/p2p"
 	"github.com/ethereum/go-ethereum/triedb/pathdb"
+	"github.com/holiman/uint256"
 )
 
 const (
@@ -73,7 +74,7 @@ type txPool interface {
 
 	// Pending should return pending transactions.
 	// The slice should be modifiable by the caller.
-	Pending(enforceTips bool) map[common.Address][]*txpool.LazyTransaction
+	Pending(minTip *uint256.Int, baseFee *uint256.Int, blobFee *uint256.Int) map[common.Address][]*txpool.LazyTransaction
 
 	// SubscribeTransactions subscribes to new transaction events. The subscriber
 	// can decide whether to receive notifications only for newly seen transactions

--- a/eth/handler_test.go
+++ b/eth/handler_test.go
@@ -34,6 +34,7 @@ import (
 	"github.com/ethereum/go-ethereum/ethdb"
 	"github.com/ethereum/go-ethereum/event"
 	"github.com/ethereum/go-ethereum/params"
+	"github.com/holiman/uint256"
 )
 
 var (
@@ -92,7 +93,7 @@ func (p *testTxPool) Add(txs []*types.Transaction, local bool, sync bool) []erro
 }
 
 // Pending returns all the transactions known to the pool
-func (p *testTxPool) Pending(enforceTips bool) map[common.Address][]*txpool.LazyTransaction {
+func (p *testTxPool) Pending(minTip *uint256.Int, baseFee *uint256.Int, blobFee *uint256.Int) map[common.Address][]*txpool.LazyTransaction {
 	p.lock.RLock()
 	defer p.lock.RUnlock()
 

--- a/eth/sync.go
+++ b/eth/sync.go
@@ -36,7 +36,7 @@ const (
 // syncTransactions starts sending all currently pending transactions to the given peer.
 func (h *handler) syncTransactions(p *eth.Peer) {
 	var hashes []common.Hash
-	for _, batch := range h.txpool.Pending(false) {
+	for _, batch := range h.txpool.Pending(nil, nil, nil) {
 		for _, tx := range batch {
 			hashes = append(hashes, tx.Hash)
 		}

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -37,6 +37,7 @@ import (
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/params"
 	"github.com/ethereum/go-ethereum/trie"
+	"github.com/holiman/uint256"
 )
 
 const (
@@ -999,7 +1000,20 @@ func (w *worker) prepareWork(genParams *generateParams) (*environment, error) {
 // into the given sealing block. The transaction selection and ordering strategy can
 // be customized with the plugin in the future.
 func (w *worker) fillTransactions(interrupt *atomic.Int32, env *environment) error {
-	pending := w.eth.TxPool().Pending(true)
+	w.mu.RLock()
+	tip := w.tip
+	w.mu.RUnlock()
+
+	// Retrieve the pending transactions pre-filtered by the 1559/4844 dynaimc fees
+	var baseFee *uint256.Int
+	if env.header.BaseFee != nil {
+		baseFee = uint256.MustFromBig(env.header.BaseFee)
+	}
+	var blobFee *uint256.Int
+	if env.header.ExcessBlobGas != nil {
+		blobFee = uint256.MustFromBig(eip4844.CalcBlobFee(*env.header.ExcessBlobGas))
+	}
+	pending := w.eth.TxPool().Pending(uint256.MustFromBig(tip), baseFee, blobFee)
 
 	// Split the pending transactions into locals and remotes.
 	localTxs, remoteTxs := make(map[common.Address][]*txpool.LazyTransaction), pending
@@ -1011,10 +1025,6 @@ func (w *worker) fillTransactions(interrupt *atomic.Int32, env *environment) err
 	}
 
 	// Fill the block with all available pending transactions.
-	w.mu.RLock()
-	tip := w.tip
-	w.mu.RUnlock()
-
 	if len(localTxs) > 0 {
 		txs := newTransactionsByPriceAndNonce(env.signer, localTxs, env.header.BaseFee)
 		if err := w.commitTransactions(env, txs, interrupt, new(big.Int)); err != nil {

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -1004,7 +1004,7 @@ func (w *worker) fillTransactions(interrupt *atomic.Int32, env *environment) err
 	tip := w.tip
 	w.mu.RUnlock()
 
-	// Retrieve the pending transactions pre-filtered by the 1559/4844 dynaimc fees
+	// Retrieve the pending transactions pre-filtered by the 1559/4844 dynamic fees
 	var baseFee *uint256.Int
 	if env.header.BaseFee != nil {
 		baseFee = uint256.MustFromBig(env.header.BaseFee)


### PR DESCRIPTION
This issue was found by @MariusVanDerWijden!

This PR fixes a number of performance bugs in the transaction pool pending retrieval:

- In the blob pool, we have done no pre-filtering whatsoever when the miner requested the transactions, rather just shipped everything over. The idea was that all the necessary information is already there for the miner to pick what it needs and throw everything else away. Unfortunately we haven't forwarded the blobFee, so the miner couldn't check if the blob transaction can actually be included without loading the entire thing from disk. This made the miner extremely suboptimal and also caused the memory blowup (fixed on master, but the root cause was unknown). This PR solves it by adding a pre-filtering step into the blob pool. Whilst we could have fixed it too by forwarding the blobFee to the miner in txpool.LazyTransaction, there's no point really to send over all the transactions, most of which will be non-executable anyway.
- In the legacy txpool, the tracked basefee could have been ever so slightly outdated if a reset operation is lagging behind the chain head's last reset. By passing in the basefee from the miner, this issue is also solved.
- Again, in the legacy txpool, we've recently introduced the change where the txpool.gasprice and miner.gasprice can move independently from one another. Because of that, the `enforceTips` flag because useless, as it had no access to the miner's tip any more. This PR also fixes that with the passed parameter.

Benchmarks:

<img width="526" alt="Screenshot 2024-02-16 at 22 58 51" src="https://github.com/ethereum/go-ethereum/assets/129561/cd26deba-ba1c-4777-a3d8-1bf4f906f1b2">
<img width="526" alt="Screenshot 2024-02-16 at 22 59 05" src="https://github.com/ethereum/go-ethereum/assets/129561/171ca881-c8c3-4cca-bdbb-c7af4b198348">
<img width="526" alt="Screenshot 2024-02-16 at 22 58 45" src="https://github.com/ethereum/go-ethereum/assets/129561/76ac6448-8199-45d0-af85-232a4398b921">
