### PR TITLE
ethdb/pebble: fix pebble metrics registration

### DIFF
--- a/ethdb/pebble/pebble.go
+++ b/ethdb/pebble/pebble.go
@@ -240,19 +240,19 @@ func New(file string, cache int, handles int, namespace string, readonly bool, e
 	}
 	db.db = innerDB
 
-	db.compTimeMeter = metrics.NewRegisteredMeter(namespace+"compact/time", nil)
-	db.compReadMeter = metrics.NewRegisteredMeter(namespace+"compact/input", nil)
-	db.compWriteMeter = metrics.NewRegisteredMeter(namespace+"compact/output", nil)
-	db.diskSizeGauge = metrics.NewRegisteredGauge(namespace+"disk/size", nil)
-	db.diskReadMeter = metrics.NewRegisteredMeter(namespace+"disk/read", nil)
-	db.diskWriteMeter = metrics.NewRegisteredMeter(namespace+"disk/write", nil)
-	db.writeDelayMeter = metrics.NewRegisteredMeter(namespace+"compact/writedelay/duration", nil)
-	db.writeDelayNMeter = metrics.NewRegisteredMeter(namespace+"compact/writedelay/counter", nil)
-	db.memCompGauge = metrics.NewRegisteredGauge(namespace+"compact/memory", nil)
-	db.level0CompGauge = metrics.NewRegisteredGauge(namespace+"compact/level0", nil)
-	db.nonlevel0CompGauge = metrics.NewRegisteredGauge(namespace+"compact/nonlevel0", nil)
-	db.seekCompGauge = metrics.NewRegisteredGauge(namespace+"compact/seek", nil)
-	db.manualMemAllocGauge = metrics.NewRegisteredGauge(namespace+"memory/manualalloc", nil)
+	db.compTimeMeter = metrics.GetOrRegisterMeter(namespace+"compact/time", nil)
+	db.compReadMeter = metrics.GetOrRegisterMeter(namespace+"compact/input", nil)
+	db.compWriteMeter = metrics.GetOrRegisterMeter(namespace+"compact/output", nil)
+	db.diskSizeGauge = metrics.GetOrRegisterGauge(namespace+"disk/size", nil)
+	db.diskReadMeter = metrics.GetOrRegisterMeter(namespace+"disk/read", nil)
+	db.diskWriteMeter = metrics.GetOrRegisterMeter(namespace+"disk/write", nil)
+	db.writeDelayMeter = metrics.GetOrRegisterMeter(namespace+"compact/writedelay/duration", nil)
+	db.writeDelayNMeter = metrics.GetOrRegisterMeter(namespace+"compact/writedelay/counter", nil)
+	db.memCompGauge = metrics.GetOrRegisterGauge(namespace+"compact/memory", nil)
+	db.level0CompGauge = metrics.GetOrRegisterGauge(namespace+"compact/level0", nil)
+	db.nonlevel0CompGauge = metrics.GetOrRegisterGauge(namespace+"compact/nonlevel0", nil)
+	db.seekCompGauge = metrics.GetOrRegisterGauge(namespace+"compact/seek", nil)
+	db.manualMemAllocGauge = metrics.GetOrRegisterGauge(namespace+"memory/manualalloc", nil)
 
 	// Start up the metrics gathering and return
 	go db.meter(metricsGatheringInterval, namespace)
@@ -543,7 +543,7 @@ func (d *Database) meter(refresh time.Duration, namespace string) {
 		for i, level := range stats.Levels {
 			// Append metrics for additional layers
 			if i >= len(d.levelsGauge) {
-				d.levelsGauge = append(d.levelsGauge, metrics.NewRegisteredGauge(namespace+fmt.Sprintf("tables/level%v", i), nil))
+				d.levelsGauge = append(d.levelsGauge, metrics.GetOrRegisterGauge(namespace+fmt.Sprintf("tables/level%v", i), nil))
 			}
 			d.levelsGauge[i].Update(level.NumFiles)
 		}


### PR DESCRIPTION
Pebble gauge metrics are stuck when opening a database for the second time (within the same metrics namespace, after closing first one). 

Gauge metrics are created with `metrics.NewRegisteredGauge` and it fails silently if metric name already exists. The Meter metrics work despite that `metrics.NewRegisteredMeter` is used, because it calls `metrics.GetOrRegisterMeter` internally.

This PR fixes the issue by using `metrics.GetOrRegister*` functions instead.