### PR TITLE
eth/protocols/snap: save nodes on right boundary in hash mode

### DIFF
--- a/eth/protocols/snap/gentrie.go
+++ b/eth/protocols/snap/gentrie.go
@@ -280,8 +280,9 @@ func (t *hashTrie) update(key, value []byte) error {
 
 // commit implements genTrie interface, committing the nodes on right boundary.
 func (t *hashTrie) commit(complete bool) common.Hash {
+	hash := t.tr.Hash() // flush the nodes on right boundary
 	if !complete {
 		return common.Hash{} // the hash is meaningless for incomplete commit
 	}
-	return t.tr.Hash() // return hash only if it's claimed as complete
+	return hash // return hash only if it's claimed as complete
 }

--- a/trie/sync.go
+++ b/trie/sync.go
@@ -542,9 +542,6 @@ func (s *Sync) children(req *nodeRequest, object node) ([]*nodeRequest, error) {
 		if _, ok := node.Val.(hashNode); ok && s.scheme == rawdb.PathScheme {
 			owner, inner := ResolvePath(req.path)
 			for i := 1; i < len(key); i++ {
-				// While checking for a non-existent item in Pebble can be less efficient
-				// without a bloom filter, the relatively low frequency of lookups makes
-				// the performance impact negligible.
 				var exists bool
 				if owner == (common.Hash{}) {
 					exists = rawdb.HasAccountTrieNode(s.database, append(inner, key[:i]...))


### PR DESCRIPTION
This pull request fixes an issue in hash gentrie.

In hash-mode, no matter the gentrie is complete or not, all the nodes on the right boundary should be flushed into disk if `commit` is called. As the garbage nodes will be unlinked from the trie by state healer.

Currently, if the right boundary of gentrie is claimed as incomplete, nodes on it are silently discarded. Given that the nodes on incomplete boundary are usually useless, but still the behavior should be aligned in hash gentrie.