### PR TITLE
node: fix test if directory already exists

### DIFF
--- a/node/node_test.go
+++ b/node/node_test.go
@@ -418,7 +418,9 @@ func TestRegisterHandler_Successful(t *testing.T) {
 // Tests that the given handler will not be successfully mounted since no HTTP server
 // is enabled for RPC
 func TestRegisterHandler_Unsuccessful(t *testing.T) {
-	node, err := New(&DefaultConfig)
+	cfg := DefaultConfig
+	cfg.DataDir = t.TempDir()
+	node, err := New(&cfg)
 	if err != nil {
 		t.Fatalf("could not create new node: %v", err)
 	}

--- a/node/node_test.go
+++ b/node/node_test.go
@@ -415,23 +415,6 @@ func TestRegisterHandler_Successful(t *testing.T) {
 	assert.Equal(t, "success", string(buf))
 }
 
-// Tests that the given handler will not be successfully mounted since no HTTP server
-// is enabled for RPC
-func TestRegisterHandler_Unsuccessful(t *testing.T) {
-	cfg := DefaultConfig
-	cfg.DataDir = t.TempDir()
-	node, err := New(&cfg)
-	if err != nil {
-		t.Fatalf("could not create new node: %v", err)
-	}
-
-	// create and mount handler
-	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Write([]byte("success"))
-	})
-	node.RegisterHandler("test", "/test", handler)
-}
-
 // Tests whether websocket requests can be handled on the same port as a regular http server.
 func TestWebsocketHTTPOnSamePort_WebsocketRequest(t *testing.T) {
 	node := startHTTP(t, 0, 0)


### PR DESCRIPTION
fixes
```
--- FAIL: TestRegisterHandler_Unsuccessful (0.00s)
    node_test.go:423: could not create new node: mkdir /home/matematik/.ethereum: file exists
FAIL
FAIL    github.com/ethereum/go-ethereum/node    2.549s
```