### PR TITLE
cmd, core/state: snapshot dump can skip EOA or CA

### DIFF
--- a/cmd/geth/chaincmd.go
+++ b/cmd/geth/chaincmd.go
@@ -177,6 +177,8 @@ It's deprecated, please use "geth db import" instead.
 			utils.IterativeOutputFlag,
 			utils.ExcludeCodeFlag,
 			utils.ExcludeStorageFlag,
+			utils.ExcludeContractFlag,
+			utils.ExcludeEOAFlag,
 			utils.IncludeIncompletesFlag,
 			utils.StartKeyFlag,
 			utils.DumpLimitFlag,
@@ -564,13 +566,15 @@ func parseDumpConfig(ctx *cli.Context, stack *node.Node) (*state.DumpConfig, eth
 	var conf = &state.DumpConfig{
 		SkipCode:          ctx.Bool(utils.ExcludeCodeFlag.Name),
 		SkipStorage:       ctx.Bool(utils.ExcludeStorageFlag.Name),
+		SkipContract:      ctx.Bool(utils.ExcludeContractFlag.Name),
+		SkipEOA:           ctx.Bool(utils.ExcludeEOAFlag.Name),
 		OnlyWithAddresses: !ctx.Bool(utils.IncludeIncompletesFlag.Name),
 		Start:             start.Bytes(),
 		Max:               ctx.Uint64(utils.DumpLimitFlag.Name),
 	}
 	log.Info("State dump configured", "block", header.Number, "hash", header.Hash().Hex(),
-		"skipcode", conf.SkipCode, "skipstorage", conf.SkipStorage,
-		"start", hexutil.Encode(conf.Start), "limit", conf.Max)
+		"skipcode", conf.SkipCode, "skipstorage", conf.SkipStorage, "skipcontract", conf.SkipContract,
+		"skipeoa", conf.SkipEOA, "start", hexutil.Encode(conf.Start), "limit", conf.Max)
 	return conf, db, header.Root, nil
 }
 

--- a/cmd/geth/snapshot.go
+++ b/cmd/geth/snapshot.go
@@ -139,6 +139,8 @@ It's also usable without snapshot enabled.
 				Flags: flags.Merge([]cli.Flag{
 					utils.ExcludeCodeFlag,
 					utils.ExcludeStorageFlag,
+					utils.ExcludeContractFlag,
+					utils.ExcludeEOAFlag,
 					utils.StartKeyFlag,
 					utils.DumpLimitFlag,
 				}, utils.NetworkFlags, utils.DatabaseFlags),
@@ -545,6 +547,9 @@ func dumpState(ctx *cli.Context) error {
 	if err != nil {
 		return err
 	}
+	if conf.SkipEOA && conf.SkipContract {
+		return fmt.Errorf("both EOA and contract accounts are skipped, nothing to dump")
+	}
 	triedb := utils.MakeTrieDatabase(ctx, db, false, true, false)
 	defer triedb.Close()
 
@@ -578,6 +583,12 @@ func dumpState(ctx *cli.Context) error {
 		account, err := types.FullAccount(accIt.Account())
 		if err != nil {
 			return err
+		}
+		if conf.SkipContract && !bytes.Equal(account.CodeHash, types.EmptyCodeHash.Bytes()) {
+			continue
+		}
+		if conf.SkipEOA && bytes.Equal(account.CodeHash, types.EmptyCodeHash.Bytes()) {
+			continue
 		}
 		da := &state.DumpAccount{
 			Balance:     account.Balance.String(),

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -208,6 +208,14 @@ var (
 		Name:  "nocode",
 		Usage: "Exclude contract code (save db lookups)",
 	}
+	ExcludeContractFlag = &cli.BoolFlag{
+		Name:  "nocontract",
+		Usage: "Exclude contract accounts",
+	}
+	ExcludeEOAFlag = &cli.BoolFlag{
+		Name:  "noeoa",
+		Usage: "Exclude EOA accounts",
+	}
 	StartKeyFlag = &cli.StringFlag{
 		Name:  "start",
 		Usage: "Start position. Either a hash or address",

--- a/core/state/dump.go
+++ b/core/state/dump.go
@@ -34,6 +34,8 @@ import (
 type DumpConfig struct {
 	SkipCode          bool
 	SkipStorage       bool
+	SkipContract      bool
+	SkipEOA           bool
 	OnlyWithAddresses bool
 	Start             []byte
 	Max               uint64


### PR DESCRIPTION
### Description
This PR adds new flags to allow users to exclude EOA accounts or contract accounts while dumping the snapshot data to a JSON file.

### Rationale
Originally to filter out EOA accounts or contract accounts, users first have to do `geth snapshot dump` and then do filtering once the JSON file is obtained like `grep -v "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470" filename`.

This feature allows users to do the filtering directly when dumping snapshot data, making the process of obtaining EOA accounts or contract accounts only faster.

### Example
Usage: `./geth snapshot dump --noeoa` or `./geth snapshot dump --nocontract`.
