### PR TITLE
website: fix nested list margin

### DIFF
--- a/src/components/UI/docs/MDComponents.tsx
+++ b/src/components/UI/docs/MDComponents.tsx
@@ -128,7 +128,7 @@ const MDComponents = {
   ul: ({ children }: any) => {
     return (
       <Stack>
-        <UnorderedList mb={7} px={4}>
+        <UnorderedList mb={7} px={4} sx={{ 'ul, ol': { mb: 0 } }}>
           {children}
         </UnorderedList>
       </Stack>
@@ -137,7 +137,7 @@ const MDComponents = {
   ol: ({ children }: any) => {
     return (
       <Stack>
-        <OrderedList mb={7} px={4}>
+        <OrderedList mb={7} px={4} sx={{ 'ul, ol': { mb: 0 } }}>
           {children}
         </OrderedList>
       </Stack>


### PR DESCRIPTION
## Description
- Removes bottom margin from _nested_ `ul` and `ol` elements on markdown pages

## Examples

### Current:
<img width="819" alt="image" src="https://github.com/ethereum/go-ethereum/assets/54227730/a262a285-75c2-449c-aa3e-9c2932084dc1">

### With change:
<img width="834" alt="image" src="https://github.com/ethereum/go-ethereum/assets/54227730/dde1917e-cbee-45ca-bfd0-43bd7569d6c8">

cc: @s1na @nloureiro 
