### PR TITLE
all: integrate snapshot into pathdb

### DIFF
--- a/core/rawdb/accessors_trie.go
+++ b/core/rawdb/accessors_trie.go
@@ -99,8 +99,8 @@ func DeleteAccountTrieNode(db ethdb.KeyValueWriter, path []byte) {
 func EncodeNibbles(bytes []byte) []byte {
 	nibbles := make([]byte, len(bytes)*2)
 	for i, b := range bytes {
-		nibbles[i*2] = b >> 4     // 取字节高4位
-		nibbles[i*2+1] = b & 0x0F // 取字节低4位
+		nibbles[i*2] = b >> 4
+		nibbles[i*2+1] = b & 0x0F
 	}
 	return nibbles
 }

--- a/core/rawdb/table.go
+++ b/core/rawdb/table.go
@@ -27,6 +27,11 @@ type table struct {
 	prefix string
 }
 
+func (t *table) DeleteRange(start, end []byte) error {
+	// TODO implement me
+	panic("implement me")
+}
+
 // NewTable returns a database object that prefixes all keys with a given string.
 func NewTable(db ethdb.Database, prefix string) ethdb.Database {
 	return &table{
@@ -214,6 +219,11 @@ type tableBatch struct {
 	prefix string
 }
 
+func (b *tableBatch) DeleteRange(start, end []byte) error {
+	// TODO implement me
+	panic("implement me")
+}
+
 // Put inserts the given value into the batch for later committing.
 func (b *tableBatch) Put(key, value []byte) error {
 	return b.batch.Put(append([]byte(b.prefix), key...), value)
@@ -246,6 +256,11 @@ type tableReplayer struct {
 	prefix string
 }
 
+func (r *tableReplayer) DeleteRange(start, end []byte) error {
+	// TODO implement me
+	panic("implement me")
+}
+
 // Put implements the interface KeyValueWriter.
 func (r *tableReplayer) Put(key []byte, value []byte) error {
 	trimmed := key[len(r.prefix):]
@@ -268,6 +283,11 @@ func (b *tableBatch) Replay(w ethdb.KeyValueWriter) error {
 type tableIterator struct {
 	iter   ethdb.Iterator
 	prefix string
+}
+
+func (iter *tableIterator) Seek(key []byte) bool {
+	// TODO implement me
+	panic("implement me")
 }
 
 // Next moves the iterator to the next key/value pair. It returns whether the

--- a/core/state/database.go
+++ b/core/state/database.go
@@ -85,12 +85,12 @@ type Trie interface {
 	// the trie, nil will be returned. If the trie is corrupted(e.g. some nodes
 	// are missing or the account blob is incorrect for decoding), an error will
 	// be returned.
-	GetAccount(address common.Address) (*types.StateAccount, error)
+	GetAccount(address common.Address, direct bool) (*types.StateAccount, error)
 
 	// GetStorage returns the value for key stored in the trie. The value bytes
 	// must not be modified by the caller. If a node was not found in the database,
 	// a trie.MissingNodeError is returned.
-	GetStorage(addr common.Address, key []byte) ([]byte, error)
+	GetStorage(addr common.Address, key []byte, direct bool) ([]byte, error)
 
 	// UpdateAccount abstracts an account write to the trie. It encodes the
 	// provided account object with associated algorithm and then updates it

--- a/core/state/pruner/bloom.go
+++ b/core/state/pruner/bloom.go
@@ -51,6 +51,11 @@ type stateBloom struct {
 	bloom *bloomfilter.Filter
 }
 
+func (bloom *stateBloom) DeleteRange(start, end []byte) error {
+	// TODO implement me
+	panic("implement me")
+}
+
 // newStateBloomWithSize creates a brand new state bloom for state generation.
 // The bloom filter will be created by the passing bloom filter size. According
 // to the https://hur.st/bloomfilter/?n=600000000&p=&m=2048MB&k=4, the parameters

--- a/core/state/state_object.go
+++ b/core/state/state_object.go
@@ -202,7 +202,7 @@ func (s *stateObject) GetCommittedState(key common.Hash) common.Hash {
 			s.db.setError(err)
 			return common.Hash{}
 		}
-		val, err := tr.GetStorage(s.address, key.Bytes())
+		val, err := tr.GetStorage(s.address, key.Bytes(), true)
 		s.db.StorageReads += time.Since(start)
 
 		if err != nil {

--- a/core/state/trie_prefetcher.go
+++ b/core/state/trie_prefetcher.go
@@ -344,9 +344,9 @@ func (sf *subfetcher) loop() {
 						sf.dups++
 					} else {
 						if len(task) == common.AddressLength {
-							sf.trie.GetAccount(common.BytesToAddress(task))
+							sf.trie.GetAccount(common.BytesToAddress(task), false)
 						} else {
-							sf.trie.GetStorage(sf.addr, task)
+							sf.trie.GetStorage(sf.addr, task, false)
 						}
 						sf.seen[string(task)] = struct{}{}
 					}

--- a/core/types/state_account.go
+++ b/core/types/state_account.go
@@ -18,6 +18,7 @@ package types
 
 import (
 	"bytes"
+	"fmt"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/rlp"
@@ -118,4 +119,25 @@ func FullAccountRLP(data []byte) ([]byte, error) {
 		return nil, err
 	}
 	return rlp.EncodeToBytes(account)
+}
+
+func MustFullAccountRLP(data []byte) []byte {
+	if data == nil {
+		return nil
+	}
+	val, err := FullAccountRLP(data)
+	if err != nil {
+		panic(fmt.Sprintf("must full account rlp faield, err %v", err))
+	}
+	return val
+}
+func FullToSlimAccountRLP(data []byte) []byte {
+	if data == nil {
+		return nil
+	}
+	var account StateAccount
+	if err := rlp.DecodeBytes(data, &account); err != nil {
+		panic(fmt.Sprintf("full to slim account rlp failed, err %v", err))
+	}
+	return SlimAccountRLP(account)
 }

--- a/ethdb/database.go
+++ b/ethdb/database.go
@@ -35,6 +35,9 @@ type KeyValueWriter interface {
 
 	// Delete removes the key from the key-value data store.
 	Delete(key []byte) error
+
+	// DeleteRange deletes all of the keys (and values) in the range [start,end)
+	DeleteRange(start, end []byte) error
 }
 
 // KeyValueStater wraps the Stat method of a backing data store.

--- a/ethdb/iterator.go
+++ b/ethdb/iterator.go
@@ -44,6 +44,9 @@ type Iterator interface {
 	// may change on the next call to Next.
 	Value() []byte
 
+	// Seek moves the iterator to the target key/value pair. Only support Lower-bound
+	Seek(key []byte) bool
+
 	// Release releases associated resources. Release should always succeed and can
 	// be called multiple times without causing error.
 	Release()

--- a/ethdb/leveldb/leveldb.go
+++ b/ethdb/leveldb/leveldb.go
@@ -84,6 +84,11 @@ type Database struct {
 	log log.Logger // Contextual logger tracking the database path
 }
 
+func (db *Database) DeleteRange(start, end []byte) error {
+	// TODO implement me
+	panic("implement me")
+}
+
 // New returns a wrapped LevelDB object. The namespace is the prefix that the
 // metrics reporting should use for surfacing internal stats.
 func New(file string, cache int, handles int, namespace string, readonly bool) (*Database, error) {
@@ -391,6 +396,11 @@ type batch struct {
 	db   *leveldb.DB
 	b    *leveldb.Batch
 	size int
+}
+
+func (b *batch) DeleteRange(start, end []byte) error {
+	// TODO implement me
+	panic("implement me")
 }
 
 // Put inserts the given value into the batch for later committing.

--- a/ethdb/memorydb/memorydb.go
+++ b/ethdb/memorydb/memorydb.go
@@ -49,6 +49,11 @@ type Database struct {
 	lock sync.RWMutex
 }
 
+func (db *Database) DeleteRange(start, end []byte) error {
+	// TODO implement me
+	panic("implement me")
+}
+
 // New returns a wrapped map with all the required database interface methods
 // implemented.
 func New() *Database {
@@ -220,6 +225,11 @@ type batch struct {
 	size   int
 }
 
+func (b *batch) DeleteRange(start, end []byte) error {
+	// TODO implement me
+	panic("implement me")
+}
+
 // Put inserts the given value into the batch for later committing.
 func (b *batch) Put(key, value []byte) error {
 	b.writes = append(b.writes, keyvalue{string(key), common.CopyBytes(value), false})
@@ -286,6 +296,11 @@ type iterator struct {
 	index  int
 	keys   []string
 	values [][]byte
+}
+
+func (it *iterator) Seek(key []byte) bool {
+	// TODO implement me
+	panic("implement me")
 }
 
 // Next moves the iterator to the next key/value pair. It returns whether the

--- a/ethdb/remotedb/remotedb.go
+++ b/ethdb/remotedb/remotedb.go
@@ -32,6 +32,11 @@ type Database struct {
 	remote *rpc.Client
 }
 
+func (db *Database) DeleteRange(start, end []byte) error {
+	// TODO implement me
+	panic("implement me")
+}
+
 func (db *Database) Has(key []byte) (bool, error) {
 	if _, err := db.Get(key); err != nil {
 		return false, nil

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -694,6 +694,11 @@ type StorageResult struct {
 // hex-strings for delivery to rpc-caller.
 type proofList []string
 
+func (n *proofList) DeleteRange(start, end []byte) error {
+	// TODO implement me
+	panic("implement me")
+}
+
 func (n *proofList) Put(key []byte, value []byte) error {
 	*n = append(*n, hexutil.Encode(value))
 	return nil

--- a/trie/node.go
+++ b/trie/node.go
@@ -231,6 +231,23 @@ func decodeRef(buf []byte) (node, []byte, error) {
 	}
 }
 
+// DecodeLeafNode return the Key and Val part of the shorNode
+func DecodeLeafNode(hash, path, value []byte) ([]byte, []byte) {
+	n := mustDecodeNode(hash, value)
+	switch sn := n.(type) {
+	case *shortNode:
+		if val, ok := sn.Val.(valueNode); ok {
+			// remove the prefix key of path
+			key := append(path, sn.Key...)
+			if hasTerm(key) {
+				key = key[:len(key)-1]
+			}
+			return val, hexToKeybytes(append(path, sn.Key...))
+		}
+	}
+	return nil, nil
+}
+
 // wraps a decoding error with information about the path to the
 // invalid child node (for debugging encoding issues).
 type decodeError struct {

--- a/trie/secure_trie.go
+++ b/trie/secure_trie.go
@@ -86,8 +86,16 @@ func (t *StateTrie) MustGet(key []byte) []byte {
 // and slot key. The value bytes must not be modified by the caller.
 // If the specified storage slot is not in the trie, nil will be returned.
 // If a trie node is not found in the database, a MissingNodeError is returned.
-func (t *StateTrie) GetStorage(_ common.Address, key []byte) ([]byte, error) {
-	enc, err := t.trie.Get(t.hashKey(key))
+func (t *StateTrie) GetStorage(_ common.Address, key []byte, direct bool) ([]byte, error) {
+	var (
+		enc []byte
+		err error
+	)
+	if direct {
+		enc, err = t.trie.GetDirectly(t.hashKey(key))
+	} else {
+		enc, err = t.trie.Get(t.hashKey(key))
+	}
 	if err != nil || len(enc) == 0 {
 		return nil, err
 	}
@@ -98,8 +106,16 @@ func (t *StateTrie) GetStorage(_ common.Address, key []byte) ([]byte, error) {
 // GetAccount attempts to retrieve an account with provided account address.
 // If the specified account is not in the trie, nil will be returned.
 // If a trie node is not found in the database, a MissingNodeError is returned.
-func (t *StateTrie) GetAccount(address common.Address) (*types.StateAccount, error) {
-	res, err := t.trie.Get(t.hashKey(address.Bytes()))
+func (t *StateTrie) GetAccount(address common.Address, direct bool) (*types.StateAccount, error) {
+	var (
+		res []byte
+		err error
+	)
+	if direct {
+		res, err = t.trie.GetDirectly(t.hashKey(address.Bytes()))
+	} else {
+		res, err = t.trie.Get(t.hashKey(address.Bytes()))
+	}
 	if res == nil || err != nil {
 		return nil, err
 	}

--- a/trie/tracer.go
+++ b/trie/tracer.go
@@ -112,10 +112,15 @@ func (t *tracer) deletedNodes() []string {
 		// It's possible a few deleted nodes were embedded
 		// in their parent before, the deletions can be no
 		// effect by deleting nothing, filter them out.
-		_, ok := t.accessList[path]
-		if !ok {
-			continue
-		}
+
+		// Note: In order to read the account/storage
+		// directly from pathdb, redundant storage is made
+		// for the embedded node in committer.store, so it
+		// cannot be filtered out here.
+		// _, ok := t.accessList[path]
+		// if !ok {
+		// 	continue
+		// }
 		paths = append(paths, path)
 	}
 	return paths

--- a/trie/trie.go
+++ b/trie/trie.go
@@ -153,6 +153,17 @@ func (t *Trie) Get(key []byte) ([]byte, error) {
 	return value, err
 }
 
+func (t *Trie) GetDirectly(key []byte) ([]byte, error) {
+	if t.reader.reader == nil {
+		return nil, nil
+	}
+	if t.owner == (common.Hash{}) {
+		return t.reader.reader.Account(common.BytesToHash(key))
+	} else {
+		return t.reader.reader.Storage(t.owner, common.BytesToHash(key))
+	}
+}
+
 func (t *Trie) get(origNode node, key []byte, pos int) (value []byte, newnode node, didResolve bool, err error) {
 	switch n := (origNode).(type) {
 	case nil:

--- a/trie/trie_test.go
+++ b/trie/trie_test.go
@@ -447,9 +447,9 @@ func verifyAccessList(old *Trie, new *Trie, set *trienode.NodeSet) error {
 		if !ok || n.IsDeleted() {
 			return errors.New("expect new node")
 		}
-		//if len(n.Prev) > 0 {
+		// if len(n.Prev) > 0 {
 		//	return errors.New("unexpected origin value")
-		//}
+		// }
 	}
 	// Check deletion set
 	for path := range deletes {
@@ -457,12 +457,12 @@ func verifyAccessList(old *Trie, new *Trie, set *trienode.NodeSet) error {
 		if !ok || !n.IsDeleted() {
 			return errors.New("expect deleted node")
 		}
-		//if len(n.Prev) == 0 {
+		// if len(n.Prev) == 0 {
 		//	return errors.New("expect origin value")
-		//}
-		//if !bytes.Equal(n.Prev, blob) {
+		// }
+		// if !bytes.Equal(n.Prev, blob) {
 		//	return errors.New("invalid origin value")
-		//}
+		// }
 	}
 	// Check update set
 	for path := range updates {
@@ -470,12 +470,12 @@ func verifyAccessList(old *Trie, new *Trie, set *trienode.NodeSet) error {
 		if !ok || n.IsDeleted() {
 			return errors.New("expect updated node")
 		}
-		//if len(n.Prev) == 0 {
+		// if len(n.Prev) == 0 {
 		//	return errors.New("expect origin value")
-		//}
-		//if !bytes.Equal(n.Prev, blob) {
+		// }
+		// if !bytes.Equal(n.Prev, blob) {
 		//	return errors.New("invalid origin value")
-		//}
+		// }
 	}
 	return nil
 }
@@ -696,7 +696,7 @@ func BenchmarkHash(b *testing.B) {
 	}
 	b.ResetTimer()
 	b.ReportAllocs()
-	//trie.hashRoot(nil, nil)
+	// trie.hashRoot(nil, nil)
 	trie.Hash()
 }
 
@@ -793,7 +793,7 @@ func makeAccounts(size int) (addresses [][20]byte, accounts [][]byte) {
 		)
 		// The big.Rand function is not deterministic with regards to 64 vs 32 bit systems,
 		// and will consume different amount of data from the rand source.
-		//balance = new(big.Int).Rand(random, new(big.Int).Exp(common.Big2, common.Big256, nil))
+		// balance = new(big.Int).Rand(random, new(big.Int).Exp(common.Big2, common.Big256, nil))
 		// Therefore, we instead just read via byte buffer
 		numBytes := random.Uint32() % 33 // [0, 32] bytes
 		balanceBytes := make([]byte, numBytes)
@@ -812,6 +812,11 @@ type spongeDb struct {
 	journal []string
 	keys    []string
 	values  map[string]string
+}
+
+func (s *spongeDb) DeleteRange(start, end []byte) error {
+	// TODO implement me
+	panic("implement me")
 }
 
 func (s *spongeDb) Has(key []byte) (bool, error)             { panic("implement me") }
@@ -859,6 +864,11 @@ func (s *spongeDb) Flush() {
 // spongeBatch is a dummy batch which immediately writes to the underlying spongedb
 type spongeBatch struct {
 	db *spongeDb
+}
+
+func (b *spongeBatch) DeleteRange(start, end []byte) error {
+	// TODO implement me
+	panic("implement me")
 }
 
 func (b *spongeBatch) Put(key, value []byte) error {

--- a/trie/trienode/proof.go
+++ b/trie/trienode/proof.go
@@ -36,6 +36,11 @@ type ProofSet struct {
 	lock     sync.RWMutex
 }
 
+func (db *ProofSet) DeleteRange(start, end []byte) error {
+	// TODO implement me
+	panic("implement me")
+}
+
 // NewProofSet creates an empty node set
 func NewProofSet() *ProofSet {
 	return &ProofSet{

--- a/trie/triestate/state.go
+++ b/trie/triestate/state.go
@@ -58,6 +58,10 @@ type TrieLoader interface {
 // The value refers to the original content of state before the transition
 // is made. Nil means that the state was not present previously.
 type Set struct {
+	LatestAccounts map[common.Hash][]byte
+	LatestStorages map[common.Hash]map[common.Hash][]byte
+	DestructSet    map[common.Hash]struct{}
+
 	Accounts map[common.Address][]byte                 // Mutated account set, nil means the account was not present
 	Storages map[common.Address]map[common.Hash][]byte // Mutated storage set, nil means the slot was not present
 	size     common.StorageSize                        // Approximate size of set

--- a/trie/triestate/state.go
+++ b/trie/triestate/state.go
@@ -68,10 +68,14 @@ type Set struct {
 }
 
 // New constructs the state set with provided data.
-func New(accounts map[common.Address][]byte, storages map[common.Address]map[common.Hash][]byte) *Set {
+func New(accounts map[common.Address][]byte, storages map[common.Address]map[common.Hash][]byte,
+	latestAccount map[common.Hash][]byte, latestStorages map[common.Hash]map[common.Hash][]byte, destructSet map[common.Hash]struct{}) *Set {
 	return &Set{
-		Accounts: accounts,
-		Storages: storages,
+		Accounts:       accounts,
+		Storages:       storages,
+		LatestAccounts: latestAccount,
+		LatestStorages: latestStorages,
+		DestructSet:    destructSet,
 	}
 }
 

--- a/trie/verkle.go
+++ b/trie/verkle.go
@@ -78,7 +78,7 @@ func (t *VerkleTrie) GetKey(key []byte) []byte {
 // GetAccount implements state.Trie, retrieving the account with the specified
 // account address. If the specified account is not in the verkle tree, nil will
 // be returned. If the tree is corrupted, an error will be returned.
-func (t *VerkleTrie) GetAccount(addr common.Address) (*types.StateAccount, error) {
+func (t *VerkleTrie) GetAccount(addr common.Address, _ bool) (*types.StateAccount, error) {
 	var (
 		acc    = &types.StateAccount{}
 		values [][]byte
@@ -118,7 +118,7 @@ func (t *VerkleTrie) GetAccount(addr common.Address) (*types.StateAccount, error
 // GetStorage implements state.Trie, retrieving the storage slot with the specified
 // account address and storage key. If the specified slot is not in the verkle tree,
 // nil will be returned. If the tree is corrupted, an error will be returned.
-func (t *VerkleTrie) GetStorage(addr common.Address, key []byte) ([]byte, error) {
+func (t *VerkleTrie) GetStorage(addr common.Address, key []byte, _ bool) ([]byte, error) {
 	k := utils.StorageSlotKeyWithEvaluatedAddress(t.cache.Get(addr.Bytes()), key)
 	val, err := t.root.Get(k, t.nodeResolver)
 	if err != nil {

--- a/triedb/database/database.go
+++ b/triedb/database/database.go
@@ -29,6 +29,12 @@ type Reader interface {
 	// Don't modify the returned byte slice since it's not deep-copied and
 	// still be referenced by database.
 	Node(owner common.Hash, path []byte, hash common.Hash) ([]byte, error)
+
+	// Account retrieves the account with the provided account hash,
+	Account(hash common.Hash) ([]byte, error)
+
+	// Storage retrieves the storage key-value with the provided account hash,
+	Storage(accountHash, storageHash common.Hash) ([]byte, error)
 }
 
 // PreimageStore wraps the methods of a backing store for reading and writing

--- a/triedb/hashdb/database.go
+++ b/triedb/hashdb/database.go
@@ -493,6 +493,11 @@ type cleaner struct {
 	db *Database
 }
 
+func (c *cleaner) DeleteRange(start, end []byte) error {
+	// TODO implement me
+	panic("implement me")
+}
+
 // Put reacts to database writes and implements dirty data uncaching. This is the
 // post-processing step of a commit operation where the already persisted trie is
 // removed from the dirty cache and moved into the clean cache. The reason behind

--- a/triedb/hashdb/database.go
+++ b/triedb/hashdb/database.go
@@ -642,6 +642,14 @@ type reader struct {
 	db *Database
 }
 
+func (reader reader) Account(hash common.Hash) ([]byte, error) {
+	panic("Not Supported")
+}
+
+func (reader reader) Storage(accountHash, storageHash common.Hash) ([]byte, error) {
+	panic("Not Supported")
+}
+
 // Node retrieves the trie node with the given node hash. No error will be
 // returned if the node is not found.
 func (reader *reader) Node(owner common.Hash, path []byte, hash common.Hash) ([]byte, error) {

--- a/triedb/pathdb/database.go
+++ b/triedb/pathdb/database.go
@@ -67,6 +67,13 @@ type layer interface {
 	// Note, no error will be returned if the requested node is not found in database.
 	node(owner common.Hash, path []byte, depth int) ([]byte, common.Hash, *nodeLoc, error)
 
+	// Account directly retrieves the account data associated with a particular hash
+	Account(hash common.Hash) ([]byte, error)
+
+	// Storage directly retrieves the storage data associated with a particular hash,
+	// within a particular account.
+	Storage(accountHash, storageHash common.Hash) ([]byte, error)
+
 	// rootHash returns the root hash for which this layer was made.
 	rootHash() common.Hash
 

--- a/triedb/pathdb/database.go
+++ b/triedb/pathdb/database.go
@@ -340,7 +340,7 @@ func (db *Database) Enable(root common.Hash) error {
 	}
 	// Re-construct a new disk layer backed by persistent state
 	// with **empty clean cache and node buffer**.
-	db.tree.reset(newDiskLayer(root, 0, db, nil, newNodeBuffer(db.bufferSize, nil, 0)))
+	db.tree.reset(newDiskLayer(root, 0, db, nil, newNodeBuffer(db.bufferSize, nil, nil, nil, nil, 0)))
 
 	// Re-enable the database as the final step.
 	db.waitSync = false

--- a/triedb/pathdb/journal.go
+++ b/triedb/pathdb/journal.go
@@ -75,6 +75,24 @@ type journalStorage struct {
 	Slots   [][]byte
 }
 
+// journalDestruct is an account deletion entry in a diffLayer's disk journal.
+type journalDestruct struct {
+	Hash common.Hash
+}
+
+// journalAccount is an account entry in a diffLayer's disk journal.
+type journalLatestAccount struct {
+	Hash common.Hash
+	Blob []byte
+}
+
+// journalStorage is an account's storage map in a diffLayer's disk journal.
+type journalLatestStorage struct {
+	Hash common.Hash
+	Keys []common.Hash
+	Vals [][]byte
+}
+
 // loadJournal tries to parse the layer journal from the disk.
 func (db *Database) loadJournal(diskRoot common.Hash) (layer, error) {
 	journal := rawdb.ReadTrieJournal(db.diskdb)
@@ -136,7 +154,7 @@ func (db *Database) loadLayers() layer {
 		log.Info("Failed to load journal, discard it", "err", err)
 	}
 	// Return single layer with persistent state.
-	return newDiskLayer(root, rawdb.ReadPersistentStateID(db.diskdb), db, nil, newNodeBuffer(db.bufferSize, nil, 0))
+	return newDiskLayer(root, rawdb.ReadPersistentStateID(db.diskdb), db, nil, newNodeBuffer(db.bufferSize, nil, nil, nil, nil, 0))
 }
 
 // loadDiskLayer reads the binary blob from the layer journal, reconstructing
@@ -175,8 +193,42 @@ func (db *Database) loadDiskLayer(r *rlp.Stream) (layer, error) {
 		}
 		nodes[entry.Owner] = subset
 	}
+
+	// Resolve latest states
+	var (
+		jdestructSet    []journalDestruct
+		jlatestAccounts []journalLatestAccount
+		jlatestStorage  []journalLatestStorage
+
+		latestAccounts = make(map[common.Hash][]byte)
+		latestStorages = make(map[common.Hash]map[common.Hash][]byte)
+		destructSet    = make(map[common.Hash]struct{})
+	)
+	if err := r.Decode(&jdestructSet); err != nil {
+		return nil, fmt.Errorf("load destrctSet: %v", err)
+	}
+	for _, entry := range jdestructSet {
+		destructSet[entry.Hash] = struct{}{}
+	}
+
+	if err := r.Decode(&jlatestAccounts); err != nil {
+		return nil, fmt.Errorf("load latest accounts: %v", err)
+	}
+	for _, entry := range jlatestAccounts {
+		latestAccounts[entry.Hash] = entry.Blob
+	}
+
+	if err := r.Decode(&jlatestStorage); err != nil {
+		return nil, fmt.Errorf("load latest accounts: %v", err)
+	}
+	for _, entry := range jlatestStorage {
+		latestStorages[entry.Hash] = make(map[common.Hash][]byte)
+		for i, key := range entry.Keys {
+			latestStorages[entry.Hash][key] = entry.Vals[i]
+		}
+	}
 	// Calculate the internal state transitions by id difference.
-	base := newDiskLayer(root, id, db, nil, newNodeBuffer(db.bufferSize, nodes, id-stored))
+	base := newDiskLayer(root, id, db, nil, newNodeBuffer(db.bufferSize, nodes, latestAccounts, latestStorages, destructSet, id-stored))
 	return base, nil
 }
 
@@ -219,6 +271,14 @@ func (db *Database) loadDiffLayer(parent layer, r *rlp.Stream) (layer, error) {
 		jstorages []journalStorage
 		accounts  = make(map[common.Address][]byte)
 		storages  = make(map[common.Address]map[common.Hash][]byte)
+
+		jdestructSet    []journalDestruct
+		jlatestAccounts []journalLatestAccount
+		jlatestStorage  []journalLatestStorage
+
+		latestAccounts = make(map[common.Hash][]byte)
+		latestStorages = make(map[common.Hash]map[common.Hash][]byte)
+		destructSet    = make(map[common.Hash]struct{})
 	)
 	if err := r.Decode(&jaccounts); err != nil {
 		return nil, fmt.Errorf("load diff accounts: %v", err)
@@ -240,7 +300,30 @@ func (db *Database) loadDiffLayer(parent layer, r *rlp.Stream) (layer, error) {
 		}
 		storages[entry.Account] = set
 	}
-	return db.loadDiffLayer(newDiffLayer(parent, root, parent.stateID()+1, block, nodes, triestate.New(accounts, storages)), r)
+	if err := r.Decode(&jdestructSet); err != nil {
+		return nil, fmt.Errorf("load destrctSet: %v", err)
+	}
+	for _, entry := range jdestructSet {
+		destructSet[entry.Hash] = struct{}{}
+	}
+
+	if err := r.Decode(&jlatestAccounts); err != nil {
+		return nil, fmt.Errorf("load latest accounts: %v", err)
+	}
+	for _, entry := range jlatestAccounts {
+		latestAccounts[entry.Hash] = entry.Blob
+	}
+
+	if err := r.Decode(&jlatestStorage); err != nil {
+		return nil, fmt.Errorf("load latest accounts: %v", err)
+	}
+	for _, entry := range jlatestStorage {
+		latestStorages[entry.Hash] = make(map[common.Hash][]byte)
+		for i, key := range entry.Keys {
+			latestStorages[entry.Hash][key] = entry.Vals[i]
+		}
+	}
+	return db.loadDiffLayer(newDiffLayer(parent, root, parent.stateID()+1, block, nodes, triestate.New(accounts, storages, latestAccounts, latestStorages, destructSet)), r)
 }
 
 // journal implements the layer interface, marshaling the un-flushed trie nodes
@@ -271,6 +354,36 @@ func (dl *diskLayer) journal(w io.Writer) error {
 		nodes = append(nodes, entry)
 	}
 	if err := rlp.Encode(w, nodes); err != nil {
+		return err
+	}
+
+	// Step four Write latest accounts/storages/destructSet into buffer
+	destructs := make([]journalDestruct, 0, len(dl.buffer.destructSet))
+	for hash := range dl.buffer.destructSet {
+		destructs = append(destructs, journalDestruct{Hash: hash})
+	}
+	if err := rlp.Encode(w, destructs); err != nil {
+		return err
+	}
+
+	latestAccounts := make([]journalLatestAccount, 0, len(dl.buffer.latestAccounts))
+	for hash, blob := range dl.buffer.latestAccounts {
+		latestAccounts = append(latestAccounts, journalLatestAccount{Hash: hash, Blob: blob})
+	}
+	if err := rlp.Encode(w, latestAccounts); err != nil {
+		return err
+	}
+	latestStorage := make([]journalLatestStorage, 0, len(dl.buffer.latestStorages))
+	for hash, slots := range dl.buffer.latestStorages {
+		keys := make([]common.Hash, 0, len(slots))
+		vals := make([][]byte, 0, len(slots))
+		for key, val := range slots {
+			keys = append(keys, key)
+			vals = append(vals, val)
+		}
+		latestStorage = append(latestStorage, journalLatestStorage{Hash: hash, Keys: keys, Vals: vals})
+	}
+	if err := rlp.Encode(w, latestStorage); err != nil {
 		return err
 	}
 	log.Debug("Journaled pathdb disk layer", "root", dl.root, "nodes", len(dl.buffer.nodes))
@@ -325,6 +438,36 @@ func (dl *diffLayer) journal(w io.Writer) error {
 		storage = append(storage, entry)
 	}
 	if err := rlp.Encode(w, storage); err != nil {
+		return err
+	}
+
+	// Write latest accounts/storages/destructSet into buffer
+	destructs := make([]journalDestruct, 0, len(dl.states.DestructSet))
+	for hash := range dl.states.DestructSet {
+		destructs = append(destructs, journalDestruct{Hash: hash})
+	}
+	if err := rlp.Encode(w, destructs); err != nil {
+		return err
+	}
+
+	latestAccounts := make([]journalLatestAccount, 0, len(dl.states.LatestAccounts))
+	for hash, blob := range dl.states.LatestAccounts {
+		latestAccounts = append(latestAccounts, journalLatestAccount{Hash: hash, Blob: blob})
+	}
+	if err := rlp.Encode(w, latestAccounts); err != nil {
+		return err
+	}
+	latestStorage := make([]journalLatestStorage, 0, len(dl.states.LatestStorages))
+	for hash, slots := range dl.states.LatestStorages {
+		keys := make([]common.Hash, 0, len(slots))
+		vals := make([][]byte, 0, len(slots))
+		for key, val := range slots {
+			keys = append(keys, key)
+			vals = append(vals, val)
+		}
+		latestStorage = append(latestStorage, journalLatestStorage{Hash: hash, Keys: keys, Vals: vals})
+	}
+	if err := rlp.Encode(w, latestStorage); err != nil {
 		return err
 	}
 	log.Debug("Journaled pathdb diff layer", "root", dl.root, "parent", dl.parent.rootHash(), "id", dl.stateID(), "block", dl.block, "nodes", len(dl.nodes))

--- a/triedb/pathdb/metrics.go
+++ b/triedb/pathdb/metrics.go
@@ -48,4 +48,7 @@ var (
 	historyBuildTimeMeter  = metrics.NewRegisteredTimer("pathdb/history/time", nil)
 	historyDataBytesMeter  = metrics.NewRegisteredMeter("pathdb/history/bytes/data", nil)
 	historyIndexBytesMeter = metrics.NewRegisteredMeter("pathdb/history/bytes/index", nil)
+
+	bloomIndexTimer = metrics.NewRegisteredResettingTimer("pathdb/bloom/index", nil)
+	bloomErrorGauge = metrics.NewRegisteredGaugeFloat64("pathdb/bloom/error", nil)
 )

--- a/triedb/pathdb/reader.go
+++ b/triedb/pathdb/reader.go
@@ -52,6 +52,15 @@ type reader struct {
 	noHashCheck bool
 }
 
+func (r *reader) Account(hash common.Hash) ([]byte, error) {
+	return r.layer.Account(hash)
+
+}
+
+func (r *reader) Storage(accountHash, storageHash common.Hash) ([]byte, error) {
+	return r.layer.Storage(accountHash, storageHash)
+}
+
 // Node implements database.Reader interface, retrieving the node with specified
 // node info. Don't modify the returned byte slice since it's not deep-copied
 // and still be referenced by database.


### PR DESCRIPTION
This PR implements a way to fetch account/storage directly from pathdb as an alternative to snapshot for better robustness and simplicity, then reducing data storage space.

Major changes:

- add latestaccount/lateststorage/destructset cache to pathdb
- use `db.seekLT` to query the leaf node of account/storage in pathdb
- use `deleteRange` to destruct the storage trie

Status: Testing