### PR TITLE
metrics/librato: fix incorrect calculation of sumSquares

### DIFF
--- a/metrics/librato/librato.go
+++ b/metrics/librato/librato.go
@@ -62,22 +62,14 @@ func (rep *Reporter) Run() {
 // calculate sum of squares from data provided by metrics.Histogram
 // see http://en.wikipedia.org/wiki/Standard_deviation#Rapid_calculation_methods
 func sumSquares(icount int64, mean, stDev float64) float64 {
-	count := float64(icount)
-	sumSquared := math.Pow(count*mean, 2)
-	sumSquares := math.Pow(count*stDev, 2) + sumSquared/count
+	sumSquares := float64(icount) * (math.Pow(mean, 2) + math.Pow(stDev, 2))
 	if math.IsNaN(sumSquares) {
 		return 0.0
 	}
 	return sumSquares
 }
 func sumSquaresTimer(t metrics.TimerSnapshot) float64 {
-	count := float64(t.Count())
-	sumSquared := math.Pow(count*t.Mean(), 2)
-	sumSquares := math.Pow(count*t.StdDev(), 2) + sumSquared/count
-	if math.IsNaN(sumSquares) {
-		return 0.0
-	}
-	return sumSquares
+	return sumSquares(t.Count(), t.Mean(), t.StdDev())
 }
 
 func (rep *Reporter) BuildRequest(now time.Time, r metrics.Registry) (snapshot Batch, err error) {

--- a/metrics/librato/librato.go
+++ b/metrics/librato/librato.go
@@ -62,7 +62,7 @@ func (rep *Reporter) Run() {
 // calculate sum of squares from data provided by metrics.Histogram
 // see http://en.wikipedia.org/wiki/Standard_deviation#Rapid_calculation_methods
 func sumSquares(icount int64, mean, stDev float64) float64 {
-	sumSquares := float64(icount) * (math.Pow(mean, 2) + math.Pow(stDev, 2))
+	sumSquares := float64(icount) * (mean * mean + stDev * stDev)
 	if math.IsNaN(sumSquares) {
 		return 0.0
 	}


### PR DESCRIPTION
According to the wikipedia link, https://en.wikipedia.org/wiki/Standard_deviation#Rapid_calculation_methods
```
sumSquares := math.Pow(count*stDev, 2) + sumSquared/count
```
should be
```
sumSquares := (math.Pow(count*stDev, 2) + sumSquared)/count
```