### PR TITLE
core/txpool/blobpool: calculate log1.125 faster

### DIFF
--- a/core/txpool/blobpool/priority.go
+++ b/core/txpool/blobpool/priority.go
@@ -23,8 +23,8 @@ import (
 	"github.com/holiman/uint256"
 )
 
-// log2_1_125 is used in the eviction priority calculation.
-var log2_1_125 = math.Log2(1.125)
+// log1_125 is used in the eviction priority calculation.
+var log1_125 = math.Log(1.125)
 
 // evictionPriority calculates the eviction priority based on the algorithm
 // described in the BlobPool docs for both fee components.
@@ -57,8 +57,8 @@ func evictionPriority1D(basefeeJumps float64, txfeeJumps float64) int {
 
 // dynamicFeeJumps calculates the log1.125(fee), namely the number of fee jumps
 // needed to reach the requested one. We only use it when calculating the jumps
-// between 2 fees, so it doesn't matter from what exact number with returns.
-// it returns the result from (0, 1, 1.125).
+// between 2 fees, so it doesn't matter from what exact number it returns.
+// It returns the result from (0, 1, 1.125).
 //
 // This method is very expensive, taking about 75ns on a very recent laptop CPU,
 // but the result does not change with the lifetime of a transaction, so it can
@@ -67,7 +67,7 @@ func dynamicFeeJumps(fee *uint256.Int) float64 {
 	if fee.IsZero() {
 		return 0 // can't log2 zero, should never happen outside tests, but don't choke
 	}
-	return math.Log2(fee.Float64()) / log2_1_125
+	return math.Log(fee.Float64()) / log1_125
 }
 
 // intLog2 is a helper to calculate the integral part of a log2 of an unsigned


### PR DESCRIPTION
`log1.125(x) = log(x) / log(1.125) = log2(x) / log2(1.125)
`

In golang, math.Log is faster than math.Log2 about 35%, because math.log2 calls math.Log internally https://github.com/golang/go/blob/fba54f6345449586518039043ab38df337c25146/src/math/log10.go#L36

My benchmark code:
```
package main

import (
    "testing"
    "math"

    "github.com/holiman/uint256"
)

var fee, _ = uint256.FromDecimal("12345678910")
var log2_1_125 = math.Log2(1.125)
var log1_125 = math.Log(1.125)

func BenchmarkLog2(b *testing.B) {
    var result float64
    for i := 0; i < b.N; i++ {
        result = math.Log2(fee.Float64()) / log2_1_125
    }
    _ = result // Prevent compiler optimization
}

func BenchmarkLog(b *testing.B) {
    var result float64
    for i := 0; i < b.N; i++ {
        result = math.Log(fee.Float64()) / log1_125
    }
    _ = result // Prevent compiler optimization
}
```

```
go test -bench=.
```
```
goos: linux
goarch: amd64
pkg: mul
cpu: AMD Ryzen 7 7735H with Radeon Graphics         
BenchmarkLog2-16    	84192789	        14.43 ns/op
BenchmarkLog-16     	152682724	         7.832 ns/op
PASS
ok  	mul	3.227s
```
