### PR TITLE
tests: fix panic via state test runner using json logger

### DIFF
--- a/tests/state_test_util.go
+++ b/tests/state_test_util.go
@@ -297,6 +297,11 @@ func (t *StateTest) RunNoVerify(subtest StateSubtest, vmconfig vm.Config, snapsh
 
 	if tracer := vmconfig.Tracer; tracer != nil && tracer.OnTxStart != nil {
 		tracer.OnTxStart(evm.GetVMContext(), nil, msg.From)
+		if evm.Config.Tracer.OnTxEnd != nil {
+			defer func() {
+				evm.Config.Tracer.OnTxEnd(nil, err)
+			}()
+		}
 	}
 	// Execute the message.
 	snapshot := st.StateDB.Snapshot()

--- a/tests/state_test_util.go
+++ b/tests/state_test_util.go
@@ -295,6 +295,9 @@ func (t *StateTest) RunNoVerify(subtest StateSubtest, vmconfig vm.Config, snapsh
 	}
 	evm := vm.NewEVM(context, txContext, st.StateDB, config, vmconfig)
 
+	if tracer := vmconfig.Tracer; tracer != nil && tracer.OnTxStart != nil {
+		tracer.OnTxStart(evm.GetVMContext(), nil, msg.From)
+	}
 	// Execute the message.
 	snapshot := st.StateDB.Snapshot()
 	gaspool := new(core.GasPool)


### PR DESCRIPTION
Fixes a `panic` due to the TxStart not having been called, which results in the `env` in the json logger to be `nil`. 

```
]$ go run ./cmd/evm/ --json --noreturndata --nomemory statetest ./fuzz.json 
{"output":"","gasUsed":"0x79bff8"}
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x40 pc=0xd05322]

goroutine 1 [running]:
github.com/ethereum/go-ethereum/eth/tracers/logger.(*jsonLogger).OnOpcode(0xc0000128d0, 0x0, 0x7f, 0x79bff8, 0x3, {0x1634008, 0xc0000138d8}, {0x0, 0x0, 0x0}, ...)
        /home/user/go/src/github.com/ethereum/go-ethereum/eth/tracers/logger/logger_json.go:67 +0xa2
github.com/ethereum/go-ethereum/core/vm.(*EVMInterpreter).Run(0xc000040780, 0xc000000540, {0x20d8400, 0x0, 0x0}, 0x0)
        /home/user/go/src/github.com/ethereum/go-ethereum/core/vm/interpreter.go:280 +0xb95
github.com/ethereum/go-ethereum/core/vm.(*EVM).Call(0xc0002e90e0, {0x16253c0, 0xc000681860}, {0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, ...}, ...)
        /home/user/go/src/github.com/ethereum/go-ethereum/core/vm/evm.go:223 +0x8a5
github.com/ethereum/go-ethereum/core.(*StateTransition).TransitionDb(0xc00052ccf8)
        /home/user/go/src/github.com/ethereum/go-ethereum/core/state_transition.go:436 +0x6d6
github.com/ethereum/go-ethereum/core.ApplyMessage(0x0?, 0x14ca298?, 0x14ca318?)
        /home/user/go/src/github.com/ethereum/go-ethereum/core/state_transition.go:184 +0x57
github.com/ethereum/go-ethereum/tests.(*StateTest).RunNoVerify(0xc00052d4c8, {{0xc000133fa0?, 0x0?}, 0x0?}, {0xc00032e090, 0x0, 0x0, {0x0, 0x0, 0x0}}, ...)
        /home/user/go/src/github.com/ethereum/go-ethereum/tests/state_test_util.go:302 +0x9f0
github.com/ethereum/go-ethereum/tests.(*StateTest).Run(0xc00052d4c8, {{0xc000133fa0?, 0x41451b?}, 0x10?}, {0xc00032e090, 0x0, 0x0, {0x0, 0x0, 0x0}}, ...)
        /home/user/go/src/github.com/ethereum/go-ethereum/tests/state_test_util.go:199 +0xf7
main.runStateTest({0x7ffd29a4afdd?, 0x134ac6c?}, {0xc00032e090, 0x0, 0x0, {0x0, 0x0, 0x0}}, 0x0)
        /home/user/go/src/github.com/ethereum/go-ethereum/cmd/evm/staterunner.go:103 +0x537
main.stateTestCmd(0xc0002d17c0)
        /home/user/go/src/github.com/ethereum/go-ethereum/cmd/evm/staterunner.go:70 +0x698
github.com/ethereum/go-ethereum/internal/flags.MigrateGlobalFlags.func2.1(0xc0002d17c0)
        /home/user/go/src/github.com/ethereum/go-ethereum/internal/flags/helpers.go:100 +0x34
github.com/urfave/cli/v2.(*Command).Run(0x1ec98a0, 0xc0002d17c0, {0xc00028d8c0, 0x2, 0x2})
        /home/user/go/pkg/mod/github.com/urfave/cli/v2@v2.25.7/command.go:274 +0x93f
github.com/urfave/cli/v2.(*Command).Run(0xc000400f20, 0xc0002d0c00, {0xc0000401e0, 0x6, 0x6})
        /home/user/go/pkg/mod/github.com/urfave/cli/v2@v2.25.7/command.go:267 +0xb7d
github.com/urfave/cli/v2.(*App).RunContext(0xc0003e05a0, {0x1630628, 0x20d8400}, {0xc0000401e0, 0x6, 0x6})
```
