### PR TITLE
internal/ethapi: use block GasLimit if gas is nil in DoEstimateGas

### DIFF
--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -1182,6 +1182,12 @@ func DoEstimateGas(ctx context.Context, b Backend, args TransactionArgs, blockNr
 		State:      state,
 		ErrorRatio: estimateGasErrorRatio,
 	}
+
+	// If the user has not specified a gas limit, use the block gas limit
+	if args.Gas == nil {
+		args.Gas = new(hexutil.Uint64)
+		*args.Gas = hexutil.Uint64(header.GasLimit)
+	}
 	if err := args.CallDefaults(gasCap, header.BaseFee, b.ChainConfig().ChainID); err != nil {
 		return 0, err
 	}


### PR DESCRIPTION
Hi. Prior to the refactor made in https://github.com/ethereum/go-ethereum/pull/28600/files, when `args.Gas == nil`, the block's `GasLimit` was used as the upper limit for gas estimation: https://github.com/ethereum/go-ethereum/pull/28600/files#diff-c426ecd2f7d247753b9ea8c1cc003f21fa412661c1f967d203d4edf8163da344L1208-L1216

After the mentioned PR, when `args.Gas == nil`, in case the default set in `args.ToMessage` (usually globalGasCap) is greater than the block's GasLimit, this can result in an estimation higher than the block GasLimit as it would be overwritten here: https://github.com/ethereum/go-ethereum/pull/28600/files#diff-66f4d55a856f5b04d4c6e1ee99582788b0510add7bd64c7332b948c2aeadbfdfR57-R60

This PR restores the previous behavior by setting the header's `GasLimit` in args prior to calling `CallDefaults` or `ToMessage`. Thanks for your consideration.