### PR TITLE
feat(index_error): move index error into core module

### DIFF
--- a/core/blockchain_reader.go
+++ b/core/blockchain_reader.go
@@ -277,12 +277,12 @@ func (bc *BlockChain) GetTransactionLookup(hash common.Hash) (*rawdb.LegacyTxLoo
 	if tx == nil {
 		progress, err := bc.TxIndexProgress()
 		if err != nil {
-			return nil, nil, nil
+			return nil, nil, err
 		}
 		// The transaction indexing is not finished yet, returning an
 		// error to explicitly indicate it.
 		if !progress.Done() {
-			return nil, nil, errors.New("transaction indexing still in progress")
+			return nil, nil, NewTxIndexingError()
 		}
 		// The transaction is already indexed, the transaction is either
 		// not existent or not in the range of index, returning null.

--- a/core/errors.go
+++ b/core/errors.go
@@ -108,3 +108,24 @@ var (
 	// ErrBlobTxCreate is returned if a blob transaction has no explicit to field.
 	ErrBlobTxCreate = errors.New("blob transaction of type create")
 )
+
+// TxIndexingError is an API error that indicates the transaction indexing is not
+// fully finished yet with JSON error code and a binary data blob.
+type TxIndexingError struct{}
+
+// NewTxIndexingError creates a TxIndexingError instance.
+func NewTxIndexingError() *TxIndexingError { return &TxIndexingError{} }
+
+// Error implement error interface, returning the error message.
+func (e *TxIndexingError) Error() string {
+	return "transaction indexing is in progress"
+}
+
+// ErrorCode returns the JSON error code for a revert.
+// See: https://github.com/ethereum/wiki/wiki/JSON-RPC-Error-Codes-Improvement-Proposal
+func (e *TxIndexingError) ErrorCode() int {
+	return -32000 // to be decided
+}
+
+// ErrorData returns the hex encoded revert reason.
+func (e *TxIndexingError) ErrorData() interface{} { return "transaction indexing is in progress" }

--- a/eth/tracers/api.go
+++ b/eth/tracers/api.go
@@ -830,7 +830,7 @@ func containsTx(block *types.Block, hash common.Hash) bool {
 func (api *API) TraceTransaction(ctx context.Context, hash common.Hash, config *TraceConfig) (interface{}, error) {
 	found, _, blockHash, blockNumber, index, err := api.backend.GetTransaction(ctx, hash)
 	if err != nil {
-		return nil, ethapi.NewTxIndexingError()
+		return nil, err
 	}
 	// Only mined txes are supported
 	if !found {

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -1642,10 +1642,7 @@ func (s *TransactionAPI) GetTransactionByHash(ctx context.Context, hash common.H
 		if tx := s.b.GetPoolTransaction(hash); tx != nil {
 			return NewRPCPendingTransaction(tx, s.b.CurrentHeader(), s.b.ChainConfig()), nil
 		}
-		if err == nil {
-			return nil, nil
-		}
-		return nil, NewTxIndexingError()
+		return nil, err
 	}
 	header, err := s.b.HeaderByHash(ctx, blockHash)
 	if err != nil {
@@ -1662,10 +1659,7 @@ func (s *TransactionAPI) GetRawTransactionByHash(ctx context.Context, hash commo
 		if tx = s.b.GetPoolTransaction(hash); tx != nil {
 			return tx.MarshalBinary()
 		}
-		if err == nil {
-			return nil, nil
-		}
-		return nil, NewTxIndexingError()
+		return nil, err
 	}
 	return tx.MarshalBinary()
 }
@@ -1674,7 +1668,7 @@ func (s *TransactionAPI) GetRawTransactionByHash(ctx context.Context, hash commo
 func (s *TransactionAPI) GetTransactionReceipt(ctx context.Context, hash common.Hash) (map[string]interface{}, error) {
 	found, tx, blockHash, blockNumber, index, err := s.b.GetTransaction(ctx, hash)
 	if err != nil {
-		return nil, NewTxIndexingError() // transaction is not fully indexed
+		return nil, err
 	}
 	if !found {
 		return nil, nil // transaction is not existent or reachable
@@ -2082,10 +2076,7 @@ func (s *DebugAPI) GetRawTransaction(ctx context.Context, hash common.Hash) (hex
 		if tx = s.b.GetPoolTransaction(hash); tx != nil {
 			return tx.MarshalBinary()
 		}
-		if err == nil {
-			return nil, nil
-		}
-		return nil, NewTxIndexingError()
+		return nil, err
 	}
 	return tx.MarshalBinary()
 }

--- a/internal/ethapi/errors.go
+++ b/internal/ethapi/errors.go
@@ -55,24 +55,3 @@ func newRevertError(revert []byte) *revertError {
 		reason: hexutil.Encode(revert),
 	}
 }
-
-// TxIndexingError is an API error that indicates the transaction indexing is not
-// fully finished yet with JSON error code and a binary data blob.
-type TxIndexingError struct{}
-
-// NewTxIndexingError creates a TxIndexingError instance.
-func NewTxIndexingError() *TxIndexingError { return &TxIndexingError{} }
-
-// Error implement error interface, returning the error message.
-func (e *TxIndexingError) Error() string {
-	return "transaction indexing is in progress"
-}
-
-// ErrorCode returns the JSON error code for a revert.
-// See: https://github.com/ethereum/wiki/wiki/JSON-RPC-Error-Codes-Improvement-Proposal
-func (e *TxIndexingError) ErrorCode() int {
-	return -32000 // to be decided
-}
-
-// ErrorData returns the hex encoded revert reason.
-func (e *TxIndexingError) ErrorData() interface{} { return "transaction indexing is in progress" }


### PR DESCRIPTION
Directly returning `NewTxIndexingError` in the `internal/ethapi` module may cover other types of errors.