### PR TITLE
beacon,console,core,eth,p2p,rpc: keep `wg.Add` and `wg.Done` closer

### DIFF
--- a/beacon/blsync/engineclient.go
+++ b/beacon/blsync/engineclient.go
@@ -47,7 +47,10 @@ func startEngineClient(config *lightClientConfig, rpc *rpc.Client, headCh <-chan
 		cancelRoot: cancel,
 	}
 	ec.wg.Add(1)
-	go ec.updateLoop(headCh)
+	go func() {
+		defer ec.wg.Done()
+		ec.updateLoop(headCh)
+	}()
 	return ec
 }
 
@@ -57,8 +60,6 @@ func (ec *engineClient) stop() {
 }
 
 func (ec *engineClient) updateLoop(headCh <-chan types.ChainHeadEvent) {
-	defer ec.wg.Done()
-
 	for {
 		select {
 		case <-ec.rootCtx.Done():

--- a/console/console.go
+++ b/console/console.go
@@ -120,7 +120,10 @@ func New(config Config) (*Console, error) {
 	}
 
 	console.wg.Add(1)
-	go console.interruptHandler()
+	go func() {
+		defer console.wg.Done()
+		console.interruptHandler()
+	}()
 
 	return console, nil
 }
@@ -363,8 +366,6 @@ func (c *Console) Evaluate(statement string) {
 // interruptHandler runs in its own goroutine and waits for signals.
 // When a signal is received, it interrupts the JS interpreter.
 func (c *Console) interruptHandler() {
-	defer c.wg.Done()
-
 	// During Interactive, liner inhibits the signal while it is prompting for
 	// input. However, the signal will be received while evaluating JS.
 	//

--- a/core/state/statedb_test.go
+++ b/core/state/statedb_test.go
@@ -197,16 +197,24 @@ func TestCopy(t *testing.T) {
 	}
 
 	// Finalise the changes on all concurrently
-	finalise := func(wg *sync.WaitGroup, db *StateDB) {
-		defer wg.Done()
+	finalise := func(db *StateDB) {
 		db.Finalise(true)
 	}
 
 	var wg sync.WaitGroup
 	wg.Add(3)
-	go finalise(&wg, orig)
-	go finalise(&wg, copy)
-	go finalise(&wg, ccopy)
+	go func() {
+		defer wg.Done()
+		finalise(orig)
+	}()
+	go func() {
+		defer wg.Done()
+		finalise(copy)
+	}()
+	go func() {
+		defer wg.Done()
+		finalise(ccopy)
+	}()
 	wg.Wait()
 
 	// Verify that the three states have been updated independently

--- a/core/state/statedb_test.go
+++ b/core/state/statedb_test.go
@@ -197,23 +197,19 @@ func TestCopy(t *testing.T) {
 	}
 
 	// Finalise the changes on all concurrently
-	finalise := func(db *StateDB) {
-		db.Finalise(true)
-	}
-
 	var wg sync.WaitGroup
 	wg.Add(3)
 	go func() {
 		defer wg.Done()
-		finalise(orig)
+		orig.Finalise(true)
 	}()
 	go func() {
 		defer wg.Done()
-		finalise(copy)
+		copy.Finalise(true)
 	}()
 	go func() {
 		defer wg.Done()
-		finalise(ccopy)
+		ccopy.Finalise(true)
 	}()
 	wg.Wait()
 

--- a/p2p/dial.go
+++ b/p2p/dial.go
@@ -178,8 +178,14 @@ func newDialScheduler(config dialConfig, it enode.Iterator, setupFunc dialSetupF
 	d.lastStatsLog = d.clock.Now()
 	d.ctx, d.cancel = context.WithCancel(context.Background())
 	d.wg.Add(2)
-	go d.readNodes(it)
-	go d.loop(it)
+	go func() {
+		defer d.wg.Done()
+		d.readNodes(it)
+	}()
+	go func() {
+		defer d.wg.Done()
+		d.loop(it)
+	}()
 	return d
 }
 
@@ -311,14 +317,11 @@ loop:
 	for range d.dialing {
 		<-d.doneCh
 	}
-	d.wg.Done()
 }
 
 // readNodes runs in its own goroutine and delivers nodes from
 // the input iterator to the nodesIn channel.
 func (d *dialScheduler) readNodes(it enode.Iterator) {
-	defer d.wg.Done()
-
 	for it.Next() {
 		select {
 		case d.nodesIn <- it.Node():

--- a/p2p/discover/v4_udp.go
+++ b/p2p/discover/v4_udp.go
@@ -411,8 +411,6 @@ func (t *UDPv4) handleReply(from enode.ID, fromIP net.IP, req v4wire.Packet) boo
 // loop runs in its own goroutine. it keeps track of
 // the refresh timer and the pending reply queue.
 func (t *UDPv4) loop() {
-	defer t.wg.Done()
-
 	var (
 		plist        = list.New()
 		timeout      = time.NewTimer(0)
@@ -518,7 +516,6 @@ func (t *UDPv4) write(toaddr *net.UDPAddr, toid enode.ID, what string, packet []
 
 // readLoop runs in its own goroutine. it handles incoming UDP packets.
 func (t *UDPv4) readLoop(unhandled chan<- ReadPacket) {
-	defer t.wg.Done()
 	if unhandled != nil {
 		defer close(unhandled)
 	}

--- a/p2p/discover/v4_udp.go
+++ b/p2p/discover/v4_udp.go
@@ -150,8 +150,14 @@ func ListenV4(c UDPConn, ln *enode.LocalNode, cfg Config) (*UDPv4, error) {
 	go tab.loop()
 
 	t.wg.Add(2)
-	go t.loop()
-	go t.readLoop(cfg.Unhandled)
+	go func() {
+		defer t.wg.Done()
+		t.loop()
+	}()
+	go func() {
+		defer t.wg.Done()
+		t.readLoop(cfg.Unhandled)
+	}()
 	return t, nil
 }
 

--- a/p2p/enode/iter.go
+++ b/p2p/enode/iter.go
@@ -174,10 +174,13 @@ func (m *FairMix) AddSource(it Iterator) {
 	if m.closed == nil {
 		return
 	}
-	m.wg.Add(1)
 	source := &mixSource{it, make(chan *Node), m.timeout}
 	m.sources = append(m.sources, source)
-	go m.runSource(m.closed, source)
+	m.wg.Add(1)
+	go func() {
+		defer m.wg.Done()
+		m.runSource(m.closed, source)
+	}()
 }
 
 // Close shuts down the mixer and all current sources.
@@ -281,7 +284,6 @@ func (m *FairMix) deleteSource(s *mixSource) {
 
 // runSource reads a single source in a loop.
 func (m *FairMix) runSource(closed chan struct{}, s *mixSource) {
-	defer m.wg.Done()
 	defer close(s.next)
 	for s.it.Next() {
 		n := s.it.Node()

--- a/p2p/simulations/adapters/exec.go
+++ b/p2p/simulations/adapters/exec.go
@@ -334,15 +334,20 @@ func (n *ExecNode) ServeRPC(clientConn *websocket.Conn) error {
 	}
 	var wg sync.WaitGroup
 	wg.Add(2)
-	go wsCopy(&wg, conn, clientConn)
-	go wsCopy(&wg, clientConn, conn)
+	go func() {
+		defer wg.Done()
+		wsCopy(conn, clientConn)
+	}()
+	go func() {
+		defer wg.Done()
+		wsCopy(clientConn, conn)
+	}()
 	wg.Wait()
 	conn.Close()
 	return nil
 }
 
-func wsCopy(wg *sync.WaitGroup, src, dst *websocket.Conn) {
-	defer wg.Done()
+func wsCopy(src, dst *websocket.Conn) {
 	for {
 		msgType, r, err := src.NextReader()
 		if err != nil {

--- a/rpc/client_test.go
+++ b/rpc/client_test.go
@@ -352,7 +352,6 @@ func testClientCancel(transport string, t *testing.T) {
 		ncallers = 10
 	)
 	caller := func(index int) {
-		defer wg.Done()
 		for i := 0; i < nreqs; i++ {
 			var (
 				ctx     context.Context
@@ -386,7 +385,10 @@ func testClientCancel(transport string, t *testing.T) {
 	}
 	wg.Add(ncallers)
 	for i := 0; i < ncallers; i++ {
-		go caller(i)
+		go func(idx int) {
+			defer wg.Done()
+			caller(idx)
+		}(i)
 	}
 	wg.Wait()
 }

--- a/rpc/websocket.go
+++ b/rpc/websocket.go
@@ -319,7 +319,10 @@ func newWebsocketCodec(conn *websocket.Conn, host string, req http.Header, readL
 		return nil
 	})
 	wc.wg.Add(1)
-	go wc.pingLoop()
+	go func() {
+		defer wc.wg.Done()
+		wc.pingLoop()
+	}()
 	return wc
 }
 
@@ -347,7 +350,6 @@ func (wc *websocketCodec) writeJSON(ctx context.Context, v interface{}, isError 
 // pingLoop sends periodic ping frames when the connection is idle.
 func (wc *websocketCodec) pingLoop() {
 	var pingTimer = time.NewTimer(wsPingInterval)
-	defer wc.wg.Done()
 	defer pingTimer.Stop()
 
 	for {


### PR DESCRIPTION
Similar to #29813, this PR modifies all other `sync.WaitGroup` cases.

1. call `wg.Done` without `wg.Add` will cause panic.
2. `wg.Done()` is meaningless without `wg.Add` and goroutine
3. Putting `wg.Add` and `wg.Done` together can makes us easily ensure that both counts are equal. 