### PR TITLE
cmd/devp2p: fix decode raw RLP value

### DIFF
--- a/cmd/devp2p/enrcmd.go
+++ b/cmd/devp2p/enrcmd.go
@@ -183,8 +183,8 @@ var attrFormatters = map[string]func(rlp.RawValue) (string, bool){
 }
 
 func formatAttrRaw(v rlp.RawValue) (string, bool) {
-	s := hex.EncodeToString(v)
-	return s, true
+	content, _, err := rlp.SplitString(v)
+	return hex.EncodeToString(content), err == nil
 }
 
 func formatAttrString(v rlp.RawValue) (string, bool) {


### PR DESCRIPTION
### Description
Fixed #29252

### Example
Command:
```
devp2p enrdump "enr:-Ku4QImhMc1z8yCiNJ1TyUxdcfNucje3BGwEHzodEZUan8PherEo4sF7pPHPSIB1NNuSg5fZy7qFsjmUKs2ea1Whi0EBh2F0dG5ldHOIAAAAAAAAAACEZXRoMpD1pf1CAAAAAP__________gmlkgnY0gmlwhBLf22SJc2VjcDI1NmsxoQOVphkDqal4QzPMksc5wnpuC3gvSC8AfbFOnZY_On34wIN1ZHCCIyg"
```

Output:
```
Node ID: 191bbf49632da5393590a33d54421e79e8e5c96ade72f0ba69e1803095de6b04
URLv4:   enode://95a61903a9a9784333cc92c739c27a6e0b782f482f007db14e9d963f3a7df8c01ad6a387e8021f13e684e576ca9e5d8759b3116df521b280a887a0bdc72e457f@18.223.219.100:0?discport=9000
Record has sequence number 1 and 6 key/value pairs.
  "attnets"   0000000000000000
  "eth2"      f5a5fd4200000000ffffffffffffffff
  "id"        "v4"
  "ip"        18.223.219.100
  "secp256k1" 0395a61903a9a9784333cc92c739c27a6e0b782f482f007db14e9d963f3a7df8c0
  "udp"       9000
```