### PR TITLE
accounts: remove redundant string conversion

### DIFF
--- a/accounts/accounts.go
+++ b/accounts/accounts.go
@@ -195,7 +195,7 @@ func TextHash(data []byte) []byte {
 //
 // This gives context to the signed message and prevents signing of transactions.
 func TextAndHash(data []byte) ([]byte, string) {
-	msg := fmt.Sprintf("\x19Ethereum Signed Message:\n%d%s", len(data), string(data))
+	msg := fmt.Sprintf("\x19Ethereum Signed Message:\n%d%s", len(data), data)
 	hasher := sha3.NewLegacyKeccak256()
 	hasher.Write([]byte(msg))
 	return hasher.Sum(nil), msg


### PR DESCRIPTION
This conversion is unnecessary, the bottom layer will do it, and it is omitted to save overhead.

For more information, please refer to go’s official modifications https://go-review.googlesource.com/c/go/+/520918/1/src/os/exec/lp_windows_test.go#b48