### PR TITLE
core/vm: move bls precompiles to correct addresses

### DIFF
--- a/core/vm/contracts.go
+++ b/core/vm/contracts.go
@@ -111,15 +111,15 @@ var PrecompiledContractsCancun = map[common.Address]PrecompiledContract{
 // PrecompiledContractsBLS contains the set of pre-compiled Ethereum
 // contracts specified in EIP-2537. These are exported for testing purposes.
 var PrecompiledContractsBLS = map[common.Address]PrecompiledContract{
-	common.BytesToAddress([]byte{10}): &bls12381G1Add{},
-	common.BytesToAddress([]byte{11}): &bls12381G1Mul{},
-	common.BytesToAddress([]byte{12}): &bls12381G1MultiExp{},
-	common.BytesToAddress([]byte{13}): &bls12381G2Add{},
-	common.BytesToAddress([]byte{14}): &bls12381G2Mul{},
-	common.BytesToAddress([]byte{15}): &bls12381G2MultiExp{},
-	common.BytesToAddress([]byte{16}): &bls12381Pairing{},
-	common.BytesToAddress([]byte{17}): &bls12381MapG1{},
-	common.BytesToAddress([]byte{18}): &bls12381MapG2{},
+	common.BytesToAddress([]byte{11}): &bls12381G1Add{},
+	common.BytesToAddress([]byte{12}): &bls12381G1Mul{},
+	common.BytesToAddress([]byte{13}): &bls12381G1MultiExp{},
+	common.BytesToAddress([]byte{14}): &bls12381G2Add{},
+	common.BytesToAddress([]byte{15}): &bls12381G2Mul{},
+	common.BytesToAddress([]byte{16}): &bls12381G2MultiExp{},
+	common.BytesToAddress([]byte{17}): &bls12381Pairing{},
+	common.BytesToAddress([]byte{18}): &bls12381MapG1{},
+	common.BytesToAddress([]byte{19}): &bls12381MapG2{},
 }
 
 var (

--- a/tests/fuzzers/bls12381/precompile_fuzzer.go
+++ b/tests/fuzzers/bls12381/precompile_fuzzer.go
@@ -25,15 +25,15 @@ import (
 )
 
 const (
-	blsG1Add      = byte(10)
-	blsG1Mul      = byte(11)
-	blsG1MultiExp = byte(12)
-	blsG2Add      = byte(13)
-	blsG2Mul      = byte(14)
-	blsG2MultiExp = byte(15)
-	blsPairing    = byte(16)
-	blsMapG1      = byte(17)
-	blsMapG2      = byte(18)
+	blsG1Add      = byte(11)
+	blsG1Mul      = byte(12)
+	blsG1MultiExp = byte(13)
+	blsG2Add      = byte(14)
+	blsG2Mul      = byte(15)
+	blsG2MultiExp = byte(16)
+	blsPairing    = byte(17)
+	blsMapG1      = byte(18)
+	blsMapG2      = byte(19)
 )
 
 func checkInput(id byte, inputLen int) bool {


### PR DESCRIPTION
https://eips.ethereum.org/EIPS/eip-2537

Name	Value	Comment
FORK_TIMESTAMP	TBD	Mainnet
BLS12_G1ADD	0x0b	precompile address
BLS12_G1MUL	0x0c	precompile address
BLS12_G1MULTIEXP	0x0d	precompile address
BLS12_G2ADD	0x0e	precompile address
BLS12_G2MUL	0x0f	precompile address
BLS12_G2MULTIEXP	0x10	precompile address
BLS12_PAIRING	0x11	precompile address
BLS12_MAP_FP_TO_G1	0x12	precompile address
BLS12_MAP_FP2_TO_G2	0x13	precompile address