### PR TITLE
ethclient/simulated: clean up Node resources when simulated backend is closed

### DIFF
--- a/eth/backend.go
+++ b/eth/backend.go
@@ -101,8 +101,8 @@ type Ethereum struct {
 	shutdownTracker *shutdowncheck.ShutdownTracker // Tracks if and when the node has shutdown ungracefully
 }
 
-// New creates a new Ethereum object (including the
-// initialisation of the common Ethereum object)
+// New creates a new Ethereum object (including the initialisation of the common Ethereum object),
+// whose lifecycle will be managed by the provided node.
 func New(stack *node.Node, config *ethconfig.Config) (*Ethereum, error) {
 	// Ensure configuration values are compatible and sane
 	if config.SyncMode == downloader.LightSync {

--- a/ethclient/simulated/backend.go
+++ b/ethclient/simulated/backend.go
@@ -17,6 +17,7 @@
 package simulated
 
 import (
+	"errors"
 	"time"
 
 	"github.com/ethereum/go-ethereum"
@@ -142,18 +143,16 @@ func (n *Backend) Close() error {
 		n.client.Close()
 		n.client = simClient{}
 	}
-	var rerr error // return only last error if there are multiple
+	var err error
 	if n.beacon != nil {
-		rerr = n.beacon.Stop()
+		err = n.beacon.Stop()
 		n.beacon = nil
 	}
 	if n.node != nil {
-		if err := n.node.Close(); err != nil {
-			rerr = err
-		}
+		err = errors.Join(err, n.node.Close())
 		n.node = nil
 	}
-	return rerr
+	return err
 }
 
 // Commit seals a block and moves the chain forward to a new empty block.


### PR DESCRIPTION
This PR makes the simulated backend keep track of the underlying Node (instead of the eth.Backend) and closes it when Close() is called. It also adds to the eth.New() function godoc to clarify the returned object's lifecycle gets managed by the Node, since I found this a bit surprising.

Context: Lingering resources were causing a bit of bloat during OP-stack end to end testing, some of which seemed to come from the simulated backends used throughout.