### PR TITLE
eth/catalyst: fix flaw in withdrawal-gathering in simulated beacon

### DIFF
--- a/eth/catalyst/simulated_beacon.go
+++ b/eth/catalyst/simulated_beacon.go
@@ -63,7 +63,7 @@ func (w *withdrawalQueue) gatherPending(maxCount int) []*types.Withdrawal {
 		case withdrawal := <-w.pending:
 			withdrawals = append(withdrawals, withdrawal)
 			if len(withdrawals) == maxCount {
-				break
+				return withdrawals
 			}
 		default:
 			return withdrawals


### PR DESCRIPTION
The break only breaks out of the select statement, making maxCount useless.
It should return immediately instead.