### PR TITLE
rpc: close handler connections on read error

### DIFF
--- a/rpc/client.go
+++ b/rpc/client.go
@@ -652,6 +652,7 @@ func (c *Client) dispatch(codec ServerCodec) {
 
 		case err := <-c.readErr:
 			conn.handler.log.Debug("RPC connection read error", "err", err)
+			conn.handler.cancelRoot()
 			conn.close(err, lastOp)
 			reading = false
 


### PR DESCRIPTION
Hi.
I noticed that when `TestClientCancelWebsocket` is running, sometimes the handler on line 625 created here:
https://github.com/ethereum/go-ethereum/blob/34aac1d7562bf141fe6da1d4f3cdea8819e7b23b/rpc/client.go#L621-L626

cannot be closed, i.e., the test execution sometimes reaches line 656 and sometimes does not
https://github.com/ethereum/go-ethereum/blob/34aac1d7562bf141fe6da1d4f3cdea8819e7b23b/rpc/client.go#L653-L657

This is because the change made https://github.com/ethereum/go-ethereum/commit/e4cb7b80d59a4154327ea96f4a040ef18ef90c5b (which waits for in-flight requests to complete before closing the handler) doesn't account for the case where the context may be `context.Background()` (such as in the test, which calls `test_block`).

I'm not sure this is the best fix for this, however it seems to resolve the issue I described. Thanks for looking.