### PR TITLE
fix(miner): fix typos

### DIFF
--- a/miner/worker.go
+++ b/miner/worker.go
@@ -339,7 +339,7 @@ func (miner *Miner) commitTransactions(env *environment, plainTxs, blobTxs *tran
 			continue
 		}
 		// Error may be ignored here. The error has already been checked
-		// during transaction acceptance is the transaction pool.
+		// during transaction acceptance in the transaction pool.
 		from, _ := types.Sender(env.signer, tx)
 
 		// Check whether the tx is replay protected. If we're not in the EIP155 hf


### PR DESCRIPTION
fix a typo in `miner/worker.go`