### PR TITLE
trie/utils: simplify codeChunkIndex

### DIFF
--- a/trie/utils/verkle.go
+++ b/trie/utils/verkle.go
@@ -209,7 +209,7 @@ func codeChunkIndex(chunk *uint256.Int) (*uint256.Int, byte) {
 		chunkOffset            = new(uint256.Int).Add(codeOffset, chunk)
 		treeIndex, subIndexMod = new(uint256.Int).DivMod(chunkOffset, verkleNodeWidth, new(uint256.Int))
 	)
-	return treeIndex, byte(subIndexMod[0])
+	return treeIndex, byte(subIndexMod.Uint64())
 }
 
 // CodeChunkKey returns the verkle tree key of the code chunk for the

--- a/trie/utils/verkle.go
+++ b/trie/utils/verkle.go
@@ -209,11 +209,7 @@ func codeChunkIndex(chunk *uint256.Int) (*uint256.Int, byte) {
 		chunkOffset            = new(uint256.Int).Add(codeOffset, chunk)
 		treeIndex, subIndexMod = new(uint256.Int).DivMod(chunkOffset, verkleNodeWidth, new(uint256.Int))
 	)
-	var subIndex byte
-	if len(subIndexMod) != 0 {
-		subIndex = byte(subIndexMod[0])
-	}
-	return treeIndex, subIndex
+	return treeIndex, byte(subIndexMod[0])
 }
 
 // CodeChunkKey returns the verkle tree key of the code chunk for the


### PR DESCRIPTION
The type of `subIndexMod` is `*uint256.Int` (alias `[4]uint64`) and `DivMod` never returns a `nil`. So `len(subIndexMod)` is always `4` and this code can be simplified.