### PR TITLE
all: remove code that will not be executed

### DIFF
--- a/accounts/keystore/account_cache_test.go
+++ b/accounts/keystore/account_cache_test.go
@@ -358,7 +358,6 @@ func TestUpdatedKeyfileContents(t *testing.T) {
 	// Now replace file contents
 	if err := forceCopyFile(file, cachetestAccounts[1].URL.Path); err != nil {
 		t.Fatal(err)
-		return
 	}
 	wantAccounts = []accounts.Account{cachetestAccounts[1]}
 	wantAccounts[0].URL = accounts.URL{Scheme: KeyStoreScheme, Path: file}
@@ -374,7 +373,6 @@ func TestUpdatedKeyfileContents(t *testing.T) {
 	// Now replace file contents again
 	if err := forceCopyFile(file, cachetestAccounts[2].URL.Path); err != nil {
 		t.Fatal(err)
-		return
 	}
 	wantAccounts = []accounts.Account{cachetestAccounts[2]}
 	wantAccounts[0].URL = accounts.URL{Scheme: KeyStoreScheme, Path: file}
@@ -390,7 +388,6 @@ func TestUpdatedKeyfileContents(t *testing.T) {
 	// Now replace file contents with crap
 	if err := os.WriteFile(file, []byte("foo"), 0600); err != nil {
 		t.Fatal(err)
-		return
 	}
 	if err := waitForAccounts([]accounts.Account{}, ks); err != nil {
 		t.Errorf("Emptying account file failed")

--- a/consensus/clique/snapshot_test.go
+++ b/consensus/clique/snapshot_test.go
@@ -467,7 +467,6 @@ func (tt *cliqueTest) run(t *testing.T) {
 	for j := 0; j < len(batches)-1; j++ {
 		if k, err := chain.InsertChain(batches[j]); err != nil {
 			t.Fatalf("failed to import batch %d, block %d: %v", j, k, err)
-			break
 		}
 	}
 	if _, err = chain.InsertChain(batches[len(batches)-1]); err != tt.failure {

--- a/eth/filters/bench_test.go
+++ b/eth/filters/bench_test.go
@@ -95,7 +95,6 @@ func benchmarkBloomBits(b *testing.B, sectionSize uint64) {
 			hash := rawdb.ReadCanonicalHash(db, i)
 			if header = rawdb.ReadHeader(db, hash, i); header == nil {
 				b.Fatalf("Error creating bloomBits data")
-				return
 			}
 			bc.AddBloom(uint(i-sectionIdx*sectionSize), header.Bloom)
 		}

--- a/p2p/discover/v5_udp_test.go
+++ b/p2p/discover/v5_udp_test.go
@@ -822,12 +822,10 @@ func (test *udpV5Test) waitPacketOut(validate interface{}) (closed bool) {
 	}
 	if err == errTimeout {
 		test.t.Fatalf("timed out waiting for %v", exptype)
-		return false
 	}
 	ln := test.nodesByIP[string(dgram.to.IP)]
 	if ln == nil {
 		test.t.Fatalf("attempt to send to non-existing node %v", &dgram.to)
-		return false
 	}
 	codec := &testCodec{test: test, id: ln.ID()}
 	frame, p, err := codec.decodeFrame(dgram.data)

--- a/tests/state_test.go
+++ b/tests/state_test.go
@@ -232,11 +232,9 @@ func runBenchmarkFile(b *testing.B, path string) {
 	m := make(map[string]StateTest)
 	if err := readJSONFile(path, &m); err != nil {
 		b.Fatal(err)
-		return
 	}
 	if len(m) != 1 {
 		b.Fatal("expected single benchmark in a file")
-		return
 	}
 	for _, t := range m {
 		t := t


### PR DESCRIPTION
After Fatal, the program will exit directly and the subsequent code will not be executed