### PR TITLE
cmd/utils, core: Ensure Dev Mode Genesis TTD/Difficulty are 0

### DIFF
--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -1877,8 +1877,11 @@ func SetEthConfig(ctx *cli.Context, stack *node.Node, cfg *ethconfig.Config) {
 				if genesis.Config.TerminalTotalDifficulty == nil {
 					Fatalf("Bad developer-mode genesis configuration: terminalTotalDifficulty must be specified.")
 				}
-				if genesis.Difficulty.Cmp(genesis.Config.TerminalTotalDifficulty) != 1 {
-					Fatalf("Bad developer-mode genesis configuration: genesis block difficulty must be > terminalTotalDifficulty")
+				if genesis.Difficulty.Cmp(big.NewInt(0)) != 0 {
+					Fatalf("Bad developer-mode genesis configuration:  genesis block difficulty must be 0")
+				}
+				if genesis.Config.TerminalTotalDifficulty.Cmp(big.NewInt(0)) != 0 {
+					Fatalf("Bad developer-mode genesis configuration: genesis block terminalTotalDifficulty must be 0")
 				}
 			}
 			chaindb.Close()


### PR DESCRIPTION
After https://github.com/ethereum/go-ethereum/issues/29404 , dev mode will fail to start up when a custom genesis is used because of this check:

```
if genesis.Difficulty.Cmp(genesis.Config.TerminalTotalDifficulty) != 1 {
					Fatalf("Bad developer-mode genesis configuration: genesis block difficulty must be > terminalTotalDifficulty")
				}
```

We now default the dev genesis TTD to 0, which also technically makes it the last block before the merge.  However, post-merge timestamp-activated forks are activated at genesis.  Withdrawals also still seem to work.  It's a weird situation all-around and I'm not sure what the ramifications are.