### PR TITLE
feat(txIndexer): genesis head remaining number sould be zero

### DIFF
--- a/core/txindexer.go
+++ b/core/txindexer.go
@@ -176,12 +176,9 @@ func (indexer *txIndexer) loop(chain *BlockChain) {
 
 // report returns the tx indexing progress.
 func (indexer *txIndexer) report(head uint64, tail *uint64) TxIndexProgress {
-	if head == 0 {
-		return TxIndexProgress{}
-	}
 	total := indexer.limit
 	if indexer.limit == 0 || total > head {
-		total = head + 1 // genesis included
+		total = head
 	}
 	var indexed uint64
 	if tail != nil {

--- a/core/txindexer.go
+++ b/core/txindexer.go
@@ -176,6 +176,9 @@ func (indexer *txIndexer) loop(chain *BlockChain) {
 
 // report returns the tx indexing progress.
 func (indexer *txIndexer) report(head uint64, tail *uint64) TxIndexProgress {
+	if head == 0 {
+		return TxIndexProgress{}
+	}
 	total := indexer.limit
 	if indexer.limit == 0 || total > head {
 		total = head + 1 // genesis included


### PR DESCRIPTION
When the block height is 0, calling "eth_syncing" returns "txIndexRemainingBlocks": "0x1", but txIndexer does not process the genesis block, this may not be correct. 