### PR TITLE
core: use range loop for subpool iteration

### DIFF
--- a/core/txpool/txpool.go
+++ b/core/txpool/txpool.go
@@ -334,8 +334,8 @@ func (p *TxPool) Add(txs []*types.Transaction, local bool, sync bool) []error {
 	// Add the transactions split apart to the individual subpools and piece
 	// back the errors into the original sort order.
 	errsets := make([][]error, len(p.subpools))
-	for i := 0; i < len(p.subpools); i++ {
-		errsets[i] = p.subpools[i].Add(txsets[i], local, sync)
+	for i, subpool := range p.subpools {
+		errsets[i] = subpool.Add(txsets[i], local, sync)
 	}
 	errs := make([]error, len(txs))
 	for i, split := range splits {


### PR DESCRIPTION
Refactor subpool iteration to range loop for consistency within function.
example:
```
for i, tx := range txs {
    // Mark this transaction belonging to no-subpool
    splits[i] = -1
    ...
}
```
```
for i, split := range splits {
    // If the transaction was rejected by all subpools, mark it unsupported
    if split == -1 {
        errs[i] = core.ErrTxTypeNotSupported
        continue
    }
    ...
}
```
