### PR TITLE
signer/core/apitypes: fix apitypes breakage due to bitrotted PR

### DIFF
--- a/signer/core/apitypes/types.go
+++ b/signer/core/apitypes/types.go
@@ -243,12 +243,12 @@ func (args *SendTxArgs) validateTxSidecar() error {
 		commitments := make([]kzg4844.Commitment, n)
 		proofs := make([]kzg4844.Proof, n)
 		for i, b := range args.Blobs {
-			c, err := kzg4844.BlobToCommitment(b)
+			c, err := kzg4844.BlobToCommitment(&b)
 			if err != nil {
 				return fmt.Errorf("blobs[%d]: error computing commitment: %v", i, err)
 			}
 			commitments[i] = c
-			p, err := kzg4844.ComputeBlobProof(b, c)
+			p, err := kzg4844.ComputeBlobProof(&b, c)
 			if err != nil {
 				return fmt.Errorf("blobs[%d]: error computing proof: %v", i, err)
 			}
@@ -258,7 +258,7 @@ func (args *SendTxArgs) validateTxSidecar() error {
 		args.Proofs = proofs
 	} else {
 		for i, b := range args.Blobs {
-			if err := kzg4844.VerifyBlobProof(b, args.Commitments[i], args.Proofs[i]); err != nil {
+			if err := kzg4844.VerifyBlobProof(&b, args.Commitments[i], args.Proofs[i]); err != nil {
 				return fmt.Errorf("failed to verify blob proof: %v", err)
 			}
 		}

--- a/signer/core/apitypes/types_test.go
+++ b/signer/core/apitypes/types_test.go
@@ -109,11 +109,11 @@ func TestTxArgs(t *testing.T) {
 
 func TestBlobTxs(t *testing.T) {
 	blob := kzg4844.Blob{0x1}
-	commitment, err := kzg4844.BlobToCommitment(blob)
+	commitment, err := kzg4844.BlobToCommitment(&blob)
 	if err != nil {
 		t.Fatal(err)
 	}
-	proof, err := kzg4844.ComputeBlobProof(blob, commitment)
+	proof, err := kzg4844.ComputeBlobProof(&blob, commitment)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
I br0ke master, this change unbreaks it again