### PR TITLE
New nodes map with capacity

### DIFF
--- a/core/state/statedb.go
+++ b/core/state/statedb.go
@@ -947,7 +947,7 @@ func (s *StateDB) fastDeleteStorage(addrHash common.Hash, root common.Hash) (com
 
 	var (
 		size  common.StorageSize
-		nodes = trienode.NewNodeSet(addrHash)
+		nodes = trienode.NewNodeSet(addrHash, 0)
 		slots = make(map[common.Hash][]byte)
 	)
 	stack := trie.NewStackTrie(func(path []byte, hash common.Hash, blob []byte) {
@@ -989,7 +989,7 @@ func (s *StateDB) slowDeleteStorage(addr common.Address, addrHash common.Hash, r
 	}
 	var (
 		size  common.StorageSize
-		nodes = trienode.NewNodeSet(addrHash)
+		nodes = trienode.NewNodeSet(addrHash, 0)
 		slots = make(map[common.Hash][]byte)
 	)
 	for it.Next(true) {

--- a/trie/trie.go
+++ b/trie/trie.go
@@ -622,7 +622,7 @@ func (t *Trie) Commit(collectLeaf bool) (common.Hash, *trienode.NodeSet, error) 
 		if len(paths) == 0 {
 			return types.EmptyRootHash, nil, nil // case (a)
 		}
-		nodes := trienode.NewNodeSet(t.owner)
+		nodes := trienode.NewNodeSet(t.owner, len(paths))
 		for _, path := range paths {
 			nodes.AddNode([]byte(path), trienode.NewDeleted())
 		}
@@ -640,7 +640,7 @@ func (t *Trie) Commit(collectLeaf bool) (common.Hash, *trienode.NodeSet, error) 
 		t.root = hashedNode
 		return rootHash, nil, nil
 	}
-	nodes := trienode.NewNodeSet(t.owner)
+	nodes := trienode.NewNodeSet(t.owner, len(t.tracer.deletedNodes()))
 	for _, path := range t.tracer.deletedNodes() {
 		nodes.AddNode([]byte(path), trienode.NewDeleted())
 	}

--- a/trie/trienode/node.go
+++ b/trie/trienode/node.go
@@ -68,10 +68,10 @@ type NodeSet struct {
 
 // NewNodeSet initializes a node set. The owner is zero for the account trie and
 // the owning account address hash for storage tries.
-func NewNodeSet(owner common.Hash) *NodeSet {
+func NewNodeSet(owner common.Hash, capacity int) *NodeSet {
 	return &NodeSet{
 		Owner: owner,
-		Nodes: make(map[string]*Node),
+		Nodes: make(map[string]*Node, capacity),
 	}
 }
 
@@ -186,7 +186,7 @@ func (set *MergedNodeSet) Merge(other *NodeSet) error {
 
 // Flatten returns a two-dimensional map for internal nodes.
 func (set *MergedNodeSet) Flatten() map[common.Hash]map[string]*Node {
-	nodes := make(map[common.Hash]map[string]*Node)
+	nodes := make(map[common.Hash]map[string]*Node, len(set.Sets))
 	for owner, set := range set.Sets {
 		nodes[owner] = set.Nodes
 	}

--- a/trie/trienode/node_test.go
+++ b/trie/trienode/node_test.go
@@ -34,8 +34,8 @@ func BenchmarkMerge(b *testing.B) {
 }
 
 func benchmarkMerge(b *testing.B, count int) {
-	x := NewNodeSet(common.Hash{})
-	y := NewNodeSet(common.Hash{})
+	x := NewNodeSet(common.Hash{}, count)
+	y := NewNodeSet(common.Hash{}, count)
 	addNode := func(s *NodeSet) {
 		path := make([]byte, 4)
 		rand.Read(path)
@@ -52,7 +52,7 @@ func benchmarkMerge(b *testing.B, count int) {
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		// Store set x into a backup
-		z := NewNodeSet(common.Hash{})
+		z := NewNodeSet(common.Hash{}, len(x.Nodes))
 		z.Merge(common.Hash{}, x.Nodes)
 		// Merge y into x
 		x.Merge(common.Hash{}, y.Nodes)

--- a/trie/verkle.go
+++ b/trie/verkle.go
@@ -226,7 +226,7 @@ func (t *VerkleTrie) Commit(_ bool) (common.Hash, *trienode.NodeSet, error) {
 	if err != nil {
 		return common.Hash{}, nil, fmt.Errorf("serializing tree nodes: %s", err)
 	}
-	nodeset := trienode.NewNodeSet(common.Hash{})
+	nodeset := trienode.NewNodeSet(common.Hash{}, len(nodes))
 	for _, node := range nodes {
 		// hash parameter is not used in pathdb
 		nodeset.AddNode(node.Path, trienode.New(common.Hash{}, node.SerializedBytes))

--- a/triedb/pathdb/testutils.go
+++ b/triedb/pathdb/testutils.go
@@ -83,7 +83,7 @@ func (h *testHasher) Delete(key []byte) error {
 func (h *testHasher) Commit(collectLeaf bool) (common.Hash, *trienode.NodeSet, error) {
 	var (
 		nodes = make(map[common.Hash][]byte)
-		set   = trienode.NewNodeSet(h.owner)
+		set   = trienode.NewNodeSet(h.owner, len(h.dirties))
 	)
 	for hash, val := range h.cleans {
 		nodes[hash] = val


### PR DESCRIPTION
- change before:
BenchmarkMerge/1K-12 	    4980	    224241 ns/op
BenchmarkMerge/10K-12         	     470	   2482620 ns/op

- change after:
BenchmarkMerge/1K-12 	    6000	    186740 ns/op
BenchmarkMerge/10K-12         	     574	   2000180 ns/op
