### PR TITLE
accounts/abi/bind: use SubscribeFilterLogs to simplify code

### DIFF
--- a/accounts/abi/bind/base.go
+++ b/accounts/abi/bind/base.go
@@ -454,24 +454,7 @@ func (c *BoundContract) FilterLogs(opts *FilterOpts, name string, query ...[]int
 	if opts.End != nil {
 		config.ToBlock = new(big.Int).SetUint64(*opts.End)
 	}
-	/* TODO(karalabe): Replace the rest of the method below with this when supported
 	sub, err := c.filterer.SubscribeFilterLogs(ensureContext(opts.Context), config, logs)
-	*/
-	buff, err := c.filterer.FilterLogs(ensureContext(opts.Context), config)
-	if err != nil {
-		return nil, nil, err
-	}
-	sub, err := event.NewSubscription(func(quit <-chan struct{}) error {
-		for _, log := range buff {
-			select {
-			case logs <- log:
-			case <-quit:
-				return nil
-			}
-		}
-		return nil
-	}), nil
-
 	if err != nil {
 		return nil, nil, err
 	}


### PR DESCRIPTION
FilterQuery with `FromBlock` is supported now,
so SubscribeFilterLogs can be used to  simplify code