### PR TITLE
internal/jsre: format blob fields from hexdecimal to int 

### DIFF
--- a/internal/jsre/deps/web3.js
+++ b/internal/jsre/deps/web3.js
@@ -3840,11 +3840,17 @@ var outputBlockFormatter = function(block) {
     if (block.baseFeePerGas !== undefined) {
       block.baseFeePerGas = utils.toBigNumber(block.baseFeePerGas);
     }
+    if (block.blobGasUsed !== undefined) {
+      block.blobGasUsed = utils.toBigNumber(block.blobGasUsed);
+    }
+    if (block.excessBlobGas !== undefined) {
+      block.excessBlobGas = utils.toBigNumber(block.excessBlobGas);
+    }
     block.gasLimit = utils.toDecimal(block.gasLimit);
     block.gasUsed = utils.toDecimal(block.gasUsed);
     block.size = utils.toDecimal(block.size);
     block.timestamp = utils.toDecimal(block.timestamp);
-    if(block.number !== null)
+    if (block.number !== null)
         block.number = utils.toDecimal(block.number);
 
     block.difficulty = utils.toBigNumber(block.difficulty);

--- a/internal/jsre/deps/web3.js
+++ b/internal/jsre/deps/web3.js
@@ -3810,6 +3810,12 @@ var outputTransactionReceiptFormatter = function (receipt){
     if(receipt.effectiveGasPrice !== undefined) {
       receipt.effectiveGasPrice = utils.toBigNumber(receipt.effectiveGasPrice);
     }
+    if(receipt.blobGasPrice !== undefined) {
+      receipt.blobGasPrice = utils.toBigNumber(receipt.blobGasPrice);
+    }
+    if(receipt.blobGasUsed !== undefined) {
+      receipt.blobGasUsed = utils.toBigNumber(receipt.blobGasUsed);
+    }
     if(utils.isArray(receipt.logs)) {
         receipt.logs = receipt.logs.map(function(log){
             return outputLogFormatter(log);

--- a/internal/jsre/deps/web3.js
+++ b/internal/jsre/deps/web3.js
@@ -3734,7 +3734,7 @@ var inputCallFormatter = function (options){
         options.to = inputAddressFormatter(options.to);
     }
 
-    ['maxFeePerGas', 'maxPriorityFeePerGas', 'gasPrice', 'gas', 'value', 'nonce'].filter(function (key) {
+    ['maxFeePerBlobGas', 'maxFeePerGas', 'maxPriorityFeePerGas', 'gasPrice', 'gas', 'value', 'nonce'].filter(function (key) {
         return options[key] !== undefined;
     }).forEach(function(key){
         options[key] = utils.fromDecimal(options[key]);
@@ -3759,7 +3759,7 @@ var inputTransactionFormatter = function (options){
         options.to = inputAddressFormatter(options.to);
     }
 
-    ['maxFeePerGas', 'maxPriorityFeePerGas', 'gasPrice', 'gas', 'value', 'nonce'].filter(function (key) {
+    ['maxFeePerBlobGas', 'maxFeePerGas', 'maxPriorityFeePerGas', 'gasPrice', 'gas', 'value', 'nonce'].filter(function (key) {
         return options[key] !== undefined;
     }).forEach(function(key){
         options[key] = utils.fromDecimal(options[key]);
@@ -3788,6 +3788,9 @@ var outputTransactionFormatter = function (tx){
     }
     if(tx.maxPriorityFeePerGas !== undefined) {
       tx.maxPriorityFeePerGas = utils.toBigNumber(tx.maxPriorityFeePerGas);
+    }
+    if(tx.maxFeePerBlobGas !== undefined) {
+      tx.maxFeePerBlobGas = utils.toBigNumber(tx.maxFeePerBlobGas);
     }
     tx.value = utils.toBigNumber(tx.value);
     return tx;


### PR DESCRIPTION
In the geth's console, the output of `blob` related fields not formated:


<img width="775" alt="image" src="https://github.com/ethereum/go-ethereum/assets/3627395/c1130701-5a91-44c8-8587-d5760ccb8015">
