### PR TITLE
cmd, eth: introduce BlockPeriod type for flexible beacon chain simulation

### DIFF
--- a/cmd/geth/config.go
+++ b/cmd/geth/config.go
@@ -218,7 +218,11 @@ func makeFullNode(ctx *cli.Context) (*node.Node, ethapi.Backend) {
 
 	if ctx.IsSet(utils.DeveloperFlag.Name) {
 		// Start dev mode.
-		simBeacon, err := catalyst.NewSimulatedBeacon(ctx.Uint64(utils.DeveloperPeriodFlag.Name), eth)
+		p, err := catalyst.ParseBlockPeriod(ctx.String(utils.DeveloperFlag.Name))
+		if err != nil {
+			utils.Fatalf("failed to parse developer mode block interval: %v", err)
+		}
+		simBeacon, err := catalyst.NewSimulatedBeacon(p, eth)
 		if err != nil {
 			utils.Fatalf("failed to register dev mode catalyst service: %v", err)
 		}

--- a/eth/catalyst/simulated_beacon_test.go
+++ b/eth/catalyst/simulated_beacon_test.go
@@ -55,7 +55,7 @@ func startSimulatedBeaconEthService(t *testing.T, genesis *core.Genesis) (*node.
 		t.Fatal("can't create eth service:", err)
 	}
 
-	simBeacon, err := NewSimulatedBeacon(1, ethservice)
+	simBeacon, err := NewSimulatedBeacon(BlockPeriod(time.Second), ethservice)
 	if err != nil {
 		t.Fatal("can't create simulated beacon:", err)
 	}

--- a/ethclient/simulated/backend.go
+++ b/ethclient/simulated/backend.go
@@ -96,7 +96,7 @@ func NewBackend(alloc types.GenesisAlloc, options ...func(nodeConf *node.Config,
 	if err != nil {
 		panic(err) // this should never happen
 	}
-	sim, err := newWithNode(stack, &ethConf, 0)
+	sim, err := newWithNode(stack, &ethConf, catalyst.ManualPeriod)
 	if err != nil {
 		panic(err) // this should never happen
 	}
@@ -105,17 +105,19 @@ func NewBackend(alloc types.GenesisAlloc, options ...func(nodeConf *node.Config,
 
 // newWithNode sets up a simulated backend on an existing node. The provided node
 // must not be started and will be started by this method.
-func newWithNode(stack *node.Node, conf *eth.Config, blockPeriod uint64) (*Backend, error) {
+func newWithNode(stack *node.Node, conf *eth.Config, blockPeriod catalyst.BlockPeriod) (*Backend, error) {
 	backend, err := eth.New(stack, conf)
 	if err != nil {
 		return nil, err
 	}
 	// Register the filter system
 	filterSystem := filters.NewFilterSystem(backend.APIBackend, filters.Config{})
-	stack.RegisterAPIs([]rpc.API{{
-		Namespace: "eth",
-		Service:   filters.NewFilterAPI(filterSystem, false),
-	}})
+	stack.RegisterAPIs([]rpc.API{
+		{
+			Namespace: "eth",
+			Service:   filters.NewFilterAPI(filterSystem, false),
+		},
+	})
 	// Start the node
 	if err := stack.Start(); err != nil {
 		return nil, err


### PR DESCRIPTION
This PR adds the `BlockPeriod` type, improving how the block intervals is introduced in the simulated beacon chain. It shifts from using simple numbers to a more descriptive approach, making our code clearer and addressing the primitive obsession anti-pattern modestly.