### PR TITLE
accounts/abi/bind: keep test file package name consistent

### DIFF
--- a/accounts/abi/bind/bind_test.go
+++ b/accounts/abi/bind/bind_test.go
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
 
-package bind
+package bind_test
 
 import (
 	"fmt"
@@ -25,6 +25,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
 )
 
@@ -2096,7 +2097,7 @@ func TestGolangBindings(t *testing.T) {
 				types = []string{tt.name}
 			}
 			// Generate the binding and create a Go source file in the workspace
-			bind, err := Bind(types, tt.abi, tt.bytecode, tt.fsigs, "bindtest", LangGo, tt.libs, tt.aliases)
+			bind, err := bind.Bind(types, tt.abi, tt.bytecode, tt.fsigs, "bindtest", bind.LangGo, tt.libs, tt.aliases)
 			if err != nil {
 				t.Fatalf("test %d: failed to generate binding: %v", i, err)
 			}

--- a/common/big.go
+++ b/common/big.go
@@ -24,10 +24,10 @@ import (
 
 // Common big integers often used
 var (
+	Big0   = big.NewInt(0)
 	Big1   = big.NewInt(1)
 	Big2   = big.NewInt(2)
 	Big3   = big.NewInt(3)
-	Big0   = big.NewInt(0)
 	Big32  = big.NewInt(32)
 	Big256 = big.NewInt(256)
 	Big257 = big.NewInt(257)

--- a/core/genesis.go
+++ b/core/genesis.go
@@ -594,7 +594,7 @@ func DeveloperGenesisBlock(gasLimit uint64, faucet *common.Address) *Genesis {
 			common.BytesToAddress([]byte{8}): {Balance: big.NewInt(1)}, // ECPairing
 			common.BytesToAddress([]byte{9}): {Balance: big.NewInt(1)}, // BLAKE2b
 			// Pre-deploy EIP-4788 system contract
-			params.BeaconRootsAddress: types.Account{Nonce: 1, Code: params.BeaconRootsCode},
+			params.BeaconRootsAddress: {Nonce: 1, Code: params.BeaconRootsCode},
 		},
 	}
 	if faucet != nil {


### PR DESCRIPTION
This PR adds some small code cleanup:
- accounts/abi/bind: keep test file package name consistent
- common: sort variables to make code more clear
- core: remove redundant type declaration