### PR TITLE
log: Unused variable 

### DIFF
--- a/log/format.go
+++ b/log/format.go
@@ -79,7 +79,7 @@ func (h *TerminalHandler) format(buf []byte, r slog.Record, usecolor bool) []byt
 }
 
 func (h *TerminalHandler) formatAttributes(buf *bytes.Buffer, r slog.Record, color string) {
-	writeAttr := func(attr slog.Attr, first, last bool) {
+	writeAttr := func(attr slog.Attr, _, last bool) {
 		buf.WriteByte(' ')
 
 		if color != "" {


### PR DESCRIPTION
writeAttr := func(attr slog.Attr, first, last bool)  ->  writeAttr := func(attr slog.Attr, _, last bool)

Clear Communication: It clearly indicates that the variable is intentionally ignored.

Avoiding Warnings: Prevents compiler warnings for unused variables.

Simplicity: Eliminates unnecessary variable assignments, making the code cleaner and more concise.

Maintainability: Reduces cognitive load for other developers and improves code maintainability.