### PR TITLE
core/vm: add subgroup checks for mul/mulexp for G1/G2

### DIFF
--- a/core/vm/contracts.go
+++ b/core/vm/contracts.go
@@ -734,6 +734,11 @@ func (c *bls12381G1Mul) Run(input []byte) ([]byte, error) {
 	if p0, err = decodePointG1(input[:128]); err != nil {
 		return nil, err
 	}
+	// 'point is on curve' check already done,
+	// Here we need to apply subgroup checks.
+	if !p0.IsInSubGroup() {
+		return nil, errBLS12381G1PointSubgroup
+	}
 	// Decode scalar value
 	e := new(big.Int).SetBytes(input[128:])
 
@@ -786,6 +791,11 @@ func (c *bls12381G1MultiExp) Run(input []byte) ([]byte, error) {
 		p, err := decodePointG1(input[t0:t1])
 		if err != nil {
 			return nil, err
+		}
+		// 'point is on curve' check already done,
+		// Here we need to apply subgroup checks.
+		if !p.IsInSubGroup() {
+			return nil, errBLS12381G1PointSubgroup
 		}
 		points[i] = *p
 		// Decode scalar value
@@ -857,6 +867,11 @@ func (c *bls12381G2Mul) Run(input []byte) ([]byte, error) {
 	if p0, err = decodePointG2(input[:256]); err != nil {
 		return nil, err
 	}
+	// 'point is on curve' check already done,
+	// Here we need to apply subgroup checks.
+	if !p0.IsInSubGroup() {
+		return nil, errBLS12381G2PointSubgroup
+	}
 	// Decode scalar value
 	e := new(big.Int).SetBytes(input[256:])
 
@@ -909,6 +924,11 @@ func (c *bls12381G2MultiExp) Run(input []byte) ([]byte, error) {
 		p, err := decodePointG2(input[t0:t1])
 		if err != nil {
 			return nil, err
+		}
+		// 'point is on curve' check already done,
+		// Here we need to apply subgroup checks.
+		if !p.IsInSubGroup() {
+			return nil, errBLS12381G2PointSubgroup
 		}
 		points[i] = *p
 		// Decode scalar value

--- a/core/vm/contracts.go
+++ b/core/vm/contracts.go
@@ -705,6 +705,8 @@ func (c *bls12381G1Add) Run(input []byte) ([]byte, error) {
 		return nil, err
 	}
 
+	// No need to check the subgroup here, as specified by EIP-2537
+
 	// Compute r = p_0 + p_1
 	p0.Add(p0, p1)
 
@@ -836,6 +838,8 @@ func (c *bls12381G2Add) Run(input []byte) ([]byte, error) {
 	if p1, err = decodePointG2(input[256:]); err != nil {
 		return nil, err
 	}
+
+	// No need to check the subgroup here, as specified by EIP-2537
 
 	// Compute r = p_0 + p_1
 	r := new(bls12381.G2Affine)


### PR DESCRIPTION
Adds the subgroup checks as required by the current spec: https://github.com/ethereum/EIPs/pull/8456/files