### PR TITLE
Allow signing nil data struct

### DIFF
--- a/signer/core/apitypes/types.go
+++ b/signer/core/apitypes/types.go
@@ -493,6 +493,10 @@ func (typedData *TypedData) EncodeData(primaryType string, data map[string]inter
 
 			buffer.Write(crypto.Keccak256(arrayBuffer.Bytes()))
 		} else if typedData.Types[field.Type] != nil {
+			if encValue == nil {
+				buffer.Write(common.Hash{}.Bytes())
+				continue
+			}
 			mapValue, ok := encValue.(map[string]interface{})
 			if !ok {
 				return nil, dataMismatchError(encType, encValue)

--- a/signer/core/signed_data_test.go
+++ b/signer/core/signed_data_test.go
@@ -359,15 +359,15 @@ func TestEncodeData(t *testing.T) {
 	}
 }
 
-func TestEncodeDataWithMissingParams(t *testing.T) {
+func TestWeakEncodeData(t *testing.T) {
 	t.Parallel()
-	hash, err := typedData.EncodeData(typedDataWithMissing.PrimaryType, typedDataWithMissing.Message, 0)
+	hash, err := typedData.WeakEncodeData(typedDataWithMissing.PrimaryType, typedDataWithMissing.Message, 0)
 	if err != nil {
 		t.Fatal(err)
 	}
 	dataEncoding := fmt.Sprintf("0x%s", common.Bytes2Hex(hash))
 	if dataEncoding != "0xa0cedeb2dc280ba39b857546d74f5549c3a1d7bdc2dd96bf881f76108e23dac20000000000000000000000000000000000000000000000000000000000000000cd54f074a4af31b4411ff6a60c9719dbd559c221c8ac3492d9d872b041d703d1b5aadf3154a261abdd9086fc627b61efca26ae5702701d05cd2305f7c52a2fc8" {
-		t.Errorf("Expected different encodeData result (got %s)", dataEncoding)
+		t.Errorf("Expected different weakEncodeData result (got %s)", dataEncoding)
 	}
 }
 

--- a/signer/core/signed_data_test.go
+++ b/signer/core/signed_data_test.go
@@ -182,6 +182,21 @@ var typedData = apitypes.TypedData{
 	Message:     messageStandard,
 }
 
+var messageWithMissingFrom = map[string]interface{}{
+	"to": map[string]interface{}{
+		"name":   "Bob",
+		"wallet": "0xbBbBBBBbbBBBbbbBbbBbbbbBBbBbbbbBbBbbBBbB",
+	},
+	"contents": "Hello, Bob!",
+}
+
+var typedDataWithMissing = apitypes.TypedData{
+	Types:       typesStandard,
+	PrimaryType: primaryType,
+	Domain:      domainStandard,
+	Message:     messageWithMissingFrom,
+}
+
 func TestSignData(t *testing.T) {
 	t.Parallel()
 	api, control := setup(t)
@@ -340,6 +355,18 @@ func TestEncodeData(t *testing.T) {
 	}
 	dataEncoding := fmt.Sprintf("0x%s", common.Bytes2Hex(hash))
 	if dataEncoding != "0xa0cedeb2dc280ba39b857546d74f5549c3a1d7bdc2dd96bf881f76108e23dac2fc71e5fa27ff56c350aa531bc129ebdf613b772b6604664f5d8dbe21b85eb0c8cd54f074a4af31b4411ff6a60c9719dbd559c221c8ac3492d9d872b041d703d1b5aadf3154a261abdd9086fc627b61efca26ae5702701d05cd2305f7c52a2fc8" {
+		t.Errorf("Expected different encodeData result (got %s)", dataEncoding)
+	}
+}
+
+func TestEncodeDataWithMissingParams(t *testing.T) {
+	t.Parallel()
+	hash, err := typedData.EncodeData(typedDataWithMissing.PrimaryType, typedDataWithMissing.Message, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	dataEncoding := fmt.Sprintf("0x%s", common.Bytes2Hex(hash))
+	if dataEncoding != "0xa0cedeb2dc280ba39b857546d74f5549c3a1d7bdc2dd96bf881f76108e23dac20000000000000000000000000000000000000000000000000000000000000000cd54f074a4af31b4411ff6a60c9719dbd559c221c8ac3492d9d872b041d703d1b5aadf3154a261abdd9086fc627b61efca26ae5702701d05cd2305f7c52a2fc8" {
 		t.Errorf("Expected different encodeData result (got %s)", dataEncoding)
 	}
 }


### PR DESCRIPTION
brower's wallet's `eth_signTypedData_v4` allows message to be missing certain param for struct. It seems they are using `0x0000000000000000000000000000000000000000` to encode missing data for a struct

For example, this piece of JS script is perfectly fine using metamask, but won't be able to verify using `apitypes.TypedData`
```
const RINKEBY_TESTNET_CHAIN_ID = "42161";

async function createEthereumSignedAuthToken(chainId = RINKEBY_TESTNET_CHAIN_ID) {
  // More info on typed data: https://docs.metamask.io/guide/signing-data.html#sign-typed-data-v4
  const typedData = JSON.stringify({
      "types": {
        "EIP712Domain": [
          {
            "name": "name",
            "type": "string"
          },
          {
            "name": "version",
            "type": "string"
          },
          {
            "name": "chainId",
            "type": "uint256"
          },
          {
            "name": "verifyingContract",
            "type": "address"
          }
        ],
        "Person": [
          {
            "name": "name",
            "type": "string"
          },
          {
            "name": "wallet",
            "type": "address"
          }
        ],
        "Mail": [
          {
            "name": "from",
            "type": "Person"
          },
          {
            "name": "to",
            "type": "Person"
          },
          {
            "name": "contents",
            "type": "string"
          }
        ]
      },
      "primaryType": "Mail",
      "domain": {
        "name": "Ether Mail",
        "version": "1",
        "chainId": "1",
        "verifyingContract": "0xCCCcccccCCCCcCCCCCCcCcCccCcCCCcCcccccccC"
      },
      "message": {
// the "from" is missed
        "to": {
          "name": "Bob",
          "wallet": "0xbBbBBBBbbBBBbbbBbbBbbbbBBbBbbbbBbBbbBBbB"
        },
        "contents": "Hello, Bob!"
      }
    });

  // this requests to connect wallet if it isn't already connected
  const accounts = await window.ethereum.request({ method: 'eth_requestAccounts' });

  var from = accounts[0];

  var params = [from, typedData];
  var method = 'eth_signTypedData_v4';

  const signature = await window.ethereum.request({ method, params });

  return JSON.stringify({
    address: from,
    typedData: btoa(typedData),
    signature,
  });
}
```