### PR TITLE
trie/trienode: minor speedup in nodeset merging

### DIFF
--- a/trie/trienode/node.go
+++ b/trie/trienode/node.go
@@ -114,7 +114,12 @@ func (set *NodeSet) Merge(owner common.Hash, nodes map[string]*Node) error {
 				set.updates -= 1
 			}
 		}
-		set.AddNode([]byte(path), node)
+		if node.IsDeleted() {
+			set.deletes += 1
+		} else {
+			set.updates += 1
+		}
+		set.Nodes[path] = node
 	}
 	return nil
 }

--- a/trie/trienode/node_test.go
+++ b/trie/trienode/node_test.go
@@ -1,0 +1,61 @@
+// Copyright 2023 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>
+
+package trienode
+
+import (
+	"crypto/rand"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/crypto"
+)
+
+func BenchmarkMerge(b *testing.B) {
+	b.Run("1K", func(b *testing.B) {
+		benchmarkMerge(b, 1000)
+	})
+	b.Run("10K", func(b *testing.B) {
+		benchmarkMerge(b, 10_000)
+	})
+}
+func benchmarkMerge(b *testing.B, count int) {
+	x := NewNodeSet(common.Hash{})
+	y := NewNodeSet(common.Hash{})
+	addNode := func(s *NodeSet) {
+		path := make([]byte, 4)
+		rand.Read(path)
+		blob := make([]byte, 32)
+		rand.Read(blob)
+		hash := crypto.Keccak256Hash(blob)
+		s.AddNode(path, New(hash, blob))
+	}
+	for i := 0; i < count; i++ {
+		// Random path of 4 nibbles
+		addNode(x)
+		addNode(y)
+	}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		// Store set x into a backup
+		z := NewNodeSet(common.Hash{})
+		z.Merge(common.Hash{}, x.Nodes)
+		// Merge y into x
+		x.Merge(common.Hash{}, y.Nodes)
+		x = z
+	}
+
+}

--- a/trie/trienode/node_test.go
+++ b/trie/trienode/node_test.go
@@ -32,6 +32,7 @@ func BenchmarkMerge(b *testing.B) {
 		benchmarkMerge(b, 10_000)
 	})
 }
+
 func benchmarkMerge(b *testing.B, count int) {
 	x := NewNodeSet(common.Hash{})
 	y := NewNodeSet(common.Hash{})
@@ -57,5 +58,4 @@ func benchmarkMerge(b *testing.B, count int) {
 		x.Merge(common.Hash{}, y.Nodes)
 		x = z
 	}
-
 }


### PR DESCRIPTION
Shaves off a bit of alloc during nodes merge
```
name         old time/op    new time/op    delta
Merge/1K-8      600µs ± 7%     544µs ± 4%   -9.26%  (p=0.000 n=9+10)
Merge/10K-8    5.99ms ± 8%    5.48ms ± 7%   -8.64%  (p=0.000 n=10+10)

name         old alloc/op   new alloc/op   delta
Merge/1K-8      252kB ± 0%     244kB ± 0%   -3.17%  (p=0.000 n=8+10)
Merge/10K-8    2.02MB ± 0%    1.94MB ± 0%   -3.96%  (p=0.000 n=10+10)

name         old allocs/op  new allocs/op  delta
Merge/1K-8      2.08k ± 0%     0.08k ± 0%  -96.29%  (p=0.000 n=10+9)
Merge/10K-8     20.6k ± 0%      0.6k ± 1%  -97.31%  (p=0.000 n=10+10)
```