### PR TITLE
fix warning flagging the use of DeepEqual on error

### DIFF
--- a/accounts/keystore/account_cache_test.go
+++ b/accounts/keystore/account_cache_test.go
@@ -308,7 +308,7 @@ func TestCacheFind(t *testing.T) {
 	}
 	for i, test := range tests {
 		a, err := cache.find(test.Query)
-		if !reflect.DeepEqual(err, test.WantError) {
+		if !errors.Is(err, test.WantError) {
 			t.Errorf("test %d: error mismatch for query %v\ngot %q\nwant %q", i, test.Query, err, test.WantError)
 			continue
 		}

--- a/core/genesis_test.go
+++ b/core/genesis_test.go
@@ -19,6 +19,7 @@ package core
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"math/big"
 	"reflect"
 	"testing"
@@ -157,7 +158,7 @@ func testSetupGenesis(t *testing.T, scheme string) {
 		db := rawdb.NewMemoryDatabase()
 		config, hash, err := test.fn(db)
 		// Check the return values.
-		if !reflect.DeepEqual(err, test.wantErr) {
+		if !errors.Is(err, test.wantErr) {
 			spew := spew.ConfigState{DisablePointerAddresses: true, DisableCapacities: true}
 			t.Errorf("%s: returned error %#v, want %#v", test.name, spew.NewFormatter(err), spew.NewFormatter(test.wantErr))
 		}

--- a/eth/tracers/api_test.go
+++ b/eth/tracers/api_test.go
@@ -380,7 +380,7 @@ func TestTraceCall(t *testing.T) {
 				t.Errorf("test %d: expect error %v, got nothing", i, testspec.expectErr)
 				continue
 			}
-			if !reflect.DeepEqual(err.Error(), testspec.expectErr.Error()) {
+			if !errors.Is(err, testspec.expectErr) {
 				t.Errorf("test %d: error mismatch, want '%v', got '%v'", i, testspec.expectErr, err)
 			}
 		} else {
@@ -531,7 +531,7 @@ func TestTraceBlock(t *testing.T) {
 				t.Errorf("test %d, want error %v", i, tc.expectErr)
 				continue
 			}
-			if !reflect.DeepEqual(err, tc.expectErr) {
+			if !errors.Is(err, tc.expectErr) {
 				t.Errorf("test %d: error mismatch, want %v, get %v", i, tc.expectErr, err)
 			}
 			continue

--- a/internal/ethapi/api_test.go
+++ b/internal/ethapi/api_test.go
@@ -957,7 +957,7 @@ func TestCall(t *testing.T) {
 			}
 			if !errors.Is(err, tc.expectErr) {
 				// Second try
-				if !reflect.DeepEqual(err, tc.expectErr) {
+				if !errors.Is(err, tc.expectErr) {
 					t.Errorf("test %d: error mismatch, want %v, have %v", i, tc.expectErr, err)
 				}
 			}

--- a/p2p/netutil/net_test.go
+++ b/p2p/netutil/net_test.go
@@ -17,6 +17,7 @@
 package netutil
 
 import (
+	"errors"
 	"fmt"
 	"net"
 	"reflect"
@@ -56,7 +57,7 @@ func TestParseNetlist(t *testing.T) {
 
 	for _, test := range tests {
 		l, err := ParseNetlist(test.input)
-		if !reflect.DeepEqual(err, test.wantErr) {
+		if !errors.Is(err, test.wantErr) {
 			t.Errorf("%q: got error %q, want %q", test.input, err, test.wantErr)
 			continue
 		}

--- a/p2p/transport_test.go
+++ b/p2p/transport_test.go
@@ -141,7 +141,7 @@ func TestProtocolHandshakeErrors(t *testing.T) {
 		p1, p2 := MsgPipe()
 		go Send(p1, test.code, test.msg)
 		_, err := readProtocolHandshake(p2)
-		if !reflect.DeepEqual(err, test.err) {
+		if !errors.Is(err, test.err) {
 			t.Errorf("test %d: error mismatch: got %q, want %q", i, err, test.err)
 		}
 	}

--- a/params/config_test.go
+++ b/params/config_test.go
@@ -17,8 +17,8 @@
 package params
 
 import (
+	"errors"
 	"math/big"
-	"reflect"
 	"testing"
 	"time"
 
@@ -113,7 +113,7 @@ func TestCheckCompatible(t *testing.T) {
 
 	for _, test := range tests {
 		err := test.stored.CheckCompatible(test.new, test.headBlock, test.headTimestamp)
-		if !reflect.DeepEqual(err, test.wantErr) {
+		if !errors.Is(err, test.wantErr) {
 			t.Errorf("error mismatch:\nstored: %v\nnew: %v\nheadBlock: %v\nheadTimestamp: %v\nerr: %v\nwant: %v", test.stored, test.new, test.headBlock, test.headTimestamp, err, test.wantErr)
 		}
 	}

--- a/tests/state_test.go
+++ b/tests/state_test.go
@@ -19,12 +19,12 @@ package tests
 import (
 	"bufio"
 	"bytes"
+	"errors"
 	"fmt"
 	"math/big"
 	"math/rand"
 	"os"
 	"path/filepath"
-	"reflect"
 	"strings"
 	"testing"
 	"time"
@@ -192,7 +192,7 @@ func withTrace(t *testing.T, gasLimit uint64, test func(vm.Config) error) {
 	w := bufio.NewWriter(buf)
 	config.Tracer = logger.NewJSONLogger(&logger.Config{}, w)
 	err2 := test(config)
-	if !reflect.DeepEqual(err, err2) {
+	if !errors.Is(err, err2) {
 		t.Errorf("different error for second run: %v", err2)
 	}
 	w.Flush()


### PR DESCRIPTION
It's the same issue as below.

- all: fix warning flagging the use of DeepEqual on error #23624

