### PR TITLE
internal/ethapi: able to returns bytes of the custom errors

### DIFF
--- a/internal/ethapi/errors.go
+++ b/internal/ethapi/errors.go
@@ -49,6 +49,8 @@ func newRevertError(revert []byte) *revertError {
 	reason, errUnpack := abi.UnpackRevert(revert)
 	if errUnpack == nil {
 		err = fmt.Errorf("%w: %v", vm.ErrExecutionReverted, reason)
+	} else if len(revert) >= 4 {
+		err = fmt.Errorf("execution reverted with a custom error: %x", revert)
 	}
 	return &revertError{
 		error:  err,

--- a/internal/ethapi/errors.go
+++ b/internal/ethapi/errors.go
@@ -50,7 +50,7 @@ func newRevertError(revert []byte) *revertError {
 	if errUnpack == nil {
 		err = fmt.Errorf("%w: %v", vm.ErrExecutionReverted, reason)
 	} else if len(revert) >= 4 {
-		err = fmt.Errorf("execution reverted with a custom error: %x", revert)
+		err = fmt.Errorf("execution reverted with a custom error: %#x", revert)
 	}
 	return &revertError{
 		error:  err,


### PR DESCRIPTION
Since many projects start using custom errors, it's a pain to debug the `execution reverted` error.

This PR can provide the addition data, so dapps and any web3 clients can use it to display user-friendly errors

We don't need to provide it for trace calls due to there is an `output` field for the case.