### PR TITLE
rewrite the GCM encrypt and decrypt function

### DIFF
--- a/signer/storage/aes_gcm_storage.go
+++ b/signer/storage/aes_gcm_storage.go
@@ -159,9 +159,9 @@ func (s *AESEncryptedStorage) writeEncryptedStorage(creds map[string]storedCrede
 	return nil
 }
 
-func randBytes(size int) (blk []byte, err error) {
-	blk = make([]byte, size)
-	_, err = rand.Read(blk)
+func (s *AESEncryptedStorage) randBytes() (nonce []byte, err error) {
+	nonce = make([]byte, s.gcmNS)
+	_, err = io.ReadFull(rand.Reader, nonce)
 	return
 }
 
@@ -173,7 +173,7 @@ func (s *AESEncryptedStorage) encrypt(plaintext []byte, additionalData []byte) (
 	// key because of the risk of a repeat.
 	var n []byte
 
-	if n, err = randBytes(s.gcmNS); err != nil {
+	if n, err = s.randBytes(); err != nil {
 		return
 	}
 	return append(n, s.gcm.Seal(nil, n, plaintext, additionalData)...), n, nil

--- a/signer/storage/aes_gcm_storage_test.go
+++ b/signer/storage/aes_gcm_storage_test.go
@@ -36,13 +36,15 @@ func TestEncryption(t *testing.T) {
 	key := []byte("AES256Key-32Characters1234567890")
 	plaintext := []byte("exampleplaintext")
 
-	c, iv, err := encrypt(key, plaintext, nil)
+	aesStore := NewAESEncryptedStorage("", key)
+
+	c, iv, err := aesStore.encrypt(plaintext, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
 	t.Logf("Ciphertext %x, nonce %x\n", c, iv)
 
-	p, err := decrypt(key, iv, c, nil)
+	p, err := aesStore.decrypt(c, nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/signer/storage/aes_gcm_storage_test.go
+++ b/signer/storage/aes_gcm_storage_test.go
@@ -99,14 +99,15 @@ func TestEnd2End(t *testing.T) {
 
 	d := t.TempDir()
 
-	s1 := &AESEncryptedStorage{
-		filename: fmt.Sprintf("%v/vault.json", d),
-		key:      []byte("AES256Key-32Characters1234567890"),
-	}
-	s2 := &AESEncryptedStorage{
-		filename: fmt.Sprintf("%v/vault.json", d),
-		key:      []byte("AES256Key-32Characters1234567890"),
-	}
+	s1 := NewAESEncryptedStorage(
+		fmt.Sprintf("%v/vault.json", d),
+		[]byte("AES256Key-32Characters1234567890"),
+	)
+
+	s2 := NewAESEncryptedStorage(
+		fmt.Sprintf("%v/vault.json", d),
+		[]byte("AES256Key-32Characters1234567890"),
+	)
 
 	s1.Put("bazonk", "foobar")
 	if v, err := s2.Get("bazonk"); v != "foobar" || err != nil {
@@ -122,10 +123,10 @@ func TestSwappedKeys(t *testing.T) {
 
 	d := t.TempDir()
 
-	s1 := &AESEncryptedStorage{
-		filename: fmt.Sprintf("%v/vault.json", d),
-		key:      []byte("AES256Key-32Characters1234567890"),
-	}
+	s1 := NewAESEncryptedStorage(
+		fmt.Sprintf("%v/vault.json", d),
+		[]byte("AES256Key-32Characters1234567890"),
+	)
 	s1.Put("k1", "v1")
 	s1.Put("k2", "v2")
 	// Now make a modified copy


### PR DESCRIPTION
* AESEncryptedStorage struct now includes a *gcm* field of type *cipher.AEAD* and a *gcmNS* field to store the nonce size. These additions help in initializing the AES-GCM cipher once during object creation, improving performance by avoiding repeated initialization.

* added *randBytes* function to generate random nonce (one-time number) to ensure that each encryption operation uses a different nonce to increase the security of encryption.