### PR TITLE
event: fix typo

### DIFF
--- a/event/multisub.go
+++ b/event/multisub.go
@@ -17,7 +17,7 @@
 package event
 
 // JoinSubscriptions joins multiple subscriptions to be able to track them as
-// one entity and collectively cancel them of consume any errors from them.
+// one entity and collectively cancel them or consume any errors from them.
 func JoinSubscriptions(subs ...Subscription) Subscription {
 	return NewSubscription(func(unsubbed <-chan struct{}) error {
 		// Unsubscribe all subscriptions before returning


### PR DESCRIPTION
replace "of" with "or" in the code's comment so that its meaning can be more clearly understood.