### PR TITLE
gethclient: add blob transaction fields in toCallArg

### DIFF
--- a/ethclient/gethclient/gethclient.go
+++ b/ethclient/gethclient/gethclient.go
@@ -245,6 +245,12 @@ func toCallArg(msg ethereum.CallMsg) interface{} {
 	if msg.AccessList != nil {
 		arg["accessList"] = msg.AccessList
 	}
+	if msg.BlobGasFeeCap != nil {
+		arg["maxFeePerBlobGas"] = (*hexutil.Big)(msg.BlobGasFeeCap)
+	}
+	if msg.BlobHashes != nil {
+		arg["blobVersionedHashes"] = msg.BlobHashes
+	}
 	return arg
 }
 


### PR DESCRIPTION
`eth_createAccessList` and `eth_call` will use `blobVersionedHashes` if the transaction is a contract call and the contract uses `blobhash` opcode. Otherwise, the simulation would fail.