### PR TITLE
params: clarify consensus engine config `String`s

### DIFF
--- a/params/config.go
+++ b/params/config.go
@@ -374,7 +374,7 @@ type ChainConfig struct {
 type EthashConfig struct{}
 
 // String implements the stringer interface, returning the consensus engine details.
-func (c *EthashConfig) String() string {
+func (c EthashConfig) String() string {
 	return "ethash"
 }
 
@@ -385,8 +385,8 @@ type CliqueConfig struct {
 }
 
 // String implements the stringer interface, returning the consensus engine details.
-func (c *CliqueConfig) String() string {
-	return "clique"
+func (c CliqueConfig) String() string {
+	return fmt.Sprintf("clique(period: %d, epoch: %d)", c.Period, c.Epoch)
 }
 
 // Description returns a human-readable description of ChainConfig.


### PR DESCRIPTION
- Defines the `String()` methods on a value receiever so that nil is shown differently.
- Adds the parameters to the representation for `CliqueConfig`.

Currently these config objects will display the same whether they're nil or present. For example, this chain config:
```json
{
  "chainId": 1212,
  "homesteadBlock": 0,
  "eip150Block": 0,
  "eip155Block": 0,
  "eip158Block": 0,
  "byzantiumBlock": 0,
  "constantinopleBlock": 0,
  "petersburgBlock": 0,
  "istanbulBlock": 0,
  "berlinBlock": 0,
  "londonBlock": 0,
  "mergeNetsplitBlock": 0,
  "terminalTotalDifficulty": 0,
  "shanghaiTime": 0,
  "cancunTime": 0
}
```
when printed with `%+v`, shows as (note `Ethash:ethash Clique:clique` at the end):
```
&{ChainID:+1212 HomesteadBlock:+0 DAOForkBlock:<nil> DAOForkSupport:false EIP150Block:+0 EIP155Block:+0 EIP158Block:+0 ByzantiumBlock:+0 ConstantinopleBlock:+0 PetersburgBlock:+0 IstanbulBlock:+0 MuirGlacierBlock:<nil> BerlinBlock:+0 LondonBlock:+0 ArrowGlacierBlock:<nil> GrayGlacierBlock:<nil> MergeNetsplitBlock:+0 ShanghaiTime:0x14000312da0 CancunTime:0x14000312da8 PragueTime:<nil> VerkleTime:<nil> TerminalTotalDifficulty:+0 Ethash:ethash Clique:clique}
```

With this change, we see `Ethash:<nil> Clique:<nil>`.

If we add a `clique` key to the config:
```json
{
  "chainId": 1212,
  "homesteadBlock": 0,
  "eip150Block": 0,
  "eip155Block": 0,
  "eip158Block": 0,
  "byzantiumBlock": 0,
  "constantinopleBlock": 0,
  "petersburgBlock": 0,
  "istanbulBlock": 0,
  "berlinBlock": 0,
  "londonBlock": 0,
  "mergeNetsplitBlock": 0,
  "terminalTotalDifficulty": 0,
  "shanghaiTime": 0,
  "cancunTime": 0,
  "clique": {
    "period": 5,
    "epoch": 30000
  }
}
```
and print it, it currently shows identically to the first one (`Ethash:ethash Clique:clique`).

With this change we see `Ethash:<nil> Clique:clique(period: 5, epoch: 30000)`.
This makes it more clear which engines are and are not active.

This is revised from https://github.com/ethereum/go-ethereum/pull/29635.