### PR TITLE
docs: replace deprecated function NewTransactor in native-bindings page

### DIFF
--- a/docs/developers/dapp-developer/native-bindings.md
+++ b/docs/developers/dapp-developer/native-bindings.md
@@ -223,12 +223,12 @@ func main() {
 	if err != nil {
 		log.Fatalf("Failed to connect to the Ethereum client: %v", err)
 	}
-	auth, err := bind.NewTransactor(strings.NewReader(key), "<<strong_password>>")
+	auth, err := bind.NewTransactorWithChainID(strings.NewReader(key), "<<strong_password>>", ChainId)
 	if err != nil {
 		log.Fatalf("Failed to create authorized transactor: %v", err)
 	}
 	// Deploy the contract passing the newly created `auth` and `conn` vars
-	address, tx, instance, err := DeployStorage(auth, conn), new(big.Int), "Storage contract in Go!", 0, "Go!")
+	address, tx, instance, err := DeployStorage(auth, conn)
 	if err != nil {
 		log.Fatalf("Failed to deploy new storage contract: %v", err)
 	}


### PR DESCRIPTION
According to the lastest design, the `bind.NewTransactor` function is [deprecated](https://github.com/ethereum/go-ethereum/blob/304879da20200f6912d241ccd471e140d3487093/accounts/abi/bind/auth.go#L44-L56)