### PR TITLE
internal/ethapi: fix defaults for blob fields

### DIFF
--- a/internal/ethapi/transaction_args.go
+++ b/internal/ethapi/transaction_args.go
@@ -180,7 +180,7 @@ func (args *TransactionArgs) setFeeDefaults(ctx context.Context, b Backend) erro
 	head := b.CurrentHeader()
 	// Sanity check the EIP-4844 fee parameters.
 	if args.BlobFeeCap != nil && args.BlobFeeCap.ToInt().Sign() == 0 {
-		return errors.New("maxFeePerBlobGas must be non-zero")
+		return errors.New("maxFeePerBlobGas, if specified, must be non-zero")
 	}
 	if err := args.setCancunFeeDefaults(ctx, head, b); err != nil {
 		return err

--- a/internal/ethapi/transaction_args.go
+++ b/internal/ethapi/transaction_args.go
@@ -182,14 +182,8 @@ func (args *TransactionArgs) setFeeDefaults(ctx context.Context, b Backend) erro
 	if args.BlobFeeCap != nil && args.BlobFeeCap.ToInt().Sign() == 0 {
 		return errors.New("maxFeePerBlobGas must be non-zero")
 	}
-	if b.ChainConfig().IsCancun(head.Number, head.Time) {
-		if err := args.setCancunFeeDefaults(ctx, head, b); err != nil {
-			return err
-		}
-	} else {
-		if args.BlobFeeCap != nil {
-			return errors.New("maxFeePerBlobGas is not valid before Cancun is active")
-		}
+	if err := args.setCancunFeeDefaults(ctx, head, b); err != nil {
+		return err
 	}
 	// If both gasPrice and at least one of the EIP-1559 fee parameters are specified, error.
 	if args.GasPrice != nil && (args.MaxFeePerGas != nil || args.MaxPriorityFeePerGas != nil) {
@@ -245,15 +239,19 @@ func (args *TransactionArgs) setFeeDefaults(ctx context.Context, b Backend) erro
 func (args *TransactionArgs) setCancunFeeDefaults(ctx context.Context, head *types.Header, b Backend) error {
 	// Set maxFeePerBlobGas if it is missing.
 	if args.BlobHashes != nil && args.BlobFeeCap == nil {
+		var excessBlobGas uint64
+		if head.ExcessBlobGas != nil {
+			excessBlobGas = *head.ExcessBlobGas
+		}
 		// ExcessBlobGas must be set for a Cancun block.
-		blobBaseFee := eip4844.CalcBlobFee(*head.ExcessBlobGas)
+		blobBaseFee := eip4844.CalcBlobFee(excessBlobGas)
 		// Set the max fee to be 2 times larger than the previous block's blob base fee.
 		// The additional slack allows the tx to not become invalidated if the base
 		// fee is rising.
 		val := new(big.Int).Mul(blobBaseFee, big.NewInt(2))
 		args.BlobFeeCap = (*hexutil.Big)(val)
 	}
-	return args.setLondonFeeDefaults(ctx, head, b)
+	return nil
 }
 
 // setLondonFeeDefaults fills in reasonable default fee values for unspecified fields.
@@ -286,10 +284,6 @@ func (args *TransactionArgs) setLondonFeeDefaults(ctx context.Context, head *typ
 
 // setBlobTxSidecar adds the blob tx
 func (args *TransactionArgs) setBlobTxSidecar(ctx context.Context, b Backend) error {
-	isCancun := b.ChainConfig().IsCancun(b.CurrentHeader().Number, b.CurrentHeader().Time)
-	if !isCancun && (args.Blobs != nil || args.Commitments != nil || args.Proofs != nil || args.BlobHashes != nil) {
-		return errors.New("blobs are only valid after Cancun is active")
-	}
 	// No blobs, we're done.
 	if args.Blobs == nil {
 		return nil

--- a/internal/ethapi/transaction_args_test.go
+++ b/internal/ethapi/transaction_args_test.go
@@ -153,14 +153,14 @@ func TestSetFeeDefaults(t *testing.T) {
 			"legacy",
 			&TransactionArgs{MaxFeePerGas: maxFee},
 			nil,
-			errors.New("maxFeePerGas and maxPriorityFeePerGas and maxFeePerBlobGas are not valid before London is active"),
+			errors.New("maxFeePerGas and maxPriorityFeePerGas are not valid before London is active"),
 		},
 		{
 			"dynamic fee tx pre-London, priorityFee set",
 			"legacy",
 			&TransactionArgs{MaxPriorityFeePerGas: fortytwo},
 			nil,
-			errors.New("maxFeePerGas and maxPriorityFeePerGas and maxFeePerBlobGas are not valid before London is active"),
+			errors.New("maxFeePerGas and maxPriorityFeePerGas are not valid before London is active"),
 		},
 		{
 			"dynamic fee tx, maxFee < priorityFee",
@@ -219,7 +219,7 @@ func TestSetFeeDefaults(t *testing.T) {
 			"legacy",
 			&TransactionArgs{BlobFeeCap: fortytwo},
 			nil,
-			errors.New("maxFeePerGas and maxPriorityFeePerGas and maxFeePerBlobGas are not valid before London is active"),
+			errors.New("maxFeePerBlobGas is not valid before Cancun is active"),
 		},
 		{
 			"set gas price and maxFee for blob transaction",
@@ -235,6 +235,13 @@ func TestSetFeeDefaults(t *testing.T) {
 			&TransactionArgs{BlobHashes: []common.Hash{}, BlobFeeCap: (*hexutil.Big)(big.NewInt(4)), MaxFeePerGas: maxFee, MaxPriorityFeePerGas: fortytwo},
 			nil,
 		},
+		{
+			"fill maxFeePerBlobGas when dynamic fees are set",
+			"cancun",
+			&TransactionArgs{BlobHashes: []common.Hash{}, MaxFeePerGas: maxFee, MaxPriorityFeePerGas: fortytwo},
+			&TransactionArgs{BlobHashes: []common.Hash{}, BlobFeeCap: (*hexutil.Big)(big.NewInt(4)), MaxFeePerGas: maxFee, MaxPriorityFeePerGas: fortytwo},
+			nil,
+		},
 	}
 
 	ctx := context.Background()
@@ -244,11 +251,16 @@ func TestSetFeeDefaults(t *testing.T) {
 		}
 		got := test.in
 		err := got.setFeeDefaults(ctx, b)
-		if err != nil && err.Error() == test.err.Error() {
-			// Test threw expected error.
+		if err != nil {
+			if test.err == nil {
+				t.Fatalf("test %d (%s): unexpected error: %s", i, test.name, err)
+			} else if err.Error() != test.err.Error() {
+				t.Fatalf("test %d (%s): unexpected error: (got: %s, want: %s)", i, test.name, err, test.err)
+			}
+			// Matching error.
 			continue
-		} else if err != nil {
-			t.Fatalf("test %d (%s): unexpected error: %s", i, test.name, err)
+		} else if test.err != nil {
+			t.Fatalf("test %d (%s): expected error: %s", i, test.name, test.err)
 		}
 		if !reflect.DeepEqual(got, test.want) {
 			t.Fatalf("test %d (%s): did not fill defaults as expected: (got: %v, want: %v)", i, test.name, got, test.want)

--- a/internal/ethapi/transaction_args_test.go
+++ b/internal/ethapi/transaction_args_test.go
@@ -208,20 +208,6 @@ func TestSetFeeDefaults(t *testing.T) {
 		},
 		// EIP-4844
 		{
-			"set maxFeePerBlobGas pre cancun",
-			"london",
-			&TransactionArgs{BlobFeeCap: fortytwo},
-			nil,
-			errors.New("maxFeePerBlobGas is not valid before Cancun is active"),
-		},
-		{
-			"set maxFeePerBlobGas pre london",
-			"legacy",
-			&TransactionArgs{BlobFeeCap: fortytwo},
-			nil,
-			errors.New("maxFeePerBlobGas is not valid before Cancun is active"),
-		},
-		{
 			"set gas price and maxFee for blob transaction",
 			"cancun",
 			&TransactionArgs{GasPrice: fortytwo, MaxFeePerGas: maxFee, BlobHashes: []common.Hash{}},


### PR DESCRIPTION
This PR comes with 2 fixes:
- We shouldn't fill blob proofs/commitments before cancun
- setDefaults has shortcuts to avoid doing extra work if gasPrice or EIP-1559 fee fields are already provided by the user. This shortcut caused us not to fill the maxBlobFee as well.

I have a refactor of setDefaults that I need for #27720 that I'd like to port to master which includes these fixes. Will post that as a separate PR to have fix and refactoring separate.