### PR TITLE
trie: preallocate map capacities

### DIFF
--- a/trie/tracer.go
+++ b/trie/tracer.go
@@ -93,9 +93,9 @@ func (t *tracer) reset() {
 // copy returns a deep copied tracer instance.
 func (t *tracer) copy() *tracer {
 	var (
-		inserts    = make(map[string]struct{})
-		deletes    = make(map[string]struct{})
-		accessList = make(map[string][]byte)
+		inserts    = make(map[string]struct{}, len(t.inserts))
+		deletes    = make(map[string]struct{}, len(t.deletes))
+		accessList = make(map[string][]byte, len(t.accessList))
 	)
 	for path := range t.inserts {
 		inserts[path] = struct{}{}


### PR DESCRIPTION
Preallocate capacities for `inserts`, `deletes`, and `accessList` maps based on the lengths of the original maps. This avoids multiple memory allocations and map resizing operations when adding elements.