### PR TITLE
core/vm: better error-info for vm errors

### DIFF
--- a/core/vm/errors.go
+++ b/core/vm/errors.go
@@ -31,6 +31,7 @@ var (
 	ErrContractAddressCollision = errors.New("contract address collision")
 	ErrExecutionReverted        = errors.New("execution reverted")
 	ErrMaxCodeSizeExceeded      = errors.New("max code size exceeded")
+	ErrMaxInitCodeSizeExceeded  = errors.New("max initcode size exceeded")
 	ErrInvalidJump              = errors.New("invalid jump destination")
 	ErrWriteProtection          = errors.New("write protection")
 	ErrReturnDataOutOfBounds    = errors.New("return data out of bounds")

--- a/core/vm/gas_table.go
+++ b/core/vm/gas_table.go
@@ -19,6 +19,7 @@ package vm
 import (
 	"errors"
 
+	"fmt"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/math"
 	"github.com/ethereum/go-ethereum/params"
@@ -326,8 +327,11 @@ func gasCreate2Eip3860(evm *EVM, contract *Contract, stack *Stack, mem *Memory, 
 		return 0, err
 	}
 	size, overflow := stack.Back(2).Uint64WithOverflow()
-	if overflow || size > params.MaxInitCodeSize {
+	if overflow {
 		return 0, ErrGasUintOverflow
+	}
+	if size > params.MaxInitCodeSize {
+		return 0, fmt.Errorf("%w: size %d", ErrMaxInitCodeSizeExceeded, size)
 	}
 	// Since size <= params.MaxInitCodeSize, these multiplication cannot overflow
 	moreGas := (params.InitCodeWordGas + params.Keccak256WordGas) * ((size + 31) / 32)

--- a/core/vm/gas_table.go
+++ b/core/vm/gas_table.go
@@ -18,8 +18,8 @@ package vm
 
 import (
 	"errors"
-
 	"fmt"
+
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/math"
 	"github.com/ethereum/go-ethereum/params"

--- a/core/vm/gas_table.go
+++ b/core/vm/gas_table.go
@@ -311,8 +311,11 @@ func gasCreateEip3860(evm *EVM, contract *Contract, stack *Stack, mem *Memory, m
 		return 0, err
 	}
 	size, overflow := stack.Back(2).Uint64WithOverflow()
-	if overflow || size > params.MaxInitCodeSize {
+	if overflow {
 		return 0, ErrGasUintOverflow
+	}
+	if size > params.MaxInitCodeSize {
+		return 0, fmt.Errorf("%w: size %d", ErrMaxInitCodeSizeExceeded, size)
 	}
 	// Since size <= params.MaxInitCodeSize, these multiplication cannot overflow
 	moreGas := params.InitCodeWordGas * ((size + 31) / 32)

--- a/core/vm/gas_table_test.go
+++ b/core/vm/gas_table_test.go
@@ -18,6 +18,7 @@ package vm
 
 import (
 	"bytes"
+	"errors"
 	"math"
 	"math/big"
 	"sort"
@@ -98,7 +99,7 @@ func TestEIP2200(t *testing.T) {
 		vmenv := NewEVM(vmctx, TxContext{}, statedb, params.AllEthashProtocolChanges, Config{ExtraEips: []int{2200}})
 
 		_, gas, err := vmenv.Call(AccountRef(common.Address{}), address, nil, tt.gaspool, new(uint256.Int))
-		if err != tt.failure {
+		if !errors.Is(err, tt.failure) {
 			t.Errorf("test %d: failure mismatch: have %v, want %v", i, err, tt.failure)
 		}
 		if used := tt.gaspool - gas; used != tt.used {

--- a/core/vm/interpreter.go
+++ b/core/vm/interpreter.go
@@ -18,6 +18,7 @@ package vm
 
 import (
 	"fmt"
+
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/math"
 	"github.com/ethereum/go-ethereum/core/tracing"

--- a/core/vm/interpreter.go
+++ b/core/vm/interpreter.go
@@ -17,6 +17,7 @@
 package vm
 
 import (
+	"fmt"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/math"
 	"github.com/ethereum/go-ethereum/core/tracing"
@@ -256,7 +257,7 @@ func (in *EVMInterpreter) Run(contract *Contract, input []byte, readOnly bool) (
 			dynamicCost, err = operation.dynamicGas(in.evm, contract, stack, mem, memorySize)
 			cost += dynamicCost // for tracing
 			if err != nil {
-				return nil, err
+				return nil, fmt.Errorf("%w: %v", ErrOutOfGas, err)
 			}
 			if !contract.UseGas(dynamicCost, in.evm.Config.Tracer, tracing.GasChangeIgnored) {
 				return nil, ErrOutOfGas

--- a/core/vm/interpreter.go
+++ b/core/vm/interpreter.go
@@ -255,7 +255,10 @@ func (in *EVMInterpreter) Run(contract *Contract, input []byte, readOnly bool) (
 			var dynamicCost uint64
 			dynamicCost, err = operation.dynamicGas(in.evm, contract, stack, mem, memorySize)
 			cost += dynamicCost // for tracing
-			if err != nil || !contract.UseGas(dynamicCost, in.evm.Config.Tracer, tracing.GasChangeIgnored) {
+			if err != nil {
+				return nil, err
+			}
+			if !contract.UseGas(dynamicCost, in.evm.Config.Tracer, tracing.GasChangeIgnored) {
 				return nil, ErrOutOfGas
 			}
 

--- a/eth/tracers/internal/tracetest/testdata/call_tracer_flat/callcode_precompiled_throw.json
+++ b/eth/tracers/internal/tracetest/testdata/call_tracer_flat/callcode_precompiled_throw.json
@@ -57,7 +57,7 @@
         "gas": "0x1a034",
         "init": "0x36600060003760406103e8366000600060095af26001556103e8516002556104085160035500"
       },
-      "error": "out of gas",
+      "error": "out of gas: not enough gas for reentrancy sentry",
       "traceAddress": [],
       "subtraces": 1,
       "transactionPosition": 117,

--- a/eth/tracers/internal/tracetest/testdata/call_tracer_flat/nested_create_action_gas.json
+++ b/eth/tracers/internal/tracetest/testdata/call_tracer_flat/nested_create_action_gas.json
@@ -57,7 +57,7 @@
         "gas": "0x19ee4",
         "init": "0x5a600055600060006000f0505a60015500"
       },
-      "error": "out of gas",
+      "error": "out of gas: not enough gas for reentrancy sentry",
       "traceAddress": [],
       "subtraces": 1,
       "transactionPosition": 63,


### PR DESCRIPTION
While investigating https://github.com/ethereum/execution-specs/issues/914, I noticed that geth hid the actual error, in some cases

- which was hidden as a `ErrOutOfGas`, 
- Behind that, there as an `ErrGasUintOverflow`, 
- But actually, the error we should have returned was `max initcode size exceeded`. 

This PR changes that to surface the actual error

Without this PR: 
```
{"pc":45,"op":106,"gas":"0x1acf1","gasCost":"0x3","memSize":192,"stack":["0x43","0x50","0xab","0x70","0xcc","0x6c","0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff","0x20000","0x0"],"depth":1,"refund":0,"opName":"PUSH11"}
{"pc":57,"op":245,"gas":"0x1acee","gasCost":"0x7d00","memSize":192,"stack":["0x43","0x50","0xab","0x70","0xcc","0x6c","0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff","0x20000","0x0","0x11531063346aa0fa774654"],"depth":1,"refund":0,"opName":"CREATE2","error":"out of gas"}
{"output":"","gasUsed":"0x1ad29","error":"out of gas"}
```


With this PR: 
```
{"pc":45,"op":106,"gas":"0x1acf1","gasCost":"0x3","memSize":192,"stack":["0x43","0x50","0xab","0x70","0xcc","0x6c","0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff","0x20000","0x0"],"depth":1,"refund":0,"opName":"PUSH11"}
{"pc":57,"op":245,"gas":"0x1acee","gasCost":"0x7d00","memSize":192,"stack":["0x43","0x50","0xab","0x70","0xcc","0x6c","0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff","0x20000","0x0","0x11531063346aa0fa774654"],"depth":1,"refund":0,"opName":"CREATE2","error":"out of gas: max initcode size exceeded: size 131072"}
{"output":"","gasUsed":"0x1ad29","error":"out of gas: max initcode size exceeded: size 131072"}
```
