### PR TITLE
eth, eth/tracers: process beacon root before transactions

### DIFF
--- a/eth/state_accessor.go
+++ b/eth/state_accessor.go
@@ -233,14 +233,12 @@ func (eth *Ethereum) stateAtTransaction(ctx context.Context, block *types.Block,
 	if err != nil {
 		return nil, vm.BlockContext{}, nil, nil, err
 	}
-
+	// Insert parent beacon block root in the state as per EIP-4788.
 	if beaconRoot := block.BeaconRoot(); beaconRoot != nil {
 		context := core.NewEVMBlockContext(block.Header(), eth.blockchain, nil)
 		vmenv := vm.NewEVM(context, vm.TxContext{}, statedb, eth.blockchain.Config(), vm.Config{})
-
-		core.ProcessBeaconBlockRoot(*block.BeaconRoot(), vmenv, statedb)
+		core.ProcessBeaconBlockRoot(*beaconRoot, vmenv, statedb)
 	}
-
 	if txIndex == 0 && len(block.Transactions()) == 0 {
 		return nil, vm.BlockContext{}, statedb, release, nil
 	}

--- a/eth/state_accessor.go
+++ b/eth/state_accessor.go
@@ -233,6 +233,14 @@ func (eth *Ethereum) stateAtTransaction(ctx context.Context, block *types.Block,
 	if err != nil {
 		return nil, vm.BlockContext{}, nil, nil, err
 	}
+
+	if beaconRoot := block.BeaconRoot(); beaconRoot != nil {
+		context := core.NewEVMBlockContext(block.Header(), eth.blockchain, nil)
+		vmenv := vm.NewEVM(context, vm.TxContext{}, statedb, eth.blockchain.Config(), vm.Config{})
+
+		core.ProcessBeaconBlockRoot(*block.BeaconRoot(), vmenv, statedb)
+	}
+
 	if txIndex == 0 && len(block.Transactions()) == 0 {
 		return nil, vm.BlockContext{}, statedb, release, nil
 	}

--- a/eth/tracers/api.go
+++ b/eth/tracers/api.go
@@ -935,16 +935,6 @@ func (api *API) TraceCall(ctx context.Context, args ethapi.TransactionArgs, bloc
 	}
 	defer release()
 
-	// Apply only when we have used StateAtBlock since `StateAtTransaction` already handles the beacon root
-	if config == nil || config.TxIndex == nil {
-		if beaconRoot := block.BeaconRoot(); beaconRoot != nil {
-			context := core.NewEVMBlockContext(block.Header(), api.chainContext(ctx), nil)
-			vmenv := vm.NewEVM(context, vm.TxContext{}, statedb, api.backend.ChainConfig(), vm.Config{})
-
-			core.ProcessBeaconBlockRoot(*block.BeaconRoot(), vmenv, statedb)
-		}
-	}
-
 	vmctx := core.NewEVMBlockContext(block.Header(), api.chainContext(ctx), nil)
 	// Apply the customization rules if required.
 	if config != nil {

--- a/eth/tracers/api.go
+++ b/eth/tracers/api.go
@@ -524,11 +524,6 @@ func (api *API) IntermediateRoots(ctx context.Context, hash common.Hash, config 
 		return nil, err
 	}
 	defer release()
-	if beaconRoot := block.BeaconRoot(); beaconRoot != nil {
-		context := core.NewEVMBlockContext(block.Header(), api.chainContext(ctx), nil)
-		vmenv := vm.NewEVM(context, vm.TxContext{}, statedb, api.backend.ChainConfig(), vm.Config{})
-		core.ProcessBeaconBlockRoot(*beaconRoot, vmenv, statedb)
-	}
 	var (
 		roots              []common.Hash
 		signer             = types.MakeSigner(api.backend.ChainConfig(), block.Number(), block.Time())
@@ -536,6 +531,10 @@ func (api *API) IntermediateRoots(ctx context.Context, hash common.Hash, config 
 		vmctx              = core.NewEVMBlockContext(block.Header(), api.chainContext(ctx), nil)
 		deleteEmptyObjects = chainConfig.IsEIP158(block.Number())
 	)
+	if beaconRoot := block.BeaconRoot(); beaconRoot != nil {
+		vmenv := vm.NewEVM(vmctx, vm.TxContext{}, statedb, chainConfig, vm.Config{})
+		core.ProcessBeaconBlockRoot(*beaconRoot, vmenv, statedb)
+	}
 	for i, tx := range block.Transactions() {
 		if err := ctx.Err(); err != nil {
 			return nil, err
@@ -595,11 +594,6 @@ func (api *API) traceBlock(ctx context.Context, block *types.Block, config *Trac
 		return nil, err
 	}
 	defer release()
-	if beaconRoot := block.BeaconRoot(); beaconRoot != nil {
-		context := core.NewEVMBlockContext(block.Header(), api.chainContext(ctx), nil)
-		vmenv := vm.NewEVM(context, vm.TxContext{}, statedb, api.backend.ChainConfig(), vm.Config{})
-		core.ProcessBeaconBlockRoot(*beaconRoot, vmenv, statedb)
-	}
 	// JS tracers have high overhead. In this case run a parallel
 	// process that generates states in one thread and traces txes
 	// in separate worker threads.
@@ -616,6 +610,10 @@ func (api *API) traceBlock(ctx context.Context, block *types.Block, config *Trac
 		signer    = types.MakeSigner(api.backend.ChainConfig(), block.Number(), block.Time())
 		results   = make([]*txTraceResult, len(txs))
 	)
+	if beaconRoot := block.BeaconRoot(); beaconRoot != nil {
+		vmenv := vm.NewEVM(blockCtx, vm.TxContext{}, statedb, api.backend.ChainConfig(), vm.Config{})
+		core.ProcessBeaconBlockRoot(*beaconRoot, vmenv, statedb)
+	}
 	for i, tx := range txs {
 		// Generate the next state snapshot fast without tracing
 		msg, _ := core.TransactionToMessage(tx, signer, block.BaseFee())
@@ -742,11 +740,6 @@ func (api *API) standardTraceBlockToFile(ctx context.Context, block *types.Block
 		return nil, err
 	}
 	defer release()
-	if beaconRoot := block.BeaconRoot(); beaconRoot != nil {
-		context := core.NewEVMBlockContext(block.Header(), api.chainContext(ctx), nil)
-		vmenv := vm.NewEVM(context, vm.TxContext{}, statedb, api.backend.ChainConfig(), vm.Config{})
-		core.ProcessBeaconBlockRoot(*beaconRoot, vmenv, statedb)
-	}
 	// Retrieve the tracing configurations, or use default values
 	var (
 		logConfig logger.Config
@@ -774,6 +767,10 @@ func (api *API) standardTraceBlockToFile(ctx context.Context, block *types.Block
 	if config != nil && config.Overrides != nil {
 		// Note: This copies the config, to not screw up the main config
 		chainConfig, canon = overrideConfig(chainConfig, config.Overrides)
+	}
+	if beaconRoot := block.BeaconRoot(); beaconRoot != nil {
+		vmenv := vm.NewEVM(vmctx, vm.TxContext{}, statedb, chainConfig, vm.Config{})
+		core.ProcessBeaconBlockRoot(*beaconRoot, vmenv, statedb)
 	}
 	for i, tx := range block.Transactions() {
 		// Prepare the transaction for un-traced execution

--- a/eth/tracers/api.go
+++ b/eth/tracers/api.go
@@ -945,7 +945,8 @@ func (api *API) TraceCall(ctx context.Context, args ethapi.TransactionArgs, bloc
 	}
 	defer release()
 
-	if config != nil && config.TxIndex != nil {
+	// Apply only when we have used StateAtBlock since `StateAtTransaction` already handles the beacon root
+	if config == nil || config.TxIndex == nil {
 		if beaconRoot := block.BeaconRoot(); beaconRoot != nil {
 			context := core.NewEVMBlockContext(block.Header(), api.chainContext(ctx), nil)
 			vmenv := vm.NewEVM(context, vm.TxContext{}, statedb, api.backend.ChainConfig(), vm.Config{})

--- a/eth/tracers/api.go
+++ b/eth/tracers/api.go
@@ -376,14 +376,13 @@ func (api *API) traceChain(start, end *types.Block, config *TraceConfig, closed 
 				failed = err
 				break
 			}
-
-			if beaconRoot := block.BeaconRoot(); beaconRoot != nil {
-				context := core.NewEVMBlockContext(block.Header(), api.chainContext(ctx), nil)
+			// Insert block's parent beacon block root in the state
+			// as per EIP-4788.
+			if beaconRoot := next.BeaconRoot(); beaconRoot != nil {
+				context := core.NewEVMBlockContext(next.Header(), api.chainContext(ctx), nil)
 				vmenv := vm.NewEVM(context, vm.TxContext{}, statedb, api.backend.ChainConfig(), vm.Config{})
-
-				core.ProcessBeaconBlockRoot(*block.BeaconRoot(), vmenv, statedb)
+				core.ProcessBeaconBlockRoot(*beaconRoot, vmenv, statedb)
 			}
-
 			// Clean out any pending release functions of trace state. Note this
 			// step must be done after constructing tracing state, because the
 			// tracing state of block next depends on the parent state and construction

--- a/eth/tracers/api.go
+++ b/eth/tracers/api.go
@@ -524,14 +524,11 @@ func (api *API) IntermediateRoots(ctx context.Context, hash common.Hash, config 
 		return nil, err
 	}
 	defer release()
-
 	if beaconRoot := block.BeaconRoot(); beaconRoot != nil {
 		context := core.NewEVMBlockContext(block.Header(), api.chainContext(ctx), nil)
 		vmenv := vm.NewEVM(context, vm.TxContext{}, statedb, api.backend.ChainConfig(), vm.Config{})
-
-		core.ProcessBeaconBlockRoot(*block.BeaconRoot(), vmenv, statedb)
+		core.ProcessBeaconBlockRoot(*beaconRoot, vmenv, statedb)
 	}
-
 	var (
 		roots              []common.Hash
 		signer             = types.MakeSigner(api.backend.ChainConfig(), block.Number(), block.Time())
@@ -598,14 +595,11 @@ func (api *API) traceBlock(ctx context.Context, block *types.Block, config *Trac
 		return nil, err
 	}
 	defer release()
-
 	if beaconRoot := block.BeaconRoot(); beaconRoot != nil {
 		context := core.NewEVMBlockContext(block.Header(), api.chainContext(ctx), nil)
 		vmenv := vm.NewEVM(context, vm.TxContext{}, statedb, api.backend.ChainConfig(), vm.Config{})
-
-		core.ProcessBeaconBlockRoot(*block.BeaconRoot(), vmenv, statedb)
+		core.ProcessBeaconBlockRoot(*beaconRoot, vmenv, statedb)
 	}
-
 	// JS tracers have high overhead. In this case run a parallel
 	// process that generates states in one thread and traces txes
 	// in separate worker threads.
@@ -748,14 +742,11 @@ func (api *API) standardTraceBlockToFile(ctx context.Context, block *types.Block
 		return nil, err
 	}
 	defer release()
-
 	if beaconRoot := block.BeaconRoot(); beaconRoot != nil {
 		context := core.NewEVMBlockContext(block.Header(), api.chainContext(ctx), nil)
 		vmenv := vm.NewEVM(context, vm.TxContext{}, statedb, api.backend.ChainConfig(), vm.Config{})
-
-		core.ProcessBeaconBlockRoot(*block.BeaconRoot(), vmenv, statedb)
+		core.ProcessBeaconBlockRoot(*beaconRoot, vmenv, statedb)
 	}
-
 	// Retrieve the tracing configurations, or use default values
 	var (
 		logConfig logger.Config


### PR DESCRIPTION
The beacon root when applied in `state_processor.go` is performed right before executing transaction. That means that contract reliying on this value would query the same value found in the block header.

In that spirit, it means that any tracing/operation relying on state data which touches transaction must have updated the beacon root before any transaction processing. This PR brings this where I spotted where it was important through `StateAtTransaction` and those using with `StateAtBlock` and transactions.

For now I've put the beacon root update outside of `StateAtBlock`. I was reluctant to include it in `StateAtBlock` because technically the state at block doesn't include any state happening "in the block". But everywhere that `StateAtBlock` was used, it felt setting the beacon root was needed, so it would be posssible to change the semantic of the function and run any system pre-hooks.

Kinda relevant with PR #29372