### PR TITLE
rpc: implement Unwrap() for wsHandshakeError

### DIFF
--- a/rpc/client.go
+++ b/rpc/client.go
@@ -431,7 +431,7 @@ func (c *Client) BatchCallContext(ctx context.Context, b []BatchElem) error {
 	}
 
 	// Wait for all responses to come back.
-	for n := 0; n < len(batchresp) && err == nil; n++ {
+	for n := 0; n < len(batchresp); n++ {
 		resp := batchresp[n]
 		if resp == nil {
 			// Ignore null responses. These can happen for batches sent via HTTP.

--- a/rpc/websocket.go
+++ b/rpc/websocket.go
@@ -122,6 +122,10 @@ func (e wsHandshakeError) Error() string {
 	return s
 }
 
+func (e wsHandshakeError) Unwrap() error {
+	return e.err
+}
+
 func originIsAllowed(allowedOrigins mapset.Set[string], browserOrigin string) bool {
 	it := allowedOrigins.Iterator()
 	for origin := range it.C {


### PR DESCRIPTION
- PR to implement `Unwrap()` for wsHandshakeError
- Removes a tautological condition