### PR TITLE
core,syscall: move 4788 system call into separate package

### DIFF
--- a/core/syscall/syscall.go
+++ b/core/syscall/syscall.go
@@ -1,0 +1,66 @@
+// Copyright 2024 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+
+package syscall
+
+import (
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/state"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/core/vm"
+	"github.com/ethereum/go-ethereum/params"
+	"github.com/holiman/uint256"
+)
+
+var sysTxContext = vm.TxContext{
+	Origin:   params.SystemAddress,
+	GasPrice: common.Big0,
+}
+
+func newBlockContext(header *types.Header) vm.BlockContext {
+	return vm.BlockContext{
+		CanTransfer: func(db vm.StateDB, addr common.Address, amount *uint256.Int) bool { return false },
+		Transfer:    func(vm.StateDB, common.Address, common.Address, *uint256.Int) {},
+		GetHash:     func(uint64) common.Hash { return common.Hash{} },
+		Coinbase:    common.Address{},
+		BlockNumber: header.Number,
+		Time:        header.Time,
+		Difficulty:  common.Big0,
+		BaseFee:     common.Big0,
+		BlobBaseFee: common.Big0,
+		GasLimit:    30_000_000,
+		Random:      &common.Hash{},
+	}
+}
+
+// RunPreBlockHooks executes all relevant pre-block operations. It will update statedb.
+func RunPreBlockHooks(header *types.Header, statedb *state.StateDB, config *params.ChainConfig) {
+	ProcessBeaconBlockRoot(header, statedb, config)
+}
+
+// ProcessBeaconBlockRoot applies the EIP-4788 system call to the beacon block root
+// contract. This method is exported to be used in tests.
+func ProcessBeaconBlockRoot(header *types.Header, statedb *state.StateDB, config *params.ChainConfig) {
+	if header.ParentBeaconRoot == nil {
+		return
+	}
+	// If EIP-4788 is enabled, we need to invoke the beaconroot storage contract with
+	// the new root
+	statedb.AddAddressToAccessList(params.BeaconRootsAddress)
+	evm := vm.NewEVM(newBlockContext(header), sysTxContext, statedb, config, vm.Config{})
+	evm.Call(vm.AccountRef(params.SystemAddress), params.BeaconRootsAddress, header.ParentBeaconRoot.Bytes(), 30_000_000, common.U2560)
+	statedb.Finalise(true)
+}


### PR DESCRIPTION
This is a proposal to simplify and better abstract the system call interface.

Currently we only have one system call, but with Prague we will have at least one additional system call (EIP-7002, a post-block system call) and others are actively being considered. This type of operation is also commonly used downstream by forks of geth to seed other execution environments with custom data.

It seems like there is demand to improve the interface for writing and using system calls.

Originally I considered revamping the `consensus.Engine` interface to initiate these calls. Many of our system calls are directly related to consensus operations: triggering validator exits and writing beacon roots into state. I still think from an organizational standpoint, it makes sense to tie these operations to specific consensus engines. However, it isn't as easy to jam these system calls into the Engine interface as I thought.

Pre-block hooks could naturally be executed in the `Prepare(..)` method, but currently `Prepare(..)` is only used by the miner as it actually sets the header difficulty directly. It seems weird to call this function in `state_processor` and modify the header.

Post-block hooks could be executed in `Finalize`, however with 7002 we're actually pulling data out of a contract which needs to be packaged into the block and verified against the header. Since finalize currently has the semantic of only modifying `statedb` it feels weird to force it to deal with exits.

--

For these reasons, I'm proposing the api of:

* `RunPreBlockHooks(..)`
* `RunPostBlockHooks(..)` (n/a in this PR, will incorporate in 7002 PR if we accept this API)

These two methods can be called in four common code paths we have for block building / validation: the chain maker, miner, state processor, and t8n.