### PR TITLE
chore: fix typos

### DIFF
--- a/crypto/secp256k1/libsecp256k1/src/java/org/bitcoin/NativeSecp256k1.java
+++ b/crypto/secp256k1/libsecp256k1/src/java/org/bitcoin/NativeSecp256k1.java
@@ -24,6 +24,9 @@ import java.math.BigInteger;
 import com.google.common.base.Preconditions;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
+
+import org.bitcoin.NativeSecp256k1Util.AssertFailException;
+
 import static org.bitcoin.NativeSecp256k1Util.*;
 
 /**
@@ -359,8 +362,8 @@ public class NativeSecp256k1 {
     /**
      * libsecp256k1 create ECDH secret - constant time ECDH calculation
      *
-     * @param seckey byte array of secret key used in exponentiaion
-     * @param pubkey byte array of public key used in exponentiaion
+     * @param seckey byte array of secret key used in exponentiation
+     * @param pubkey byte array of public key used in exponentiation
      */
     public static byte[] createECDHSecret(byte[] seckey, byte[] pubkey) throws AssertFailException{
         Preconditions.checkArgument(seckey.length <= 32 && pubkey.length <= 65);

--- a/crypto/secp256k1/libsecp256k1/src/java/org/bitcoin/NativeSecp256k1.java
+++ b/crypto/secp256k1/libsecp256k1/src/java/org/bitcoin/NativeSecp256k1.java
@@ -24,9 +24,6 @@ import java.math.BigInteger;
 import com.google.common.base.Preconditions;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
-
-import org.bitcoin.NativeSecp256k1Util.AssertFailException;
-
 import static org.bitcoin.NativeSecp256k1Util.*;
 
 /**

--- a/tests/solidity/test/opCodes.js
+++ b/tests/solidity/test/opCodes.js
@@ -25,7 +25,7 @@ contract('OpCodes', (accounts) => {
    beforeEach(async () => {
       contractInstance = await TodoList.deployed()
    })
-   it('Should run without errors the majorit of opcodes', async () => {
+   it('Should run without errors the majority of opcodes', async () => {
      await contractInstance.test()
      await contractInstance.test_stop()
 


### PR DESCRIPTION
1. Fix `crypto/secp256k1/libsecp256k1/src/java/org/bitcoin/NativeSecp256k1.java` typo
2. Fix `tests/solidity/test/opCodes.js` typo