### PR TITLE
Rename vmtrace.config to vmtrace.jsonconfig

### DIFF
--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -545,7 +545,7 @@ var (
 		Category: flags.VMCategory,
 	}
 	VMTraceConfigFlag = &cli.StringFlag{
-		Name:     "vmtrace.config",
+		Name:     "vmtrace.jsonconfig",
 		Usage:    "Tracer configuration (JSON)",
 		Category: flags.VMCategory,
 	}


### PR DESCRIPTION
In order to be consistent with t8ntool [trace.jsonconfig](https://github.com/ethereum/go-ethereum/blob/master/cmd/evm/internal/t8ntool/flags.go#L38) we rename the to `vmtrace.jsonconfig`.