### PR TITLE
accounts/usbwallet/trezor: remove redundant import aliases

### DIFF
--- a/accounts/usbwallet/trezor/messages-common.pb.go
+++ b/accounts/usbwallet/trezor/messages-common.pb.go
@@ -7,7 +7,7 @@ import (
 	fmt "fmt"
 	math "math"
 
-	proto "github.com/golang/protobuf/proto"
+	"github.com/golang/protobuf/proto"
 )
 
 // Reference imports to suppress errors if they are not otherwise used.

--- a/accounts/usbwallet/trezor/messages-ethereum.pb.go
+++ b/accounts/usbwallet/trezor/messages-ethereum.pb.go
@@ -7,7 +7,7 @@ import (
 	fmt "fmt"
 	math "math"
 
-	proto "github.com/golang/protobuf/proto"
+	"github.com/golang/protobuf/proto"
 )
 
 // Reference imports to suppress errors if they are not otherwise used.

--- a/accounts/usbwallet/trezor/messages-management.pb.go
+++ b/accounts/usbwallet/trezor/messages-management.pb.go
@@ -7,7 +7,7 @@ import (
 	fmt "fmt"
 	math "math"
 
-	proto "github.com/golang/protobuf/proto"
+	"github.com/golang/protobuf/proto"
 )
 
 // Reference imports to suppress errors if they are not otherwise used.

--- a/accounts/usbwallet/trezor/messages.pb.go
+++ b/accounts/usbwallet/trezor/messages.pb.go
@@ -7,8 +7,8 @@ import (
 	fmt "fmt"
 	math "math"
 
-	proto "github.com/golang/protobuf/proto"
-	descriptor "github.com/golang/protobuf/protoc-gen-go/descriptor"
+	"github.com/golang/protobuf/proto"
+	"github.com/golang/protobuf/protoc-gen-go/descriptor"
 )
 
 // Reference imports to suppress errors if they are not otherwise used.


### PR DESCRIPTION
similar to [29144](https://github.com/ethereum/go-ethereum/pull/29144)