### PR TITLE
Update README.md to indicate go >= 1.20

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ archives are published at https://geth.ethereum.org/downloads/.
 
 For prerequisites and detailed build instructions please read the [Installation Instructions](https://geth.ethereum.org/docs/getting-started/installing-geth).
 
-Building `geth` requires both a Go (version 1.19 or later) and a C compiler. You can install
+Building `geth` requires both a Go (version 1.20 or later) and a C compiler. You can install
 them using your favourite package manager. Once the dependencies are installed, run
 
 ```shell


### PR DESCRIPTION


```
go run build/ci.go install ./cmd/geth
[...]
# github.com/cockroachdb/pebble/vfs
../go/pkg/mod/github.com/cockroachdb/pebble@v0.0.0-20230928194634-aa077af62593/vfs/mem_fs.go:469:29: y.lockedFiles.Swap undefined (type sync.Map has no field or method Swap)
note: module requires Go 1.20
```