### PR TITLE
triedb/pathdb: improve tests

### DIFF
--- a/eth/protocols/snap/sync_test.go
+++ b/eth/protocols/snap/sync_test.go
@@ -32,10 +32,10 @@ import (
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/ethdb"
+	"github.com/ethereum/go-ethereum/internal/testrand"
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/rlp"
 	"github.com/ethereum/go-ethereum/trie"
-	"github.com/ethereum/go-ethereum/trie/testutil"
 	"github.com/ethereum/go-ethereum/trie/trienode"
 	"github.com/ethereum/go-ethereum/triedb"
 	"github.com/ethereum/go-ethereum/triedb/pathdb"
@@ -1816,8 +1816,8 @@ func makeUnevenStorageTrie(owner common.Hash, slots int, db *triedb.Database) (c
 			break
 		}
 		for j := 0; j < slots/3; j++ {
-			key := append([]byte{byte(n)}, testutil.RandBytes(31)...)
-			val, _ := rlp.EncodeToBytes(testutil.RandBytes(32))
+			key := append([]byte{byte(n)}, testrand.Bytes(31)...)
+			val, _ := rlp.EncodeToBytes(testrand.Bytes(32))
 
 			elem := &kv{key, val}
 			tr.MustUpdate(elem.k, elem.v)

--- a/internal/testrand/rand.go
+++ b/internal/testrand/rand.go
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
 
-package testutil
+package testrand
 
 import (
 	crand "crypto/rand"
@@ -22,11 +22,9 @@ import (
 	mrand "math/rand"
 
 	"github.com/ethereum/go-ethereum/common"
-	"github.com/ethereum/go-ethereum/crypto"
-	"github.com/ethereum/go-ethereum/trie/trienode"
 )
 
-// Prng is a pseudo random number generator seeded by strong randomness.
+// prng is a pseudo random number generator seeded by strong randomness.
 // The randomness is printed on startup in order to make failures reproducible.
 var prng = initRand()
 
@@ -37,25 +35,19 @@ func initRand() *mrand.Rand {
 	return rnd
 }
 
-// RandBytes generates a random byte slice with specified length.
-func RandBytes(n int) []byte {
+// Bytes generates a random byte slice with specified length.
+func Bytes(n int) []byte {
 	r := make([]byte, n)
 	prng.Read(r)
 	return r
 }
 
-// RandomHash generates a random blob of data and returns it as a hash.
-func RandomHash() common.Hash {
-	return common.BytesToHash(RandBytes(common.HashLength))
+// Hash generates a random hash.
+func Hash() common.Hash {
+	return common.BytesToHash(Bytes(common.HashLength))
 }
 
-// RandomAddress generates a random blob of data and returns it as an address.
-func RandomAddress() common.Address {
-	return common.BytesToAddress(RandBytes(common.AddressLength))
-}
-
-// RandomNode generates a random node.
-func RandomNode() *trienode.Node {
-	val := RandBytes(100)
-	return trienode.New(crypto.Keccak256Hash(val), val)
+// Address generates a random address.
+func Address() common.Address {
+	return common.BytesToAddress(Bytes(common.AddressLength))
 }

--- a/trie/stacktrie_test.go
+++ b/trie/stacktrie_test.go
@@ -25,7 +25,7 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/rawdb"
 	"github.com/ethereum/go-ethereum/crypto"
-	"github.com/ethereum/go-ethereum/trie/testutil"
+	"github.com/ethereum/go-ethereum/internal/testrand"
 	"github.com/stretchr/testify/assert"
 	"golang.org/x/exp/slices"
 )
@@ -431,12 +431,12 @@ func TestPartialStackTrie(t *testing.T) {
 		for i := 0; i < n; i++ {
 			var val []byte
 			if rand.Intn(3) == 0 {
-				val = testutil.RandBytes(3)
+				val = testrand.Bytes(3)
 			} else {
-				val = testutil.RandBytes(32)
+				val = testrand.Bytes(32)
 			}
 			entries = append(entries, &kv{
-				k: testutil.RandBytes(32),
+				k: testrand.Bytes(32),
 				v: val,
 			})
 		}

--- a/triedb/pathdb/database.go
+++ b/triedb/pathdb/database.go
@@ -34,9 +34,6 @@ import (
 )
 
 const (
-	// maxDiffLayers is the maximum diff layers allowed in the layer tree.
-	maxDiffLayers = 128
-
 	// defaultCleanSize is the default memory allowance of clean cache.
 	defaultCleanSize = 16 * 1024 * 1024
 
@@ -52,6 +49,11 @@ const (
 	// Do not increase the buffer size arbitrarily, otherwise the system
 	// pause time will increase when the database writes happen.
 	DefaultBufferSize = 64 * 1024 * 1024
+)
+
+var (
+	// maxDiffLayers is the maximum diff layers allowed in the layer tree.
+	maxDiffLayers = 128
 )
 
 // layer is the interface implemented by all state layers which includes some

--- a/triedb/pathdb/difflayer_test.go
+++ b/triedb/pathdb/difflayer_test.go
@@ -22,7 +22,8 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/rawdb"
-	"github.com/ethereum/go-ethereum/trie/testutil"
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/ethereum/go-ethereum/internal/testrand"
 	"github.com/ethereum/go-ethereum/trie/trienode"
 )
 
@@ -66,8 +67,9 @@ func benchmarkSearch(b *testing.B, depth int, total int) {
 		nodes[common.Hash{}] = make(map[string]*trienode.Node)
 		for i := 0; i < 3000; i++ {
 			var (
-				path = testutil.RandBytes(32)
-				node = testutil.RandomNode()
+				path = testrand.Bytes(32)
+				blob = testrand.Bytes(100)
+				node = trienode.New(crypto.Keccak256Hash(blob), blob)
 			)
 			nodes[common.Hash{}][string(path)] = trienode.New(node.Hash, node.Blob)
 			if npath == nil && depth == index {
@@ -112,8 +114,9 @@ func BenchmarkPersist(b *testing.B) {
 		nodes[common.Hash{}] = make(map[string]*trienode.Node)
 		for i := 0; i < 3000; i++ {
 			var (
-				path = testutil.RandBytes(32)
-				node = testutil.RandomNode()
+				path = testrand.Bytes(32)
+				blob = testrand.Bytes(100)
+				node = trienode.New(crypto.Keccak256Hash(blob), blob)
 			)
 			nodes[common.Hash{}][string(path)] = trienode.New(node.Hash, node.Blob)
 		}
@@ -149,8 +152,9 @@ func BenchmarkJournal(b *testing.B) {
 		nodes[common.Hash{}] = make(map[string]*trienode.Node)
 		for i := 0; i < 3000; i++ {
 			var (
-				path = testutil.RandBytes(32)
-				node = testutil.RandomNode()
+				path = testrand.Bytes(32)
+				blob = testrand.Bytes(100)
+				node = trienode.New(crypto.Keccak256Hash(blob), blob)
 			)
 			nodes[common.Hash{}][string(path)] = trienode.New(node.Hash, node.Blob)
 		}

--- a/triedb/pathdb/history_test.go
+++ b/triedb/pathdb/history_test.go
@@ -26,8 +26,8 @@ import (
 	"github.com/ethereum/go-ethereum/core/rawdb"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/ethdb"
+	"github.com/ethereum/go-ethereum/internal/testrand"
 	"github.com/ethereum/go-ethereum/rlp"
-	"github.com/ethereum/go-ethereum/trie/testutil"
 	"github.com/ethereum/go-ethereum/trie/triestate"
 )
 
@@ -38,11 +38,11 @@ func randomStateSet(n int) *triestate.Set {
 		storages = make(map[common.Address]map[common.Hash][]byte)
 	)
 	for i := 0; i < n; i++ {
-		addr := testutil.RandomAddress()
+		addr := testrand.Address()
 		storages[addr] = make(map[common.Hash][]byte)
 		for j := 0; j < 3; j++ {
-			v, _ := rlp.EncodeToBytes(common.TrimLeftZeroes(testutil.RandBytes(32)))
-			storages[addr][testutil.RandomHash()] = v
+			v, _ := rlp.EncodeToBytes(common.TrimLeftZeroes(testrand.Bytes(32)))
+			storages[addr][testrand.Hash()] = v
 		}
 		account := generateAccount(types.EmptyRootHash)
 		accounts[addr] = types.SlimAccountRLP(account)
@@ -51,7 +51,7 @@ func randomStateSet(n int) *triestate.Set {
 }
 
 func makeHistory() *history {
-	return newHistory(testutil.RandomHash(), types.EmptyRootHash, 0, randomStateSet(3))
+	return newHistory(testrand.Hash(), types.EmptyRootHash, 0, randomStateSet(3))
 }
 
 func makeHistories(n int) []*history {
@@ -60,7 +60,7 @@ func makeHistories(n int) []*history {
 		result []*history
 	)
 	for i := 0; i < n; i++ {
-		root := testutil.RandomHash()
+		root := testrand.Hash()
 		h := newHistory(root, parent, uint64(i), randomStateSet(3))
 		parent = root
 		result = append(result, h)

--- a/triedb/pathdb/testutils.go
+++ b/triedb/pathdb/testutils.go
@@ -93,10 +93,13 @@ func (h *testHasher) Commit(collectLeaf bool) (common.Hash, *trienode.NodeSet, e
 		if bytes.Equal(val, h.cleans[hash]) {
 			continue
 		}
+		// Utilize the hash of the state key as the node path to mitigate
+		// potential collisions within the path.
+		path := crypto.Keccak256(hash.Bytes())
 		if len(val) == 0 {
-			set.AddNode(hash.Bytes(), trienode.NewDeleted())
+			set.AddNode(path, trienode.NewDeleted())
 		} else {
-			set.AddNode(hash.Bytes(), trienode.New(crypto.Keccak256Hash(val), val))
+			set.AddNode(path, trienode.New(crypto.Keccak256Hash(val), val))
 		}
 	}
 	root, blob := hash(nodes)


### PR DESCRIPTION
This pull request improves the existing unit tests in triedb package. Highlight the changes as follow:

- define `internal/testrand` package for generating random bytes, address, hash for testing purpose. The package can be used/shared in other places.
- change pathdb's maximum difflayer allowance to 4 to fasten unit tests
- fix a clean cache bug in test

---

Expand the third fix a bit. 

In PathDB, there is a clean cache for maintaining trie node caches of persistent state. The key of each cache item should be unique to prevent accidental content modification. For actual usage, the item key is derived by following this rule:

```
// cacheKey constructs the unique key of clean cache.
func cacheKey(owner common.Hash, path []byte) []byte {
	if owner == (common.Hash{}) {
		return path
	}
	return append(owner.Bytes(), path...)
}
```


- If the item is an account trie node, the key is the node path, whose length is less than 32.
- If the item is a storage trie node, the key is the concatenated bytes of owner and path, with a length of at least 32.

Therefore, the key is unique for both an account trie node and a storage trie node.

Unfortunately, the unit test breaks this guarantee and leads to a situation that different items may have same cache key. A unexpected node in clean cache is raised eventually.

The fix is applied to change the node path formula in tests to address the issue.