### PR TITLE
metrics: add test for `SampleSnapshot.Sum`

### DIFF
--- a/metrics/sample_test.go
+++ b/metrics/sample_test.go
@@ -112,15 +112,10 @@ func TestExpDecaySample(t *testing.T) {
 		if have, want := len(values), min(tc.updates, tc.reservoirSize); have != want {
 			t.Errorf("unexpected values length: have %d want %d", have, want)
 		}
-		sum := int64(0)
 		for _, v := range values {
-			sum += v
 			if v > int64(tc.updates) || v < 0 {
 				t.Errorf("out of range [0, %d]: %v", tc.updates, v)
 			}
-		}
-		if have, want := snap.Sum(), sum; have != want {
-			t.Errorf("unexpected sum: have %d want %d", have, want)
 		}
 	}
 }
@@ -256,6 +251,9 @@ func benchmarkSample(b *testing.B, s Sample) {
 }
 
 func testExpDecaySampleStatistics(t *testing.T, s SampleSnapshot) {
+	if sum := s.Sum(); sum != 496598 {
+		t.Errorf("s.Sum(): 496598 != %v\n", sum)
+	}
 	if count := s.Count(); count != 10000 {
 		t.Errorf("s.Count(): 10000 != %v\n", count)
 	}

--- a/metrics/sample_test.go
+++ b/metrics/sample_test.go
@@ -103,19 +103,24 @@ func TestExpDecaySample(t *testing.T) {
 		}
 		snap := sample.Snapshot()
 		if have, want := int(snap.Count()), tc.updates; have != want {
-			t.Errorf("have %d want %d", have, want)
+			t.Errorf("unexpected count: have %d want %d", have, want)
 		}
 		if have, want := snap.Size(), min(tc.updates, tc.reservoirSize); have != want {
-			t.Errorf("have %d want %d", have, want)
+			t.Errorf("unexpected size: have %d want %d", have, want)
 		}
 		values := snap.(*sampleSnapshot).values
 		if have, want := len(values), min(tc.updates, tc.reservoirSize); have != want {
-			t.Errorf("have %d want %d", have, want)
+			t.Errorf("unexpected values length: have %d want %d", have, want)
 		}
+		sum := int64(0)
 		for _, v := range values {
+			sum += v
 			if v > int64(tc.updates) || v < 0 {
 				t.Errorf("out of range [0, %d]: %v", tc.updates, v)
 			}
+		}
+		if have, want := snap.Sum(), sum; have != want {
+			t.Errorf("unexpected sum: have %d want %d", have, want)
 		}
 	}
 }


### PR DESCRIPTION
Refer [comments](https://github.com/ethereum/go-ethereum/pull/29826#issuecomment-2128364846) from @fjl 

Since we calculated the average by totalizing the `values`, there is no test case to ensure `SampleSnapshot.Sum()` is calculated correctly, I think we need this test case.

BTW, if we have guaranteed the result of `SampleSnapshot.Sum()` in a test, why should we do another redundant round of computation in other tests?