### PR TITLE
params: fix consensus config string representations

### DIFF
--- a/params/config.go
+++ b/params/config.go
@@ -392,7 +392,7 @@ func (c *CliqueConfig) String() string {
 	if c == nil {
 		return "<nil>"
 	}
-	return fmt.Sprintf("Clique { Period: %d, Epoch: %d }", c.Period, c.Epoch)
+	return fmt.Sprintf("clique { period: %d, epoch: %d }", c.Period, c.Epoch)
 }
 
 // Description returns a human-readable description of ChainConfig.

--- a/params/config.go
+++ b/params/config.go
@@ -375,6 +375,9 @@ type EthashConfig struct{}
 
 // String implements the stringer interface, returning the consensus engine details.
 func (c *EthashConfig) String() string {
+	if c == nil {
+		return "<nil>"
+	}
 	return "ethash"
 }
 
@@ -386,7 +389,10 @@ type CliqueConfig struct {
 
 // String implements the stringer interface, returning the consensus engine details.
 func (c *CliqueConfig) String() string {
-	return "clique"
+	if c == nil {
+		return "<nil>"
+	}
+	return fmt.Sprintf("Clique { Period: %d, Epoch: %d }", c.Period, c.Epoch)
 }
 
 // Description returns a human-readable description of ChainConfig.


### PR DESCRIPTION
These should at least indicate whether the object is nil.