### PR TITLE
p2p/discover: improved node revalidation

### DIFF
--- a/cmd/devp2p/discv4cmd.go
+++ b/cmd/devp2p/discv4cmd.go
@@ -21,7 +21,6 @@ import (
 	"fmt"
 	"net"
 	"net/http"
-	"net/rpc"
 	"strconv"
 	"strings"
 	"time"
@@ -34,6 +33,7 @@ import (
 	"github.com/ethereum/go-ethereum/p2p/discover"
 	"github.com/ethereum/go-ethereum/p2p/enode"
 	"github.com/ethereum/go-ethereum/params"
+	"github.com/ethereum/go-ethereum/rpc"
 	"github.com/urfave/cli/v2"
 )
 

--- a/cmd/devp2p/discv4cmd.go
+++ b/cmd/devp2p/discv4cmd.go
@@ -48,6 +48,7 @@ var (
 			discv4ResolveJSONCommand,
 			discv4CrawlCommand,
 			discv4TestCommand,
+			discv4ListenCommand,
 		},
 	}
 	discv4PingCommand = &cli.Command{
@@ -77,6 +78,14 @@ var (
 		Action:    discv4ResolveJSON,
 		Flags:     discoveryNodeFlags,
 		ArgsUsage: "<nodes.json file>",
+	}
+	discv4ListenCommand = &cli.Command{
+		Name:   "listen",
+		Usage:  "Runs a discovery node",
+		Action: discv4Listen,
+		Flags: flags.Merge(discoveryNodeFlags, []cli.Flag{
+			httpAddrFlag,
+		}),
 	}
 	discv4CrawlCommand = &cli.Command{
 		Name:   "crawl",

--- a/internal/testlog/testlog.go
+++ b/internal/testlog/testlog.go
@@ -58,7 +58,7 @@ func (h *bufHandler) Handle(_ context.Context, r slog.Record) error {
 }
 
 func (h *bufHandler) Enabled(_ context.Context, lvl slog.Level) bool {
-	return lvl <= h.level
+	return lvl >= h.level
 }
 
 func (h *bufHandler) WithAttrs(attrs []slog.Attr) slog.Handler {

--- a/node/api.go
+++ b/node/api.go
@@ -26,6 +26,7 @@ import (
 	"github.com/ethereum/go-ethereum/internal/debug"
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/p2p"
+	"github.com/ethereum/go-ethereum/p2p/discover"
 	"github.com/ethereum/go-ethereum/p2p/enode"
 	"github.com/ethereum/go-ethereum/rpc"
 )
@@ -39,6 +40,9 @@ func (n *Node) apis() []rpc.API {
 		}, {
 			Namespace: "debug",
 			Service:   debug.Handler,
+		}, {
+			Namespace: "debug",
+			Service:   &p2pDebugAPI{n},
 		}, {
 			Namespace: "web3",
 			Service:   &web3API{n},
@@ -332,4 +336,17 @@ func (s *web3API) ClientVersion() string {
 // It assumes the input is hex encoded.
 func (s *web3API) Sha3(input hexutil.Bytes) hexutil.Bytes {
 	return crypto.Keccak256(input)
+}
+
+// p2pDebugAPI provides access to p2p internals for debugging.
+type p2pDebugAPI struct {
+	stack *Node
+}
+
+func (s *p2pDebugAPI) DiscoveryV4Table() [][]discover.BucketNode {
+	disc := s.stack.server.DiscoveryV4()
+	if disc != nil {
+		return disc.TableBuckets()
+	}
+	return nil
 }

--- a/p2p/discover/common.go
+++ b/p2p/discover/common.go
@@ -66,7 +66,7 @@ type Config struct {
 func (cfg Config) withDefaults() Config {
 	// Node table configuration:
 	if cfg.PingInterval == 0 {
-		cfg.PingInterval = 5 * time.Second
+		cfg.PingInterval = 3 * time.Second
 	}
 	if cfg.RefreshInterval == 0 {
 		cfg.RefreshInterval = 30 * time.Minute

--- a/p2p/discover/common.go
+++ b/p2p/discover/common.go
@@ -104,20 +104,14 @@ type randomSource interface {
 
 // reseedingRandom is a random number generator that tracks when it was last re-seeded.
 type reseedingRandom struct {
-	cur      atomic.Pointer[rand.Rand]
-	lastSeed mclock.AbsTime
+	cur atomic.Pointer[rand.Rand]
 }
 
-func (r *reseedingRandom) nextReseedTime() mclock.AbsTime {
-	return r.lastSeed.Add(10 * time.Minute)
-}
-
-func (r *reseedingRandom) seed(now mclock.AbsTime) {
+func (r *reseedingRandom) seed() {
 	var b [8]byte
 	crand.Read(b[:])
 	seed := binary.BigEndian.Uint64(b[:])
 	r.cur.Store(rand.New(rand.NewSource(int64(seed))))
-	r.lastSeed = now
 }
 
 func (r *reseedingRandom) Intn(n int) int {

--- a/p2p/discover/common.go
+++ b/p2p/discover/common.go
@@ -66,7 +66,7 @@ type Config struct {
 func (cfg Config) withDefaults() Config {
 	// Node table configuration:
 	if cfg.PingInterval == 0 {
-		cfg.PingInterval = 10 * time.Second
+		cfg.PingInterval = 5 * time.Second
 	}
 	if cfg.RefreshInterval == 0 {
 		cfg.RefreshInterval = 30 * time.Minute

--- a/p2p/discover/common.go
+++ b/p2p/discover/common.go
@@ -100,6 +100,7 @@ type ReadPacket struct {
 type randomSource interface {
 	Intn(int) int
 	Int63n(int64) int64
+	Shuffle(int, func(int, int))
 }
 
 // reseedingRandom is a random number generator that tracks when it was last re-seeded.
@@ -129,4 +130,10 @@ func (r *reseedingRandom) Int63n(n int64) int64 {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	return r.cur.Int63n(n)
+}
+
+func (r *reseedingRandom) Shuffle(n int, swap func(i, j int)) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.cur.Shuffle(n, swap)
 }

--- a/p2p/discover/lookup.go
+++ b/p2p/discover/lookup.go
@@ -165,7 +165,7 @@ func (it *lookup) query(n *node, reply chan<- []*node) {
 	// Grab as many nodes as possible. Some of them might not be alive anymore, but we'll
 	// just remove those again during revalidation.
 	for _, n := range r {
-		it.tab.addSeenNode(n)
+		it.tab.addFoundNode(n)
 	}
 	reply <- r
 }

--- a/p2p/discover/lookup.go
+++ b/p2p/discover/lookup.go
@@ -152,9 +152,9 @@ func (it *lookup) query(n *node, reply chan<- []*node) {
 		// Remove the node from the local table if it fails to return anything useful too
 		// many times, but only if there are enough other nodes in the bucket.
 		dropped := false
-		if fails >= maxFindnodeFailures && it.tab.bucketLen(n.ID()) >= bucketSize/2 {
+		if fails >= maxFindnodeFailures {
 			dropped = true
-			it.tab.delete(n)
+			it.tab.trackFindFailure(n)
 		}
 		it.tab.log.Trace("FINDNODE failed", "id", n.ID(), "failcount", fails, "dropped", dropped, "err", err)
 	} else if fails > 0 {

--- a/p2p/discover/lookup.go
+++ b/p2p/discover/lookup.go
@@ -140,32 +140,12 @@ func (it *lookup) slowdown() {
 }
 
 func (it *lookup) query(n *node, reply chan<- []*node) {
-	fails := it.tab.db.FindFails(n.ID(), n.IP())
 	r, err := it.queryfunc(n)
-	if errors.Is(err, errClosed) {
+	if !errors.Is(err, errClosed) {
 		// Avoid recording failures on shutdown.
-		reply <- nil
-		return
-	} else if len(r) == 0 {
-		fails++
-		it.tab.db.UpdateFindFails(n.ID(), n.IP(), fails)
-		// Remove the node from the local table if it fails to return anything useful too
-		// many times, but only if there are enough other nodes in the bucket.
-		dropped := false
-		if fails >= maxFindnodeFailures {
-			dropped = true
-			it.tab.trackFindFailure(n)
-		}
-		it.tab.log.Trace("FINDNODE failed", "id", n.ID(), "failcount", fails, "dropped", dropped, "err", err)
-	} else if fails > 0 {
-		// Reset failure counter because it counts _consecutive_ failures.
-		it.tab.db.UpdateFindFails(n.ID(), n.IP(), 0)
-	}
-
-	// Grab as many nodes as possible. Some of them might not be alive anymore, but we'll
-	// just remove those again during revalidation.
-	for _, n := range r {
-		it.tab.addFoundNode(n)
+		success := len(r) > 0
+		it.tab.trackRequest(n, success, r)
+		it.tab.log.Trace("FINDNODE failed", "id", n.ID(), "err", err)
 	}
 	reply <- r
 }

--- a/p2p/discover/lookup.go
+++ b/p2p/discover/lookup.go
@@ -141,11 +141,12 @@ func (it *lookup) slowdown() {
 
 func (it *lookup) query(n *node, reply chan<- []*node) {
 	r, err := it.queryfunc(n)
-	if !errors.Is(err, errClosed) {
-		// Avoid recording failures on shutdown.
+	if !errors.Is(err, errClosed) { // avoid recording failures on shutdown.
 		success := len(r) > 0
 		it.tab.trackRequest(n, success, r)
-		it.tab.log.Trace("FINDNODE failed", "id", n.ID(), "err", err)
+		if err != nil {
+			it.tab.log.Trace("FINDNODE failed", "id", n.ID(), "err", err)
+		}
 	}
 	reply <- r
 }

--- a/p2p/discover/node.go
+++ b/p2p/discover/node.go
@@ -29,6 +29,12 @@ import (
 	"github.com/ethereum/go-ethereum/p2p/enode"
 )
 
+type BucketNode struct {
+	Node    *enode.Node `json:"node"`
+	AddedAt time.Time   `json:"added"`
+	Checks  int         `json:"checks"`
+}
+
 // node represents a host on the network.
 // The fields of Node may not be modified.
 type node struct {

--- a/p2p/discover/node.go
+++ b/p2p/discover/node.go
@@ -30,19 +30,21 @@ import (
 )
 
 type BucketNode struct {
-	Node    *enode.Node `json:"node"`
-	AddedAt time.Time   `json:"added"`
-	Checks  int         `json:"checks"`
-	Live    bool        `json:"live"`
+	Node        *enode.Node `json:"node"`
+	AddedTable  time.Time   `json:"addedToTable"`
+	AddedBucket time.Time   `json:"addedToBucket"`
+	Checks      int         `json:"checks"`
+	Live        bool        `json:"live"`
 }
 
 // node represents a host on the network.
 // The fields of Node may not be modified.
 type node struct {
 	*enode.Node
-	addedAt         time.Time // time when the node was added to the table
+	addedToTable    time.Time // first time node was added to bucket or replacement list
+	addedToBucket   time.Time // time it was added in the actual bucket
 	livenessChecks  uint      // how often liveness was checked
-	isValidatedLive bool
+	isValidatedLive bool      // true if existence of node is considered validated right now
 }
 
 type encPubkey [64]byte

--- a/p2p/discover/node.go
+++ b/p2p/discover/node.go
@@ -30,11 +30,11 @@ import (
 )
 
 type BucketNode struct {
-	Node        *enode.Node `json:"node"`
-	AddedTable  time.Time   `json:"addedToTable"`
-	AddedBucket time.Time   `json:"addedToBucket"`
-	Checks      int         `json:"checks"`
-	Live        bool        `json:"live"`
+	Node          *enode.Node `json:"node"`
+	AddedToTable  time.Time   `json:"addedToTable"`
+	AddedToBucket time.Time   `json:"addedToBucket"`
+	Checks        int         `json:"checks"`
+	Live          bool        `json:"live"`
 }
 
 // node represents a host on the network.

--- a/p2p/discover/node.go
+++ b/p2p/discover/node.go
@@ -33,6 +33,7 @@ type BucketNode struct {
 	Node    *enode.Node `json:"node"`
 	AddedAt time.Time   `json:"added"`
 	Checks  int         `json:"checks"`
+	Live    bool        `json:"live"`
 }
 
 // node represents a host on the network.

--- a/p2p/discover/node.go
+++ b/p2p/discover/node.go
@@ -38,9 +38,10 @@ type BucketNode struct {
 // node represents a host on the network.
 // The fields of Node may not be modified.
 type node struct {
-	enode.Node
-	addedAt        time.Time // time when the node was added to the table
-	livenessChecks uint      // how often liveness was checked
+	*enode.Node
+	addedAt         time.Time // time when the node was added to the table
+	livenessChecks  uint      // how often liveness was checked
+	isValidatedLive bool
 }
 
 type encPubkey [64]byte
@@ -71,7 +72,7 @@ func (e encPubkey) id() enode.ID {
 }
 
 func wrapNode(n *enode.Node) *node {
-	return &node{Node: *n}
+	return &node{Node: n}
 }
 
 func wrapNodes(ns []*enode.Node) []*node {
@@ -83,7 +84,7 @@ func wrapNodes(ns []*enode.Node) []*node {
 }
 
 func unwrapNode(n *node) *enode.Node {
-	return &n.Node
+	return n.Node
 }
 
 func unwrapNodes(ns []*node) []*enode.Node {

--- a/p2p/discover/table.go
+++ b/p2p/discover/table.go
@@ -150,18 +150,19 @@ func newMeteredTable(t transport, db *enode.DB, cfg Config) (*Table, error) {
 }
 
 // Nodes returns all nodes contained in the table.
-func (tab *Table) Nodes() []*enode.Node {
-	if !tab.isInitDone() {
-		return nil
-	}
-
+func (tab *Table) Nodes() [][]BucketNode {
 	tab.mutex.Lock()
 	defer tab.mutex.Unlock()
 
-	var nodes []*enode.Node
-	for _, b := range &tab.buckets {
-		for _, n := range b.entries {
-			nodes = append(nodes, unwrapNode(n))
+	nodes := make([][]BucketNode, len(tab.buckets))
+	for i, b := range &tab.buckets {
+		nodes[i] = make([]BucketNode, len(b.entries))
+		for j, n := range b.entries {
+			nodes[i][j] = BucketNode{
+				Node:    &n.Node,
+				Checks:  int(n.livenessChecks),
+				AddedAt: n.addedAt,
+			}
 		}
 	}
 	return nodes

--- a/p2p/discover/table.go
+++ b/p2p/discover/table.go
@@ -435,7 +435,7 @@ func (tab *Table) loadSeedNodes() {
 			age := time.Since(tab.db.LastPongReceived(seed.ID(), seed.IP()))
 			tab.log.Trace("Found seed node in database", "id", seed.ID(), "addr", seed.addr(), "age", age)
 		}
-		tab.addSeenNode(seed)
+		tab.handleAddNode(addNodeRequest{node: seed, isLive: true})
 	}
 }
 

--- a/p2p/discover/table.go
+++ b/p2p/discover/table.go
@@ -444,7 +444,7 @@ func (tab *Table) loadSeedNodes() {
 			age := time.Since(tab.db.LastPongReceived(seed.ID(), seed.IP()))
 			tab.log.Trace("Found seed node in database", "id", seed.ID(), "addr", seed.addr(), "age", age)
 		}
-		tab.handleAddNode(addNodeOp{node: seed, isInbound: true})
+		tab.handleAddNode(addNodeOp{node: seed, isInbound: false})
 	}
 }
 

--- a/p2p/discover/table.go
+++ b/p2p/discover/table.go
@@ -163,11 +163,11 @@ func (tab *Table) Nodes() [][]BucketNode {
 		nodes[i] = make([]BucketNode, len(b.entries))
 		for j, n := range b.entries {
 			nodes[i][j] = BucketNode{
-				Node:        n.Node,
-				Checks:      int(n.livenessChecks),
-				Live:        n.isValidatedLive,
-				AddedTable:  n.addedToTable,
-				AddedBucket: n.addedToBucket,
+				Node:          n.Node,
+				Checks:        int(n.livenessChecks),
+				Live:          n.isValidatedLive,
+				AddedToTable:  n.addedToTable,
+				AddedToBucket: n.addedToBucket,
 			}
 		}
 	}

--- a/p2p/discover/table.go
+++ b/p2p/discover/table.go
@@ -568,7 +568,7 @@ func (tab *Table) deleteInBucket(b *bucket, id enode.ID) *node {
 
 	// Add replacement.
 	if len(b.replacements) == 0 {
-		tab.log.Debug("Removed dead node", "b", b.index, "id", n.ID(), "ip", n.IP(), "checks", n.livenessChecks)
+		tab.log.Debug("Removed dead node", "b", b.index, "id", n.ID(), "ip", n.IP())
 		return nil
 	}
 	rindex := tab.rand.Intn(len(b.replacements))
@@ -577,7 +577,7 @@ func (tab *Table) deleteInBucket(b *bucket, id enode.ID) *node {
 	b.entries = append(b.entries, rep)
 	tab.nodeAdded(b, rep)
 
-	tab.log.Debug("Replaced dead node", "b", b.index, "id", n.ID(), "ip", n.IP(), "checks", n.livenessChecks, "r", rep.ID(), "rip", rep.IP())
+	tab.log.Debug("Replaced dead node", "b", b.index, "id", n.ID(), "ip", n.IP(), "r", rep.ID(), "rip", rep.IP())
 	return rep
 }
 

--- a/p2p/discover/table.go
+++ b/p2p/discover/table.go
@@ -167,6 +167,7 @@ func (tab *Table) Nodes() [][]BucketNode {
 			nodes[i][j] = BucketNode{
 				Node:    n.Node,
 				Checks:  int(n.livenessChecks),
+				Live:    n.isValidatedLive,
 				AddedAt: n.addedAt,
 			}
 		}

--- a/p2p/discover/table.go
+++ b/p2p/discover/table.go
@@ -510,7 +510,7 @@ func (tab *Table) handleAddNode(req addNodeRequest) {
 	}
 
 	// Add to bucket.
-	b.entries, _ = pushNode(b.entries, req.node, bucketSize)
+	b.entries = append(b.entries, req.node)
 	b.replacements = deleteNode(b.replacements, req.node)
 	req.node.addedAt = time.Now()
 	tab.nodeAdded(b, req.node)

--- a/p2p/discover/table.go
+++ b/p2p/discover/table.go
@@ -79,7 +79,7 @@ type Table struct {
 	refreshReq      chan chan struct{}
 	revalResponseCh chan revalidationResponse
 	addNodeCh       chan addNodeOp
-	addNodeHandled  chan bool
+	addNodeHandled  chan 1bool
 	trackRequestCh  chan trackRequestOp
 	initDone        chan struct{}
 	closeReq        chan struct{}
@@ -638,8 +638,10 @@ func (tab *Table) handleTrackRequest(op trackRequestOp) {
 
 	b := tab.bucket(op.node.ID())
 	// Remove the node from the local table if it fails to return anything useful too
-	// many times, but only if there are enough other nodes in the bucket.
-	if fails >= maxFindnodeFailures && len(b.entries) >= bucketSize/2 {
+	// many times, but only if there are enough other nodes in the bucket. This latter
+	// condition specifically exists to make bootstrapping in smaller test networks more
+	// reliable.
+	if fails >= maxFindnodeFailures && len(b.entries) >= bucketSize/4 {
 		tab.deleteInBucket(b, op.node.ID())
 	}
 

--- a/p2p/discover/table.go
+++ b/p2p/discover/table.go
@@ -309,7 +309,7 @@ func (tab *Table) addSeenNode(n *node) {
 	select {
 	case tab.addNodeCh <- req:
 		<-tab.addNodeHandled
-	case <-tab.closed:
+	case <-tab.closeReq:
 	}
 }
 
@@ -326,7 +326,7 @@ func (tab *Table) addVerifiedNode(n *node) {
 	select {
 	case tab.addNodeCh <- req:
 		<-tab.addNodeHandled
-	case <-tab.closed:
+	case <-tab.closeReq:
 	}
 }
 

--- a/p2p/discover/table.go
+++ b/p2p/discover/table.go
@@ -165,7 +165,7 @@ func (tab *Table) Nodes() [][]BucketNode {
 		nodes[i] = make([]BucketNode, len(b.entries))
 		for j, n := range b.entries {
 			nodes[i][j] = BucketNode{
-				Node:    &n.Node,
+				Node:    n.Node,
 				Checks:  int(n.livenessChecks),
 				AddedAt: n.addedAt,
 			}

--- a/p2p/discover/table_reval.go
+++ b/p2p/discover/table_reval.go
@@ -76,12 +76,6 @@ func (tr *tableRevalidation) run(tab *Table, now mclock.AbsTime) (nextTime mcloc
 		tr.slow.schedule(now, &tab.rand)
 	}
 
-	if tr.fast.nextTime == never {
-		return tr.slow.nextTime
-	}
-	if tr.slow.nextTime == never {
-		return tr.fast.nextTime
-	}
 	return min(tr.fast.nextTime, tr.slow.nextTime)
 }
 

--- a/p2p/discover/table_reval.go
+++ b/p2p/discover/table_reval.go
@@ -132,11 +132,10 @@ func (tr *tableRevalidation) handleResponse(tab *Table, resp revalidationRespons
 	if !resp.didRespond {
 		// Revalidation failed.
 		n.livenessChecks /= 3
-		if n.livenessChecks == 0 || resp.isNewNode {
+		if n.livenessChecks <= 0 {
 			tab.deleteInBucket(b, n.ID())
-		}
-		// Move to fast queue.
-		if !resp.isNewNode {
+		} else if !resp.isNewNode {
+			// Move to fast queue.
 			tr.moveToList(&tr.fast, &tr.slow, n, now, &tab.rand)
 		}
 		return

--- a/p2p/discover/table_reval.go
+++ b/p2p/discover/table_reval.go
@@ -1,0 +1,204 @@
+// Copyright 2024 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+
+package discover
+
+import (
+	"fmt"
+	"slices"
+	"time"
+
+	"github.com/ethereum/go-ethereum/common/mclock"
+	"github.com/ethereum/go-ethereum/p2p/enode"
+)
+
+const never = ^mclock.AbsTime(0)
+
+type tableRevalidation struct {
+	newNodes  revalidationQueue
+	nodes     revalidationQueue
+	activeReq map[enode.ID]struct{}
+}
+
+type revalidationResponse struct {
+	n          *node
+	didRespond bool
+	isNewNode  bool
+	newRecord  *enode.Node
+}
+
+func (tr *tableRevalidation) init(cfg *Config) {
+	tr.activeReq = make(map[enode.ID]struct{})
+	tr.newNodes.nextTime = never
+	tr.newNodes.interval = cfg.PingInterval
+	tr.nodes.nextTime = never
+	tr.nodes.interval = cfg.PingInterval
+}
+
+// nodeAdded is called when the table receives a new node.
+func (tr *tableRevalidation) nodeAdded(tab *Table, n *node) {
+	tr.newNodes.push(n, tab.rand)
+}
+
+// nodeRemoved is called when a node was removed from the table.
+func (tr *tableRevalidation) nodeRemoved(n *node) {
+	wasnew := tr.newNodes.remove(n)
+	if !wasnew {
+		tr.nodes.remove(n)
+	}
+}
+
+// nextTime returns the next time run() should be invoked.
+// The Table main loop uses this to schedule a timer.
+func (tr *tableRevalidation) nextTime() mclock.AbsTime {
+	return min(tr.newNodes.nextTime, tr.nodes.nextTime)
+}
+
+// run performs node revalidation.
+func (tr *tableRevalidation) run(tab *Table, now mclock.AbsTime) {
+	if n := tr.newNodes.get(now, tab.rand, tr.activeReq); n != nil {
+		tr.startRequest(tab, n, true)
+		tr.newNodes.schedule(tab.rand)
+	}
+	if n := tr.nodes.get(now, tab.rand, tr.activeReq); n != nil {
+		tr.startRequest(tab, n, false)
+		tr.nodes.schedule(tab.rand)
+	}
+}
+
+// startRequest spawns a revalidation request for node n.
+func (tr *tableRevalidation) startRequest(tab *Table, n *node, newNode bool) {
+	if _, ok := tr.activeReq[n.ID()]; ok {
+		panic("duplicate startRequest")
+	}
+	tr.activeReq[n.ID()] = struct{}{}
+	resp := revalidationResponse{n: n, isNewNode: newNode}
+
+	go func() {
+		// Ping the selected node and wait for a pong response.
+		remoteSeq, err := tab.net.ping(unwrapNode(n))
+		resp.didRespond = err == nil
+
+		// Also fetch record if the node replied and returned a higher sequence number.
+		if remoteSeq > n.Seq() {
+			newrec, err := tab.net.RequestENR(unwrapNode(n))
+			if err != nil {
+				tab.log.Debug("ENR request failed", "id", n.ID(), "addr", n.addr(), "err", err)
+			} else {
+				resp.newRecord = newrec
+			}
+		}
+
+		select {
+		case tab.revalidateResp <- resp:
+		case <-tab.closed:
+		}
+	}()
+}
+
+// handleResponse processes the result of a revalidation request.
+func (tr *tableRevalidation) handleResponse(tab *Table, resp revalidationResponse) {
+	n := resp.n
+	b := tab.bucket(n.ID())
+	delete(tr.activeReq, n.ID())
+
+	tab.mutex.Lock()
+	defer tab.mutex.Unlock()
+
+	if !resp.didRespond {
+		// Revalidation failed.
+		n.livenessChecks /= 3
+		if n.livenessChecks == 0 || resp.isNewNode {
+			tab.deleteInBucket(b, n.ID())
+		}
+		return
+	}
+
+	// The node responded.
+	n.livenessChecks++
+	n.isValidatedLive = true
+	tab.log.Debug("Revalidated node", "b", b.index, "id", n.ID(), "checks", n.livenessChecks)
+	if resp.newRecord != nil {
+		updated := tab.bumpInBucket(b, resp.newRecord)
+		if updated {
+			// If the node changed its advertised endpoint, the updated ENR is not served
+			// until it has been revalidated.
+			n.isValidatedLive = false
+		}
+	}
+
+	// Move node over to main queue after first validation.
+	if resp.isNewNode {
+		tr.newNodes.remove(n)
+		tr.nodes.push(n, tab.rand)
+	}
+
+	// Store potential seeds in database.
+	if n.isValidatedLive && n.livenessChecks > 5 {
+		tab.db.UpdateNode(resp.n.Node)
+	}
+}
+
+// revalidationQueue holds a list nodes and the next revalidation time.
+type revalidationQueue struct {
+	nodes    []*node
+	nextTime mclock.AbsTime
+	interval time.Duration
+}
+
+// get returns a random node from the queue. Nodes in the 'exclude' map are not returned.
+func (rq *revalidationQueue) get(now mclock.AbsTime, rand randomSource, exclude map[enode.ID]struct{}) *node {
+	if now < rq.nextTime || len(rq.nodes) == 0 {
+		return nil
+	}
+	for i := 0; i < len(rq.nodes)*3; i++ {
+		n := rq.nodes[rand.Intn(len(rq.nodes))]
+		_, excluded := exclude[n.ID()]
+		if !excluded {
+			return n
+		}
+	}
+	return nil
+}
+
+func (rq *revalidationQueue) push(n *node, rand randomSource) {
+	rq.nodes = append(rq.nodes, n)
+	if rq.nextTime == never {
+		rq.schedule(rand)
+	}
+}
+
+func (rq *revalidationQueue) schedule(rand randomSource) {
+	rq.nextTime = mclock.AbsTime(rand.Int63n(int64(rq.interval)))
+}
+
+func (rq *revalidationQueue) remove(n *node) bool {
+	i := slices.Index(rq.nodes, n)
+	if i == -1 {
+		return false
+	}
+	rq.nodes = slices.Delete(rq.nodes, i, i+1)
+	if len(rq.nodes) == 0 {
+		rq.nextTime = never
+	}
+	return true
+}
+
+func printIDs(list []*node) {
+	for i, n := range list {
+		fmt.Println("   - ", i, n.ID())
+	}
+}

--- a/p2p/discover/table_reval.go
+++ b/p2p/discover/table_reval.go
@@ -128,7 +128,7 @@ func (tr *tableRevalidation) handleResponse(tab *Table, resp revalidationRespons
 
 	if !resp.didRespond {
 		// Revalidation failed.
-		n.livenessChecks /= 5
+		n.livenessChecks /= 3
 		if n.livenessChecks <= 0 {
 			tab.deleteInBucket(b, n.ID())
 		} else {

--- a/p2p/discover/table_reval.go
+++ b/p2p/discover/table_reval.go
@@ -134,7 +134,7 @@ func (tr *tableRevalidation) handleResponse(tab *Table, resp revalidationRespons
 
 	if !resp.didRespond {
 		// Revalidation failed.
-		n.livenessChecks /= 3
+		n.livenessChecks /= 5
 		if n.livenessChecks <= 0 {
 			tab.deleteInBucket(b, n.ID())
 		} else {

--- a/p2p/discover/table_reval.go
+++ b/p2p/discover/table_reval.go
@@ -148,7 +148,7 @@ func (tr *tableRevalidation) handleResponse(tab *Table, resp revalidationRespons
 	n.isValidatedLive = true
 	var endpointChanged bool
 	if resp.newRecord != nil {
-		endpointChanged := tab.bumpInBucket(b, resp.newRecord)
+		endpointChanged = tab.bumpInBucket(b, resp.newRecord)
 		if endpointChanged {
 			// If the node changed its advertised endpoint, the updated ENR is not served
 			// until it has been revalidated.

--- a/p2p/discover/table_reval.go
+++ b/p2p/discover/table_reval.go
@@ -189,12 +189,12 @@ type revalidationList struct {
 }
 
 // get returns a random node from the queue. Nodes in the 'exclude' map are not returned.
-func (rq *revalidationList) get(now mclock.AbsTime, rand randomSource, exclude map[enode.ID]struct{}) *node {
-	if now < rq.nextTime || len(rq.nodes) == 0 {
+func (list *revalidationList) get(now mclock.AbsTime, rand randomSource, exclude map[enode.ID]struct{}) *node {
+	if now < list.nextTime || len(list.nodes) == 0 {
 		return nil
 	}
-	for i := 0; i < len(rq.nodes)*3; i++ {
-		n := rq.nodes[rand.Intn(len(rq.nodes))]
+	for i := 0; i < len(list.nodes)*3; i++ {
+		n := list.nodes[rand.Intn(len(list.nodes))]
 		_, excluded := exclude[n.ID()]
 		if !excluded {
 			return n
@@ -203,25 +203,25 @@ func (rq *revalidationList) get(now mclock.AbsTime, rand randomSource, exclude m
 	return nil
 }
 
-func (rq *revalidationList) schedule(now mclock.AbsTime, rand randomSource) {
-	rq.nextTime = now.Add(time.Duration(rand.Int63n(int64(rq.interval))))
+func (list *revalidationList) schedule(now mclock.AbsTime, rand randomSource) {
+	list.nextTime = now.Add(time.Duration(rand.Int63n(int64(list.interval))))
 }
 
-func (rq *revalidationList) push(n *node, now mclock.AbsTime, rand randomSource) {
-	rq.nodes = append(rq.nodes, n)
-	if rq.nextTime == never {
-		rq.schedule(now, rand)
+func (list *revalidationList) push(n *node, now mclock.AbsTime, rand randomSource) {
+	list.nodes = append(list.nodes, n)
+	if list.nextTime == never {
+		list.schedule(now, rand)
 	}
 }
 
-func (rq *revalidationList) remove(n *node) bool {
-	i := slices.Index(rq.nodes, n)
+func (list *revalidationList) remove(n *node) bool {
+	i := slices.Index(list.nodes, n)
 	if i == -1 {
 		return false
 	}
-	rq.nodes = slices.Delete(rq.nodes, i, i+1)
-	if len(rq.nodes) == 0 {
-		rq.nextTime = never
+	list.nodes = slices.Delete(list.nodes, i, i+1)
+	if len(list.nodes) == 0 {
+		list.nextTime = never
 	}
 	return true
 }

--- a/p2p/discover/table_reval.go
+++ b/p2p/discover/table_reval.go
@@ -28,6 +28,8 @@ import (
 
 const never = mclock.AbsTime(math.MaxInt64)
 
+// tableRevalidation implements the node revalidation process.
+// It tracks all nodes contained in Table, and schedules sending PING to them.
 type tableRevalidation struct {
 	fast      revalidationList
 	slow      revalidationList

--- a/p2p/discover/table_reval.go
+++ b/p2p/discover/table_reval.go
@@ -17,6 +17,7 @@
 package discover
 
 import (
+	"math"
 	"slices"
 	"time"
 
@@ -24,7 +25,7 @@ import (
 	"github.com/ethereum/go-ethereum/p2p/enode"
 )
 
-const never = ^mclock.AbsTime(0)
+const never = mclock.AbsTime(math.MaxInt64)
 
 type tableRevalidation struct {
 	newNodes  revalidationList

--- a/p2p/discover/table_test.go
+++ b/p2p/discover/table_test.go
@@ -71,7 +71,7 @@ func testPingReplace(t *testing.T, newNodeIsResponding, lastInBucketIsResponding
 	// this node in the bucket if it is unresponsive.
 	transport.dead[last.ID()] = !lastInBucketIsResponding
 	transport.dead[replacementNode.ID()] = !newNodeIsResponding
-	tab.addSeenNode(replacementNode)
+	tab.addFoundNode(replacementNode)
 
 	// Wait until the last node was pinged.
 	waitForRevalidationPing(t, transport, tab, last.ID())
@@ -127,7 +127,7 @@ func TestTable_IPLimit(t *testing.T) {
 
 	for i := 0; i < tableIPLimit+1; i++ {
 		n := nodeAtDistance(tab.self().ID(), i, net.IP{172, 0, 1, byte(i)})
-		tab.addSeenNode(n)
+		tab.addFoundNode(n)
 	}
 	if tab.len() > tableIPLimit {
 		t.Errorf("too many nodes in table")
@@ -145,7 +145,7 @@ func TestTable_BucketIPLimit(t *testing.T) {
 	d := 3
 	for i := 0; i < bucketIPLimit+1; i++ {
 		n := nodeAtDistance(tab.self().ID(), d, net.IP{172, 0, 1, byte(i)})
-		tab.addSeenNode(n)
+		tab.addFoundNode(n)
 	}
 	if tab.len() > bucketIPLimit {
 		t.Errorf("too many nodes in table")
@@ -258,8 +258,8 @@ func TestTable_addVerifiedNode(t *testing.T) {
 	// Insert two nodes.
 	n1 := nodeAtDistance(tab.self().ID(), 256, net.IP{88, 77, 66, 1})
 	n2 := nodeAtDistance(tab.self().ID(), 256, net.IP{88, 77, 66, 2})
-	tab.addSeenNode(n1)
-	tab.addSeenNode(n2)
+	tab.addFoundNode(n1)
+	tab.addFoundNode(n2)
 	bucket := tab.bucket(n1.ID())
 
 	// Verify bucket content:
@@ -272,7 +272,7 @@ func TestTable_addVerifiedNode(t *testing.T) {
 	newrec := n2.Record()
 	newrec.Set(enr.IP{99, 99, 99, 99})
 	newn2 := wrapNode(enode.SignNull(newrec, n2.ID()))
-	tab.addVerifiedNode(newn2)
+	tab.addInboundNode(newn2)
 
 	// Check that bucket is updated correctly.
 	newBcontent := []*node{n1, newn2}
@@ -291,8 +291,8 @@ func TestTable_addSeenNode(t *testing.T) {
 	// Insert two nodes.
 	n1 := nodeAtDistance(tab.self().ID(), 256, net.IP{88, 77, 66, 1})
 	n2 := nodeAtDistance(tab.self().ID(), 256, net.IP{88, 77, 66, 2})
-	tab.addSeenNode(n1)
-	tab.addSeenNode(n2)
+	tab.addFoundNode(n1)
+	tab.addFoundNode(n2)
 
 	// Verify bucket content:
 	bcontent := []*node{n1, n2}
@@ -304,7 +304,7 @@ func TestTable_addSeenNode(t *testing.T) {
 	newrec := n2.Record()
 	newrec.Set(enr.IP{99, 99, 99, 99})
 	newn2 := wrapNode(enode.SignNull(newrec, n2.ID()))
-	tab.addSeenNode(newn2)
+	tab.addFoundNode(newn2)
 
 	// Check that bucket content is unchanged.
 	if !reflect.DeepEqual(tab.bucket(n1.ID()).entries, bcontent) {
@@ -330,7 +330,7 @@ func TestTable_revalidateSyncRecord(t *testing.T) {
 	r.Set(enr.IP(net.IP{127, 0, 0, 1}))
 	id := enode.ID{1}
 	n1 := wrapNode(enode.SignNull(&r, id))
-	tab.addSeenNode(n1)
+	tab.addFoundNode(n1)
 
 	// Update the node record.
 	r.Set(enr.WithEntry("foo", "bar"))

--- a/p2p/discover/table_test.go
+++ b/p2p/discover/table_test.go
@@ -363,6 +363,9 @@ func TestTable_revalidateSyncRecord(t *testing.T) {
 	n2 := enode.SignNull(&r, id)
 	transport.updateRecord(n2)
 
+	// Wait for revalidation. We wait for the node to be revalidated two times
+	// in order to synchronize with the update in the able.
+	waitForRevalidationPing(t, transport, tab, n2.ID())
 	waitForRevalidationPing(t, transport, tab, n2.ID())
 
 	intable := tab.getNode(id)

--- a/p2p/discover/table_test.go
+++ b/p2p/discover/table_test.go
@@ -63,10 +63,10 @@ func testPingReplace(t *testing.T, newNodeIsResponding, lastInBucketIsResponding
 	<-tab.initDone
 
 	// Fill up the sender's bucket.
-	tab.mutex.Lock()
 	replacementNodeKey, _ := crypto.HexToECDSA("45a915e4d060149eb4365960e6a7a45f334393093061116b197e3240065ff2d8")
 	replacementNode := wrapNode(enode.NewV4(&replacementNodeKey.PublicKey, net.IP{127, 0, 0, 1}, 99, 99))
 	last := fillBucket(tab, replacementNode.ID())
+	tab.mutex.Lock()
 	nodeEvents := newNodeEventRecorder(128)
 	tab.nodeAddedHook = nodeEvents.nodeAdded
 	tab.nodeRemovedHook = nodeEvents.nodeRemoved

--- a/p2p/discover/table_util_test.go
+++ b/p2p/discover/table_util_test.go
@@ -116,11 +116,12 @@ func fillTable(tab *Table, nodes []*node, setLive bool) {
 	for _, n := range nodes {
 		if setLive {
 			n.livenessChecks = 1
+			n.isValidatedLive = true
 		}
 		tab.addSeenNode(n)
 	}
 }
-7
+
 type pingRecorder struct {
 	mu      sync.Mutex
 	cond    *sync.Cond

--- a/p2p/discover/table_util_test.go
+++ b/p2p/discover/table_util_test.go
@@ -104,8 +104,9 @@ func fillBucket(tab *Table, id enode.ID) (last *node) {
 	b := tab.bucket(id)
 	for len(b.entries) < bucketSize {
 		node := nodeAtDistance(tab.self().ID(), ld, intIP(ld))
-		b.entries = append(b.entries, node)
-		tab.nodeAdded(b, node)
+		if !tab.addFoundNode(node) {
+			panic("node not added")
+		}
 	}
 	return b.entries[bucketSize-1]
 }

--- a/p2p/discover/table_util_test.go
+++ b/p2p/discover/table_util_test.go
@@ -118,7 +118,7 @@ func fillTable(tab *Table, nodes []*node, setLive bool) {
 			n.livenessChecks = 1
 			n.isValidatedLive = true
 		}
-		tab.addSeenNode(n)
+		tab.addFoundNode(n)
 	}
 }
 

--- a/p2p/discover/table_util_test.go
+++ b/p2p/discover/table_util_test.go
@@ -120,7 +120,7 @@ func fillTable(tab *Table, nodes []*node, setLive bool) {
 		tab.addSeenNode(n)
 	}
 }
-
+7
 type pingRecorder struct {
 	mu      sync.Mutex
 	cond    *sync.Cond
@@ -156,12 +156,6 @@ func (t *pingRecorder) updateRecord(n *enode.Node) {
 func (t *pingRecorder) Self() *enode.Node           { return nullNode }
 func (t *pingRecorder) lookupSelf() []*enode.Node   { return nil }
 func (t *pingRecorder) lookupRandom() []*enode.Node { return nil }
-
-func (t *pingRecorder) wasPinged(id enode.ID) bool {
-	t.mu.Lock()
-	defer t.mu.Unlock()
-	return slices.ContainsFunc(t.pinged, func(n *enode.Node) bool { return n.ID() == id })
-}
 
 func (t *pingRecorder) waitPing(timeout time.Duration) *enode.Node {
 	t.mu.Lock()

--- a/p2p/discover/v4_udp.go
+++ b/p2p/discover/v4_udp.go
@@ -142,7 +142,7 @@ func ListenV4(c UDPConn, ln *enode.LocalNode, cfg Config) (*UDPv4, error) {
 		log:             cfg.Log,
 	}
 
-	tab, err := newMeteredTable(t, ln.Database(), cfg)
+	tab, err := newTable(t, ln.Database(), cfg)
 	if err != nil {
 		return nil, err
 	}

--- a/p2p/discover/v4_udp.go
+++ b/p2p/discover/v4_udp.go
@@ -375,6 +375,10 @@ func (t *UDPv4) RequestENR(n *enode.Node) (*enode.Node, error) {
 	return respN, nil
 }
 
+func (t *UDPv4) TableBuckets() [][]BucketNode {
+	return t.tab.Nodes()
+}
+
 // pending adds a reply matcher to the pending reply queue.
 // see the documentation of type replyMatcher for a detailed explanation.
 func (t *UDPv4) pending(id enode.ID, ip net.IP, ptype byte, callback replyMatchFunc) *replyMatcher {

--- a/p2p/discover/v4_udp.go
+++ b/p2p/discover/v4_udp.go
@@ -673,10 +673,10 @@ func (t *UDPv4) handlePing(h *packetHandlerV4, from *net.UDPAddr, fromID enode.I
 	n := wrapNode(enode.NewV4(h.senderKey, from.IP, int(req.From.TCP), from.Port))
 	if time.Since(t.db.LastPongReceived(n.ID(), from.IP)) > bondExpiration {
 		t.sendPing(fromID, from, func() {
-			t.tab.addVerifiedNode(n)
+			t.tab.addInboundNode(n)
 		})
 	} else {
-		t.tab.addVerifiedNode(n)
+		t.tab.addInboundNode(n)
 	}
 
 	// Update node database and endpoint predictor.

--- a/p2p/discover/v4_udp_test.go
+++ b/p2p/discover/v4_udp_test.go
@@ -264,7 +264,7 @@ func TestUDPv4_findnode(t *testing.T) {
 		n := wrapNode(enode.NewV4(&key.PublicKey, ip, 0, 2000))
 		// Ensure half of table content isn't verified live yet.
 		if i > numCandidates/2 {
-			n.livenessChecks = 1
+			n.isValidatedLive = true
 			live[n.ID()] = true
 		}
 		nodes.push(n, numCandidates)

--- a/p2p/discover/v5_udp.go
+++ b/p2p/discover/v5_udp.go
@@ -699,7 +699,7 @@ func (t *UDPv5) handlePacket(rawpacket []byte, fromAddr *net.UDPAddr) error {
 	}
 	if fromNode != nil {
 		// Handshake succeeded, add to table.
-		t.tab.addSeenNode(wrapNode(fromNode))
+		t.tab.addInboundNode(wrapNode(fromNode))
 	}
 	if packet.Kind() != v5wire.WhoareyouPacket {
 		// WHOAREYOU logged separately to report errors.

--- a/p2p/discover/v5_udp.go
+++ b/p2p/discover/v5_udp.go
@@ -175,7 +175,7 @@ func newUDPv5(conn UDPConn, ln *enode.LocalNode, cfg Config) (*UDPv5, error) {
 		cancelCloseCtx: cancelCloseCtx,
 	}
 	t.talk = newTalkSystem(t)
-	tab, err := newMeteredTable(t, t.db, cfg)
+	tab, err := newTable(t, t.db, cfg)
 	if err != nil {
 		return nil, err
 	}

--- a/p2p/discover/v5_udp_test.go
+++ b/p2p/discover/v5_udp_test.go
@@ -141,7 +141,7 @@ func TestUDPv5_unknownPacket(t *testing.T) {
 
 	// Make node known.
 	n := test.getNode(test.remotekey, test.remoteaddr).Node()
-	test.table.addSeenNode(wrapNode(n))
+	test.table.addFoundNode(wrapNode(n))
 
 	test.packetIn(&v5wire.Unknown{Nonce: nonce})
 	test.waitPacketOut(func(p *v5wire.Whoareyou, addr *net.UDPAddr, _ v5wire.Nonce) {

--- a/p2p/server.go
+++ b/p2p/server.go
@@ -190,8 +190,8 @@ type Server struct {
 
 	nodedb    *enode.DB
 	localnode *enode.LocalNode
-	ntab      *discover.UDPv4
-	DiscV5    *discover.UDPv5
+	discv4    *discover.UDPv4
+	discv5    *discover.UDPv5
 	discmix   *enode.FairMix
 	dialsched *dialScheduler
 
@@ -400,6 +400,16 @@ func (srv *Server) Self() *enode.Node {
 	return ln.Node()
 }
 
+// DiscoveryV4 returns the discovery v4 instance, if configured.
+func (srv *Server) DiscoveryV4() *discover.UDPv4 {
+	return srv.discv4
+}
+
+// DiscoveryV4 returns the discovery v5 instance, if configured.
+func (srv *Server) DiscoveryV5() *discover.UDPv5 {
+	return srv.discv5
+}
+
 // Stop terminates the server and all active peer connections.
 // It blocks until all active connections have been closed.
 func (srv *Server) Stop() {
@@ -547,13 +557,13 @@ func (srv *Server) setupDiscovery() error {
 	)
 	// If both versions of discovery are running, setup a shared
 	// connection, so v5 can read unhandled messages from v4.
-	if srv.DiscoveryV4 && srv.DiscoveryV5 {
+	if srv.Config.DiscoveryV4 && srv.Config.DiscoveryV5 {
 		unhandled = make(chan discover.ReadPacket, 100)
 		sconn = &sharedUDPConn{conn, unhandled}
 	}
 
 	// Start discovery services.
-	if srv.DiscoveryV4 {
+	if srv.Config.DiscoveryV4 {
 		cfg := discover.Config{
 			PrivateKey:  srv.PrivateKey,
 			NetRestrict: srv.NetRestrict,
@@ -565,17 +575,17 @@ func (srv *Server) setupDiscovery() error {
 		if err != nil {
 			return err
 		}
-		srv.ntab = ntab
+		srv.discv4 = ntab
 		srv.discmix.AddSource(ntab.RandomNodes())
 	}
-	if srv.DiscoveryV5 {
+	if srv.Config.DiscoveryV5 {
 		cfg := discover.Config{
 			PrivateKey:  srv.PrivateKey,
 			NetRestrict: srv.NetRestrict,
 			Bootnodes:   srv.BootstrapNodesV5,
 			Log:         srv.log,
 		}
-		srv.DiscV5, err = discover.ListenV5(sconn, srv.localnode, cfg)
+		srv.discv5, err = discover.ListenV5(sconn, srv.localnode, cfg)
 		if err != nil {
 			return err
 		}
@@ -602,8 +612,8 @@ func (srv *Server) setupDialScheduler() {
 		dialer:         srv.Dialer,
 		clock:          srv.clock,
 	}
-	if srv.ntab != nil {
-		config.resolver = srv.ntab
+	if srv.discv4 != nil {
+		config.resolver = srv.discv4
 	}
 	if config.dialer == nil {
 		config.dialer = tcpDialer{&net.Dialer{Timeout: defaultDialTimeout}}
@@ -799,11 +809,11 @@ running:
 	srv.log.Trace("P2P networking is spinning down")
 
 	// Terminate discovery. If there is a running lookup it will terminate soon.
-	if srv.ntab != nil {
-		srv.ntab.Close()
+	if srv.discv4 != nil {
+		srv.discv4.Close()
 	}
-	if srv.DiscV5 != nil {
-		srv.DiscV5.Close()
+	if srv.discv5 != nil {
+		srv.discv5.Close()
 	}
 	// Disconnect all peers.
 	for _, p := range peers {


### PR DESCRIPTION
Node discovery periodically *revalidates* the nodes in its table by sending PING, checking if they are still alive. I recently noticed some issues with the implementation of this process, which can cause strange results such as nodes dropping unexpectedly, certain nodes not getting revalidated often enough, and bad results being returned to incoming FINDNODE queries.

Let me first describe how the revalidation process worked previously:

- We set a randomized timer < 10s. When that timer expires, a random bucket is chosen, and within that bucket the last node will be validated.
- The idea of revalidating the *last node* was taken from the original Kademlia paper. Certain contacts, such as incoming PING, will move nodes to the first position of the bucket. Other events (i.e. adding nodes from NODES responses) will put them in the back of the bucket. This is supposed to play out such that we always pick a node that requires revalidation the most because any successful contact moves it back to the front. The bucket behaves like a queue, basically.
- We first send a PING message to the chosen node. If it responds, we increase it's `livenessChecks` value by one. Since PONG also has the node's ENR sequence number, we request the node's new ENR when it has changed.
- If the node does not respond to PING, we immediately remove it from the bucket. In place of the old node, we put a random one from the bucket's *replacement cache* (a list of recently-encountered nodes). However, this only happens if the node is still the *last node* after revalidation. This condition exists because another event may have updated the node's position, in which case it shouldn't be removed.
- Finally, note there are some edge cases to consider. when we fetch an updated ENR from the node it can have an updated endpoint, which might not fit into the bucket/table IP limits anymore. In that case, we can't apply the update and just stick with the older ENR. We could also drop the node at that point, but it will be dropped later anyway if the node really isn't reachable on the old endpoint anymore.

Now on to issues with the above process:

- Revalidation is too slow. We check one node every 5s, and the table's top 10 buckets of 16 nodes are expected to be full at all times. Assuming an even distribution across all table members, we check each node every `160 * 5s == 13.3 min`. Note this time applies also to all nodes, even the ones freshly added to the table from a query. It's just too slow to maintain a healthy table.
- And the distribution isn't even. The concept of moving nodes around within the bucket made less sense the longer I looked at it, because it just complicates things in the implementation. Also, since the process chooses a random bucket and only then picks the node, nodes in deeper buckets will be revalidated more often simply because those buckets are usually less full. The distribution of revalidation requests across table nodes should be even because they may all go offline with an equal chance.
- Node replacement edge cases are mostly handled correctly by the current implementation, but it's really hard to follow the code, and I had a lot of trouble seeing through it. That part about not replacing the node if it's *not last anymore* is just useless. There is also at least one code path where nodes were deleted without choosing a replacement.

Here is my proposed design for the new revalidation process:

- We maintain two 'revalidation lists' containing the table nodes. The lists could be named 'fast' and 'slow'.
- The process chooses random nodes from each list on a randomized interval, the interval being faster for the 'fast' list, and performs revalidation for the chosen node.
- Whenever a node is newly inserted into the table, it goes into the 'fast' list. Once validation passes, it transfers to the 'slow' list. If a request fails, or the node changes endpoint, it transfers back into 'fast'.
- `livenessChecks` is incremented by one for successful checks. Unlike the old implementation, we will not drop the node on the first failing check. We instead quickly decay the `livenessChecks` by `/ 5` or so to give it another chance.
- Order of nodes in bucket doesn't matter anymore.
- I intend to write the implementation in a way that makes it easy to dynamically adjust the rate of revalidation requests if needed. This is important because the implementation also uses revalidation requests as an input to the endpoint predictor. We could increase activity if the predictor doesn't have enough statements, for example.
