### PR TITLE
core/txpool/legacypool: locals-tracker (second attempt) 

### DIFF
--- a/core/txpool/legacypool/legacypool.go
+++ b/core/txpool/legacypool/legacypool.go
@@ -244,6 +244,11 @@ func New(config Config, chain BlockChain) *LegacyPool {
 	// Sanitize the input to ensure no vulnerable gas prices are set
 	config = (&config).sanitize()
 
+	// Disable locals-handling in this pool. This is a precursor to fully
+	// deleting locals-related code
+	config.NoLocals = true
+	config.Locals = nil
+
 	// Create the transaction pool with its initial settings
 	pool := &LegacyPool{
 		config:          config,

--- a/core/txpool/legacypool/tx_tracker.go
+++ b/core/txpool/legacypool/tx_tracker.go
@@ -1,0 +1,189 @@
+// Copyright 2023 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+
+// Package legacypool implements the normal EVM execution transaction pool.
+package legacypool
+
+import (
+	"sync"
+	"time"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/txpool"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/log"
+	"github.com/ethereum/go-ethereum/params"
+	"golang.org/x/exp/slices"
+)
+
+var recheckInterval = time.Minute
+
+// TxTracker is a struct used to track priority transactions; it will check from
+// time to time if the main pool has forgotten about any of the transaction
+// it is tracking, and if so, submit it again.
+// This is used to track 'locals'.
+// This struct does not care about transaction validity, price-bumps or account limits,
+// but optimistically accepts transactions.
+type TxTracker struct {
+	all    map[common.Hash]*types.Transaction // All tracked transactions
+	byAddr map[common.Address]*sortedMap      // Transactions by address
+
+	journal   *journal       // Journal of local transaction to back up to disk
+	rejournal time.Duration  // How often to rotate journal
+	pool      *txpool.TxPool // The tx pool to interact with
+	signer    types.Signer
+
+	shutdownCh chan struct{}
+	mu         sync.Mutex
+	wg         sync.WaitGroup
+}
+
+func NewTxTracker(journalPath string, journalTime time.Duration, chainConfig *params.ChainConfig, next *txpool.TxPool) *TxTracker {
+	signer := types.LatestSigner(chainConfig)
+	pool := &TxTracker{
+		all:        make(map[common.Hash]*types.Transaction),
+		byAddr:     make(map[common.Address]*sortedMap),
+		signer:     signer,
+		shutdownCh: make(chan struct{}),
+		pool:       next,
+	}
+	if journalPath != "" {
+		pool.journal = newTxJournal(journalPath)
+		pool.rejournal = journalTime
+	}
+	return pool
+}
+
+// Track adds a transaction to the tracked set.
+func (tracker *TxTracker) Track(tx *types.Transaction) {
+	tracker.TrackAll([]*types.Transaction{tx})
+}
+
+// TrackAll adds a list of transactions to the tracked set.
+func (tracker *TxTracker) TrackAll(txs []*types.Transaction) {
+	tracker.mu.Lock()
+	defer tracker.mu.Unlock()
+	for _, tx := range txs {
+		// If we're already tracking it, it's a no-op
+		if _, ok := tracker.all[tx.Hash()]; ok {
+			continue
+		}
+		tracker.all[tx.Hash()] = tx
+		addr, _ := types.Sender(tracker.signer, tx)
+		if tracker.byAddr[addr] == nil {
+			tracker.byAddr[addr] = newSortedMap()
+		}
+		tracker.byAddr[addr].Put(tx)
+		_ = tracker.journal.insert(tx)
+	}
+}
+
+// recheck checks and returns any transactions that needs to be resubmitted.
+func (tracker *TxTracker) recheck(journalCheck bool) (resubmits []*types.Transaction, rejournal map[common.Address]types.Transactions) {
+	tracker.mu.Lock()
+	defer tracker.mu.Unlock()
+	var (
+		numStales = 0
+		numOk     = 0
+	)
+	for sender, txs := range tracker.byAddr {
+		stales := txs.Forward(tracker.pool.Nonce(sender))
+		// Wipe the stales
+		for _, tx := range stales {
+			delete(tracker.all, tx.Hash())
+		}
+		numStales += len(stales)
+		// Check the non-stale
+		for _, tx := range txs.Flatten() {
+			if tracker.pool.Has(tx.Hash()) {
+				numOk++
+				continue
+			}
+			resubmits = append(resubmits, tx)
+		}
+	}
+
+	if journalCheck { // rejournal
+		rejournal = make(map[common.Address]types.Transactions)
+		for _, tx := range tracker.all {
+			addr, _ := types.Sender(tracker.signer, tx)
+			rejournal[addr] = append(rejournal[addr], tx)
+		}
+		// Sort them
+		for _, list := range rejournal {
+			// cmp(a, b) should return a negative number when a < b,
+			slices.SortFunc(list, func(a, b *types.Transaction) int {
+				return int(a.Nonce() - b.Nonce())
+			})
+		}
+	}
+	log.Debug("Tx tracker status", "need-resubmit", len(resubmits), "stale", numStales, "ok", numOk)
+	return resubmits, rejournal
+}
+
+// Start implements node.Lifecycle interface
+// Start is called after all services have been constructed and the networking
+// layer was also initialized to spawn any goroutines required by the service.
+func (tracker *TxTracker) Start() error {
+	tracker.wg.Add(1)
+	go tracker.loop()
+	return nil
+}
+
+// Start implements node.Lifecycle interface
+// Stop terminates all goroutines belonging to the service, blocking until they
+// are all terminated.
+func (tracker *TxTracker) Stop() error {
+	close(tracker.shutdownCh)
+	tracker.wg.Wait()
+	return nil
+}
+
+func (tracker *TxTracker) loop() {
+	defer tracker.wg.Done()
+	if tracker.journal != nil {
+		tracker.journal.load(func(transactions []*types.Transaction) []error {
+			tracker.TrackAll(transactions)
+			return nil
+		})
+		defer tracker.journal.close()
+	}
+	var lastJournal = time.Now()
+	// Do initial check after 10 seconds, do rechecks more seldom.
+	t := time.NewTimer(10 * time.Second)
+	for {
+		select {
+		case <-tracker.shutdownCh:
+			return
+		case <-t.C:
+			checkJournal := tracker.journal != nil && time.Since(lastJournal) > tracker.rejournal
+			resubmits, rejournal := tracker.recheck(checkJournal)
+			if len(resubmits) > 0 {
+				tracker.pool.Add(resubmits, false, false)
+			}
+			if checkJournal {
+				// Lock to prevent journal.rotate <-> journal.insert (via TrackAll) conflicts
+				tracker.mu.Lock()
+				lastJournal = time.Now()
+				if err := tracker.journal.rotate(rejournal); err != nil {
+					log.Warn("Transaction journal rotation failed", "err", err)
+				}
+				tracker.mu.Unlock()
+			}
+			t.Reset(recheckInterval)
+		}
+	}
+}

--- a/core/txpool/legacypool/tx_tracker.go
+++ b/core/txpool/legacypool/tx_tracker.go
@@ -87,7 +87,9 @@ func (tracker *TxTracker) TrackAll(txs []*types.Transaction) {
 			tracker.byAddr[addr] = newSortedMap()
 		}
 		tracker.byAddr[addr].Put(tx)
-		_ = tracker.journal.insert(tx)
+		if tracker.journal != nil {
+			_ = tracker.journal.insert(tx)
+		}
 	}
 }
 

--- a/core/txpool/txpool.go
+++ b/core/txpool/txpool.go
@@ -335,7 +335,8 @@ func (p *TxPool) Add(txs []*types.Transaction, local bool, sync bool) []error {
 	// back the errors into the original sort order.
 	errsets := make([][]error, len(p.subpools))
 	for i := 0; i < len(p.subpools); i++ {
-		errsets[i] = p.subpools[i].Add(txsets[i], local, sync)
+		// Note: local is explicitly set to false here.
+		errsets[i] = p.subpools[i].Add(txsets[i], false, sync)
 	}
 	errs := make([]error, len(txs))
 	for i, split := range splits {

--- a/eth/api_backend.go
+++ b/eth/api_backend.go
@@ -284,6 +284,9 @@ func (b *EthAPIBackend) SubscribeLogsEvent(ch chan<- []*types.Log) event.Subscri
 }
 
 func (b *EthAPIBackend) SendTx(ctx context.Context, signedTx *types.Transaction) error {
+	if locals := b.eth.localTxTracker; locals != nil {
+		locals.Track(signedTx)
+	}
 	return b.eth.txPool.Add([]*types.Transaction{signedTx}, true, false)[0]
 }
 

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -65,9 +65,10 @@ type Config = ethconfig.Config
 // Ethereum implements the Ethereum full node service.
 type Ethereum struct {
 	// core protocol objects
-	config     *ethconfig.Config
-	txPool     *txpool.TxPool
-	blockchain *core.BlockChain
+	config         *ethconfig.Config
+	txPool         *txpool.TxPool
+	localTxTracker *legacypool.TxTracker
+	blockchain     *core.BlockChain
 
 	handler *handler
 	discmix *enode.FairMix
@@ -232,6 +233,14 @@ func New(stack *node.Node, config *ethconfig.Config) (*Ethereum, error) {
 	legacyPool := legacypool.New(config.TxPool, eth.blockchain)
 
 	eth.txPool, err = txpool.New(config.TxPool.PriceLimit, eth.blockchain, []txpool.SubPool{legacyPool, blobPool})
+
+	if !config.TxPool.NoLocals {
+		eth.localTxTracker = legacypool.NewTxTracker(config.TxPool.Journal,
+			config.TxPool.Rejournal,
+			eth.blockchain.Config(), eth.txPool)
+		stack.RegisterLifecycle(eth.localTxTracker)
+	}
+
 	if err != nil {
 		return nil, err
 	}

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -262,6 +262,7 @@ func New(stack *node.Node, config *ethconfig.Config) (*Ethereum, error) {
 
 	eth.miner = miner.New(eth, config.Miner, eth.engine)
 	eth.miner.SetExtra(makeExtraData(config.Miner.ExtraData))
+	eth.miner.SetPrioAddresses(config.TxPool.Locals)
 
 	eth.APIBackend = &EthAPIBackend{stack.Config().ExtRPCEnabled(), stack.Config().AllowUnprotectedTxs, eth, nil}
 	if eth.APIBackend.allowUnprotectedTxs {

--- a/miner/miner.go
+++ b/miner/miner.go
@@ -70,6 +70,7 @@ type Miner struct {
 	chainConfig *params.ChainConfig
 	engine      consensus.Engine
 	txpool      *txpool.TxPool
+	prio        []common.Address // A list of senders to prioritize
 	chain       *core.BlockChain
 	pending     *pending
 	pendingMu   sync.Mutex // Lock protects the pending block
@@ -107,6 +108,12 @@ func (miner *Miner) SetExtra(extra []byte) error {
 	miner.config.ExtraData = extra
 	miner.confMu.Unlock()
 	return nil
+}
+
+func (miner *Miner) SetPrioAddresses(prio []common.Address) {
+	miner.confMu.Lock()
+	miner.prio = prio
+	miner.confMu.Unlock()
 }
 
 // SetGasCeil sets the gaslimit to strive for when mining blocks post 1559.

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -418,6 +418,7 @@ func (miner *Miner) commitTransactions(env *environment, plainTxs, blobTxs *tran
 func (miner *Miner) fillTransactions(interrupt *atomic.Int32, env *environment) error {
 	miner.confMu.RLock()
 	tip := miner.config.GasPrice
+	prio := miner.prio
 	miner.confMu.RUnlock()
 
 	// Retrieve the pending transactions pre-filtered by the 1559/4844 dynamic fees
@@ -437,31 +438,31 @@ func (miner *Miner) fillTransactions(interrupt *atomic.Int32, env *environment) 
 	pendingBlobTxs := miner.txpool.Pending(filter)
 
 	// Split the pending transactions into locals and remotes.
-	localPlainTxs, remotePlainTxs := make(map[common.Address][]*txpool.LazyTransaction), pendingPlainTxs
-	localBlobTxs, remoteBlobTxs := make(map[common.Address][]*txpool.LazyTransaction), pendingBlobTxs
+	prioPlainTxs, normalPlainTxs := make(map[common.Address][]*txpool.LazyTransaction), pendingPlainTxs
+	prioBlobTxs, normalBlobTxs := make(map[common.Address][]*txpool.LazyTransaction), pendingBlobTxs
 
-	for _, account := range miner.txpool.Locals() {
-		if txs := remotePlainTxs[account]; len(txs) > 0 {
-			delete(remotePlainTxs, account)
-			localPlainTxs[account] = txs
+	for _, account := range prio {
+		if txs := normalPlainTxs[account]; len(txs) > 0 {
+			delete(normalPlainTxs, account)
+			prioPlainTxs[account] = txs
 		}
-		if txs := remoteBlobTxs[account]; len(txs) > 0 {
-			delete(remoteBlobTxs, account)
-			localBlobTxs[account] = txs
+		if txs := normalBlobTxs[account]; len(txs) > 0 {
+			delete(normalBlobTxs, account)
+			prioBlobTxs[account] = txs
 		}
 	}
 	// Fill the block with all available pending transactions.
-	if len(localPlainTxs) > 0 || len(localBlobTxs) > 0 {
-		plainTxs := newTransactionsByPriceAndNonce(env.signer, localPlainTxs, env.header.BaseFee)
-		blobTxs := newTransactionsByPriceAndNonce(env.signer, localBlobTxs, env.header.BaseFee)
+	if len(prioPlainTxs) > 0 || len(prioBlobTxs) > 0 {
+		plainTxs := newTransactionsByPriceAndNonce(env.signer, prioPlainTxs, env.header.BaseFee)
+		blobTxs := newTransactionsByPriceAndNonce(env.signer, prioBlobTxs, env.header.BaseFee)
 
 		if err := miner.commitTransactions(env, plainTxs, blobTxs, interrupt); err != nil {
 			return err
 		}
 	}
-	if len(remotePlainTxs) > 0 || len(remoteBlobTxs) > 0 {
-		plainTxs := newTransactionsByPriceAndNonce(env.signer, remotePlainTxs, env.header.BaseFee)
-		blobTxs := newTransactionsByPriceAndNonce(env.signer, remoteBlobTxs, env.header.BaseFee)
+	if len(normalPlainTxs) > 0 || len(normalBlobTxs) > 0 {
+		plainTxs := newTransactionsByPriceAndNonce(env.signer, normalPlainTxs, env.header.BaseFee)
+		blobTxs := newTransactionsByPriceAndNonce(env.signer, normalBlobTxs, env.header.BaseFee)
 
 		if err := miner.commitTransactions(env, plainTxs, blobTxs, interrupt); err != nil {
 			return err


### PR DESCRIPTION
This is a re-run of https://github.com/ethereum/go-ethereum/pull/27535

I still think the idea is solid. Basically, our nodes transaction pool should have no concept of `locals`. Therefore, it is also a very good simulation/approximation of how our peers' pools behave. 

This PR implements a locals-tracker, which basically is a little thing which, from time to time, asks the pool "did you forget this transaction?". If it did, the tracker resubmits it. 

If the txpool _had_ forgotten it, chances are that the peers had also forgotten it. It will be propagated again. 

Doing this change means that we can simplify the pool internals, quite a lot (not included in this PR). 
This PR as is, does not integrate with worker: hence, block building will pay no special attention to local transactions. If we want to use the approach in this PR, we can discuss if / how to do such an integration (now that mining-pools no longer function like they did earlier, during ethash, I'm not sure that local txs in block-building is as important any longer) .


cc @lightclient since we discussed this a bit