### PR TITLE
core/state: better randomized testing (postcheck) on journalling

### DIFF
--- a/core/state/access_list.go
+++ b/core/state/access_list.go
@@ -17,7 +17,10 @@
 package state
 
 import (
+	"fmt"
 	"maps"
+	"slices"
+	"strings"
 
 	"github.com/ethereum/go-ethereum/common"
 )
@@ -129,4 +132,35 @@ func (al *accessList) DeleteSlot(address common.Address, slot common.Hash) {
 // operations.
 func (al *accessList) DeleteAddress(address common.Address) {
 	delete(al.addresses, address)
+}
+
+// Equal returns true if the two access lists are identical
+func (al *accessList) Equal(other *accessList) bool {
+	if !maps.Equal(al.addresses, other.addresses) {
+		return false
+	}
+	return slices.EqualFunc(al.slots, other.slots,
+		func(m map[common.Hash]struct{}, m2 map[common.Hash]struct{}) bool {
+			return maps.Equal(m, m2)
+		})
+}
+
+func (al *accessList) PrettyPrint() string {
+	out := new(strings.Builder)
+	var sortedAddrs []common.Address
+	for addr, _ := range al.addresses {
+		sortedAddrs = append(sortedAddrs, addr)
+	}
+	slices.SortFunc(sortedAddrs, common.Address.Cmp)
+	for _, addr := range sortedAddrs {
+		idx := al.addresses[addr]
+		fmt.Fprintf(out, "%#x : (idx %d)\n", addr, idx)
+		if idx >= 0 {
+			slotmap := al.slots[idx]
+			for h, _ := range slotmap {
+				fmt.Fprintf(out, "    %#x\n", h)
+			}
+		}
+	}
+	return out.String()
 }

--- a/core/state/access_list.go
+++ b/core/state/access_list.go
@@ -149,7 +149,7 @@ func (al *accessList) Equal(other *accessList) bool {
 func (al *accessList) PrettyPrint() string {
 	out := new(strings.Builder)
 	var sortedAddrs []common.Address
-	for addr, _ := range al.addresses {
+	for addr := range al.addresses {
 		sortedAddrs = append(sortedAddrs, addr)
 	}
 	slices.SortFunc(sortedAddrs, common.Address.Cmp)
@@ -158,7 +158,7 @@ func (al *accessList) PrettyPrint() string {
 		fmt.Fprintf(out, "%#x : (idx %d)\n", addr, idx)
 		if idx >= 0 {
 			slotmap := al.slots[idx]
-			for h, _ := range slotmap {
+			for h := range slotmap {
 				fmt.Fprintf(out, "    %#x\n", h)
 			}
 		}

--- a/core/state/access_list.go
+++ b/core/state/access_list.go
@@ -145,6 +145,7 @@ func (al *accessList) Equal(other *accessList) bool {
 		})
 }
 
+// PrettyPrint prints the contents of the access list in a human-readable form
 func (al *accessList) PrettyPrint() string {
 	out := new(strings.Builder)
 	var sortedAddrs []common.Address

--- a/core/state/state_object.go
+++ b/core/state/state_object.go
@@ -459,22 +459,22 @@ func (s *stateObject) setBalance(amount *uint256.Int) {
 
 func (s *stateObject) deepCopy(db *StateDB) *stateObject {
 	obj := &stateObject{
-		db:       db,
-		address:  s.address,
-		addrHash: s.addrHash,
-		origin:   s.origin,
-		data:     s.data,
+		db:             db,
+		address:        s.address,
+		addrHash:       s.addrHash,
+		origin:         s.origin,
+		data:           s.data,
+		code:           s.code,
+		originStorage:  s.originStorage.Copy(),
+		pendingStorage: s.pendingStorage.Copy(),
+		dirtyStorage:   s.dirtyStorage.Copy(),
+		dirtyCode:      s.dirtyCode,
+		selfDestructed: s.selfDestructed,
+		newContract:    s.newContract,
 	}
 	if s.trie != nil {
 		obj.trie = db.db.CopyTrie(s.trie)
 	}
-	obj.code = s.code
-	obj.originStorage = s.originStorage.Copy()
-	obj.pendingStorage = s.pendingStorage.Copy()
-	obj.dirtyStorage = s.dirtyStorage.Copy()
-	obj.dirtyCode = s.dirtyCode
-	obj.selfDestructed = s.selfDestructed
-	obj.newContract = s.newContract
 	return obj
 }
 

--- a/core/state/statedb_test.go
+++ b/core/state/statedb_test.go
@@ -637,7 +637,6 @@ func (test *snapshotTest) checkEqual(state, checkstate *StateDB) error {
 					print(obj.dirtyStorage),
 					print(other.dirtyStorage))
 			}
-
 		}
 		// Check transient storage.
 		{

--- a/core/state/statedb_test.go
+++ b/core/state/statedb_test.go
@@ -601,6 +601,10 @@ func (test *snapshotTest) checkEqual(state, checkstate *StateDB) error {
 		checkeq("GetCode", state.GetCode(addr), checkstate.GetCode(addr))
 		checkeq("GetCodeHash", state.GetCodeHash(addr), checkstate.GetCodeHash(addr))
 		checkeq("GetCodeSize", state.GetCodeSize(addr), checkstate.GetCodeSize(addr))
+		// Check created-flag
+		if obj := state.getStateObject(addr); obj != nil {
+			checkeq("IsNewContract", obj.newContract, checkstate.getStateObject(addr).newContract)
+		}
 		// Check storage.
 		if obj := state.getStateObject(addr); obj != nil {
 			forEachStorage(state, addr, func(key, value common.Hash) bool {

--- a/core/state/transient_storage.go
+++ b/core/state/transient_storage.go
@@ -17,6 +17,10 @@
 package state
 
 import (
+	"fmt"
+	"slices"
+	"strings"
+
 	"github.com/ethereum/go-ethereum/common"
 )
 
@@ -30,10 +34,19 @@ func newTransientStorage() transientStorage {
 
 // Set sets the transient-storage `value` for `key` at the given `addr`.
 func (t transientStorage) Set(addr common.Address, key, value common.Hash) {
-	if _, ok := t[addr]; !ok {
-		t[addr] = make(Storage)
+	if value == (common.Hash{}) { // this is a 'delete'
+		if _, ok := t[addr]; ok {
+			delete(t[addr], key)
+			if len(t[addr]) == 0 {
+				delete(t, addr)
+			}
+		}
+	} else {
+		if _, ok := t[addr]; !ok {
+			t[addr] = make(Storage)
+		}
+		t[addr][key] = value
 	}
-	t[addr][key] = value
 }
 
 // Get gets the transient storage for `key` at the given `addr`.
@@ -52,4 +65,27 @@ func (t transientStorage) Copy() transientStorage {
 		storage[key] = value.Copy()
 	}
 	return storage
+}
+
+func (t transientStorage) PrettyPrint() string {
+	out := new(strings.Builder)
+	var sortedAddrs []common.Address
+	for addr := range t {
+		sortedAddrs = append(sortedAddrs, addr)
+		slices.SortFunc(sortedAddrs, common.Address.Cmp)
+	}
+
+	for _, addr := range sortedAddrs {
+		fmt.Fprintf(out, "%#x:", addr)
+		var sortedKeys []common.Hash
+		storage := t[addr]
+		for key := range storage {
+			sortedKeys = append(sortedKeys, key)
+		}
+		slices.SortFunc(sortedKeys, common.Hash.Cmp)
+		for _, key := range sortedKeys {
+			fmt.Fprintf(out, "  %X : %X\n", key, storage[key])
+		}
+	}
+	return out.String()
 }

--- a/core/state/transient_storage.go
+++ b/core/state/transient_storage.go
@@ -67,6 +67,7 @@ func (t transientStorage) Copy() transientStorage {
 	return storage
 }
 
+// PrettyPrint prints the contents of the access list in a human-readable form
 func (t transientStorage) PrettyPrint() string {
 	out := new(strings.Builder)
 	var sortedAddrs []common.Address


### PR DESCRIPTION
This PR fixes some flaws with the existing tests, which I discovered while working on a different journalling system. 

The randomized testing (`TestSnapshotRandom`) executes a series of steps which modify the state and create journal-events. 
Later on, we compare the forward-going-states against the backwards-unrolling-journal-states, and check that they are identical. 

The "identical" check is performed using various accessors. It turned out that we failed to check some things: the accesslist contents and the transient storage contents. 

After we remove the account reset operation in https://github.com/ethereum/go-ethereum/pull/29520, we should also add accessors/checks for `newContract`