### PR TITLE
core: deploy EIP-4788 contract in dev mode genesis

### DIFF
--- a/core/chain_makers_test.go
+++ b/core/chain_makers_test.go
@@ -43,12 +43,11 @@ func TestGeneratePOSChain(t *testing.T) {
 		bb      = common.Address{0xbb}
 		funds   = big.NewInt(0).Mul(big.NewInt(1337), big.NewInt(params.Ether))
 		config  = *params.AllEthashProtocolChanges
-		asm4788 = params.BeaconRootsCode
 		gspec   = &Genesis{
 			Config: &config,
 			Alloc: types.GenesisAlloc{
 				address:                   {Balance: funds},
-				params.BeaconRootsAddress: {Balance: common.Big0, Code: asm4788},
+				params.BeaconRootsAddress: {Balance: common.Big0, Code: params.BeaconRootsCode},
 			},
 			BaseFee:    big.NewInt(params.InitialBaseFee),
 			Difficulty: common.Big1,

--- a/core/chain_makers_test.go
+++ b/core/chain_makers_test.go
@@ -47,7 +47,7 @@ func TestGeneratePOSChain(t *testing.T) {
 			Config: &config,
 			Alloc: types.GenesisAlloc{
 				address:                   {Balance: funds},
-				params.BeaconRootsAddress: {Balance: common.Big0, Code: params.BeaconRootsCode},
+				params.BeaconRootsAddress: {Code: params.BeaconRootsCode},
 			},
 			BaseFee:    big.NewInt(params.InitialBaseFee),
 			Difficulty: common.Big1,

--- a/core/chain_makers_test.go
+++ b/core/chain_makers_test.go
@@ -43,7 +43,7 @@ func TestGeneratePOSChain(t *testing.T) {
 		bb      = common.Address{0xbb}
 		funds   = big.NewInt(0).Mul(big.NewInt(1337), big.NewInt(params.Ether))
 		config  = *params.AllEthashProtocolChanges
-		asm4788 = common.Hex2Bytes("3373fffffffffffffffffffffffffffffffffffffffe14604d57602036146024575f5ffd5b5f35801560495762001fff810690815414603c575f5ffd5b62001fff01545f5260205ff35b5f5ffd5b62001fff42064281555f359062001fff015500")
+		asm4788 = params.BeaconRootsCode
 		gspec   = &Genesis{
 			Config: &config,
 			Alloc: types.GenesisAlloc{

--- a/core/genesis.go
+++ b/core/genesis.go
@@ -593,11 +593,10 @@ func DeveloperGenesisBlock(gasLimit uint64, faucet *common.Address) *Genesis {
 			common.BytesToAddress([]byte{7}): {Balance: big.NewInt(1)}, // ECScalarMul
 			common.BytesToAddress([]byte{8}): {Balance: big.NewInt(1)}, // ECPairing
 			common.BytesToAddress([]byte{9}): {Balance: big.NewInt(1)}, // BLAKE2b
+			// Pre-deploy EIP-4788 system contract
+			params.BeaconRootsAddress: types.Account{Code: params.BeaconRootsCode},
 		},
 	}
-	// Pre-deploy EIP-4788 system contract
-	genesis.Alloc[params.BeaconRootsAddress] = types.Account{Code: params.BeaconRootsCode}
-	
 	if faucet != nil {
 		genesis.Alloc[*faucet] = types.Account{Balance: new(big.Int).Sub(new(big.Int).Lsh(big.NewInt(1), 256), big.NewInt(9))}
 	}

--- a/core/genesis.go
+++ b/core/genesis.go
@@ -595,6 +595,9 @@ func DeveloperGenesisBlock(gasLimit uint64, faucet *common.Address) *Genesis {
 			common.BytesToAddress([]byte{9}): {Balance: big.NewInt(1)}, // BLAKE2b
 		},
 	}
+	// Pre-deploy EIP-4788 system contract
+	genesis.Alloc[params.BeaconRootsAddress] = types.Account{Code: params.BeaconRootsCode}
+	
 	if faucet != nil {
 		genesis.Alloc[*faucet] = types.Account{Balance: new(big.Int).Sub(new(big.Int).Lsh(big.NewInt(1), 256), big.NewInt(9))}
 	}

--- a/core/genesis.go
+++ b/core/genesis.go
@@ -594,7 +594,7 @@ func DeveloperGenesisBlock(gasLimit uint64, faucet *common.Address) *Genesis {
 			common.BytesToAddress([]byte{8}): {Balance: big.NewInt(1)}, // ECPairing
 			common.BytesToAddress([]byte{9}): {Balance: big.NewInt(1)}, // BLAKE2b
 			// Pre-deploy EIP-4788 system contract
-			params.BeaconRootsAddress: types.Account{Code: params.BeaconRootsCode},
+			params.BeaconRootsAddress: types.Account{Nonce: 1, Code: params.BeaconRootsCode},
 		},
 	}
 	if faucet != nil {

--- a/params/protocol_params.go
+++ b/params/protocol_params.go
@@ -188,7 +188,7 @@ var (
 	BeaconRootsAddress = common.HexToAddress("0x000F3df6D732807Ef1319fB7B8bB8522d0Beac02")
 
 	// BeaconRootsCode is the code where historical beacon roots are stored as per EIP-4788
-	BeaconRootsCode = []byte("3373fffffffffffffffffffffffffffffffffffffffe14604d57602036146024575f5ffd5b5f35801560495762001fff810690815414603c575f5ffd5b62001fff01545f5260205ff35b5f5ffd5b62001fff42064281555f359062001fff015500")
+	BeaconRootsCode = common.FromHex("3373fffffffffffffffffffffffffffffffffffffffe14604d57602036146024575f5ffd5b5f35801560495762001fff810690815414603c575f5ffd5b62001fff01545f5260205ff35b5f5ffd5b62001fff42064281555f359062001fff015500")
 	
 	// SystemAddress is where the system-transaction is sent from as per EIP-4788
 	SystemAddress = common.HexToAddress("0xfffffffffffffffffffffffffffffffffffffffe")

--- a/params/protocol_params.go
+++ b/params/protocol_params.go
@@ -189,7 +189,7 @@ var (
 
 	// BeaconRootsCode is the code where historical beacon roots are stored as per EIP-4788
 	BeaconRootsCode = common.FromHex("3373fffffffffffffffffffffffffffffffffffffffe14604d57602036146024575f5ffd5b5f35801560495762001fff810690815414603c575f5ffd5b62001fff01545f5260205ff35b5f5ffd5b62001fff42064281555f359062001fff015500")
-	
+
 	// SystemAddress is where the system-transaction is sent from as per EIP-4788
 	SystemAddress = common.HexToAddress("0xfffffffffffffffffffffffffffffffffffffffe")
 )

--- a/params/protocol_params.go
+++ b/params/protocol_params.go
@@ -186,6 +186,10 @@ var (
 
 	// BeaconRootsAddress is the address where historical beacon roots are stored as per EIP-4788
 	BeaconRootsAddress = common.HexToAddress("0x000F3df6D732807Ef1319fB7B8bB8522d0Beac02")
+
+	// BeaconRootsCode is the code where historical beacon roots are stored as per EIP-4788
+	BeaconRootsCode = []byte("3373fffffffffffffffffffffffffffffffffffffffe14604d57602036146024575f5ffd5b5f35801560495762001fff810690815414603c575f5ffd5b62001fff01545f5260205ff35b5f5ffd5b62001fff42064281555f359062001fff015500")
+	
 	// SystemAddress is where the system-transaction is sent from as per EIP-4788
 	SystemAddress = common.HexToAddress("0xfffffffffffffffffffffffffffffffffffffffe")
 )


### PR DESCRIPTION
Dev/Private chain setup now supports EIP-4788 at Genesis block.

Took `BeaconRootsCode` from [here](https://github.com/lightclient/4788asm?tab=readme-ov-file#building) and then added to `Alloc`.

Result on console:
`> eth.call({ from: eth.accounts[0], input: '0x5f6020818181720f3df6d732807ef1319fb7b8bb8522d0beac024282525afa1460275760205ff35b5f80fd' })
"0x0000000000000000000000000000000000000000000000000000000000000000"`


Fixes #29539 