### PR TITLE
Improve the application of EIP150 for create2

### DIFF
--- a/core/vm/instructions.go
+++ b/core/vm/instructions.go
@@ -628,7 +628,9 @@ func opCreate2(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([]
 		gas          = scope.Contract.Gas
 	)
 	// Apply EIP150
-	gas -= gas / 64
+	if interpreter.evm.chainRules.IsEIP150 {
+		gas -= gas / 64
+	}
 	scope.Contract.UseGas(gas, interpreter.evm.Config.Tracer, tracing.GasChangeCallContractCreation2)
 	// reuse size int for stackvalue
 	stackvalue := size


### PR DESCRIPTION
When EIP150 is enabled, gas constraints on sub contracts are only applied. This fix is to ensure consistency with create and to correctly interpret EIP150