### PR TITLE
Improve aes-gcm performance

### DIFF
--- a/signer/storage/aes_gcm_storage.go
+++ b/signer/storage/aes_gcm_storage.go
@@ -159,9 +159,9 @@ func (s *AESEncryptedStorage) writeEncryptedStorage(creds map[string]storedCrede
 	return nil
 }
 
-func randBytes(size int) (blk []byte, err error) {
-	blk = make([]byte, size)
-	_, err = rand.Read(blk)
+func (s *AESEncryptedStorage) randBytes() (nonce []byte, err error) {
+	nonce = make([]byte, s.gcmNS)
+	_, err = io.ReadFull(rand.Reader, nonce)
 	return
 }
 
@@ -173,7 +173,7 @@ func (s *AESEncryptedStorage) encrypt(plaintext []byte, additionalData []byte) (
 	// key because of the risk of a repeat.
 	var n []byte
 
-	if n, err = randBytes(s.gcmNS); err != nil {
+	if n, err = s.randBytes(); err != nil {
 		return
 	}
 	return append(n, s.gcm.Seal(nil, n, plaintext, additionalData)...), n, nil

--- a/signer/storage/aes_gcm_storage.go
+++ b/signer/storage/aes_gcm_storage.go
@@ -22,6 +22,7 @@ import (
 	"crypto/rand"
 	"encoding/json"
 	"errors"
+	"io"
 	"os"
 
 	"github.com/ethereum/go-ethereum/log"

--- a/signer/storage/aes_gcm_storage_test.go
+++ b/signer/storage/aes_gcm_storage_test.go
@@ -160,3 +160,31 @@ func TestSwappedKeys(t *testing.T) {
 		t.Errorf("double-swapped value should work fine")
 	}
 }
+
+func BenchmarkEncryption(b *testing.B) {
+	storage := NewAESEncryptedStorage("test.json", []byte("x?^0^fIhNpSkTKbN"))
+
+	// Generate plaintext and additional data
+	plaintext := []byte("example plaintext")
+	additionalData := []byte("additional data")
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		// Encrypt plaintext
+		ciphertext, _, err := storage.encrypt(plaintext, additionalData)
+		if err != nil {
+			b.Fatalf("Encryption failed: %v", err)
+		}
+
+		// Decrypt ciphertext
+		decryptedPlaintext, err := storage.decrypt(ciphertext, additionalData)
+		if err != nil {
+			b.Fatalf("Decryption failed: %v", err)
+		}
+
+		// Verify decryption
+		if string(decryptedPlaintext) != string(plaintext) {
+			b.Fatalf("Decryption failed: plaintext mismatch")
+		}
+	}
+}

--- a/signer/storage/aes_gcm_storage_test.go
+++ b/signer/storage/aes_gcm_storage_test.go
@@ -36,13 +36,15 @@ func TestEncryption(t *testing.T) {
 	key := []byte("AES256Key-32Characters1234567890")
 	plaintext := []byte("exampleplaintext")
 
-	c, iv, err := encrypt(key, plaintext, nil)
+	aesStore := NewAESEncryptedStorage("", key)
+
+	c, iv, err := aesStore.encrypt(plaintext, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
 	t.Logf("Ciphertext %x, nonce %x\n", c, iv)
 
-	p, err := decrypt(key, iv, c, nil)
+	p, err := aesStore.decrypt(c, nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/signer/storage/aes_gcm_storage_test.go
+++ b/signer/storage/aes_gcm_storage_test.go
@@ -99,14 +99,15 @@ func TestEnd2End(t *testing.T) {
 
 	d := t.TempDir()
 
-	s1 := &AESEncryptedStorage{
-		filename: fmt.Sprintf("%v/vault.json", d),
-		key:      []byte("AES256Key-32Characters1234567890"),
-	}
-	s2 := &AESEncryptedStorage{
-		filename: fmt.Sprintf("%v/vault.json", d),
-		key:      []byte("AES256Key-32Characters1234567890"),
-	}
+	s1 := NewAESEncryptedStorage(
+		fmt.Sprintf("%v/vault.json", d),
+		[]byte("AES256Key-32Characters1234567890"),
+	)
+
+	s2 := NewAESEncryptedStorage(
+		fmt.Sprintf("%v/vault.json", d),
+		[]byte("AES256Key-32Characters1234567890"),
+	)
 
 	s1.Put("bazonk", "foobar")
 	if v, err := s2.Get("bazonk"); v != "foobar" || err != nil {
@@ -122,10 +123,10 @@ func TestSwappedKeys(t *testing.T) {
 
 	d := t.TempDir()
 
-	s1 := &AESEncryptedStorage{
-		filename: fmt.Sprintf("%v/vault.json", d),
-		key:      []byte("AES256Key-32Characters1234567890"),
-	}
+	s1 := NewAESEncryptedStorage(
+		fmt.Sprintf("%v/vault.json", d),
+		[]byte("AES256Key-32Characters1234567890"),
+	)
 	s1.Put("k1", "v1")
 	s1.Put("k2", "v2")
 	// Now make a modified copy


### PR DESCRIPTION
* this modification does not change the encryption method
##  before: 
``` 
goos: darwin
goarch: arm64
pkg: github.com/ethereum/go-ethereum/signer/storage
BenchmarkEncryption
BenchmarkEncryption-11    	 1306752	       906.1 ns/op
PASS
```  
## after:
 ``` 
goos: darwin
goarch: arm64
pkg: github.com/ethereum/go-ethereum/signer/storage
BenchmarkEncryption
BenchmarkEncryption-11    	 2077677	       545.8 ns/op
PASS
 ```