### PR TITLE
cmd/utils: require TTD and difficulty to be zero at genesis for dev mode

### DIFF
--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -1872,13 +1872,15 @@ func SetEthConfig(ctx *cli.Context, stack *node.Node, cfg *ethconfig.Config) {
 					Fatalf("Could not read genesis from database: %v", err)
 				}
 				if !genesis.Config.TerminalTotalDifficultyPassed {
-					Fatalf("Bad developer-mode genesis configuration: terminalTotalDifficultyPassed must be true in developer mode")
+					Fatalf("Bad developer-mode genesis configuration: terminalTotalDifficultyPassed must be true")
 				}
 				if genesis.Config.TerminalTotalDifficulty == nil {
-					Fatalf("Bad developer-mode genesis configuration: terminalTotalDifficulty must be specified.")
+					Fatalf("Bad developer-mode genesis configuration: terminalTotalDifficulty must be specified")
+				} else if genesis.Config.TerminalTotalDifficulty.Cmp(big.NewInt(0)) != 0 {
+					Fatalf("Bad developer-mode genesis configuration: terminalTotalDifficulty must be 0")
 				}
-				if genesis.Difficulty.Cmp(genesis.Config.TerminalTotalDifficulty) != 1 {
-					Fatalf("Bad developer-mode genesis configuration: genesis block difficulty must be > terminalTotalDifficulty")
+				if genesis.Difficulty.Cmp(big.NewInt(0)) != 0 {
+					Fatalf("Bad developer-mode genesis configuration: difficulty must be 0")
 				}
 			}
 			chaindb.Close()


### PR DESCRIPTION
Related to #29469 as that doesn't seem resolved if the user sets their own genesis config. I also discovered TTD can be negative and I could trick the correct state by setting `TTD = -1` and `difficulty = 0` since 0 difficulty is what triggers the correct EVM rules. This PR also validates that negative values are not accepted.

---

If genesis config is set by the user, `difficulty` must be > TTD. However, if TTD is `0` and we are post-merge, setting `difficulty > 0` will use the wrong EVM fork rules and raise issues like:

```
WARN [04-18|09:34:02.022] Served eth_estimateGas                   reqid=3 duration="419.912µs" err="invalid opcode: PUSH0"
```

I'm not sure if this is the best way to resolve it but if the user can set both to `0` at genesis, that makes sense that we'd be in a state where the difficulty is `0` *and* we are at TTD - which seems to be required for correct EVM rules. Perhaps a better message is needed for when TTD is set to `0` and difficulty is `>0`. As of right now, that would just end up using incorrect EVM rules which might be confusing to the user.

I can confirm this works as expected for me. Setting `TTD = 0` and `difficulty = 0`, I get correct EVM rules. I can also no longer set `TTD = -1` and `difficulty = 0` to trick the EVM rules to trigger.

Thoughts?

---
edit: I think a better UX may be to only allow `TTD = 0` and `difficulty = 0` for dev mode (see my comment below). If that's the case I can force push the change here.

**Note: I've updated the code to be this latter option instead of validating any other values for TTD and difficulty.**