### PR TITLE
core/state: fix inconsistent verkle test error messages

### DIFF
--- a/core/state/access_events_test.go
+++ b/core/state/access_events_test.go
@@ -41,7 +41,7 @@ func TestAccountHeaderGas(t *testing.T) {
 
 	// Check cold read cost
 	gas := ae.VersionGas(testAddr, false)
-	if want := params.WitnessBranchReadCost+params.WitnessChunkReadCost; gas != want {
+	if want := params.WitnessBranchReadCost + params.WitnessChunkReadCost; gas != want {
 		t.Fatalf("incorrect gas computed, got %d, want %d", gas, want)
 	}
 
@@ -71,7 +71,7 @@ func TestAccountHeaderGas(t *testing.T) {
 
 	// Check cold write cost
 	gas = ae.VersionGas(testAddr, true)
-	if want := params.WitnessBranchWriteCost+params.WitnessChunkWriteCost; gas != want {
+	if want := params.WitnessBranchWriteCost + params.WitnessChunkWriteCost; gas != want {
 		t.Fatalf("incorrect gas computed, got %d, want %d", gas, want)
 	}
 
@@ -83,7 +83,7 @@ func TestAccountHeaderGas(t *testing.T) {
 
 	// Check a write without a read charges both read and write costs
 	gas = ae.BalanceGas(testAddr2, true)
-	if want := params.WitnessBranchReadCost+params.WitnessBranchWriteCost+params.WitnessChunkWriteCost+params.WitnessChunkReadCost; gas != want {
+	if want := params.WitnessBranchReadCost + params.WitnessBranchWriteCost + params.WitnessChunkWriteCost + params.WitnessChunkReadCost; gas != want {
 		t.Fatalf("incorrect gas computed, got %d, want %d", gas, want)
 	}
 
@@ -113,7 +113,7 @@ func TestContractCreateInitGas(t *testing.T) {
 
 	// Check cold read cost, without a value
 	gas := ae.ContractCreateInitGas(testAddr, false)
-	if want := params.WitnessBranchWriteCost+params.WitnessBranchReadCost+params.WitnessChunkWriteCost*2+params.WitnessChunkReadCost*2; gas != want {
+	if want := params.WitnessBranchWriteCost + params.WitnessBranchReadCost + params.WitnessChunkWriteCost*2 + params.WitnessChunkReadCost*2; gas != want {
 		t.Fatalf("incorrect gas computed, got %d, want %d", gas, want)
 	}
 
@@ -131,7 +131,7 @@ func TestMessageCallGas(t *testing.T) {
 
 	// Check cold read cost, without a value
 	gas := ae.MessageCallGas(testAddr)
-	if want := params.WitnessBranchReadCost+params.WitnessChunkReadCost*2; gas != want {
+	if want := params.WitnessBranchReadCost + params.WitnessChunkReadCost*2; gas != want {
 		t.Fatalf("incorrect gas computed, got %d, want %d", gas, want)
 	}
 

--- a/core/state/access_events_test.go
+++ b/core/state/access_events_test.go
@@ -41,8 +41,9 @@ func TestAccountHeaderGas(t *testing.T) {
 
 	// Check cold read cost
 	gas := ae.VersionGas(testAddr, false)
-	if gas != params.WitnessBranchReadCost+params.WitnessChunkReadCost {
-		t.Fatalf("incorrect gas computed, got %d, want %d", gas, params.WitnessBranchReadCost+params.WitnessChunkReadCost)
+	want := params.WitnessBranchReadCost+params.WitnessChunkReadCost
+	if gas != want {
+		t.Fatalf("incorrect gas computed, got %d, want %d", gas, want)
 	}
 
 	// Check warm read cost
@@ -71,8 +72,9 @@ func TestAccountHeaderGas(t *testing.T) {
 
 	// Check cold write cost
 	gas = ae.VersionGas(testAddr, true)
-	if gas != params.WitnessBranchWriteCost+params.WitnessChunkWriteCost {
-		t.Fatalf("incorrect gas computed, got %d, want %d", gas, params.WitnessBranchReadCost+params.WitnessBranchWriteCost)
+	want := params.WitnessBranchWriteCost+params.WitnessChunkWriteCost
+	if gas != want {
+		t.Fatalf("incorrect gas computed, got %d, want %d", gas, want)
 	}
 
 	// Check warm write cost
@@ -83,8 +85,9 @@ func TestAccountHeaderGas(t *testing.T) {
 
 	// Check a write without a read charges both read and write costs
 	gas = ae.BalanceGas(testAddr2, true)
-	if gas != params.WitnessBranchReadCost+params.WitnessBranchWriteCost+params.WitnessChunkWriteCost+params.WitnessChunkReadCost {
-		t.Fatalf("incorrect gas computed, got %d, want %d", gas, params.WitnessBranchReadCost+params.WitnessBranchWriteCost+params.WitnessChunkWriteCost+params.WitnessChunkReadCost)
+	want := params.WitnessBranchReadCost+params.WitnessBranchWriteCost+params.WitnessChunkWriteCost+params.WitnessChunkReadCost
+	if gas != want {
+		t.Fatalf("incorrect gas computed, got %d, want %d", gas, want)
 	}
 
 	// Check that a write followed by a read charges nothing
@@ -113,8 +116,9 @@ func TestContractCreateInitGas(t *testing.T) {
 
 	// Check cold read cost, without a value
 	gas := ae.ContractCreateInitGas(testAddr, false)
-	if gas != params.WitnessBranchWriteCost+params.WitnessBranchReadCost+params.WitnessChunkWriteCost*2+params.WitnessChunkReadCost*2 {
-		t.Fatalf("incorrect gas computed, got %d, want %d", gas, params.WitnessBranchWriteCost+params.WitnessBranchReadCost+params.WitnessChunkWriteCost*3)
+	want := params.WitnessBranchWriteCost+params.WitnessBranchReadCost+params.WitnessChunkWriteCost*2+params.WitnessChunkReadCost*2
+	if gas != want {
+		t.Fatalf("incorrect gas computed, got %d, want %d", gas, want)
 	}
 
 	// Check warm read cost
@@ -131,8 +135,9 @@ func TestMessageCallGas(t *testing.T) {
 
 	// Check cold read cost, without a value
 	gas := ae.MessageCallGas(testAddr)
-	if gas != params.WitnessBranchReadCost+params.WitnessChunkReadCost*2 {
-		t.Fatalf("incorrect gas computed, got %d, want %d", gas, params.WitnessBranchReadCost+params.WitnessChunkReadCost*2)
+	want := params.WitnessBranchReadCost+params.WitnessChunkReadCost*2
+	if gas != want {
+		t.Fatalf("incorrect gas computed, got %d, want %d", gas, want)
 	}
 
 	// Check that reading the version and code size of the same account does not incur the branch read cost

--- a/core/state/access_events_test.go
+++ b/core/state/access_events_test.go
@@ -41,8 +41,7 @@ func TestAccountHeaderGas(t *testing.T) {
 
 	// Check cold read cost
 	gas := ae.VersionGas(testAddr, false)
-	want := params.WitnessBranchReadCost+params.WitnessChunkReadCost
-	if gas != want {
+	if want := params.WitnessBranchReadCost+params.WitnessChunkReadCost; gas != want {
 		t.Fatalf("incorrect gas computed, got %d, want %d", gas, want)
 	}
 
@@ -72,8 +71,7 @@ func TestAccountHeaderGas(t *testing.T) {
 
 	// Check cold write cost
 	gas = ae.VersionGas(testAddr, true)
-	want := params.WitnessBranchWriteCost+params.WitnessChunkWriteCost
-	if gas != want {
+	if want := params.WitnessBranchWriteCost+params.WitnessChunkWriteCost; gas != want {
 		t.Fatalf("incorrect gas computed, got %d, want %d", gas, want)
 	}
 
@@ -85,8 +83,7 @@ func TestAccountHeaderGas(t *testing.T) {
 
 	// Check a write without a read charges both read and write costs
 	gas = ae.BalanceGas(testAddr2, true)
-	want := params.WitnessBranchReadCost+params.WitnessBranchWriteCost+params.WitnessChunkWriteCost+params.WitnessChunkReadCost
-	if gas != want {
+	if want := params.WitnessBranchReadCost+params.WitnessBranchWriteCost+params.WitnessChunkWriteCost+params.WitnessChunkReadCost; gas != want {
 		t.Fatalf("incorrect gas computed, got %d, want %d", gas, want)
 	}
 
@@ -116,8 +113,7 @@ func TestContractCreateInitGas(t *testing.T) {
 
 	// Check cold read cost, without a value
 	gas := ae.ContractCreateInitGas(testAddr, false)
-	want := params.WitnessBranchWriteCost+params.WitnessBranchReadCost+params.WitnessChunkWriteCost*2+params.WitnessChunkReadCost*2
-	if gas != want {
+	if want := params.WitnessBranchWriteCost+params.WitnessBranchReadCost+params.WitnessChunkWriteCost*2+params.WitnessChunkReadCost*2; gas != want {
 		t.Fatalf("incorrect gas computed, got %d, want %d", gas, want)
 	}
 
@@ -135,8 +131,7 @@ func TestMessageCallGas(t *testing.T) {
 
 	// Check cold read cost, without a value
 	gas := ae.MessageCallGas(testAddr)
-	want := params.WitnessBranchReadCost+params.WitnessChunkReadCost*2
-	if gas != want {
+	if want := params.WitnessBranchReadCost+params.WitnessChunkReadCost*2; gas != want {
 		t.Fatalf("incorrect gas computed, got %d, want %d", gas, want)
 	}
 


### PR DESCRIPTION
Some of the values for comparison and in error message are inconsistent.
Correct me if I chose the wrong one.