### PR TITLE
core/state: fix prefetcher for verkle

### DIFF
--- a/core/state/statedb.go
+++ b/core/state/statedb.go
@@ -907,9 +907,12 @@ func (s *StateDB) IntermediateRoot(deleteEmptyObjects bool) common.Hash {
 	// Now we're about to start to write changes to the trie. The trie is so far
 	// _untouched_. We can check with the prefetcher, if it can give us a trie
 	// which has the same root, but also has some content loaded into it.
+	//
+	// Don't check prefetcher if verkle trie has been used. In the context of verkle,
+	// only a single trie is used for state hashing. Replacing a non-nil verkle tree
+	// here could result in losing uncommitted changes from storage.
 	start = time.Now()
-
-	if s.prefetcher != nil {
+	if s.prefetcher != nil && (s.trie == nil || !s.trie.IsVerkle()) {
 		if trie := s.prefetcher.trie(common.Hash{}, s.originalRoot); trie == nil {
 			log.Error("Failed to retrieve account pre-fetcher trie")
 		} else {


### PR DESCRIPTION
This pull request fixes a flaw in verkle.

Inside of the statedb, there is a tool named "prefetcher". It will pull the necessary data for state hashing in the background to accelerate the state hashing performance. Unfortunately, it's broken in the verkle context.

The root cause is once verkle is activated, there is only a single trie used for state hashing(instead of two-layer tree structure in merkle). And storage trie commits are schedule before the account trie for performance consideration. If the verkle trie is resolved from the prefetcher *after committing the storage changes*, the changes caused by storage will be silently dropped.

This pull request disables the prefetching in verkle as a quick fix.