### PR TITLE
fix eth_estimateGas: remove ErrorRatio

### DIFF
--- a/eth/gasestimator/gasestimator.go
+++ b/eth/gasestimator/gasestimator.go
@@ -42,8 +42,6 @@ type Options struct {
 	Chain  core.ChainContext   // Chain context to access past block hashes
 	Header *types.Header       // Header defining the block context to execute in
 	State  *state.StateDB      // Pre-state on top of which to estimate the gas
-
-	ErrorRatio float64 // Allowed overestimation ratio for faster estimation termination
 }
 
 // Estimate returns the lowest possible gas limit that allows the transaction to
@@ -159,15 +157,6 @@ func Estimate(ctx context.Context, call *core.Message, opts *Options, gasCap uin
 	}
 	// Binary search for the smallest gas limit that allows the tx to execute successfully.
 	for lo+1 < hi {
-		if opts.ErrorRatio > 0 {
-			// It is a bit pointless to return a perfect estimation, as changing
-			// network conditions require the caller to bump it up anyway. Since
-			// wallets tend to use 20-25% bump, allowing a small approximation
-			// error is fine (as long as it's upwards).
-			if float64(hi-lo)/float64(hi) < opts.ErrorRatio {
-				break
-			}
-		}
 		mid := (hi + lo) / 2
 		if mid > lo*2 {
 			// Most txs don't need much higher gas limit than their gas used, and most txs don't

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -53,9 +53,6 @@ import (
 	"github.com/ethereum/go-ethereum/trie"
 )
 
-// estimateGasErrorRatio is the amount of overestimation eth_estimateGas is
-// allowed to produce in order to speed up calculations.
-const estimateGasErrorRatio = 0.015
 
 var errBlobTxNotSupported = errors.New("signing blob transactions not supported")
 
@@ -1197,7 +1194,6 @@ func DoEstimateGas(ctx context.Context, b Backend, args TransactionArgs, blockNr
 		Chain:      NewChainContext(ctx, b),
 		Header:     header,
 		State:      state,
-		ErrorRatio: estimateGasErrorRatio,
 	}
 	if err := args.CallDefaults(gasCap, header.BaseFee, b.ChainConfig().ChainID); err != nil {
 		return 0, err

--- a/internal/ethapi/api_test.go
+++ b/internal/ethapi/api_test.go
@@ -773,7 +773,7 @@ func TestEstimateGas(t *testing.T) {
 			t.Errorf("test %d: want no error, have %v", i, err)
 			continue
 		}
-		if float64(result) > float64(tc.want)*(1+estimateGasErrorRatio) {
+		if uint64(result) != tc.want {
 			t.Errorf("test %d, result mismatch, have\n%v\n, want\n%v\n", i, uint64(result), tc.want)
 		}
 	}


### PR DESCRIPTION
Fixes https://github.com/ethereum/go-ethereum/issues/29726 by removing ErrorRatio from the gas estimator.

I prefer this fix to https://github.com/ethereum/go-ethereum/pull/29727 because eth_estimateGas has defined behavior that is important for users such as myself. This defined behavior is found in several places, listed below. The "estimate" meaning pertains to how the execution can change if the contingent state changes, and does not excuse inaccuracy. False results are very bad in my line of work, and can cause huge losses.

### Defined in geth codebase:

>  DoEstimateGas returns the lowest possible gas limit that allows the transaction to run

> EstimateGas returns the lowest possible gas limit that allows the transaction to run

### Defined in ethjsonrpc

> Generates and returns an estimate of how much gas is necessary to allow the transaction to complete.