### PR TITLE
params: use the same variable name as EIP-4788

### DIFF
--- a/core/chain_makers_test.go
+++ b/core/chain_makers_test.go
@@ -47,7 +47,7 @@ func TestGeneratePOSChain(t *testing.T) {
 		gspec   = &Genesis{
 			Config: &config,
 			Alloc: types.GenesisAlloc{
-				address:                          {Balance: funds},
+				address:                   {Balance: funds},
 				params.BeaconRootsAddress: {Balance: common.Big0, Code: asm4788},
 			},
 			BaseFee:    big.NewInt(params.InitialBaseFee),

--- a/core/chain_makers_test.go
+++ b/core/chain_makers_test.go
@@ -48,7 +48,7 @@ func TestGeneratePOSChain(t *testing.T) {
 			Config: &config,
 			Alloc: types.GenesisAlloc{
 				address:                          {Balance: funds},
-				params.BeaconRootsStorageAddress: {Balance: common.Big0, Code: asm4788},
+				params.BeaconRootsAddress: {Balance: common.Big0, Code: asm4788},
 			},
 			BaseFee:    big.NewInt(params.InitialBaseFee),
 			Difficulty: common.Big1,
@@ -180,7 +180,7 @@ func TestGeneratePOSChain(t *testing.T) {
 		}
 		state, _ := blockchain.State()
 		idx := block.Time()%8191 + 8191
-		got := state.GetState(params.BeaconRootsStorageAddress, common.BigToHash(new(big.Int).SetUint64(idx)))
+		got := state.GetState(params.BeaconRootsAddress, common.BigToHash(new(big.Int).SetUint64(idx)))
 		if got != want {
 			t.Fatalf("block %d, wrong parent beacon root in state: got %s, want %s", i, got, want)
 		}

--- a/core/state_processor.go
+++ b/core/state_processor.go
@@ -181,11 +181,11 @@ func ProcessBeaconBlockRoot(beaconRoot common.Hash, vmenv *vm.EVM, statedb *stat
 		GasPrice:  common.Big0,
 		GasFeeCap: common.Big0,
 		GasTipCap: common.Big0,
-		To:        &params.BeaconRootsStorageAddress,
+		To:        &params.BeaconRootsAddress,
 		Data:      beaconRoot[:],
 	}
 	vmenv.Reset(NewEVMTxContext(msg), statedb)
-	statedb.AddAddressToAccessList(params.BeaconRootsStorageAddress)
+	statedb.AddAddressToAccessList(params.BeaconRootsAddress)
 	_, _, _ = vmenv.Call(vm.AccountRef(msg.From), *msg.To, msg.Data, 30_000_000, common.U2560)
 	statedb.Finalise(true)
 }

--- a/eth/catalyst/api_test.go
+++ b/eth/catalyst/api_test.go
@@ -72,7 +72,7 @@ func generateMergeChain(n int, merged bool) (*core.Genesis, []*types.Block) {
 	genesis := &core.Genesis{
 		Config: &config,
 		Alloc: types.GenesisAlloc{
-			testAddr:                         {Balance: testBalance},
+			testAddr:                  {Balance: testBalance},
 			params.BeaconRootsAddress: {Balance: common.Big0, Code: common.Hex2Bytes("3373fffffffffffffffffffffffffffffffffffffffe14604457602036146024575f5ffd5b620180005f350680545f35146037575f5ffd5b6201800001545f5260205ff35b6201800042064281555f359062018000015500")},
 		},
 		ExtraData:  []byte("test genesis"),

--- a/eth/catalyst/api_test.go
+++ b/eth/catalyst/api_test.go
@@ -73,7 +73,7 @@ func generateMergeChain(n int, merged bool) (*core.Genesis, []*types.Block) {
 		Config: &config,
 		Alloc: types.GenesisAlloc{
 			testAddr:                         {Balance: testBalance},
-			params.BeaconRootsStorageAddress: {Balance: common.Big0, Code: common.Hex2Bytes("3373fffffffffffffffffffffffffffffffffffffffe14604457602036146024575f5ffd5b620180005f350680545f35146037575f5ffd5b6201800001545f5260205ff35b6201800042064281555f359062018000015500")},
+			params.BeaconRootsAddress: {Balance: common.Big0, Code: common.Hex2Bytes("3373fffffffffffffffffffffffffffffffffffffffe14604457602036146024575f5ffd5b620180005f350680545f35146037575f5ffd5b6201800001545f5260205ff35b6201800042064281555f359062018000015500")},
 		},
 		ExtraData:  []byte("test genesis"),
 		Timestamp:  9000,
@@ -1650,10 +1650,10 @@ func TestParentBeaconBlockRoot(t *testing.T) {
 		rootIdx = common.BigToHash(big.NewInt(int64((execData.ExecutionPayload.Timestamp % 98304) + 98304)))
 	)
 
-	if num := db.GetState(params.BeaconRootsStorageAddress, timeIdx); num != timeIdx {
+	if num := db.GetState(params.BeaconRootsAddress, timeIdx); num != timeIdx {
 		t.Fatalf("incorrect number stored: want %s, got %s", timeIdx, num)
 	}
-	if root := db.GetState(params.BeaconRootsStorageAddress, rootIdx); root != *blockParams.BeaconRoot {
+	if root := db.GetState(params.BeaconRootsAddress, rootIdx); root != *blockParams.BeaconRoot {
 		t.Fatalf("incorrect root stored: want %s, got %s", *blockParams.BeaconRoot, root)
 	}
 }

--- a/params/protocol_params.go
+++ b/params/protocol_params.go
@@ -184,8 +184,8 @@ var (
 	MinimumDifficulty      = big.NewInt(131072) // The minimum that the difficulty may ever be.
 	DurationLimit          = big.NewInt(13)     // The decision boundary on the blocktime duration used to determine whether difficulty should go up or not.
 
-	// BeaconRootsStorageAddress is the address where historical beacon roots are stored as per EIP-4788
-	BeaconRootsStorageAddress = common.HexToAddress("0x000F3df6D732807Ef1319fB7B8bB8522d0Beac02")
+	// BeaconRootsAddress is the address where historical beacon roots are stored as per EIP-4788
+	BeaconRootsAddress = common.HexToAddress("0x000F3df6D732807Ef1319fB7B8bB8522d0Beac02")
 	// SystemAddress is where the system-transaction is sent from as per EIP-4788
-	SystemAddress common.Address = common.HexToAddress("0xfffffffffffffffffffffffffffffffffffffffe")
+	SystemAddress = common.HexToAddress("0xfffffffffffffffffffffffffffffffffffffffe")
 )


### PR DESCRIPTION
in https://eips.ethereum.org/EIPS/eip-4788 we use `BEACON_ROOTS_ADDRESS`, this should be better to use the same variable name to avoid confusion, so people will know if this is a contract address, not a contract storage key slot address