### PR TITLE
core/state: remove useless operation

### DIFF
--- a/core/state/state_object.go
+++ b/core/state/state_object.go
@@ -304,10 +304,9 @@ func (s *stateObject) finalise() {
 // loading or updating of the trie, an error will be returned. Furthermore,
 // this function will return the mutated storage trie, or nil if there is no
 // storage change at all.
+//
+// It assumes all the dirty storage slots have been finalized before.
 func (s *stateObject) updateTrie() (Trie, error) {
-	// Make sure all dirty slots are finalized into the pending storage area
-	s.finalise()
-
 	// Short circuit if nothing changed, don't bother with hashing anything
 	if len(s.pendingStorage) == 0 {
 		return s.trie, nil


### PR DESCRIPTION
Originally `updateTrie` will try to finalize the dirty storages first before trie committing. This operation is removed in this pull request, reasons as below:

- Before the `updateTrie`, all the finalization has already been done in `IntermediateRoot`, the operation here is duplicated
- The prefetcher has been terminated at that time and if there are some leftover slots, they will be failed for prefetching

