### PR TITLE
core/txpool: no need to run rotate if no local txs

### DIFF
--- a/core/txpool/legacypool/journal.go
+++ b/core/txpool/legacypool/journal.go
@@ -164,7 +164,12 @@ func (journal *journal) rotate(all map[common.Address]types.Transactions) error 
 		return err
 	}
 	journal.writer = sink
-	log.Info("Regenerated local transaction journal", "transactions", journaled, "accounts", len(all))
+
+	logger := log.Info
+	if len(all) == 0 {
+		logger = log.Debug
+	}
+	logger("Regenerated local transaction journal", "transactions", journaled, "accounts", len(all))
 
 	return nil
 }

--- a/core/txpool/legacypool/journal.go
+++ b/core/txpool/legacypool/journal.go
@@ -131,11 +131,6 @@ func (journal *journal) insert(tx *types.Transaction) error {
 // rotate regenerates the transaction journal based on the current contents of
 // the transaction pool.
 func (journal *journal) rotate(all map[common.Address]types.Transactions) error {
-	// No need to rotate if there are no transactions to write
-	if len(all) == 0 {
-		return nil
-	}
-
 	// Close the current journal (if any is open)
 	if journal.writer != nil {
 		if err := journal.writer.Close(); err != nil {

--- a/core/txpool/legacypool/journal.go
+++ b/core/txpool/legacypool/journal.go
@@ -131,6 +131,11 @@ func (journal *journal) insert(tx *types.Transaction) error {
 // rotate regenerates the transaction journal based on the current contents of
 // the transaction pool.
 func (journal *journal) rotate(all map[common.Address]types.Transactions) error {
+	// No need to rotate if there are no transactions to write
+	if len(all) == 0 {
+		return nil
+	}
+
 	// Close the current journal (if any is open)
 	if journal.writer != nil {
 		if err := journal.writer.Close(); err != nil {


### PR DESCRIPTION
A private node that I run locally has relatively few transactions. I noticed the following logs (every hour) and found that the rotate process can be skipped if there are no local transactions.

```bash
INFO [02-26|12:39:36.200] Regenerated local transaction journal    transactions=0 accounts=0
INFO [02-26|13:39:36.043] Regenerated local transaction journal    transactions=0 accounts=0
INFO [02-26|14:39:35.885] Regenerated local transaction journal    transactions=0 accounts=0
```