### PR TITLE
ipv6 address used as extip results in 127.0.0.1 being used

### DIFF
--- a/p2p/enode/node.go
+++ b/p2p/enode/node.go
@@ -100,7 +100,6 @@ func (n *Node) Load(k enr.Entry) error {
 }
 
 // IP returns the IP address of the node. This prefers IPv4 addresses.
-// IP returns the IP address of the node. This prefers IPv4 addresses.
 func (n *Node) IP() net.IP {
 	var (
 		ip4 enr.IPv4

--- a/p2p/enode/node.go
+++ b/p2p/enode/node.go
@@ -114,8 +114,11 @@ func (n *Node) IP() net.IP {
     if n.Load(&ip6) == nil {
         return net.IP(ip6)
     }
-    if net.IP(ip4).IsLoopback() {
-        return net.IP(ip4)
+    if n.Load(&ip4) == nil {
+        ipv4Addr := net.IP(ip4)
+        if ipv4Addr.IsLoopback() {
+            return ipv4Addr
+        }
     }
     return nil
 }

--- a/p2p/enode/node.go
+++ b/p2p/enode/node.go
@@ -101,18 +101,25 @@ func (n *Node) Load(k enr.Entry) error {
 
 // IP returns the IP address of the node. This prefers IPv4 addresses.
 func (n *Node) IP() net.IP {
-	var (
-		ip4 enr.IPv4
-		ip6 enr.IPv6
-	)
-	if n.Load(&ip4) == nil {
-		return net.IP(ip4)
-	}
-	if n.Load(&ip6) == nil {
-		return net.IP(ip6)
-	}
-	return nil
+    var (
+        ip4 enr.IPv4
+        ip6 enr.IPv6
+    )
+    if n.Load(&ip4) == nil {
+        ipv4Addr := net.IP(ip4)
+        if !ipv4Addr.IsLoopback() {
+            return ipv4Addr
+        }
+    }
+    if n.Load(&ip6) == nil {
+        return net.IP(ip6)
+    }
+    if net.IP(ip4).IsLoopback() {
+        return net.IP(ip4)
+    }
+    return nil
 }
+
 
 // UDP returns the UDP port of the node.
 func (n *Node) UDP() int {

--- a/p2p/enode/node.go
+++ b/p2p/enode/node.go
@@ -101,26 +101,23 @@ func (n *Node) Load(k enr.Entry) error {
 
 // IP returns the IP address of the node. This prefers IPv4 addresses.
 func (n *Node) IP() net.IP {
-    var (
-        ip4 enr.IPv4
-        ip6 enr.IPv6
-    )
-    if n.Load(&ip4) == nil {
-        ipv4Addr := net.IP(ip4)
-        if !ipv4Addr.IsLoopback() {
-            return ipv4Addr
-        }
-    }
-    if n.Load(&ip6) == nil {
-        return net.IP(ip6)
-    }
-    if n.Load(&ip4) == nil {
-        ipv4Addr := net.IP(ip4)
-        if ipv4Addr.IsLoopback() {
-            return ipv4Addr
-        }
-    }
-    return nil
+	var (
+		ip4 enr.IPv4
+		ip6 enr.IPv6
+	)
+	if n.Load(&ip4) == nil {
+		ipv4Addr := net.IP(ip4)
+		if !ipv4Addr.IsLoopback() {
+			return ipv4Addr
+		}
+	}
+	if n.Load(&ip6) == nil {
+		return net.IP(ip6)
+	}
+	if ipv4Addr := net.IP(ip4); ipv4Addr.IsLoopback() {
+		return ipv4Addr
+	}
+	return nil
 }
 
 

--- a/p2p/enode/node.go
+++ b/p2p/enode/node.go
@@ -100,6 +100,7 @@ func (n *Node) Load(k enr.Entry) error {
 }
 
 // IP returns the IP address of the node. This prefers IPv4 addresses.
+// IP returns the IP address of the node. This prefers IPv4 addresses.
 func (n *Node) IP() net.IP {
 	var (
 		ip4 enr.IPv4
@@ -114,12 +115,14 @@ func (n *Node) IP() net.IP {
 	if n.Load(&ip6) == nil {
 		return net.IP(ip6)
 	}
-	if ipv4Addr := net.IP(ip4); ipv4Addr.IsLoopback() {
-		return ipv4Addr
+	if n.Load(&ip4) == nil {
+		ipv4Addr := net.IP(ip4)
+		if ipv4Addr.IsLoopback() {
+			return ipv4Addr
+		}
 	}
 	return nil
 }
-
 
 // UDP returns the UDP port of the node.
 func (n *Node) UDP() int {


### PR DESCRIPTION
Fix #29495.

Add a condition to the IP() function to check if ip4 is the local host.
Prefer ip6 over localhost.
