### PR TITLE
Makefile: add fmt, update help

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,31 +2,35 @@
 # with Go source code. If you know what GOPATH is then you probably
 # don't need to bother with make.
 
-.PHONY: geth all test lint clean devtools help
+.PHONY: geth all test lint fmt clean devtools help
 
 GOBIN = ./build/bin
 GO ?= latest
 GORUN = go run
 
-#? geth: Build geth
+#? geth: Build geth.
 geth:
 	$(GORUN) build/ci.go install ./cmd/geth
 	@echo "Done building."
 	@echo "Run \"$(GOBIN)/geth\" to launch geth."
 
-#? all: Build all packages and executables
+#? all: Build all packages and executables.
 all:
 	$(GORUN) build/ci.go install
 
-#? test: Run the tests
+#? test: Run the tests.
 test: all
 	$(GORUN) build/ci.go test
 
-#? lint: Run certain pre-selected linters
+#? lint: Run certain pre-selected linters.
 lint: ## Run linters.
 	$(GORUN) build/ci.go lint
 
-#? clean: Clean go cache, built executables, and the auto generated folder
+#? fmt: Ensure consistent code formatting.
+fmt:
+	gofmt -s -w $(shell find . -name "*.go")
+
+#? clean: Clean go cache, built executables, and the auto generated folder.
 clean:
 	go clean -cache
 	rm -fr build/_workspace/pkg/ $(GOBIN)/*
@@ -34,7 +38,7 @@ clean:
 # The devtools target installs tools required for 'go generate'.
 # You need to put $GOBIN (or $GOPATH/bin) in your PATH to use 'go generate'.
 
-#? devtools: Install recommended developer tools
+#? devtools: Install recommended developer tools.
 devtools:
 	env GOBIN= go install golang.org/x/tools/cmd/stringer@latest
 	env GOBIN= go install github.com/fjl/gencodec@latest
@@ -45,5 +49,9 @@ devtools:
 
 #? help: Get more info on make commands.
 help: Makefile
-	@echo " Choose a command run in go-ethereum:"
+	@echo ''
+	@echo 'Usage:'
+	@echo '  make [target]'
+	@echo ''
+	@echo 'Targets:'
 	@sed -n 's/^#?//p' $< | column -t -s ':' |  sort | sed -e 's/^/ /'


### PR DESCRIPTION
- Added `fmt` command to **Makefile** for easier formatting.
- Formatted '.go' files with `make fmt`.
- Made `help` the default command and updated it.