### PR TITLE
cmd/utils/diskusage: fix unreachable bavail check

### DIFF
--- a/cmd/utils/diskusage.go
+++ b/cmd/utils/diskusage.go
@@ -33,12 +33,10 @@ func getFreeDiskSpace(path string) (uint64, error) {
 
 	// Available blocks * size per block = available space in bytes
 	var bavail = stat.Bavail
-	// nolint:staticcheck
-	if stat.Bavail < 0 {
+	if int64(stat.Bavail) < 0 {
 		// FreeBSD can have a negative number of blocks available
 		// because of the grace limit.
 		bavail = 0
 	}
-	//nolint:unconvert
-	return uint64(bavail) * uint64(stat.Bsize), nil
+	return bavail * uint64(stat.Bsize), nil
 }

--- a/cmd/utils/diskusage_openbsd.go
+++ b/cmd/utils/diskusage_openbsd.go
@@ -39,6 +39,5 @@ func getFreeDiskSpace(path string) (uint64, error) {
 		// because of the grace limit.
 		bavail = 0
 	}
-	//nolint:unconvert
 	return uint64(bavail) * uint64(stat.F_bsize), nil
 }


### PR DESCRIPTION
`stat.Bavail`'s type is `uint64`, see: [https://pkg.go.dev/golang.org/x/sys/unix#Statfs_t](https://pkg.go.dev/golang.org/x/sys/unix#Statfs_t),  so the `if stat.Bavail < 0 {` conditional check will never hold. 

For non-FreeBSD systems, `Bavail` is almost impossible to be larger than `1 << 63 - 1`, so I think the correct and the most convenient approach is to convert uint64 to int64 for comparison. 

> This code was introduced from this PR: https://github.com/ethereum/go-ethereum/pull/22310