### PR TITLE
Use DiscoveryV5 as a source of peers

### DIFF
--- a/p2p/server.go
+++ b/p2p/server.go
@@ -579,6 +579,7 @@ func (srv *Server) setupDiscovery() error {
 		if err != nil {
 			return err
 		}
+		srv.discmix.AddSource(srv.DiscV5.RandomNodes())
 	}
 
 	// Add protocol-specific discovery sources.


### PR DESCRIPTION
In the current version, when DiscoveryV5 is enabled, it runs and discovers peers, however they are not pushed into the `dialScheduler`, so they are actually not used.