### PR TITLE
eth/tracers: fix json logger for evm blocktest

### DIFF
--- a/eth/tracers/api.go
+++ b/eth/tracers/api.go
@@ -805,9 +805,13 @@ func (api *API) standardTraceBlockToFile(ctx context.Context, block *types.Block
 		// Execute the transaction and flush any traces to disk
 		vmenv := vm.NewEVM(vmctx, txContext, statedb, chainConfig, vmConf)
 		statedb.SetTxContext(tx.Hash(), i)
-		vmConf.Tracer.OnTxStart(vmenv.GetVMContext(), tx, msg.From)
+		if vmConf.Tracer.OnTxStart != nil {
+			vmConf.Tracer.OnTxStart(vmenv.GetVMContext(), tx, msg.From)
+		}
 		vmRet, err := core.ApplyMessage(vmenv, msg, new(core.GasPool).AddGas(msg.GasLimit))
-		vmConf.Tracer.OnTxEnd(&types.Receipt{GasUsed: vmRet.UsedGas}, err)
+		if vmConf.Tracer.OnTxEnd != nil {
+			vmConf.Tracer.OnTxEnd(&types.Receipt{GasUsed: vmRet.UsedGas}, err)
+		}
 		if writer != nil {
 			writer.Flush()
 		}


### PR DESCRIPTION
`evm blocktest` goes through the main block processing code path, triggering the system calls. That caused a crash because we start opcode processing without doing `OnTxStart` (which sets the env).

This PR removes events from the system call. I'm open to keeping them if they are useful for testers, and instead fix the crash.