### PR TITLE
fix: traceCall having baseFee 0 despite gas price being set.

### DIFF
--- a/eth/tracers/api.go
+++ b/eth/tracers/api.go
@@ -22,7 +22,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"math/big"
 	"os"
 	"runtime"
 	"sync"
@@ -982,7 +981,7 @@ func (api *API) traceTx(ctx context.Context, tx *types.Transaction, message *cor
 			return nil, err
 		}
 	}
-	vmenv := vm.NewEVM(vmctx, vm.TxContext{GasPrice: big.NewInt(0)}, statedb, api.backend.ChainConfig(), vm.Config{Tracer: tracer.Hooks, NoBaseFee: true})
+	vmenv := vm.NewEVM(vmctx, vm.TxContext{GasPrice: message.GasPrice}, statedb, api.backend.ChainConfig(), vm.Config{Tracer: tracer.Hooks, NoBaseFee: true})
 	statedb.SetLogger(tracer.Hooks)
 
 	// Define a meaningful timeout of a single transaction trace


### PR DESCRIPTION
This fixes baseFee being zero despite gas prices being set. 

There are situations in tracing where we would like the baseFee not to be zero. This is to get traces that are as accurate to transaction execution as possible. In the current implementation of `NewEVM` inside `traceTx`, the `GasPrice` is set to a dummy price of 0 despite the transaction including a gas price. This results in the block context base fee always being set to zero.

To solve this, we pass in the gas price provided by the transaction.

The bug was introduced in https://github.com/ethereum/go-ethereum/commit/064f37d6f67a012eea0bf8d410346fb1684004b4 during the rework of tracing.