### PR TITLE
eth/protocols/snap, internal/testlog: fix dataraces

### DIFF
--- a/eth/protocols/snap/sync_test.go
+++ b/eth/protocols/snap/sync_test.go
@@ -1873,8 +1873,9 @@ func verifyTrie(scheme string, db ethdb.KeyValueStore, root common.Hash, t *test
 // TestSyncAccountPerformance tests how efficient the snap algo is at minimizing
 // state healing
 func TestSyncAccountPerformance(t *testing.T) {
-	t.Parallel()
-
+	// These tests must not run in parallel: they modify the
+	// global var accountConcurrency
+	// t.Parallel()
 	testSyncAccountPerformance(t, rawdb.HashScheme)
 	testSyncAccountPerformance(t, rawdb.PathScheme)
 }


### PR DESCRIPTION
This PR fixes two races from `go test --race ./...` : 

```
==================
WARNING: DATA RACE
Write at 0x000001f2af90 by goroutine 39:
  github.com/ethereum/go-ethereum/eth/protocols/snap.testSyncAccountPerformance.func1()
      /home/user/go/src/github.com/ethereum/go-ethereum/eth/protocols/snap/sync_test.go:1885 +0x35
  github.com/ethereum/go-ethereum/eth/protocols/snap.testSyncAccountPerformance.deferwrap1()
      /home/user/go/src/github.com/ethereum/go-ethereum/eth/protocols/snap/sync_test.go:1885 +0x17
  runtime.deferreturn()
      /usr/local/go/src/runtime/panic.go:602 +0x5d
  github.com/ethereum/go-ethereum/eth/protocols/snap.TestSyncAccountPerformance()
      /home/user/go/src/github.com/ethereum/go-ethereum/eth/protocols/snap/sync_test.go:1878 +0x3c
  testing.tRunner()
      /usr/local/go/src/testing/testing.go:1689 +0x21e
  testing.(*T).Run.gowrap1()
      /usr/local/go/src/testing/testing.go:1742 +0x44

Previous read at 0x000001f2af90 by goroutine 38:
  github.com/ethereum/go-ethereum/eth/protocols/snap.(*Syncer).loadSyncStatus()
      /home/user/go/src/github.com/ethereum/go-ethereum/eth/protocols/snap/sync.go:833 +0x4b8
  github.com/ethereum/go-ethereum/eth/protocols/snap.(*Syncer).Sync()
      /home/user/go/src/github.com/ethereum/go-ethereum/eth/protocols/snap/sync.go:588 +0x4c4
  github.com/ethereum/go-ethereum/eth/protocols/snap.testSyncWithUnevenStorage()
      /home/user/go/src/github.com/ethereum/go-ethereum/eth/protocols/snap/sync_test.go:1453 +0x394
  github.com/ethereum/go-ethereum/eth/protocols/snap.TestSyncWithUnevenStorage()
      /home/user/go/src/github.com/ethereum/go-ethereum/eth/protocols/snap/sync_test.go:1425 +0x3c
  testing.tRunner()
      /usr/local/go/src/testing/testing.go:1689 +0x21e
  testing.(*T).Run.gowrap1()
      /usr/local/go/src/testing/testing.go:1742 +0x44

```

and 
```
WARNING: DATA RACE
Read at 0x00c0002e8700 by goroutine 9196:
  github.com/ethereum/go-ethereum/internal/testlog.(*bufHandler).WithAttrs()
      /home/user/go/src/github.com/ethereum/go-ethereum/internal/testlog/testlog.go:62 +0x3c
  golang.org/x/exp/slog.(*Logger).With()
      /home/user/go/pkg/mod/golang.org/x/exp@v0.0.0-20231110203233-9a3e6036ecaa/slog/logger.go:99 +0xf4
  github.com/ethereum/go-ethereum/log.(*logger).With()
      /home/user/go/src/github.com/ethereum/go-ethereum/log/logger.go:182 +0x57
  github.com/ethereum/go-ethereum/internal/testlog.(*logger).With()
      /home/user/go/src/github.com/ethereum/go-ethereum/internal/testlog/testlog.go:168 +0x66
  github.com/ethereum/go-ethereum/internal/testlog.(*logger).New()
      /home/user/go/src/github.com/ethereum/go-ethereum/internal/testlog/testlog.go:172 +0x12
  github.com/ethereum/go-ethereum/p2p.(*Server).setupConn()


Previous write at 0x00c0002e8700 by goroutine 9195:
  github.com/ethereum/go-ethereum/internal/testlog.(*logger).flush()
      /home/user/go/src/github.com/ethereum/go-ethereum/internal/testlog/testlog.go:206 +0x204
  github.com/ethereum/go-ethereum/internal/testlog.(*logger).Info()
      /home/user/go/src/github.com/ethereum/go-ethereum/internal/testlog/testlog.go:140 +0x167
  github.com/ethereum/go-ethereum/p2p.(*Server).run()
```