### PR TITLE
core/tracing: add system call callback when performing `ProcessBeaconBlockRoot`

### DIFF
--- a/core/state_processor.go
+++ b/core/state_processor.go
@@ -186,6 +186,13 @@ func ApplyTransaction(config *params.ChainConfig, bc ChainContext, author *commo
 // ProcessBeaconBlockRoot applies the EIP-4788 system call to the beacon block root
 // contract. This method is exported to be used in tests.
 func ProcessBeaconBlockRoot(beaconRoot common.Hash, vmenv *vm.EVM, statedb *state.StateDB) {
+	if vmenv.Config.Tracer != nil && vmenv.Config.Tracer.OnSystemCallStart != nil {
+		vmenv.Config.Tracer.OnSystemCallStart()
+	}
+	if vmenv.Config.Tracer != nil && vmenv.Config.Tracer.OnSystemCallEnd != nil {
+		defer vmenv.Config.Tracer.OnSystemCallEnd()
+	}
+
 	// If EIP-4788 is enabled, we need to invoke the beaconroot storage contract with
 	// the new root
 	msg := &Message{

--- a/core/tracing/CHANGELOG.md
+++ b/core/tracing/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to the tracing interface will be documented in this file.
 
 ## [Unreleased]
 
+There have been minor backwards-compatible changes to the tracing interface to explicitly mark the execution of **system** contracts. As of now the only system call updates the parent beacon block root as per [EIP-4788](https://eips.ethereum.org/EIPS/eip-4788). Other system calls are being considered for the future hardfork.
+
+### New methods
+
+- `OnSystemCallStart()`: This hook is called when EVM starts processing a system call. Note system calls happen outside the scope of a transaction. This event will be followed by normal EVM execution events.
+- `OnSystemCallEnd()`: This hook is called when EVM finishes processing a system call.
+
+## [v1.14.0]
+
 There has been a major breaking change in the tracing interface for custom native tracers. JS and built-in tracers are not affected by this change and tracing API methods may be used as before. This overhaul has been done as part of the new live tracing feature ([#29189](https://github.com/ethereum/go-ethereum/pull/29189)). To learn more about live tracing please refer to the [docs](https://geth.ethereum.org/docs/developers/evm-tracing/live-tracing).
 
 **The `EVMLogger` interface which the tracers implemented has been removed.** It has been replaced by a new struct `tracing.Hooks`. `Hooks` keeps pointers to event listening functions. Internally the EVM will use these function pointers to emit events and can skip an event if the tracer has opted not to implement it. In fact this is the main reason for this change of approach. Another benefit is the ease of adding new hooks in future, and dynamically assigning event receivers.
@@ -66,4 +75,5 @@ The hooks `CaptureStart` and `CaptureEnd` have been removed. These hooks signale
 - `CaptureState` -> `OnOpcode(pc uint64, op byte, gas, cost uint64, scope tracing.OpContext, rData []byte, depth int, err error)`. `op` is of type `byte` which can be cast to `vm.OpCode` when necessary. A `*vm.ScopeContext` is not passed anymore. It is replaced by `tracing.OpContext` which offers access to the memory, stack and current contract.
 - `CaptureFault` -> `OnFault(pc uint64, op byte, gas, cost uint64, scope tracing.OpContext, depth int, err error)`. Similar to above.
 
-[unreleased]: https://github.com/ethereum/go-ethereum/compare/v1.13.14...master
+[unreleased]: https://github.com/ethereum/go-ethereum/compare/v1.14.0...master
+[v1.14.0]: https://github.com/ethereum/go-ethereum/releases/tag/v1.14.0

--- a/core/tracing/hooks.go
+++ b/core/tracing/hooks.go
@@ -81,6 +81,10 @@ type (
 	TxEndHook = func(receipt *types.Receipt, err error)
 
 	// EnterHook is invoked when the processing of a message starts.
+	//
+	// Take note that EnterHook, when in the context of a live tracer, can be invoked
+	// outside of the `OnTxStart` and `OnTxEnd` hooks when dealing with system calls,
+	// see [OnSystemCallStartHook] and [OnSystemCallEndHook] for more information.
 	EnterHook = func(depth int, typ byte, from common.Address, to common.Address, input []byte, gas uint64, value *big.Int)
 
 	// ExitHook is invoked when the processing of a message ends.
@@ -89,6 +93,10 @@ type (
 	// ran out of gas when attempting to persist the code to database did not
 	// count as a call failure and did not cause a revert of the call. This will
 	// be indicated by `reverted == false` and `err == ErrCodeStoreOutOfGas`.
+	//
+	// Take note that ExitHook, when in the context of a live tracer, can be invoked
+	// outside of the `OnTxStart` and `OnTxEnd` hooks when dealing with system calls,
+	// see [OnSystemCallStartHook] and [OnSystemCallEndHook] for more information.
 	ExitHook = func(depth int, output []byte, gasUsed uint64, err error, reverted bool)
 
 	// OpcodeHook is invoked just prior to the execution of an opcode.
@@ -125,6 +133,22 @@ type (
 	// GenesisBlockHook is called when the genesis block is being processed.
 	GenesisBlockHook = func(genesis *types.Block, alloc types.GenesisAlloc)
 
+	// OnSystemCallStartHook is called when a system call is about to be executed. Today,
+	// this hook is invoked when the EIP-4788 system call is about to be executed to set the
+	// beacon block root.
+	//
+	// After this hook, the EVM call tracing will happened as usual so you will receive a `OnEnter/OnExit`
+	// as well as state hooks between this hook and the `OnSystemCallEndHook`.
+	//
+	// Note that system call happens outside normal transaction execution, so the `OnTxStart/OnTxEnd` hooks
+	// will not be invoked.
+	OnSystemCallStartHook = func()
+
+	// OnSystemCallEndHook is called when a system call has finished executing. Today,
+	// this hook is invoked when the EIP-4788 system call is about to be executed to set the
+	// beacon block root.
+	OnSystemCallEndHook = func()
+
 	/*
 		- State events -
 	*/
@@ -155,12 +179,14 @@ type Hooks struct {
 	OnFault     FaultHook
 	OnGasChange GasChangeHook
 	// Chain events
-	OnBlockchainInit BlockchainInitHook
-	OnClose          CloseHook
-	OnBlockStart     BlockStartHook
-	OnBlockEnd       BlockEndHook
-	OnSkippedBlock   SkippedBlockHook
-	OnGenesisBlock   GenesisBlockHook
+	OnBlockchainInit  BlockchainInitHook
+	OnClose           CloseHook
+	OnBlockStart      BlockStartHook
+	OnBlockEnd        BlockEndHook
+	OnSkippedBlock    SkippedBlockHook
+	OnGenesisBlock    GenesisBlockHook
+	OnSystemCallStart OnSystemCallStartHook
+	OnSystemCallEnd   OnSystemCallEndHook
 	// State events
 	OnBalanceChange BalanceChangeHook
 	OnNonceChange   NonceChangeHook


### PR DESCRIPTION
Added a `start/end` system where tracer can be notified that processing of some Ethereum system calls is starting processing and also notifies it when the processing has completed.

Doing a `start/end` for system call will enable tracers to "route" incoming next tracing events to go to a separate bucket than other EVM calls. Those not interested by this fact can simply avoid registering the hooks.

The EVM call is going to be traced normally afterward between the signals provided by those 2 new hooks but outside of a transaction context `OnTxStart/End`. That something implementors of live tracers will need to be aware of (since only "trx tracers" are not concerned by `ProcessBeaconRoot`).

I've looked into providing some kind of unit tests for that but it prove harder than anticipated. Since this has a minimal implementation surface, it think it's fine but I can take a second look if deemed required.