### PR TITLE
beacon/types, beacon/light: use OptimisticUpdate instead of SignedHeader

### DIFF
--- a/beacon/blsync/block_sync_test.go
+++ b/beacon/blsync/block_sync_test.go
@@ -134,8 +134,12 @@ func (h *testHeadTracker) PrefetchHead() types.HeadInfo {
 	return h.prefetch
 }
 
-func (h *testHeadTracker) ValidatedHead() (types.SignedHeader, bool) {
-	return h.validated, h.validated.Header != (types.Header{})
+func (h *testHeadTracker) ValidatedOptimistic() (types.OptimisticUpdate, bool) {
+	return types.OptimisticUpdate{
+		Attested:      types.HeaderWithExecProof{Header: h.validated.Header},
+		Signature:     h.validated.Signature,
+		SignatureSlot: h.validated.SignatureSlot,
+	}, h.validated.Header != (types.Header{})
 }
 
 // TODO add test case for finality

--- a/beacon/light/api/api_server.go
+++ b/beacon/light/api/api_server.go
@@ -46,13 +46,13 @@ func (s *ApiServer) Subscribe(eventCallback func(event request.Event)) {
 			log.Debug("New head received", "slot", slot, "blockRoot", blockRoot)
 			eventCallback(request.Event{Type: sync.EvNewHead, Data: types.HeadInfo{Slot: slot, BlockRoot: blockRoot}})
 		},
-		OnSignedHead: func(head types.SignedHeader) {
-			log.Debug("New signed head received", "slot", head.Header.Slot, "blockRoot", head.Header.Hash(), "signerCount", head.Signature.SignerCount())
-			eventCallback(request.Event{Type: sync.EvNewSignedHead, Data: head})
+		OnOptimistic: func(update types.OptimisticUpdate) {
+			log.Debug("New optimistic update received", "slot", update.Attested.Slot, "blockRoot", update.Attested.Hash(), "signerCount", update.Signature.SignerCount())
+			eventCallback(request.Event{Type: sync.EvNewOptimisticUpdate, Data: update})
 		},
-		OnFinality: func(head types.FinalityUpdate) {
-			log.Debug("New finality update received", "slot", head.Attested.Slot, "blockRoot", head.Attested.Hash(), "signerCount", head.Signature.SignerCount())
-			eventCallback(request.Event{Type: sync.EvNewFinalityUpdate, Data: head})
+		OnFinality: func(update types.FinalityUpdate) {
+			log.Debug("New finality update received", "slot", update.Attested.Slot, "blockRoot", update.Attested.Hash(), "signerCount", update.Signature.SignerCount())
+			eventCallback(request.Event{Type: sync.EvNewFinalityUpdate, Data: update})
 		},
 		OnError: func(err error) {
 			log.Warn("Head event stream error", "err", err)

--- a/beacon/light/sync/head_sync.go
+++ b/beacon/light/sync/head_sync.go
@@ -19,11 +19,12 @@ package sync
 import (
 	"github.com/ethereum/go-ethereum/beacon/light/request"
 	"github.com/ethereum/go-ethereum/beacon/types"
+	"github.com/ethereum/go-ethereum/log"
 )
 
 type headTracker interface {
-	ValidateHead(head types.SignedHeader) (bool, error)
-	ValidateFinality(head types.FinalityUpdate) (bool, error)
+	ValidateOptimistic(update types.OptimisticUpdate) (bool, error)
+	ValidateFinality(update types.FinalityUpdate) (bool, error)
 	SetPrefetchHead(head types.HeadInfo)
 }
 
@@ -33,16 +34,16 @@ type headTracker interface {
 // It can also postpone the validation of the latest announced signed head
 // until the committee chain is synced up to at least the required period.
 type HeadSync struct {
-	headTracker         headTracker
-	chain               committeeChain
-	nextSyncPeriod      uint64
-	chainInit           bool
-	unvalidatedHeads    map[request.Server]types.SignedHeader
-	unvalidatedFinality map[request.Server]types.FinalityUpdate
-	serverHeads         map[request.Server]types.HeadInfo
-	headServerCount     map[types.HeadInfo]headServerCount
-	headCounter         uint64
-	prefetchHead        types.HeadInfo
+	headTracker           headTracker
+	chain                 committeeChain
+	nextSyncPeriod        uint64
+	chainInit             bool
+	unvalidatedOptimistic map[request.Server]types.OptimisticUpdate
+	unvalidatedFinality   map[request.Server]types.FinalityUpdate
+	serverHeads           map[request.Server]types.HeadInfo
+	headServerCount       map[types.HeadInfo]headServerCount
+	headCounter           uint64
+	prefetchHead          types.HeadInfo
 }
 
 // headServerCount is associated with most recently seen head infos; it counts
@@ -57,12 +58,12 @@ type headServerCount struct {
 // NewHeadSync creates a new HeadSync.
 func NewHeadSync(headTracker headTracker, chain committeeChain) *HeadSync {
 	s := &HeadSync{
-		headTracker:         headTracker,
-		chain:               chain,
-		unvalidatedHeads:    make(map[request.Server]types.SignedHeader),
-		unvalidatedFinality: make(map[request.Server]types.FinalityUpdate),
-		serverHeads:         make(map[request.Server]types.HeadInfo),
-		headServerCount:     make(map[types.HeadInfo]headServerCount),
+		headTracker:           headTracker,
+		chain:                 chain,
+		unvalidatedOptimistic: make(map[request.Server]types.OptimisticUpdate),
+		unvalidatedFinality:   make(map[request.Server]types.FinalityUpdate),
+		serverHeads:           make(map[request.Server]types.HeadInfo),
+		headServerCount:       make(map[types.HeadInfo]headServerCount),
 	}
 	return s
 }
@@ -73,59 +74,68 @@ func (s *HeadSync) Process(requester request.Requester, events []request.Event) 
 		switch event.Type {
 		case EvNewHead:
 			s.setServerHead(event.Server, event.Data.(types.HeadInfo))
-		case EvNewSignedHead:
-			s.newSignedHead(event.Server, event.Data.(types.SignedHeader))
+		case EvNewOptimisticUpdate:
+			s.newOptimisticUpdate(event.Server, event.Data.(types.OptimisticUpdate))
 		case EvNewFinalityUpdate:
 			s.newFinalityUpdate(event.Server, event.Data.(types.FinalityUpdate))
 		case request.EvUnregistered:
 			s.setServerHead(event.Server, types.HeadInfo{})
 			delete(s.serverHeads, event.Server)
-			delete(s.unvalidatedHeads, event.Server)
+			delete(s.unvalidatedOptimistic, event.Server)
+			delete(s.unvalidatedFinality, event.Server)
 		}
 	}
 
 	nextPeriod, chainInit := s.chain.NextSyncPeriod()
 	if nextPeriod != s.nextSyncPeriod || chainInit != s.chainInit {
 		s.nextSyncPeriod, s.chainInit = nextPeriod, chainInit
-		s.processUnvalidated()
+		s.processUnvalidatedUpdates()
 	}
 }
 
-// newSignedHead handles received signed head; either validates it if the chain
-// is properly synced or stores it for further validation.
-func (s *HeadSync) newSignedHead(server request.Server, signedHead types.SignedHeader) {
-	if !s.chainInit || types.SyncPeriod(signedHead.SignatureSlot) > s.nextSyncPeriod {
-		s.unvalidatedHeads[server] = signedHead
+// newOptimisticUpdate handles received optimistic update; either validates it if
+// the chain is properly synced or stores it for further validation.
+func (s *HeadSync) newOptimisticUpdate(server request.Server, optimisticUpdate types.OptimisticUpdate) {
+	if !s.chainInit || types.SyncPeriod(optimisticUpdate.SignatureSlot) > s.nextSyncPeriod {
+		s.unvalidatedOptimistic[server] = optimisticUpdate
 		return
 	}
-	s.headTracker.ValidateHead(signedHead)
+	if _, err := s.headTracker.ValidateOptimistic(optimisticUpdate); err != nil {
+		log.Debug("Error validating optimistic update", "error", err)
+	}
 }
 
-// newFinalityUpdate handles received finality update; either validates it if the chain
-// is properly synced or stores it for further validation.
+// newFinalityUpdate handles received finality update; either validates it if
+// the chain is properly synced or stores it for further validation.
 func (s *HeadSync) newFinalityUpdate(server request.Server, finalityUpdate types.FinalityUpdate) {
 	if !s.chainInit || types.SyncPeriod(finalityUpdate.SignatureSlot) > s.nextSyncPeriod {
 		s.unvalidatedFinality[server] = finalityUpdate
 		return
 	}
-	s.headTracker.ValidateFinality(finalityUpdate)
+	if _, err := s.headTracker.ValidateFinality(finalityUpdate); err != nil {
+		log.Debug("Error validating finality update", "error", err)
+	}
 }
 
-// processUnvalidated iterates the list of unvalidated heads and validates
+// processUnvalidatedUpdates iterates the list of unvalidated updates and validates
 // those which can be validated.
-func (s *HeadSync) processUnvalidated() {
+func (s *HeadSync) processUnvalidatedUpdates() {
 	if !s.chainInit {
 		return
 	}
-	for server, signedHead := range s.unvalidatedHeads {
-		if types.SyncPeriod(signedHead.SignatureSlot) <= s.nextSyncPeriod {
-			s.headTracker.ValidateHead(signedHead)
-			delete(s.unvalidatedHeads, server)
+	for server, optimisticUpdate := range s.unvalidatedOptimistic {
+		if types.SyncPeriod(optimisticUpdate.SignatureSlot) <= s.nextSyncPeriod {
+			if _, err := s.headTracker.ValidateOptimistic(optimisticUpdate); err != nil {
+				log.Debug("Error validating deferred optimistic update", "error", err)
+			}
+			delete(s.unvalidatedOptimistic, server)
 		}
 	}
 	for server, finalityUpdate := range s.unvalidatedFinality {
 		if types.SyncPeriod(finalityUpdate.SignatureSlot) <= s.nextSyncPeriod {
-			s.headTracker.ValidateFinality(finalityUpdate)
+			if _, err := s.headTracker.ValidateFinality(finalityUpdate); err != nil {
+				log.Debug("Error validating deferred finality update", "error", err)
+			}
 			delete(s.unvalidatedFinality, server)
 		}
 	}

--- a/beacon/light/sync/head_sync_test.go
+++ b/beacon/light/sync/head_sync_test.go
@@ -35,11 +35,11 @@ var (
 	testHead3 = types.HeadInfo{Slot: 124, BlockRoot: common.Hash{3}}
 	testHead4 = types.HeadInfo{Slot: 125, BlockRoot: common.Hash{4}}
 
-	testSHead1 = types.SignedHeader{SignatureSlot: 0x0124, Header: types.Header{Slot: 0x0123, StateRoot: common.Hash{1}}}
-	testSHead2 = types.SignedHeader{SignatureSlot: 0x2010, Header: types.Header{Slot: 0x200e, StateRoot: common.Hash{2}}}
-	// testSHead3 is at the end of period 1 but signed in period 2
-	testSHead3 = types.SignedHeader{SignatureSlot: 0x4000, Header: types.Header{Slot: 0x3fff, StateRoot: common.Hash{3}}}
-	testSHead4 = types.SignedHeader{SignatureSlot: 0x6444, Header: types.Header{Slot: 0x6443, StateRoot: common.Hash{4}}}
+	testOptUpdate1 = types.OptimisticUpdate{SignatureSlot: 0x0124, Attested: types.HeaderWithExecProof{Header: types.Header{Slot: 0x0123, StateRoot: common.Hash{1}}}}
+	testOptUpdate2 = types.OptimisticUpdate{SignatureSlot: 0x2010, Attested: types.HeaderWithExecProof{Header: types.Header{Slot: 0x200e, StateRoot: common.Hash{2}}}}
+	// testOptUpdate3 is at the end of period 1 but signed in period 2
+	testOptUpdate3 = types.OptimisticUpdate{SignatureSlot: 0x4000, Attested: types.HeaderWithExecProof{Header: types.Header{Slot: 0x3fff, StateRoot: common.Hash{3}}}}
+	testOptUpdate4 = types.OptimisticUpdate{SignatureSlot: 0x6444, Attested: types.HeaderWithExecProof{Header: types.Header{Slot: 0x6443, StateRoot: common.Hash{4}}}}
 )
 
 func TestValidatedHead(t *testing.T) {
@@ -51,7 +51,7 @@ func TestValidatedHead(t *testing.T) {
 	ht.ExpValidated(t, 0, nil)
 
 	ts.AddServer(testServer1, 1)
-	ts.ServerEvent(EvNewSignedHead, testServer1, testSHead1)
+	ts.ServerEvent(EvNewOptimisticUpdate, testServer1, testOptUpdate1)
 	ts.Run(1)
 	// announced head should be queued because of uninitialized chain
 	ht.ExpValidated(t, 1, nil)
@@ -59,27 +59,27 @@ func TestValidatedHead(t *testing.T) {
 	chain.SetNextSyncPeriod(0) // initialize chain
 	ts.Run(2)
 	// expect previously queued head to be validated
-	ht.ExpValidated(t, 2, []types.SignedHeader{testSHead1})
+	ht.ExpValidated(t, 2, []types.OptimisticUpdate{testOptUpdate1})
 
 	chain.SetNextSyncPeriod(1)
-	ts.ServerEvent(EvNewSignedHead, testServer1, testSHead2)
+	ts.ServerEvent(EvNewOptimisticUpdate, testServer1, testOptUpdate2)
 	ts.AddServer(testServer2, 1)
-	ts.ServerEvent(EvNewSignedHead, testServer2, testSHead2)
+	ts.ServerEvent(EvNewOptimisticUpdate, testServer2, testOptUpdate2)
 	ts.Run(3)
 	// expect both head announcements to be validated instantly
-	ht.ExpValidated(t, 3, []types.SignedHeader{testSHead2, testSHead2})
+	ht.ExpValidated(t, 3, []types.OptimisticUpdate{testOptUpdate2, testOptUpdate2})
 
-	ts.ServerEvent(EvNewSignedHead, testServer1, testSHead3)
+	ts.ServerEvent(EvNewOptimisticUpdate, testServer1, testOptUpdate3)
 	ts.AddServer(testServer3, 1)
-	ts.ServerEvent(EvNewSignedHead, testServer3, testSHead4)
+	ts.ServerEvent(EvNewOptimisticUpdate, testServer3, testOptUpdate4)
 	ts.Run(4)
-	// future period announced heads should be queued
+	// future period annonced heads should be queued
 	ht.ExpValidated(t, 4, nil)
 
 	chain.SetNextSyncPeriod(2)
 	ts.Run(5)
-	// testSHead3 can be validated now but not testSHead4
-	ht.ExpValidated(t, 5, []types.SignedHeader{testSHead3})
+	// testOptUpdate3 can be validated now but not testOptUpdate4
+	ht.ExpValidated(t, 5, []types.OptimisticUpdate{testOptUpdate3})
 
 	// server 3 disconnected without proving period 3, its announced head should be dropped
 	ts.RemoveServer(testServer3)
@@ -88,13 +88,13 @@ func TestValidatedHead(t *testing.T) {
 
 	chain.SetNextSyncPeriod(3)
 	ts.Run(7)
-	// testSHead4 could be validated now but it's not queued by any registered server
+	// testOptUpdate4 could be validated now but it's not queued by any registered server
 	ht.ExpValidated(t, 7, nil)
 
-	ts.ServerEvent(EvNewSignedHead, testServer2, testSHead4)
+	ts.ServerEvent(EvNewOptimisticUpdate, testServer2, testOptUpdate4)
 	ts.Run(8)
-	// now testSHead4 should be validated
-	ht.ExpValidated(t, 8, []types.SignedHeader{testSHead4})
+	// now testOptUpdate4 should be validated
+	ht.ExpValidated(t, 8, []types.OptimisticUpdate{testOptUpdate4})
 }
 
 func TestPrefetchHead(t *testing.T) {

--- a/beacon/light/sync/test_helpers.go
+++ b/beacon/light/sync/test_helpers.go
@@ -212,32 +212,32 @@ func (tc *TestCommitteeChain) ExpNextSyncPeriod(t *testing.T, expNsp uint64) {
 
 type TestHeadTracker struct {
 	phead     types.HeadInfo
-	validated []types.SignedHeader
+	validated []types.OptimisticUpdate
 }
 
-func (ht *TestHeadTracker) ValidateHead(head types.SignedHeader) (bool, error) {
-	ht.validated = append(ht.validated, head)
+func (ht *TestHeadTracker) ValidateOptimistic(update types.OptimisticUpdate) (bool, error) {
+	ht.validated = append(ht.validated, update)
 	return true, nil
 }
 
-// TODO add test case for finality
-func (ht *TestHeadTracker) ValidateFinality(head types.FinalityUpdate) (bool, error) {
+//TODO add test case for finality
+func (ht *TestHeadTracker) ValidateFinality(update types.FinalityUpdate) (bool, error) {
 	return true, nil
 }
 
-func (ht *TestHeadTracker) ExpValidated(t *testing.T, tci int, expHeads []types.SignedHeader) {
+func (ht *TestHeadTracker) ExpValidated(t *testing.T, tci int, expHeads []types.OptimisticUpdate) {
 	for i, expHead := range expHeads {
 		if i >= len(ht.validated) {
-			t.Errorf("Missing validated head in test case #%d index #%d (expected {slot %d blockRoot %x}, got none)", tci, i, expHead.Header.Slot, expHead.Header.Hash())
+			t.Errorf("Missing validated head in test case #%d index #%d (expected {slot %d blockRoot %x}, got none)", tci, i, expHead.Attested.Header.Slot, expHead.Attested.Header.Hash())
 			continue
 		}
-		if ht.validated[i] != expHead {
-			vhead := ht.validated[i].Header
-			t.Errorf("Wrong validated head in test case #%d index #%d (expected {slot %d blockRoot %x}, got {slot %d blockRoot %x})", tci, i, expHead.Header.Slot, expHead.Header.Hash(), vhead.Slot, vhead.Hash())
+		if !reflect.DeepEqual(ht.validated[i], expHead) {
+			vhead := ht.validated[i].Attested.Header
+			t.Errorf("Wrong validated head in test case #%d index #%d (expected {slot %d blockRoot %x}, got {slot %d blockRoot %x})", tci, i, expHead.Attested.Header.Slot, expHead.Attested.Header.Hash(), vhead.Slot, vhead.Hash())
 		}
 	}
 	for i := len(expHeads); i < len(ht.validated); i++ {
-		vhead := ht.validated[i].Header
+		vhead := ht.validated[i].Attested.Header
 		t.Errorf("Unexpected validated head in test case #%d index #%d (expected none, got {slot %d blockRoot %x})", tci, i, vhead.Slot, vhead.Hash())
 	}
 	ht.validated = nil

--- a/beacon/light/sync/types.go
+++ b/beacon/light/sync/types.go
@@ -23,9 +23,9 @@ import (
 )
 
 var (
-	EvNewHead           = &request.EventType{Name: "newHead"}           // data: types.HeadInfo
-	EvNewSignedHead     = &request.EventType{Name: "newSignedHead"}     // data: types.SignedHeader
-	EvNewFinalityUpdate = &request.EventType{Name: "newFinalityUpdate"} // data: types.FinalityUpdate
+	EvNewHead             = &request.EventType{Name: "newHead"}             // data: types.HeadInfo
+	EvNewOptimisticUpdate = &request.EventType{Name: "newOptimisticUpdate"} // data: types.OptimisticUpdate
+	EvNewFinalityUpdate   = &request.EventType{Name: "newFinalityUpdate"}   // data: types.FinalityUpdate
 )
 
 type (

--- a/beacon/light/sync/update_sync.go
+++ b/beacon/light/sync/update_sync.go
@@ -221,9 +221,9 @@ func (s *ForwardUpdateSync) Process(requester request.Requester, events []reques
 			if !queued {
 				s.unlockRange(sid, req)
 			}
-		case EvNewSignedHead:
-			signedHead := event.Data.(types.SignedHeader)
-			s.nextSyncPeriod[event.Server] = types.SyncPeriod(signedHead.SignatureSlot + 256)
+		case EvNewOptimisticUpdate:
+			update := event.Data.(types.OptimisticUpdate)
+			s.nextSyncPeriod[event.Server] = types.SyncPeriod(update.SignatureSlot + 256)
 		case request.EvUnregistered:
 			delete(s.nextSyncPeriod, event.Server)
 		}

--- a/beacon/light/sync/update_sync_test.go
+++ b/beacon/light/sync/update_sync_test.go
@@ -68,9 +68,9 @@ func TestUpdateSyncParallel(t *testing.T) {
 	ts := NewTestScheduler(t, updateSync)
 	// add 2 servers, head at period 100; allow 3-3 parallel requests for each
 	ts.AddServer(testServer1, 3)
-	ts.ServerEvent(EvNewSignedHead, testServer1, types.SignedHeader{SignatureSlot: 0x2000*100 + 0x1000})
+	ts.ServerEvent(EvNewOptimisticUpdate, testServer1, types.OptimisticUpdate{SignatureSlot: 0x2000*100 + 0x1000})
 	ts.AddServer(testServer2, 3)
-	ts.ServerEvent(EvNewSignedHead, testServer2, types.SignedHeader{SignatureSlot: 0x2000*100 + 0x1000})
+	ts.ServerEvent(EvNewOptimisticUpdate, testServer2, types.OptimisticUpdate{SignatureSlot: 0x2000*100 + 0x1000})
 
 	// expect 6 requests to be sent
 	ts.Run(1,
@@ -150,11 +150,11 @@ func TestUpdateSyncDifferentHeads(t *testing.T) {
 	ts := NewTestScheduler(t, updateSync)
 	// add 3 servers with different announced head periods
 	ts.AddServer(testServer1, 1)
-	ts.ServerEvent(EvNewSignedHead, testServer1, types.SignedHeader{SignatureSlot: 0x2000*15 + 0x1000})
+	ts.ServerEvent(EvNewOptimisticUpdate, testServer1, types.OptimisticUpdate{SignatureSlot: 0x2000*15 + 0x1000})
 	ts.AddServer(testServer2, 1)
-	ts.ServerEvent(EvNewSignedHead, testServer2, types.SignedHeader{SignatureSlot: 0x2000*16 + 0x1000})
+	ts.ServerEvent(EvNewOptimisticUpdate, testServer2, types.OptimisticUpdate{SignatureSlot: 0x2000*16 + 0x1000})
 	ts.AddServer(testServer3, 1)
-	ts.ServerEvent(EvNewSignedHead, testServer3, types.SignedHeader{SignatureSlot: 0x2000*17 + 0x1000})
+	ts.ServerEvent(EvNewOptimisticUpdate, testServer3, types.OptimisticUpdate{SignatureSlot: 0x2000*17 + 0x1000})
 
 	// expect request to the best announced head
 	ts.Run(1, testServer3, ReqUpdates{FirstPeriod: 10, Count: 7})
@@ -190,7 +190,7 @@ func TestUpdateSyncDifferentHeads(t *testing.T) {
 
 	// a new server is registered with announced head period 17
 	ts.AddServer(testServer4, 1)
-	ts.ServerEvent(EvNewSignedHead, testServer4, types.SignedHeader{SignatureSlot: 0x2000*17 + 0x1000})
+	ts.ServerEvent(EvNewOptimisticUpdate, testServer4, types.OptimisticUpdate{SignatureSlot: 0x2000*17 + 0x1000})
 	// expect request to sync one more period
 	ts.Run(7, testServer4, ReqUpdates{FirstPeriod: 16, Count: 1})
 

--- a/beacon/types/exec_payload.go
+++ b/beacon/types/exec_payload.go
@@ -66,9 +66,8 @@ func convertPayload[T payloadType](payload T, parentRoot *zrntcommon.Root) (*typ
 	block := types.NewBlockWithHeader(&header)
 	block = block.WithBody(transactions, nil)
 	block = block.WithWithdrawals(withdrawals)
-	hash := block.Hash()
-	if hash != expectedHash {
-		return block, fmt.Errorf("Sanity check failed, payload hash does not match (expected %x, got %x)", expectedHash, hash)
+	if hash := block.Hash(); hash != expectedHash {
+		return nil, fmt.Errorf("Sanity check failed, payload hash does not match (expected %x, got %x)", expectedHash, hash)
 	}
 	return block, nil
 }


### PR DESCRIPTION
This PR introduces `types.OptimisticUpdate` which represents the full information content of the optimistic updates, including the `ExecutionPayloadHeader` belonging to the attested beacon header, proven by a Merkle proof. This change does not change the behavior of blsync but it is useful for the light `ethclient` (implemented by https://github.com/ethereum/go-ethereum/pull/29033 ) because it makes execution header info automatically available for the current head and recent blocks.