### PR TITLE
Refactor for loop

### DIFF
--- a/core/txpool/txpool.go
+++ b/core/txpool/txpool.go
@@ -334,9 +334,9 @@ func (p *TxPool) Add(txs []*types.Transaction, local bool, sync bool) []error {
 	// Add the transactions split apart to the individual subpools and piece
 	// back the errors into the original sort order.
 	errsets := make([][]error, len(p.subpools))
-	for i := 0; i < len(p.subpools); i++ {
-		errsets[i] = p.subpools[i].Add(txsets[i], local, sync)
-	}
+        for i, subpool := range p.subpools {
+		    errsets[i] = subpool.Add(txsets[i], local, sync)
+        }
 	errs := make([]error, len(txs))
 	for i, split := range splits {
 		// If the transaction was rejected by all subpools, mark it unsupported

--- a/rpc/service.go
+++ b/rpc/service.go
@@ -227,7 +227,7 @@ func isSubscriptionType(t reflect.Type) bool {
 	return t == subscriptionType
 }
 
-// isPubSub tests whether the given method has as as first argument a context.Context and
+// isPubSub tests whether the given method's first argument is a context.Context and
 // returns the pair (Subscription, error).
 func isPubSub(methodType reflect.Type) bool {
 	// numIn(0) is the receiver type


### PR DESCRIPTION
To match other for loop style in that function
example:
```
for i, tx := range txs {
    // Mark this transaction belonging to no-subpool
    splits[i] = -1
    ...
}
```
```
for i, split := range splits {
    // If the transaction was rejected by all subpools, mark it unsupported
    if split == -1 {
        errs[i] = core.ErrTxTypeNotSupported
        continue
    }
    ...
}
```