### PR TITLE
eth/tracers/call: Fix call_tracer withLog == true && onlyTopCall == true

### DIFF
--- a/eth/tracers/native/call.go
+++ b/eth/tracers/native/call.go
@@ -161,7 +161,7 @@ func (t *callTracer) CaptureState(pc uint64, op vm.OpCode, gas, cost uint64, sco
 		return
 	}
 	// Avoid processing nested calls when only caring about top call
-	if t.config.OnlyTopCall && depth > 0 {
+	if t.config.OnlyTopCall && depth > 1 {
 		return
 	}
 	// Skip if tracing was interrupted


### PR DESCRIPTION
Fixed missing logs for `callTracer` calls having `withLog == true && onlyTopCall == true`:
```bash
curl --location 'http://0.0.0.0:8545' \
--header 'Content-Type: application/json' \
--data '{
    "jsonrpc": "2.0",
    "method": "debug_traceTransaction",
    "params": [
        "0x506d0ce623a33ef868780a99f051b5eba5c82fc5dd2826ee1bb0b666131a6fb8",
        {
            "tracer": "callTracer",
            "tracerConfig": {
                "withLog": true,
                "onlyTopCall": true
            }
        }
    ],
    "id": 1234
}'
```
So the expected response is:
```json
{
    "jsonrpc": "2.0",
    "id": 1234,
    "result": {
        "from": "0x82211934c340b29561381392348d48413e15adc8",
        "gas": "0x742e",
        "gasUsed": "0x72d1",
        "to": "0x83e32b17b3a5fee7ea3294bca3840f54818edf92",
        "input": "0xfc0a63300000000000000000000000009f333fc2a4b329addb8e0b5ac34653b53c79c264",
        "logs": [
            {
                "address": "0x83e32b17b3a5fee7ea3294bca3840f54818edf92",
                "topics": [
                    "0x7d66f3d4c967eba69bdb4c62e318bc2e28aa1d6cdd37ebd8f1b310c56c9159a3"
                ],
                "data": "0x00000000000000000000000000000000000000000000000000000000000000400000000000000000000000009f333fc2a4b329addb8e0b5ac34653b53c79c264000000000000000000000000000000000000000000000000000000000000003043616c6c6572436f6e7472616374322066756e6374696f6e2063616c6c656420616e6f7468657220636f6e747261637400000000000000000000000000000000",
                "position": "0x0"
            }
        ],
        "value": "0x0",
        "type": "CALL"
    }
}
```

The `depth` parameter of `func (t *callTracer) CaptureState(pc uint64, op vm.OpCode, gas, cost uint64, scope *vm.ScopeContext, rData []byte, depth int, err error)` is `1` for root EVM in a transaction, not `0`.