### PR TITLE
metrics: fix `TestExpDecaySampleNanosecondRegression` sometimes failed

### DIFF
--- a/metrics/sample_test.go
+++ b/metrics/sample_test.go
@@ -125,12 +125,12 @@ func TestExpDecaySample(t *testing.T) {
 // The priority becomes +Inf quickly after starting if this is done,
 // effectively freezing the set of samples until a rescale step happens.
 func TestExpDecaySampleNanosecondRegression(t *testing.T) {
-	sw := NewExpDecaySample(100, 0.99)
-	for i := 0; i < 100; i++ {
+	sw := NewExpDecaySample(1000, 0.99)
+	for i := 0; i < 1000; i++ {
 		sw.Update(10)
 	}
 	time.Sleep(1 * time.Millisecond)
-	for i := 0; i < 100; i++ {
+	for i := 0; i < 1000; i++ {
 		sw.Update(20)
 	}
 	s := sw.Snapshot()


### PR DESCRIPTION
TestExpDecaySampleNanosecondRegression will fail sometimes
​
Found this issue in [ci job](https://ci.appveyor.com/project/ethereum/go-ethereum/builds/49864753/job/7fm535t8f0jugt4l)
```shell
--- FAIL: TestExpDecaySampleNanosecondRegression (0.00s)
    sample_test.go:144: out of range [14, 16]: 13.9
```
​
It hasn't always failed, I ran it on my local machine, and it's mostly been passed.
​
The problem is the test case using 100 as sample `reservoirSize`, which is a bit small. 
​
- If we use 100 as `reservoirSize` and run the test 1000 times, it will most likely be failed.
- If we use 1000 as `reservoirSize` and run the test 10000 times, it will most likely be successful, I haven't failed at least