### PR TITLE
core: using math.MaxUint64 instead of 0xffffffffffffffff

### DIFF
--- a/core/vm/instructions.go
+++ b/core/vm/instructions.go
@@ -305,7 +305,7 @@ func opCallDataCopy(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext
 	)
 	dataOffset64, overflow := dataOffset.Uint64WithOverflow()
 	if overflow {
-		dataOffset64 = 0xffffffffffffffff
+		dataOffset64 = math.MaxUint64
 	}
 	// These values are checked for overflow during gas cost calculation
 	memOffset64 := memOffset.Uint64()


### PR DESCRIPTION
I am still reading the code in core/vm.

relate PR: https://github.com/ethereum/go-ethereum/pull/29022