### PR TITLE
console: preallocate slice capacities

### DIFF
--- a/console/bridge.go
+++ b/console/bridge.go
@@ -406,7 +406,7 @@ func (b *bridge) Send(call jsre.Call) (goja.Value, error) {
 	}
 
 	// Execute the requests.
-	var resps []*goja.Object
+	resps := make([]*goja.Object, 0, len(reqs))
 	for _, req := range reqs {
 		resp := call.VM.NewObject()
 		resp.Set("jsonrpc", "2.0")


### PR DESCRIPTION
Change resps slice declaration to preallocate its capacity based on the length of reqs. 

This optimizes memory allocation and avoids unnecessary slice resizing during appending.