### PR TITLE
cmd, triedb: implement history inspection

### DIFF
--- a/cmd/geth/dbcmd.go
+++ b/cmd/geth/dbcmd.go
@@ -860,11 +860,11 @@ func inspectHistory(ctx *cli.Context) error {
 	}
 	// Print out the result.
 	if slot == (common.Hash{}) {
-		fmt.Printf("Account history:\n\taddress: %s\n", address.Hex())
+		fmt.Printf("Account history:\n\taddress: %s\n\tblockrange: [#%d-#%d]\n", address.Hex(), stats.Start, stats.End)
 	} else {
-		fmt.Printf("Storage history:\n\taddress: %s\n\tslot: %s\n", address.Hex(), slot.Hex())
+		fmt.Printf("Storage history:\n\taddress: %s\n\tslot: %s\nblockrange: [#%d-#%d]\n", address.Hex(), slot.Hex(), stats.Start, stats.End)
 	}
-	fmt.Printf("Range: [#%d-#%d]\n\n", stats.Start, stats.End)
+	fmt.Printf("\nThe output shows block number where account/slot was modified, along with the _old_ rlp-encoded value\n")
 	for i := 0; i < len(stats.Blocks); i++ {
 		fmt.Printf("#%d: %#x\n", stats.Blocks[i], stats.Origins[i])
 	}

--- a/cmd/geth/dbcmd.go
+++ b/cmd/geth/dbcmd.go
@@ -800,7 +800,7 @@ func inspectAccount(db *triedb.Database, start uint64, end uint64, address commo
 			content = "<empty>"
 		} else {
 			if !raw {
-				content = fmt.Sprintf("%x", stats.Origins[i])
+				content = fmt.Sprintf("%#x", stats.Origins[i])
 			} else {
 				account := new(types.SlimAccount)
 				if err := rlp.DecodeBytes(stats.Origins[i], account); err != nil {
@@ -808,13 +808,13 @@ func inspectAccount(db *triedb.Database, start uint64, end uint64, address commo
 				}
 				code := "<nil>"
 				if len(account.CodeHash) > 0 {
-					code = fmt.Sprintf("%x", account.CodeHash)
+					code = fmt.Sprintf("%#x", account.CodeHash)
 				}
 				root := "<nil>"
 				if len(account.Root) > 0 {
-					root = fmt.Sprintf("%x", account.Root)
+					root = fmt.Sprintf("%#x", account.Root)
 				}
-				content = fmt.Sprintf("nonce: %d, balance: %d, code: %s, root: %s", account.Nonce, account.Balance, code, root)
+				content = fmt.Sprintf("nonce: %d, balance: %d, codeHash: %s, root: %s", account.Nonce, account.Balance, code, root)
 			}
 		}
 		fmt.Printf("#%d - #%d: %s\n", from, stats.Blocks[i], content)
@@ -840,14 +840,14 @@ func inspectStorage(db *triedb.Database, start uint64, end uint64, address commo
 			content = "<empty>"
 		} else {
 			if !raw {
-				content = fmt.Sprintf("%x", stats.Origins[i])
+				content = fmt.Sprintf("%#x", stats.Origins[i])
 			} else {
 				_, data, _, err := rlp.Split(stats.Origins[i])
 				if err != nil {
 					fmt.Printf("Failed to decode storage slot, %v", err)
 					return err
 				}
-				content = fmt.Sprintf("%x", data)
+				content = fmt.Sprintf("%#x", data)
 			}
 		}
 		fmt.Printf("#%d - #%d: %s\n", from, stats.Blocks[i], content)

--- a/cmd/geth/dbcmd.go
+++ b/cmd/geth/dbcmd.go
@@ -861,7 +861,7 @@ func inspectHistory(ctx *cli.Context) error {
 	} else {
 		fmt.Printf("Storage history: %s-%s\n", address.Hex(), slot.Hex())
 	}
-	fmt.Printf("Range: [#%d-#%d]\n", stats.Start, stats.End)
+	fmt.Printf("Range: [#%d-#%d]\n\n", stats.Start, stats.End)
 	for i := 0; i < len(stats.Blocks); i++ {
 		fmt.Printf("#%d: %x\n", stats.Blocks[i], stats.Origins[i])
 	}

--- a/cmd/geth/dbcmd.go
+++ b/cmd/geth/dbcmd.go
@@ -224,7 +224,7 @@ WARNING: This is a low-level operation which may cause database corruption!`,
 			},
 			&cli.BoolFlag{
 				Name:  "raw",
-				Usage: "display the decoded raw state value",
+				Usage: "display the decoded raw state value (otherwise shows rlp-encoded value)",
 			},
 		}, utils.NetworkFlags, utils.DatabaseFlags),
 		Description: "This command queries the history of the account or storage slot within the specified block range",
@@ -808,11 +808,11 @@ func inspectAccount(db *triedb.Database, start uint64, end uint64, address commo
 				}
 				code := "<nil>"
 				if len(account.CodeHash) > 0 {
-					code = fmt.Sprintf("%x", common.Bytes2Hex(account.CodeHash))
+					code = fmt.Sprintf("%x", account.CodeHash)
 				}
 				root := "<nil>"
 				if len(account.Root) > 0 {
-					root = fmt.Sprintf("%x", common.Bytes2Hex(account.Root))
+					root = fmt.Sprintf("%x", account.Root)
 				}
 				content = fmt.Sprintf("nonce: %d, balance: %d, code: %s, root: %s", account.Nonce, account.Balance, code, root)
 			}

--- a/cmd/geth/dbcmd.go
+++ b/cmd/geth/dbcmd.go
@@ -847,7 +847,7 @@ func inspectStorage(db *triedb.Database, start uint64, end uint64, address commo
 					fmt.Printf("Failed to decode storage slot, %v", err)
 					return err
 				}
-				content = fmt.Sprintf("#%x", data)
+				content = fmt.Sprintf("%x", data)
 			}
 		}
 		fmt.Printf("#%d - #%d: %s\n", from, stats.Blocks[i], content)

--- a/cmd/geth/dbcmd.go
+++ b/cmd/geth/dbcmd.go
@@ -817,7 +817,7 @@ func inspectAccount(db *triedb.Database, start uint64, end uint64, address commo
 				content = fmt.Sprintf("nonce: %d, balance: %d, code: %s, root: %s", account.Nonce, account.Balance, code, root)
 			}
 		}
-		fmt.Printf("#%d - #%d: %s\n", from, stats.Blocks[i]-1, content)
+		fmt.Printf("#%d - #%d: %s\n", from, stats.Blocks[i], content)
 		from = stats.Blocks[i]
 	}
 	return nil
@@ -850,7 +850,7 @@ func inspectStorage(db *triedb.Database, start uint64, end uint64, address commo
 				content = fmt.Sprintf("#%x", data)
 			}
 		}
-		fmt.Printf("#%d - #%d: %s\n", from, stats.Blocks[i]-1, content)
+		fmt.Printf("#%d - #%d: %s\n", from, stats.Blocks[i], content)
 		from = stats.Blocks[i]
 	}
 	return nil

--- a/cmd/geth/dbcmd.go
+++ b/cmd/geth/dbcmd.go
@@ -862,7 +862,7 @@ func inspectHistory(ctx *cli.Context) error {
 	if slot == (common.Hash{}) {
 		fmt.Printf("Account history:\n\taddress: %s\n\tblockrange: [#%d-#%d]\n", address.Hex(), stats.Start, stats.End)
 	} else {
-		fmt.Printf("Storage history:\n\taddress: %s\n\tslot: %s\nblockrange: [#%d-#%d]\n", address.Hex(), slot.Hex(), stats.Start, stats.End)
+		fmt.Printf("Storage history:\n\taddress: %s\n\tslot: %s\n\tblockrange: [#%d-#%d]\n", address.Hex(), slot.Hex(), stats.Start, stats.End)
 	}
 	fmt.Printf("\nThe output shows block number where account/slot was modified, along with the _old_ rlp-encoded value\n")
 	for i := 0; i < len(stats.Blocks); i++ {

--- a/triedb/history.go
+++ b/triedb/history.go
@@ -1,0 +1,72 @@
+// Copyright 2023 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+
+package triedb
+
+import (
+	"errors"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/triedb/pathdb"
+)
+
+// AccountHistory inspects the account history within the specified range.
+//
+// Start: State ID of the first history object for the query. 0 implies the first
+// available object is selected as the starting point.
+//
+// End: State ID of the last history for the query. 0 implies the last available
+// object is selected as the starting point. Note end is included for query.
+//
+// This function is only supported by path mode database.
+func (db *Database) AccountHistory(address common.Address, start, end uint64) (*pathdb.HistoryStats, error) {
+	pdb, ok := db.backend.(*pathdb.Database)
+	if !ok {
+		return nil, errors.New("not supported")
+	}
+	return pdb.AccountHistory(address, start, end)
+}
+
+// StorageHistory inspects the storage history within the specified range.
+//
+// Start: State ID of the first history object for the query. 0 implies the first
+// available object is selected as the starting point.
+//
+// End: State ID of the last history for the query. 0 implies the last available
+// object is selected as the starting point. Note end is included for query.
+//
+// Note, slot refers to the hash of the raw slot key.
+//
+// This function is only supported by path mode database.
+func (db *Database) StorageHistory(address common.Address, slot common.Hash, start uint64, end uint64) (*pathdb.HistoryStats, error) {
+	pdb, ok := db.backend.(*pathdb.Database)
+	if !ok {
+		return nil, errors.New("not supported")
+	}
+	return pdb.StorageHistory(address, slot, start, end)
+}
+
+// HistoryRange returns the block numbers associated with earliest and latest
+// state history in the local store.
+//
+// This function is only supported by path mode database.
+func (db *Database) HistoryRange() (uint64, uint64, error) {
+	pdb, ok := db.backend.(*pathdb.Database)
+	if !ok {
+		return 0, 0, errors.New("not supported")
+	}
+	return pdb.HistoryRange()
+}

--- a/triedb/pathdb/database.go
+++ b/triedb/pathdb/database.go
@@ -492,7 +492,7 @@ func (db *Database) modifyAllowed() error {
 // available object is selected as the starting point.
 //
 // End: State ID of the last history for the query. 0 implies the last available
-// object is selected as the starting point. Note end is included for query.
+// object is selected as the ending point. Note end is included in the query.
 func (db *Database) AccountHistory(address common.Address, start, end uint64) (*HistoryStats, error) {
 	return accountHistory(db.freezer, address, start, end)
 }
@@ -503,7 +503,7 @@ func (db *Database) AccountHistory(address common.Address, start, end uint64) (*
 // available object is selected as the starting point.
 //
 // End: State ID of the last history for the query. 0 implies the last available
-// object is selected as the starting point. Note end is included for query.
+// object is selected as the ending point. Note end is included in the query.
 //
 // Note, slot refers to the hash of the raw slot key.
 func (db *Database) StorageHistory(address common.Address, slot common.Hash, start uint64, end uint64) (*HistoryStats, error) {

--- a/triedb/pathdb/database.go
+++ b/triedb/pathdb/database.go
@@ -485,3 +485,33 @@ func (db *Database) modifyAllowed() error {
 	}
 	return nil
 }
+
+// AccountHistory inspects the account history within the specified range.
+//
+// Start: State ID of the first history object for the query. 0 implies the first
+// available object is selected as the starting point.
+//
+// End: State ID of the last history for the query. 0 implies the last available
+// object is selected as the starting point. Note end is included for query.
+func (db *Database) AccountHistory(address common.Address, start, end uint64) (*HistoryStats, error) {
+	return accountHistory(db.freezer, address, start, end)
+}
+
+// StorageHistory inspects the storage history within the specified range.
+//
+// Start: State ID of the first history object for the query. 0 implies the first
+// available object is selected as the starting point.
+//
+// End: State ID of the last history for the query. 0 implies the last available
+// object is selected as the starting point. Note end is included for query.
+//
+// Note, slot refers to the hash of the raw slot key.
+func (db *Database) StorageHistory(address common.Address, slot common.Hash, start uint64, end uint64) (*HistoryStats, error) {
+	return storageHistory(db.freezer, address, slot, start, end)
+}
+
+// HistoryRange returns the block numbers associated with earliest and latest
+// state history in the local store.
+func (db *Database) HistoryRange() (uint64, uint64, error) {
+	return historyRange(db.freezer)
+}

--- a/triedb/pathdb/history_inspect.go
+++ b/triedb/pathdb/history_inspect.go
@@ -27,8 +27,8 @@ import (
 
 // HistoryStats wraps the history inspection statistics.
 type HistoryStats struct {
-	Start   uint64   // Block number of first queried history
-	End     uint64   // Block number of last queried history
+	Start   uint64   // Block number of the first queried history
+	End     uint64   // Block number of the last queried history
 	Blocks  []uint64 // Blocks refers to the list of block numbers in which the state is mutated
 	Origins [][]byte // Origins refers to the original value of the state before its mutation
 }

--- a/triedb/pathdb/history_inspect.go
+++ b/triedb/pathdb/history_inspect.go
@@ -1,0 +1,149 @@
+// Copyright 2024 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/
+
+package pathdb
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/rawdb"
+	"github.com/ethereum/go-ethereum/log"
+)
+
+// HistoryStats wraps the history inspection statistics.
+type HistoryStats struct {
+	Start   uint64   // Block number of first queried history
+	End     uint64   // Block number of last queried history
+	Blocks  []uint64 // Blocks refers to the list of block numbers in which the state is mutated
+	Origins [][]byte // Origins refers to the original value of the state before its mutation
+}
+
+// sanitizeRange limits the given range to fit within the local history store.
+func sanitizeRange(start, end uint64, freezer *rawdb.ResettableFreezer) (uint64, uint64, error) {
+	// Load the id of the first history object in local store.
+	tail, err := freezer.Tail()
+	if err != nil {
+		return 0, 0, err
+	}
+	first := tail + 1
+	if start != 0 && start > first {
+		first = start
+	}
+	// Load the id of the last history object in local store.
+	head, err := freezer.Ancients()
+	if err != nil {
+		return 0, 0, err
+	}
+	last := head - 1
+	if end != 0 && end < last {
+		last = end
+	}
+	// Make sure the range is valid
+	if first >= last {
+		return 0, 0, fmt.Errorf("range is invalid, first: %d, last: %d", first, last)
+	}
+	return first, last, nil
+}
+
+func inspectHistory(freezer *rawdb.ResettableFreezer, start, end uint64, onHistory func(*history, *HistoryStats)) (*HistoryStats, error) {
+	var (
+		stats  = &HistoryStats{}
+		init   = time.Now()
+		logged = time.Now()
+	)
+	start, end, err := sanitizeRange(start, end, freezer)
+	if err != nil {
+		return nil, err
+	}
+	for id := start; id <= end; id += 1 {
+		h, err := readHistory(freezer, id)
+		if err != nil {
+			return nil, err
+		}
+		if id == start {
+			stats.Start = h.meta.block
+		}
+		if id == end {
+			stats.End = h.meta.block
+		}
+		onHistory(h, stats)
+
+		if time.Since(logged) > time.Second*8 {
+			logged = time.Now()
+			eta := float64(time.Since(init)) / float64(id-start+1) * float64(end-id)
+			log.Info("Inspecting state history", "checked", id-start+1, "left", end-id, "elapsed", common.PrettyDuration(time.Since(init)), "eta", common.PrettyDuration(eta))
+		}
+	}
+	log.Info("Inspected state history", "total", end-start+1, "elapsed", common.PrettyDuration(time.Since(init)))
+	return stats, nil
+}
+
+// accountHistory inspects the account history within the range.
+func accountHistory(freezer *rawdb.ResettableFreezer, address common.Address, start, end uint64) (*HistoryStats, error) {
+	return inspectHistory(freezer, start, end, func(h *history, stats *HistoryStats) {
+		blob, exists := h.accounts[address]
+		if !exists {
+			return
+		}
+		stats.Blocks = append(stats.Blocks, h.meta.block)
+		stats.Origins = append(stats.Origins, blob)
+	})
+}
+
+// storageHistory inspects the storage history within the range.
+func storageHistory(freezer *rawdb.ResettableFreezer, address common.Address, slot common.Hash, start uint64, end uint64) (*HistoryStats, error) {
+	return inspectHistory(freezer, start, end, func(h *history, stats *HistoryStats) {
+		slots, exists := h.storages[address]
+		if !exists {
+			return
+		}
+		blob, exists := slots[slot]
+		if !exists {
+			return
+		}
+		stats.Blocks = append(stats.Blocks, h.meta.block)
+		stats.Origins = append(stats.Origins, blob)
+	})
+}
+
+// historyRange returns the block number range of local state histories.
+func historyRange(freezer *rawdb.ResettableFreezer) (uint64, uint64, error) {
+	// Load the id of the first history object in local store.
+	tail, err := freezer.Tail()
+	if err != nil {
+		return 0, 0, err
+	}
+	first := tail + 1
+
+	// Load the id of the last history object in local store.
+	head, err := freezer.Ancients()
+	if err != nil {
+		return 0, 0, err
+	}
+	last := head - 1
+
+	fh, err := readHistory(freezer, first)
+	if err != nil {
+		return 0, 0, err
+	}
+	lh, err := readHistory(freezer, last)
+	if err != nil {
+		return 0, 0, err
+	}
+	return fh.meta.block, lh.meta.block, nil
+}

--- a/triedb/pathdb/history_inspect.go
+++ b/triedb/pathdb/history_inspect.go
@@ -71,6 +71,8 @@ func inspectHistory(freezer *rawdb.ResettableFreezer, start, end uint64, onHisto
 		return nil, err
 	}
 	for id := start; id <= end; id += 1 {
+		// The entire history object is decoded, although it's unnecessary for
+		// account inspection. TODO(rjl493456442) optimization is worthwhile.
 		h, err := readHistory(freezer, id)
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
This pull request introduces a database tool for inspecting the state history. It can be used for either account history or storage slot history, within a specific block range.

The state output format can be chosen either with 
- the "rlp-encoded" values (those inserted into the merkle trie)
- the "rlp-decoded" value (the raw state value)

The latter one needs `--raw` flag.

---

Example usage:

`geth db inspect-history -start 4972612 -end 4974412 0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2 0x321690423bfa8088917640d62a3b42bb0acc95376d9366929f697905e89aead8`

```
Storage history:
        address: 0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2
        slot: 0x321690423bfa8088917640d62a3b42bb0acc95376d9366929f697905e89aead8
        blockrange: [#4972612-#4974412]
#4972612 - #4972815: 88180a84df00995800
#4972815 - #4973208: 89027aa9ebbfc5c95800
#4973208 - #4973565: 8902f2b4e4eb60ea5800
...
```

`#4972612 - #4972815: 88180a84df00995800` means the value of state in the block range [4972612, 4972815] is `88180a84df00995800`, and it's changed at `4972815` from `88180a84df00995800` to `89027aa9ebbfc5c95800`.


If `--raw` flag is applied, the value will be decoded which is the actual raw state value, e.g.

```
Storage history:
        address: 0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2
        slot: 0x321690423bfa8088917640d62a3b42bb0acc95376d9366929f697905e89aead8
        blockrange: [#4972612-#4974412]
#4972612 - #4972815: 180a84df00995800
#4972815 - #4973208: 027aa9ebbfc5c95800
#4973208 - #4973565: 02f2b4e4eb60ea5800
#4973565 - #4973578: 02f2b51a65d2073800
```

---

For account inspection, the example output looks like:

```
geth db inspect-history -start 4972612 -end 4974412 --datadir ./geth_data -raw 0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2

Account history:
        address: 0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2
        blockrange: [#4972612-#4974412]
#4972612 - #4972618: nonce: 1, balance: 42177939099148876461584, code: d0a06b12ac47863b5c7be4185c2deaad1c61557033f56c7d4ea74429cbb25e23, root: 3839514ff720f7dc16d8e686e3a96bcaedcfb6c248d0488d81e3aba787dc7d6b
#4972618 - #4972620: nonce: 1, balance: 42177939099148876461584, code: d0a06b12ac47863b5c7be4185c2deaad1c61557033f56c7d4ea74429cbb25e23, root: dc018422a1996deb08e4342fb171dbcf1d1956da71e0f4bf717e61074179e773
#4972620 - #4972716: nonce: 1, balance: 42177939099148876461584, code: d0a06b12ac47863b5c7be4185c2deaad1c61557033f56c7d4ea74429cbb25e23, root: 3839514ff720f7dc16d8e686e3a96bcaedcfb6c248d0488d81e3aba787dc7d6b

...
```

