### PR TITLE
declare the 'already reserved' error in txpool's errors.go

### DIFF
--- a/core/txpool/errors.go
+++ b/core/txpool/errors.go
@@ -54,4 +54,10 @@ var (
 	// ErrFutureReplacePending is returned if a future transaction replaces a pending
 	// one. Future transactions should only be able to replace other future transactions.
 	ErrFutureReplacePending = errors.New("future transaction tries to replace pending")
+
+	// ErrAlreadyReserved is returned if the sender address has a pending transaction
+	// in a different subpool. For example, this error is returned in response to any
+	// input transaction of non-blob type when a blob transaction from this sender
+	// remains pending (and vice-versa).
+	ErrAlreadyReserved = errors.New("address already reserved")
 )

--- a/core/txpool/txpool.go
+++ b/core/txpool/txpool.go
@@ -122,7 +122,7 @@ func (p *TxPool) reserver(id int, subpool SubPool) AddressReserver {
 					log.Error("pool attempted to reserve already-owned address", "address", addr)
 					return nil // Ignore fault to give the pool a chance to recover while the bug gets fixed
 				}
-				return errors.New("address already reserved")
+				return ErrAlreadyReserved
 			}
 			p.reservations[addr] = subpool
 			if metrics.Enabled {


### PR DESCRIPTION
We see this error when switching between blob and non-blob txs and must handle it specially (e.g. by submitting a cancel transaction to clear the old tx type). Thought this tweak might "elevate" its definition to better codify the error text we match against.