### PR TITLE
core/asm: minor code-clarification

### DIFF
--- a/core/asm/asm.go
+++ b/core/asm/asm.go
@@ -66,7 +66,7 @@ func (it *instructionIterator) Next() bool {
 
 	it.op = vm.OpCode(it.code[it.pc])
 	if it.op.IsPush() {
-		a := uint64(it.op) + 1 - uint64(vm.PUSH1)
+		a := uint64(it.op) - uint64(vm.PUSH0)
 		u := it.pc + 1 + a
 		if uint64(len(it.code)) <= it.pc || uint64(len(it.code)) < u {
 			it.error = fmt.Errorf("incomplete push instruction at %v", it.pc)

--- a/core/asm/asm.go
+++ b/core/asm/asm.go
@@ -66,7 +66,7 @@ func (it *instructionIterator) Next() bool {
 
 	it.op = vm.OpCode(it.code[it.pc])
 	if it.op.IsPush() {
-		a := uint64(it.op) - uint64(vm.PUSH1) + 1
+		a := uint64(it.op) + 1 - uint64(vm.PUSH1)
 		u := it.pc + 1 + a
 		if uint64(len(it.code)) <= it.pc || uint64(len(it.code)) < u {
 			it.error = fmt.Errorf("incomplete push instruction at %v", it.pc)


### PR DESCRIPTION
https://github.com/ethereum/go-ethereum/blob/4c1b57856f0f5ebccb6edb83ab755ab114500078/core/vm/opcodes.go#L27-L29
when op = PUSH0
uint64(it.op) - uint64(vm.PUSH1) = uint64(-1) 
uint64(it.op) - uint64(vm.PUSH1)  + 1 == 0
Although it's not a problem, it's best to put add first
