### PR TITLE
p2p/discover: delete duplicate err check

### DIFF
--- a/p2p/discover/v4_udp.go
+++ b/p2p/discover/v4_udp.go
@@ -548,7 +548,7 @@ func (t *UDPv4) handlePacket(from *net.UDPAddr, buf []byte) error {
 	}
 	packet := t.wrapPacket(rawpacket)
 	fromID := fromKey.ID()
-	if err == nil && packet.preverify != nil {
+	if packet.preverify != nil {
 		err = packet.preverify(packet, from, fromID, fromKey)
 	}
 	t.log.Trace("<< "+packet.Name(), "id", fromID, "addr", from, "err", err)


### PR DESCRIPTION
`err` has been checked in line 545:
```
if err != nil {
    t.log.Debug("Bad discv4 packet", "addr", from, "err", err)
    return err
}
```