### PR TITLE
cmd/devp2p: fix commandHasFlag

### DIFF
--- a/cmd/devp2p/main.go
+++ b/cmd/devp2p/main.go
@@ -66,9 +66,15 @@ func commandHasFlag(ctx *cli.Context, flag cli.Flag) bool {
 	for _, name := range names {
 		set[name] = struct{}{}
 	}
-	for _, fn := range ctx.FlagNames() {
-		if _, ok := set[fn]; ok {
-			return true
+	for _, ctx := range ctx.Lineage() {
+		if ctx.Command != nil {
+			for _, f := range ctx.Command.Flags {
+				for _, name := range f.Names() {
+					if _, ok := set[name]; ok {
+						return true
+					}
+				}
+			}
 		}
 	}
 	return false


### PR DESCRIPTION
It got broken in some update of the cli library, and thus bootnodes weren't being configured automatically for some of the discovery commands.

Fixes #28897