### PR TITLE
consensus/beacon,core, params, trie: verkle-compatible access list

### DIFF
--- a/consensus/beacon/consensus.go
+++ b/consensus/beacon/consensus.go
@@ -348,9 +348,9 @@ func (beacon *Beacon) Prepare(chain consensus.ChainHeaderReader, header *types.H
 }
 
 // Finalize implements consensus.Engine and processes withdrawals on top.
-func (beacon *Beacon) Finalize(chain consensus.ChainHeaderReader, header *types.Header, state *state.StateDB, txs []*types.Transaction, uncles []*types.Header, withdrawals []*types.Withdrawal) {
+func (beacon *Beacon) Finalize(chain consensus.ChainHeaderReader, header *types.Header, statedb *state.StateDB, txs []*types.Transaction, uncles []*types.Header, withdrawals []*types.Withdrawal) {
 	if !beacon.IsPoSHeader(header) {
-		beacon.ethone.Finalize(chain, header, state, txs, uncles, nil)
+		beacon.ethone.Finalize(chain, header, statedb, txs, uncles, nil)
 		return
 	}
 	// Withdrawals processing.
@@ -358,7 +358,11 @@ func (beacon *Beacon) Finalize(chain consensus.ChainHeaderReader, header *types.
 		// Convert amount from gwei to wei.
 		amount := new(uint256.Int).SetUint64(w.Amount)
 		amount = amount.Mul(amount, uint256.NewInt(params.GWei))
-		state.AddBalance(w.Address, amount)
+		statedb.AddBalance(w.Address, amount)
+
+		if chain.Config().IsVerkle(header.Number, header.Time) {
+			statedb.Witness().AddAddress(w.Address, state.ALAllItems, state.AccessListWrite)
+		}
 	}
 	// No block reward which is issued by consensus layer instead.
 }

--- a/core/error.go
+++ b/core/error.go
@@ -67,6 +67,10 @@ var (
 	// than init code size limit.
 	ErrMaxInitCodeSizeExceeded = errors.New("max initcode size exceeded")
 
+	// ErrInsufficientBalanceWitness is returned if the transaction sender does not
+	// have enough funds to cover the witness access costs.
+	ErrInsufficientBalanceWitness = errors.New("insufficient funds to cover witness access costs for transaction")
+
 	// ErrInsufficientFunds is returned if the total cost of executing a transaction
 	// is higher than the balance of the user's account.
 	ErrInsufficientFunds = errors.New("insufficient funds for gas * price + value")

--- a/core/state/access_witness.go
+++ b/core/state/access_witness.go
@@ -1,0 +1,260 @@
+// Copyright 2021 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+
+package state
+
+import (
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/params"
+	"github.com/ethereum/go-ethereum/trie/utils"
+	"github.com/holiman/uint256"
+)
+
+// mode specifies how a tree location has been accessed
+// for the byte value:
+// * the first bit is set if the branch has been edited
+// * the second bit is set if the branch has been read
+type mode byte
+
+const (
+	AccessWitnessReadFlag  = mode(1)
+	AccessWitnessWriteFlag = mode(2)
+)
+
+var zeroTreeIndex uint256.Int
+
+// AccessWitness lists the locations of the state that are being accessed
+// during the production of a block.
+type AccessWitness struct {
+	branches map[branchAccessKey]mode
+	chunks   map[chunkAccessKey]mode
+
+	pointCache *utils.PointCache
+}
+
+func NewAccessWitness() *AccessWitness {
+	return &AccessWitness{
+		branches:   make(map[branchAccessKey]mode),
+		chunks:     make(map[chunkAccessKey]mode),
+		pointCache: utils.NewPointCache(),
+	}
+}
+
+// Merge is used to merge the witness that got generated during the execution
+// of a tx, with the accumulation of witnesses that were generated during the
+// execution of all the txs preceding this one in a given block.
+func (aw *AccessWitness) Merge(o AccessList) {
+	other := o.(*AccessWitness)
+	for k := range other.branches {
+		aw.branches[k] |= other.branches[k]
+	}
+	for k, chunk := range other.chunks {
+		aw.chunks[k] |= chunk
+	}
+}
+
+// Key returns, predictably, the list of keys that were touched during the
+// buildup of the access witness.
+func (aw *AccessWitness) Keys() [][]byte {
+	// TODO: consider if parallelizing this is worth it, probably depending on len(aw.chunks).
+	keys := make([][]byte, 0, len(aw.chunks))
+	for chunk := range aw.chunks {
+		basePoint := aw.pointCache.GetTreeKeyHeader(chunk.addr[:])
+		key := utils.GetTreeKeyWithEvaluatedAddess(basePoint, &chunk.treeIndex, chunk.leafKey)
+		keys = append(keys, key)
+	}
+	return keys
+}
+
+func (aw *AccessWitness) Copy() AccessList {
+	naw := &AccessWitness{
+		branches:   make(map[branchAccessKey]mode),
+		chunks:     make(map[chunkAccessKey]mode),
+		pointCache: aw.pointCache,
+	}
+	naw.Merge(aw)
+	return naw
+}
+
+func (aw *AccessWitness) TouchAndChargeValueTransfer(callerAddr, targetAddr []byte) uint64 {
+	var gas uint64
+	gas += aw.touchAddressAndChargeGas(callerAddr, zeroTreeIndex, utils.BalanceLeafKey, AccessListWrite)
+	gas += aw.touchAddressAndChargeGas(targetAddr, zeroTreeIndex, utils.BalanceLeafKey, AccessListWrite)
+	return gas
+}
+
+// TouchAndChargeContractCreateInit charges access costs to initiate
+// a contract creation
+func (aw *AccessWitness) TouchAndChargeContractCreateInit(addr []byte, createSendsValue bool) uint64 {
+	var gas uint64
+	gas += aw.touchAddressAndChargeGas(addr, zeroTreeIndex, utils.VersionLeafKey, AccessListWrite)
+	gas += aw.touchAddressAndChargeGas(addr, zeroTreeIndex, utils.NonceLeafKey, AccessListWrite)
+	// FIXME note that this is incompatible with the spec
+	if createSendsValue {
+		gas += aw.touchAddressAndChargeGas(addr, zeroTreeIndex, utils.BalanceLeafKey, AccessListWrite)
+	}
+	return gas
+}
+
+func (aw *AccessWitness) TouchTxOriginAndComputeGas(originAddr []byte) uint64 {
+	aw.touchAddressAndChargeGas(originAddr, zeroTreeIndex, utils.VersionLeafKey, AccessListRead)
+	aw.touchAddressAndChargeGas(originAddr, zeroTreeIndex, utils.CodeSizeLeafKey, AccessListRead)
+	aw.touchAddressAndChargeGas(originAddr, zeroTreeIndex, utils.CodeKeccakLeafKey, AccessListRead)
+	aw.touchAddressAndChargeGas(originAddr, zeroTreeIndex, utils.NonceLeafKey, AccessListWrite)
+	aw.touchAddressAndChargeGas(originAddr, zeroTreeIndex, utils.BalanceLeafKey, AccessListWrite)
+
+	// Kaustinen note: we're currently experimenting with stop chargin gas for the origin address
+	// so simple transfer still take 21000 gas. This is to potentially avoid breaking existing tooling.
+	// This is the reason why we return 0 instead of `gas`.
+	// Note that we still have to touch the addresses to make sure the witness is correct.
+	return 0
+}
+
+func (aw *AccessWitness) TouchTxExistingAndComputeGas(targetAddr []byte, sendsValue bool) uint64 {
+	aw.touchAddressAndChargeGas(targetAddr, zeroTreeIndex, utils.VersionLeafKey, AccessListRead)
+	aw.touchAddressAndChargeGas(targetAddr, zeroTreeIndex, utils.CodeSizeLeafKey, AccessListRead)
+	aw.touchAddressAndChargeGas(targetAddr, zeroTreeIndex, utils.CodeKeccakLeafKey, AccessListRead)
+	aw.touchAddressAndChargeGas(targetAddr, zeroTreeIndex, utils.NonceLeafKey, AccessListRead)
+	if sendsValue {
+		aw.touchAddressAndChargeGas(targetAddr, zeroTreeIndex, utils.BalanceLeafKey, AccessListWrite)
+	} else {
+		aw.touchAddressAndChargeGas(targetAddr, zeroTreeIndex, utils.BalanceLeafKey, AccessListRead)
+	}
+
+	// Kaustinen note: we're currently experimenting with stop chargin gas for the origin address
+	// so simple transfer still take 21000 gas. This is to potentially avoid breaking existing tooling.
+	// This is the reason why we return 0 instead of `gas`.
+	// Note that we still have to touch the addresses to make sure the witness is correct.
+	return 0
+}
+
+func (aw *AccessWitness) TouchAddressOnReadAndComputeGas(addr []byte, treeIndex uint256.Int, subIndex byte) uint64 {
+	return aw.touchAddressAndChargeGas(addr, treeIndex, subIndex, AccessListRead)
+}
+
+func (aw *AccessWitness) touchAddressAndChargeGas(addr []byte, treeIndex uint256.Int, subIndex byte, isWrite ALAccessMode) uint64 {
+	stemRead, suffixRead, stemWrite, selectorWrite, selectorFill := aw.touchAddress(addr, treeIndex, subIndex, isWrite)
+
+	var gas uint64
+	if stemRead {
+		gas += params.WitnessBranchReadCost
+	}
+	if suffixRead {
+		gas += params.WitnessChunkReadCost
+	}
+	if stemWrite {
+		gas += params.WitnessBranchWriteCost
+	}
+	if selectorWrite {
+		gas += params.WitnessChunkWriteCost
+	}
+	if selectorFill {
+		gas += params.WitnessChunkFillCost
+	}
+
+	return gas
+}
+
+// touchAddress adds any missing access event to the witness.
+func (aw *AccessWitness) touchAddress(addr []byte, treeIndex uint256.Int, subIndex byte, isWrite ALAccessMode) (bool, bool, bool, bool, bool) {
+	branchKey := newBranchAccessKey(addr, treeIndex)
+	chunkKey := newChunkAccessKey(branchKey, subIndex)
+
+	// Read access.
+	var branchRead, chunkRead bool
+	if _, hasStem := aw.branches[branchKey]; !hasStem {
+		branchRead = true
+		aw.branches[branchKey] = AccessWitnessReadFlag
+	}
+	if _, hasSelector := aw.chunks[chunkKey]; !hasSelector {
+		chunkRead = true
+		aw.chunks[chunkKey] = AccessWitnessReadFlag
+	}
+
+	// Write access.
+	var branchWrite, chunkWrite, chunkFill bool
+	if isWrite {
+		if (aw.branches[branchKey] & AccessWitnessWriteFlag) == 0 {
+			branchWrite = true
+			aw.branches[branchKey] |= AccessWitnessWriteFlag
+		}
+
+		chunkValue := aw.chunks[chunkKey]
+		if (chunkValue & AccessWitnessWriteFlag) == 0 {
+			chunkWrite = true
+			aw.chunks[chunkKey] |= AccessWitnessWriteFlag
+		}
+
+		// TODO: charge chunk filling costs if the leaf was previously empty in the state
+	}
+
+	return branchRead, chunkRead, branchWrite, chunkWrite, chunkFill
+}
+
+type branchAccessKey struct {
+	addr      common.Address
+	treeIndex uint256.Int
+}
+
+func newBranchAccessKey(addr []byte, treeIndex uint256.Int) branchAccessKey {
+	var sk branchAccessKey
+	copy(sk.addr[20-len(addr):], addr)
+	sk.treeIndex = treeIndex
+	return sk
+}
+
+type chunkAccessKey struct {
+	branchAccessKey
+	leafKey byte
+}
+
+func newChunkAccessKey(branchKey branchAccessKey, leafKey byte) chunkAccessKey {
+	var lk chunkAccessKey
+	lk.branchAccessKey = branchKey
+	lk.leafKey = leafKey
+	return lk
+}
+
+func (aw *AccessWitness) AddAddress(addr common.Address, items ALAccountItem, isWrite ALAccessMode) uint64 {
+	var gas uint64
+	for index := utils.VersionLeafKey; index <= utils.CodeSizeLeafKey; index++ {
+		if (1<<index)&items != 0 {
+			gas += aw.touchAddressAndChargeGas(addr[:], zeroTreeIndex, byte(index), isWrite)
+		}
+	}
+	return gas
+}
+
+func (aw *AccessWitness) AddSlot(address common.Address, slot common.Hash, isWrite ALAccessMode) uint64 {
+	treeIndex, suffix := utils.GetTreeKeyStorageSlotTreeIndexes(slot.Bytes())
+	return aw.touchAddressAndChargeGas(address[:], *treeIndex, suffix, isWrite)
+}
+
+func (aw *AccessWitness) DeleteSlot(address common.Address, slot common.Hash) {
+	// Should remain in the witness
+}
+
+func (aw *AccessWitness) DeleteAddress(address common.Address) {
+	// Should remain in the witness
+}
+
+func (aw *AccessWitness) ContainsAddress(address common.Address) bool {
+	panic("not implemented") // TODO: Implement
+}
+
+func (aw *AccessWitness) Contains(address common.Address, slot common.Hash) (addressPresent bool, slotPresent bool) {
+	panic("not implemented") // TODO: Implement
+}

--- a/core/state/database.go
+++ b/core/state/database.go
@@ -180,7 +180,7 @@ type cachingDB struct {
 // OpenTrie opens the main account trie at a specific root hash.
 func (db *cachingDB) OpenTrie(root common.Hash) (Trie, error) {
 	if db.triedb.IsVerkle() {
-		return trie.NewVerkleTrie(root, db.triedb, utils.NewPointCache(commitmentCacheItems))
+		return trie.NewVerkleTrie(root, db.triedb, utils.NewPointCache())
 	}
 	tr, err := trie.NewStateTrie(trie.StateTrieID(root), db.triedb)
 	if err != nil {

--- a/core/state/statedb_test.go
+++ b/core/state/statedb_test.go
@@ -345,14 +345,14 @@ func newTestAction(addr common.Address, r *rand.Rand) testAction {
 		{
 			name: "AddAddressToAccessList",
 			fn: func(a testAction, s *StateDB) {
-				s.AddAddressToAccessList(addr)
+				s.AddAddressToAccessList(addr, 0, false)
 			},
 		},
 		{
 			name: "AddSlotToAccessList",
 			fn: func(a testAction, s *StateDB) {
 				s.AddSlotToAccessList(addr,
-					common.Hash{byte(a.args[0])})
+					common.Hash{byte(a.args[0])}, false)
 			},
 			args: make([]int64, 1),
 		},
@@ -879,19 +879,19 @@ func TestStateDBAccessList(t *testing.T) {
 		}
 		// Check that the given addresses are in the access list
 		for _, address := range addresses {
-			if !state.AddressInAccessList(address) {
+			if !state.addressInAccessList(address) {
 				t.Fatalf("expected %x to be in access list", address)
 			}
 		}
 		// Check that only the expected addresses are present in the access list
-		for address := range state.accessList.addresses {
+		for address := range state.accessList.(*accessList2929).addresses {
 			if _, exist := addressMap[address]; !exist {
 				t.Fatalf("extra address %x in access list", address)
 			}
 		}
 	}
 	verifySlots := func(addrString string, slotStrings ...string) {
-		if !state.AddressInAccessList(addr(addrString)) {
+		if !state.addressInAccessList(addr(addrString)) {
 			t.Fatalf("scope missing address/slots %v", addrString)
 		}
 		var address = addr(addrString)
@@ -905,14 +905,14 @@ func TestStateDBAccessList(t *testing.T) {
 		}
 		// Check that the expected items are in the access list
 		for i, s := range slots {
-			if _, slotPresent := state.SlotInAccessList(address, s); !slotPresent {
+			if _, slotPresent := state.slotInAccessList(address, s); !slotPresent {
 				t.Fatalf("input %d: scope missing slot %v (address %v)", i, s, addrString)
 			}
 		}
 		// Check that no extra elements are in the access list
-		index := state.accessList.addresses[address]
+		index := state.accessList.(*accessList2929).addresses[address]
 		if index >= 0 {
-			stateSlots := state.accessList.slots[index]
+			stateSlots := state.accessList.(*accessList2929).slots[index]
 			for s := range stateSlots {
 				if _, slotPresent := slotMap[s]; !slotPresent {
 					t.Fatalf("scope has extra slot %v (address %v)", s, addrString)
@@ -921,9 +921,9 @@ func TestStateDBAccessList(t *testing.T) {
 		}
 	}
 
-	state.AddAddressToAccessList(addr("aa"))          // 1
-	state.AddSlotToAccessList(addr("bb"), slot("01")) // 2,3
-	state.AddSlotToAccessList(addr("bb"), slot("02")) // 4
+	state.AddAddressToAccessList(addr("aa"), 0, false)       // 1
+	state.AddSlotToAccessList(addr("bb"), slot("01"), false) // 2,3
+	state.AddSlotToAccessList(addr("bb"), slot("02"), false) // 4
 	verifyAddrs("aa", "bb")
 	verifySlots("bb", "01", "02")
 
@@ -934,17 +934,17 @@ func TestStateDBAccessList(t *testing.T) {
 	}
 
 	// same again, should cause no journal entries
-	state.AddSlotToAccessList(addr("bb"), slot("01"))
-	state.AddSlotToAccessList(addr("bb"), slot("02"))
-	state.AddAddressToAccessList(addr("aa"))
+	state.AddSlotToAccessList(addr("bb"), slot("01"), false)
+	state.AddSlotToAccessList(addr("bb"), slot("02"), false)
+	state.AddAddressToAccessList(addr("aa"), 0, false)
 	if exp, got := 4, state.journal.length(); exp != got {
 		t.Fatalf("journal length mismatch: have %d, want %d", got, exp)
 	}
 	// some new ones
-	state.AddSlotToAccessList(addr("bb"), slot("03")) // 5
-	state.AddSlotToAccessList(addr("aa"), slot("01")) // 6
-	state.AddSlotToAccessList(addr("cc"), slot("01")) // 7,8
-	state.AddAddressToAccessList(addr("cc"))
+	state.AddSlotToAccessList(addr("bb"), slot("03"), false) // 5
+	state.AddSlotToAccessList(addr("aa"), slot("01"), false) // 6
+	state.AddSlotToAccessList(addr("cc"), slot("01"), false) // 7,8
+	state.AddAddressToAccessList(addr("cc"), 0, false)
 	if exp, got := 8, state.journal.length(); exp != got {
 		t.Fatalf("journal length mismatch: have %d, want %d", got, exp)
 	}
@@ -956,7 +956,7 @@ func TestStateDBAccessList(t *testing.T) {
 
 	// now start rolling back changes
 	state.journal.revert(state, 7)
-	if _, ok := state.SlotInAccessList(addr("cc"), slot("01")); ok {
+	if _, ok := state.slotInAccessList(addr("cc"), slot("01")); ok {
 		t.Fatalf("slot present, expected missing")
 	}
 	verifyAddrs("aa", "bb", "cc")
@@ -964,7 +964,7 @@ func TestStateDBAccessList(t *testing.T) {
 	verifySlots("bb", "01", "02", "03")
 
 	state.journal.revert(state, 6)
-	if state.AddressInAccessList(addr("cc")) {
+	if state.addressInAccessList(addr("cc")) {
 		t.Fatalf("addr present, expected missing")
 	}
 	verifyAddrs("aa", "bb")
@@ -972,46 +972,46 @@ func TestStateDBAccessList(t *testing.T) {
 	verifySlots("bb", "01", "02", "03")
 
 	state.journal.revert(state, 5)
-	if _, ok := state.SlotInAccessList(addr("aa"), slot("01")); ok {
+	if _, ok := state.slotInAccessList(addr("aa"), slot("01")); ok {
 		t.Fatalf("slot present, expected missing")
 	}
 	verifyAddrs("aa", "bb")
 	verifySlots("bb", "01", "02", "03")
 
 	state.journal.revert(state, 4)
-	if _, ok := state.SlotInAccessList(addr("bb"), slot("03")); ok {
+	if _, ok := state.slotInAccessList(addr("bb"), slot("03")); ok {
 		t.Fatalf("slot present, expected missing")
 	}
 	verifyAddrs("aa", "bb")
 	verifySlots("bb", "01", "02")
 
 	state.journal.revert(state, 3)
-	if _, ok := state.SlotInAccessList(addr("bb"), slot("02")); ok {
+	if _, ok := state.slotInAccessList(addr("bb"), slot("02")); ok {
 		t.Fatalf("slot present, expected missing")
 	}
 	verifyAddrs("aa", "bb")
 	verifySlots("bb", "01")
 
 	state.journal.revert(state, 2)
-	if _, ok := state.SlotInAccessList(addr("bb"), slot("01")); ok {
+	if _, ok := state.slotInAccessList(addr("bb"), slot("01")); ok {
 		t.Fatalf("slot present, expected missing")
 	}
 	verifyAddrs("aa", "bb")
 
 	state.journal.revert(state, 1)
-	if state.AddressInAccessList(addr("bb")) {
+	if state.addressInAccessList(addr("bb")) {
 		t.Fatalf("addr present, expected missing")
 	}
 	verifyAddrs("aa")
 
 	state.journal.revert(state, 0)
-	if state.AddressInAccessList(addr("aa")) {
+	if state.addressInAccessList(addr("aa")) {
 		t.Fatalf("addr present, expected missing")
 	}
-	if got, exp := len(state.accessList.addresses), 0; got != exp {
+	if got, exp := len(state.accessList.(*accessList2929).addresses), 0; got != exp {
 		t.Fatalf("expected empty, got %d", got)
 	}
-	if got, exp := len(state.accessList.slots), 0; got != exp {
+	if got, exp := len(state.accessList.(*accessList2929).slots), 0; got != exp {
 		t.Fatalf("expected empty, got %d", got)
 	}
 	// Check the copy
@@ -1019,10 +1019,10 @@ func TestStateDBAccessList(t *testing.T) {
 	state = stateCopy1
 	verifyAddrs("aa", "bb")
 	verifySlots("bb", "01", "02")
-	if got, exp := len(state.accessList.addresses), 2; got != exp {
+	if got, exp := len(state.accessList.(*accessList2929).addresses), 2; got != exp {
 		t.Fatalf("expected empty, got %d", got)
 	}
-	if got, exp := len(state.accessList.slots), 1; got != exp {
+	if got, exp := len(state.accessList.(*accessList2929).slots), 1; got != exp {
 		t.Fatalf("expected empty, got %d", got)
 	}
 }

--- a/core/state_processor.go
+++ b/core/state_processor.go
@@ -145,6 +145,8 @@ func applyTransaction(msg *Message, config *params.ChainConfig, gp *GasPool, sta
 		receipt.ContractAddress = crypto.CreateAddress(evm.TxContext.Origin, tx.Nonce())
 	}
 
+	statedb.MergeTxAccessListIntoBlockWitness()
+
 	// Set the receipt logs and create the bloom filter.
 	receipt.Logs = statedb.GetLogs(tx.Hash(), blockNumber.Uint64(), blockHash)
 	receipt.Bloom = types.CreateBloom(types.Receipts{receipt})
@@ -185,7 +187,7 @@ func ProcessBeaconBlockRoot(beaconRoot common.Hash, vmenv *vm.EVM, statedb *stat
 		Data:      beaconRoot[:],
 	}
 	vmenv.Reset(NewEVMTxContext(msg), statedb)
-	statedb.AddAddressToAccessList(params.BeaconRootsStorageAddress)
+	statedb.AddAddressToAccessList(params.BeaconRootsStorageAddress, state.ALAllItems, state.AccessListWrite)
 	_, _, _ = vmenv.Call(vm.AccountRef(msg.From), *msg.To, msg.Data, 30_000_000, common.U2560)
 	statedb.Finalise(true)
 }

--- a/core/vm/contract.go
+++ b/core/vm/contract.go
@@ -56,6 +56,8 @@ type Contract struct {
 	CodeAddr *common.Address
 	Input    []byte
 
+	IsDeployment bool
+
 	Gas   uint64
 	value *uint256.Int
 }

--- a/core/vm/eips.go
+++ b/core/vm/eips.go
@@ -37,6 +37,7 @@ var activators = map[int]func(*JumpTable){
 	1884: enable1884,
 	1344: enable1344,
 	1153: enable1153,
+	4762: enable4762,
 }
 
 // EnableEIP enables the given EIP on the config.
@@ -123,28 +124,28 @@ func enable2929(jt *JumpTable) {
 	jt[SLOAD].constantGas = 0
 	jt[SLOAD].dynamicGas = gasSLoadEIP2929
 
-	jt[EXTCODECOPY].constantGas = params.WarmStorageReadCostEIP2929
+	jt[EXTCODECOPY].constantGas = 0
 	jt[EXTCODECOPY].dynamicGas = gasExtCodeCopyEIP2929
 
-	jt[EXTCODESIZE].constantGas = params.WarmStorageReadCostEIP2929
+	jt[EXTCODESIZE].constantGas = 0
 	jt[EXTCODESIZE].dynamicGas = gasEip2929AccountCheck
 
-	jt[EXTCODEHASH].constantGas = params.WarmStorageReadCostEIP2929
+	jt[EXTCODEHASH].constantGas = 0
 	jt[EXTCODEHASH].dynamicGas = gasEip2929AccountCheck
 
-	jt[BALANCE].constantGas = params.WarmStorageReadCostEIP2929
+	jt[BALANCE].constantGas = 0
 	jt[BALANCE].dynamicGas = gasEip2929AccountCheck
 
-	jt[CALL].constantGas = params.WarmStorageReadCostEIP2929
+	jt[CALL].constantGas = 0
 	jt[CALL].dynamicGas = gasCallEIP2929
 
-	jt[CALLCODE].constantGas = params.WarmStorageReadCostEIP2929
+	jt[CALLCODE].constantGas = 0
 	jt[CALLCODE].dynamicGas = gasCallCodeEIP2929
 
-	jt[STATICCALL].constantGas = params.WarmStorageReadCostEIP2929
+	jt[STATICCALL].constantGas = 0
 	jt[STATICCALL].dynamicGas = gasStaticCallEIP2929
 
-	jt[DELEGATECALL].constantGas = params.WarmStorageReadCostEIP2929
+	jt[DELEGATECALL].constantGas = 0
 	jt[DELEGATECALL].dynamicGas = gasDelegateCallEIP2929
 
 	// This was previously part of the dynamic cost, but we're using it as a constantGas
@@ -318,4 +319,15 @@ func enable6780(jt *JumpTable) {
 		minStack:    minStack(1, 0),
 		maxStack:    maxStack(1, 0),
 	}
+}
+
+func enable4762(jt *JumpTable) {
+	jt[SSTORE].dynamicGas = gasSStore4762
+	jt[BALANCE].dynamicGas = gasBalance4762
+	jt[EXTCODESIZE].dynamicGas = gasExtCodeSize4762
+	jt[EXTCODEHASH].dynamicGas = gasExtCodeHash4762
+	jt[CALL].dynamicGas = nil
+	jt[CALLCODE].dynamicGas = nil
+	jt[DELEGATECALL].dynamicGas = nil
+	jt[STATICCALL].dynamicGas = nil
 }

--- a/core/vm/interface.go
+++ b/core/vm/interface.go
@@ -20,6 +20,7 @@ import (
 	"math/big"
 
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/state"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/params"
 	"github.com/holiman/uint256"
@@ -64,14 +65,18 @@ type StateDB interface {
 	// is defined according to EIP161 (balance = nonce = code = 0).
 	Empty(common.Address) bool
 
-	AddressInAccessList(addr common.Address) bool
-	SlotInAccessList(addr common.Address, slot common.Hash) (addressOk bool, slotOk bool)
 	// AddAddressToAccessList adds the given address to the access list. This operation is safe to perform
 	// even if the feature/fork is not active yet
-	AddAddressToAccessList(addr common.Address)
+	AddAddressToAccessList(addr common.Address, item state.ALAccountItem, isWrite state.ALAccessMode) uint64
 	// AddSlotToAccessList adds the given (address,slot) to the access list. This operation is safe to perform
 	// even if the feature/fork is not active yet
-	AddSlotToAccessList(addr common.Address, slot common.Hash)
+	AddSlotToAccessList(addr common.Address, slot common.Hash, write state.ALAccessMode) uint64
+	TouchTxOriginAndComputeGas(addr common.Address) uint64
+	TouchTxExistingAndComputeGas(addr common.Address, sendsValue bool) uint64
+	TouchAndChargeContractCreateInit(addr common.Address, sendsValue bool) uint64
+	TouchAndChargeValueTransfer(from, to common.Address) uint64
+	TouchAddressOnReadAndComputeGas(from common.Address, chunk uint64) uint64
+
 	Prepare(rules params.Rules, sender, coinbase common.Address, dest *common.Address, precompiles []common.Address, txAccesses types.AccessList)
 
 	RevertToSnapshot(int)
@@ -79,6 +84,8 @@ type StateDB interface {
 
 	AddLog(*types.Log)
 	AddPreimage(common.Hash, []byte)
+
+	Witness() state.AccessList
 }
 
 // CallContext provides a basic interface for the EVM calling conventions. The EVM

--- a/core/vm/jump_table.go
+++ b/core/vm/jump_table.go
@@ -80,6 +80,12 @@ func validate(jt JumpTable) JumpTable {
 	return jt
 }
 
+func newVerkleInstructionSet() JumpTable {
+	instructionSet := newCancunInstructionSet()
+	EnableEIP(4762, &instructionSet)
+	return validate(instructionSet)
+}
+
 func newCancunInstructionSet() JumpTable {
 	instructionSet := newShanghaiInstructionSet()
 	enable4844(&instructionSet) // EIP-4844 (BLOBHASH opcode)

--- a/params/verkle_params.go
+++ b/params/verkle_params.go
@@ -1,0 +1,36 @@
+// Copyright 2023 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+
+package params
+
+// Verkle tree EIP: costs associated to witness accesses
+var (
+	WitnessBranchReadCost  uint64 = 1900
+	WitnessChunkReadCost   uint64 = 200
+	WitnessBranchWriteCost uint64 = 3000
+	WitnessChunkWriteCost  uint64 = 500
+	WitnessChunkFillCost   uint64 = 6200
+)
+
+// ClearVerkleWitnessCosts sets all witness costs to 0, which is necessary
+// for historical block replay simulations.
+func ClearVerkleWitnessCosts() {
+	WitnessBranchReadCost = 0
+	WitnessChunkReadCost = 0
+	WitnessBranchWriteCost = 0
+	WitnessChunkWriteCost = 0
+	WitnessChunkFillCost = 0
+}

--- a/trie/utils/verkle_test.go
+++ b/trie/utils/verkle_test.go
@@ -27,7 +27,7 @@ import (
 func TestTreeKey(t *testing.T) {
 	var (
 		address      = []byte{0x01}
-		addressEval  = evaluateAddressPoint(address)
+		addressEval  = EvaluateAddressPoint(address)
 		smallIndex   = uint256.NewInt(1)
 		largeIndex   = uint256.NewInt(10000)
 		smallStorage = []byte{0x1}
@@ -91,7 +91,7 @@ func BenchmarkTreeKeyWithEvaluation(b *testing.B) {
 	verkle.GetConfig()
 
 	addr := []byte{0x01}
-	eval := evaluateAddressPoint(addr)
+	eval := EvaluateAddressPoint(addr)
 
 	b.ReportAllocs()
 	b.ResetTimer()
@@ -129,7 +129,7 @@ func BenchmarkStorageKeyWithEvaluation(b *testing.B) {
 	verkle.GetConfig()
 
 	addr := []byte{0x01}
-	eval := evaluateAddressPoint(addr)
+	eval := EvaluateAddressPoint(addr)
 
 	b.ReportAllocs()
 	b.ResetTimer()

--- a/trie/verkle_test.go
+++ b/trie/verkle_test.go
@@ -57,7 +57,7 @@ var (
 
 func TestVerkleTreeReadWrite(t *testing.T) {
 	db := newTestDatabase(rawdb.NewMemoryDatabase(), rawdb.PathScheme)
-	tr, _ := NewVerkleTrie(types.EmptyVerkleHash, db, utils.NewPointCache(100))
+	tr, _ := NewVerkleTrie(types.EmptyVerkleHash, db, utils.NewPointCache())
 
 	for addr, acct := range accounts {
 		if err := tr.UpdateAccount(addr, acct); err != nil {


### PR DESCRIPTION
Augment the interface to `accessList` to support more use cases that are necessary for verkle, in order to merge more data.

Highlights:

 * Functions to check for the presence of an account/slot in the list are removed, as they lose meaning in a verkle context
 * Instead, the function to add an account/slot to the list will directly return the consumed gas. This is necessary since the verkle gas model is quite different.
   * As a result, the `constantGas` is removed and the warm costs are directly returned by `AddSlot`/`AddAddress` when needed.
 * `AddAddress` is modified to specify which account item is accessed. This does not matter for 2929 but is necessary for verkle.
 
 https://eips.ethereum.org/EIPS/eip-4762