### PR TITLE
eth: Add eth_blobBaseFee RPC and blob fields to eth_feeHistory

### DIFF
--- a/eth/api_backend.go
+++ b/eth/api_backend.go
@@ -362,7 +362,7 @@ func (b *EthAPIBackend) SuggestGasTipCap(ctx context.Context) (*big.Int, error) 
 	return b.gpo.SuggestTipCap(ctx)
 }
 
-func (b *EthAPIBackend) FeeHistory(ctx context.Context, blockCount uint64, lastBlock rpc.BlockNumber, rewardPercentiles []float64) (firstBlock *big.Int, reward [][]*big.Int, baseFee []*big.Int, gasUsedRatio []float64, err error) {
+func (b *EthAPIBackend) FeeHistory(ctx context.Context, blockCount uint64, lastBlock rpc.BlockNumber, rewardPercentiles []float64) (firstBlock *big.Int, reward [][]*big.Int, baseFee []*big.Int, gasUsedRatio []float64, baseFeePerBlobGas []*big.Int, blobGasUsedRatio []float64, err error) {
 	return b.gpo.FeeHistory(ctx, blockCount, lastBlock, rewardPercentiles)
 }
 

--- a/eth/api_backend.go
+++ b/eth/api_backend.go
@@ -366,13 +366,11 @@ func (b *EthAPIBackend) FeeHistory(ctx context.Context, blockCount uint64, lastB
 	return b.gpo.FeeHistory(ctx, blockCount, lastBlock, rewardPercentiles)
 }
 
-func (b *EthAPIBackend) BlobBaseFee(ctx context.Context) (*big.Int, error) {
-	if excessBlobGas := b.CurrentHeader().ExcessBlobGas; excessBlobGas != nil {
-		blobBaseFee := eip4844.CalcBlobFee(*excessBlobGas)
-		return blobBaseFee, nil
-	} else {
-		return nil, nil
+func (b *EthAPIBackend) BlobBaseFee(ctx context.Context) *big.Int {
+	if excess := b.CurrentHeader().ExcessBlobGas; excess != nil {
+		return eip4844.CalcBlobFee(*excess)
 	}
+	return nil
 }
 
 func (b *EthAPIBackend) ChainDb() ethdb.Database {

--- a/eth/api_backend.go
+++ b/eth/api_backend.go
@@ -26,6 +26,7 @@ import (
 	"github.com/ethereum/go-ethereum/accounts"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/consensus"
+	"github.com/ethereum/go-ethereum/consensus/misc/eip4844"
 	"github.com/ethereum/go-ethereum/core"
 	"github.com/ethereum/go-ethereum/core/bloombits"
 	"github.com/ethereum/go-ethereum/core/rawdb"
@@ -363,6 +364,15 @@ func (b *EthAPIBackend) SuggestGasTipCap(ctx context.Context) (*big.Int, error) 
 
 func (b *EthAPIBackend) FeeHistory(ctx context.Context, blockCount uint64, lastBlock rpc.BlockNumber, rewardPercentiles []float64) (firstBlock *big.Int, reward [][]*big.Int, baseFee []*big.Int, gasUsedRatio []float64, err error) {
 	return b.gpo.FeeHistory(ctx, blockCount, lastBlock, rewardPercentiles)
+}
+
+func (b *EthAPIBackend) BlobBaseFee(ctx context.Context) (*big.Int, error) {
+	if excessBlobGas := b.CurrentHeader().ExcessBlobGas; excessBlobGas != nil {
+		blobBaseFee := eip4844.CalcBlobFee(*excessBlobGas)
+		return blobBaseFee, nil
+	} else {
+		return nil, nil
+	}
 }
 
 func (b *EthAPIBackend) ChainDb() ethdb.Database {

--- a/eth/gasprice/feehistory.go
+++ b/eth/gasprice/feehistory.go
@@ -26,10 +26,14 @@ import (
 	"slices"
 	"sync/atomic"
 
+	"golang.org/x/exp/slices"
+
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/consensus/misc/eip1559"
+	"github.com/ethereum/go-ethereum/consensus/misc/eip4844"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/log"
+	"github.com/ethereum/go-ethereum/params"
 	"github.com/ethereum/go-ethereum/rpc"
 )
 
@@ -66,6 +70,8 @@ type processedFees struct {
 	reward               []*big.Int
 	baseFee, nextBaseFee *big.Int
 	gasUsedRatio         float64
+	blobGasUsedRatio     float64
+	blobBaseFee          *big.Int
 }
 
 // txGasAndReward is sorted in ascending order based on reward
@@ -88,6 +94,16 @@ func (oracle *Oracle) processBlock(bf *blockFees, percentiles []float64) {
 		bf.results.nextBaseFee = new(big.Int)
 	}
 	bf.results.gasUsedRatio = float64(bf.header.GasUsed) / float64(bf.header.GasLimit)
+	bf.results.blobGasUsedRatio = 0.0
+	bf.results.blobBaseFee = new(big.Int)
+	if bf.header != nil && chainconfig.IsCancun(bf.header.Number, bf.header.Time) {
+		if blobGasUsed := bf.header.BlobGasUsed; blobGasUsed != nil {
+			bf.results.blobGasUsedRatio = float64(*blobGasUsed) / params.MaxBlobGasPerBlock
+		}
+		if excessBlobGas := bf.header.ExcessBlobGas; excessBlobGas != nil {
+			bf.results.blobBaseFee = eip4844.CalcBlobFee(*excessBlobGas)
+		}
+	}
 	if len(percentiles) == 0 {
 		// rewards were not requested, return null
 		return
@@ -211,9 +227,9 @@ func (oracle *Oracle) resolveBlockRange(ctx context.Context, reqEnd rpc.BlockNum
 //
 // Note: baseFee includes the next block after the newest of the returned range, because this
 // value can be derived from the newest block.
-func (oracle *Oracle) FeeHistory(ctx context.Context, blocks uint64, unresolvedLastBlock rpc.BlockNumber, rewardPercentiles []float64) (*big.Int, [][]*big.Int, []*big.Int, []float64, error) {
+func (oracle *Oracle) FeeHistory(ctx context.Context, blocks uint64, unresolvedLastBlock rpc.BlockNumber, rewardPercentiles []float64) (*big.Int, [][]*big.Int, []*big.Int, []float64, []*big.Int, []float64, error) {
 	if blocks < 1 {
-		return common.Big0, nil, nil, nil, nil // returning with no data and no error means there are no retrievable blocks
+		return common.Big0, nil, nil, nil, nil, nil, nil // returning with no data and no error means there are no retrievable blocks
 	}
 	maxFeeHistory := oracle.maxHeaderHistory
 	if len(rewardPercentiles) != 0 {
@@ -225,10 +241,10 @@ func (oracle *Oracle) FeeHistory(ctx context.Context, blocks uint64, unresolvedL
 	}
 	for i, p := range rewardPercentiles {
 		if p < 0 || p > 100 {
-			return common.Big0, nil, nil, nil, fmt.Errorf("%w: %f", errInvalidPercentile, p)
+			return common.Big0, nil, nil, nil, nil, nil, fmt.Errorf("%w: %f", errInvalidPercentile, p)
 		}
 		if i > 0 && p <= rewardPercentiles[i-1] {
-			return common.Big0, nil, nil, nil, fmt.Errorf("%w: #%d:%f >= #%d:%f", errInvalidPercentile, i-1, rewardPercentiles[i-1], i, p)
+			return common.Big0, nil, nil, nil, nil, nil, fmt.Errorf("%w: #%d:%f >= #%d:%f", errInvalidPercentile, i-1, rewardPercentiles[i-1], i, p)
 		}
 	}
 	var (
@@ -238,7 +254,7 @@ func (oracle *Oracle) FeeHistory(ctx context.Context, blocks uint64, unresolvedL
 	)
 	pendingBlock, pendingReceipts, lastBlock, blocks, err := oracle.resolveBlockRange(ctx, unresolvedLastBlock, blocks)
 	if err != nil || blocks == 0 {
-		return common.Big0, nil, nil, nil, err
+		return common.Big0, nil, nil, nil, nil, nil, err
 	}
 	oldestBlock := lastBlock + 1 - blocks
 
@@ -295,19 +311,22 @@ func (oracle *Oracle) FeeHistory(ctx context.Context, blocks uint64, unresolvedL
 		}()
 	}
 	var (
-		reward       = make([][]*big.Int, blocks)
-		baseFee      = make([]*big.Int, blocks+1)
-		gasUsedRatio = make([]float64, blocks)
-		firstMissing = blocks
+		reward           = make([][]*big.Int, blocks)
+		baseFee          = make([]*big.Int, blocks+1)
+		gasUsedRatio     = make([]float64, blocks)
+		blobGasUsedRatio = make([]float64, blocks)
+		blobBaseFee      = make([]*big.Int, blocks)
+		firstMissing     = blocks
 	)
 	for ; blocks > 0; blocks-- {
 		fees := <-results
 		if fees.err != nil {
-			return common.Big0, nil, nil, nil, fees.err
+			return common.Big0, nil, nil, nil, nil, nil, fees.err
 		}
 		i := fees.blockNumber - oldestBlock
 		if fees.results.baseFee != nil {
 			reward[i], baseFee[i], baseFee[i+1], gasUsedRatio[i] = fees.results.reward, fees.results.baseFee, fees.results.nextBaseFee, fees.results.gasUsedRatio
+			blobGasUsedRatio[i], blobBaseFee[i] = fees.results.blobGasUsedRatio, fees.results.blobBaseFee
 		} else {
 			// getting no block and no error means we are requesting into the future (might happen because of a reorg)
 			if i < firstMissing {
@@ -316,7 +335,7 @@ func (oracle *Oracle) FeeHistory(ctx context.Context, blocks uint64, unresolvedL
 		}
 	}
 	if firstMissing == 0 {
-		return common.Big0, nil, nil, nil, nil
+		return common.Big0, nil, nil, nil, nil, nil, nil
 	}
 	if len(rewardPercentiles) != 0 {
 		reward = reward[:firstMissing]
@@ -324,5 +343,5 @@ func (oracle *Oracle) FeeHistory(ctx context.Context, blocks uint64, unresolvedL
 		reward = nil
 	}
 	baseFee, gasUsedRatio = baseFee[:firstMissing+1], gasUsedRatio[:firstMissing]
-	return new(big.Int).SetUint64(oldestBlock), reward, baseFee, gasUsedRatio, nil
+	return new(big.Int).SetUint64(oldestBlock), reward, baseFee, gasUsedRatio, blobBaseFee, blobGasUsedRatio, nil
 }

--- a/eth/gasprice/feehistory.go
+++ b/eth/gasprice/feehistory.go
@@ -149,15 +149,6 @@ func (oracle *Oracle) processBlock(bf *blockFees, percentiles []float64) {
 	}
 }
 
-// getBlobBaseFee is a helper function which computes and returns the blob base
-// fee if excessBlobGas exists.
-func getBlobBaseFee(h *types.Header) *big.Int {
-	if excessBlobGas := h.ExcessBlobGas; excessBlobGas != nil {
-		return eip4844.CalcBlobFee(*excessBlobGas)
-	}
-	return new(big.Int)
-}
-
 // resolveBlockRange resolves the specified block range to absolute block numbers while also
 // enforcing backend specific limitations. The pending block and corresponding receipts are
 // also returned if requested and available.

--- a/eth/gasprice/feehistory.go
+++ b/eth/gasprice/feehistory.go
@@ -51,10 +51,11 @@ const (
 // blockFees represents a single block for processing
 type blockFees struct {
 	// set by the caller
-	blockNumber uint64
-	header      *types.Header
-	block       *types.Block // only set if reward percentiles are requested
-	receipts    types.Receipts
+	blockNumber  uint64
+	header       *types.Header
+	parentHeader *types.Header
+	block        *types.Block // only set if reward percentiles are requested
+	receipts     types.Receipts
 	// filled by processBlock
 	results processedFees
 	err     error
@@ -67,11 +68,11 @@ type cacheKey struct {
 
 // processedFees contains the results of a processed block.
 type processedFees struct {
-	reward               []*big.Int
-	baseFee, nextBaseFee *big.Int
-	gasUsedRatio         float64
-	blobGasUsedRatio     float64
-	blobBaseFee          *big.Int
+	reward                       []*big.Int
+	baseFee, nextBaseFee         *big.Int
+	gasUsedRatio                 float64
+	blobGasUsedRatio             float64
+	blobBaseFee, nextBlobBaseFee *big.Int
 }
 
 // txGasAndReward is sorted in ascending order based on reward
@@ -96,12 +97,20 @@ func (oracle *Oracle) processBlock(bf *blockFees, percentiles []float64) {
 	bf.results.gasUsedRatio = float64(bf.header.GasUsed) / float64(bf.header.GasLimit)
 	bf.results.blobGasUsedRatio = 0.0
 	bf.results.blobBaseFee = new(big.Int)
+
+	getBlobBaseFee := func(h *types.Header) *big.Int {
+		if h != nil && chainconfig.IsCancun(h.Number, h.Time) {
+			if excessBlobGas := h.ExcessBlobGas; excessBlobGas != nil {
+				return eip4844.CalcBlobFee(*excessBlobGas)
+			}
+		}
+		return new(big.Int)
+	}
+	bf.results.blobBaseFee = getBlobBaseFee(bf.parentHeader)
+	bf.results.nextBlobBaseFee = getBlobBaseFee(bf.header)
 	if bf.header != nil && chainconfig.IsCancun(bf.header.Number, bf.header.Time) {
 		if blobGasUsed := bf.header.BlobGasUsed; blobGasUsed != nil {
 			bf.results.blobGasUsedRatio = float64(*blobGasUsed) / params.MaxBlobGasPerBlock
-		}
-		if excessBlobGas := bf.header.ExcessBlobGas; excessBlobGas != nil {
-			bf.results.blobBaseFee = eip4844.CalcBlobFee(*excessBlobGas)
 		}
 	}
 	if len(percentiles) == 0 {
@@ -281,6 +290,7 @@ func (oracle *Oracle) FeeHistory(ctx context.Context, blocks uint64, unresolvedL
 				if pendingBlock != nil && blockNumber >= pendingBlock.NumberU64() {
 					fees.block, fees.receipts = pendingBlock, pendingReceipts
 					fees.header = fees.block.Header()
+					fees.parentHeader, fees.err = oracle.backend.HeaderByNumber(ctx, rpc.BlockNumber(pendingBlock.NumberU64()-1))
 					oracle.processBlock(fees, rewardPercentiles)
 					results <- fees
 				} else {
@@ -300,6 +310,9 @@ func (oracle *Oracle) FeeHistory(ctx context.Context, blocks uint64, unresolvedL
 							fees.header, fees.err = oracle.backend.HeaderByNumber(ctx, rpc.BlockNumber(blockNumber))
 						}
 						if fees.header != nil && fees.err == nil {
+							if blockNumber > 0 {
+								fees.parentHeader, fees.err = oracle.backend.HeaderByNumber(ctx, rpc.BlockNumber(blockNumber-1))
+							}
 							oracle.processBlock(fees, rewardPercentiles)
 							if fees.err == nil {
 								oracle.historyCache.Add(cacheKey, fees.results)
@@ -317,7 +330,7 @@ func (oracle *Oracle) FeeHistory(ctx context.Context, blocks uint64, unresolvedL
 		baseFee          = make([]*big.Int, blocks+1)
 		gasUsedRatio     = make([]float64, blocks)
 		blobGasUsedRatio = make([]float64, blocks)
-		blobBaseFee      = make([]*big.Int, blocks)
+		blobBaseFee      = make([]*big.Int, blocks+1)
 		firstMissing     = blocks
 	)
 	for ; blocks > 0; blocks-- {
@@ -328,7 +341,7 @@ func (oracle *Oracle) FeeHistory(ctx context.Context, blocks uint64, unresolvedL
 		i := fees.blockNumber - oldestBlock
 		if fees.results.baseFee != nil {
 			reward[i], baseFee[i], baseFee[i+1], gasUsedRatio[i] = fees.results.reward, fees.results.baseFee, fees.results.nextBaseFee, fees.results.gasUsedRatio
-			blobGasUsedRatio[i], blobBaseFee[i] = fees.results.blobGasUsedRatio, fees.results.blobBaseFee
+			blobGasUsedRatio[i], blobBaseFee[i], blobBaseFee[i+1] = fees.results.blobGasUsedRatio, fees.results.blobBaseFee, fees.results.nextBlobBaseFee
 		} else {
 			// getting no block and no error means we are requesting into the future (might happen because of a reorg)
 			if i < firstMissing {
@@ -345,5 +358,6 @@ func (oracle *Oracle) FeeHistory(ctx context.Context, blocks uint64, unresolvedL
 		reward = nil
 	}
 	baseFee, gasUsedRatio = baseFee[:firstMissing+1], gasUsedRatio[:firstMissing]
+	blobBaseFee, blobGasUsedRatio = blobBaseFee[:firstMissing+1], blobGasUsedRatio[:firstMissing]
 	return new(big.Int).SetUint64(oldestBlock), reward, baseFee, gasUsedRatio, blobBaseFee, blobGasUsedRatio, nil
 }

--- a/eth/gasprice/feehistory.go
+++ b/eth/gasprice/feehistory.go
@@ -219,14 +219,16 @@ func (oracle *Oracle) resolveBlockRange(ctx context.Context, reqEnd rpc.BlockNum
 // or blocks older than a certain age (specified in maxHistory). The first block of the
 // actually processed range is returned to avoid ambiguity when parts of the requested range
 // are not available or when the head has changed during processing this request.
-// Three arrays are returned based on the processed blocks:
+// Five arrays are returned based on the processed blocks:
 //   - reward: the requested percentiles of effective priority fees per gas of transactions in each
 //     block, sorted in ascending order and weighted by gas used.
 //   - baseFee: base fee per gas in the given block
 //   - gasUsedRatio: gasUsed/gasLimit in the given block
+//   - blobBaseFee: the blob base fee per gas in the given block
+//   - blobGasUsedRatio: blobGasUsed/blobGasLimit in the given block
 //
-// Note: baseFee includes the next block after the newest of the returned range, because this
-// value can be derived from the newest block.
+// Note: baseFee and blobBaseFee both include the next block after the newest of the returned range,
+// because this value can be derived from the newest block.
 func (oracle *Oracle) FeeHistory(ctx context.Context, blocks uint64, unresolvedLastBlock rpc.BlockNumber, rewardPercentiles []float64) (*big.Int, [][]*big.Int, []*big.Int, []float64, []*big.Int, []float64, error) {
 	if blocks < 1 {
 		return common.Big0, nil, nil, nil, nil, nil, nil // returning with no data and no error means there are no retrievable blocks

--- a/eth/gasprice/feehistory.go
+++ b/eth/gasprice/feehistory.go
@@ -26,8 +26,6 @@ import (
 	"slices"
 	"sync/atomic"
 
-	"golang.org/x/exp/slices"
-
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/consensus/misc/eip1559"
 	"github.com/ethereum/go-ethereum/consensus/misc/eip4844"

--- a/eth/gasprice/feehistory_test.go
+++ b/eth/gasprice/feehistory_test.go
@@ -61,7 +61,7 @@ func TestFeeHistory(t *testing.T) {
 		backend := newTestBackend(t, big.NewInt(16), c.pending, true)
 		oracle := NewOracle(backend, config)
 
-		first, reward, baseFee, ratio, blobBaseFee, blobUsed, err := oracle.FeeHistory(context.Background(), c.count, c.last, c.percent)
+		first, reward, baseFee, ratio, blobBaseFee, blobRatio, err := oracle.FeeHistory(context.Background(), c.count, c.last, c.percent)
 		backend.teardown()
 		expReward := c.expCount
 		if len(c.percent) == 0 {
@@ -84,8 +84,11 @@ func TestFeeHistory(t *testing.T) {
 		if len(ratio) != c.expCount {
 			t.Fatalf("Test case %d: gasUsedRatio array length mismatch, want %d, got %d", i, c.expCount, len(ratio))
 		}
-		if len(blobBaseFee) != len(blobUsed) || len(blobBaseFee) != c.expCount {
-			t.Fatalf("Test case %d: blob arrays length mismatch, want %d, got %d and %d", i, c.expCount, len(blobBaseFee), len(blobUsed))
+		if len(blobRatio) != c.expCount {
+			t.Fatalf("Test case %d: blobGasUsedRatio array length mismatch, want %d, got %d", i, c.expCount, len(blobRatio))
+		}
+		if len(blobBaseFee) != len(baseFee) {
+			t.Fatalf("Test case %d: blobBaseFee array length mismatch, want %d, got %d", i, len(baseFee), len(blobBaseFee))
 		}
 		if err != c.expErr && !errors.Is(err, c.expErr) {
 			t.Fatalf("Test case %d: error mismatch, want %v, got %v", i, c.expErr, err)

--- a/eth/gasprice/feehistory_test.go
+++ b/eth/gasprice/feehistory_test.go
@@ -58,10 +58,10 @@ func TestFeeHistory(t *testing.T) {
 			MaxHeaderHistory: c.maxHeader,
 			MaxBlockHistory:  c.maxBlock,
 		}
-		backend := newTestBackend(t, big.NewInt(16), c.pending)
+		backend := newTestBackend(t, big.NewInt(16), c.pending, true)
 		oracle := NewOracle(backend, config)
 
-		first, reward, baseFee, ratio, err := oracle.FeeHistory(context.Background(), c.count, c.last, c.percent)
+		first, reward, baseFee, ratio, blobBaseFee, blobUsed, err := oracle.FeeHistory(context.Background(), c.count, c.last, c.percent)
 		backend.teardown()
 		expReward := c.expCount
 		if len(c.percent) == 0 {
@@ -83,6 +83,9 @@ func TestFeeHistory(t *testing.T) {
 		}
 		if len(ratio) != c.expCount {
 			t.Fatalf("Test case %d: gasUsedRatio array length mismatch, want %d, got %d", i, c.expCount, len(ratio))
+		}
+		if len(blobBaseFee) != len(blobUsed) || len(blobBaseFee) != c.expCount {
+			t.Fatalf("Test case %d: blob arrays length mismatch, want %d, got %d and %d", i, c.expCount, len(blobBaseFee), len(blobUsed))
 		}
 		if err != c.expErr && !errors.Is(err, c.expErr) {
 			t.Fatalf("Test case %d: error mismatch, want %v, got %v", i, c.expErr, err)

--- a/eth/gasprice/feehistory_test.go
+++ b/eth/gasprice/feehistory_test.go
@@ -58,7 +58,7 @@ func TestFeeHistory(t *testing.T) {
 			MaxHeaderHistory: c.maxHeader,
 			MaxBlockHistory:  c.maxBlock,
 		}
-		backend := newTestBackend(t, big.NewInt(16), c.pending, true)
+		backend := newTestBackend(t, big.NewInt(16), big.NewInt(28), c.pending)
 		oracle := NewOracle(backend, config)
 
 		first, reward, baseFee, ratio, blobBaseFee, blobRatio, err := oracle.FeeHistory(context.Background(), c.count, c.last, c.percent)

--- a/eth/gasprice/gasprice_test.go
+++ b/eth/gasprice/gasprice_test.go
@@ -24,8 +24,6 @@ import (
 	"math/big"
 	"testing"
 
-	"github.com/holiman/uint256"
-
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/consensus"
 	"github.com/ethereum/go-ethereum/consensus/beacon"
@@ -39,6 +37,7 @@ import (
 	"github.com/ethereum/go-ethereum/event"
 	"github.com/ethereum/go-ethereum/params"
 	"github.com/ethereum/go-ethereum/rpc"
+	"github.com/holiman/uint256"
 )
 
 const testHead = 32
@@ -143,7 +142,7 @@ func newTestBackend(t *testing.T, londonBlock *big.Int, cancunBlock *big.Int, pe
 
 		// Compute empty blob hash.
 		emptyBlob          = kzg4844.Blob{}
-		emptyBlobCommit, _ = kzg4844.BlobToCommitment(emptyBlob)
+		emptyBlobCommit, _ = kzg4844.BlobToCommitment(&emptyBlob)
 		emptyBlobVHash     = kzg4844.CalcBlobHashV1(sha256.New(), &emptyBlobCommit)
 	)
 	config.LondonBlock = londonBlock

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -124,6 +124,11 @@ func (s *EthereumAPI) FeeHistory(ctx context.Context, blockCount math.HexOrDecim
 	return results, nil
 }
 
+func (s *EthereumAPI) BlobBaseFee(ctx context.Context) (*hexutil.Big, error) {
+	blobBaseFee, err := s.b.BlobBaseFee(ctx)
+	return (*hexutil.Big)(blobBaseFee), err
+}
+
 // Syncing returns false in case the node is currently not syncing with the network. It can be up-to-date or has not
 // yet received the latest block headers from its pears. In case it is synchronizing:
 // - startingBlock: block number this node started to synchronize from

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -26,6 +26,9 @@ import (
 	"time"
 
 	"github.com/davecgh/go-spew/spew"
+	"github.com/holiman/uint256"
+	"github.com/tyler-smith/go-bip39"
+
 	"github.com/ethereum/go-ethereum/accounts"
 	"github.com/ethereum/go-ethereum/accounts/keystore"
 	"github.com/ethereum/go-ethereum/accounts/scwallet"
@@ -48,8 +51,6 @@ import (
 	"github.com/ethereum/go-ethereum/rlp"
 	"github.com/ethereum/go-ethereum/rpc"
 	"github.com/ethereum/go-ethereum/trie"
-	"github.com/holiman/uint256"
-	"github.com/tyler-smith/go-bip39"
 )
 
 // estimateGasErrorRatio is the amount of overestimation eth_estimateGas is
@@ -90,15 +91,17 @@ func (s *EthereumAPI) MaxPriorityFeePerGas(ctx context.Context) (*hexutil.Big, e
 }
 
 type feeHistoryResult struct {
-	OldestBlock  *hexutil.Big     `json:"oldestBlock"`
-	Reward       [][]*hexutil.Big `json:"reward,omitempty"`
-	BaseFee      []*hexutil.Big   `json:"baseFeePerGas,omitempty"`
-	GasUsedRatio []float64        `json:"gasUsedRatio"`
+	OldestBlock      *hexutil.Big     `json:"oldestBlock"`
+	Reward           [][]*hexutil.Big `json:"reward,omitempty"`
+	BaseFee          []*hexutil.Big   `json:"baseFeePerGas,omitempty"`
+	GasUsedRatio     []float64        `json:"gasUsedRatio"`
+	BlobBaseFee      []*hexutil.Big   `json:"baseFeePerBlobGas,omitempty"`
+	BlobGasUsedRatio []float64        `json:"blobGasUsedRatio,omitempty"`
 }
 
 // FeeHistory returns the fee market history.
 func (s *EthereumAPI) FeeHistory(ctx context.Context, blockCount math.HexOrDecimal64, lastBlock rpc.BlockNumber, rewardPercentiles []float64) (*feeHistoryResult, error) {
-	oldest, reward, baseFee, gasUsed, err := s.b.FeeHistory(ctx, uint64(blockCount), lastBlock, rewardPercentiles)
+	oldest, reward, baseFee, gasUsed, blobBaseFee, blobGasUsed, err := s.b.FeeHistory(ctx, uint64(blockCount), lastBlock, rewardPercentiles)
 	if err != nil {
 		return nil, err
 	}
@@ -120,6 +123,15 @@ func (s *EthereumAPI) FeeHistory(ctx context.Context, blockCount math.HexOrDecim
 		for i, v := range baseFee {
 			results.BaseFee[i] = (*hexutil.Big)(v)
 		}
+	}
+	if blobBaseFee != nil {
+		results.BlobBaseFee = make([]*hexutil.Big, len(blobBaseFee))
+		for i, v := range blobBaseFee {
+			results.BlobBaseFee[i] = (*hexutil.Big)(v)
+		}
+	}
+	if blobGasUsed != nil {
+		results.BlobGasUsedRatio = blobGasUsed
 	}
 	return results, nil
 }

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -137,9 +137,8 @@ func (s *EthereumAPI) FeeHistory(ctx context.Context, blockCount math.HexOrDecim
 }
 
 // BlobBaseFee returns the base fee for blob gas at the current head.
-func (s *EthereumAPI) BlobBaseFee(ctx context.Context) (*hexutil.Big, error) {
-	blobBaseFee, err := s.b.BlobBaseFee(ctx)
-	return (*hexutil.Big)(blobBaseFee), err
+func (s *EthereumAPI) BlobBaseFee(ctx context.Context) *hexutil.Big {
+	return (*hexutil.Big)(s.b.BlobBaseFee(ctx))
 }
 
 // Syncing returns false in case the node is currently not syncing with the network. It can be up-to-date or has not

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -136,6 +136,7 @@ func (s *EthereumAPI) FeeHistory(ctx context.Context, blockCount math.HexOrDecim
 	return results, nil
 }
 
+// BlobBaseFee returns the base fee for blob gas at the current head.
 func (s *EthereumAPI) BlobBaseFee(ctx context.Context) (*hexutil.Big, error) {
 	blobBaseFee, err := s.b.BlobBaseFee(ctx)
 	return (*hexutil.Big)(blobBaseFee), err

--- a/internal/ethapi/api_test.go
+++ b/internal/ethapi/api_test.go
@@ -471,14 +471,15 @@ func (b testBackend) SuggestGasTipCap(ctx context.Context) (*big.Int, error) {
 func (b testBackend) FeeHistory(ctx context.Context, blockCount uint64, lastBlock rpc.BlockNumber, rewardPercentiles []float64) (*big.Int, [][]*big.Int, []*big.Int, []float64, error) {
 	return nil, nil, nil, nil, nil
 }
-func (b testBackend) ChainDb() ethdb.Database           { return b.db }
-func (b testBackend) AccountManager() *accounts.Manager { return b.accman }
-func (b testBackend) ExtRPCEnabled() bool               { return false }
-func (b testBackend) RPCGasCap() uint64                 { return 10000000 }
-func (b testBackend) RPCEVMTimeout() time.Duration      { return time.Second }
-func (b testBackend) RPCTxFeeCap() float64              { return 0 }
-func (b testBackend) UnprotectedAllowed() bool          { return false }
-func (b testBackend) SetHead(number uint64)             {}
+func (b testBackend) BlobBaseFee(ctx context.Context) (*big.Int, error) { return big.NewInt(0), nil }
+func (b testBackend) ChainDb() ethdb.Database                           { return b.db }
+func (b testBackend) AccountManager() *accounts.Manager                 { return b.accman }
+func (b testBackend) ExtRPCEnabled() bool                               { return false }
+func (b testBackend) RPCGasCap() uint64                                 { return 10000000 }
+func (b testBackend) RPCEVMTimeout() time.Duration                      { return time.Second }
+func (b testBackend) RPCTxFeeCap() float64                              { return 0 }
+func (b testBackend) UnprotectedAllowed() bool                          { return false }
+func (b testBackend) SetHead(number uint64)                             {}
 func (b testBackend) HeaderByNumber(ctx context.Context, number rpc.BlockNumber) (*types.Header, error) {
 	if number == rpc.LatestBlockNumber {
 		return b.chain.CurrentBlock(), nil

--- a/internal/ethapi/api_test.go
+++ b/internal/ethapi/api_test.go
@@ -472,15 +472,15 @@ func (b testBackend) SuggestGasTipCap(ctx context.Context) (*big.Int, error) {
 func (b testBackend) FeeHistory(ctx context.Context, blockCount uint64, lastBlock rpc.BlockNumber, rewardPercentiles []float64) (*big.Int, [][]*big.Int, []*big.Int, []float64, []*big.Int, []float64, error) {
 	return nil, nil, nil, nil, nil, nil, nil
 }
-func (b testBackend) BlobBaseFee(ctx context.Context) (*big.Int, error) { return big.NewInt(0), nil }
-func (b testBackend) ChainDb() ethdb.Database                           { return b.db }
-func (b testBackend) AccountManager() *accounts.Manager                 { return b.accman }
-func (b testBackend) ExtRPCEnabled() bool                               { return false }
-func (b testBackend) RPCGasCap() uint64                                 { return 10000000 }
-func (b testBackend) RPCEVMTimeout() time.Duration                      { return time.Second }
-func (b testBackend) RPCTxFeeCap() float64                              { return 0 }
-func (b testBackend) UnprotectedAllowed() bool                          { return false }
-func (b testBackend) SetHead(number uint64)                             {}
+func (b testBackend) BlobBaseFee(ctx context.Context) *big.Int { return new(big.Int) }
+func (b testBackend) ChainDb() ethdb.Database                  { return b.db }
+func (b testBackend) AccountManager() *accounts.Manager        { return b.accman }
+func (b testBackend) ExtRPCEnabled() bool                      { return false }
+func (b testBackend) RPCGasCap() uint64                        { return 10000000 }
+func (b testBackend) RPCEVMTimeout() time.Duration             { return time.Second }
+func (b testBackend) RPCTxFeeCap() float64                     { return 0 }
+func (b testBackend) UnprotectedAllowed() bool                 { return false }
+func (b testBackend) SetHead(number uint64)                    {}
 func (b testBackend) HeaderByNumber(ctx context.Context, number rpc.BlockNumber) (*types.Header, error) {
 	if number == rpc.LatestBlockNumber {
 		return b.chain.CurrentBlock(), nil

--- a/internal/ethapi/api_test.go
+++ b/internal/ethapi/api_test.go
@@ -32,6 +32,9 @@ import (
 	"testing"
 	"time"
 
+	"github.com/holiman/uint256"
+	"github.com/stretchr/testify/require"
+
 	"github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/accounts"
 	"github.com/ethereum/go-ethereum/accounts/keystore"
@@ -53,8 +56,6 @@ import (
 	"github.com/ethereum/go-ethereum/internal/blocktest"
 	"github.com/ethereum/go-ethereum/params"
 	"github.com/ethereum/go-ethereum/rpc"
-	"github.com/holiman/uint256"
-	"github.com/stretchr/testify/require"
 )
 
 func testTransactionMarshal(t *testing.T, tests []txData, config *params.ChainConfig) {
@@ -468,8 +469,8 @@ func (b testBackend) SyncProgress() ethereum.SyncProgress { return ethereum.Sync
 func (b testBackend) SuggestGasTipCap(ctx context.Context) (*big.Int, error) {
 	return big.NewInt(0), nil
 }
-func (b testBackend) FeeHistory(ctx context.Context, blockCount uint64, lastBlock rpc.BlockNumber, rewardPercentiles []float64) (*big.Int, [][]*big.Int, []*big.Int, []float64, error) {
-	return nil, nil, nil, nil, nil
+func (b testBackend) FeeHistory(ctx context.Context, blockCount uint64, lastBlock rpc.BlockNumber, rewardPercentiles []float64) (*big.Int, [][]*big.Int, []*big.Int, []float64, []*big.Int, []float64, error) {
+	return nil, nil, nil, nil, nil, nil, nil
 }
 func (b testBackend) BlobBaseFee(ctx context.Context) (*big.Int, error) { return big.NewInt(0), nil }
 func (b testBackend) ChainDb() ethdb.Database                           { return b.db }

--- a/internal/ethapi/backend.go
+++ b/internal/ethapi/backend.go
@@ -44,7 +44,8 @@ type Backend interface {
 	SyncProgress() ethereum.SyncProgress
 
 	SuggestGasTipCap(ctx context.Context) (*big.Int, error)
-	FeeHistory(ctx context.Context, blockCount uint64, lastBlock rpc.BlockNumber, rewardPercentiles []float64) (*big.Int, [][]*big.Int, []*big.Int, []float64, error)
+	FeeHistory(ctx context.Context, blockCount uint64, lastBlock rpc.BlockNumber, rewardPercentiles []float64) (*big.Int, [][]*big.Int, []*big.Int, []float64, []*big.Int, []float64, error)
+	BlobBaseFee(ctx context.Context) (*big.Int, error)
 	ChainDb() ethdb.Database
 	AccountManager() *accounts.Manager
 	ExtRPCEnabled() bool

--- a/internal/ethapi/backend.go
+++ b/internal/ethapi/backend.go
@@ -45,7 +45,7 @@ type Backend interface {
 
 	SuggestGasTipCap(ctx context.Context) (*big.Int, error)
 	FeeHistory(ctx context.Context, blockCount uint64, lastBlock rpc.BlockNumber, rewardPercentiles []float64) (*big.Int, [][]*big.Int, []*big.Int, []float64, []*big.Int, []float64, error)
-	BlobBaseFee(ctx context.Context) (*big.Int, error)
+	BlobBaseFee(ctx context.Context) *big.Int
 	ChainDb() ethdb.Database
 	AccountManager() *accounts.Manager
 	ExtRPCEnabled() bool

--- a/internal/ethapi/transaction_args_test.go
+++ b/internal/ethapi/transaction_args_test.go
@@ -322,6 +322,9 @@ func (b *backendMock) SyncProgress() ethereum.SyncProgress { return ethereum.Syn
 func (b *backendMock) FeeHistory(ctx context.Context, blockCount uint64, lastBlock rpc.BlockNumber, rewardPercentiles []float64) (*big.Int, [][]*big.Int, []*big.Int, []float64, error) {
 	return nil, nil, nil, nil, nil
 }
+func (b *backendMock) BlobBaseFee(ctx context.Context) (*big.Int, error) {
+	return big.NewInt(42), nil
+}
 func (b *backendMock) ChainDb() ethdb.Database           { return nil }
 func (b *backendMock) AccountManager() *accounts.Manager { return nil }
 func (b *backendMock) ExtRPCEnabled() bool               { return false }

--- a/internal/ethapi/transaction_args_test.go
+++ b/internal/ethapi/transaction_args_test.go
@@ -319,8 +319,8 @@ func (b *backendMock) ChainConfig() *params.ChainConfig { return b.config }
 
 // Other methods needed to implement Backend interface.
 func (b *backendMock) SyncProgress() ethereum.SyncProgress { return ethereum.SyncProgress{} }
-func (b *backendMock) FeeHistory(ctx context.Context, blockCount uint64, lastBlock rpc.BlockNumber, rewardPercentiles []float64) (*big.Int, [][]*big.Int, []*big.Int, []float64, error) {
-	return nil, nil, nil, nil, nil
+func (b *backendMock) FeeHistory(ctx context.Context, blockCount uint64, lastBlock rpc.BlockNumber, rewardPercentiles []float64) (*big.Int, [][]*big.Int, []*big.Int, []float64, []*big.Int, []float64, error) {
+	return nil, nil, nil, nil, nil, nil, nil
 }
 func (b *backendMock) BlobBaseFee(ctx context.Context) (*big.Int, error) {
 	return big.NewInt(42), nil

--- a/internal/ethapi/transaction_args_test.go
+++ b/internal/ethapi/transaction_args_test.go
@@ -314,6 +314,8 @@ func (b *backendMock) setFork(fork string) error {
 func (b *backendMock) SuggestGasTipCap(ctx context.Context) (*big.Int, error) {
 	return big.NewInt(42), nil
 }
+func (b *backendMock) BlobBaseFee(ctx context.Context) *big.Int { return big.NewInt(42) }
+
 func (b *backendMock) CurrentHeader() *types.Header     { return b.current }
 func (b *backendMock) ChainConfig() *params.ChainConfig { return b.config }
 
@@ -321,9 +323,6 @@ func (b *backendMock) ChainConfig() *params.ChainConfig { return b.config }
 func (b *backendMock) SyncProgress() ethereum.SyncProgress { return ethereum.SyncProgress{} }
 func (b *backendMock) FeeHistory(ctx context.Context, blockCount uint64, lastBlock rpc.BlockNumber, rewardPercentiles []float64) (*big.Int, [][]*big.Int, []*big.Int, []float64, []*big.Int, []float64, error) {
 	return nil, nil, nil, nil, nil, nil, nil
-}
-func (b *backendMock) BlobBaseFee(ctx context.Context) (*big.Int, error) {
-	return big.NewInt(42), nil
 }
 func (b *backendMock) ChainDb() ethdb.Database           { return nil }
 func (b *backendMock) AccountManager() *accounts.Manager { return nil }

--- a/internal/jsre/deps/web3.js
+++ b/internal/jsre/deps/web3.js
@@ -5520,6 +5520,11 @@ var properties = function () {
             outputFormatter: formatters.outputBigNumberFormatter
         }),
         new Property({
+            name: 'blobBaseFee',
+            getter: 'eth_blobBaseFee',
+            outputFormatter: formatters.outputBigNumberFormatter
+        }),
+        new Property({
             name: 'accounts',
             getter: 'eth_accounts'
         }),


### PR DESCRIPTION
Fixes #29139, this adds the new `eth_blobBaseFee` RPC and the new fields to `eth_feeHistory` from https://github.com/ethereum/execution-apis/pull/486.

~There's still one issue with the code: the `baseFeePerBlobGas` array is missing the "next" block so is one shorter than it should be, but I ran out of time and am not sure how much bandwidth I'll have to work on this again next week.~ Update: I believe this is working as expected now as of [cc1649a](https://github.com/ethereum/go-ethereum/pull/29140/commits/cc1649a364563651d5b18a8a3bf60ec0a17629a3).

Also, the unit test coverage could be a bit better, but I was having trouble getting the `newTestBackend` to actually raise the blob gas price even when blocks were full.  I had to add a fair amount of other logic to `newTestBackend` to support the merge and Cancun since it hasn't been touched in awhile, I borrowed as much logic from other tests as I could until it seemed to work.  

I also considered refactoring `oracle.FeeHistory` to return a struct (or at least named return values) but ultimately opted not to make too many changes w/o discussing them first.

In addition, I've tested on Sepolia:

```
$ curl -H "Content-Type: application/json" -d '{"id": 1, "jsonrpc": "2.0", "method": "eth_feeHistory", "params": ["0x5", "latest", [20,30]] }' http://$NODE:8545/ | jq .

{
  "jsonrpc": "2.0",
  "id": 1,
  "result": {
    "oldestBlock": "0x526002",
    "reward": [
      [
        "0x186a1",
        "0x186a1"
      ],
      [
        "0x186a1",
        "0x186a1"
      ],
      [
        "0x59682f00",
        "0x59682f00"
      ],
      [
        "0x0",
        "0x0"
      ],
      [
        "0x3b9aca00",
        "0x3b9aca00"
      ]
    ],
    "baseFeePerGas": [
      "0x4506f",
      "0x43d32",
      "0x44d30",
      "0x42021",
      "0x39c1d",
      "0x38cd0"
    ],
    "gasUsedRatio": [
      0.4303144,
      0.5589600333333333,
      0.3363257666666667,
      0,
      0.4337706333333333
    ],
    "baseFeePerBlobGas": [
      "0x535f4d983",
      "0x4a1bd3218",
      "0x502994693",
      "0x4d137e31b",
      "0x4741676a3",
      "0x3f5694c1f"
    ],
    "blobGasUsedRatio": [
      0.8333333333333334,
      0.3333333333333333,
      0.16666666666666666,
      0,
      1
    ]
  }
}
```

```
$ curl -H "Content-Type: application/json" -d '{"id": 1, "jsonrpc": "2.0", "method": "eth_blobBaseFee", "params": [] }' http://$NODE:8545/
{"jsonrpc":"2.0","id":1,"result":"0x3f5694c1f"}
```
  