### PR TITLE
eth/protocols/snap: check storage root existence for hash too

### DIFF
--- a/eth/protocols/snap/sync.go
+++ b/eth/protocols/snap/sync.go
@@ -2201,7 +2201,7 @@ func (s *Syncer) processStorageResponse(res *storageResponse) {
 			// If the chunk's root is an overflown but full delivery,
 			// clear the heal request.
 			accountHash := res.accounts[len(res.accounts)-1]
-			if root == res.subTask.root && rawdb.HasStorageTrieNode(s.db, accountHash, nil, root) {
+			if root == res.subTask.root && rawdb.HasTrieNode(s.db, accountHash, nil, root, s.scheme) {
 				for i, account := range res.mainTask.res.hashes {
 					if account == accountHash {
 						res.mainTask.needHeal[i] = false


### PR DESCRIPTION
This pull request fixes an error for checking storage root existence, introduced by https://github.com/ethereum/go-ethereum/pull/28327/files#diff-d26ea400bc58a59ffc652f18f3e402fe7e3279c1569c8374c216b5d702f2fe7cR2204

In snap sync, there is a special case that a storage is split into several chunks for retrieval, while all the slots are found in the first range in the end. In this case the root node produced by the stackTrie in first range matches with the full one and state healing can be skipped.

In the PR 28327, in order to enhance the condition, an additional check is added to ensure the root storage trie node is indeed present in the database before skipping state healing. **However, the check only reads node in path scheme, namely in hash based the mechanism is no longer working.**

The check is replaced with a correct one, which works for both path and hash scheme.