### PR TITLE
all: replace path.Join with filepath.Join

### DIFF
--- a/core/blockchain_sethead_test.go
+++ b/core/blockchain_sethead_test.go
@@ -22,7 +22,7 @@ package core
 import (
 	"fmt"
 	"math/big"
-	"path"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -1966,7 +1966,7 @@ func testSetHeadWithScheme(t *testing.T, tt *rewindTest, snapshots bool, scheme 
 
 	// Create a temporary persistent database
 	datadir := t.TempDir()
-	ancient := path.Join(datadir, "ancient")
+	ancient := filepath.Join(datadir, "ancient")
 
 	db, err := rawdb.Open(rawdb.OpenOptions{
 		Directory:         datadir,

--- a/core/rawdb/database.go
+++ b/core/rawdb/database.go
@@ -21,7 +21,6 @@ import (
 	"errors"
 	"fmt"
 	"os"
-	"path"
 	"path/filepath"
 	"strings"
 	"time"
@@ -172,7 +171,7 @@ func resolveChainFreezerDir(ancient string) string {
 	// sub folder, if not then two possibilities:
 	// - chain freezer is not initialized
 	// - chain freezer exists in legacy location (root ancient folder)
-	freezer := path.Join(ancient, ChainFreezerName)
+	freezer := filepath.Join(ancient, ChainFreezerName)
 	if !common.FileExist(freezer) {
 		if !common.FileExist(ancient) {
 			// The entire ancient store is not initialized, still use the sub

--- a/core/rawdb/freezer_test.go
+++ b/core/rawdb/freezer_test.go
@@ -23,7 +23,6 @@ import (
 	"math/big"
 	"math/rand"
 	"os"
-	"path"
 	"path/filepath"
 	"sync"
 	"testing"
@@ -398,11 +397,11 @@ func TestRenameWindows(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	f2, err := os.Create(path.Join(dir1, fname2))
+	f2, err := os.Create(filepath.Join(dir1, fname2))
 	if err != nil {
 		t.Fatal(err)
 	}
-	f3, err := os.Create(path.Join(dir2, fname2))
+	f3, err := os.Create(filepath.Join(dir2, fname2))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -424,15 +423,15 @@ func TestRenameWindows(t *testing.T) {
 	if err := f3.Close(); err != nil {
 		t.Fatal(err)
 	}
-	if err := os.Rename(f.Name(), path.Join(dir2, fname)); err != nil {
+	if err := os.Rename(f.Name(), filepath.Join(dir2, fname)); err != nil {
 		t.Fatal(err)
 	}
-	if err := os.Rename(f2.Name(), path.Join(dir2, fname2)); err != nil {
+	if err := os.Rename(f2.Name(), filepath.Join(dir2, fname2)); err != nil {
 		t.Fatal(err)
 	}
 
 	// Check file contents
-	f, err = os.Open(path.Join(dir2, fname))
+	f, err = os.Open(filepath.Join(dir2, fname))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -446,7 +445,7 @@ func TestRenameWindows(t *testing.T) {
 		t.Errorf("unexpected file contents. Got %v\n", buf)
 	}
 
-	f, err = os.Open(path.Join(dir2, fname2))
+	f, err = os.Open(filepath.Join(dir2, fname2))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/build/util.go
+++ b/internal/build/util.go
@@ -175,7 +175,7 @@ func UploadSFTP(identityFile, host, dir string, files []string) error {
 	}
 	in := io.MultiWriter(stdin, os.Stdout)
 	for _, f := range files {
-		fmt.Fprintln(in, "put", f, path.Join(dir, filepath.Base(f)))
+		fmt.Fprintln(in, "put", f, filepath.Join(dir, filepath.Base(f)))
 	}
 	fmt.Fprintln(in, "exit")
 	// Some issue with the PPA sftp server makes it so the server does not

--- a/node/node_auth_test.go
+++ b/node/node_auth_test.go
@@ -22,7 +22,7 @@ import (
 	"fmt"
 	"net/http"
 	"os"
-	"path"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -98,7 +98,7 @@ func TestAuthEndpoints(t *testing.T) {
 		t.Fatalf("failed to create jwt secret: %v", err)
 	}
 	// Geth must read it from a file, and does not support in-memory JWT secrets, so we create a temporary file.
-	jwtPath := path.Join(t.TempDir(), "jwt_secret")
+	jwtPath := filepath.Join(t.TempDir(), "jwt_secret")
 	if err := os.WriteFile(jwtPath, []byte(hexutil.Encode(secret[:])), 0600); err != nil {
 		t.Fatalf("failed to prepare jwt secret file: %v", err)
 	}

--- a/signer/core/signed_data_test.go
+++ b/signer/core/signed_data_test.go
@@ -24,6 +24,7 @@ import (
 	"math/big"
 	"os"
 	"path"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -411,7 +412,7 @@ func TestJsonFiles(t *testing.T) {
 // crashes or hangs.
 func TestFuzzerFiles(t *testing.T) {
 	t.Parallel()
-	corpusdir := path.Join("testdata", "fuzzing")
+	corpusdir := filepath.Join("testdata", "fuzzing")
 	testfiles, err := os.ReadDir(corpusdir)
 	if err != nil {
 		t.Fatalf("failed reading files: %v", err)


### PR DESCRIPTION
path.Join will have a '/' file separator in the window environment

![image](https://github.com/ethereum/go-ethereum/assets/55082705/1e909b02-82dc-4462-91ad-fed5f9a956e0)
