### PR TITLE
core/txpool/blobpool: reduce default database cap for rollout

### DIFF
--- a/core/txpool/blobpool/config.go
+++ b/core/txpool/blobpool/config.go
@@ -30,8 +30,8 @@ type Config struct {
 // DefaultConfig contains the default configurations for the transaction pool.
 var DefaultConfig = Config{
 	Datadir:   "blobpool",
-	Datacap:   10 * 1024 * 1024 * 1024,
-	PriceBump: 100, // either have patience or be aggressive, no mushy ground
+	Datacap:   10 * 1024 * 1024 * 1024 / 4, // TODO(karalabe): /4 handicap for rollout, gradually bump back up to 10GB
+	PriceBump: 100,                         // either have patience or be aggressive, no mushy ground
 }
 
 // sanitize checks the provided user configurations and changes anything that's


### PR DESCRIPTION
Whilst a 10GB blob pool should be fine, maybe lets start a bit slower and gradually build up to it. This PR handicaps the blob pool to 2.5GB. If everything works as intended, we can gradually build it up to 10GB (+ if there's even a need for it).