### PR TITLE
cmd/evm: make staterunner always output stateroot to stderr

### DIFF
--- a/cmd/evm/staterunner.go
+++ b/cmd/evm/staterunner.go
@@ -67,7 +67,7 @@ func stateTestCmd(ctx *cli.Context) error {
 	}
 	// Load the test content from the input file
 	if len(ctx.Args().First()) != 0 {
-		return runStateTest(ctx.Args().First(), cfg, ctx.Bool(MachineFlag.Name), ctx.Bool(DumpFlag.Name))
+		return runStateTest(ctx.Args().First(), cfg, ctx.Bool(MachineFlag.Name))
 	}
 	// Read filenames from stdin and execute back-to-back
 	scanner := bufio.NewScanner(os.Stdin)
@@ -76,7 +76,7 @@ func stateTestCmd(ctx *cli.Context) error {
 		if len(fname) == 0 {
 			return nil
 		}
-		if err := runStateTest(fname, cfg, ctx.Bool(MachineFlag.Name), ctx.Bool(DumpFlag.Name)); err != nil {
+		if err := runStateTest(fname, cfg, ctx.Bool(MachineFlag.Name)); err != nil {
 			return err
 		}
 	}
@@ -84,7 +84,7 @@ func stateTestCmd(ctx *cli.Context) error {
 }
 
 // runStateTest loads the state-test given by fname, and executes the test.
-func runStateTest(fname string, cfg vm.Config, jsonOut, dump bool) error {
+func runStateTest(fname string, cfg vm.Config, dump bool) error {
 	src, err := os.ReadFile(fname)
 	if err != nil {
 		return err
@@ -105,9 +105,7 @@ func runStateTest(fname string, cfg vm.Config, jsonOut, dump bool) error {
 				if tstate.StateDB != nil {
 					root = tstate.StateDB.IntermediateRoot(false)
 					result.Root = &root
-					if jsonOut {
-						fmt.Fprintf(os.Stderr, "{\"stateRoot\": \"%#x\"}\n", root)
-					}
+					fmt.Fprintf(os.Stderr, "{\"stateRoot\": \"%#x\"}\n", root)
 					if dump { // Dump any state to aid debugging
 						cpy, _ := state.New(root, tstate.StateDB.Database(), nil)
 						dump := cpy.RawDump(nil)


### PR DESCRIPTION
This fixes a minor quirk in the evm. When goevmlab runs speed-tests, it currently cannot use the "batch" mode of operation. 

Ideally, we can omit all json traces and still obtain the stateroot from the stderr, which is what this PR fixes: it always prints the stateroot to the `stderr` regardless of whther `--json` was specified or not. 

It does change the behaviour (a bit) of `evm .. statetest xx`, but I don't think we have a lot of consumers of that API, so should be fine. 