### PR TITLE
core: add an end-to-end verkle test

### DIFF
--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -147,8 +147,11 @@ type CacheConfig struct {
 }
 
 // triedbConfig derives the configures for trie database.
-func (c *CacheConfig) triedbConfig() *triedb.Config {
-	config := &triedb.Config{Preimages: c.Preimages}
+func (c *CacheConfig) triedbConfig(isVerkle bool) *triedb.Config {
+	config := &triedb.Config{
+		Preimages: c.Preimages,
+		IsVerkle:  isVerkle,
+	}
 	if c.StateScheme == rawdb.HashScheme {
 		config.HashDB = &hashdb.Config{
 			CleanCacheSize: c.TrieCleanLimit * 1024 * 1024,
@@ -265,7 +268,7 @@ func NewBlockChain(db ethdb.Database, cacheConfig *CacheConfig, genesis *Genesis
 		cacheConfig = defaultCacheConfig
 	}
 	// Open trie database with provided config
-	triedb := triedb.NewDatabase(db, cacheConfig.triedbConfig())
+	triedb := triedb.NewDatabase(db, cacheConfig.triedbConfig(genesis != nil && genesis.IsVerkle()))
 
 	// Setup the genesis block, commit the provided genesis specification
 	// to database if the genesis block is not present yet, or load the

--- a/core/state/database.go
+++ b/core/state/database.go
@@ -209,6 +209,8 @@ func (db *cachingDB) CopyTrie(t Trie) Trie {
 	switch t := t.(type) {
 	case *trie.StateTrie:
 		return t.Copy()
+	case *trie.VerkleTrie:
+		return t.Copy()
 	default:
 		panic(fmt.Errorf("unknown trie type %T", t))
 	}

--- a/core/state/statedb.go
+++ b/core/state/statedb.go
@@ -1143,6 +1143,11 @@ func (s *StateDB) handleDestruction(nodes *trienode.MergedNodeSet) error {
 	return nil
 }
 
+// GetTrie returns the account trie.
+func (s *StateDB) GetTrie() Trie {
+	return s.trie
+}
+
 // Commit writes the state to the underlying in-memory trie database.
 // Once the state is committed, tries cached in stateDB (including account
 // trie, storage tries) will no longer be functional. A new state instance

--- a/core/state_processor_test.go
+++ b/core/state_processor_test.go
@@ -422,3 +422,108 @@ func GenerateBadBlock(parent *types.Block, engine consensus.Engine, txs types.Tr
 	}
 	return types.NewBlock(header, txs, nil, receipts, trie.NewStackTrie(nil))
 }
+
+var (
+	code                            = common.FromHex(`6060604052600a8060106000396000f360606040526008565b00`)
+	intrinsicContractCreationGas, _ = IntrinsicGas(code, nil, true, true, true, true)
+	// A contract creation that calls EXTCODECOPY in the constructor. Used to ensure that the witness
+	// will not contain that copied data.
+	// Source: https://gist.github.com/gballet/a23db1e1cb4ed105616b5920feb75985
+	codeWithExtCodeCopy                = common.FromHex(`0x60806040526040516100109061017b565b604051809103906000f08015801561002c573d6000803e3d6000fd5b506000806101000a81548173ffffffffffffffffffffffffffffffffffffffff021916908373ffffffffffffffffffffffffffffffffffffffff16021790555034801561007857600080fd5b5060008067ffffffffffffffff8111156100955761009461024a565b5b6040519080825280601f01601f1916602001820160405280156100c75781602001600182028036833780820191505090505b50905060008060009054906101000a900473ffffffffffffffffffffffffffffffffffffffff1690506020600083833c81610101906101e3565b60405161010d90610187565b61011791906101a3565b604051809103906000f080158015610133573d6000803e3d6000fd5b50600160006101000a81548173ffffffffffffffffffffffffffffffffffffffff021916908373ffffffffffffffffffffffffffffffffffffffff160217905550505061029b565b60d58061046783390190565b6102068061053c83390190565b61019d816101d9565b82525050565b60006020820190506101b86000830184610194565b92915050565b6000819050602082019050919050565b600081519050919050565b6000819050919050565b60006101ee826101ce565b826101f8846101be565b905061020381610279565b925060208210156102435761023e7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff8360200360080261028e565b831692505b5050919050565b7f4e487b7100000000000000000000000000000000000000000000000000000000600052604160045260246000fd5b600061028582516101d9565b80915050919050565b600082821b905092915050565b6101bd806102aa6000396000f3fe608060405234801561001057600080fd5b506004361061002b5760003560e01c8063f566852414610030575b600080fd5b61003861004e565b6040516100459190610146565b60405180910390f35b6000600160009054906101000a900473ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff166381ca91d36040518163ffffffff1660e01b815260040160206040518083038186803b1580156100b857600080fd5b505afa1580156100cc573d6000803e3d6000fd5b505050506040513d601f19601f820116820180604052508101906100f0919061010a565b905090565b60008151905061010481610170565b92915050565b6000602082840312156101205761011f61016b565b5b600061012e848285016100f5565b91505092915050565b61014081610161565b82525050565b600060208201905061015b6000830184610137565b92915050565b6000819050919050565b600080fd5b61017981610161565b811461018457600080fd5b5056fea2646970667358221220a6a0e11af79f176f9c421b7b12f441356b25f6489b83d38cc828a701720b41f164736f6c63430008070033608060405234801561001057600080fd5b5060b68061001f6000396000f3fe6080604052348015600f57600080fd5b506004361060285760003560e01c8063ab5ed15014602d575b600080fd5b60336047565b604051603e9190605d565b60405180910390f35b60006001905090565b6057816076565b82525050565b6000602082019050607060008301846050565b92915050565b600081905091905056fea26469706673582212203a14eb0d5cd07c277d3e24912f110ddda3e553245a99afc4eeefb2fbae5327aa64736f6c63430008070033608060405234801561001057600080fd5b5060405161020638038061020683398181016040528101906100329190610063565b60018160001c6100429190610090565b60008190555050610145565b60008151905061005d8161012e565b92915050565b60006020828403121561007957610078610129565b5b60006100878482850161004e565b91505092915050565b600061009b826100f0565b91506100a6836100f0565b9250827fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff038211156100db576100da6100fa565b5b828201905092915050565b6000819050919050565b6000819050919050565b7f4e487b7100000000000000000000000000000000000000000000000000000000600052601160045260246000fd5b600080fd5b610137816100e6565b811461014257600080fd5b50565b60b3806101536000396000f3fe6080604052348015600f57600080fd5b506004361060285760003560e01c806381ca91d314602d575b600080fd5b60336047565b604051603e9190605a565b60405180910390f35b60005481565b6054816073565b82525050565b6000602082019050606d6000830184604d565b92915050565b600081905091905056fea26469706673582212209bff7098a2f526de1ad499866f27d6d0d6f17b74a413036d6063ca6a0998ca4264736f6c63430008070033`)
+	intrinsicCodeWithExtCodeCopyGas, _ = IntrinsicGas(codeWithExtCodeCopy, nil, true, true, true, true)
+)
+
+func TestProcessVerkle(t *testing.T) {
+	var (
+		config = &params.ChainConfig{
+			ChainID:                       big.NewInt(1),
+			HomesteadBlock:                big.NewInt(0),
+			EIP150Block:                   big.NewInt(0),
+			EIP155Block:                   big.NewInt(0),
+			EIP158Block:                   big.NewInt(0),
+			ByzantiumBlock:                big.NewInt(0),
+			ConstantinopleBlock:           big.NewInt(0),
+			PetersburgBlock:               big.NewInt(0),
+			IstanbulBlock:                 big.NewInt(0),
+			MuirGlacierBlock:              big.NewInt(0),
+			BerlinBlock:                   big.NewInt(0),
+			LondonBlock:                   big.NewInt(0),
+			Ethash:                        new(params.EthashConfig),
+			ShanghaiTime:                  u64(0),
+			VerkleTime:                    u64(0),
+			TerminalTotalDifficulty:       common.Big0,
+			TerminalTotalDifficultyPassed: true,
+			// TODO uncomment when proof generation is merged
+			// ProofInBlocks:                 true,
+		}
+		signer     = types.LatestSigner(config)
+		testKey, _ = crypto.HexToECDSA("b71c71a67e1177ad4e901695e1b4b9ee17ae16c6668d313eac2f96dbcda3f291")
+		bcdb       = rawdb.NewMemoryDatabase() // Database for the blockchain
+		coinbase   = common.HexToAddress("0x71562b71999873DB5b286dF957af199Ec94617F7")
+		gspec      = &Genesis{
+			Config: config,
+			Alloc: GenesisAlloc{
+				coinbase: GenesisAccount{
+					Balance: big.NewInt(1000000000000000000), // 1 ether
+					Nonce:   0,
+				},
+			},
+		}
+	)
+	// Verkle trees use the snapshot, which must be enabled before the
+	// data is saved into the tree+database.
+	// genesis := gspec.MustCommit(bcdb, triedb)
+	cacheConfig := DefaultCacheConfigWithScheme("path")
+	cacheConfig.SnapshotLimit = 0
+	blockchain, _ := NewBlockChain(bcdb, cacheConfig, gspec, nil, beacon.New(ethash.NewFaker()), vm.Config{}, nil, nil)
+	defer blockchain.Stop()
+
+	txCost1 := params.TxGas
+	txCost2 := params.TxGas
+	contractCreationCost := intrinsicContractCreationGas + uint64(2039 /* execution costs */)
+	codeWithExtCodeCopyGas := intrinsicCodeWithExtCodeCopyGas + uint64(293644 /* execution costs */)
+	blockGasUsagesExpected := []uint64{
+		txCost1*2 + txCost2,
+		txCost1*2 + txCost2 + contractCreationCost + codeWithExtCodeCopyGas,
+	}
+	_, chain, _, _, _ := GenerateVerkleChainWithGenesis(gspec, beacon.New(ethash.NewFaker()), 2, func(i int, gen *BlockGen) {
+		gen.SetPoS()
+
+		// TODO need to check that the tx cost provided is the exact amount used (no remaining left-over)
+		tx, _ := types.SignTx(types.NewTransaction(uint64(i)*3, common.Address{byte(i), 2, 3}, big.NewInt(999), txCost1, big.NewInt(875000000), nil), signer, testKey)
+		gen.AddTx(tx)
+		tx, _ = types.SignTx(types.NewTransaction(uint64(i)*3+1, common.Address{}, big.NewInt(999), txCost1, big.NewInt(875000000), nil), signer, testKey)
+		gen.AddTx(tx)
+		tx, _ = types.SignTx(types.NewTransaction(uint64(i)*3+2, common.Address{}, big.NewInt(0), txCost2, big.NewInt(875000000), nil), signer, testKey)
+		gen.AddTx(tx)
+
+		// Add two contract creations in block #2
+		if i == 1 {
+			tx, _ = types.SignTx(types.NewContractCreation(6, big.NewInt(16), 3000000, big.NewInt(875000000), code), signer, testKey)
+			gen.AddTx(tx)
+
+			tx, _ = types.SignTx(types.NewContractCreation(7, big.NewInt(0), 3000000, big.NewInt(875000000), codeWithExtCodeCopy), signer, testKey)
+			gen.AddTx(tx)
+		}
+	})
+
+	t.Log("inserting blocks into the chain")
+
+	endnum, err := blockchain.InsertChain(chain)
+	if err != nil {
+		t.Fatalf("block %d imported with error: %v", endnum, err)
+	}
+
+	for i := 0; i < 2; i++ {
+		b := blockchain.GetBlockByNumber(uint64(i) + 1)
+		if b == nil {
+			t.Fatalf("expected block %d to be present in chain", i+1)
+		}
+		if b.Hash() != chain[i].Hash() {
+			t.Fatalf("block #%d not found at expected height", b.NumberU64())
+		}
+		if b.GasUsed() != blockGasUsagesExpected[i] {
+			t.Fatalf("expected block #%d txs to use %d, got %d\n", b.NumberU64(), blockGasUsagesExpected[i], b.GasUsed())
+		}
+	}
+}

--- a/triedb/database.go
+++ b/triedb/database.go
@@ -108,12 +108,12 @@ func NewDatabase(diskdb ethdb.Database, config *Config) *Database {
 		log.Crit("Both 'hash' and 'path' mode are configured")
 	}
 	if config.PathDB != nil {
-		db.backend = pathdb.New(diskdb, config.PathDB)
+		db.backend = pathdb.New(diskdb, config.PathDB, config.IsVerkle)
 	} else {
 		var resolver hashdb.ChildResolver
 		if config.IsVerkle {
 			// TODO define verkle resolver
-			log.Crit("Verkle node resolver is not defined")
+			log.Crit("verkle does not use a hash db")
 		} else {
 			resolver = trie.MerkleResolver{}
 		}

--- a/triedb/pathdb/database_test.go
+++ b/triedb/pathdb/database_test.go
@@ -106,7 +106,7 @@ func newTester(t *testing.T, historyLimit uint64) *tester {
 			StateHistory:   historyLimit,
 			CleanCacheSize: 16 * 1024,
 			DirtyCacheSize: 16 * 1024,
-		})
+		}, false)
 		obj = &tester{
 			db:           db,
 			preimages:    make(map[common.Hash]common.Address),
@@ -550,7 +550,7 @@ func TestJournal(t *testing.T) {
 		t.Errorf("Failed to journal, err: %v", err)
 	}
 	tester.db.Close()
-	tester.db = New(tester.db.diskdb, nil)
+	tester.db = New(tester.db.diskdb, nil, false)
 
 	// Verify states including disk layer and all diff on top.
 	for i := 0; i < len(tester.roots); i++ {
@@ -588,7 +588,7 @@ func TestCorruptedJournal(t *testing.T) {
 	rawdb.WriteTrieJournal(tester.db.diskdb, blob)
 
 	// Verify states, all not-yet-written states should be discarded
-	tester.db = New(tester.db.diskdb, nil)
+	tester.db = New(tester.db.diskdb, nil, false)
 	for i := 0; i < len(tester.roots); i++ {
 		if tester.roots[i] == root {
 			if err := tester.verifyState(root); err != nil {
@@ -625,7 +625,7 @@ func TestTailTruncateHistory(t *testing.T) {
 	defer tester.release()
 
 	tester.db.Close()
-	tester.db = New(tester.db.diskdb, &Config{StateHistory: 10})
+	tester.db = New(tester.db.diskdb, &Config{StateHistory: 10}, false)
 
 	head, err := tester.db.freezer.Ancients()
 	if err != nil {

--- a/triedb/pathdb/difflayer_test.go
+++ b/triedb/pathdb/difflayer_test.go
@@ -29,7 +29,7 @@ import (
 
 func emptyLayer() *diskLayer {
 	return &diskLayer{
-		db:     New(rawdb.NewMemoryDatabase(), nil),
+		db:     New(rawdb.NewMemoryDatabase(), nil, false),
 		buffer: newNodeBuffer(DefaultBufferSize, nil, 0),
 	}
 }
@@ -58,7 +58,6 @@ func BenchmarkSearch1Layer(b *testing.B) { benchmarkSearch(b, 127, 128) }
 func benchmarkSearch(b *testing.B, depth int, total int) {
 	var (
 		npath []byte
-		nhash common.Hash
 		nblob []byte
 	)
 	// First, we set up 128 diff layers, with 3K items each
@@ -75,7 +74,6 @@ func benchmarkSearch(b *testing.B, depth int, total int) {
 			if npath == nil && depth == index {
 				npath = common.CopyBytes(path)
 				nblob = common.CopyBytes(node.Blob)
-				nhash = node.Hash
 			}
 		}
 		return newDiffLayer(parent, common.Hash{}, 0, 0, nodes, nil)
@@ -92,7 +90,7 @@ func benchmarkSearch(b *testing.B, depth int, total int) {
 		err  error
 	)
 	for i := 0; i < b.N; i++ {
-		have, err = layer.Node(common.Hash{}, npath, nhash)
+		have, _, _, err = layer.node(common.Hash{}, npath, 0)
 		if err != nil {
 			b.Fatal(err)
 		}

--- a/triedb/pathdb/errors.go
+++ b/triedb/pathdb/errors.go
@@ -16,13 +16,7 @@
 
 package pathdb
 
-import (
-	"errors"
-	"fmt"
-
-	"github.com/ethereum/go-ethereum/common"
-	"github.com/ethereum/go-ethereum/common/hexutil"
-)
+import "errors"
 
 var (
 	// errDatabaseReadOnly is returned if the database is opened in read only mode
@@ -45,16 +39,4 @@ var (
 	// errStateUnrecoverable is returned if state is required to be reverted to
 	// a destination without associated state history available.
 	errStateUnrecoverable = errors.New("state is unrecoverable")
-
-	// errUnexpectedNode is returned if the requested node with specified path is
-	// not hash matched with expectation.
-	errUnexpectedNode = errors.New("unexpected node")
 )
-
-func newUnexpectedNodeError(loc string, expHash common.Hash, gotHash common.Hash, owner common.Hash, path []byte, blob []byte) error {
-	blobHex := "nil"
-	if len(blob) > 0 {
-		blobHex = hexutil.Encode(blob)
-	}
-	return fmt.Errorf("%w, loc: %s, node: (%x %v), %x!=%x, blob: %s", errUnexpectedNode, loc, owner, path, expHash, gotHash, blobHex)
-}

--- a/triedb/pathdb/metrics.go
+++ b/triedb/pathdb/metrics.go
@@ -33,6 +33,7 @@ var (
 	cleanFalseMeter = metrics.NewRegisteredMeter("pathdb/clean/false", nil)
 	dirtyFalseMeter = metrics.NewRegisteredMeter("pathdb/dirty/false", nil)
 	diskFalseMeter  = metrics.NewRegisteredMeter("pathdb/disk/false", nil)
+	diffFalseMeter  = metrics.NewRegisteredMeter("pathdb/diff/false", nil)
 
 	commitTimeTimer  = metrics.NewRegisteredTimer("pathdb/commit/time", nil)
 	commitNodesMeter = metrics.NewRegisteredMeter("pathdb/commit/nodes", nil)

--- a/triedb/pathdb/nodebuffer.go
+++ b/triedb/pathdb/nodebuffer.go
@@ -59,21 +59,16 @@ func newNodeBuffer(limit int, nodes map[common.Hash]map[string]*trienode.Node, l
 }
 
 // node retrieves the trie node with given node info.
-func (b *nodebuffer) node(owner common.Hash, path []byte, hash common.Hash) (*trienode.Node, error) {
+func (b *nodebuffer) node(owner common.Hash, path []byte) (*trienode.Node, bool) {
 	subset, ok := b.nodes[owner]
 	if !ok {
-		return nil, nil
+		return nil, false
 	}
 	n, ok := subset[string(path)]
 	if !ok {
-		return nil, nil
+		return nil, false
 	}
-	if n.Hash != hash {
-		dirtyFalseMeter.Mark(1)
-		log.Error("Unexpected trie node in node buffer", "owner", owner, "path", path, "expect", hash, "got", n.Hash)
-		return nil, newUnexpectedNodeError("dirty", hash, n.Hash, owner, path, n.Blob)
-	}
-	return n, nil
+	return n, true
 }
 
 // commit merges the dirty nodes into the nodebuffer. This operation won't take

--- a/triedb/pathdb/reader.go
+++ b/triedb/pathdb/reader.go
@@ -1,0 +1,94 @@
+// Copyright 2024 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>
+
+package pathdb
+
+import (
+	"fmt"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/ethereum/go-ethereum/log"
+	"github.com/ethereum/go-ethereum/triedb/database"
+)
+
+// The types of locations where the node is found.
+const (
+	locDirtyCache = "dirty" // dirty cache
+	locCleanCache = "clean" // clean cache
+	locDiskLayer  = "disk"  // persistent state
+	locDiffLayer  = "diff"  // diff layers
+)
+
+// nodeLoc is a helpful structure that contains the location where the node
+// is found, as it's useful for debugging purposes.
+type nodeLoc struct {
+	loc   string
+	depth int
+}
+
+// string returns the string representation of node location.
+func (loc *nodeLoc) string() string {
+	return fmt.Sprintf("loc: %s, depth: %d", loc.loc, loc.depth)
+}
+
+// reader implements the database.Reader interface, providing the functionalities to
+// retrieve trie nodes by wrapping the internal state layer.
+type reader struct {
+	layer       layer
+	noHashCheck bool
+}
+
+// Node implements database.Reader interface, retrieving the node with specified
+// node info. Don't modify the returned byte slice since it's not deep-copied
+// and still be referenced by database.
+func (r *reader) Node(owner common.Hash, path []byte, hash common.Hash) ([]byte, error) {
+	blob, got, loc, err := r.layer.node(owner, path, 0)
+	if err != nil {
+		return nil, err
+	}
+	// Error out if the local one is inconsistent with the target.
+	if !r.noHashCheck && got != hash {
+		// Location is always available even if the node
+		// is not found.
+		switch loc.loc {
+		case locCleanCache:
+			cleanFalseMeter.Mark(1)
+		case locDirtyCache:
+			dirtyFalseMeter.Mark(1)
+		case locDiffLayer:
+			diffFalseMeter.Mark(1)
+		case locDiskLayer:
+			diskFalseMeter.Mark(1)
+		}
+		blobHex := "nil"
+		if len(blob) > 0 {
+			blobHex = hexutil.Encode(blob)
+		}
+		log.Error("Unexpected trie node", "location", loc.loc, "owner", owner, "path", path, "expect", hash, "got", got, "blob", blobHex)
+		return nil, fmt.Errorf("unexpected node: (%x %v), %x!=%x, %s, blob: %s", owner, path, hash, got, loc.string(), blobHex)
+	}
+	return blob, nil
+}
+
+// Reader retrieves a layer belonging to the given state root.
+func (db *Database) Reader(root common.Hash) (database.Reader, error) {
+	layer := db.tree.get(root)
+	if layer == nil {
+		return nil, fmt.Errorf("state %#x is not available", root)
+	}
+	return &reader{layer: layer, noHashCheck: db.isVerkle}, nil
+}


### PR DESCRIPTION
In order to reduce the merging complexity of verkle, this PR adds a test meant to serve as a sentinel for changes that break verkle execution. It is a subset of a test that is used extensively in the verkle branch.

This requires #29084 as the current code hashes the node, which isn't really practical to do in a verkle way (on top of using a different hashing algorithm).

Co-authored-by: Ignacio Hagopian <jsign.uy@gmail.com>