### PR TITLE
core/state: move metrics out of state objects

### DIFF
--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -68,7 +68,6 @@ var (
 	accountCommitTimer = metrics.NewRegisteredResettingTimer("chain/account/commits", nil)
 
 	storageReadTimer   = metrics.NewRegisteredResettingTimer("chain/storage/reads", nil)
-	storageHashTimer   = metrics.NewRegisteredResettingTimer("chain/storage/hashes", nil)
 	storageUpdateTimer = metrics.NewRegisteredResettingTimer("chain/storage/updates", nil)
 	storageCommitTimer = metrics.NewRegisteredResettingTimer("chain/storage/commits", nil)
 
@@ -1937,8 +1936,7 @@ func (bc *BlockChain) processBlock(block *types.Block, statedb *state.StateDB, s
 	accountUpdateTimer.Update(statedb.AccountUpdates)               // Account updates are complete(in validation)
 	storageUpdateTimer.Update(statedb.StorageUpdates)               // Storage updates are complete(in validation)
 	accountHashTimer.Update(statedb.AccountHashes)                  // Account hashes are complete(in validation)
-	storageHashTimer.Update(statedb.StorageHashes)                  // Storage hashes are complete(in validation)
-	triehash := statedb.AccountHashes + statedb.StorageHashes       // The time spent on tries hashing
+	triehash := statedb.AccountHashes                               // The time spent on tries hashing
 	trieUpdate := statedb.AccountUpdates + statedb.StorageUpdates   // The time spent on tries update
 	trieRead := statedb.SnapshotAccountReads + statedb.AccountReads // The time spent on account read
 	trieRead += statedb.SnapshotStorageReads + statedb.StorageReads // The time spent on storage read

--- a/core/state/state_object.go
+++ b/core/state/state_object.go
@@ -294,9 +294,6 @@ func (s *stateObject) updateTrie() (Trie, error) {
 	if len(s.pendingStorage) == 0 {
 		return s.trie, nil
 	}
-	// Track the amount of time wasted on updating the storage trie
-	defer func(start time.Time) { s.db.StorageUpdates += time.Since(start) }(time.Now())
-
 	// The snapshot storage map for the object
 	var (
 		storage map[common.Hash][]byte
@@ -400,9 +397,6 @@ func (s *stateObject) updateRoot() {
 	if err != nil || tr == nil {
 		return
 	}
-	// Track the amount of time wasted on hashing the storage trie
-	defer func(start time.Time) { s.db.StorageHashes += time.Since(start) }(time.Now())
-
 	s.data.Root = tr.Hash()
 }
 
@@ -415,9 +409,6 @@ func (s *stateObject) commit() (*trienode.NodeSet, error) {
 		s.origin = s.data.Copy()
 		return nil, nil
 	}
-	// Track the amount of time wasted on committing the storage trie
-	defer func(start time.Time) { s.db.StorageCommits += time.Since(start) }(time.Now())
-
 	// The trie is currently in an open state and could potentially contain
 	// cached mutations. Call commit to acquire a set of nodes that have been
 	// modified, the set can be nil if nothing to commit.


### PR DESCRIPTION
This PR is more of a prep thing and maaaaybe (?) a very light performance optimization.

Currently we're trying to measure things very accurately when it comes to state object updates, hashes and commits. The only problem is that there are *a lot* of these, and many will have insignificant runtimes (maybe update 1 slot?). The overhead of retriving system timers and updating metrics might be more than teh actual computation of 1 slot. Due to that, this PR moves the metering a bit to the outside. It does mean we lose the ability to differentiate between storage update and storage hash, but I doubt it's really relevant given that we can only change so many slots in a block.

On the other hand, moving these metrics out does a few useful cleanups: state objects don't start poking at statedb fields directly. It was a fairly bad design (yeah, there's plenty left). The other cleanup is that if we want to make any of the above operations (update, hash, commit) concurrent across state objects, then measuring them individually becomes noise; we want the real time across all of them, not the sum of times elapsed concurrently. This PR also does the prep work for that.