### PR TITLE
update disk root more frequently

### DIFF
--- a/core/blockchain_repair_test.go
+++ b/core/blockchain_repair_test.go
@@ -1820,7 +1820,7 @@ func testRepairWithScheme(t *testing.T, tt *rewindTest, snapshots bool, scheme s
 			t.Fatalf("Failed to flush trie state: %v", err)
 		}
 		if snapshots {
-			if err := chain.snaps.Cap(canonblocks[tt.commitBlock-1].Root(), 0); err != nil {
+			if err := chain.snaps.Cap(canonblocks[tt.commitBlock-1].Root(), 0, false); err != nil {
 				t.Fatalf("Failed to flatten snapshots: %v", err)
 			}
 		}
@@ -1950,7 +1950,7 @@ func testIssue23496(t *testing.T, scheme string) {
 	if _, err := chain.InsertChain(blocks[1:2]); err != nil {
 		t.Fatalf("Failed to import canonical chain start: %v", err)
 	}
-	if err := chain.snaps.Cap(blocks[1].Root(), 0); err != nil {
+	if err := chain.snaps.Cap(blocks[1].Root(), 0, false); err != nil {
 		t.Fatalf("Failed to flatten snapshots: %v", err)
 	}
 

--- a/core/blockchain_sethead_test.go
+++ b/core/blockchain_sethead_test.go
@@ -2023,7 +2023,7 @@ func testSetHeadWithScheme(t *testing.T, tt *rewindTest, snapshots bool, scheme 
 	if tt.commitBlock > 0 {
 		chain.triedb.Commit(canonblocks[tt.commitBlock-1].Root(), false)
 		if snapshots {
-			if err := chain.snaps.Cap(canonblocks[tt.commitBlock-1].Root(), 0); err != nil {
+			if err := chain.snaps.Cap(canonblocks[tt.commitBlock-1].Root(), 0, false); err != nil {
 				t.Fatalf("Failed to flatten snapshots: %v", err)
 			}
 		}

--- a/core/blockchain_snapshot_test.go
+++ b/core/blockchain_snapshot_test.go
@@ -108,7 +108,7 @@ func (basic *snapshotTestBasic) prepare(t *testing.T) (*BlockChain, []*types.Blo
 			// Flushing the entire snap tree into the disk, the
 			// relevant (a) snapshot root and (b) snapshot generator
 			// will be persisted atomically.
-			chain.snaps.Cap(blocks[point-1].Root(), 0)
+			chain.snaps.Cap(blocks[point-1].Root(), 0, false)
 			diskRoot, blockRoot := chain.snaps.DiskRoot(), blocks[point-1].Root()
 			if !bytes.Equal(diskRoot.Bytes(), blockRoot.Bytes()) {
 				t.Fatalf("Failed to flush disk layer change, want %x, got %x", blockRoot, diskRoot)

--- a/core/state/pruner/pruner.go
+++ b/core/state/pruner/pruner.go
@@ -192,7 +192,7 @@ func prune(snaptree *snapshot.Tree, root common.Hash, maindb ethdb.Database, sta
 	// Pruning is done, now drop the "useless" layers from the snapshot.
 	// Firstly, flushing the target layer into the disk. After that all
 	// diff layers below the target will all be merged into the disk.
-	if err := snaptree.Cap(root, 0); err != nil {
+	if err := snaptree.Cap(root, 0, false); err != nil {
 		return err
 	}
 	// Secondly, flushing the snapshot journal into the disk. All diff

--- a/core/state/snapshot/difflayer.go
+++ b/core/state/snapshot/difflayer.go
@@ -76,6 +76,9 @@ var (
 	bloomDestructHasherOffset = 0
 	bloomAccountHasherOffset  = 0
 	bloomStorageHasherOffset  = 0
+
+	// Setting a minimum to prevent very low input from user
+	minTimeThreshold = 1 * time.Minute
 )
 
 func init() {

--- a/core/state/snapshot/difflayer.go
+++ b/core/state/snapshot/difflayer.go
@@ -77,8 +77,10 @@ var (
 	bloomAccountHasherOffset  = 0
 	bloomStorageHasherOffset  = 0
 
-	// Setting a minimum to prevent very low input from user
-	minTimeThreshold = 1 * time.Minute
+	// Count for number of commits before force disk update
+	// after the first 128 layers, the 129 layers would be committed
+	// to disk.
+	defaultCommitThreshold = 128
 )
 
 func init() {

--- a/core/state/snapshot/disklayer_test.go
+++ b/core/state/snapshot/disklayer_test.go
@@ -133,7 +133,7 @@ func TestDiskMerge(t *testing.T) {
 	}); err != nil {
 		t.Fatalf("failed to update snapshot tree: %v", err)
 	}
-	if err := snaps.Cap(diffRoot, 0); err != nil {
+	if err := snaps.Cap(diffRoot, 0, false); err != nil {
 		t.Fatalf("failed to flatten snapshot tree: %v", err)
 	}
 	// Retrieve all the data through the disk layer and validate it
@@ -356,7 +356,7 @@ func TestDiskPartialMerge(t *testing.T) {
 		}); err != nil {
 			t.Fatalf("test %d: failed to update snapshot tree: %v", i, err)
 		}
-		if err := snaps.Cap(diffRoot, 0); err != nil {
+		if err := snaps.Cap(diffRoot, 0, false); err != nil {
 			t.Fatalf("test %d: failed to flatten snapshot tree: %v", i, err)
 		}
 		// Retrieve all the data through the disk layer and validate it
@@ -467,7 +467,7 @@ func TestDiskGeneratorPersistence(t *testing.T) {
 	}, nil); err != nil {
 		t.Fatalf("failed to update snapshot tree: %v", err)
 	}
-	if err := snaps.Cap(diffRoot, 0); err != nil {
+	if err := snaps.Cap(diffRoot, 0, false); err != nil {
 		t.Fatalf("failed to flatten snapshot tree: %v", err)
 	}
 	blob := rawdb.ReadSnapshotGenerator(db)
@@ -489,7 +489,7 @@ func TestDiskGeneratorPersistence(t *testing.T) {
 	}
 	diskLayer := snaps.layers[snaps.diskRoot()].(*diskLayer)
 	diskLayer.genMarker = nil // Construction finished
-	if err := snaps.Cap(diffTwoRoot, 0); err != nil {
+	if err := snaps.Cap(diffTwoRoot, 0, false); err != nil {
 		t.Fatalf("failed to flatten snapshot tree: %v", err)
 	}
 	blob = rawdb.ReadSnapshotGenerator(db)

--- a/core/state/snapshot/iterator_test.go
+++ b/core/state/snapshot/iterator_test.go
@@ -248,7 +248,7 @@ func TestAccountIteratorTraversal(t *testing.T) {
 		aggregatorMemoryLimit = limit
 	}()
 	aggregatorMemoryLimit = 0 // Force pushing the bottom-most layer into disk
-	snaps.Cap(common.HexToHash("0x04"), 2)
+	snaps.Cap(common.HexToHash("0x04"), 2, false)
 	verifyIterator(t, 7, head.(*diffLayer).newBinaryAccountIterator(), verifyAccount)
 
 	it, _ = snaps.AccountIterator(common.HexToHash("0x04"), common.Hash{})
@@ -296,7 +296,7 @@ func TestStorageIteratorTraversal(t *testing.T) {
 		aggregatorMemoryLimit = limit
 	}()
 	aggregatorMemoryLimit = 0 // Force pushing the bottom-most layer into disk
-	snaps.Cap(common.HexToHash("0x04"), 2)
+	snaps.Cap(common.HexToHash("0x04"), 2, false)
 	verifyIterator(t, 6, head.(*diffLayer).newBinaryStorageIterator(common.HexToHash("0xaa")), verifyStorage)
 
 	it, _ = snaps.StorageIterator(common.HexToHash("0x04"), common.HexToHash("0xaa"), common.Hash{})
@@ -384,7 +384,7 @@ func TestAccountIteratorTraversalValues(t *testing.T) {
 		aggregatorMemoryLimit = limit
 	}()
 	aggregatorMemoryLimit = 0 // Force pushing the bottom-most layer into disk
-	snaps.Cap(common.HexToHash("0x09"), 2)
+	snaps.Cap(common.HexToHash("0x09"), 2, false)
 
 	it, _ = snaps.AccountIterator(common.HexToHash("0x09"), common.Hash{})
 	for it.Next() {
@@ -483,7 +483,7 @@ func TestStorageIteratorTraversalValues(t *testing.T) {
 		aggregatorMemoryLimit = limit
 	}()
 	aggregatorMemoryLimit = 0 // Force pushing the bottom-most layer into disk
-	snaps.Cap(common.HexToHash("0x09"), 2)
+	snaps.Cap(common.HexToHash("0x09"), 2, false)
 
 	it, _ = snaps.StorageIterator(common.HexToHash("0x09"), common.HexToHash("0xaa"), common.Hash{})
 	for it.Next() {
@@ -541,7 +541,7 @@ func TestAccountIteratorLargeTraversal(t *testing.T) {
 		aggregatorMemoryLimit = limit
 	}()
 	aggregatorMemoryLimit = 0 // Force pushing the bottom-most layer into disk
-	snaps.Cap(common.HexToHash("0x80"), 2)
+	snaps.Cap(common.HexToHash("0x80"), 2, false)
 
 	verifyIterator(t, 200, head.(*diffLayer).newBinaryAccountIterator(), verifyAccount)
 
@@ -580,7 +580,7 @@ func TestAccountIteratorFlattening(t *testing.T) {
 	it, _ := snaps.AccountIterator(common.HexToHash("0x04"), common.Hash{})
 	defer it.Release()
 
-	if err := snaps.Cap(common.HexToHash("0x04"), 1); err != nil {
+	if err := snaps.Cap(common.HexToHash("0x04"), 1, false); err != nil {
 		t.Fatalf("failed to flatten snapshot stack: %v", err)
 	}
 	//verifyIterator(t, 7, it)

--- a/core/state/snapshot/snapshot.go
+++ b/core/state/snapshot/snapshot.go
@@ -164,6 +164,7 @@ func (c *Config) sanitize() Config {
 	conf := *c
 
 	if conf.CommitThreshold == 0 {
+		log.Warn("Sanitizing commit threshold", "provided", conf.CommitThreshold, "updated", defaultCommitThreshold)
 		conf.CommitThreshold = defaultCommitThreshold
 	}
 	return conf
@@ -209,13 +210,11 @@ type Tree struct {
 func New(config Config, diskdb ethdb.KeyValueStore, triedb *triedb.Database, root common.Hash) (*Tree, error) {
 	// Create a new, empty snapshot tree
 	snap := &Tree{
-		config: config,
+		config: config.sanitize(),
 		diskdb: diskdb,
 		triedb: triedb,
 		layers: make(map[common.Hash]snapshot),
 	}
-
-	config = config.sanitize()
 
 	// Attempt to load a previously persisted snapshot and rebuild one if failed
 	head, disabled, err := loadSnapshot(diskdb, triedb, root, config.CacheSize, config.Recovery, config.NoBuild)

--- a/core/state/statedb.go
+++ b/core/state/statedb.go
@@ -1276,7 +1276,7 @@ func (s *StateDB) Commit(block uint64, deleteEmptyObjects bool) (common.Hash, er
 			// - head layer is paired with HEAD state
 			// - head-1 layer is paired with HEAD-1 state
 			// - head-127 layer(bottom-most diff layer) is paired with HEAD-127 state
-			if err := s.snaps.Cap(root, TriesInMemory); err != nil {
+			if err := s.snaps.Cap(root, TriesInMemory, s.snaps.CompareThreshold()); err != nil {
 				log.Warn("Failed to cap snapshot tree", "root", root, "layers", TriesInMemory, "err", err)
 			}
 		}

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -190,15 +190,17 @@ func New(stack *node.Node, config *ethconfig.Config) (*Ethereum, error) {
 			EnablePreimageRecording: config.EnablePreimageRecording,
 		}
 		cacheConfig = &core.CacheConfig{
-			TrieCleanLimit:      config.TrieCleanCache,
-			TrieCleanNoPrefetch: config.NoPrefetch,
-			TrieDirtyLimit:      config.TrieDirtyCache,
-			TrieDirtyDisabled:   config.NoPruning,
-			TrieTimeLimit:       config.TrieTimeout,
-			SnapshotLimit:       config.SnapshotCache,
-			Preimages:           config.Preimages,
-			StateHistory:        config.StateHistory,
-			StateScheme:         scheme,
+			TrieCleanLimit:         config.TrieCleanCache,
+			TrieCleanNoPrefetch:    config.NoPrefetch,
+			TrieDirtyLimit:         config.TrieDirtyCache,
+			TrieDirtyDisabled:      config.NoPruning,
+			TrieTimeLimit:          config.TrieTimeout,
+			SnapshotLimit:          config.SnapshotCache,
+			Preimages:              config.Preimages,
+			StateHistory:           config.StateHistory,
+			StateScheme:            scheme,
+			EnableDiskRootInterval: config.EnableDiskRootInterval,
+			DiskRootThreshold:      config.DiskRootThreshold,
 		}
 	)
 	if config.VMTrace != "" {

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -190,17 +190,17 @@ func New(stack *node.Node, config *ethconfig.Config) (*Ethereum, error) {
 			EnablePreimageRecording: config.EnablePreimageRecording,
 		}
 		cacheConfig = &core.CacheConfig{
-			TrieCleanLimit:         config.TrieCleanCache,
-			TrieCleanNoPrefetch:    config.NoPrefetch,
-			TrieDirtyLimit:         config.TrieDirtyCache,
-			TrieDirtyDisabled:      config.NoPruning,
-			TrieTimeLimit:          config.TrieTimeout,
-			SnapshotLimit:          config.SnapshotCache,
-			Preimages:              config.Preimages,
-			StateHistory:           config.StateHistory,
-			StateScheme:            scheme,
-			EnableDiskRootInterval: config.EnableDiskRootInterval,
-			DiskRootThreshold:      config.DiskRootThreshold,
+			TrieCleanLimit:      config.TrieCleanCache,
+			TrieCleanNoPrefetch: config.NoPrefetch,
+			TrieDirtyLimit:      config.TrieDirtyCache,
+			TrieDirtyDisabled:   config.NoPruning,
+			TrieTimeLimit:       config.TrieTimeout,
+			SnapshotLimit:       config.SnapshotCache,
+			Preimages:           config.Preimages,
+			StateHistory:        config.StateHistory,
+			StateScheme:         scheme,
+			AllowForceUpdate:    config.AllowForceUpdate,
+			CommitThreshold:     config.CommitThreshold,
 		}
 	)
 	if config.VMTrace != "" {

--- a/eth/ethconfig/config.go
+++ b/eth/ethconfig/config.go
@@ -48,25 +48,27 @@ var FullNodeGPO = gasprice.Config{
 
 // Defaults contains default settings for use on the Ethereum main net.
 var Defaults = Config{
-	SyncMode:           downloader.SnapSync,
-	NetworkId:          0, // enable auto configuration of networkID == chainID
-	TxLookupLimit:      2350000,
-	TransactionHistory: 2350000,
-	StateHistory:       params.FullImmutabilityThreshold,
-	LightPeers:         100,
-	DatabaseCache:      512,
-	TrieCleanCache:     154,
-	TrieDirtyCache:     256,
-	TrieTimeout:        60 * time.Minute,
-	SnapshotCache:      102,
-	FilterLogCacheSize: 32,
-	Miner:              miner.DefaultConfig,
-	TxPool:             legacypool.DefaultConfig,
-	BlobPool:           blobpool.DefaultConfig,
-	RPCGasCap:          50000000,
-	RPCEVMTimeout:      5 * time.Second,
-	GPO:                FullNodeGPO,
-	RPCTxFeeCap:        1, // 1 ether
+	SyncMode:               downloader.SnapSync,
+	NetworkId:              0, // enable auto configuration of networkID == chainID
+	TxLookupLimit:          2350000,
+	TransactionHistory:     2350000,
+	StateHistory:           params.FullImmutabilityThreshold,
+	LightPeers:             100,
+	DatabaseCache:          512,
+	TrieCleanCache:         154,
+	TrieDirtyCache:         256,
+	TrieTimeout:            60 * time.Minute,
+	SnapshotCache:          102,
+	EnableDiskRootInterval: false,
+	DiskRootThreshold:      60 * time.Minute,
+	FilterLogCacheSize:     32,
+	Miner:                  miner.DefaultConfig,
+	TxPool:                 legacypool.DefaultConfig,
+	BlobPool:               blobpool.DefaultConfig,
+	RPCGasCap:              50000000,
+	RPCEVMTimeout:          5 * time.Second,
+	GPO:                    FullNodeGPO,
+	RPCTxFeeCap:            1, // 1 ether
 }
 
 //go:generate go run github.com/fjl/gencodec -type Config -formats toml -out gen_config.go
@@ -119,11 +121,13 @@ type Config struct {
 	DatabaseCache      int
 	DatabaseFreezer    string
 
-	TrieCleanCache int
-	TrieDirtyCache int
-	TrieTimeout    time.Duration
-	SnapshotCache  int
-	Preimages      bool
+	TrieCleanCache         int
+	TrieDirtyCache         int
+	TrieTimeout            time.Duration
+	SnapshotCache          int
+	Preimages              bool
+	EnableDiskRootInterval bool
+	DiskRootThreshold      time.Duration
 
 	// This is the number of blocks for which logs will be cached in the filter system.
 	FilterLogCacheSize int

--- a/eth/ethconfig/config.go
+++ b/eth/ethconfig/config.go
@@ -48,27 +48,27 @@ var FullNodeGPO = gasprice.Config{
 
 // Defaults contains default settings for use on the Ethereum main net.
 var Defaults = Config{
-	SyncMode:               downloader.SnapSync,
-	NetworkId:              0, // enable auto configuration of networkID == chainID
-	TxLookupLimit:          2350000,
-	TransactionHistory:     2350000,
-	StateHistory:           params.FullImmutabilityThreshold,
-	LightPeers:             100,
-	DatabaseCache:          512,
-	TrieCleanCache:         154,
-	TrieDirtyCache:         256,
-	TrieTimeout:            60 * time.Minute,
-	SnapshotCache:          102,
-	EnableDiskRootInterval: false,
-	DiskRootThreshold:      60 * time.Minute,
-	FilterLogCacheSize:     32,
-	Miner:                  miner.DefaultConfig,
-	TxPool:                 legacypool.DefaultConfig,
-	BlobPool:               blobpool.DefaultConfig,
-	RPCGasCap:              50000000,
-	RPCEVMTimeout:          5 * time.Second,
-	GPO:                    FullNodeGPO,
-	RPCTxFeeCap:            1, // 1 ether
+	SyncMode:           downloader.SnapSync,
+	NetworkId:          0, // enable auto configuration of networkID == chainID
+	TxLookupLimit:      2350000,
+	TransactionHistory: 2350000,
+	StateHistory:       params.FullImmutabilityThreshold,
+	LightPeers:         100,
+	DatabaseCache:      512,
+	TrieCleanCache:     154,
+	TrieDirtyCache:     256,
+	TrieTimeout:        60 * time.Minute,
+	SnapshotCache:      102,
+	AllowForceUpdate:   false,
+	CommitThreshold:    128,
+	FilterLogCacheSize: 32,
+	Miner:              miner.DefaultConfig,
+	TxPool:             legacypool.DefaultConfig,
+	BlobPool:           blobpool.DefaultConfig,
+	RPCGasCap:          50000000,
+	RPCEVMTimeout:      5 * time.Second,
+	GPO:                FullNodeGPO,
+	RPCTxFeeCap:        1, // 1 ether
 }
 
 //go:generate go run github.com/fjl/gencodec -type Config -formats toml -out gen_config.go
@@ -121,13 +121,13 @@ type Config struct {
 	DatabaseCache      int
 	DatabaseFreezer    string
 
-	TrieCleanCache         int
-	TrieDirtyCache         int
-	TrieTimeout            time.Duration
-	SnapshotCache          int
-	Preimages              bool
-	EnableDiskRootInterval bool
-	DiskRootThreshold      time.Duration
+	TrieCleanCache   int
+	TrieDirtyCache   int
+	TrieTimeout      time.Duration
+	SnapshotCache    int
+	Preimages        bool
+	AllowForceUpdate bool
+	CommitThreshold  int
 
 	// This is the number of blocks for which logs will be cached in the filter system.
 	FilterLogCacheSize int

--- a/eth/ethconfig/gen_config.go
+++ b/eth/ethconfig/gen_config.go
@@ -44,8 +44,8 @@ func (c Config) MarshalTOML() (interface{}, error) {
 		TrieTimeout             time.Duration
 		SnapshotCache           int
 		Preimages               bool
-		EnableDiskRootInterval  bool
-		DiskRootThreshold       time.Duration
+		AllowForceUpdate        bool
+		CommitThreshold         int
 		FilterLogCacheSize      int
 		Miner                   miner.Config
 		TxPool                  legacypool.Config
@@ -89,8 +89,8 @@ func (c Config) MarshalTOML() (interface{}, error) {
 	enc.TrieTimeout = c.TrieTimeout
 	enc.SnapshotCache = c.SnapshotCache
 	enc.Preimages = c.Preimages
-	enc.EnableDiskRootInterval = c.EnableDiskRootInterval
-	enc.DiskRootThreshold = c.DiskRootThreshold
+	enc.AllowForceUpdate = c.AllowForceUpdate
+	enc.CommitThreshold = c.CommitThreshold
 	enc.FilterLogCacheSize = c.FilterLogCacheSize
 	enc.Miner = c.Miner
 	enc.TxPool = c.TxPool
@@ -138,8 +138,8 @@ func (c *Config) UnmarshalTOML(unmarshal func(interface{}) error) error {
 		TrieTimeout             *time.Duration
 		SnapshotCache           *int
 		Preimages               *bool
-		EnableDiskRootInterval  *bool
-		DiskRootThreshold       *time.Duration
+		AllowForceUpdate        *bool
+		CommitThreshold         *int
 		FilterLogCacheSize      *int
 		Miner                   *miner.Config
 		TxPool                  *legacypool.Config
@@ -240,11 +240,11 @@ func (c *Config) UnmarshalTOML(unmarshal func(interface{}) error) error {
 	if dec.Preimages != nil {
 		c.Preimages = *dec.Preimages
 	}
-	if dec.EnableDiskRootInterval != nil {
-		c.EnableDiskRootInterval = *dec.EnableDiskRootInterval
+	if dec.AllowForceUpdate != nil {
+		c.AllowForceUpdate = *dec.AllowForceUpdate
 	}
-	if dec.DiskRootThreshold != nil {
-		c.DiskRootThreshold = *dec.DiskRootThreshold
+	if dec.CommitThreshold != nil {
+		c.CommitThreshold = *dec.CommitThreshold
 	}
 	if dec.FilterLogCacheSize != nil {
 		c.FilterLogCacheSize = *dec.FilterLogCacheSize

--- a/eth/ethconfig/gen_config.go
+++ b/eth/ethconfig/gen_config.go
@@ -44,6 +44,8 @@ func (c Config) MarshalTOML() (interface{}, error) {
 		TrieTimeout             time.Duration
 		SnapshotCache           int
 		Preimages               bool
+		EnableDiskRootInterval  bool
+		DiskRootThreshold       time.Duration
 		FilterLogCacheSize      int
 		Miner                   miner.Config
 		TxPool                  legacypool.Config
@@ -87,6 +89,8 @@ func (c Config) MarshalTOML() (interface{}, error) {
 	enc.TrieTimeout = c.TrieTimeout
 	enc.SnapshotCache = c.SnapshotCache
 	enc.Preimages = c.Preimages
+	enc.EnableDiskRootInterval = c.EnableDiskRootInterval
+	enc.DiskRootThreshold = c.DiskRootThreshold
 	enc.FilterLogCacheSize = c.FilterLogCacheSize
 	enc.Miner = c.Miner
 	enc.TxPool = c.TxPool
@@ -134,6 +138,8 @@ func (c *Config) UnmarshalTOML(unmarshal func(interface{}) error) error {
 		TrieTimeout             *time.Duration
 		SnapshotCache           *int
 		Preimages               *bool
+		EnableDiskRootInterval  *bool
+		DiskRootThreshold       *time.Duration
 		FilterLogCacheSize      *int
 		Miner                   *miner.Config
 		TxPool                  *legacypool.Config
@@ -233,6 +239,12 @@ func (c *Config) UnmarshalTOML(unmarshal func(interface{}) error) error {
 	}
 	if dec.Preimages != nil {
 		c.Preimages = *dec.Preimages
+	}
+	if dec.EnableDiskRootInterval != nil {
+		c.EnableDiskRootInterval = *dec.EnableDiskRootInterval
+	}
+	if dec.DiskRootThreshold != nil {
+		c.DiskRootThreshold = *dec.DiskRootThreshold
 	}
 	if dec.FilterLogCacheSize != nil {
 		c.FilterLogCacheSize = *dec.FilterLogCacheSize

--- a/triedb/pathdb/layertree.go
+++ b/triedb/pathdb/layertree.go
@@ -111,7 +111,7 @@ func (tree *layerTree) add(root common.Hash, parentRoot common.Hash, block uint6
 
 // cap traverses downwards the diff tree until the number of allowed diff layers
 // are crossed. All diffs beyond the permitted number are flattened downwards.
-func (tree *layerTree) cap(root common.Hash, layers int) error {
+func (tree *layerTree) cap(root common.Hash, layers int, force bool) error {
 	// Retrieve the head layer to cap from
 	root = types.TrieRootHash(root)
 	l := tree.get(root)
@@ -156,7 +156,7 @@ func (tree *layerTree) cap(root common.Hash, layers int) error {
 		// parent is linked correctly.
 		diff.lock.Lock()
 
-		base, err := parent.persist(false)
+		base, err := parent.persist(force)
 		if err != nil {
 			diff.lock.Unlock()
 			return err


### PR DESCRIPTION
This PR adds the ability to update the diskRoot after a time threshold along with the memory threshold.

## Current Scenario
For permissioned/private networks, where there can be a lot of empty blocks, it can take a lot of time/transactions to meet the ~4MB memory limit before the disk root is updated. Thus when a chain experiences an unclean shutdown, the rewind logic which takes the state back to the disk Root causes a massive rewind which can take a long time to build back up.

## Proposed Scenario
This PR adds a commit threshold that triggers a disk root update once the threshold has been crossed. It still maintains the concept of 128 layers above the disk root but provides the ability to merge the flatten layer with the disk layer more frequently for chain with less transaction activity. This ensure that the disk root is updated at a threshold thus preventing massive rollbacks. This is disabled by default and can be enabled by the following in the config file
`AllowForceUpdate` - toggle to enable/disable it
`CommitThreshold` - Desired commit threshold for diskRoot update