### PR TITLE
rlp: using unsafe.Slice instead of SliceHeader

### DIFF
--- a/rlp/unsafe.go
+++ b/rlp/unsafe.go
@@ -26,10 +26,5 @@ import (
 
 // byteArrayBytes returns a slice of the byte array v.
 func byteArrayBytes(v reflect.Value, length int) []byte {
-	var s []byte
-	hdr := (*reflect.SliceHeader)(unsafe.Pointer(&s))
-	hdr.Data = v.UnsafeAddr()
-	hdr.Cap = length
-	hdr.Len = length
-	return s
+	return unsafe.Slice((*byte)((unsafe.Pointer)(v.UnsafeAddr())), length)
 }

--- a/rlp/unsafe.go
+++ b/rlp/unsafe.go
@@ -26,5 +26,5 @@ import (
 
 // byteArrayBytes returns a slice of the byte array v.
 func byteArrayBytes(v reflect.Value, length int) []byte {
-	return unsafe.Slice((*byte)((unsafe.Pointer)(v.UnsafeAddr())), length)
+	return unsafe.Slice((*byte)(unsafe.Pointer(v.UnsafeAddr())), length)
 }


### PR DESCRIPTION
SliceHeader is deprecated  in [go](https://github.com/golang/go/blob/e41fabd6886ec16db6026b30486e20732f89960a/src/reflect/value.go#L2842-L2847).