### PR TITLE
rpc: fix ipc max path size

### DIFF
--- a/rpc/ipc_unix.go
+++ b/rpc/ipc_unix.go
@@ -25,14 +25,16 @@ import (
 	"net"
 	"os"
 	"path/filepath"
+	"syscall"
 
 	"github.com/ethereum/go-ethereum/log"
 )
 
 const (
-	// On Linux, sun_path is 108 bytes in size
-	// see http://man7.org/linux/man-pages/man7/unix.7.html
-	maxPathSize = int(108)
+	// The limit of unix domain socket path diverse between OS, on Darwin it's 104 bytes
+	// but on Linux it's 108 byte, so we should depend on syscall.RawSockaddrUnix's
+	// definition dynamically
+	maxPathSize = len(syscall.RawSockaddrUnix{}.Path)
 )
 
 // ipcListen will create a Unix socket on the given endpoint.


### PR DESCRIPTION
Accidentally ran into a issue when start a private network node on my mac with a long datadir name. 

```
WARN [03-28|15:24:36.794] IPC opening failed                       url="/Users/mileschen/Library/Mobile Documents/com~apple~CloudDocs/Dev/labs/ethereum_blockchain/node1/geth.ipc" error="listen unix /Users/mileschen/Library/Mobile Documents/com~apple~CloudDocs/Dev/labs/ethereum_blockchain/node1/geth.ipc: bind: invalid argument"
Fatal: Error starting protocol stack: listen unix /Users/mileschen/Library/Mobile Documents/com~apple~CloudDocs/Dev/labs/ethereum_blockchain/node1/geth.ipc: bind: invalid argument
```

After reading the code, i realize it's the socket path too long, above ipc path's length is 105, But meanwhile i found geth assume Unix Socket Path limit is 108 bytes meanwhile it is diverse between OSes in golang's implementation, eg, [104 bytes](https://github.com/golang/go/blob/master/src/syscall/ztypes_darwin_arm64.go#L178) in darwin, so i fix it
