### PR TITLE
trie: Change the algorithm that converts a trie commitment to 32 bytes

### DIFF
--- a/cmd/geth/verkle.go
+++ b/cmd/geth/verkle.go
@@ -28,7 +28,7 @@ import (
 	"github.com/ethereum/go-ethereum/core/rawdb"
 	"github.com/ethereum/go-ethereum/internal/flags"
 	"github.com/ethereum/go-ethereum/log"
-	"github.com/gballet/go-verkle"
+	"github.com/ethereum/go-verkle"
 	cli "github.com/urfave/cli/v2"
 )
 

--- a/go.mod
+++ b/go.mod
@@ -21,13 +21,13 @@ require (
 	github.com/deckarep/golang-set/v2 v2.1.0
 	github.com/dop251/goja v0.0.0-20230806174421-c933cf95e127
 	github.com/ethereum/c-kzg-4844 v0.4.0
+	github.com/ethereum/go-verkle v0.1.1-0.20240229153627-ffdbaba9f2e2
 	github.com/fatih/color v1.13.0
 	github.com/ferranbt/fastssz v0.1.2
 	github.com/fjl/gencodec v0.0.0-20230517082657-f9840df7b83e
 	github.com/fjl/memsize v0.0.2
 	github.com/fsnotify/fsnotify v1.6.0
 	github.com/gballet/go-libpcsclite v0.0.0-20190607065134-2772fd86a8ff
-	github.com/gballet/go-verkle v0.1.1-0.20231031103413-a67434b50f46
 	github.com/gofrs/flock v0.8.1
 	github.com/golang-jwt/jwt/v4 v4.5.0
 	github.com/golang/protobuf v1.5.3

--- a/go.sum
+++ b/go.sum
@@ -183,6 +183,8 @@ github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7
 github.com/etcd-io/bbolt v1.3.3/go.mod h1:ZF2nL25h33cCyBtcyWeZ2/I3HQOfTP+0PIEvHjkjCrw=
 github.com/ethereum/c-kzg-4844 v0.4.0 h1:3MS1s4JtA868KpJxroZoepdV0ZKBp3u/O5HcZ7R3nlY=
 github.com/ethereum/c-kzg-4844 v0.4.0/go.mod h1:VewdlzQmpT5QSrVhbBuGoCdFJkpaJlO1aQputP83wc0=
+github.com/ethereum/go-verkle v0.1.1-0.20240229153627-ffdbaba9f2e2 h1:SCH0ZTBF3oMFNDqNbIPuQD4ER6TnCaD5BRgdX2xBnJY=
+github.com/ethereum/go-verkle v0.1.1-0.20240229153627-ffdbaba9f2e2/go.mod h1:cZmLDzTyZPwUygE2ksQEcxOLZ8YpfRghnVtfxRnhgJM=
 github.com/fasthttp-contrib/websocket v0.0.0-20160511215533-1f3b11f56072/go.mod h1:duJ4Jxv5lDcvg4QuQr0oowTf7dz4/CR8NtyCooz9HL8=
 github.com/fatih/color v1.13.0 h1:8LOYc1KYPPmyKMuN8QV2DNRWNbLo6LZ0iLs8+mlH53w=
 github.com/fatih/color v1.13.0/go.mod h1:kLAiJbzzSOZDVNGyDpeOxJ47H46qBXwg5ILebYFFOfk=
@@ -203,8 +205,6 @@ github.com/garslo/gogen v0.0.0-20170306192744-1d203ffc1f61/go.mod h1:Q0X6pkwTILD
 github.com/gavv/httpexpect v2.0.0+incompatible/go.mod h1:x+9tiU1YnrOvnB725RkpoLv1M62hOWzwo5OXotisrKc=
 github.com/gballet/go-libpcsclite v0.0.0-20190607065134-2772fd86a8ff h1:tY80oXqGNY4FhTFhk+o9oFHGINQ/+vhlm8HFzi6znCI=
 github.com/gballet/go-libpcsclite v0.0.0-20190607065134-2772fd86a8ff/go.mod h1:x7DCsMOv1taUwEWCzT4cmDeAkigA5/QCwUodaVOe8Ww=
-github.com/gballet/go-verkle v0.1.1-0.20231031103413-a67434b50f46 h1:BAIP2GihuqhwdILrV+7GJel5lyPV3u1+PgzrWLc0TkE=
-github.com/gballet/go-verkle v0.1.1-0.20231031103413-a67434b50f46/go.mod h1:QNpY22eby74jVhqH4WhDLDwxc/vqsern6pW+u2kbkpc=
 github.com/getkin/kin-openapi v0.53.0/go.mod h1:7Yn5whZr5kJi6t+kShccXS8ae1APpYTW6yheSwk8Yi4=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/gin-contrib/sse v0.0.0-20190301062529-5545eab6dad3/go.mod h1:VJ0WA2NBN22VlZ2dKZQPAPnyWw5XTlK1KymzLKsr59s=

--- a/trie/utils/verkle.go
+++ b/trie/utils/verkle.go
@@ -305,16 +305,17 @@ func StorageSlotKeyWithEvaluatedAddress(evaluated *verkle.Point, storageKey []by
 	return GetTreeKeyWithEvaluatedAddress(evaluated, treeIndex, subIndex)
 }
 
+// TODO: We can remove this method once https://github.com/ethereum/go-verkle/pull/428
+// TODO is merged.
+// TODO: we would then be able to call `verkle.MapToScalarFieldBytes`
+func MapToScalarFieldBytes(point *verkle.Point) [32]byte {
+	var hashedPoint verkle.Fr
+	point.MapToScalarField(&hashedPoint)
+	return hashedPoint.BytesLE()
+}
+
 func pointToHash(evaluated *verkle.Point, suffix byte) []byte {
-	// The output of Byte() is big endian for banderwagon. This
-	// introduces an imbalance in the tree, because hashes are
-	// elements of a 253-bit field. This means more than half the
-	// tree would be empty. To avoid this problem, use a little
-	// endian commitment and chop the MSB.
-	bytes := evaluated.Bytes()
-	for i := 0; i < 16; i++ {
-		bytes[31-i], bytes[i] = bytes[i], bytes[31-i]
-	}
+	bytes := MapToScalarFieldBytes(evaluated)
 	bytes[31] = suffix
 	return bytes[:]
 }

--- a/trie/utils/verkle.go
+++ b/trie/utils/verkle.go
@@ -308,14 +308,14 @@ func StorageSlotKeyWithEvaluatedAddress(evaluated *verkle.Point, storageKey []by
 // TODO: We can remove this method once https://github.com/ethereum/go-verkle/pull/428
 // TODO is merged.
 // TODO: we would then be able to call `verkle.MapToScalarFieldBytes`
-func MapToScalarFieldBytes(point *verkle.Point) [32]byte {
+func mapToScalarFieldBytes(point *verkle.Point) [32]byte {
 	var hashedPoint verkle.Fr
 	point.MapToScalarField(&hashedPoint)
 	return hashedPoint.BytesLE()
 }
 
 func pointToHash(evaluated *verkle.Point, suffix byte) []byte {
-	bytes := MapToScalarFieldBytes(evaluated)
+	bytes := mapToScalarFieldBytes(evaluated)
 	bytes[31] = suffix
 	return bytes[:]
 }

--- a/trie/utils/verkle.go
+++ b/trie/utils/verkle.go
@@ -23,7 +23,7 @@ import (
 	"github.com/crate-crypto/go-ipa/bandersnatch/fr"
 	"github.com/ethereum/go-ethereum/common/lru"
 	"github.com/ethereum/go-ethereum/metrics"
-	"github.com/gballet/go-verkle"
+	"github.com/ethereum/go-verkle"
 	"github.com/holiman/uint256"
 )
 

--- a/trie/utils/verkle_test.go
+++ b/trie/utils/verkle_test.go
@@ -20,7 +20,7 @@ import (
 	"bytes"
 	"testing"
 
-	"github.com/gballet/go-verkle"
+	"github.com/ethereum/go-verkle"
 	"github.com/holiman/uint256"
 )
 

--- a/trie/verkle.go
+++ b/trie/verkle.go
@@ -27,7 +27,7 @@ import (
 	"github.com/ethereum/go-ethereum/trie/trienode"
 	"github.com/ethereum/go-ethereum/trie/utils"
 	"github.com/ethereum/go-ethereum/triedb/database"
-	"github.com/gballet/go-verkle"
+	"github.com/ethereum/go-verkle"
 	"github.com/holiman/uint256"
 )
 


### PR DESCRIPTION
## Problem

Initially this PR was aiming to move us towards one way of converting a point to a 32 byte slice. Unfortunately, we need the Serialize/Deserialize method when converting the root node to a 32 byte slice. So we only change pedersenHash to use `MapToScalarFieldBytes`

## Rationale

This issue specifies most of the rationale: https://github.com/crate-crypto/rust-verkle/issues/86

As its currently written, this PR is not technically blocked by https://github.com/ethereum/go-verkle/pull/428 -- If that PR gets merged, then we can replace a method that I've temporarily duplicated