### PR TITLE
internal, signer/core: replace path.Join with filepath.Join

### DIFF
--- a/internal/build/util.go
+++ b/internal/build/util.go
@@ -27,7 +27,6 @@ import (
 	"log"
 	"os"
 	"os/exec"
-	"path"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -112,7 +111,7 @@ func RunGit(args ...string) string {
 
 // readGitFile returns content of file in .git directory.
 func readGitFile(file string) string {
-	content, err := os.ReadFile(path.Join(".git", file))
+	content, err := os.ReadFile(filepath.Join(".git", file))
 	if err != nil {
 		return ""
 	}

--- a/internal/jsre/jsre_test.go
+++ b/internal/jsre/jsre_test.go
@@ -18,7 +18,7 @@ package jsre
 
 import (
 	"os"
-	"path"
+	"path/filepath"
 	"reflect"
 	"testing"
 	"time"
@@ -42,7 +42,7 @@ func (no *testNativeObjectBinding) TestMethod(call goja.FunctionCall) goja.Value
 func newWithTestJS(t *testing.T, testjs string) *JSRE {
 	dir := t.TempDir()
 	if testjs != "" {
-		if err := os.WriteFile(path.Join(dir, "test.js"), []byte(testjs), os.ModePerm); err != nil {
+		if err := os.WriteFile(filepath.Join(dir, "test.js"), []byte(testjs), os.ModePerm); err != nil {
 			t.Fatal("cannot create test.js:", err)
 		}
 	}

--- a/signer/core/signed_data_test.go
+++ b/signer/core/signed_data_test.go
@@ -23,7 +23,6 @@ import (
 	"fmt"
 	"math/big"
 	"os"
-	"path"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -386,7 +385,7 @@ func TestJsonFiles(t *testing.T) {
 			continue
 		}
 		expectedFailure := strings.HasPrefix(fInfo.Name(), "expfail")
-		data, err := os.ReadFile(path.Join("testdata", fInfo.Name()))
+		data, err := os.ReadFile(filepath.Join("testdata", fInfo.Name()))
 		if err != nil {
 			t.Errorf("Failed to read file %v: %v", fInfo.Name(), err)
 			continue
@@ -419,7 +418,7 @@ func TestFuzzerFiles(t *testing.T) {
 	}
 	verbose := false
 	for i, fInfo := range testfiles {
-		data, err := os.ReadFile(path.Join(corpusdir, fInfo.Name()))
+		data, err := os.ReadFile(filepath.Join(corpusdir, fInfo.Name()))
 		if err != nil {
 			t.Errorf("Failed to read file %v: %v", fInfo.Name(), err)
 			continue


### PR DESCRIPTION
Following #29479, replace `path.Join` with `filepath.Join`.