### PR TITLE
rpc: close Clients in tests

### DIFF
--- a/rpc/client_test.go
+++ b/rpc/client_test.go
@@ -253,6 +253,7 @@ func TestClientBatchRequestLimit(t *testing.T) {
 	defer server.Stop()
 	server.SetBatchLimits(2, 100000)
 	client := DialInProc(server)
+	defer client.Close()
 
 	batch := []BatchElem{
 		{Method: "foo"},
@@ -342,6 +343,7 @@ func testClientCancel(transport string, t *testing.T) {
 	default:
 		panic("unknown transport: " + transport)
 	}
+	defer client.Close()
 
 	// The actual test starts here.
 	var (
@@ -592,6 +594,7 @@ func TestClientSubscriptionChannelClose(t *testing.T) {
 
 	srv.RegisterName("nftest", new(notificationTestService))
 	client, _ := Dial(wsURL)
+	defer client.Close()
 
 	for i := 0; i < 100; i++ {
 		ch := make(chan int, 100)
@@ -708,7 +711,6 @@ func TestClientHTTP(t *testing.T) {
 		errc       = make(chan error, len(results))
 		wantResult = echoResult{"a", 1, new(echoArgs)}
 	)
-	defer client.Close()
 	for i := range results {
 		i := i
 		go func() {

--- a/rpc/websocket_test.go
+++ b/rpc/websocket_test.go
@@ -187,6 +187,7 @@ func TestWebsocketPeerInfo(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	defer c.Close()
 
 	// Request peer information.
 	var connInfo PeerInfo
@@ -273,6 +274,7 @@ func TestClientWebsocketLargeMessage(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	defer c.Close()
 
 	var r string
 	if err := c.Call(&r, "test_largeResp"); err != nil {


### PR DESCRIPTION
Hi. This PR adds some `defer client.Close()` to rpc tests where it was missing and removes a duplicate call.
This helps reduce the number of goroutines left running after the tests execute.
Thanks for your review.