### PR TITLE
core/vm: remove a redundant zero check in opAddmod

### DIFF
--- a/core/vm/instructions.go
+++ b/core/vm/instructions.go
@@ -173,11 +173,7 @@ func opByte(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([]byt
 
 func opAddmod(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([]byte, error) {
 	x, y, z := scope.Stack.pop(), scope.Stack.pop(), scope.Stack.peek()
-	if z.IsZero() {
-		z.Clear()
-	} else {
-		z.AddMod(&x, &y, z)
-	}
+	z.AddMod(&x, &y, z)
 	return nil, nil
 }
 


### PR DESCRIPTION
zero check has been added to `uint256.AddMod` since this commit https://github.com/holiman/uint256/commit/6785da6e3eea403260a5760029e722aa4ff1716d