### PR TITLE
p2p: add inbound and outbound peers metric

### DIFF
--- a/p2p/metrics.go
+++ b/p2p/metrics.go
@@ -37,7 +37,9 @@ const (
 )
 
 var (
-	activePeerGauge metrics.Gauge = metrics.NilGauge{}
+	activePeerGauge         metrics.Gauge = metrics.NilGauge{}
+	activeInboundPeerGauge  metrics.Gauge = metrics.NilGauge{}
+	activeOutboundPeerGauge metrics.Gauge = metrics.NilGauge{}
 
 	ingressTrafficMeter = metrics.NewRegisteredMeter("p2p/ingress", nil)
 	egressTrafficMeter  = metrics.NewRegisteredMeter("p2p/egress", nil)
@@ -65,6 +67,8 @@ func init() {
 	}
 
 	activePeerGauge = metrics.NewRegisteredGauge("p2p/peers", nil)
+	activeInboundPeerGauge = metrics.NewRegisteredGauge("p2p/peers/inbound", nil)
+	activeOutboundPeerGauge = metrics.NewRegisteredGauge("p2p/peers/outbound", nil)
 	serveMeter = metrics.NewRegisteredMeter("p2p/serves", nil)
 	serveSuccessMeter = metrics.NewRegisteredMeter("p2p/serves/success", nil)
 	dialMeter = metrics.NewRegisteredMeter("p2p/dials", nil)

--- a/p2p/server.go
+++ b/p2p/server.go
@@ -771,8 +771,10 @@ running:
 				if p.Inbound() {
 					inboundCount++
 					serveSuccessMeter.Mark(1)
+					activeInboundPeerGauge.Inc(1)
 				} else {
 					dialSuccessMeter.Mark(1)
+					activeOutboundPeerGauge.Inc(1)
 				}
 				activePeerGauge.Inc(1)
 			}
@@ -786,6 +788,9 @@ running:
 			srv.dialsched.peerRemoved(pd.rw)
 			if pd.Inbound() {
 				inboundCount--
+				activeInboundPeerGauge.Dec(1)
+			} else {
+				activeOutboundPeerGauge.Dec(1)
 			}
 			activePeerGauge.Dec(1)
 		}


### PR DESCRIPTION
### Description
This PR adds new inbound and outbound peer metrics as follows:

1. `p2p/peers/inbound`
2. `p2p/peers/outbound`

### Rationale
It's useful to get those data in the form of metrics, rather than getting them through `admin_peers` and then manually filtering them by the `inbound` field.