### PR TITLE
cmd: use package filepath over path for file system operations

### DIFF
--- a/cmd/devp2p/internal/ethtest/chain.go
+++ b/cmd/devp2p/internal/ethtest/chain.go
@@ -26,7 +26,7 @@ import (
 	"io"
 	"math/big"
 	"os"
-	"path"
+	"path/filepath"
 	"sort"
 	"strings"
 
@@ -56,21 +56,21 @@ type Chain struct {
 // NewChain takes the given chain.rlp file, and decodes and returns
 // the blocks from the file.
 func NewChain(dir string) (*Chain, error) {
-	gen, err := loadGenesis(path.Join(dir, "genesis.json"))
+	gen, err := loadGenesis(filepath.Join(dir, "genesis.json"))
 	if err != nil {
 		return nil, err
 	}
 	gblock := gen.ToBlock()
 
-	blocks, err := blocksFromFile(path.Join(dir, "chain.rlp"), gblock)
+	blocks, err := blocksFromFile(filepath.Join(dir, "chain.rlp"), gblock)
 	if err != nil {
 		return nil, err
 	}
-	state, err := readState(path.Join(dir, "headstate.json"))
+	state, err := readState(filepath.Join(dir, "headstate.json"))
 	if err != nil {
 		return nil, err
 	}
-	accounts, err := readAccounts(path.Join(dir, "accounts.json"))
+	accounts, err := readAccounts(filepath.Join(dir, "accounts.json"))
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/devp2p/internal/ethtest/engine.go
+++ b/cmd/devp2p/internal/ethtest/engine.go
@@ -22,7 +22,7 @@ import (
 	"io"
 	"net/http"
 	"os"
-	"path"
+	"path/filepath"
 	"time"
 
 	"github.com/ethereum/go-ethereum/common"
@@ -38,7 +38,7 @@ type EngineClient struct {
 
 // NewEngineClient creates a new engine client.
 func NewEngineClient(dir, url, jwt string) (*EngineClient, error) {
-	headfcu, err := os.ReadFile(path.Join(dir, "headfcu.json"))
+	headfcu, err := os.ReadFile(filepath.Join(dir, "headfcu.json"))
 	if err != nil {
 		return nil, fmt.Errorf("failed to read headfcu: %w", err)
 	}

--- a/cmd/devp2p/internal/ethtest/suite_test.go
+++ b/cmd/devp2p/internal/ethtest/suite_test.go
@@ -20,7 +20,7 @@ import (
 	crand "crypto/rand"
 	"fmt"
 	"os"
-	"path"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -39,7 +39,7 @@ func makeJWTSecret() (string, [32]byte, error) {
 	if _, err := crand.Read(secret[:]); err != nil {
 		return "", secret, fmt.Errorf("failed to create jwt secret: %v", err)
 	}
-	jwtPath := path.Join(os.TempDir(), "jwt_secret")
+	jwtPath := filepath.Join(os.TempDir(), "jwt_secret")
 	if err := os.WriteFile(jwtPath, []byte(hexutil.Encode(secret[:])), 0600); err != nil {
 		return "", secret, fmt.Errorf("failed to prepare jwt secret file: %v", err)
 	}

--- a/cmd/era/main.go
+++ b/cmd/era/main.go
@@ -22,7 +22,7 @@ import (
 	"fmt"
 	"math/big"
 	"os"
-	"path"
+	"path/filepath"
 	"strconv"
 	"strings"
 	"time"
@@ -176,7 +176,7 @@ func open(ctx *cli.Context, epoch uint64) (*era.Era, error) {
 	if epoch >= uint64(len(entries)) {
 		return nil, fmt.Errorf("epoch out-of-bounds: last %d, want %d", len(entries)-1, epoch)
 	}
-	return era.Open(path.Join(dir, entries[epoch]))
+	return era.Open(filepath.Join(dir, entries[epoch]))
 }
 
 // verify checks each era1 file in a directory to ensure it is well-formed and
@@ -212,7 +212,7 @@ func verify(ctx *cli.Context) error {
 		// Wrap in function so defers don't stack.
 		err := func() error {
 			name := entries[i]
-			e, err := era.Open(path.Join(dir, name))
+			e, err := era.Open(filepath.Join(dir, name))
 			if err != nil {
 				return fmt.Errorf("error opening era1 file %s: %w", name, err)
 			}

--- a/cmd/evm/internal/t8ntool/transition.go
+++ b/cmd/evm/internal/t8ntool/transition.go
@@ -22,7 +22,7 @@ import (
 	"fmt"
 	"math/big"
 	"os"
-	"path"
+	"path/filepath"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
@@ -96,7 +96,7 @@ func Transition(ctx *cli.Context) error {
 			Debug:            true,
 		}
 		getTracer = func(txIndex int, txHash common.Hash) (vm.EVMLogger, error) {
-			traceFile, err := os.Create(path.Join(baseDir, fmt.Sprintf("trace-%d-%v.jsonl", txIndex, txHash.String())))
+			traceFile, err := os.Create(filepath.Join(baseDir, fmt.Sprintf("trace-%d-%v.jsonl", txIndex, txHash.String())))
 			if err != nil {
 				return nil, NewError(ErrorIO, fmt.Errorf("failed creating trace-file: %v", err))
 			}
@@ -108,7 +108,7 @@ func Transition(ctx *cli.Context) error {
 			config = []byte(ctx.String(TraceTracerConfigFlag.Name))
 		}
 		getTracer = func(txIndex int, txHash common.Hash) (vm.EVMLogger, error) {
-			traceFile, err := os.Create(path.Join(baseDir, fmt.Sprintf("trace-%d-%v.json", txIndex, txHash.String())))
+			traceFile, err := os.Create(filepath.Join(baseDir, fmt.Sprintf("trace-%d-%v.json", txIndex, txHash.String())))
 			if err != nil {
 				return nil, NewError(ErrorIO, fmt.Errorf("failed creating trace-file: %v", err))
 			}
@@ -302,7 +302,7 @@ func saveFile(baseDir, filename string, data interface{}) error {
 	if err != nil {
 		return NewError(ErrorJson, fmt.Errorf("failed marshalling output: %v", err))
 	}
-	location := path.Join(baseDir, filename)
+	location := filepath.Join(baseDir, filename)
 	if err = os.WriteFile(location, b, 0644); err != nil {
 		return NewError(ErrorIO, fmt.Errorf("failed writing output: %v", err))
 	}

--- a/cmd/utils/cmd.go
+++ b/cmd/utils/cmd.go
@@ -27,7 +27,7 @@ import (
 	"io"
 	"os"
 	"os/signal"
-	"path"
+	"path/filepath"
 	"runtime"
 	"strings"
 	"syscall"
@@ -251,7 +251,7 @@ func ImportHistory(chain *core.BlockChain, db ethdb.Database, dir string, networ
 	if err != nil {
 		return fmt.Errorf("error reading %s: %w", dir, err)
 	}
-	checksums, err := readList(path.Join(dir, "checksums.txt"))
+	checksums, err := readList(filepath.Join(dir, "checksums.txt"))
 	if err != nil {
 		return fmt.Errorf("unable to read checksums.txt: %w", err)
 	}
@@ -268,7 +268,7 @@ func ImportHistory(chain *core.BlockChain, db ethdb.Database, dir string, networ
 	)
 	for i, filename := range entries {
 		err := func() error {
-			f, err := os.Open(path.Join(dir, filename))
+			f, err := os.Open(filepath.Join(dir, filename))
 			if err != nil {
 				return fmt.Errorf("unable to open era: %w", err)
 			}
@@ -425,7 +425,7 @@ func ExportHistory(bc *core.BlockChain, dir string, first, last, step uint64) er
 	)
 	for i := first; i <= last; i += step {
 		err := func() error {
-			filename := path.Join(dir, era.Filename(network, int(i/step), common.Hash{}))
+			filename := filepath.Join(dir, era.Filename(network, int(i/step), common.Hash{}))
 			f, err := os.Create(filename)
 			if err != nil {
 				return fmt.Errorf("could not create era file: %w", err)
@@ -458,7 +458,7 @@ func ExportHistory(bc *core.BlockChain, dir string, first, last, step uint64) er
 				return fmt.Errorf("export failed to finalize %d: %w", step/i, err)
 			}
 			// Set correct filename with root.
-			os.Rename(filename, path.Join(dir, era.Filename(network, int(i/step), root)))
+			os.Rename(filename, filepath.Join(dir, era.Filename(network, int(i/step), root)))
 
 			// Compute checksum of entire Era1.
 			if _, err := f.Seek(0, io.SeekStart); err != nil {
@@ -481,7 +481,7 @@ func ExportHistory(bc *core.BlockChain, dir string, first, last, step uint64) er
 		}
 	}
 
-	os.WriteFile(path.Join(dir, "checksums.txt"), []byte(strings.Join(checksums, "\n")), os.ModePerm)
+	os.WriteFile(filepath.Join(dir, "checksums.txt"), []byte(strings.Join(checksums, "\n")), os.ModePerm)
 
 	log.Info("Exported blockchain to", "dir", dir)
 

--- a/cmd/utils/history_test.go
+++ b/cmd/utils/history_test.go
@@ -22,7 +22,7 @@ import (
 	"io"
 	"math/big"
 	"os"
-	"path"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -99,7 +99,7 @@ func TestHistoryImportAndExport(t *testing.T) {
 	}
 
 	// Read checksums.
-	b, err := os.ReadFile(path.Join(dir, "checksums.txt"))
+	b, err := os.ReadFile(filepath.Join(dir, "checksums.txt"))
 	if err != nil {
 		t.Fatalf("failed to read checksums: %v", err)
 	}
@@ -109,7 +109,7 @@ func TestHistoryImportAndExport(t *testing.T) {
 	entries, _ := era.ReadDir(dir, "mainnet")
 	for i, filename := range entries {
 		func() {
-			f, err := os.Open(path.Join(dir, filename))
+			f, err := os.Open(filepath.Join(dir, filename))
 			if err != nil {
 				t.Fatalf("error opening era file: %v", err)
 			}

--- a/core/blockchain_repair_test.go
+++ b/core/blockchain_repair_test.go
@@ -22,7 +22,7 @@ package core
 
 import (
 	"math/big"
-	"path"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -1762,7 +1762,7 @@ func testRepairWithScheme(t *testing.T, tt *rewindTest, snapshots bool, scheme s
 
 	// Create a temporary persistent database
 	datadir := t.TempDir()
-	ancient := path.Join(datadir, "ancient")
+	ancient := filepath.Join(datadir, "ancient")
 
 	db, err := rawdb.Open(rawdb.OpenOptions{
 		Directory:         datadir,
@@ -1912,7 +1912,7 @@ func testIssue23496(t *testing.T, scheme string) {
 
 	// Create a temporary persistent database
 	datadir := t.TempDir()
-	ancient := path.Join(datadir, "ancient")
+	ancient := filepath.Join(datadir, "ancient")
 
 	db, err := rawdb.Open(rawdb.OpenOptions{
 		Directory:         datadir,

--- a/core/blockchain_snapshot_test.go
+++ b/core/blockchain_snapshot_test.go
@@ -24,7 +24,7 @@ import (
 	"fmt"
 	"math/big"
 	"os"
-	"path"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -63,7 +63,7 @@ type snapshotTestBasic struct {
 func (basic *snapshotTestBasic) prepare(t *testing.T) (*BlockChain, []*types.Block) {
 	// Create a temporary persistent database
 	datadir := t.TempDir()
-	ancient := path.Join(datadir, "ancient")
+	ancient := filepath.Join(datadir, "ancient")
 
 	db, err := rawdb.Open(rawdb.OpenOptions{
 		Directory:         datadir,

--- a/core/rawdb/freezer_test.go
+++ b/core/rawdb/freezer_test.go
@@ -24,6 +24,7 @@ import (
 	"math/rand"
 	"os"
 	"path"
+	"path/filepath"
 	"sync"
 	"testing"
 
@@ -393,7 +394,7 @@ func TestRenameWindows(t *testing.T) {
 	dir2 := t.TempDir()
 
 	// Create file in dir1 and fill with data
-	f, err := os.Create(path.Join(dir1, fname))
+	f, err := os.Create(filepath.Join(dir1, fname))
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
// Package filepath implements utility routines for manipulating filename paths
// in a way compatible with the target operating system-defined file paths.
//
// The filepath package uses either forward slashes or backslashes,
// depending on the operating system. To process paths such as URLs
// that always use forward slashes regardless of the operating
// system, see the path package.


// Package path implements utility routines for manipulating slash-separated
// paths.
//
// The path package should only be used for paths separated by forward
// slashes, such as the paths in URLs. This package does not deal with
// Windows paths with drive letters or backslashes; to manipulate
// operating system paths, use the path/filepath package.

Filepath is used to process file paths, path is used to process url paths