### PR TITLE
cmd, node: initialize ports with --instance

### DIFF
--- a/cmd/geth/main.go
+++ b/cmd/geth/main.go
@@ -127,6 +127,7 @@ var (
 		utils.NoDiscoverFlag,
 		utils.DiscoveryV4Flag,
 		utils.DiscoveryV5Flag,
+		utils.InstanceFlag,
 		utils.LegacyDiscoveryV5Flag, // deprecated
 		utils.NetrestrictFlag,
 		utils.NodeKeyFileFlag,

--- a/node/config.go
+++ b/node/config.go
@@ -211,6 +211,8 @@ type Config struct {
 	EnablePersonal bool `toml:"-"`
 
 	DBEngine string `toml:",omitempty"`
+
+	Instance int `toml:",omitempty"`
 }
 
 // IPCEndpoint resolves an IPC endpoint based on a configured value, taking into

--- a/node/defaults.go
+++ b/node/defaults.go
@@ -17,6 +17,7 @@
 package node
 
 import (
+	"fmt"
 	"os"
 	"os/user"
 	"path/filepath"
@@ -28,12 +29,14 @@ import (
 )
 
 const (
-	DefaultHTTPHost = "localhost" // Default host interface for the HTTP RPC server
-	DefaultHTTPPort = 8545        // Default TCP port for the HTTP RPC server
-	DefaultWSHost   = "localhost" // Default host interface for the websocket RPC server
-	DefaultWSPort   = 8546        // Default TCP port for the websocket RPC server
-	DefaultAuthHost = "localhost" // Default host interface for the authenticated apis
-	DefaultAuthPort = 8551        // Default port for the authenticated apis
+	DefaultHTTPHost   = "localhost" // Default host interface for the HTTP RPC server
+	DefaultHTTPPort   = 8545        // Default TCP port for the HTTP RPC server
+	DefaultWSHost     = "localhost" // Default host interface for the websocket RPC server
+	DefaultWSPort     = 8546        // Default TCP port for the websocket RPC server
+	DefaultAuthHost   = "localhost" // Default host interface for the authenticated apis
+	DefaultAuthPort   = 8551        // Default port for the authenticated apis
+	DefaultListenPort = 30303       // Default port for the TCP listening address
+	DefaultDiscPort   = 30303       // Default port for the UDP discovery address
 )
 
 const (
@@ -68,11 +71,12 @@ var DefaultConfig = Config{
 	BatchResponseMaxSize: 25 * 1000 * 1000,
 	GraphQLVirtualHosts:  []string{"localhost"},
 	P2P: p2p.Config{
-		ListenAddr: ":30303",
+		ListenAddr: fmt.Sprintf(":%d", DefaultListenPort),
 		MaxPeers:   50,
 		NAT:        nat.Any(),
 	},
 	DBEngine: "", // Use whatever exists, will default to Pebble if non-existent and supported
+	Instance: 1,
 }
 
 // DefaultDataDir is the default data directory to use for the databases and other


### PR DESCRIPTION
### Description
This PR adds a new CLI flag called `--instance <value>`, used to configure ports when running multiple nodes on the same machine to avoid port conflicts. This is only applicable for `port, authrpc.port, discovery,port, http.port, ws.port`.

The calculation of port numbers is as follows:

```
authrpc.port = 8551 (default) + `instance`*100 - 100
http.port = 8545 (default) - `instance` + 1
ws.port = 8546 (default) + `instance`*2 - 2
port = 30303 (default) + `instance` - 1
discovery.port = 30303 (default) + `instance` - 1
```

In a scenario where the user specify both `--instance` and the supported port list (i.e. `port, authrpc.port, ...`), then the ports specified will supersede the port values configured by `--instance`.

### Example
Usage: `geth --instance 2`
```
authrpc.port = 8651
http.port = 8544
ws.port = 8548
port = 30304
discovery.port = 30304
```

Usage: `geth --instance 2 --authrpc.port 8551`
```
authrpc.port = 8551
http.port = 8544
ws.port = 8548
port = 30304
discovery.port = 30304
```

Usage: `geth --instance 201`
```
Fatal: Instance number 201 is too high, maximum is 200
```
### Credits
This flag is inspired by [reth](https://paradigmxyz.github.io/reth/cli/reth/node.html).