### PR TITLE
core/state: storage journal entry should revert dirtyness too

### DIFF
--- a/core/state/journal.go
+++ b/core/state/journal.go
@@ -129,8 +129,9 @@ type (
 		prev    uint64
 	}
 	storageChange struct {
-		account       *common.Address
-		key, prevalue common.Hash
+		account   *common.Address
+		key       common.Hash
+		prevvalue *common.Hash
 	}
 	codeChange struct {
 		account            *common.Address
@@ -277,7 +278,7 @@ func (ch codeChange) copy() journalEntry {
 }
 
 func (ch storageChange) revert(s *StateDB) {
-	s.getStateObject(*ch.account).setState(ch.key, ch.prevalue)
+	s.getStateObject(*ch.account).setState(ch.key, ch.prevvalue)
 }
 
 func (ch storageChange) dirtied() *common.Address {
@@ -286,9 +287,9 @@ func (ch storageChange) dirtied() *common.Address {
 
 func (ch storageChange) copy() journalEntry {
 	return storageChange{
-		account:  ch.account,
-		key:      ch.key,
-		prevalue: ch.prevalue,
+		account:   ch.account,
+		key:       ch.key,
+		prevvalue: ch.prevvalue,
 	}
 }
 


### PR DESCRIPTION
Currently our state journal tracks each storage update to a contract, having the ability to revert those changes to the previously set value.

For the very first modification however, it behaves a bit wonky. Reverting the update doesn't actually remove the dirty-ness of the slot, rather leaves it as "change this slot to it's original value". This can cause issues down the line with for example write witnesses needing to gather an unneeded proof.

This PR modifies the `storageChange` journal entry to not only track the previous value of a slot, but also whether there was any previous value at all set in the current execution context. In essence, the PR **changes the semantic of `storageChange` so it *does not* simply track storage changes, rather it tracks *dirty storage changes*, an important distinction for being able to cleanly revert the journal item.**

I do not expect any performance impact whatsoever, even if we load a few slots fewer. The PR is more about correctness to handle a corner-case that would bubble up in later code.