### PR TITLE
eth/gasestimator: include blobs in virtual balance computation

### DIFF
--- a/eth/gasestimator/gasestimator.go
+++ b/eth/gasestimator/gasestimator.go
@@ -83,6 +83,9 @@ func Estimate(ctx context.Context, call *core.Message, opts *Options, gasCap uin
 		if opts.Config.IsCancun(opts.Header.Number, opts.Header.Time) && len(call.BlobHashes) > 0 {
 			blobBalanceUsage := new(big.Int).SetInt64(int64(len(call.BlobHashes) * params.BlobTxBlobGasPerBlob))
 			blobBalanceUsage.Mul(blobBalanceUsage, call.BlobGasFeeCap)
+			if blobBalanceUsage.Cmp(available) >= 0 {
+				return 0, nil, core.ErrInsufficientFunds
+			}
 			available.Sub(available, blobBalanceUsage)
 		}
 		allowance := new(big.Int).Div(available, feeCap)

--- a/eth/gasestimator/gasestimator.go
+++ b/eth/gasestimator/gasestimator.go
@@ -80,6 +80,11 @@ func Estimate(ctx context.Context, call *core.Message, opts *Options, gasCap uin
 			}
 			available.Sub(available, call.Value)
 		}
+		if opts.Config.IsCancun(opts.Header.Number, opts.Header.Time) && len(call.BlobHashes) > 0 {
+			blobBalanceUsage := new(big.Int).SetInt64(int64(len(call.BlobHashes) * params.BlobTxBlobGasPerBlob))
+			blobBalanceUsage.Mul(blobBalanceUsage, call.BlobGasFeeCap)
+			available.Sub(available, blobBalanceUsage)
+		}
 		allowance := new(big.Int).Div(available, feeCap)
 
 		// If the allowance is larger than maximum uint64, skip checking

--- a/eth/gasestimator/gasestimator.go
+++ b/eth/gasestimator/gasestimator.go
@@ -81,7 +81,7 @@ func Estimate(ctx context.Context, call *core.Message, opts *Options, gasCap uin
 			available.Sub(available, call.Value)
 		}
 		if opts.Config.IsCancun(opts.Header.Number, opts.Header.Time) && len(call.BlobHashes) > 0 {
-			blobBalanceUsage := new(big.Int).SetInt64(int64(len(call.BlobHashes) * params.BlobTxBlobGasPerBlob))
+			blobBalanceUsage := new(big.Int).SetInt64(int64(len(call.BlobHashes)) * params.BlobTxBlobGasPerBlob)
 			blobBalanceUsage.Mul(blobBalanceUsage, call.BlobGasFeeCap)
 			if blobBalanceUsage.Cmp(available) >= 0 {
 				return 0, nil, core.ErrInsufficientFunds

--- a/eth/gasestimator/gasestimator.go
+++ b/eth/gasestimator/gasestimator.go
@@ -81,7 +81,9 @@ func Estimate(ctx context.Context, call *core.Message, opts *Options, gasCap uin
 			available.Sub(available, call.Value)
 		}
 		if opts.Config.IsCancun(opts.Header.Number, opts.Header.Time) && len(call.BlobHashes) > 0 {
-			blobBalanceUsage := new(big.Int).SetInt64(int64(len(call.BlobHashes)) * params.BlobTxBlobGasPerBlob)
+			blobGasPerBlob := new(big.Int).SetInt64(params.BlobTxBlobGasPerBlob)
+			blobBalanceUsage := new(big.Int).SetInt64(int64(len(call.BlobHashes)))
+			blobBalanceUsage.Mul(blobBalanceUsage, blobGasPerBlob)
 			blobBalanceUsage.Mul(blobBalanceUsage, call.BlobGasFeeCap)
 			if blobBalanceUsage.Cmp(available) >= 0 {
 				return 0, nil, core.ErrInsufficientFunds


### PR DESCRIPTION
Fix for the bug descripted on https://github.com/ethereum/go-ethereum/issues/29702 -- I no longer see the bug.

I am new to go-ethereum codebase, so I may have missed things, please tell me :-)

Also, would you like some test with it? 