### PR TITLE
beacon/blsync: proceed with empty finalized hash if proof is not expected soon

### DIFF
--- a/beacon/blsync/block_sync.go
+++ b/beacon/blsync/block_sync.go
@@ -135,7 +135,7 @@ func (s *beaconBlockSync) updateEventFeed() {
 		case he < fe:
 			return
 		case he == fe+1:
-			parent, ok := s.recentBlocks.Get(head.Header.ParentRoot)	
+			parent, ok := s.recentBlocks.Get(head.Header.ParentRoot)
 			if !ok || parent.Slot()/params.EpochLength == fe {
 				return // head is at first slot of next epoch, wait for finality update
 				//TODO trt to fetch finality update directly if subscription does not deliver

--- a/beacon/blsync/block_sync.go
+++ b/beacon/blsync/block_sync.go
@@ -138,7 +138,7 @@ func (s *beaconBlockSync) updateEventFeed() {
 			parent, ok := s.recentBlocks.Get(head.Header.ParentRoot)
 			if !ok || parent.Slot()/params.EpochLength == fe {
 				return // head is at first slot of next epoch, wait for finality update
-				//TODO trt to fetch finality update directly if subscription does not deliver
+				//TODO: try to fetch finality update directly if subscription does not deliver
 			}
 		}
 	}


### PR DESCRIPTION
This PR fixes an issue that happens when the chain either cannot finalize or is new and does not have a finality proof yet. Now if a finality proof is not expected soon then blsync proceeds without a finalized block hash.