### PR TITLE
internal/ethapi: fix typos

### DIFF
--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -966,7 +966,7 @@ func (s *BlockChainAPI) GetBlockReceipts(ctx context.Context, blockNrOrHash rpc.
 // of a message call.
 // Note, state and stateDiff can't be specified at the same time. If state is
 // set, message execution will only use the data in the given state. Otherwise
-// if statDiff is set, all diff will be applied first and then execute the call
+// if stateDiff is set, all diff will be applied first and then execute the call
 // message.
 type OverrideAccount struct {
 	Nonce     *hexutil.Uint64              `json:"nonce"`
@@ -1203,7 +1203,7 @@ func DoEstimateGas(ctx context.Context, b Backend, args TransactionArgs, blockNr
 		return 0, err
 	}
 	call := args.ToMessage(header.BaseFee)
-	// Run the gas estimation andwrap any revertals into a custom return
+	// Run the gas estimation and wrap any revertals into a custom return
 	estimate, revert, err := gasestimator.Estimate(ctx, call, opts, gasCap)
 	if err != nil {
 		if len(revert) > 0 {


### PR DESCRIPTION
Since the recent release notes said that you like nitpick PRs, here's one more!

Personally, I would also say "revert" instead of "revertal", but since it occurs five times in the code base, it doesn't seem to be an accident.