### PR TITLE
p2p: delete duplicate flags

### DIFF
--- a/p2p/server.go
+++ b/p2p/server.go
@@ -937,7 +937,7 @@ func (srv *Server) SetupConn(fd net.Conn, flags connFlag, dialDest *enode.Node) 
 		c.transport = srv.newTransport(fd, dialDest.Pubkey())
 	}
 
-	err := srv.setupConn(c, flags, dialDest)
+	err := srv.setupConn(c, dialDest)
 	if err != nil {
 		if !c.is(inboundConn) {
 			markDialError(err)
@@ -947,7 +947,7 @@ func (srv *Server) SetupConn(fd net.Conn, flags connFlag, dialDest *enode.Node) 
 	return err
 }
 
-func (srv *Server) setupConn(c *conn, flags connFlag, dialDest *enode.Node) error {
+func (srv *Server) setupConn(c *conn, dialDest *enode.Node) error {
 	// Prevent leftover pending conns from entering the handshake.
 	srv.lock.Lock()
 	running := srv.running


### PR DESCRIPTION
```
c := &conn{fd: fd, flags: flags, cont: make(chan error)}
err := srv.setupConn(c, flags, dialDest)
```
function `setupConn` has not used param `flags`. And the first struct param `c` contains `flags`, we can use `c.flags` in setupConn if needed.