### PR TITLE
metrics: change r/wchar to read/write_bytes

### DIFF
--- a/metrics/disk_linux.go
+++ b/metrics/disk_linux.go
@@ -63,9 +63,9 @@ func ReadDiskStats(stats *DiskStats) error {
 			stats.ReadCount = value
 		case "syscw":
 			stats.WriteCount = value
-		case "rchar":
+		case "read_bytes":
 			stats.ReadBytes = value
-		case "wchar":
+		case "write_bytes":
 			stats.WriteBytes = value
 		}
 	}


### PR DESCRIPTION
In the context of disk information within a process, "rchar" and "readbytes" are two distinct metrics that measure the performance of disk read operations. The key differences and the aspects they focus on:


- rchar measures the total number of characters read from the disk, regardless of whether these characters are cached. This includes characters read into the cache as well as those read directly from the disk. It is a broader metric, taking into account all data read from the disk.

- readbytes measures the actual number of bytes read from the disk to the user space. Unlike rchar, readbytes does not include data read into the cache; it focuses solely on the amount of data transmitted to the application. This provides a more accurate reflection of the impact of disk reads on the application.

In some cases, the value of rchar may be greater than that of readbytes, as rchar considers all read operations, including data read into the cache. 

However, when analyzing the impact of the disk on geth's performance, readbytes is typically more useful.