### PR TITLE
common/math: delete unused function Exp

### DIFF
--- a/common/math/big.go
+++ b/common/math/big.go
@@ -248,23 +248,3 @@ func S256(x *big.Int) *big.Int {
 	}
 	return new(big.Int).Sub(x, tt256)
 }
-
-// Exp implements exponentiation by squaring.
-// Exp returns a newly-allocated big integer and does not change
-// base or exponent. The result is truncated to 256 bits.
-//
-// Courtesy @karalabe and @chfast
-func Exp(base, exponent *big.Int) *big.Int {
-	result := big.NewInt(1)
-
-	for _, word := range exponent.Bits() {
-		for i := 0; i < wordBits; i++ {
-			if word&1 == 1 {
-				U256(result.Mul(result, base))
-			}
-			U256(base.Mul(base, base))
-			word >>= 1
-		}
-	}
-	return result
-}

--- a/common/math/big_test.go
+++ b/common/math/big_test.go
@@ -306,19 +306,3 @@ func TestS256(t *testing.T) {
 		}
 	}
 }
-
-func TestExp(t *testing.T) {
-	tests := []struct{ base, exponent, result *big.Int }{
-		{base: big.NewInt(0), exponent: big.NewInt(0), result: big.NewInt(1)},
-		{base: big.NewInt(1), exponent: big.NewInt(0), result: big.NewInt(1)},
-		{base: big.NewInt(1), exponent: big.NewInt(1), result: big.NewInt(1)},
-		{base: big.NewInt(1), exponent: big.NewInt(2), result: big.NewInt(1)},
-		{base: big.NewInt(3), exponent: big.NewInt(144), result: MustParseBig256("507528786056415600719754159741696356908742250191663887263627442114881")},
-		{base: big.NewInt(2), exponent: big.NewInt(255), result: MustParseBig256("57896044618658097711785492504343953926634992332820282019728792003956564819968")},
-	}
-	for _, test := range tests {
-		if result := Exp(test.base, test.exponent); result.Cmp(test.result) != 0 {
-			t.Errorf("Exp(%d, %d) = %d, want %d", test.base, test.exponent, result, test.result)
-		}
-	}
-}


### PR DESCRIPTION
The function Exp in common/math/big.go is not used in the code base anymore. The package uint256 or big.Int is preferred if needed.