### PR TITLE
triedb/hashdb: Avoid setting db.cleans on Close

### DIFF
--- a/triedb/hashdb/database.go
+++ b/triedb/hashdb/database.go
@@ -619,7 +619,6 @@ func (db *Database) Size() (common.StorageSize, common.StorageSize) {
 func (db *Database) Close() error {
 	if db.cleans != nil {
 		db.cleans.Reset()
-		db.cleans = nil
 	}
 	return nil
 }


### PR DESCRIPTION
Hi. Setting `db.cleans` to nil on Close() can cause concurrent access (data race) with other functions accessing `db`.
This is not likely an issue, but also setting `db.cleans` to nil does not achieve much since the cache is reset, so it seems easier to let it be and let the cache be collected along with the owner of `db`.
