### PR TITLE
eth/catalyst: (try to) fix flaky tests

### DIFF
--- a/eth/catalyst/api_test.go
+++ b/eth/catalyst/api_test.go
@@ -112,7 +112,7 @@ func TestEth2AssembleBlock(t *testing.T) {
 	if err != nil {
 		t.Fatalf("error signing transaction, err=%v", err)
 	}
-	ethservice.TxPool().Add([]*types.Transaction{tx}, true, false)
+	ethservice.TxPool().Add([]*types.Transaction{tx}, true, true)
 	blockParams := engine.PayloadAttributes{
 		Timestamp: blocks[9].Time() + 5,
 	}
@@ -310,13 +310,13 @@ func TestEth2NewBlock(t *testing.T) {
 		statedb, _ := ethservice.BlockChain().StateAt(parent.Root())
 		nonce := statedb.GetNonce(testAddr)
 		tx, _ := types.SignTx(types.NewContractCreation(nonce, new(big.Int), 1000000, big.NewInt(2*params.InitialBaseFee), logCode), types.LatestSigner(ethservice.BlockChain().Config()), testKey)
-		ethservice.TxPool().Add([]*types.Transaction{tx}, true, false)
+		ethservice.TxPool().Add([]*types.Transaction{tx}, true, true)
 
 		execData, err := assembleWithTransactions(api, parent.Hash(), &engine.PayloadAttributes{
 			Timestamp: parent.Time() + 5,
 		}, 1)
 		if err != nil {
-			t.Fatalf("Failed to create the executable data %v", err)
+			t.Fatalf("Failed to create the executable data, block %d: %v", i, err)
 		}
 		block, err := engine.ExecutableDataToBlock(*execData, nil, nil)
 		if err != nil {

--- a/eth/catalyst/api_test.go
+++ b/eth/catalyst/api_test.go
@@ -189,7 +189,7 @@ func TestEth2PrepareAndGetPayload(t *testing.T) {
 
 	// Put the 10th block's tx in the pool and produce a new block
 	txs := blocks[9].Transactions()
-	ethservice.TxPool().Add(txs, true, false)
+	ethservice.TxPool().Add(txs, true, true)
 	blockParams := engine.PayloadAttributes{
 		Timestamp: blocks[8].Time() + 5,
 	}

--- a/triedb/pathdb/database.go
+++ b/triedb/pathdb/database.go
@@ -293,6 +293,7 @@ func (db *Database) Enable(root common.Hash) error {
 	// Ensure the provided state root matches the stored one.
 	root = types.TrieRootHash(root)
 	_, stored := rawdb.ReadAccountTrieNode(db.diskdb, nil)
+	stored = types.TrieRootHash(stored)
 	if stored != root {
 		return fmt.Errorf("state root mismatch: stored %x, synced %x", stored, root)
 	}

--- a/triedb/pathdb/database_test.go
+++ b/triedb/pathdb/database_test.go
@@ -476,13 +476,13 @@ func TestDisable(t *testing.T) {
 
 	_, stored := rawdb.ReadAccountTrieNode(tester.db.diskdb, nil)
 	if err := tester.db.Disable(); err != nil {
-		t.Fatal("Failed to deactivate database")
+		t.Fatalf("Failed to deactivate database: %v", err)
 	}
 	if err := tester.db.Enable(types.EmptyRootHash); err == nil {
-		t.Fatalf("Invalid activation should be rejected")
+		t.Fatal("Invalid activation should be rejected")
 	}
 	if err := tester.db.Enable(stored); err != nil {
-		t.Fatal("Failed to activate database")
+		t.Fatalf("Failed to activate database: %v", err)
 	}
 
 	// Ensure journal is deleted from disk


### PR DESCRIPTION
This PR tries to fix two tests that often fail on CI: `TestEth2AssembleBlock` and `TestEth2NewBlock` (edit: and `TestEth2PrepareAndGetPayload`). It changes the call to `Add` a tx to the pool by setting `sync=true`.  

I don't know if doing so somehow makes the test moot, but I don't see why that would be so (?) 