### PR TITLE
Tosca CT integration

### DIFF
--- a/core/vm/evm.go
+++ b/core/vm/evm.go
@@ -125,6 +125,9 @@ type EVM struct {
 	// available gas is calculated in gasCall* according to the 63/64 rule and later
 	// applied in opCall*.
 	callGasTemp uint64
+
+	// An optional override to intercept EVM calls.
+	CallContext CallContextInterceptor
 }
 
 // NewEVM returns a new EVM. The returned EVM is not thread safe and should
@@ -181,6 +184,9 @@ func (evm *EVM) Interpreter() *EVMInterpreter {
 // the necessary steps to create accounts and reverses the state in case of an
 // execution error or failed value transfer.
 func (evm *EVM) Call(caller ContractRef, addr common.Address, input []byte, gas uint64, value *uint256.Int) (ret []byte, leftOverGas uint64, err error) {
+	if evm.CallContext != nil {
+		return evm.CallContext.Call(evm, caller, addr, input, new(big.Int).SetUint64(gas), value.ToBig())
+	}
 	// Capture the tracer start/end events in debug mode
 	if evm.Config.Tracer != nil {
 		evm.captureBegin(evm.depth, CALL, caller.Address(), addr, input, gas, value.ToBig())
@@ -253,6 +259,9 @@ func (evm *EVM) Call(caller ContractRef, addr common.Address, input []byte, gas 
 // CallCode differs from Call in the sense that it executes the given address'
 // code with the caller as context.
 func (evm *EVM) CallCode(caller ContractRef, addr common.Address, input []byte, gas uint64, value *uint256.Int) (ret []byte, leftOverGas uint64, err error) {
+	if evm.CallContext != nil {
+		return evm.CallContext.CallCode(evm, caller, addr, input, new(big.Int).SetUint64(gas), value.ToBig())
+	}
 	// Invoke tracer hooks that signal entering/exiting a call frame
 	if evm.Config.Tracer != nil {
 		evm.captureBegin(evm.depth, CALLCODE, caller.Address(), addr, input, gas, value.ToBig())
@@ -304,6 +313,9 @@ func (evm *EVM) CallCode(caller ContractRef, addr common.Address, input []byte, 
 // DelegateCall differs from CallCode in the sense that it executes the given address'
 // code with the caller as context and the caller is set to the caller of the caller.
 func (evm *EVM) DelegateCall(caller ContractRef, addr common.Address, input []byte, gas uint64) (ret []byte, leftOverGas uint64, err error) {
+	if evm.CallContext != nil {
+		return evm.CallContext.DelegateCall(evm, caller, addr, input, new(big.Int).SetUint64(gas))
+	}
 	// Invoke tracer hooks that signal entering/exiting a call frame
 	if evm.Config.Tracer != nil {
 		// NOTE: caller must, at all times be a contract. It should never happen
@@ -349,6 +361,9 @@ func (evm *EVM) DelegateCall(caller ContractRef, addr common.Address, input []by
 // Opcodes that attempt to perform such modifications will result in exceptions
 // instead of performing the modifications.
 func (evm *EVM) StaticCall(caller ContractRef, addr common.Address, input []byte, gas uint64) (ret []byte, leftOverGas uint64, err error) {
+	if evm.CallContext != nil {
+		return evm.CallContext.StaticCall(evm, caller, addr, input, new(big.Int).SetUint64(gas))
+	}
 	// Invoke tracer hooks that signal entering/exiting a call frame
 	if evm.Config.Tracer != nil {
 		evm.captureBegin(evm.depth, STATICCALL, caller.Address(), addr, input, gas, nil)
@@ -520,6 +535,9 @@ func (evm *EVM) create(caller ContractRef, codeAndHash *codeAndHash, gas uint64,
 
 // Create creates a new contract using code as deployment code.
 func (evm *EVM) Create(caller ContractRef, code []byte, gas uint64, value *uint256.Int) (ret []byte, contractAddr common.Address, leftOverGas uint64, err error) {
+	if evm.CallContext != nil {
+		return evm.CallContext.Create(evm, caller, code, new(big.Int).SetUint64(gas), value.ToBig())
+	}
 	contractAddr = crypto.CreateAddress(caller.Address(), evm.StateDB.GetNonce(caller.Address()))
 	return evm.create(caller, &codeAndHash{code: code}, gas, value, contractAddr, CREATE)
 }
@@ -529,6 +547,9 @@ func (evm *EVM) Create(caller ContractRef, code []byte, gas uint64, value *uint2
 // The different between Create2 with Create is Create2 uses keccak256(0xff ++ msg.sender ++ salt ++ keccak256(init_code))[12:]
 // instead of the usual sender-and-nonce-hash as the address where the contract is initialized at.
 func (evm *EVM) Create2(caller ContractRef, code []byte, gas uint64, endowment *uint256.Int, salt *uint256.Int) (ret []byte, contractAddr common.Address, leftOverGas uint64, err error) {
+	if evm.CallContext != nil {
+		return evm.CallContext.Create2(evm, caller, code, new(big.Int).SetUint64(gas), endowment.ToBig(), salt)
+	}
 	codeAndHash := &codeAndHash{code: code}
 	contractAddr = crypto.CreateAddress2(caller.Address(), salt.Bytes32(), codeAndHash.Hash().Bytes())
 	return evm.create(caller, codeAndHash, gas, endowment, contractAddr, CREATE2)

--- a/core/vm/tosca_ct_integration.go
+++ b/core/vm/tosca_ct_integration.go
@@ -1,0 +1,165 @@
+package vm
+
+import (
+	"math/big"
+	"strings"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/log"
+	"github.com/holiman/uint256"
+)
+
+// Error
+var ErrStopToken = errStopToken
+
+// Gas table
+func MemoryGasCost(mem *Memory, wordSize uint64) (uint64, error) {
+	return memoryGasCost(mem, wordSize)
+}
+
+// Stack
+func NewStack() *Stack {
+	return newstack()
+}
+
+func (st *Stack) Len() int {
+	return st.len()
+}
+
+func (st *Stack) Push(d *uint256.Int) {
+	st.push(d)
+}
+
+// EVM
+func (evm *EVM) GetDepth() int {
+	return evm.depth
+}
+
+func (evm *EVM) SetDepth(depth int) {
+	evm.depth = depth
+}
+
+// Interpreter
+func (g *EVMInterpreter) SetLastCallReturnData(data []byte) {
+	g.returnData = data
+}
+
+func (g *EVMInterpreter) GetLastCallReturnData() []byte {
+	return g.returnData
+}
+
+func (g *EVMInterpreter) SetReadOnly(readOnly bool) {
+	g.readOnly = readOnly
+}
+
+func (g *EVMInterpreter) IsReadOnly() bool {
+	return g.readOnly
+}
+
+// CallContext Call interceptor
+
+// CallContext provides a basic interface for the EVM calling conventions. The EVM
+// depends on this context being implemented for doing subcalls and initialising new EVM contracts.
+type CallContextInterceptor interface {
+	// Call calls another contract.
+	Call(env *EVM, me ContractRef, addr common.Address, data []byte, gas, value *big.Int) ([]byte, uint64, error)
+	// CallCode takes another contracts code and execute within our own context
+	CallCode(env *EVM, me ContractRef, addr common.Address, data []byte, gas, value *big.Int) ([]byte, uint64, error)
+	// DelegateCall is same as CallCode except sender and value is propagated from parent to child scope
+	DelegateCall(env *EVM, me ContractRef, addr common.Address, data []byte, gas *big.Int) ([]byte, uint64, error)
+	// Create creates a new contract
+	Create(env *EVM, me ContractRef, data []byte, gas, value *big.Int) ([]byte, common.Address, uint64, error)
+
+	StaticCall(env *EVM, me ContractRef, addr common.Address, input []byte, gas *big.Int) ([]byte, uint64, error)
+	Create2(env *EVM, me ContractRef, code []byte, gas *big.Int, value *big.Int, salt *uint256.Int) ([]byte, common.Address, uint64, error)
+}
+
+// Interpreter interface
+// EVMInterpreter defines an interface for different interpreter implementations.
+type GethEVMInterpreter interface {
+	// Run the contract's code with the given input data and returns the return byte-slice
+	// and an error if one occurred.
+	Run(contract *Contract, input []byte, readOnly bool) (ret []byte, err error)
+}
+
+type InterpreterFactory func(evm *EVM, cfg Config) GethEVMInterpreter
+
+var interpreter_registry = map[string]InterpreterFactory{}
+
+func RegisterInterpreterFactory(name string, factory InterpreterFactory) {
+	interpreter_registry[strings.ToLower(name)] = factory
+}
+
+func NewInterpreter(name string, evm *EVM, cfg Config) GethEVMInterpreter {
+	factory, found := interpreter_registry[strings.ToLower(name)]
+	if !found {
+		log.Error("no factory for interpreter registered", "name", name)
+	}
+	return factory(evm, cfg)
+}
+
+func init() {
+	factory := func(evm *EVM, cfg Config) GethEVMInterpreter {
+		return NewEVMInterpreter(evm)
+	}
+	RegisterInterpreterFactory("", factory)
+	RegisterInterpreterFactory("geth", factory)
+}
+
+// Abstracted interpreter with single step execution.
+
+// GethState represents the internal state of the interpreter.
+type GethState struct {
+	Contract *Contract // processed contract
+	Memory   *Memory   // bound memory
+	Stack    *Stack    // local stack
+	// For optimisation reason we're using uint64 as the program counter.
+	// It's theoretically possible to go above 2^64. The YP defines the PC
+	// to be uint256. Practically much less so feasible.
+	Pc          uint64 // program counter
+	Result      []byte // result of the opcode execution function
+	Err         error
+	CallContext *ScopeContext
+	ReadOnly    bool
+	Halted      bool
+
+	op   OpCode // current opcode
+	cost uint64
+
+	// copies used by tracer
+	pcCopy  uint64 // needed for the deferred Tracer
+	gasCopy uint64 // for Tracer to log gas remaining before execution
+	logged  bool   // deferred Tracer should ignore already logged steps
+}
+
+func NewGethState(contract *Contract, memory *Memory, stack *Stack, Pc uint64) *GethState {
+	return &GethState{
+		Contract: contract,
+		Memory:   memory,
+		Stack:    stack,
+		Pc:       Pc,
+		CallContext: &ScopeContext{
+			Memory:   memory,
+			Stack:    stack,
+			Contract: contract,
+		},
+	}
+}
+
+type InterpreterState struct {
+	Contract *Contract
+	Stack    *Stack
+	Memory   *Memory
+	pc       uint64
+	finished bool
+}
+
+func (in *EVMInterpreter) Run(contract *Contract, input []byte, readOnly bool) (ret []byte, err error) {
+	state := InterpreterState{
+		Contract: contract,
+		Stack:    NewStack(),
+		Memory:   NewMemory(),
+	}
+	defer returnStack(state.Stack)
+	return in.run(&state, input, readOnly)
+}


### PR DESCRIPTION
This PR applies the required changes to use this geth fork with the Tosca CT.
Mainly the changes consist of adding a public wrapper to private functions and moving the interpreter loop into a separate `Step` function. 
By implementing most of the changes in a newly introduced file it should be possible to keep the geth version up to date without major code changes.