### PR TITLE
core: initialize `gasRemaining` with `=` instead of `+=`

### DIFF
--- a/core/state_transition.go
+++ b/core/state_transition.go
@@ -263,7 +263,7 @@ func (st *StateTransition) buyGas() error {
 	if err := st.gp.SubGas(st.msg.GasLimit); err != nil {
 		return err
 	}
-	st.gasRemaining += st.msg.GasLimit
+	st.gasRemaining = st.msg.GasLimit
 
 	st.initialGas = st.msg.GasLimit
 	mgvalU256, _ := uint256.FromBig(mgval)


### PR DESCRIPTION
Current code is like below:

```golang
	st.gasRemaining += st.msg.GasLimit

	st.initialGas = st.msg.GasLimit
```

It makes readers think `gasRemaining` is accumulated across transactions in a block while `initialGas` is only for a single transaction.

But in fact both `gasRemaining` and `initialGas` are accounting for a single transaction **only**.
(each transaction will have its own `StateTransition` object.)

And this codestyle is copied downstream to [op](https://github.com/ethereum-optimism/op-geth/blob/optimism/core/state_transition.go#L292-L293).

I think it helps understanding to make the initializing style the same for `gasRemaining` and `initialGas`.