### PR TITLE
eth/tracers,internal/ethapi: use correct baseFee when BlockOverrides is provided in call/traceCall

### DIFF
--- a/eth/tracers/api.go
+++ b/eth/tracers/api.go
@@ -919,7 +919,7 @@ func (api *API) TraceCall(ctx context.Context, args ethapi.TransactionArgs, bloc
 		config.BlockOverrides.Apply(&vmctx)
 	}
 	// Execute the trace
-	msg, err := args.ToMessage(api.backend.RPCGasCap(), block.BaseFee())
+	msg, err := args.ToMessage(api.backend.RPCGasCap(), vmctx.BaseFee)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -1093,13 +1093,13 @@ func doCall(ctx context.Context, b Backend, args TransactionArgs, state *state.S
 	defer cancel()
 
 	// Get a new instance of the EVM.
-	msg, err := args.ToMessage(globalGasCap, header.BaseFee)
-	if err != nil {
-		return nil, err
-	}
 	blockCtx := core.NewEVMBlockContext(header, NewChainContext(ctx, b), nil)
 	if blockOverrides != nil {
 		blockOverrides.Apply(&blockCtx)
+	}
+	msg, err := args.ToMessage(globalGasCap, blockCtx.BaseFee)
+	if err != nil {
+		return nil, err
 	}
 	evm := b.GetEVM(ctx, msg, state, header, &vm.Config{NoBaseFee: true}, &blockCtx)
 


### PR DESCRIPTION
Previously, even if `baseFee` was overridden via `BlockOverrides` parameters, the sender of the call would be charged based on the original block's `baseFee`. This leads to incorrectly calculated `gasPrice` in `TransactionArgs#ToMessage` function for calls that provided `gasFeeCap`/`gasTipCap` parameters.

Solution is to use the `baseFee` from block context, which includes overridden values. 