### PR TITLE
cmd/evm: Add evm t8n server

### DIFF
--- a/cmd/evm/internal/t8ntool/flags.go
+++ b/cmd/evm/internal/t8ntool/flags.go
@@ -154,4 +154,13 @@ var (
 		Usage: "sets the verbosity level",
 		Value: 3,
 	}
+	PortFlag = &cli.IntFlag{
+		Name:  "port",
+		Usage: "port to listen on",
+		Value: 0,
+	}
+	UnixSocketFlag = &cli.StringFlag{
+		Name:  "unix-socket",
+		Usage: "File path to the unix socket to use",
+	}
 )

--- a/cmd/evm/internal/t8ntool/transaction.go
+++ b/cmd/evm/internal/t8ntool/transaction.go
@@ -89,7 +89,7 @@ func Transaction(ctx *cli.Context) error {
 			return NewError(ErrorJson, fmt.Errorf("failed unmarshalling stdin: %v", err))
 		}
 		// Decode the body of already signed transactions
-		body = common.FromHex(inputData.TxRlp)
+		body = inputData.TxRlp
 	} else {
 		// Read input from file
 		inFile, err := os.Open(txStr)

--- a/cmd/evm/internal/t8ntool/tx_iterator.go
+++ b/cmd/evm/internal/t8ntool/tx_iterator.go
@@ -22,14 +22,10 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"os"
-	"strings"
 
 	"github.com/ethereum/go-ethereum/common"
-	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/crypto"
-	"github.com/ethereum/go-ethereum/params"
 	"github.com/ethereum/go-ethereum/rlp"
 )
 
@@ -110,37 +106,6 @@ func signUnsignedTransactions(txs []*txWithKey, signer types.Signer) (types.Tran
 		signedTxs = append(signedTxs, signed)
 	}
 	return signedTxs, nil
-}
-
-func loadTransactions(txStr string, inputData *input, env stEnv, chainConfig *params.ChainConfig) (txIterator, error) {
-	var txsWithKeys []*txWithKey
-	if txStr != stdinSelector {
-		data, err := os.ReadFile(txStr)
-		if err != nil {
-			return nil, NewError(ErrorIO, fmt.Errorf("failed reading txs file: %v", err))
-		}
-		if strings.HasSuffix(txStr, ".rlp") { // A file containing an rlp list
-			var body hexutil.Bytes
-			if err := json.Unmarshal(data, &body); err != nil {
-				return nil, err
-			}
-			return newRlpTxIterator(body), nil
-		}
-		if err := json.Unmarshal(data, &txsWithKeys); err != nil {
-			return nil, NewError(ErrorJson, fmt.Errorf("failed unmarshalling txs-file: %v", err))
-		}
-	} else {
-		if len(inputData.TxRlp) > 0 {
-			// Decode the body of already signed transactions
-			return newRlpTxIterator(common.FromHex(inputData.TxRlp)), nil
-		}
-		// JSON encoded transactions
-		txsWithKeys = inputData.Txs
-	}
-	// We may have to sign the transactions.
-	signer := types.LatestSignerForChainID(chainConfig.ChainID)
-	txs, err := signUnsignedTransactions(txsWithKeys, signer)
-	return newSliceTxIterator(txs), err
 }
 
 type txIterator interface {

--- a/cmd/evm/internal/t8ntool/utils.go
+++ b/cmd/evm/internal/t8ntool/utils.go
@@ -40,15 +40,20 @@ func readFile(path, desc string, dest interface{}) error {
 
 // createBasedir makes sure the basedir exists, if user specified one.
 func createBasedir(ctx *cli.Context) (string, error) {
-	baseDir := ""
 	if ctx.IsSet(OutputBasedir.Name) {
-		if base := ctx.String(OutputBasedir.Name); len(base) > 0 {
-			err := os.MkdirAll(base, 0755) // //rw-r--r--
-			if err != nil {
-				return "", err
-			}
-			baseDir = base
-		}
+		base := ctx.String(OutputBasedir.Name)
+		return createBasedirFromString(base)
 	}
-	return baseDir, nil
+	return "", nil
+}
+
+func createBasedirFromString(baseDirPath string) (string, error) {
+	if len(baseDirPath) > 0 {
+		err := os.MkdirAll(baseDirPath, 0755) // //rw-r--r--
+		if err != nil {
+			return "", err
+		}
+		return baseDirPath, nil
+	}
+	return "", nil
 }

--- a/cmd/evm/main.go
+++ b/cmd/evm/main.go
@@ -166,6 +166,24 @@ var stateTransitionCommand = &cli.Command{
 	},
 }
 
+var stateTransitionServerCommand = &cli.Command{
+	Name:    "transition-server",
+	Aliases: []string{"t8n-server"},
+	Usage:   "Instantiates a server that accepts requests for full state transition",
+	Action:  t8ntool.TransitionServer,
+	Flags: []cli.Flag{
+		t8ntool.TraceFlag,
+		t8ntool.TraceTracerFlag,
+		t8ntool.TraceTracerConfigFlag,
+		t8ntool.TraceEnableMemoryFlag,
+		t8ntool.TraceDisableStackFlag,
+		t8ntool.TraceEnableReturnDataFlag,
+		t8ntool.TraceEnableCallFramesFlag,
+		t8ntool.PortFlag,
+		t8ntool.UnixSocketFlag,
+	},
+}
+
 var transactionCommand = &cli.Command{
 	Name:    "transaction",
 	Aliases: []string{"t9n"},
@@ -233,6 +251,7 @@ func init() {
 		blockTestCommand,
 		stateTestCommand,
 		stateTransitionCommand,
+		stateTransitionServerCommand,
 		transactionCommand,
 		blockBuilderCommand,
 	}


### PR DESCRIPTION
Adds a server mode to the evm transition tool, currently as a new subcommand `evm t8n-server` but could easily be added as a flag to the existing `evm t8n` subcommand.

Two modes are added:
- HTTP through TCP port: `--port 1234`
- HTTP through an unix socket: `--unix-socket /path/to/file`

The TCP port implementation causes some issues with our filler and the unix socket flavor is what currently we are using to fill tests.

This speeds up test filling by some significant margin. E.g. filling all cancun tests takes 70s with current implementation and 40s using the server.