### PR TITLE
beacon/engine: Fix json param name in GetClientVersionV1

### DIFF
--- a/beacon/engine/types.go
+++ b/beacon/engine/types.go
@@ -313,7 +313,7 @@ const (
 // ClientVersionV1 contains information which identifies a client implementation.
 type ClientVersionV1 struct {
 	Code    string `json:"code"`
-	Name    string `json:"clientName"`
+	Name    string `json:"name"`
 	Version string `json:"version"`
 	Commit  string `json:"commit"`
 }


### PR DESCRIPTION
rename `clientName` to `name` in `ClientVersionV1 `
https://github.com/ethereum/execution-apis/blob/main/src/engine/identification.md#clientversionv1