### PR TITLE
Add eth_necessaryGas to restore eth_estimateGas behavior

### DIFF
--- a/graphql/graphql.go
+++ b/graphql/graphql.go
@@ -1213,7 +1213,7 @@ func (b *Block) Call(ctx context.Context, args struct {
 func (b *Block) EstimateGas(ctx context.Context, args struct {
 	Data ethapi.TransactionArgs
 }) (hexutil.Uint64, error) {
-	return ethapi.DoEstimateGas(ctx, b.r.backend, args.Data, *b.numberOrHash, nil, b.r.backend.RPCGasCap())
+	return ethapi.DoEstimateGas(ctx, b.r.backend, args.Data, *b.numberOrHash, nil, b.r.backend.RPCGasCap(), 0)
 }
 
 type Pending struct {
@@ -1277,7 +1277,7 @@ func (p *Pending) EstimateGas(ctx context.Context, args struct {
 	Data ethapi.TransactionArgs
 }) (hexutil.Uint64, error) {
 	latestBlockNr := rpc.BlockNumberOrHashWithNumber(rpc.LatestBlockNumber)
-	return ethapi.DoEstimateGas(ctx, p.r.backend, args.Data, latestBlockNr, nil, p.r.backend.RPCGasCap())
+	return ethapi.DoEstimateGas(ctx, p.r.backend, args.Data, latestBlockNr, nil, p.r.backend.RPCGasCap(), 0)
 }
 
 // Resolver is the top-level object in the GraphQL hierarchy.

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -1178,10 +1178,11 @@ func (s *BlockChainAPI) Call(ctx context.Context, args TransactionArgs, blockNrO
 	return result.Return(), result.Err
 }
 
-// DoEstimateGas returns the lowest possible gas limit that allows the transaction to run
+// DoEstimateGas returns some gas limit that allows the transaction to run
 // successfully at block `blockNrOrHash`. It returns error if the transaction would revert, or if
 // there are unexpected failures. The gas limit is capped by both `args.Gas` (if non-nil &
 // non-zero) and `gasCap` (if non-zero).
+// The errorRatio specifies how much larger than the minimum necessary gas the result can be.
 func DoEstimateGas(ctx context.Context, b Backend, args TransactionArgs, blockNrOrHash rpc.BlockNumberOrHash, overrides *StateOverride, gasCap uint64, errorRatio float64) (hexutil.Uint64, error) {
 	// Retrieve the base state and mutate it with any overrides
 	state, header, err := b.StateAndHeaderByNumberOrHash(ctx, blockNrOrHash)

--- a/internal/ethapi/transaction_args.go
+++ b/internal/ethapi/transaction_args.go
@@ -160,7 +160,7 @@ func (args *TransactionArgs) setDefaults(ctx context.Context, b Backend, skipGas
 				BlobHashes:           args.BlobHashes,
 			}
 			latestBlockNr := rpc.BlockNumberOrHashWithNumber(rpc.LatestBlockNumber)
-			estimated, err := DoEstimateGas(ctx, b, callArgs, latestBlockNr, nil, b.RPCGasCap())
+			estimated, err := DoEstimateGas(ctx, b, callArgs, latestBlockNr, nil, b.RPCGasCap(), 0)
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
Fixes https://github.com/ethereum/go-ethereum/issues/29726 by keeping eth_estimateGas broken in favor of a new method that forces precision.

Fixes documentation for eth_estimateGas to signal its current behavior.

IMO eth_estimateGas should be correct and the faster version should be the non-standard method. eth_estimateGas [has defined behavior](https://ethereum.org/en/developers/docs/apis/json-rpc/#eth_estimategas): 
> Generates and returns an estimate of how much gas is necessary to allow the transaction to complete.

However if geth can truly single-handledly change the specification of ethjsonrpc, then I am powerless to stop them. Instead I create a new method, eth_necessaryGas to implement the defined behavior of eth_estimateGas.

But a more ethical fix would be to revert the PR that introduced ErrorRatio.