### PR TITLE
.mailmap: remove invalid email address

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -56,7 +56,6 @@ Diederik Loerakker <proto@protolambda.com>
 Dimitry Khokhlov <winsvega@mail.ru>
 
 Domino Valdano <dominoplural@gmail.com>
-Domino Valdano <dominoplural@gmail.com> <jeff@okcupid.com>
 
 Edgar Aroutiounian <edgar.factorial@gmail.com>
 


### PR DESCRIPTION
This was an old work email of mine that hasn't been valid since 2015.  git history also confirms it has never been associated with any commits to this repo, no idea how it ended up in this file