### PR TITLE
all: use timer instead of time.After in loops, to avoid memleaks

### DIFF
--- a/eth/downloader/beaconsync.go
+++ b/eth/downloader/beaconsync.go
@@ -289,7 +289,6 @@ func (d *Downloader) fetchBeaconHeaders(from uint64) error {
 		localHeaders = d.readHeaderRange(tail, int(count))
 		log.Warn("Retrieved beacon headers from local", "from", from, "count", count)
 	}
-
 	fsHeaderContCheckTimer := time.NewTimer(fsHeaderContCheck)
 	defer fsHeaderContCheckTimer.Stop()
 

--- a/eth/downloader/beaconsync.go
+++ b/eth/downloader/beaconsync.go
@@ -289,6 +289,10 @@ func (d *Downloader) fetchBeaconHeaders(from uint64) error {
 		localHeaders = d.readHeaderRange(tail, int(count))
 		log.Warn("Retrieved beacon headers from local", "from", from, "count", count)
 	}
+
+	fsHeaderContCheckTimer := time.NewTimer(fsHeaderContCheck)
+	defer fsHeaderContCheckTimer.Stop()
+
 	for {
 		// Some beacon headers might have appeared since the last cycle, make
 		// sure we're always syncing to all available ones
@@ -381,8 +385,9 @@ func (d *Downloader) fetchBeaconHeaders(from uint64) error {
 		}
 		// State sync still going, wait a bit for new headers and retry
 		log.Trace("Pivot not yet committed, waiting...")
+		fsHeaderContCheckTimer.Reset(fsHeaderContCheck)
 		select {
-		case <-time.After(fsHeaderContCheck):
+		case <-fsHeaderContCheckTimer.C:
 		case <-d.cancelCh:
 			return errCanceled
 		}

--- a/eth/downloader/downloader.go
+++ b/eth/downloader/downloader.go
@@ -1579,6 +1579,7 @@ func (d *Downloader) processSnapSyncContent() error {
 		timer    = time.NewTimer(time.Second)
 	)
 	defer timer.Stop()
+	
 	for {
 		// Wait for the next batch of downloaded data to be available. If we have
 		// not yet reached the pivot point, wait blockingly as there's no need to

--- a/eth/downloader/downloader.go
+++ b/eth/downloader/downloader.go
@@ -1021,7 +1021,6 @@ func (d *Downloader) fetchHeaders(p *peerConnection, from uint64, head uint64) e
 		mode                   = d.getMode()
 		fsHeaderContCheckTimer = time.NewTimer(fsHeaderContCheck)
 	)
-
 	defer fsHeaderContCheckTimer.Stop()
 
 	for {

--- a/eth/downloader/downloader.go
+++ b/eth/downloader/downloader.go
@@ -1280,12 +1280,12 @@ func (d *Downloader) fetchReceipts(from uint64, beaconMode bool) error {
 // queue until the stream ends or a failure occurs.
 func (d *Downloader) processHeaders(origin uint64, td, ttd *big.Int, beaconMode bool) error {
 	var (
-		mode        = d.getMode()
-		gotHeaders  = false // Wait for batches of headers to process
-		secondTimer = time.NewTimer(time.Second)
+		mode       = d.getMode()
+		gotHeaders = false // Wait for batches of headers to process
+		timer      = time.NewTimer(time.Second)
 	)
 
-	defer secondTimer.Stop()
+	defer timer.Stop()
 
 	for {
 		select {
@@ -1407,11 +1407,11 @@ func (d *Downloader) processHeaders(origin uint64, td, ttd *big.Int, beaconMode 
 				if mode == FullSync || mode == SnapSync {
 					// If we've reached the allowed number of pending headers, stall a bit
 					for d.queue.PendingBodies() >= maxQueuedHeaders || d.queue.PendingReceipts() >= maxQueuedHeaders {
-						secondTimer.Reset(time.Second)
+						timer.Reset(time.Second)
 						select {
 						case <-d.cancelCh:
 							return errCanceled
-						case <-secondTimer.C:
+						case <-timer.C:
 						}
 					}
 					// Otherwise insert the headers for content retrieval
@@ -1576,11 +1576,11 @@ func (d *Downloader) processSnapSyncContent() error {
 	// Note, there's no issue with memory piling up since after 64 blocks the
 	// pivot will forcefully move so these accumulators will be dropped.
 	var (
-		oldPivot    *fetchResult   // Locked in pivot block, might change eventually
-		oldTail     []*fetchResult // Downloaded content after the pivot
-		secondTimer = time.NewTimer(time.Second)
+		oldPivot *fetchResult   // Locked in pivot block, might change eventually
+		oldTail  []*fetchResult // Downloaded content after the pivot
+		timer    = time.NewTimer(time.Second)
 	)
-	defer secondTimer.Stop()
+	defer timer.Stop()
 	for {
 		// Wait for the next batch of downloaded data to be available. If we have
 		// not yet reached the pivot point, wait blockingly as there's no need to
@@ -1663,7 +1663,7 @@ func (d *Downloader) processSnapSyncContent() error {
 				oldPivot = P
 			}
 			// Wait for completion, occasionally checking for pivot staleness
-			secondTimer.Reset(time.Second)
+			timer.Reset(time.Second)
 			select {
 			case <-sync.done:
 				if sync.err != nil {
@@ -1674,7 +1674,7 @@ func (d *Downloader) processSnapSyncContent() error {
 				}
 				oldPivot = nil
 
-			case <-secondTimer.C:
+			case <-timer.C:
 				oldTail = afterP
 				continue
 			}

--- a/eth/downloader/downloader.go
+++ b/eth/downloader/downloader.go
@@ -1579,7 +1579,7 @@ func (d *Downloader) processSnapSyncContent() error {
 		timer    = time.NewTimer(time.Second)
 	)
 	defer timer.Stop()
-	
+
 	for {
 		// Wait for the next batch of downloaded data to be available. If we have
 		// not yet reached the pivot point, wait blockingly as there's no need to

--- a/eth/downloader/downloader.go
+++ b/eth/downloader/downloader.go
@@ -1015,13 +1015,13 @@ func (d *Downloader) fetchHeaders(p *peerConnection, from uint64, head uint64) e
 
 	// Start pulling the header chain skeleton until all is done
 	var (
-		skeleton = true  // Skeleton assembly phase or finishing up
-		pivoting = false // Whether the next request is pivot verification
-		ancestor = from
-		mode     = d.getMode()
+		skeleton               = true  // Skeleton assembly phase or finishing up
+		pivoting               = false // Whether the next request is pivot verification
+		ancestor               = from
+		mode                   = d.getMode()
+		fsHeaderContCheckTimer = time.NewTimer(fsHeaderContCheck)
 	)
 
-	fsHeaderContCheckTimer := time.NewTimer(fsHeaderContCheck)
 	defer fsHeaderContCheckTimer.Stop()
 
 	for {

--- a/eth/downloader/downloader.go
+++ b/eth/downloader/downloader.go
@@ -1284,7 +1284,6 @@ func (d *Downloader) processHeaders(origin uint64, td, ttd *big.Int, beaconMode 
 		gotHeaders = false // Wait for batches of headers to process
 		timer      = time.NewTimer(time.Second)
 	)
-
 	defer timer.Stop()
 
 	for {

--- a/ethstats/ethstats.go
+++ b/ethstats/ethstats.go
@@ -544,7 +544,6 @@ func (s *Service) reportLatency(conn *connWrapper) error {
 		return err
 	}
 	// Wait for the pong request to arrive back
-
 	timer := time.NewTimer(5 * time.Second)
 	defer timer.Stop()
 

--- a/ethstats/ethstats.go
+++ b/ethstats/ethstats.go
@@ -544,10 +544,14 @@ func (s *Service) reportLatency(conn *connWrapper) error {
 		return err
 	}
 	// Wait for the pong request to arrive back
+
+	timer := time.NewTimer(5 * time.Second)
+	defer timer.Stop()
+
 	select {
 	case <-s.pongCh:
 		// Pong delivered, report the latency
-	case <-time.After(5 * time.Second):
+	case <-timer.C:
 		// Ping timeout, abort
 		return errors.New("ping timed out")
 	}

--- a/p2p/simulations/adapters/exec.go
+++ b/p2p/simulations/adapters/exec.go
@@ -303,10 +303,14 @@ func (n *ExecNode) Stop() error {
 	go func() {
 		waitErr <- n.Cmd.Wait()
 	}()
+
+	timer := time.NewTimer(5 * time.Second)
+	defer timer.Stop()
+
 	select {
 	case err := <-waitErr:
 		return err
-	case <-time.After(5 * time.Second):
+	case <-timer.C:
 		return n.Cmd.Process.Kill()
 	}
 }

--- a/p2p/simulations/adapters/exec.go
+++ b/p2p/simulations/adapters/exec.go
@@ -303,7 +303,6 @@ func (n *ExecNode) Stop() error {
 	go func() {
 		waitErr <- n.Cmd.Wait()
 	}()
-
 	timer := time.NewTimer(5 * time.Second)
 	defer timer.Stop()
 

--- a/p2p/simulations/mocker.go
+++ b/p2p/simulations/mocker.go
@@ -65,10 +65,13 @@ func startStop(net *Network, quit chan struct{}, nodeCount int) {
 	if err != nil {
 		panic("Could not startup node network for mocker")
 	}
-	tick := time.NewTicker(10 * time.Second)
-	defer tick.Stop()
 
-	timer := time.NewTimer(3 * time.Second)
+	var (
+		tick  = time.NewTicker(10 * time.Second)
+		timer = time.NewTimer(3 * time.Second)
+	)
+
+	defer tick.Stop()
 	defer timer.Stop()
 
 	for {

--- a/p2p/simulations/mocker.go
+++ b/p2p/simulations/mocker.go
@@ -67,6 +67,10 @@ func startStop(net *Network, quit chan struct{}, nodeCount int) {
 	}
 	tick := time.NewTicker(10 * time.Second)
 	defer tick.Stop()
+
+	timer := time.NewTimer(3 * time.Second)
+	defer timer.Stop()
+
 	for {
 		select {
 		case <-quit:
@@ -80,11 +84,12 @@ func startStop(net *Network, quit chan struct{}, nodeCount int) {
 				return
 			}
 
+			timer.Reset(3 * time.Second)
 			select {
 			case <-quit:
 				log.Info("Terminating simulation loop")
 				return
-			case <-time.After(3 * time.Second):
+			case <-timer.C:
 			}
 
 			log.Debug("starting node", "id", id)

--- a/p2p/simulations/mocker.go
+++ b/p2p/simulations/mocker.go
@@ -70,7 +70,6 @@ func startStop(net *Network, quit chan struct{}, nodeCount int) {
 		tick  = time.NewTicker(10 * time.Second)
 		timer = time.NewTimer(3 * time.Second)
 	)
-
 	defer tick.Stop()
 	defer timer.Stop()
 

--- a/p2p/simulations/mocker.go
+++ b/p2p/simulations/mocker.go
@@ -65,7 +65,6 @@ func startStop(net *Network, quit chan struct{}, nodeCount int) {
 	if err != nil {
 		panic("Could not startup node network for mocker")
 	}
-
 	var (
 		tick  = time.NewTicker(10 * time.Second)
 		timer = time.NewTimer(3 * time.Second)

--- a/p2p/simulations/network.go
+++ b/p2p/simulations/network.go
@@ -1028,14 +1028,14 @@ func (net *Network) Load(snap *Snapshot) error {
 		}
 	}
 
-	snapshotLoadTimeoutTimer := time.NewTimer(snapshotLoadTimeout)
-	defer snapshotLoadTimeoutTimer.Stop()
+	timeout := time.NewTimer(snapshotLoadTimeout)
+	defer timeout.Stop()
 
 	select {
 	// Wait until all connections from the snapshot are established.
 	case <-allConnected:
 	// Make sure that we do not wait forever.
-	case <-snapshotLoadTimeoutTimer.C:
+	case <-timeout.C:
 		return errors.New("snapshot connections not established")
 	}
 	return nil

--- a/p2p/simulations/network.go
+++ b/p2p/simulations/network.go
@@ -1028,11 +1028,14 @@ func (net *Network) Load(snap *Snapshot) error {
 		}
 	}
 
+	snapshotLoadTimeoutTimer := time.NewTimer(snapshotLoadTimeout)
+	defer snapshotLoadTimeoutTimer.Stop()
+
 	select {
 	// Wait until all connections from the snapshot are established.
 	case <-allConnected:
 	// Make sure that we do not wait forever.
-	case <-time.After(snapshotLoadTimeout):
+	case <-snapshotLoadTimeoutTimer.C:
 		return errors.New("snapshot connections not established")
 	}
 	return nil


### PR DESCRIPTION
```
// After waits for the duration to elapse and then sends the current time
// on the returned channel.
// It is equivalent to NewTimer(d).C.
// The underlying Timer is not recovered by the garbage collector
// until the timer fires. If efficiency is a concern, use NewTimer
// instead and call Timer.Stop if the timer is no longer needed.
```
use time.NewTimer should be used in loop uncertainties to avoid possible memory leaks