### PR TITLE
eth/tracers: refactor block context in test runner

### DIFF
--- a/eth/tracers/internal/tracetest/calltrace_test.go
+++ b/eth/tracers/internal/tracetest/calltrace_test.go
@@ -65,11 +65,8 @@ type callTrace struct {
 
 // callTracerTest defines a single test to check the call tracer against.
 type callTracerTest struct {
-	Genesis      *core.Genesis   `json:"genesis"`
-	Context      *traceContext   `json:"context"`
-	Input        string          `json:"input"`
-	TracerConfig json.RawMessage `json:"tracerConfig"`
-	Result       *callTrace      `json:"result"`
+	tracerTestEnv
+	Result *callTrace `json:"result"`
 }
 
 // Iterates over all the input-output datasets in the tracer test harness and

--- a/eth/tracers/internal/tracetest/calltrace_test.go
+++ b/eth/tracers/internal/tracetest/calltrace_test.go
@@ -66,7 +66,7 @@ type callTrace struct {
 // callTracerTest defines a single test to check the call tracer against.
 type callTracerTest struct {
 	Genesis      *core.Genesis   `json:"genesis"`
-	Context      *callContext    `json:"context"`
+	Context      *traceContext   `json:"context"`
 	Input        string          `json:"input"`
 	TracerConfig json.RawMessage `json:"tracerConfig"`
 	Result       *callTrace      `json:"result"`

--- a/eth/tracers/internal/tracetest/flat_calltrace_test.go
+++ b/eth/tracers/internal/tracetest/flat_calltrace_test.go
@@ -77,11 +77,8 @@ type flatCallTraceResult struct {
 
 // flatCallTracerTest defines a single test to check the call tracer against.
 type flatCallTracerTest struct {
-	Genesis      *core.Genesis   `json:"genesis"`
-	Context      *traceContext   `json:"context"`
-	Input        string          `json:"input"`
-	TracerConfig json.RawMessage `json:"tracerConfig"`
-	Result       []flatCallTrace `json:"result"`
+	tracerTestEnv
+	Result []flatCallTrace `json:"result"`
 }
 
 func flatCallTracerTestRunner(tracerName string, filename string, dirPath string, t testing.TB) error {

--- a/eth/tracers/internal/tracetest/flat_calltrace_test.go
+++ b/eth/tracers/internal/tracetest/flat_calltrace_test.go
@@ -78,7 +78,7 @@ type flatCallTraceResult struct {
 // flatCallTracerTest defines a single test to check the call tracer against.
 type flatCallTracerTest struct {
 	Genesis      *core.Genesis   `json:"genesis"`
-	Context      *callContext    `json:"context"`
+	Context      *traceContext   `json:"context"`
 	Input        string          `json:"input"`
 	TracerConfig json.RawMessage `json:"tracerConfig"`
 	Result       []flatCallTrace `json:"result"`

--- a/eth/tracers/internal/tracetest/makeTest.js
+++ b/eth/tracers/internal/tracetest/makeTest.js
@@ -69,10 +69,9 @@ var makeTest = function(tx, traceConfig) {
         input:   eth.getRawTransaction(tx),
         result:  result,
     };
-    if (traceConfig) {
-        data.tracerConfig = traceConfig;
+    if (traceConfig && traceConfig.tracerConfig) {
+        data.tracerConfig = traceConfig.tracerConfig;
     }
-
 
     console.log(JSON.stringify(data, null, 2));
 }

--- a/eth/tracers/internal/tracetest/makeTest.js
+++ b/eth/tracers/internal/tracetest/makeTest.js
@@ -31,6 +31,9 @@ var makeTest = function(tx, traceConfig) {
     delete genesis.transactions;
     delete genesis.transactionsRoot;
     delete genesis.uncles;
+    delete genesis.withdrawals;
+    delete genesis.withdrawalsRoot;
+    delete genesis.baseFeePerGas;
 
     genesis.gasLimit  = genesis.gasLimit.toString();
     genesis.number    = genesis.number.toString();
@@ -60,11 +63,16 @@ var makeTest = function(tx, traceConfig) {
         context.baseFeePerGas = block.baseFeePerGas.toString();
     }
 
-    console.log(JSON.stringify({
+    var data = {
         genesis: genesis,
         context: context,
-        input:  eth.getRawTransaction(tx),
-        result: result,
-        tracerConfig: traceConfig.tracerConfig,
-    }, null, 2));
+        input:   eth.getRawTransaction(tx),
+        result:  result,
+    };
+    if (traceConfig) {
+        data.tracerConfig = traceConfig;
+    }
+
+
+    console.log(JSON.stringify(data, null, 2));
 }

--- a/eth/tracers/internal/tracetest/prestate_test.go
+++ b/eth/tracers/internal/tracetest/prestate_test.go
@@ -50,18 +50,18 @@ type prestateTracerTest struct {
 }
 
 func TestPrestateTracerLegacy(t *testing.T) {
-	testPrestateDiffTracer("prestateTracerLegacy", "prestate_tracer_legacy", t)
+	testPrestateTracer("prestateTracerLegacy", "prestate_tracer_legacy", t)
 }
 
 func TestPrestateTracer(t *testing.T) {
-	testPrestateDiffTracer("prestateTracer", "prestate_tracer", t)
+	testPrestateTracer("prestateTracer", "prestate_tracer", t)
 }
 
 func TestPrestateWithDiffModeTracer(t *testing.T) {
-	testPrestateDiffTracer("prestateTracer", "prestate_tracer_with_diff_mode", t)
+	testPrestateTracer("prestateTracer", "prestate_tracer_with_diff_mode", t)
 }
 
-func testPrestateDiffTracer(tracerName string, dirPath string, t *testing.T) {
+func testPrestateTracer(tracerName string, dirPath string, t *testing.T) {
 	files, err := os.ReadDir(filepath.Join("testdata", dirPath))
 	if err != nil {
 		t.Fatalf("failed to retrieve tracer test suite: %v", err)

--- a/eth/tracers/internal/tracetest/prestate_test.go
+++ b/eth/tracers/internal/tracetest/prestate_test.go
@@ -43,13 +43,10 @@ type account struct {
 	Storage map[common.Hash]common.Hash `json:"storage"`
 }
 
-// testcase defines a single test to check the stateDiff tracer against.
-type testcase struct {
-	Genesis      *core.Genesis   `json:"genesis"`
-	Context      *traceContext   `json:"context"`
-	Input        string          `json:"input"`
-	TracerConfig json.RawMessage `json:"tracerConfig"`
-	Result       interface{}     `json:"result"`
+// prestateTracerTest defines a single test to check the stateDiff tracer against.
+type prestateTracerTest struct {
+	tracerTestEnv
+	Result interface{} `json:"result"`
 }
 
 func TestPrestateTracerLegacy(t *testing.T) {
@@ -77,7 +74,7 @@ func testPrestateDiffTracer(tracerName string, dirPath string, t *testing.T) {
 			t.Parallel()
 
 			var (
-				test = new(testcase)
+				test = new(prestateTracerTest)
 				tx   = new(types.Transaction)
 			)
 			// Call tracer test found, read if from disk

--- a/eth/tracers/internal/tracetest/prestate_test.go
+++ b/eth/tracers/internal/tracetest/prestate_test.go
@@ -46,7 +46,7 @@ type account struct {
 // testcase defines a single test to check the stateDiff tracer against.
 type testcase struct {
 	Genesis      *core.Genesis   `json:"genesis"`
-	Context      *callContext    `json:"context"`
+	Context      *traceContext   `json:"context"`
 	Input        string          `json:"input"`
 	TracerConfig json.RawMessage `json:"tracerConfig"`
 	Result       interface{}     `json:"result"`

--- a/eth/tracers/internal/tracetest/testdata/call_tracer/blob_tx.json
+++ b/eth/tracers/internal/tracetest/testdata/call_tracer/blob_tx.json
@@ -14,8 +14,7 @@
     "parentBeaconBlockRoot": "0x0000000000000000000000000000000000000000000000000000000000000000",
     "stateRoot": "0x577f42ab21ccfd946511c57869ace0bdf7c217c36f02b7cd3459df0ed1cffc1a",
     "timestamp": "1709626771",
-    "withdrawals": [],
-    "withdrawalsRoot": "0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421",
+    "totalDifficulty": "1",
     "alloc": {
       "0x0000000000000000000000000000000000000000": {
         "balance": "0x272e0528"

--- a/eth/tracers/internal/tracetest/testdata/call_tracer/blob_tx.json
+++ b/eth/tracers/internal/tracetest/testdata/call_tracer/blob_tx.json
@@ -14,7 +14,6 @@
     "parentBeaconBlockRoot": "0x0000000000000000000000000000000000000000000000000000000000000000",
     "stateRoot": "0x577f42ab21ccfd946511c57869ace0bdf7c217c36f02b7cd3459df0ed1cffc1a",
     "timestamp": "1709626771",
-    "totalDifficulty": "1",
     "alloc": {
       "0x0000000000000000000000000000000000000000": {
         "balance": "0x272e0528"

--- a/eth/tracers/internal/tracetest/testdata/prestate_tracer/blob_tx.json
+++ b/eth/tracers/internal/tracetest/testdata/prestate_tracer/blob_tx.json
@@ -14,8 +14,7 @@
     "parentBeaconBlockRoot": "0x0000000000000000000000000000000000000000000000000000000000000000",
     "stateRoot": "0x577f42ab21ccfd946511c57869ace0bdf7c217c36f02b7cd3459df0ed1cffc1a",
     "timestamp": "1709626771",
-    "withdrawals": [],
-    "withdrawalsRoot": "0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421",
+    "totalDifficulty": "1",
     "alloc": {
       "0x0000000000000000000000000000000000000000": {
         "balance": "0x272e0528"

--- a/eth/tracers/internal/tracetest/testdata/prestate_tracer/blob_tx.json
+++ b/eth/tracers/internal/tracetest/testdata/prestate_tracer/blob_tx.json
@@ -14,7 +14,6 @@
     "parentBeaconBlockRoot": "0x0000000000000000000000000000000000000000000000000000000000000000",
     "stateRoot": "0x577f42ab21ccfd946511c57869ace0bdf7c217c36f02b7cd3459df0ed1cffc1a",
     "timestamp": "1709626771",
-    "totalDifficulty": "1",
     "alloc": {
       "0x0000000000000000000000000000000000000000": {
         "balance": "0x272e0528"

--- a/eth/tracers/internal/tracetest/testdata/prestate_tracer/create_create.json
+++ b/eth/tracers/internal/tracetest/testdata/prestate_tracer/create_create.json
@@ -11,7 +11,6 @@
     "number": "1",
     "stateRoot": "0xd2ebe0a7f3572ffe3e5b4c78147376d3fca767f236e4dd23f9151acfec7cb0d1",
     "timestamp": "1699617692",
-    "totalDifficulty": "0",
     "alloc": {
       "0x0000000000000000000000000000000000000000": {
         "balance": "0x5208"

--- a/eth/tracers/internal/tracetest/testdata/prestate_tracer/create_create.json
+++ b/eth/tracers/internal/tracetest/testdata/prestate_tracer/create_create.json
@@ -11,8 +11,7 @@
     "number": "1",
     "stateRoot": "0xd2ebe0a7f3572ffe3e5b4c78147376d3fca767f236e4dd23f9151acfec7cb0d1",
     "timestamp": "1699617692",
-    "withdrawals": [],
-    "withdrawalsRoot": "0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421",
+    "totalDifficulty": "0",
     "alloc": {
       "0x0000000000000000000000000000000000000000": {
         "balance": "0x5208"

--- a/eth/tracers/internal/tracetest/util.go
+++ b/eth/tracers/internal/tracetest/util.go
@@ -42,7 +42,8 @@ func camel(str string) string {
 	return strings.Join(pieces, "")
 }
 
-type callContext struct {
+// traceContext defines a context used to construct the block context
+type traceContext struct {
 	Number     math.HexOrDecimal64   `json:"number"`
 	Difficulty *math.HexOrDecimal256 `json:"difficulty"`
 	Time       math.HexOrDecimal64   `json:"timestamp"`
@@ -51,7 +52,7 @@ type callContext struct {
 	BaseFee    *math.HexOrDecimal256 `json:"baseFeePerGas"`
 }
 
-func (c *callContext) toBlockContext(genesis *core.Genesis) vm.BlockContext {
+func (c *traceContext) toBlockContext(genesis *core.Genesis) vm.BlockContext {
 	context := vm.BlockContext{
 		CanTransfer: core.CanTransfer,
 		Transfer:    core.Transfer,

--- a/eth/tracers/internal/tracetest/util.go
+++ b/eth/tracers/internal/tracetest/util.go
@@ -17,6 +17,7 @@
 package tracetest
 
 import (
+	"encoding/json"
 	"math/big"
 	"strings"
 	"unicode"
@@ -77,4 +78,12 @@ func (c *traceContext) toBlockContext(genesis *core.Genesis) vm.BlockContext {
 		context.BlobBaseFee = eip4844.CalcBlobFee(genesis.Config, header)
 	}
 	return context
+}
+
+// tracerTestEnv defines a tracer test required fields
+type tracerTestEnv struct {
+	Genesis      *core.Genesis   `json:"genesis"`
+	Context      *traceContext   `json:"context"`
+	Input        string          `json:"input"`
+	TracerConfig json.RawMessage `json:"tracerConfig"`
 }


### PR DESCRIPTION
Made some simple adjustment for the trace testcase:

1. rm `withdrawals{Root}`, `genesis.baseFeePerGas` in `makeTest.js`;
2. add `tracerConfig` in `maketest.js` is not null;
3. reuse `tracerTestEnv` struct;