### PR TITLE
EIP-XXXX: AuthCreate

### DIFF
--- a/core/tracing/hooks.go
+++ b/core/tracing/hooks.go
@@ -268,6 +268,8 @@ const (
 	GasChangeCallStorageColdAccess GasChangeReason = 13
 	// GasChangeCallFailedExecution is the burning of the remaining gas when the execution failed without a revert.
 	GasChangeCallFailedExecution GasChangeReason = 14
+	// GasChangeContractCreation is the amount of gas that will be burned for a AUTH_CREATE.
+	GasChangeCallAuthCreation GasChangeReason = 15
 
 	// GasChangeIgnored is a special value that can be used to indicate that the gas change should be ignored as
 	// it will be "manually" tracked by a direct emit of the gas change event.

--- a/core/vm/eips.go
+++ b/core/vm/eips.go
@@ -319,3 +319,14 @@ func enable6780(jt *JumpTable) {
 		maxStack:    maxStack(1, 0),
 	}
 }
+
+func enableXXXX(jt *JumpTable) {
+	jt[AUTH_CREATE] = &operation{
+		execute:     opAuthCreate,
+		constantGas: params.AuthCreateGas,
+		dynamicGas:  gasAuthCreate,
+		minStack:    minStack(3, 1),
+		maxStack:    maxStack(3, 1),
+		memorySize:  memoryAuthCreate,
+	}
+}

--- a/core/vm/errors.go
+++ b/core/vm/errors.go
@@ -38,6 +38,7 @@ var (
 	ErrGasUintOverflow          = errors.New("gas uint64 overflow")
 	ErrInvalidCode              = errors.New("invalid code: must not begin with 0xef")
 	ErrNonceUintOverflow        = errors.New("nonce uint64 overflow")
+	ErrAuthCreateSigType        = errors.New("auth_create signature type not found ")
 
 	// errStopToken is an internal token indicating interpreter loop termination,
 	// never returned to outside callers.

--- a/core/vm/gas_table.go
+++ b/core/vm/gas_table.go
@@ -484,3 +484,20 @@ func gasSelfdestruct(evm *EVM, contract *Contract, stack *Stack, mem *Memory, me
 	}
 	return gas, nil
 }
+
+func gasAuthCreate(evm *EVM, contract *Contract, stack *Stack, mem *Memory, memorySize uint64) (uint64, error) {
+	gas, err := memoryGasCost(mem, memorySize)
+	if err != nil {
+		return 0, err
+	}
+	size, overflow := stack.Back(2).Uint64WithOverflow()
+	if overflow || size > params.MaxInitCodeSize {
+		return 0, ErrGasUintOverflow
+	}
+	// Since size <= params.MaxInitCodeSize, these multiplication cannot overflow
+	moreGas := (params.InitCodeWordGas + params.Keccak256WordGas) * ((size + 31) / 32)
+	if gas, overflow = math.SafeAdd(gas, moreGas); overflow {
+		return 0, ErrGasUintOverflow
+	}
+	return gas, nil
+}

--- a/core/vm/interpreter.go
+++ b/core/vm/interpreter.go
@@ -99,6 +99,8 @@ func NewEVMInterpreter(evm *EVM) *EVMInterpreter {
 	// If jump table was not initialised we set the default one.
 	var table *JumpTable
 	switch {
+	case evm.chainRules.IsPrague:
+		table = &pragueInstructionSet
 	case evm.chainRules.IsCancun:
 		table = &cancunInstructionSet
 	case evm.chainRules.IsShanghai:

--- a/core/vm/jump_table.go
+++ b/core/vm/jump_table.go
@@ -57,6 +57,7 @@ var (
 	mergeInstructionSet            = newMergeInstructionSet()
 	shanghaiInstructionSet         = newShanghaiInstructionSet()
 	cancunInstructionSet           = newCancunInstructionSet()
+	pragueInstructionSet           = newPraugeInstructionSet()
 )
 
 // JumpTable contains the EVM opcodes supported at a given fork.
@@ -78,6 +79,12 @@ func validate(jt JumpTable) JumpTable {
 		}
 	}
 	return jt
+}
+
+func newPraugeInstructionSet() JumpTable {
+	instructionSet := newCancunInstructionSet()
+	enableXXXX(&instructionSet) // EIP-XXXX AuthCreate
+	return validate(instructionSet)
 }
 
 func newCancunInstructionSet() JumpTable {

--- a/core/vm/memory_table.go
+++ b/core/vm/memory_table.go
@@ -64,6 +64,10 @@ func memoryCreate2(stack *Stack) (uint64, bool) {
 	return calcMemSize64(stack.Back(1), stack.Back(2))
 }
 
+func memoryAuthCreate(stack *Stack) (uint64, bool) {
+	return calcMemSize64(stack.Back(1), stack.Back(2))
+}
+
 func memoryCall(stack *Stack) (uint64, bool) {
 	x, overflow := calcMemSize64(stack.Back(5), stack.Back(6))
 	if overflow {

--- a/core/vm/opcodes.go
+++ b/core/vm/opcodes.go
@@ -217,6 +217,7 @@ const (
 	RETURN       OpCode = 0xf3
 	DELEGATECALL OpCode = 0xf4
 	CREATE2      OpCode = 0xf5
+	AUTH_CREATE  OpCode = 0xf6
 
 	STATICCALL   OpCode = 0xfa
 	REVERT       OpCode = 0xfd
@@ -391,6 +392,7 @@ var opCodeToString = [256]string{
 	CALLCODE:     "CALLCODE",
 	DELEGATECALL: "DELEGATECALL",
 	CREATE2:      "CREATE2",
+	AUTH_CREATE:  "AUTH_CREATE",
 	STATICCALL:   "STATICCALL",
 	REVERT:       "REVERT",
 	INVALID:      "INVALID",
@@ -548,6 +550,7 @@ var stringToOp = map[string]OpCode{
 	"LOG4":           LOG4,
 	"CREATE":         CREATE,
 	"CREATE2":        CREATE2,
+	"AUTH_CREATE":    AUTH_CREATE,
 	"CALL":           CALL,
 	"RETURN":         RETURN,
 	"CALLCODE":       CALLCODE,

--- a/params/config.go
+++ b/params/config.go
@@ -184,6 +184,7 @@ var (
 		GrayGlacierBlock:              big.NewInt(0),
 		ShanghaiTime:                  newUint64(0),
 		CancunTime:                    newUint64(0),
+		PragueTime:                    newUint64(0),
 		TerminalTotalDifficulty:       big.NewInt(0),
 		TerminalTotalDifficultyPassed: true,
 	}

--- a/params/protocol_params.go
+++ b/params/protocol_params.go
@@ -86,6 +86,7 @@ const (
 	LogTopicGas           uint64 = 375   // Multiplied by the * of the LOG*, per LOG transaction. e.g. LOG0 incurs 0 * c_txLogTopicGas, LOG4 incurs 4 * c_txLogTopicGas.
 	CreateGas             uint64 = 32000 // Once per CREATE operation & contract-creation transaction.
 	Create2Gas            uint64 = 32000 // Once per CREATE2 operation
+	AuthCreateGas         uint64 = 32000 // Once per CREATE2 operation
 	SelfdestructRefundGas uint64 = 24000 // Refunded following a selfdestruct operation.
 	MemoryGas             uint64 = 3     // Times the address of the (highest referenced byte in memory + 1). NOTE: referencing happens on read, write and in instructions such as RETURN and CALL.
 
@@ -187,5 +188,6 @@ var (
 	// BeaconRootsAddress is the address where historical beacon roots are stored as per EIP-4788
 	BeaconRootsAddress = common.HexToAddress("0x000F3df6D732807Ef1319fB7B8bB8522d0Beac02")
 	// SystemAddress is where the system-transaction is sent from as per EIP-4788
-	SystemAddress = common.HexToAddress("0xfffffffffffffffffffffffffffffffffffffffe")
+	SystemAddress   = common.HexToAddress("0xfffffffffffffffffffffffffffffffffffffffe")
+	AuthCreateMagic = byte(0x04)
 )


### PR DESCRIPTION
## Abstract

This EIP introduces an EVM instruction `AUTH_CREATE`. It allows an externally owned account (EOA) to migrate to a smart contract.

AuthCreate = Ecrecover(secp256k1,secp256r1) + Create2

[auth_create demo](https://github.com/txgyy/go-ethereum/tree/EIP-XXXX)

## Motivation

First, I would like to thank [EIP-3074](./eip-3074.md) for its inspiration, although I do not agree with it: if Ethereum's goal is 'FULL-AA', it should not permit proposals that merely enhance EOAs for short-term benefits.

This proposal mainly aims to address three issues, all closely related to AAs:

1. The cost for EOA users to migrate to AA is too high; this proposal helps EOA accounts directly upgrade to AA.
2. In a multi-chain environment, it is difficult for AA accounts to ensure consistent addresses across different chains; this proposal directly uses EOA addresses as AA addresses.
3. Once Ethereum supports [EIP-7012](./eip-7012.md), it will enable users to upgrade to AA using methods such as passkeys.
