### PR TITLE
log: use native log/slog instead of golang/exp

### DIFF
--- a/eth/downloader/queue_test.go
+++ b/eth/downloader/queue_test.go
@@ -18,6 +18,7 @@ package downloader
 
 import (
 	"fmt"
+	"log/slog"
 	"math/big"
 	"math/rand"
 	"os"
@@ -32,7 +33,6 @@ import (
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/params"
 	"github.com/ethereum/go-ethereum/trie"
-	"golang.org/x/exp/slog"
 )
 
 // makeChain creates a chain of n blocks starting at and including parent.

--- a/internal/debug/api.go
+++ b/internal/debug/api.go
@@ -24,6 +24,7 @@ import (
 	"bytes"
 	"errors"
 	"io"
+	"log/slog"
 	"os"
 	"os/user"
 	"path/filepath"
@@ -37,7 +38,6 @@ import (
 
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/hashicorp/go-bexpr"
-	"golang.org/x/exp/slog"
 )
 
 // Handler is the global debugging handler.

--- a/internal/debug/flags.go
+++ b/internal/debug/flags.go
@@ -19,6 +19,7 @@ package debug
 import (
 	"fmt"
 	"io"
+	"log/slog"
 	"net"
 	"net/http"
 	_ "net/http/pprof"
@@ -34,7 +35,6 @@ import (
 	"github.com/mattn/go-colorable"
 	"github.com/mattn/go-isatty"
 	"github.com/urfave/cli/v2"
-	"golang.org/x/exp/slog"
 	"gopkg.in/natefinch/lumberjack.v2"
 )
 

--- a/internal/testlog/testlog.go
+++ b/internal/testlog/testlog.go
@@ -21,11 +21,11 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"log/slog"
 	"sync"
 	"testing"
 
 	"github.com/ethereum/go-ethereum/log"
-	"golang.org/x/exp/slog"
 )
 
 const (

--- a/log/format.go
+++ b/log/format.go
@@ -3,6 +3,7 @@ package log
 import (
 	"bytes"
 	"fmt"
+	"log/slog"
 	"math/big"
 	"reflect"
 	"strconv"
@@ -10,7 +11,6 @@ import (
 	"unicode/utf8"
 
 	"github.com/holiman/uint256"
-	"golang.org/x/exp/slog"
 )
 
 const (

--- a/log/handler.go
+++ b/log/handler.go
@@ -4,13 +4,13 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"log/slog"
 	"math/big"
 	"reflect"
 	"sync"
 	"time"
 
 	"github.com/holiman/uint256"
-	"golang.org/x/exp/slog"
 )
 
 type discardHandler struct{}

--- a/log/handler_glog.go
+++ b/log/handler_glog.go
@@ -20,14 +20,13 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"log/slog"
 	"regexp"
 	"runtime"
 	"strconv"
 	"strings"
 	"sync"
 	"sync/atomic"
-
-	"golang.org/x/exp/slog"
 )
 
 // errVmoduleSyntax is returned when a user vmodule pattern is invalid.

--- a/log/logger.go
+++ b/log/logger.go
@@ -2,12 +2,11 @@ package log
 
 import (
 	"context"
+	"log/slog"
 	"math"
 	"os"
 	"runtime"
 	"time"
-
-	"golang.org/x/exp/slog"
 )
 
 const errorKey = "LOG_ERROR"

--- a/log/logger_test.go
+++ b/log/logger_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"log/slog"
 	"math/big"
 	"os"
 	"strings"
@@ -12,7 +13,6 @@ import (
 	"time"
 
 	"github.com/holiman/uint256"
-	"golang.org/x/exp/slog"
 )
 
 // TestLoggingWithVmodule checks that vmodule works.

--- a/log/root.go
+++ b/log/root.go
@@ -1,10 +1,9 @@
 package log
 
 import (
+	"log/slog"
 	"os"
 	"sync/atomic"
-
-	"golang.org/x/exp/slog"
 )
 
 var root atomic.Value

--- a/p2p/simulations/adapters/exec.go
+++ b/p2p/simulations/adapters/exec.go
@@ -23,6 +23,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"log/slog"
 	"net"
 	"net/http"
 	"os"
@@ -41,7 +42,6 @@ import (
 	"github.com/ethereum/go-ethereum/p2p/enode"
 	"github.com/ethereum/go-ethereum/rpc"
 	"github.com/gorilla/websocket"
-	"golang.org/x/exp/slog"
 )
 
 func init() {

--- a/p2p/simulations/adapters/types.go
+++ b/p2p/simulations/adapters/types.go
@@ -21,6 +21,7 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
+	"log/slog"
 	"net"
 	"os"
 	"strconv"
@@ -34,7 +35,6 @@ import (
 	"github.com/ethereum/go-ethereum/p2p/enr"
 	"github.com/ethereum/go-ethereum/rpc"
 	"github.com/gorilla/websocket"
-	"golang.org/x/exp/slog"
 )
 
 // Node represents a node in a simulation network which is created by a

--- a/p2p/simulations/http_test.go
+++ b/p2p/simulations/http_test.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"flag"
 	"fmt"
+	"log/slog"
 	"math/rand"
 	"net/http/httptest"
 	"os"
@@ -37,7 +38,6 @@ import (
 	"github.com/ethereum/go-ethereum/p2p/simulations/adapters"
 	"github.com/ethereum/go-ethereum/rpc"
 	"github.com/mattn/go-colorable"
-	"golang.org/x/exp/slog"
 )
 
 func TestMain(m *testing.M) {

--- a/signer/core/auditlog.go
+++ b/signer/core/auditlog.go
@@ -19,6 +19,7 @@ package core
 import (
 	"context"
 	"encoding/json"
+	"log/slog"
 	"os"
 
 	"github.com/ethereum/go-ethereum/common"
@@ -26,7 +27,6 @@ import (
 	"github.com/ethereum/go-ethereum/internal/ethapi"
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/signer/core/apitypes"
-	"golang.org/x/exp/slog"
 )
 
 type AuditLogger struct {

--- a/signer/storage/aes_gcm_storage_test.go
+++ b/signer/storage/aes_gcm_storage_test.go
@@ -20,13 +20,13 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"log/slog"
 	"os"
 	"testing"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/mattn/go-colorable"
-	"golang.org/x/exp/slog"
 )
 
 func TestEncryption(t *testing.T) {


### PR DESCRIPTION
We're on go 1.21+ now, can use the "real" `slog`