### PR TITLE
ethstats: prevent panic if head block is not available

### DIFF
--- a/ethstats/ethstats.go
+++ b/ethstats/ethstats.go
@@ -611,6 +611,10 @@ func (s *Service) reportBlock(conn *connWrapper, block *types.Block) error {
 	// Gather the block details from the header or block chain
 	details := s.assembleBlockStats(block)
 
+	// Short circuit if the block detail is not available.
+	if details == nil {
+		return nil
+	}
 	// Assemble the block report and send it to the server
 	log.Trace("Sending new block to ethstats", "number", details.Number, "hash", details.Hash)
 
@@ -638,9 +642,15 @@ func (s *Service) assembleBlockStats(block *types.Block) *blockStats {
 	// check if backend is a full node
 	fullBackend, ok := s.backend.(fullNodeBackend)
 	if ok {
+		// Retrieve current chain head if no block is given.
 		if block == nil {
 			head := fullBackend.CurrentBlock()
 			block, _ = fullBackend.BlockByNumber(context.Background(), rpc.BlockNumber(head.Number.Uint64()))
+		}
+		// Short circuit if no block is available. It might happen when
+		// the blockchain is reorging.
+		if block == nil {
+			return nil
 		}
 		header = block.Header()
 		td = fullBackend.GetTd(context.Background(), header.Hash())


### PR DESCRIPTION
This pull request fixes a flaw in ethstats. 

The panic happens when the local blockchain is reorging which causes the original head block not reachable(number->hash canonical mapping is deleted).  In order to prevent the panic, the block nilness will be checked in ethstats. 

```
INFO [02-19|01:42:43.476] Chain reorg detected                     number=19,258,596 hash=9d98f1..e6fc8a drop=1 dropfrom=9e5d7e..e9aea2 add=1 addfrom=5c3ee3..9b5f97
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x100bdfa]

goroutine 4464 [running]:
github.com/ethereum/go-ethereum/core/types.(*Block).Header(...)
	github.com/ethereum/go-ethereum/core/types/block.go:356
github.com/ethereum/go-ethereum/ethstats.(*Service).assembleBlockStats(0xc000368360, 0x0)
	github.com/ethereum/go-ethereum/ethstats/ethstats.go:645 +0xba
github.com/ethereum/go-ethereum/ethstats.(*Service).reportBlock(0xc000368360, 0xc0b21b25b0?, 0xc0d185d330?)
	github.com/ethereum/go-ethereum/ethstats/ethstats.go:612 +0x25
github.com/ethereum/go-ethereum/ethstats.(*Service).report(0xc0161cbe00?, 0xc0161cbcbc?)
	github.com/ethereum/go-ethereum/ethstats/ethstats.go:527 +0x3b
github.com/ethereum/go-ethereum/ethstats.(*Service).loop(0xc000368360, 0xc00085d3e0, 0xc00085d4a0)
	github.com/ethereum/go-ethereum/ethstats/ethstats.go:334 +0x9bf
created by github.com/ethereum/go-ethereum/ethstats.(*Service).Start in goroutine 1
	github.com/ethereum/go-ethereum/ethstats/ethstats.go:210 +0x127
```