### PR TITLE
cmd/evm: fix flag-mismatch from #29290

### DIFF
--- a/cmd/evm/staterunner.go
+++ b/cmd/evm/staterunner.go
@@ -67,7 +67,7 @@ func stateTestCmd(ctx *cli.Context) error {
 	}
 	// Load the test content from the input file
 	if len(ctx.Args().First()) != 0 {
-		return runStateTest(ctx.Args().First(), cfg, ctx.Bool(MachineFlag.Name))
+		return runStateTest(ctx.Args().First(), cfg, ctx.Bool(DumpFlag.Name))
 	}
 	// Read filenames from stdin and execute back-to-back
 	scanner := bufio.NewScanner(os.Stdin)
@@ -76,7 +76,7 @@ func stateTestCmd(ctx *cli.Context) error {
 		if len(fname) == 0 {
 			return nil
 		}
-		if err := runStateTest(fname, cfg, ctx.Bool(MachineFlag.Name)); err != nil {
+		if err := runStateTest(fname, cfg, ctx.Bool(DumpFlag.Name)); err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
I mismatched the flags a bit in #29290. This PR fixes it