### PR TITLE
trie: move wg.Add(1) inside the loop and defer wg.Done() at the begin…

### DIFF
--- a/trie/hasher.go
+++ b/trie/hasher.go
@@ -112,9 +112,10 @@ func (h *hasher) hashFullNodeChildren(n *fullNode) (collapsed *fullNode, cached 
 	collapsed = n.copy()
 	if h.parallel {
 		var wg sync.WaitGroup
-		wg.Add(16)
 		for i := 0; i < 16; i++ {
+			wg.Add(1)
 			go func(i int) {
+				defer wg.Done()
 				hasher := newHasher(false)
 				if child := n.Children[i]; child != nil {
 					collapsed.Children[i], cached.Children[i] = hasher.hash(child, false)
@@ -122,7 +123,6 @@ func (h *hasher) hashFullNodeChildren(n *fullNode) (collapsed *fullNode, cached 
 					collapsed.Children[i] = nilValueNode
 				}
 				returnHasherToPool(hasher)
-				wg.Done()
 			}(i)
 		}
 		wg.Wait()


### PR DESCRIPTION
This commit optimizes the concurrent processing code by making the following changes:

1. Move the `wg.Add(1)` call inside the loop, so that it is called each time a new goroutine is started, instead of adding all the counts upfront. This avoids adding excessive counts at the beginning of the loop.

2. Move the `wg.Done()` call to the beginning of the goroutine using the `defer` keyword. This ensures that `wg.Done()` is always called when the goroutine exits, regardless of whether it exits normally or panics. By placing it at the beginning with `defer`, we guarantee that the count is properly balanced.

These changes improve the robustness and readability of the code by ensuring proper synchronization and avoiding potential issues with unbalanced counts.