### PR TITLE
core, eth/protocols/snap, internal/ethapi: Fix redundant types

### DIFF
--- a/core/genesis.go
+++ b/core/genesis.go
@@ -594,7 +594,7 @@ func DeveloperGenesisBlock(gasLimit uint64, faucet *common.Address) *Genesis {
 			common.BytesToAddress([]byte{8}): {Balance: big.NewInt(1)}, // ECPairing
 			common.BytesToAddress([]byte{9}): {Balance: big.NewInt(1)}, // BLAKE2b
 			// Pre-deploy EIP-4788 system contract
-			params.BeaconRootsAddress: types.Account{Nonce: 1, Code: params.BeaconRootsCode},
+			params.BeaconRootsAddress: {Nonce: 1, Code: params.BeaconRootsCode},
 		},
 	}
 	if faucet != nil {

--- a/eth/protocols/snap/progress_test.go
+++ b/eth/protocols/snap/progress_test.go
@@ -80,7 +80,7 @@ func makeLegacyProgress() legacyProgress {
 				Next: common.Hash{},
 				Last: common.Hash{0x77},
 				SubTasks: map[common.Hash][]*legacyStorageTask{
-					common.Hash{0x1}: {
+					{0x1}: {
 						{
 							Next: common.Hash{},
 							Last: common.Hash{0xff},

--- a/internal/ethapi/api_test.go
+++ b/internal/ethapi/api_test.go
@@ -751,7 +751,7 @@ func TestEstimateGas(t *testing.T) {
 				From:       &accounts[0].addr,
 				To:         &accounts[1].addr,
 				Value:      (*hexutil.Big)(big.NewInt(1)),
-				BlobHashes: []common.Hash{common.Hash{0x01, 0x22}},
+				BlobHashes: []common.Hash{{0x01, 0x22}},
 				BlobFeeCap: (*hexutil.Big)(big.NewInt(1)),
 			},
 			want: 21000,
@@ -939,7 +939,7 @@ func TestCall(t *testing.T) {
 			call: TransactionArgs{
 				From:       &accounts[1].addr,
 				To:         &randomAccounts[2].addr,
-				BlobHashes: []common.Hash{common.Hash{0x01, 0x22}},
+				BlobHashes: []common.Hash{{0x01, 0x22}},
 				BlobFeeCap: (*hexutil.Big)(big.NewInt(1)),
 			},
 			overrides: StateOverride{
@@ -1063,7 +1063,7 @@ func TestSendBlobTransaction(t *testing.T) {
 		From:       &b.acc.Address,
 		To:         &to,
 		Value:      (*hexutil.Big)(big.NewInt(1)),
-		BlobHashes: []common.Hash{common.Hash{0x01, 0x22}},
+		BlobHashes: []common.Hash{{0x01, 0x22}},
 	})
 	if err != nil {
 		t.Fatalf("failed to fill tx defaults: %v\n", err)


### PR DESCRIPTION
- Removed redundant use of `types.Account` and `common.Hash`.