### PR TITLE
core: fix dev mode genesis difficulty

### DIFF
--- a/core/genesis.go
+++ b/core/genesis.go
@@ -582,7 +582,7 @@ func DeveloperGenesisBlock(gasLimit uint64, faucet *common.Address) *Genesis {
 		Config:     &config,
 		GasLimit:   gasLimit,
 		BaseFee:    big.NewInt(params.InitialBaseFee),
-		Difficulty: big.NewInt(1),
+		Difficulty: big.NewInt(0),
 		Alloc: map[common.Address]types.Account{
 			common.BytesToAddress([]byte{1}): {Balance: big.NewInt(1)}, // ECRecover
 			common.BytesToAddress([]byte{2}): {Balance: big.NewInt(1)}, // SHA256


### PR DESCRIPTION
As dev mode starts in merge the difficulty of the first block should be zero. You can see a symptom of this problem when doing an eth_call on top of genesis that invokes a post-london opcode:

```terminal
> eth.call({ from: eth.accounts[0], to: '0xc000000000000000000000000000000000000000' }, 'latest', { '0xc000000000000000000000000000000000000000': { code: '0x6080604052348015600e575f80fd5b505f36606048604051602001602291906054565b6040516020818303038152906040529050915050805190602001f35b5f819050919050565b604e81603e565b82525050565b5f60208201905060655f8301846047565b9291505056fea2646970667358221220c0aef6db63bc9113c75225aa80911ead112cc205dcc1cd8b0771368b894dc4e964736f6c63430008190033' } })
WARN [04-05|18:19:22.534] Served eth_call                          reqid=12 duration=5.756917ms  err="invalid opcode: PUSH0"
Error: invalid opcode: PUSH0
```