### PR TITLE
internal/debug: convert legacy log level value in `debug_verbosity`

### DIFF
--- a/internal/debug/api.go
+++ b/internal/debug/api.go
@@ -24,7 +24,6 @@ import (
 	"bytes"
 	"errors"
 	"io"
-	"log/slog"
 	"os"
 	"os/user"
 	"path/filepath"
@@ -57,7 +56,7 @@ type HandlerT struct {
 // Verbosity sets the log verbosity ceiling. The verbosity of individual packages
 // and source files can be raised using Vmodule.
 func (*HandlerT) Verbosity(level int) {
-	glogger.Verbosity(slog.Level(level))
+	glogger.Verbosity(log.FromLegacyLevel(level))
 }
 
 // Vmodule sets the log verbosity pattern. See package log for details on the


### PR DESCRIPTION
Looks like this was never updated to convert the legacy log level we're used to sending over `debug_verbosity` to the new levels.