### PR TITLE
core/vm/runtime: set random to enable merge-opcodes

### DIFF
--- a/core/vm/runtime/runtime.go
+++ b/core/vm/runtime/runtime.go
@@ -101,6 +101,10 @@ func setDefaults(cfg *Config) {
 	if cfg.BlobBaseFee == nil {
 		cfg.BlobBaseFee = big.NewInt(params.BlobTxMinBlobGasprice)
 	}
+	// Merge indicators
+	if t := cfg.ChainConfig.ShanghaiTime; cfg.ChainConfig.TerminalTotalDifficultyPassed || (t != nil && *t == 0) {
+		cfg.Random = &(common.Hash{})
+	}
 }
 
 // Execute executes the code using the input as call data during the execution.

--- a/core/vm/runtime/runtime.go
+++ b/core/vm/runtime/runtime.go
@@ -57,24 +57,33 @@ type Config struct {
 // sets defaults on the config
 func setDefaults(cfg *Config) {
 	if cfg.ChainConfig == nil {
+		var (
+			shanghaiTime = uint64(0)
+			cancunTime   = uint64(0)
+		)
 		cfg.ChainConfig = &params.ChainConfig{
-			ChainID:             big.NewInt(1),
-			HomesteadBlock:      new(big.Int),
-			DAOForkBlock:        new(big.Int),
-			DAOForkSupport:      false,
-			EIP150Block:         new(big.Int),
-			EIP155Block:         new(big.Int),
-			EIP158Block:         new(big.Int),
-			ByzantiumBlock:      new(big.Int),
-			ConstantinopleBlock: new(big.Int),
-			PetersburgBlock:     new(big.Int),
-			IstanbulBlock:       new(big.Int),
-			MuirGlacierBlock:    new(big.Int),
-			BerlinBlock:         new(big.Int),
-			LondonBlock:         new(big.Int),
-		}
+			ChainID:                       big.NewInt(1),
+			HomesteadBlock:                new(big.Int),
+			DAOForkBlock:                  new(big.Int),
+			DAOForkSupport:                false,
+			EIP150Block:                   new(big.Int),
+			EIP155Block:                   new(big.Int),
+			EIP158Block:                   new(big.Int),
+			ByzantiumBlock:                new(big.Int),
+			ConstantinopleBlock:           new(big.Int),
+			PetersburgBlock:               new(big.Int),
+			IstanbulBlock:                 new(big.Int),
+			MuirGlacierBlock:              new(big.Int),
+			BerlinBlock:                   new(big.Int),
+			LondonBlock:                   new(big.Int),
+			ArrowGlacierBlock:             nil,
+			GrayGlacierBlock:              nil,
+			TerminalTotalDifficulty:       big.NewInt(0),
+			TerminalTotalDifficultyPassed: true,
+			MergeNetsplitBlock:            nil,
+			ShanghaiTime:                  &shanghaiTime,
+			CancunTime:                    &cancunTime}
 	}
-
 	if cfg.Difficulty == nil {
 		cfg.Difficulty = new(big.Int)
 	}

--- a/core/vm/runtime/runtime_test.go
+++ b/core/vm/runtime/runtime_test.go
@@ -105,7 +105,7 @@ func TestExecute(t *testing.T) {
 
 func TestCall(t *testing.T) {
 	state, _ := state.New(types.EmptyRootHash, state.NewDatabase(rawdb.NewMemoryDatabase()), nil)
-	address := common.HexToAddress("0x0a")
+	address := common.HexToAddress("0xaa")
 	state.SetCode(address, []byte{
 		byte(vm.PUSH1), 10,
 		byte(vm.PUSH1), 0,
@@ -725,7 +725,7 @@ func TestRuntimeJSTracer(t *testing.T) {
 				byte(vm.CREATE),
 				byte(vm.POP),
 			},
-			results: []string{`"1,1,952855,6,12"`, `"1,1,952855,6,0"`},
+			results: []string{`"1,1,952853,6,12"`, `"1,1,952853,6,0"`},
 		},
 		{
 			// CREATE2
@@ -741,7 +741,7 @@ func TestRuntimeJSTracer(t *testing.T) {
 				byte(vm.CREATE2),
 				byte(vm.POP),
 			},
-			results: []string{`"1,1,952846,6,13"`, `"1,1,952846,6,0"`},
+			results: []string{`"1,1,952844,6,13"`, `"1,1,952844,6,0"`},
 		},
 		{
 			// CALL


### PR DESCRIPTION
This PR closes https://github.com/ethereum/go-ethereum/issues/29782 and https://github.com/ethereum/go-ethereum/issues/29722 . The `IsMerge` indicator used by core/vm/runtime checked if the prevrandao/random was set. This is actually a somewhat sane indicator, because if it is `nil`, it will trigger a nil deref later on if the `RANDOM` opcode is used. 

This PR fixes it by setting it in case we're past Shanghai. 
```
[user@work go-ethereum]$ go run ./cmd/evm --nomemory=false --json --code 5f44 run 
{"pc":0,"op":95,"gas":"0x2540be400","gasCost":"0x2","memSize":0,"stack":[],"depth":1,"refund":0,"opName":"PUSH0"}
{"pc":1,"op":68,"gas":"0x2540be3fe","gasCost":"0x2","memSize":0,"stack":["0x0"],"depth":1,"refund":0,"opName":"DIFFICULTY"}
{"pc":2,"op":0,"gas":"0x2540be3fc","gasCost":"0x0","memSize":0,"stack":["0x0","0x0"],"depth":1,"refund":0,"opName":"STOP"}
{"output":"","gasUsed":"0x4"}
```