### PR TITLE
feat(pathdb): simplify path layerTree logic

### DIFF
--- a/triedb/pathdb/layertree.go
+++ b/triedb/pathdb/layertree.go
@@ -185,10 +185,9 @@ func (tree *layerTree) cap(root common.Hash, layers int) error {
 		}
 		delete(children, root)
 	}
-	for root, layer := range tree.layers {
-		if dl, ok := layer.(*diskLayer); ok && dl.isStale() {
-			remove(root)
-		}
+	// diskLayer only has one and is the bottom layer.
+	if dl := tree.bottom(); dl.isStale() {
+		remove(root)
 	}
 	return nil
 }

--- a/triedb/pathdb/layertree.go
+++ b/triedb/pathdb/layertree.go
@@ -186,8 +186,8 @@ func (tree *layerTree) cap(root common.Hash, layers int) error {
 		delete(children, root)
 	}
 	// diskLayer only has one and is the bottom layer.
-	if dl := tree.bottom(); dl.isStale() {
-		remove(root)
+	if dl := tree.bottom(); dl != nil && dl.isStale() {
+		remove(dl.root)
 	}
 	return nil
 }

--- a/triedb/pathdb/layertree.go
+++ b/triedb/pathdb/layertree.go
@@ -187,7 +187,7 @@ func (tree *layerTree) cap(root common.Hash, layers int) error {
 	}
 	// diskLayer only has one and is the bottom layer.
 	if dl := tree.bottom(); dl != nil && dl.isStale() {
-		remove(dl.root)
+		remove(dl.rootHash())
 	}
 	return nil
 }


### PR DESCRIPTION
`diskLayer` only has one and is the bottom layer, so don't need to use for loop. Is this right?