### PR TITLE
core: `balanceCheck` should always include `msg.Value`

### DIFF
--- a/core/state_transition.go
+++ b/core/state_transition.go
@@ -240,8 +240,9 @@ func (st *StateTransition) buyGas() error {
 	if st.msg.GasFeeCap != nil {
 		balanceCheck.SetUint64(st.msg.GasLimit)
 		balanceCheck = balanceCheck.Mul(balanceCheck, st.msg.GasFeeCap)
-		balanceCheck.Add(balanceCheck, st.msg.Value)
 	}
+	balanceCheck.Add(balanceCheck, st.msg.Value)
+
 	if st.evm.ChainConfig().IsCancun(st.evm.Context.BlockNumber, st.evm.Context.Time) {
 		if blobGas := st.blobGasUsed(); blobGas > 0 {
 			// Check that the user has enough funds to cover blobGasUsed * tx.BlobGasFeeCap


### PR DESCRIPTION
Currently `balanceCheck` only includes `msg.Value` when `msg.GasFeeCap!=nil`.

I think `balanceCheck` should always include `msg.Value` no matter whether `msg.GasPrice` or `msg.GasFeeCap` is chosen as the effective gas price.