### PR TITLE
accounts/keystore: fix typos in comments

### DIFF
--- a/accounts/keystore/keystore_test.go
+++ b/accounts/keystore/keystore_test.go
@@ -343,7 +343,7 @@ func TestWalletNotifications(t *testing.T) {
 	checkEvents(t, wantEvents, events)
 }
 
-// TestImportExport tests the import functionality of a keystore.
+// TestImportECDSA tests the import functionality of a keystore.
 func TestImportECDSA(t *testing.T) {
 	t.Parallel()
 	_, ks := tmpKeyStore(t)
@@ -362,7 +362,7 @@ func TestImportECDSA(t *testing.T) {
 	}
 }
 
-// TestImportECDSA tests the import and export functionality of a keystore.
+// TestImportExport tests the import and export functionality of a keystore.
 func TestImportExport(t *testing.T) {
 	t.Parallel()
 	_, ks := tmpKeyStore(t)


### PR DESCRIPTION
The annotations for these two methods have been swapped, correct them