### PR TITLE
Problem: no proper error for unsupported opcode

### DIFF
--- a/core/vm/errors.go
+++ b/core/vm/errors.go
@@ -37,6 +37,7 @@ var (
 	ErrGasUintOverflow          = errors.New("gas uint64 overflow")
 	ErrInvalidCode              = errors.New("invalid code: must not begin with 0xef")
 	ErrNonceUintOverflow        = errors.New("nonce uint64 overflow")
+	ErrUnsupportedRandom        = errors.New("unsupported random")
 
 	// errStopToken is an internal token indicating interpreter loop termination,
 	// never returned to outside callers.

--- a/core/vm/instructions.go
+++ b/core/vm/instructions.go
@@ -476,6 +476,9 @@ func opDifficulty(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) 
 }
 
 func opRandom(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([]byte, error) {
+	if interpreter.evm.Context.Random == nil {
+		return nil, ErrUnsupportedRandom
+	}
 	v := new(uint256.Int).SetBytes(interpreter.evm.Context.Random.Bytes())
 	scope.Stack.push(v)
 	return nil, nil


### PR DESCRIPTION
Currently `Random` in `BlockContext` is nullable which can cause panic in `opRandom`. Users cannot see proper error message when they pass nil as Random.