### PR TITLE
core: skip the check the statefulness of head block in repair

### DIFF
--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -891,7 +891,7 @@ func (bc *BlockChain) setHeadBeyondRoot(head uint64, time uint64, root common.Ha
 	// touching the header chain altogether, unless the freezer is broken
 	if repair {
 		if target, force := updateFn(bc.db, bc.CurrentBlock()); force {
-			bc.hc.SetHead(target.Number.Uint64(), updateFn, delFn)
+			bc.hc.SetHead(target.Number.Uint64(), nil, delFn)
 		}
 	} else {
 		// Rewind the chain to the requested head and keep going backwards until a


### PR DESCRIPTION
Geth has the mechanism to repair the chain if the associated state of head block is missing. The whole repair procedure can be divided into two steps:

(1) rewind the head block tag until the associated state is available in database
(2) truncate the extra chain segment, including headers, blocks, receipts, etc., if the new chain head is below the freezer head.

In step (2), deletion is sufficient as the head block is already considered stateful. Therefore, UpdateFn doesn't need to be invoked.