### PR TITLE
accounts/keystore: add sleep back for TestUpdatedKeyfileContents

### DIFF
--- a/accounts/keystore/account_cache_test.go
+++ b/accounts/keystore/account_cache_test.go
@@ -352,8 +352,8 @@ func TestUpdatedKeyfileContents(t *testing.T) {
 		t.Error(err)
 		return
 	}
-	// needed so that modTime of `file` is different to its current value after forceCopyFile
-	os.Chtimes(file, time.Now().Add(-time.Second), time.Now().Add(-time.Second))
+	// needed so that modTime of `file` will be greater than its current value after forceCopyFile
+	time.Sleep(time.Second)
 
 	// Now replace file contents
 	if err := forceCopyFile(file, cachetestAccounts[1].URL.Path); err != nil {
@@ -368,8 +368,8 @@ func TestUpdatedKeyfileContents(t *testing.T) {
 		return
 	}
 
-	// needed so that modTime of `file` is different to its current value after forceCopyFile
-	os.Chtimes(file, time.Now().Add(-time.Second), time.Now().Add(-time.Second))
+	// needed so that modTime of `file` will be greater than its current value after forceCopyFile
+	time.Sleep(time.Second)
 
 	// Now replace file contents again
 	if err := forceCopyFile(file, cachetestAccounts[2].URL.Path); err != nil {
@@ -384,8 +384,8 @@ func TestUpdatedKeyfileContents(t *testing.T) {
 		return
 	}
 
-	// needed so that modTime of `file` is different to its current value after os.WriteFile
-	os.Chtimes(file, time.Now().Add(-time.Second), time.Now().Add(-time.Second))
+	// needed so that modTime of `file` will be greater than its current value after os.WriteFile
+	time.Sleep(time.Second)
 
 	// Now replace file contents with crap
 	if err := os.WriteFile(file, []byte("foo"), 0600); err != nil {


### PR DESCRIPTION
Hi. I understand that in https://github.com/ethereum/go-ethereum/pull/28461 these sleeps were replaced with `Chtimes` to reduce test execution time.
However, I noticed this test sometimes fails on linux with the race detector enabled, eg:
`go test -timeout 900s github.com/ethereum/go-ethereum/accounts/keystore -cover -count=10 -race -shuffle=on`

I believe updating the mod time to a past time does not work due to the way the fileCache tracks `lastMod`: https://github.com/ethereum/go-ethereum/blob/9dcf8aae4742cc4220065489a5bdcf045c398616/accounts/keystore/file_cache.go#L71-L77

The sleeps seem preferable to modifying the file cache for testing, or alternatively resetting the `lastMod` field in the test. Thanks for your consideration.