### PR TITLE
feat(pathdb): nitpicking change

### DIFF
--- a/triedb/pathdb/database_test.go
+++ b/triedb/pathdb/database_test.go
@@ -145,8 +145,8 @@ func (t *tester) randAccount() (common.Address, []byte) {
 func (t *tester) generateStorage(ctx *genctx, addr common.Address) common.Hash {
 	var (
 		addrHash = crypto.Keccak256Hash(addr.Bytes())
-		storage  = make(map[common.Hash][]byte)
-		origin   = make(map[common.Hash][]byte)
+		storage  = make(map[common.Hash][]byte, 10)
+		origin   = make(map[common.Hash][]byte, 10)
 	)
 	for i := 0; i < 10; i++ {
 		v, _ := rlp.EncodeToBytes(common.TrimLeftZeroes(testrand.Bytes(32)))
@@ -195,8 +195,8 @@ func (t *tester) mutateStorage(ctx *genctx, addr common.Address, root common.Has
 func (t *tester) clearStorage(ctx *genctx, addr common.Address, root common.Hash) common.Hash {
 	var (
 		addrHash = crypto.Keccak256Hash(addr.Bytes())
-		storage  = make(map[common.Hash][]byte)
-		origin   = make(map[common.Hash][]byte)
+		storage  = make(map[common.Hash][]byte, len(t.storages[addrHash]))
+		origin   = make(map[common.Hash][]byte, len(t.storages[addrHash]))
 	)
 	for hash, val := range t.storages[addrHash] {
 		origin[hash] = val

--- a/triedb/pathdb/difflayer_test.go
+++ b/triedb/pathdb/difflayer_test.go
@@ -62,8 +62,7 @@ func benchmarkSearch(b *testing.B, depth int, total int) {
 	)
 	// First, we set up 128 diff layers, with 3K items each
 	fill := func(parent layer, index int) *diffLayer {
-		nodes := make(map[common.Hash]map[string]*trienode.Node)
-		nodes[common.Hash{}] = make(map[string]*trienode.Node)
+		nodes := map[common.Hash]map[string]*trienode.Node{common.Hash{}: make(map[string]*trienode.Node, 3000)}
 		for i := 0; i < 3000; i++ {
 			var (
 				path = testrand.Bytes(32)
@@ -108,8 +107,7 @@ func benchmarkSearch(b *testing.B, depth int, total int) {
 func BenchmarkPersist(b *testing.B) {
 	// First, we set up 128 diff layers, with 3K items each
 	fill := func(parent layer) *diffLayer {
-		nodes := make(map[common.Hash]map[string]*trienode.Node)
-		nodes[common.Hash{}] = make(map[string]*trienode.Node)
+		nodes := map[common.Hash]map[string]*trienode.Node{common.Hash{}: make(map[string]*trienode.Node, 3000)}
 		for i := 0; i < 3000; i++ {
 			var (
 				path = testrand.Bytes(32)
@@ -146,8 +144,7 @@ func BenchmarkJournal(b *testing.B) {
 
 	// First, we set up 128 diff layers, with 3K items each
 	fill := func(parent layer) *diffLayer {
-		nodes := make(map[common.Hash]map[string]*trienode.Node)
-		nodes[common.Hash{}] = make(map[string]*trienode.Node)
+		nodes := map[common.Hash]map[string]*trienode.Node{common.Hash{}: make(map[string]*trienode.Node, 3000)}
 		for i := 0; i < 3000; i++ {
 			var (
 				path = testrand.Bytes(32)

--- a/triedb/pathdb/history_test.go
+++ b/triedb/pathdb/history_test.go
@@ -34,8 +34,8 @@ import (
 // randomStateSet generates a random state change set.
 func randomStateSet(n int) *triestate.Set {
 	var (
-		accounts = make(map[common.Address][]byte)
-		storages = make(map[common.Address]map[common.Hash][]byte)
+		accounts = make(map[common.Address][]byte, n)
+		storages = make(map[common.Address]map[common.Hash][]byte, n)
 	)
 	for i := 0; i < n; i++ {
 		addr := testrand.Address()
@@ -154,8 +154,8 @@ func TestTruncateHeadHistory(t *testing.T) {
 
 func TestTruncateTailHistory(t *testing.T) {
 	var (
-		roots      []common.Hash
 		hs         = makeHistories(10)
+		roots      = make([]common.Hash, 0, len(hs))
 		db         = rawdb.NewMemoryDatabase()
 		freezer, _ = openFreezer(t.TempDir(), false)
 	)
@@ -197,12 +197,11 @@ func TestTruncateTailHistories(t *testing.T) {
 	}
 	for i, c := range cases {
 		var (
-			roots      []common.Hash
 			hs         = makeHistories(10)
+			roots      = make([]common.Hash, 0, len(hs))
 			db         = rawdb.NewMemoryDatabase()
 			freezer, _ = openFreezer(t.TempDir()+fmt.Sprintf("%d", i), false)
 		)
-		defer freezer.Close()
 
 		for i := 0; i < len(hs); i++ {
 			accountData, storageData, accountIndex, storageIndex := hs[i].encode()
@@ -221,6 +220,8 @@ func TestTruncateTailHistories(t *testing.T) {
 			checkHistoriesInRange(t, db, freezer, uint64(1), c.maxPruned, roots[:tail], false)
 			checkHistoriesInRange(t, db, freezer, c.minUnpruned, uint64(10), roots[tail:], true)
 		}
+
+		freezer.Close()
 	}
 }
 


### PR DESCRIPTION
- pre-allocate capacity for map if it is too big.
- avoid using `defer` in `for` loop.