### PR TITLE
core/state: revert pending storage updates if they revert to original

### DIFF
--- a/core/state/state_object.go
+++ b/core/state/state_object.go
@@ -27,6 +27,7 @@ import (
 	"github.com/ethereum/go-ethereum/core/tracing"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/rlp"
 	"github.com/ethereum/go-ethereum/trie/trienode"
 	"github.com/holiman/uint256"
@@ -255,9 +256,16 @@ func (s *stateObject) setState(key common.Hash, value *common.Hash) {
 func (s *stateObject) finalise(prefetch bool) {
 	slotsToPrefetch := make([][]byte, 0, len(s.dirtyStorage))
 	for key, value := range s.dirtyStorage {
-		s.pendingStorage[key] = value
+		// If the slot is different from its original value, move it into the
+		// pending area to be committed at the end of the block (and prefetch
+		// the pathways).
 		if value != s.originStorage[key] {
+			s.pendingStorage[key] = value
 			slotsToPrefetch = append(slotsToPrefetch, common.CopyBytes(key[:])) // Copy needed for closure
+		} else {
+			// Otherwise, the slot was reverted to its original value, remove it
+			// from the pending area to avoid thrashing the data strutures.
+			delete(s.pendingStorage, key)
 		}
 	}
 	if s.db.prefetcher != nil && prefetch && len(slotsToPrefetch) > 0 && s.data.Root != types.EmptyRootHash {
@@ -370,6 +378,11 @@ func (s *stateObject) updateTrie() (Trie, error) {
 			return nil, err
 		}
 		s.db.StorageDeleted += 1
+	}
+	// If no slots were touched, issue a warning as we shouldn't have done all
+	// the above work in the first place
+	if len(usedStorage) == 0 {
+		log.Error("State object update was noop", "addr", s.address, "slots", len(s.pendingStorage))
 	}
 	if s.db.prefetcher != nil {
 		s.db.prefetcher.used(s.addrHash, s.data.Root, usedStorage)


### PR DESCRIPTION
There are two cases in state object updates that have unexpected leftovers:

- Single tx sets slot from A -> B -> A. In this case the current code will mark the slot marked as updated, but won't prefetch it (that part was smarter). Later the commit (`stateObject.updateTrie`) will try to fetch the trie from the prefetcher, failing, after which it makes a fresh one from the db, only to throw it out because the slot didn't really change.
- Tx1 sets slot from A -> B; after which tx2 sets the same slot from B -> A within the same block. The effect is similar, but the cause slightly different. Tx1 marks the slot updated, and tx2 leaves it as updated, even though it reverted to it's original.

The fix in this PR is fairly simple: whenever a slot is change back to it's original (during tx finalization), remove the update marker off of it (pending).

The PR also adds a log to stateObject.updateTrie to detect if we missed a similar case and be noisy about it.

![Screenshot 2024-04-26 at 11 11 44](https://github.com/ethereum/go-ethereum/assets/129561/69b264ef-3ef0-49ab-95c2-6f56cfba2e86)