### PR TITLE
[website]: Command provided to run a signer leads to an error

### DIFF
--- a/docs/fundamentals/private-network.md
+++ b/docs/fundamentals/private-network.md
@@ -203,7 +203,7 @@ geth attach data2/geth.ipc --exec admin.peers
 
 ### Running A Signer (Clique) {#running-a-signer}
 
-To set up Geth for signing blocks in Clique, a signer account must be available. The account must already be available as a keyfile in the keystore. To use it for signing blocks, it must be unlocked. Once unlocked, you also need to provide specify this address as the etherbase. The following command, for address `0x7df9a875a174b3bc565e6424a0050ebc1b2d1d82` will prompt for the account password, then start signing blocks:
+To set up Geth for signing blocks in Clique, a signer account must be available. The account must already be available as a keyfile in the keystore. To use it for signing blocks, it must be unlocked. Once unlocked, this account also need to be provided as the etherbase. The following command, for address `0x7df9a875a174b3bc565e6424a0050ebc1b2d1d82` will prompt for the account password, then start signing blocks:
 
 ```sh
 geth <other-flags> --unlock 0x7df9a875a174b3bc565e6424a0050ebc1b2d1d82 --mine --miner.etherbase 0x7df9a875a174b3bc565e6424a0050ebc1b2d1d82

--- a/docs/fundamentals/private-network.md
+++ b/docs/fundamentals/private-network.md
@@ -203,10 +203,10 @@ geth attach data2/geth.ipc --exec admin.peers
 
 ### Running A Signer (Clique) {#running-a-signer}
 
-To set up Geth for signing blocks in Clique, a signer account must be available. The account must already be available as a keyfile in the keystore. To use it for signing blocks, it must be unlocked. The following command, for address `0x7df9a875a174b3bc565e6424a0050ebc1b2d1d82` will prompt for the account password, then start signing blocks:
+To set up Geth for signing blocks in Clique, a signer account must be available. The account must already be available as a keyfile in the keystore. To use it for signing blocks, it must be unlocked. Once unlocked, you also need to provide specify this address as the etherbase. The following command, for address `0x7df9a875a174b3bc565e6424a0050ebc1b2d1d82` will prompt for the account password, then start signing blocks:
 
 ```sh
-geth <other-flags> --unlock 0x7df9a875a174b3bc565e6424a0050ebc1b2d1d82 --mine
+geth <other-flags> --unlock 0x7df9a875a174b3bc565e6424a0050ebc1b2d1d82 --mine --miner.etherbase 0x7df9a875a174b3bc565e6424a0050ebc1b2d1d82
 ```
 
 Mining can be further configured by changing the default gas limit blocks converge to (with `--miner.gastarget`) and the price transactions are accepted at (with `--miner.gasprice`).


### PR DESCRIPTION
For now the documentation on [private network](https://geth.ethereum.org/docs/fundamentals/private-network) with clique says that to run a signer, the only thing to do is
`geth <other-flags> --unlock 0x7df9a875a174b3bc565e6424a0050ebc1b2d1d82 --mine`.

When trying this command with the genesis block provided in the [doc](https://geth.ethereum.org/docs/fundamentals/private-network) , the following error is returned
```bash
ERROR[03-19|13:55:07.832] Cannot start mining without etherbase    err="etherbase must be explicitly specified"
Fatal: Failed to start mining: etherbase missing: etherbase must be explicitly specified
```

Updating the doc to reflect the fact the option `--miner.etherbase $ACCOUNT` is needed to run a signer.