### PR TITLE
all: use min/max/clear from go1.21

### DIFF
--- a/accounts/keystore/keystore.go
+++ b/accounts/keystore/keystore.go
@@ -500,7 +500,5 @@ func (ks *KeyStore) isUpdating() bool {
 // zeroKey zeroes a private key in memory.
 func zeroKey(k *ecdsa.PrivateKey) {
 	b := k.D.Bits()
-	for i := range b {
-		b[i] = 0
-	}
+	clear(b)
 }

--- a/core/vm/analysis_test.go
+++ b/core/vm/analysis_test.go
@@ -93,9 +93,7 @@ func BenchmarkJumpdestOpAnalysis(bench *testing.B) {
 		bits := make(bitvec, len(code)/8+1+4)
 		b.ResetTimer()
 		for i := 0; i < b.N; i++ {
-			for j := range bits {
-				bits[j] = 0
-			}
+			clear(bits)
 			codeBitmapInternal(code, bits)
 		}
 	}

--- a/crypto/crypto.go
+++ b/crypto/crypto.go
@@ -287,7 +287,5 @@ func PubkeyToAddress(p ecdsa.PublicKey) common.Address {
 }
 
 func zeroBytes(bytes []byte) {
-	for i := range bytes {
-		bytes[i] = 0
-	}
+	clear(bytes)
 }

--- a/crypto/secp256k1/scalar_mult_cgo.go
+++ b/crypto/secp256k1/scalar_mult_cgo.go
@@ -44,12 +44,8 @@ func (BitCurve *BitCurve) ScalarMult(Bx, By *big.Int, scalar []byte) (*big.Int, 
 	// Unpack the result and clear temporaries.
 	x := new(big.Int).SetBytes(point[:32])
 	y := new(big.Int).SetBytes(point[32:])
-	for i := range point {
-		point[i] = 0
-	}
-	for i := range padded {
-		scalar[i] = 0
-	}
+	clear(point)
+	clear(scalar)
 	if res != 1 {
 		return nil, nil
 	}

--- a/eth/protocols/eth/peer.go
+++ b/eth/protocols/eth/peer.go
@@ -42,14 +42,6 @@ const (
 	maxQueuedTxAnns = 4096
 )
 
-// max is a helper function which returns the larger of the two given integers.
-func max(a, b int) int {
-	if a > b {
-		return a
-	}
-	return b
-}
-
 // Peer is a collection of relevant information we have about a `eth` peer.
 type Peer struct {
 	id string // Unique ID for the peer, cached

--- a/internal/era/era.go
+++ b/internal/era/era.go
@@ -229,7 +229,7 @@ func (e *Era) readOffset(n uint64) (int64, error) {
 	)
 	e.mu.Lock()
 	defer e.mu.Unlock()
-	clearBuffer(e.buf[:])
+	clear(e.buf[:])
 	if _, err := e.f.ReadAt(e.buf[:], offOffset); err != nil {
 		return 0, err
 	}
@@ -246,13 +246,6 @@ func newSnappyReader(e *e2store.Reader, expectedType uint16, off int64) (io.Read
 		return nil, 0, err
 	}
 	return snappy.NewReader(r), int64(n), err
-}
-
-// clearBuffer zeroes out the buffer.
-func clearBuffer(buf []byte) {
-	for i := 0; i < len(buf); i++ {
-		buf[i] = 0
-	}
 }
 
 // metadata wraps the metadata in the block index.

--- a/metrics/sample_test.go
+++ b/metrics/sample_test.go
@@ -87,13 +87,6 @@ func BenchmarkUniformSample1028(b *testing.B) {
 	benchmarkSample(b, NewUniformSample(1028))
 }
 
-func min(a, b int) int {
-	if a < b {
-		return a
-	}
-	return b
-}
-
 func TestExpDecaySample(t *testing.T) {
 	for _, tc := range []struct {
 		reservoirSize int

--- a/p2p/discover/common.go
+++ b/p2p/discover/common.go
@@ -92,10 +92,3 @@ type ReadPacket struct {
 	Data []byte
 	Addr *net.UDPAddr
 }
-
-func min(x, y int) int {
-	if x > y {
-		return y
-	}
-	return x
-}

--- a/p2p/discover/v5wire/crypto.go
+++ b/p2p/discover/v5wire/crypto.go
@@ -129,9 +129,7 @@ func deriveKeys(hash hashFn, priv *ecdsa.PrivateKey, pub *ecdsa.PublicKey, n1, n
 	sec := session{writeKey: make([]byte, aesKeySize), readKey: make([]byte, aesKeySize)}
 	kdf.Read(sec.writeKey)
 	kdf.Read(sec.readKey)
-	for i := range eph {
-		eph[i] = 0
-	}
+	clear(eph)
 	return &sec
 }
 

--- a/rlp/decode.go
+++ b/rlp/decode.go
@@ -1105,9 +1105,7 @@ func (s *Stream) readUint(size byte) (uint64, error) {
 		return uint64(b), err
 	default:
 		buffer := s.uintbuf[:8]
-		for i := range buffer {
-			buffer[i] = 0
-		}
+		clear(buffer)
 		start := int(8 - size)
 		if err := s.readFull(buffer[start:]); err != nil {
 			return 0, err


### PR DESCRIPTION
Embrace some of the stuff in `go 1.21`: https://go.dev/doc/go1.21 