### PR TITLE
eth/catalyst: implement getLocalTransaction, setLocalAccounts

### DIFF
--- a/core/txpool/legacypool/legacypool.go
+++ b/core/txpool/legacypool/legacypool.go
@@ -1955,3 +1955,8 @@ func (t *lookup) RemotesBelowTip(threshold *big.Int) types.Transactions {
 func numSlots(tx *types.Transaction) int {
 	return int((tx.Size() + txSlotSize - 1) / txSlotSize)
 }
+
+func (p *LegacyPool) AddLocalAddr(addr common.Address) {
+	p.locals.add(addr)
+	// TODO go through all txs to mark as local now
+}

--- a/core/txpool/txpool.go
+++ b/core/txpool/txpool.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core"
+	"github.com/ethereum/go-ethereum/core/txpool/legacypool"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/event"
 	"github.com/ethereum/go-ethereum/log"
@@ -463,6 +464,14 @@ func (p *TxPool) Status(hash common.Hash) TxStatus {
 		}
 	}
 	return TxStatusUnknown
+}
+
+func (p *TxPool) MarkLocal(addr common.Address) {
+	for _, pool := range p.subpools {
+		if sub, ok := pool.(*legacypool.LegacyPool); ok {
+			sub.AddLocalAddr(addr)
+		}
+	}
 }
 
 // Sync is a helper method for unit tests or simulator runs where the chain events

--- a/eth/catalyst/api.go
+++ b/eth/catalyst/api.go
@@ -893,3 +893,25 @@ func getBody(block *types.Block) *engine.ExecutionPayloadBodyV1 {
 		Withdrawals:     withdrawals,
 	}
 }
+
+func (c *ConsensusAPI) SetLocalAccounts(locals []common.Address) error {
+	for _, addr := range locals {
+		c.eth.TxPool().MarkLocal(addr)
+	}
+	return nil
+}
+
+func (c *ConsensusAPI) GetLocalTransactions() ([][]byte, error) {
+	var res [][]byte
+	for _, addr := range c.eth.TxPool().Locals() {
+		pending, _ := c.eth.TxPool().ContentFrom(addr)
+		for _, tx := range pending {
+			m, err := tx.MarshalJSON()
+			if err != nil {
+				return [][]byte{}, nil
+			}
+			res = append(res, m)
+		}
+	}
+	return res, nil
+}


### PR DESCRIPTION
Draft implementation of changes needed in geth for basic inclusion lists.
Implements two endpoints:
- `engine_setLocalAccounts` allows the caller to add a list of originating accounts that should be tracked
- `engine_getLocalTransactions` retrieves a list of transactions originating by previously marked accounts

Note: blob transactions are not supported, only transactions that arrive *after* there originator was marked will be returned, might return a long list of transactions, no limit specified at the moment. 