### PR TITLE
core/tracing: Add OnClose Trace Hook

### DIFF
--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -1153,13 +1153,13 @@ func (bc *BlockChain) Stop() {
 			}
 		}
 	}
-	// Close the trie database, release all the held resources as the last step.
-	if err := bc.triedb.Close(); err != nil {
-		log.Error("Failed to close trie database", "err", err)
-	}
 	// Allow tracers to clean-up and release resources.
 	if bc.logger != nil && bc.logger.OnClose != nil {
 		bc.logger.OnClose()
+	}
+	// Close the trie database, release all the held resources as the last step.
+	if err := bc.triedb.Close(); err != nil {
+		log.Error("Failed to close trie database", "err", err)
 	}
 	log.Info("Blockchain stopped")
 }

--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -1157,6 +1157,10 @@ func (bc *BlockChain) Stop() {
 	if err := bc.triedb.Close(); err != nil {
 		log.Error("Failed to close trie database", "err", err)
 	}
+	// Allow tracers to clean-up and release resources.
+	if bc.logger != nil && bc.logger.OnClose != nil {
+		bc.logger.OnClose()
+	}
 	log.Info("Blockchain stopped")
 }
 

--- a/core/tracing/hooks.go
+++ b/core/tracing/hooks.go
@@ -107,6 +107,9 @@ type (
 	// BlockchainInitHook is called when the blockchain is initialized.
 	BlockchainInitHook = func(chainConfig *params.ChainConfig)
 
+	// CloseHook is called when the blockchain closes.
+	CloseHook = func()
+
 	// BlockStartHook is called before executing `block`.
 	// `td` is the total difficulty prior to `block`.
 	BlockStartHook = func(event BlockEvent)
@@ -153,6 +156,7 @@ type Hooks struct {
 	OnGasChange GasChangeHook
 	// Chain events
 	OnBlockchainInit BlockchainInitHook
+	OnClose          CloseHook
 	OnBlockStart     BlockStartHook
 	OnBlockEnd       BlockEndHook
 	OnSkippedBlock   SkippedBlockHook


### PR DESCRIPTION
The `OnClose` trace hook is being triggered on blockchain Stop, so as tracers can release any resources.