### PR TITLE
website: add trace call config 

### DIFF
--- a/docs/developers/evm-tracing/built-in-tracers.md
+++ b/docs/developers/evm-tracing/built-in-tracers.md
@@ -498,7 +498,18 @@ Returns:
 
 ## State overrides {#state-overrides}
 
-It is possible to give temporary state modifications to Geth in order to simulate the effects of `eth_call`. For example, some new bytecode could be deployed to some address _temporarily just for the duration of the execution_ and then a transaction interacting with that address can be traced. This can be used for scenario testing or determining the outcome of some hypothetical transaction before executing for real.
+It is possible to give temporary state modifications to Geth in order to simulate the effects of `eth_call` or `debug_traceCall`. For example, some new bytecode could be deployed to some address _temporarily just for the duration of the execution_ and then a transaction interacting with that address can be traced. This can be used for scenario testing or determining the outcome of some hypothetical transaction before executing for real.
+
+Available state overrides are:
+
+- `nonce`: `hexdecimal`. The nonce of the account.
+- `code`: `string`. The bytecode of the account.
+- `balance`: `hexdecimal`. The balance of the account in Wei.
+- `state`: `map[common.Hash]common.Hash`. The state of the account.
+- `stateDiff`: `map[common.Hash]common.Hash`. The diff of the account.
+
+Note, `state` and `stateDiff` can't be specified at the same time. If `state` is
+set, message execution will only use the data in the given state. Otherwise if `statDiff` is set, all diff will be applied first and then execute the call.
 
 To do this, the tracer is written as normal, but the parameter `stateOverrides` is passed an address and some bytecode.
 
@@ -507,6 +518,19 @@ var code = //contract bytecode
 var tracer = //tracer name
 debug.traceCall({from: , to: , input: }, 'latest', {stateOverrides: {'0x...': {code: code}}, tracer: tracer})
 ```
+
+## Block overrides {#block-overrides}
+
+Similar to [State overrides](#state-overrides), it is also possible to override some of the block header's fields to simulate the effects of `eth_call` or `debug_traceCall`, we support the following block header fields to override:
+
+- `number`: `hexdecimal`. The block number.
+- `difficulty`: `hexdecimal`. The block hash.
+- `time`: `hexdecimal`. The block timestamp.
+- `gasLimit`: `hexdecimal`. The block gas limit.
+- `coinbase`: `common.Address`. The block coinbase.
+- `random`: `common.Hash`. The block PREVRANDAO.
+- `baseFee`: `hexdecimal`. The block base fee.
+- `blobBaseFee`: `hexdecimal`. The block blob base fee.
 
 ## Summary {#summary}
 

--- a/docs/developers/evm-tracing/built-in-tracers.md
+++ b/docs/developers/evm-tracing/built-in-tracers.md
@@ -26,6 +26,15 @@ The struct logger (aka opcode logger) is a native Go tracer which executes a tra
 
 Note that the fields `memory`, `stack`, `returnData`, and `storage` have dynamic size and depending on the exact transaction they could grow large in size. This is specially true for `memory` which could blow up the trace size. It is recommended to keep them disabled unless they are explicitly required for a given use case.
 
+### opcode config{#struct-opcode-config}
+
+- `enableMemory`: `BOOL`. Setting this to true will enable memory capture (default = false).
+- `disableStack`: `BOOL`. Setting this to true will disable stack capture (default = false).
+- `disableStorage`: `BOOL`. Setting this to true will disable storage capture (default = false).
+- `enableReturnData`: `BOOL`. Setting this to true will enable return data capture (default = false).
+- `debug`: `BOOL`. Setting this to true will print output during capture end (default = false).
+- `limit`: `INTEGER`. Setting this to a positive integer will limit the number of steps captured (default = 0, no limit).
+
 It is also possible to configure the trace by passing Boolean (true/false) values for four parameters that tweak the verbosity of the trace. By default, the _EVM memory_ and _Return data_ are not reported but the _EVM stack_ and _EVM storage_ are. To report the maximum amount of data:
 
 ```sh
@@ -180,7 +189,7 @@ Things to note about the call tracer:
 
 - In case the top level frame reverts, its `revertReason` field will contain the parsed reason of revert as returned by the Solidity contract
 
-#### Config
+#### callTracer config{#call-tracer-config}
 
 `callTracer` accepts two options:
 
@@ -203,6 +212,10 @@ The prestate tracer has two modes: `prestate` and `diff`. The `prestate` mode re
 | nonce   | uint64            | nonce                         |
 | code    | string            | hex-encoded bytecode          |
 | storage | map[string]string | storage slots of the contract |
+
+#### prestateTracer config {#prestate-tracer-config}
+
+- `diffMode`: `BOOL`. Setting this to true will enable diff mode (default = false).
 
 In `diff` mode the result object will contain a `pre` and a `post` object:
 

--- a/docs/interacting-with-geth/rpc/ns-debug.md
+++ b/docs/interacting-with-geth/rpc/ns-debug.md
@@ -688,11 +688,8 @@ hash.
 In addition to the hash of the transaction you may give it a secondary _optional_ argument, which specifies the options for this specific call. The possible options are:
 
 - `tracer`: `STRING`. Name for built-in tracer or Javascript expression. See below for more details.
-
-If set, the previous four arguments will be ignored.
-
-- `timeout`: `STRING`. Overrides the default timeout of 5 seconds for JavaScript-based tracing calls.
-  Valid values are described [here](https://golang.org/pkg/time/#ParseDuration).
+- `timeout`: `STRING`. Overrides the default timeout of 5 seconds for each transaction tracing, valid values are described [here](https://golang.org/pkg/time/#ParseDuration).
+- `reexec`: `UINT64`. The number of blocks the tracer is willing to go back and re-execute to produce missing historical state necessary to run a specific trace. (default is 128).
 - `tracerConfig`: Config for the specified `tracer`. For example see callTracer's [config](/docs/developers/evm-tracing/built-in-tracers#config).
 
 Geth comes with a bundle of [built-in tracers](/docs/developers/evm-tracing/built-in-tracers), each providing various data about a transaction. This method defaults to the [struct logger](/docs/developers/evm-tracing/built-in-tracers#structopcode-logger). The `tracer` field of the second parameter can be set to use any of the other tracers. Alternatively a [custom tracer](/docs/developers/evm-tracing/custom-tracer) can be implemented in either Go or Javascript.

--- a/docs/interacting-with-geth/rpc/ns-debug.md
+++ b/docs/interacting-with-geth/rpc/ns-debug.md
@@ -362,9 +362,9 @@ For example the value `0s` will essentially turn on archive mode. If set to `1h`
 
 Returns a printed representation of the stacks of all goroutines. Note that the web3 wrapper for this method takes care of the printing and does not return the string.
 
-| Client  | Method invocation                          |
-| :------ | ------------------------------------------ |
-| Console | `debug.stacks(filter *string)`                           |
+| Client  | Method invocation                                |
+| :------ | ------------------------------------------------ |
+| Console | `debug.stacks(filter *string)`                   |
 | RPC     | `{"method": "debug_stacks", "params": [filter]}` |
 
 ### debug_standardTraceBlockToFile
@@ -455,7 +455,7 @@ Stops writing the Go runtime trace.
 
 | Client  | Method invocation                               |
 | :------ | ----------------------------------------------- |
-| Console | `debug.stopGoTrace()`                      |
+| Console | `debug.stopGoTrace()`                           |
 | RPC     | `{"method": "debug_stopGoTrace", "params": []}` |
 
 ### debug_storageRangeAt
@@ -741,9 +741,9 @@ Sets the logging verbosity ceiling. Log messages with level up to and including 
 
 The verbosity of individual packages and source files can be raised using `debug_vmodule`.
 
-| Client  | Method invocation                                 |
-| :------ | ------------------------------------------------- |
-| Console | `debug.verbosity(level)`                          |
+| Client  | Method invocation                                   |
+| :------ | --------------------------------------------------- |
+| Console | `debug.verbosity(level)`                            |
 | RPC     | `{"method": "debug_verbosity", "params": [number]}` |
 
 ### debug_vmodule

--- a/docs/interacting-with-geth/rpc/ns-debug.md
+++ b/docs/interacting-with-geth/rpc/ns-debug.md
@@ -579,13 +579,13 @@ References:
 
 ### debug_traceCall
 
-The `debug_traceCall` method lets you run an `eth_call` within the context of the given block execution using the final state of parent block as the base. The first argument (just as in `eth_call`) is a [transaction object](/docs/interacting-with-geth/rpc/objects#transaction-call-object). The block can be specified either by hash or by number as the second argument. The trace can be configured similar to `debug_traceTransaction`, see [TraceConfig](#traceconfig). The method returns the same output as `debug_traceTransaction`.
+The `debug_traceCall` method lets you run an `eth_call` within the context of the given block execution using the final state of parent block as the base. The first argument (just as in `eth_call`) is a [transaction object](/docs/interacting-with-geth/rpc/objects#transaction-call-object). The block can be specified either by hash or by number as the second argument. The trace can be configured similar to `debug_traceTransaction`, see [TraceCallConfig](#tracecallconfig). The method returns the same output as `debug_traceTransaction`.
 
-| Client  | Method invocation                                                                                                           |
-| :-----: | --------------------------------------------------------------------------------------------------------------------------- |
-|   Go    | `debug.TraceCall(args ethapi.CallArgs, blockNrOrHash rpc.BlockNumberOrHash, config *TraceConfig) (*ExecutionResult, error)` |
-| Console | `debug.traceCall(object, blockNrOrHash, [options])`                                                                         |
-|   RPC   | `{"method": "debug_traceCall", "params": [object, blockNrOrHash, {}]}`                                                      |
+| Client  | Method invocation                                                                                                               |
+| :-----: | ------------------------------------------------------------------------------------------------------------------------------- |
+|   Go    | `debug.TraceCall(args ethapi.CallArgs, blockNrOrHash rpc.BlockNumberOrHash, config *TraceCallConfig) (*ExecutionResult, error)` |
+| Console | `debug.traceCall(object, blockNrOrHash, [options])`                                                                             |
+|   RPC   | `{"method": "debug_traceCall", "params": [object, blockNrOrHash, {}]}`                                                          |
 
 **Example:**
 
@@ -629,7 +629,7 @@ It is possible to supply 'overrides' for both state-data (accounts/storage) and 
   },
   "latest",
   {
-    "blockoverrides": {"number": "0x50"}
+    "blockOverrides": {"number": "0x50"}
   })
 {
   failed: false,
@@ -690,7 +690,7 @@ In addition to the hash of the transaction you may give it a secondary _optional
 - `tracer`: `STRING`. Name for built-in tracer or Javascript expression. See below for more details.
 - `timeout`: `STRING`. Overrides the default timeout of 5 seconds for each transaction tracing, valid values are described [here](https://golang.org/pkg/time/#ParseDuration).
 - `reexec`: `UINT64`. The number of blocks the tracer is willing to go back and re-execute to produce missing historical state necessary to run a specific trace. (default is 128).
-- `tracerConfig`: Config for the specified `tracer`. For example see callTracer's [config](/docs/developers/evm-tracing/built-in-tracers#config).
+- `tracerConfig`: Config for the specified `tracer`. For example see [callTracer's config](/docs/developers/evm-tracing/built-in-tracers#call-tracer-config).
 
 Geth comes with a bundle of [built-in tracers](/docs/developers/evm-tracing/built-in-tracers), each providing various data about a transaction. This method defaults to the [struct logger](/docs/developers/evm-tracing/built-in-tracers#structopcode-logger). The `tracer` field of the second parameter can be set to use any of the other tracers. Alternatively a [custom tracer](/docs/developers/evm-tracing/custom-tracer) can be implemented in either Go or Javascript.
 
@@ -729,6 +729,14 @@ Geth comes with a bundle of [built-in tracers](/docs/developers/evm-tracing/buil
       }
   }]
 ```
+
+#### TraceCallConfig
+
+TraceCallConfig is a superset of [TraceConfig](#traceconfig), providing additional arguments in addition to those provided by [TraceConfig](#traceconfig):
+
+- `stateOverrides`: `StateOverride`. Overrides for the state data (accounts/storage) for the call, see [StateOverride](/docs/developers/evm-tracing/built-in-tracers#state-overrides) for more details.
+- `blockOverrides`: `BlockOverrides`. Overrides for the block data (number, timestamp etc) for the call, see [BlockOverrides](/docs/developers/evm-tracing/built-in-tracers#block-overrides) for more details.
+- `txIndex`: `NUMBER`. If set, the state at the the given transaction index will be used to tracing (default = the last transaction index in the block).
 
 ### debug_verbosity
 

--- a/docs/interacting-with-geth/rpc/ns-debug.md
+++ b/docs/interacting-with-geth/rpc/ns-debug.md
@@ -604,14 +604,14 @@ No specific call options:
 Tracing a call with a destination and specific sender, disabling the storage and memory output (less data returned over RPC)
 
 ```js
-debug.traceCall(
+> debug.traceCall(
   {
-    from: '0xdeadbeef29292929192939494959594933929292',
-    to: '0xde929f939d939d393f939393f93939f393929023',
-    gas: '0x7a120',
-    data: '0xf00d4b5d00000000000000000000000001291230982139282304923482304912923823920000000000000000000000001293123098123928310239129839291010293810'
+    from: "0xdeadbeef29292929192939494959594933929292",
+    to: "0xde929f939d939d393f939393f93939f393929023",
+    gas: "0x7a120",
+    data: "0xf00d4b5d00000000000000000000000001291230982139282304923482304912923823920000000000000000000000001293123098123928310239129839291010293810"
   },
-  'latest',
+  "latest",
   { disableStorage: true, disableMemory: true }
 );
 ```
@@ -619,16 +619,18 @@ debug.traceCall(
 It is possible to supply 'overrides' for both state-data (accounts/storage) and block data (number, timestamp etc). In the example below, a call which executes `NUMBER` is performed, and the overridden number is placed on the stack:
 
 ```js
-> debug.traceCall({
+> debug.traceCall(
+  {
     from: eth.accounts[0],
-    value:"0x1",
+    value: "0x1",
     gasPrice: "0xffffffff",
     gas: "0xffff",
-    input: "0x43"},
-    "latest",
-    {"blockoverrides":
-        {"number": "0x50"}
-    })
+    input: "0x43"
+  },
+  "latest",
+  {
+    "blockoverrides": {"number": "0x50"}
+  })
 {
   failed: false,
   gas: 53018,

--- a/docs/interacting-with-geth/rpc/ns-debug.md
+++ b/docs/interacting-with-geth/rpc/ns-debug.md
@@ -687,10 +687,6 @@ hash.
 
 In addition to the hash of the transaction you may give it a secondary _optional_ argument, which specifies the options for this specific call. The possible options are:
 
-- `disableStorage`: `BOOL`. Setting this to true will disable storage capture (default = false).
-- `disableStack`: `BOOL`. Setting this to true will disable stack capture (default = false).
-- `enableMemory`: `BOOL`. Setting this to true will enable memory capture (default = false).
-- `enableReturnData`: `BOOL`. Setting this to true will enable return data capture (default = false).
 - `tracer`: `STRING`. Name for built-in tracer or Javascript expression. See below for more details.
 
 If set, the previous four arguments will be ignored.


### PR DESCRIPTION
Raised in https://github.com/ethereum/go-ethereum/pull/29423#issuecomment-2029626588, in this PR, I add the following items:

1. add `tracerConfig` for prestate,opcode tracer;
2. add `StateOverrides`, `BlockOverrides` fields;
3. add `TracerCallConfig` for `debug_traceCall`


@s1na could you please take a look