### PR TITLE
crypto: remove a moot todo

### DIFF
--- a/crypto/secp256k1/secp256_test.go
+++ b/crypto/secp256k1/secp256_test.go
@@ -160,9 +160,6 @@ func signAndRecoverWithRandomMessages(t *testing.T, keys func() ([]byte, []byte)
 		}
 		compactSigCheck(t, sig)
 
-		// TODO: why do we flip around the recovery id?
-		sig[len(sig)-1] %= 4
-
 		pubkey2, err := RecoverPubkey(msg, sig)
 		if err != nil {
 			t.Fatalf("recover error: %s", err)


### PR DESCRIPTION
the recover id is already bound to [0, 3],
refer to https://github.com/bitcoin-core/secp256k1/blob/master/src/ctime_tests.c#L128