### PR TITLE
ethdb/pebble: use consistent write option for pebble update

### DIFF
--- a/ethdb/pebble/pebble.go
+++ b/ethdb/pebble/pebble.go
@@ -322,7 +322,7 @@ func (d *Database) Delete(key []byte) error {
 	if d.closed {
 		return pebble.ErrClosed
 	}
-	return d.db.Delete(key, nil)
+	return d.db.Delete(key, d.writeOptions)
 }
 
 // NewBatch creates a write-only key-value store that buffers changes to its host


### PR DESCRIPTION
Keep a consistent write option with put/delete/batch-write.