### PR TITLE
bind: Preallocate capacity for fields slice

### DIFF
--- a/accounts/abi/bind/bind.go
+++ b/accounts/abi/bind/bind.go
@@ -395,7 +395,7 @@ func bindStructTypeGo(kind abi.Type, structs map[string]*tmplStruct) string {
 		}
 		var (
 			names  = make(map[string]bool)
-			fields []*tmplField
+			fields = make([]*tmplField, 0, len(kind.TupleElems))
 		)
 		for i, elem := range kind.TupleElems {
 			name := capitalise(kind.TupleRawNames[i])


### PR DESCRIPTION
We know the final length of the `fields` slice will be the same as `kind.TupleElems`, so we can preallocate the capacity upfront.

This avoids multiple memory allocations and array resizing when appending elements, making the code more efficient.