### PR TITLE
p2p/discover: refactor node and endpoint representation

### DIFF
--- a/cmd/devp2p/internal/v4test/framework.go
+++ b/cmd/devp2p/internal/v4test/framework.go
@@ -110,7 +110,7 @@ func (te *testenv) localEndpoint(c net.PacketConn) v4wire.Endpoint {
 }
 
 func (te *testenv) remoteEndpoint() v4wire.Endpoint {
-	return v4wire.NewEndpoint(te.remoteAddr, 0)
+	return v4wire.NewEndpoint(te.remoteAddr.AddrPort(), 0)
 }
 
 func contains(ns []v4wire.Node, key v4wire.Pubkey) bool {

--- a/p2p/discover/common.go
+++ b/p2p/discover/common.go
@@ -22,6 +22,7 @@ import (
 	"encoding/binary"
 	"math/rand"
 	"net"
+	"net/netip"
 	"sync"
 	"time"
 
@@ -34,8 +35,8 @@ import (
 
 // UDPConn is a network connection on which discovery can operate.
 type UDPConn interface {
-	ReadFromUDP(b []byte) (n int, addr *net.UDPAddr, err error)
-	WriteToUDP(b []byte, addr *net.UDPAddr) (n int, err error)
+	ReadFromUDPAddrPort(b []byte) (n int, addr netip.AddrPort, err error)
+	WriteToUDPAddrPort(b []byte, addr netip.AddrPort) (n int, err error)
 	Close() error
 	LocalAddr() net.Addr
 }
@@ -94,7 +95,7 @@ func ListenUDP(c UDPConn, ln *enode.LocalNode, cfg Config) (*UDPv4, error) {
 // channel if configured.
 type ReadPacket struct {
 	Data []byte
-	Addr *net.UDPAddr
+	Addr netip.AddrPort
 }
 
 type randomSource interface {

--- a/p2p/discover/lookup.go
+++ b/p2p/discover/lookup.go
@@ -29,16 +29,16 @@ import (
 // not need to be an actual node identifier.
 type lookup struct {
 	tab         *Table
-	queryfunc   func(*node) ([]*node, error)
-	replyCh     chan []*node
+	queryfunc   queryFunc
+	replyCh     chan []*enode.Node
 	cancelCh    <-chan struct{}
 	asked, seen map[enode.ID]bool
 	result      nodesByDistance
-	replyBuffer []*node
+	replyBuffer []*enode.Node
 	queries     int
 }
 
-type queryFunc func(*node) ([]*node, error)
+type queryFunc func(*enode.Node) ([]*enode.Node, error)
 
 func newLookup(ctx context.Context, tab *Table, target enode.ID, q queryFunc) *lookup {
 	it := &lookup{
@@ -47,7 +47,7 @@ func newLookup(ctx context.Context, tab *Table, target enode.ID, q queryFunc) *l
 		asked:     make(map[enode.ID]bool),
 		seen:      make(map[enode.ID]bool),
 		result:    nodesByDistance{target: target},
-		replyCh:   make(chan []*node, alpha),
+		replyCh:   make(chan []*enode.Node, alpha),
 		cancelCh:  ctx.Done(),
 		queries:   -1,
 	}
@@ -61,7 +61,7 @@ func newLookup(ctx context.Context, tab *Table, target enode.ID, q queryFunc) *l
 func (it *lookup) run() []*enode.Node {
 	for it.advance() {
 	}
-	return unwrapNodes(it.result.entries)
+	return it.result.entries
 }
 
 // advance advances the lookup until any new nodes have been found.
@@ -139,7 +139,7 @@ func (it *lookup) slowdown() {
 	}
 }
 
-func (it *lookup) query(n *node, reply chan<- []*node) {
+func (it *lookup) query(n *enode.Node, reply chan<- []*enode.Node) {
 	r, err := it.queryfunc(n)
 	if !errors.Is(err, errClosed) { // avoid recording failures on shutdown.
 		success := len(r) > 0
@@ -154,7 +154,7 @@ func (it *lookup) query(n *node, reply chan<- []*node) {
 // lookupIterator performs lookup operations and iterates over all seen nodes.
 // When a lookup finishes, a new one is created through nextLookup.
 type lookupIterator struct {
-	buffer     []*node
+	buffer     []*enode.Node
 	nextLookup lookupFunc
 	ctx        context.Context
 	cancel     func()
@@ -173,7 +173,7 @@ func (it *lookupIterator) Node() *enode.Node {
 	if len(it.buffer) == 0 {
 		return nil
 	}
-	return unwrapNode(it.buffer[0])
+	return it.buffer[0]
 }
 
 // Next moves to the next node.

--- a/p2p/discover/metrics.go
+++ b/p2p/discover/metrics.go
@@ -58,14 +58,14 @@ func newMeteredConn(conn UDPConn) UDPConn {
 	return &meteredUdpConn{UDPConn: conn}
 }
 
-// ReadFromUDP delegates a network read to the underlying connection, bumping the udp ingress traffic meter along the way.
+// ReadFromUDPAddrPort delegates a network read to the underlying connection, bumping the udp ingress traffic meter along the way.
 func (c *meteredUdpConn) ReadFromUDPAddrPort(b []byte) (n int, addr netip.AddrPort, err error) {
 	n, addr, err = c.UDPConn.ReadFromUDPAddrPort(b)
 	ingressTrafficMeter.Mark(int64(n))
 	return n, addr, err
 }
 
-// Write delegates a network write to the underlying connection, bumping the udp egress traffic meter along the way.
+// WriteToUDP delegates a network write to the underlying connection, bumping the udp egress traffic meter along the way.
 func (c *meteredUdpConn) WriteToUDP(b []byte, addr netip.AddrPort) (n int, err error) {
 	n, err = c.UDPConn.WriteToUDPAddrPort(b, addr)
 	egressTrafficMeter.Mark(int64(n))

--- a/p2p/discover/metrics.go
+++ b/p2p/discover/metrics.go
@@ -18,7 +18,7 @@ package discover
 
 import (
 	"fmt"
-	"net"
+	"net/netip"
 
 	"github.com/ethereum/go-ethereum/metrics"
 )
@@ -59,15 +59,15 @@ func newMeteredConn(conn UDPConn) UDPConn {
 }
 
 // ReadFromUDP delegates a network read to the underlying connection, bumping the udp ingress traffic meter along the way.
-func (c *meteredUdpConn) ReadFromUDP(b []byte) (n int, addr *net.UDPAddr, err error) {
-	n, addr, err = c.UDPConn.ReadFromUDP(b)
+func (c *meteredUdpConn) ReadFromUDPAddrPort(b []byte) (n int, addr netip.AddrPort, err error) {
+	n, addr, err = c.UDPConn.ReadFromUDPAddrPort(b)
 	ingressTrafficMeter.Mark(int64(n))
 	return n, addr, err
 }
 
 // Write delegates a network write to the underlying connection, bumping the udp egress traffic meter along the way.
-func (c *meteredUdpConn) WriteToUDP(b []byte, addr *net.UDPAddr) (n int, err error) {
-	n, err = c.UDPConn.WriteToUDP(b, addr)
+func (c *meteredUdpConn) WriteToUDP(b []byte, addr netip.AddrPort) (n int, err error) {
+	n, err = c.UDPConn.WriteToUDPAddrPort(b, addr)
 	egressTrafficMeter.Mark(int64(n))
 	return n, err
 }

--- a/p2p/discover/node.go
+++ b/p2p/discover/node.go
@@ -37,8 +37,8 @@ type BucketNode struct {
 	Live          bool        `json:"live"`
 }
 
-// node is a node table entry.
-type node struct {
+// tableNode is an entry in Table.
+type tableNode struct {
 	*enode.Node
 	revalList       *revalidationList
 	addedToTable    time.Time // first time node was added to bucket or replacement list
@@ -74,7 +74,7 @@ func (e encPubkey) id() enode.ID {
 	return enode.ID(crypto.Keccak256Hash(e[:]))
 }
 
-func unwrapNodes(ns []*node) []*enode.Node {
+func unwrapNodes(ns []*tableNode) []*enode.Node {
 	result := make([]*enode.Node, len(ns))
 	for i, n := range ns {
 		result[i] = n.Node
@@ -82,10 +82,10 @@ func unwrapNodes(ns []*node) []*enode.Node {
 	return result
 }
 
-func (n *node) addr() *net.UDPAddr {
+func (n *tableNode) addr() *net.UDPAddr {
 	return &net.UDPAddr{IP: n.IP(), Port: n.UDP()}
 }
 
-func (n *node) String() string {
+func (n *tableNode) String() string {
 	return n.Node.String()
 }

--- a/p2p/discover/node.go
+++ b/p2p/discover/node.go
@@ -84,10 +84,6 @@ func unwrapNodes(ns []*tableNode) []*enode.Node {
 	return result
 }
 
-func (n *tableNode) addr() *net.UDPAddr {
-	return &net.UDPAddr{IP: n.IP(), Port: n.UDP()}
-}
-
 func (n *tableNode) String() string {
 	return n.Node.String()
 }

--- a/p2p/discover/node.go
+++ b/p2p/discover/node.go
@@ -37,8 +37,7 @@ type BucketNode struct {
 	Live          bool        `json:"live"`
 }
 
-// node represents a host on the network.
-// The fields of Node may not be modified.
+// node is a node table entry.
 type node struct {
 	*enode.Node
 	revalList       *revalidationList
@@ -75,26 +74,10 @@ func (e encPubkey) id() enode.ID {
 	return enode.ID(crypto.Keccak256Hash(e[:]))
 }
 
-func wrapNode(n *enode.Node) *node {
-	return &node{Node: n}
-}
-
-func wrapNodes(ns []*enode.Node) []*node {
-	result := make([]*node, len(ns))
-	for i, n := range ns {
-		result[i] = wrapNode(n)
-	}
-	return result
-}
-
-func unwrapNode(n *node) *enode.Node {
-	return n.Node
-}
-
 func unwrapNodes(ns []*node) []*enode.Node {
 	result := make([]*enode.Node, len(ns))
 	for i, n := range ns {
-		result[i] = unwrapNode(n)
+		result[i] = n.Node
 	}
 	return result
 }

--- a/p2p/discover/node.go
+++ b/p2p/discover/node.go
@@ -21,7 +21,6 @@ import (
 	"crypto/elliptic"
 	"errors"
 	"math/big"
-	"net"
 	"slices"
 	"sort"
 	"time"

--- a/p2p/discover/table.go
+++ b/p2p/discover/table.go
@@ -65,7 +65,7 @@ const (
 type Table struct {
 	mutex        sync.Mutex        // protects buckets, bucket content, nursery, rand
 	buckets      [nBuckets]*bucket // index of known nodes by distance
-	nursery      []*node           // bootstrap nodes
+	nursery      []*enode.Node     // bootstrap nodes
 	rand         reseedingRandom   // source of randomness, periodically reseeded
 	ips          netutil.DistinctNetSet
 	revalidation tableRevalidation
@@ -108,13 +108,14 @@ type bucket struct {
 }
 
 type addNodeOp struct {
-	node      *node
-	isInbound bool
+	node         *enode.Node
+	isInbound    bool
+	forceSetLive bool // for tests
 }
 
 type trackRequestOp struct {
-	node       *node
-	foundNodes []*node
+	node       *enode.Node
+	foundNodes []*enode.Node
 	success    bool
 }
 
@@ -186,7 +187,7 @@ func (tab *Table) getNode(id enode.ID) *enode.Node {
 	b := tab.bucket(id)
 	for _, e := range b.entries {
 		if e.ID() == id {
-			return unwrapNode(e)
+			return e.Node
 		}
 	}
 	return nil
@@ -202,7 +203,7 @@ func (tab *Table) close() {
 // are used to connect to the network if the table is empty and there
 // are no known nodes in the database.
 func (tab *Table) setFallbackNodes(nodes []*enode.Node) error {
-	nursery := make([]*node, 0, len(nodes))
+	nursery := make([]*enode.Node, 0, len(nodes))
 	for _, n := range nodes {
 		if err := n.ValidateComplete(); err != nil {
 			return fmt.Errorf("bad bootstrap node %q: %v", n, err)
@@ -211,7 +212,7 @@ func (tab *Table) setFallbackNodes(nodes []*enode.Node) error {
 			tab.log.Error("Bootstrap node filtered by netrestrict", "id", n.ID(), "ip", n.IP())
 			continue
 		}
-		nursery = append(nursery, wrapNode(n))
+		nursery = append(nursery, n)
 	}
 	tab.nursery = nursery
 	return nil
@@ -255,9 +256,9 @@ func (tab *Table) findnodeByID(target enode.ID, nresults int, preferLive bool) *
 	liveNodes := &nodesByDistance{target: target}
 	for _, b := range &tab.buckets {
 		for _, n := range b.entries {
-			nodes.push(n, nresults)
+			nodes.push(n.Node, nresults)
 			if preferLive && n.isValidatedLive {
-				liveNodes.push(n, nresults)
+				liveNodes.push(n.Node, nresults)
 			}
 		}
 	}
@@ -309,8 +310,8 @@ func (tab *Table) len() (n int) {
 // list.
 //
 // The caller must not hold tab.mutex.
-func (tab *Table) addFoundNode(n *node) bool {
-	op := addNodeOp{node: n, isInbound: false}
+func (tab *Table) addFoundNode(n *enode.Node, forceSetLive bool) bool {
+	op := addNodeOp{node: n, isInbound: false, forceSetLive: forceSetLive}
 	select {
 	case tab.addNodeCh <- op:
 		return <-tab.addNodeHandled
@@ -327,7 +328,7 @@ func (tab *Table) addFoundNode(n *node) bool {
 // repeatedly.
 //
 // The caller must not hold tab.mutex.
-func (tab *Table) addInboundNode(n *node) bool {
+func (tab *Table) addInboundNode(n *enode.Node) bool {
 	op := addNodeOp{node: n, isInbound: true}
 	select {
 	case tab.addNodeCh <- op:
@@ -337,7 +338,7 @@ func (tab *Table) addInboundNode(n *node) bool {
 	}
 }
 
-func (tab *Table) trackRequest(n *node, success bool, foundNodes []*node) {
+func (tab *Table) trackRequest(n *enode.Node, success bool, foundNodes []*enode.Node) {
 	op := trackRequestOp{n, foundNodes, success}
 	select {
 	case tab.trackRequestCh <- op:
@@ -443,13 +444,14 @@ func (tab *Table) doRefresh(done chan struct{}) {
 }
 
 func (tab *Table) loadSeedNodes() {
-	seeds := wrapNodes(tab.db.QuerySeeds(seedCount, seedMaxAge))
+	seeds := tab.db.QuerySeeds(seedCount, seedMaxAge)
 	seeds = append(seeds, tab.nursery...)
 	for i := range seeds {
 		seed := seeds[i]
 		if tab.log.Enabled(context.Background(), log.LevelTrace) {
 			age := time.Since(tab.db.LastPongReceived(seed.ID(), seed.IP()))
-			tab.log.Trace("Found seed node in database", "id", seed.ID(), "addr", seed.addr(), "age", age)
+			addr, _ := seed.UDPEndpoint()
+			tab.log.Trace("Found seed node in database", "id", seed.ID(), "addr", addr, "age", age)
 		}
 		tab.handleAddNode(addNodeOp{node: seed, isInbound: false})
 	}
@@ -513,7 +515,7 @@ func (tab *Table) handleAddNode(req addNodeOp) bool {
 	}
 
 	b := tab.bucket(req.node.ID())
-	n, _ := tab.bumpInBucket(b, req.node.Node, req.isInbound)
+	n, _ := tab.bumpInBucket(b, req.node, req.isInbound)
 	if n != nil {
 		// Already in bucket.
 		return false
@@ -529,15 +531,20 @@ func (tab *Table) handleAddNode(req addNodeOp) bool {
 	}
 
 	// Add to bucket.
-	b.entries = append(b.entries, req.node)
-	b.replacements = deleteNode(b.replacements, req.node)
-	tab.nodeAdded(b, req.node)
+	wn := &node{Node: req.node}
+	if req.forceSetLive {
+		wn.livenessChecks = 1
+		wn.isValidatedLive = true
+	}
+	b.entries = append(b.entries, wn)
+	b.replacements = deleteNode(b.replacements, wn.ID())
+	tab.nodeAdded(b, wn)
 	return true
 }
 
 // addReplacement adds n to the replacement cache of bucket b.
-func (tab *Table) addReplacement(b *bucket, n *node) {
-	if contains(b.replacements, n.ID()) {
+func (tab *Table) addReplacement(b *bucket, n *enode.Node) {
+	if containsID(b.replacements, n.ID()) {
 		// TODO: update ENR
 		return
 	}
@@ -545,9 +552,9 @@ func (tab *Table) addReplacement(b *bucket, n *node) {
 		return
 	}
 
-	n.addedToTable = time.Now()
+	wn := &node{Node: n, addedToTable: time.Now()}
 	var removed *node
-	b.replacements, removed = pushNode(b.replacements, n, maxReplacements)
+	b.replacements, removed = pushNode(b.replacements, wn, maxReplacements)
 	if removed != nil {
 		tab.removeIP(b, removed.IP())
 	}
@@ -672,11 +679,15 @@ func (tab *Table) handleTrackRequest(op trackRequestOp) {
 
 	// Add found nodes.
 	for _, n := range op.foundNodes {
-		tab.handleAddNode(addNodeOp{n, false})
+		tab.handleAddNode(addNodeOp{n, false, false})
 	}
 }
 
-func contains(ns []*node, id enode.ID) bool {
+type nodeType interface {
+	ID() enode.ID
+}
+
+func containsID[N nodeType](ns []N, id enode.ID) bool {
 	for _, n := range ns {
 		if n.ID() == id {
 			return true
@@ -697,23 +708,20 @@ func pushNode(list []*node, n *node, max int) ([]*node, *node) {
 }
 
 // deleteNode removes n from list.
-func deleteNode(list []*node, n *node) []*node {
-	for i := range list {
-		if list[i].ID() == n.ID() {
-			return append(list[:i], list[i+1:]...)
-		}
-	}
-	return list
+func deleteNode[N nodeType](list []N, id enode.ID) []N {
+	return slices.DeleteFunc(list, func(n N) bool {
+		return n.ID() == id
+	})
 }
 
 // nodesByDistance is a list of nodes, ordered by distance to target.
 type nodesByDistance struct {
-	entries []*node
+	entries []*enode.Node
 	target  enode.ID
 }
 
 // push adds the given node to the list, keeping the total size below maxElems.
-func (h *nodesByDistance) push(n *node, maxElems int) {
+func (h *nodesByDistance) push(n *enode.Node, maxElems int) {
 	ix := sort.Search(len(h.entries), func(i int) bool {
 		return enode.DistCmp(h.target, h.entries[i].ID(), n.ID()) > 0
 	})

--- a/p2p/discover/table_reval_test.go
+++ b/p2p/discover/table_reval_test.go
@@ -110,10 +110,10 @@ func TestRevalidation_endpointUpdate(t *testing.T) {
 	}
 	tr.handleResponse(tab, resp)
 
-	if !tr.fast.contains(node.ID()) {
+	if tr.fast.nodes[0].ID() != node.ID() {
 		t.Fatal("node not contained in fast revalidation list")
 	}
-	if node.isValidatedLive {
+	if tr.fast.nodes[0].isValidatedLive {
 		t.Fatal("node is marked live after endpoint change")
 	}
 }

--- a/p2p/discover/table_test.go
+++ b/p2p/discover/table_test.go
@@ -473,18 +473,6 @@ func nodeIDEqual[N nodeType](n1, n2 N) bool {
 	return n1.ID() == n2.ID()
 }
 
-func slicesEqual[T any](s1, s2 []T, check func(e1, e2 T) bool) bool {
-	if len(s1) != len(s2) {
-		return false
-	}
-	for i := range s1 {
-		if !check(s1[i], s2[i]) {
-			return false
-		}
-	}
-	return true
-}
-
 // gen wraps quick.Value so it's easier to use.
 // it generates a random value of the given value's type.
 func gen(typ interface{}, rand *rand.Rand) interface{} {

--- a/p2p/discover/table_test.go
+++ b/p2p/discover/table_test.go
@@ -22,6 +22,7 @@ import (
 	"math/rand"
 	"net"
 	"reflect"
+	"slices"
 	"testing"
 	"testing/quick"
 	"time"
@@ -64,7 +65,7 @@ func testPingReplace(t *testing.T, newNodeIsResponding, lastInBucketIsResponding
 
 	// Fill up the sender's bucket.
 	replacementNodeKey, _ := crypto.HexToECDSA("45a915e4d060149eb4365960e6a7a45f334393093061116b197e3240065ff2d8")
-	replacementNode := wrapNode(enode.NewV4(&replacementNodeKey.PublicKey, net.IP{127, 0, 0, 1}, 99, 99))
+	replacementNode := enode.NewV4(&replacementNodeKey.PublicKey, net.IP{127, 0, 0, 1}, 99, 99)
 	last := fillBucket(tab, replacementNode.ID())
 	tab.mutex.Lock()
 	nodeEvents := newNodeEventRecorder(128)
@@ -78,7 +79,7 @@ func testPingReplace(t *testing.T, newNodeIsResponding, lastInBucketIsResponding
 	transport.dead[replacementNode.ID()] = !newNodeIsResponding
 
 	// Add replacement node to table.
-	tab.addFoundNode(replacementNode)
+	tab.addFoundNode(replacementNode, false)
 
 	t.Log("last:", last.ID())
 	t.Log("replacement:", replacementNode.ID())
@@ -115,11 +116,11 @@ func testPingReplace(t *testing.T, newNodeIsResponding, lastInBucketIsResponding
 	if l := len(bucket.entries); l != wantSize {
 		t.Errorf("wrong bucket size after revalidation: got %d, want %d", l, wantSize)
 	}
-	if ok := contains(bucket.entries, last.ID()); ok != lastInBucketIsResponding {
+	if ok := containsID(bucket.entries, last.ID()); ok != lastInBucketIsResponding {
 		t.Errorf("revalidated node found: %t, want: %t", ok, lastInBucketIsResponding)
 	}
 	wantNewEntry := newNodeIsResponding && !lastInBucketIsResponding
-	if ok := contains(bucket.entries, replacementNode.ID()); ok != wantNewEntry {
+	if ok := containsID(bucket.entries, replacementNode.ID()); ok != wantNewEntry {
 		t.Errorf("replacement node found: %t, want: %t", ok, wantNewEntry)
 	}
 }
@@ -153,7 +154,7 @@ func TestTable_IPLimit(t *testing.T) {
 
 	for i := 0; i < tableIPLimit+1; i++ {
 		n := nodeAtDistance(tab.self().ID(), i, net.IP{172, 0, 1, byte(i)})
-		tab.addFoundNode(n)
+		tab.addFoundNode(n, false)
 	}
 	if tab.len() > tableIPLimit {
 		t.Errorf("too many nodes in table")
@@ -171,7 +172,7 @@ func TestTable_BucketIPLimit(t *testing.T) {
 	d := 3
 	for i := 0; i < bucketIPLimit+1; i++ {
 		n := nodeAtDistance(tab.self().ID(), d, net.IP{172, 0, 1, byte(i)})
-		tab.addFoundNode(n)
+		tab.addFoundNode(n, false)
 	}
 	if tab.len() > bucketIPLimit {
 		t.Errorf("too many nodes in table")
@@ -232,7 +233,7 @@ func TestTable_findnodeByID(t *testing.T) {
 		// check that the result nodes have minimum distance to target.
 		for _, b := range tab.buckets {
 			for _, n := range b.entries {
-				if contains(result, n.ID()) {
+				if containsID(result, n.ID()) {
 					continue // don't run the check below for nodes in result
 				}
 				farthestResult := result[len(result)-1].ID()
@@ -255,7 +256,7 @@ func TestTable_findnodeByID(t *testing.T) {
 type closeTest struct {
 	Self   enode.ID
 	Target enode.ID
-	All    []*node
+	All    []*enode.Node
 	N      int
 }
 
@@ -268,8 +269,7 @@ func (*closeTest) Generate(rand *rand.Rand, size int) reflect.Value {
 	for _, id := range gen([]enode.ID{}, rand).([]enode.ID) {
 		r := new(enr.Record)
 		r.Set(enr.IP(genIP(rand)))
-		n := wrapNode(enode.SignNull(r, id))
-		n.livenessChecks = 1
+		n := enode.SignNull(r, id)
 		t.All = append(t.All, n)
 	}
 	return reflect.ValueOf(t)
@@ -284,16 +284,16 @@ func TestTable_addInboundNode(t *testing.T) {
 	// Insert two nodes.
 	n1 := nodeAtDistance(tab.self().ID(), 256, net.IP{88, 77, 66, 1})
 	n2 := nodeAtDistance(tab.self().ID(), 256, net.IP{88, 77, 66, 2})
-	tab.addFoundNode(n1)
-	tab.addFoundNode(n2)
-	checkBucketContent(t, tab, []*enode.Node{n1.Node, n2.Node})
+	tab.addFoundNode(n1, false)
+	tab.addFoundNode(n2, false)
+	checkBucketContent(t, tab, []*enode.Node{n1, n2})
 
 	// Add a changed version of n2. The bucket should be updated.
 	newrec := n2.Record()
 	newrec.Set(enr.IP{99, 99, 99, 99})
 	n2v2 := enode.SignNull(newrec, n2.ID())
-	tab.addInboundNode(wrapNode(n2v2))
-	checkBucketContent(t, tab, []*enode.Node{n1.Node, n2v2})
+	tab.addInboundNode(n2v2)
+	checkBucketContent(t, tab, []*enode.Node{n1, n2v2})
 
 	// Try updating n2 without sequence number change. The update is accepted
 	// because it's inbound.
@@ -301,8 +301,8 @@ func TestTable_addInboundNode(t *testing.T) {
 	newrec.Set(enr.IP{100, 100, 100, 100})
 	newrec.SetSeq(n2.Seq())
 	n2v3 := enode.SignNull(newrec, n2.ID())
-	tab.addInboundNode(wrapNode(n2v3))
-	checkBucketContent(t, tab, []*enode.Node{n1.Node, n2v3})
+	tab.addInboundNode(n2v3)
+	checkBucketContent(t, tab, []*enode.Node{n1, n2v3})
 }
 
 func TestTable_addFoundNode(t *testing.T) {
@@ -314,16 +314,16 @@ func TestTable_addFoundNode(t *testing.T) {
 	// Insert two nodes.
 	n1 := nodeAtDistance(tab.self().ID(), 256, net.IP{88, 77, 66, 1})
 	n2 := nodeAtDistance(tab.self().ID(), 256, net.IP{88, 77, 66, 2})
-	tab.addFoundNode(n1)
-	tab.addFoundNode(n2)
-	checkBucketContent(t, tab, []*enode.Node{n1.Node, n2.Node})
+	tab.addFoundNode(n1, false)
+	tab.addFoundNode(n2, false)
+	checkBucketContent(t, tab, []*enode.Node{n1, n2})
 
 	// Add a changed version of n2. The bucket should be updated.
 	newrec := n2.Record()
 	newrec.Set(enr.IP{99, 99, 99, 99})
 	n2v2 := enode.SignNull(newrec, n2.ID())
-	tab.addFoundNode(wrapNode(n2v2))
-	checkBucketContent(t, tab, []*enode.Node{n1.Node, n2v2})
+	tab.addFoundNode(n2v2, false)
+	checkBucketContent(t, tab, []*enode.Node{n1, n2v2})
 
 	// Try updating n2 without a sequence number change.
 	// The update should not be accepted.
@@ -331,8 +331,8 @@ func TestTable_addFoundNode(t *testing.T) {
 	newrec.Set(enr.IP{100, 100, 100, 100})
 	newrec.SetSeq(n2.Seq())
 	n2v3 := enode.SignNull(newrec, n2.ID())
-	tab.addFoundNode(wrapNode(n2v3))
-	checkBucketContent(t, tab, []*enode.Node{n1.Node, n2v2})
+	tab.addFoundNode(n2v3, false)
+	checkBucketContent(t, tab, []*enode.Node{n1, n2v2})
 }
 
 // This test checks that discv4 nodes can update their own endpoint via PING.
@@ -345,13 +345,13 @@ func TestTable_addInboundNodeUpdateV4Accept(t *testing.T) {
 	// Add a v4 node.
 	key, _ := crypto.HexToECDSA("dd3757a8075e88d0f2b1431e7d3c5b1562e1c0aab9643707e8cbfcc8dae5cfe3")
 	n1 := enode.NewV4(&key.PublicKey, net.IP{88, 77, 66, 1}, 9000, 9000)
-	tab.addInboundNode(wrapNode(n1))
+	tab.addInboundNode(n1)
 	checkBucketContent(t, tab, []*enode.Node{n1})
 
 	// Add an updated version with changed IP.
 	// The update will be accepted because it is inbound.
 	n1v2 := enode.NewV4(&key.PublicKey, net.IP{99, 99, 99, 99}, 9000, 9000)
-	tab.addInboundNode(wrapNode(n1v2))
+	tab.addInboundNode(n1v2)
 	checkBucketContent(t, tab, []*enode.Node{n1v2})
 }
 
@@ -366,13 +366,13 @@ func TestTable_addFoundNodeV4UpdateReject(t *testing.T) {
 	// Add a v4 node.
 	key, _ := crypto.HexToECDSA("dd3757a8075e88d0f2b1431e7d3c5b1562e1c0aab9643707e8cbfcc8dae5cfe3")
 	n1 := enode.NewV4(&key.PublicKey, net.IP{88, 77, 66, 1}, 9000, 9000)
-	tab.addFoundNode(wrapNode(n1))
+	tab.addFoundNode(n1, false)
 	checkBucketContent(t, tab, []*enode.Node{n1})
 
 	// Add an updated version with changed IP.
 	// The update won't be accepted because it isn't inbound.
 	n1v2 := enode.NewV4(&key.PublicKey, net.IP{99, 99, 99, 99}, 9000, 9000)
-	tab.addFoundNode(wrapNode(n1v2))
+	tab.addFoundNode(n1v2, false)
 	checkBucketContent(t, tab, []*enode.Node{n1})
 }
 
@@ -413,8 +413,8 @@ func TestTable_revalidateSyncRecord(t *testing.T) {
 	var r enr.Record
 	r.Set(enr.IP(net.IP{127, 0, 0, 1}))
 	id := enode.ID{1}
-	n1 := wrapNode(enode.SignNull(&r, id))
-	tab.addFoundNode(n1)
+	n1 := enode.SignNull(&r, id)
+	tab.addFoundNode(n1, false)
 
 	// Update the node record.
 	r.Set(enr.WithEntry("foo", "bar"))
@@ -437,7 +437,7 @@ func TestNodesPush(t *testing.T) {
 	n1 := nodeAtDistance(target, 255, intIP(1))
 	n2 := nodeAtDistance(target, 254, intIP(2))
 	n3 := nodeAtDistance(target, 253, intIP(3))
-	perm := [][]*node{
+	perm := [][]*enode.Node{
 		{n3, n2, n1},
 		{n3, n1, n2},
 		{n2, n3, n1},
@@ -452,7 +452,7 @@ func TestNodesPush(t *testing.T) {
 		for _, n := range nodes {
 			list.push(n, 3)
 		}
-		if !slicesEqual(list.entries, perm[0], nodeIDEqual) {
+		if !slices.EqualFunc(list.entries, perm[0], nodeIDEqual) {
 			t.Fatal("not equal")
 		}
 	}
@@ -463,13 +463,13 @@ func TestNodesPush(t *testing.T) {
 		for _, n := range nodes {
 			list.push(n, 2)
 		}
-		if !slicesEqual(list.entries, perm[0][:2], nodeIDEqual) {
+		if !slices.EqualFunc(list.entries, perm[0][:2], nodeIDEqual) {
 			t.Fatal("not equal")
 		}
 	}
 }
 
-func nodeIDEqual(n1, n2 *node) bool {
+func nodeIDEqual[N nodeType](n1, n2 N) bool {
 	return n1.ID() == n2.ID()
 }
 

--- a/p2p/discover/table_util_test.go
+++ b/p2p/discover/table_util_test.go
@@ -105,7 +105,7 @@ func intIP(i int) net.IP {
 }
 
 // fillBucket inserts nodes into the given bucket until it is full.
-func fillBucket(tab *Table, id enode.ID) (last *node) {
+func fillBucket(tab *Table, id enode.ID) (last *tableNode) {
 	ld := enode.LogDist(tab.self().ID(), id)
 	b := tab.bucket(id)
 	for len(b.entries) < bucketSize {
@@ -302,7 +302,7 @@ type nodeEventRecorder struct {
 }
 
 type recordedNodeEvent struct {
-	node  *node
+	node  *tableNode
 	added bool
 }
 
@@ -312,7 +312,7 @@ func newNodeEventRecorder(buffer int) *nodeEventRecorder {
 	}
 }
 
-func (set *nodeEventRecorder) nodeAdded(b *bucket, n *node) {
+func (set *nodeEventRecorder) nodeAdded(b *bucket, n *tableNode) {
 	select {
 	case set.evc <- recordedNodeEvent{n, true}:
 	default:
@@ -320,7 +320,7 @@ func (set *nodeEventRecorder) nodeAdded(b *bucket, n *node) {
 	}
 }
 
-func (set *nodeEventRecorder) nodeRemoved(b *bucket, n *node) {
+func (set *nodeEventRecorder) nodeRemoved(b *bucket, n *tableNode) {
 	select {
 	case set.evc <- recordedNodeEvent{n, false}:
 	default:

--- a/p2p/discover/table_util_test.go
+++ b/p2p/discover/table_util_test.go
@@ -121,8 +121,6 @@ func fillBucket(tab *Table, id enode.ID) (last *tableNode) {
 // if the bucket is not full. The caller must not hold tab.mutex.
 func fillTable(tab *Table, nodes []*enode.Node, setLive bool) {
 	for _, n := range nodes {
-		if setLive {
-		}
 		tab.addFoundNode(n, setLive)
 	}
 }

--- a/p2p/discover/table_util_test.go
+++ b/p2p/discover/table_util_test.go
@@ -56,18 +56,18 @@ func newInactiveTestTable(t transport, cfg Config) (*Table, *enode.DB) {
 }
 
 // nodeAtDistance creates a node for which enode.LogDist(base, n.id) == ld.
-func nodeAtDistance(base enode.ID, ld int, ip net.IP) *node {
+func nodeAtDistance(base enode.ID, ld int, ip net.IP) *enode.Node {
 	var r enr.Record
 	r.Set(enr.IP(ip))
 	r.Set(enr.UDP(30303))
-	return wrapNode(enode.SignNull(&r, idAtDistance(base, ld)))
+	return enode.SignNull(&r, idAtDistance(base, ld))
 }
 
 // nodesAtDistance creates n nodes for which enode.LogDist(base, node.ID()) == ld.
 func nodesAtDistance(base enode.ID, ld int, n int) []*enode.Node {
 	results := make([]*enode.Node, n)
 	for i := range results {
-		results[i] = unwrapNode(nodeAtDistance(base, ld, intIP(i)))
+		results[i] = nodeAtDistance(base, ld, intIP(i))
 	}
 	return results
 }
@@ -110,7 +110,7 @@ func fillBucket(tab *Table, id enode.ID) (last *node) {
 	b := tab.bucket(id)
 	for len(b.entries) < bucketSize {
 		node := nodeAtDistance(tab.self().ID(), ld, intIP(ld))
-		if !tab.addFoundNode(node) {
+		if !tab.addFoundNode(node, false) {
 			panic("node not added")
 		}
 	}
@@ -119,13 +119,11 @@ func fillBucket(tab *Table, id enode.ID) (last *node) {
 
 // fillTable adds nodes the table to the end of their corresponding bucket
 // if the bucket is not full. The caller must not hold tab.mutex.
-func fillTable(tab *Table, nodes []*node, setLive bool) {
+func fillTable(tab *Table, nodes []*enode.Node, setLive bool) {
 	for _, n := range nodes {
 		if setLive {
-			n.livenessChecks = 1
-			n.isValidatedLive = true
 		}
-		tab.addFoundNode(n)
+		tab.addFoundNode(n, setLive)
 	}
 }
 
@@ -219,7 +217,7 @@ func (t *pingRecorder) RequestENR(n *enode.Node) (*enode.Node, error) {
 	return t.records[n.ID()], nil
 }
 
-func hasDuplicates(slice []*node) bool {
+func hasDuplicates(slice []*enode.Node) bool {
 	seen := make(map[enode.ID]bool, len(slice))
 	for i, e := range slice {
 		if e == nil {
@@ -261,14 +259,14 @@ func nodeEqual(n1 *enode.Node, n2 *enode.Node) bool {
 	return n1.ID() == n2.ID() && n1.IP().Equal(n2.IP())
 }
 
-func sortByID(nodes []*enode.Node) {
-	slices.SortFunc(nodes, func(a, b *enode.Node) int {
+func sortByID[N nodeType](nodes []N) {
+	slices.SortFunc(nodes, func(a, b N) int {
 		return bytes.Compare(a.ID().Bytes(), b.ID().Bytes())
 	})
 }
 
-func sortedByDistanceTo(distbase enode.ID, slice []*node) bool {
-	return slices.IsSortedFunc(slice, func(a, b *node) int {
+func sortedByDistanceTo(distbase enode.ID, slice []*enode.Node) bool {
+	return slices.IsSortedFunc(slice, func(a, b *enode.Node) int {
 		return enode.DistCmp(distbase, a.ID(), b.ID())
 	})
 }

--- a/p2p/discover/v4_udp.go
+++ b/p2p/discover/v4_udp.go
@@ -95,7 +95,7 @@ type UDPv4 struct {
 type replyMatcher struct {
 	// these fields must match in the reply.
 	from  enode.ID
-	ip    net.IP
+	ip    netip.Addr
 	ptype byte
 
 	// time when the request must complete
@@ -121,7 +121,7 @@ type replyMatchFunc func(v4wire.Packet) (matched bool, requestDone bool)
 // reply is a reply packet from a certain node.
 type reply struct {
 	from enode.ID
-	ip   net.IP
+	ip   netip.Addr
 	data v4wire.Packet
 	// loop indicates whether there was
 	// a matching request by sending on this channel.
@@ -204,8 +204,8 @@ func (t *UDPv4) Resolve(n *enode.Node) *enode.Node {
 
 func (t *UDPv4) ourEndpoint() v4wire.Endpoint {
 	n := t.Self()
-	a := &net.UDPAddr{IP: n.IP(), Port: n.UDP()}
-	return v4wire.NewEndpoint(a, uint16(n.TCP()))
+	addr, _ := n.UDPEndpoint()
+	return v4wire.NewEndpoint(addr, uint16(n.TCP()))
 }
 
 // Ping sends a ping message to the given node.
@@ -216,7 +216,11 @@ func (t *UDPv4) Ping(n *enode.Node) error {
 
 // ping sends a ping message to the given node and waits for a reply.
 func (t *UDPv4) ping(n *enode.Node) (seq uint64, err error) {
-	rm := t.sendPing(n.ID(), &net.UDPAddr{IP: n.IP(), Port: n.UDP()}, nil)
+	addr, ok := n.UDPEndpoint()
+	if !ok {
+		return 0, errNoUDPEndpoint
+	}
+	rm := t.sendPing(n.ID(), addr, nil)
 	if err = <-rm.errc; err == nil {
 		seq = rm.reply.(*v4wire.Pong).ENRSeq
 	}
@@ -225,7 +229,7 @@ func (t *UDPv4) ping(n *enode.Node) (seq uint64, err error) {
 
 // sendPing sends a ping message to the given node and invokes the callback
 // when the reply arrives.
-func (t *UDPv4) sendPing(toid enode.ID, toaddr *net.UDPAddr, callback func()) *replyMatcher {
+func (t *UDPv4) sendPing(toid enode.ID, toaddr netip.AddrPort, callback func()) *replyMatcher {
 	req := t.makePing(toaddr)
 	packet, hash, err := v4wire.Encode(t.priv, req)
 	if err != nil {
@@ -235,7 +239,7 @@ func (t *UDPv4) sendPing(toid enode.ID, toaddr *net.UDPAddr, callback func()) *r
 	}
 	// Add a matcher for the reply to the pending reply queue. Pongs are matched if they
 	// reference the ping we're about to send.
-	rm := t.pending(toid, toaddr.IP, v4wire.PongPacket, func(p v4wire.Packet) (matched bool, requestDone bool) {
+	rm := t.pending(toid, toaddr.Addr(), v4wire.PongPacket, func(p v4wire.Packet) (matched bool, requestDone bool) {
 		matched = bytes.Equal(p.(*v4wire.Pong).ReplyTok, hash)
 		if matched && callback != nil {
 			callback()
@@ -243,12 +247,13 @@ func (t *UDPv4) sendPing(toid enode.ID, toaddr *net.UDPAddr, callback func()) *r
 		return matched, matched
 	})
 	// Send the packet.
-	t.localNode.UDPContact(toaddr)
+	udpAddr := &net.UDPAddr{IP: toaddr.Addr().AsSlice()}
+	t.localNode.UDPContact(udpAddr)
 	t.write(toaddr, toid, req.Name(), packet)
 	return rm
 }
 
-func (t *UDPv4) makePing(toaddr *net.UDPAddr) *v4wire.Ping {
+func (t *UDPv4) makePing(toaddr netip.AddrPort) *v4wire.Ping {
 	return &v4wire.Ping{
 		Version:    4,
 		From:       t.ourEndpoint(),
@@ -305,27 +310,26 @@ func (t *UDPv4) newLookup(ctx context.Context, targetKey encPubkey) *lookup {
 // findnode sends a findnode request to the given node and waits until
 // the node has sent up to k neighbors.
 func (t *UDPv4) findnode(toid enode.ID, toAddrPort netip.AddrPort, target v4wire.Pubkey) ([]*enode.Node, error) {
-	toaddr := &net.UDPAddr{IP: toAddrPort.Addr().AsSlice(), Port: int(toAddrPort.Port())}
-	t.ensureBond(toid, toaddr)
+	t.ensureBond(toid, toAddrPort)
 
 	// Add a matcher for 'neighbours' replies to the pending reply queue. The matcher is
 	// active until enough nodes have been received.
 	nodes := make([]*enode.Node, 0, bucketSize)
 	nreceived := 0
-	rm := t.pending(toid, toaddr.IP, v4wire.NeighborsPacket, func(r v4wire.Packet) (matched bool, requestDone bool) {
+	rm := t.pending(toid, toAddrPort.Addr(), v4wire.NeighborsPacket, func(r v4wire.Packet) (matched bool, requestDone bool) {
 		reply := r.(*v4wire.Neighbors)
 		for _, rn := range reply.Nodes {
 			nreceived++
-			n, err := t.nodeFromRPC(toaddr, rn)
+			n, err := t.nodeFromRPC(toAddrPort, rn)
 			if err != nil {
-				t.log.Trace("Invalid neighbor node received", "ip", rn.IP, "addr", toaddr, "err", err)
+				t.log.Trace("Invalid neighbor node received", "ip", rn.IP, "addr", toAddrPort, "err", err)
 				continue
 			}
 			nodes = append(nodes, n)
 		}
 		return true, nreceived >= bucketSize
 	})
-	t.send(toaddr, toid, &v4wire.Findnode{
+	t.send(toAddrPort, toid, &v4wire.Findnode{
 		Target:     target,
 		Expiration: uint64(time.Now().Add(expiration).Unix()),
 	})
@@ -343,7 +347,7 @@ func (t *UDPv4) findnode(toid enode.ID, toAddrPort netip.AddrPort, target v4wire
 
 // RequestENR sends ENRRequest to the given node and waits for a response.
 func (t *UDPv4) RequestENR(n *enode.Node) (*enode.Node, error) {
-	addr := &net.UDPAddr{IP: n.IP(), Port: n.UDP()}
+	addr, _ := n.UDPEndpoint()
 	t.ensureBond(n.ID(), addr)
 
 	req := &v4wire.ENRRequest{
@@ -356,7 +360,7 @@ func (t *UDPv4) RequestENR(n *enode.Node) (*enode.Node, error) {
 
 	// Add a matcher for the reply to the pending reply queue. Responses are matched if
 	// they reference the request we're about to send.
-	rm := t.pending(n.ID(), addr.IP, v4wire.ENRResponsePacket, func(r v4wire.Packet) (matched bool, requestDone bool) {
+	rm := t.pending(n.ID(), addr.Addr(), v4wire.ENRResponsePacket, func(r v4wire.Packet) (matched bool, requestDone bool) {
 		matched = bytes.Equal(r.(*v4wire.ENRResponse).ReplyTok, hash)
 		return matched, matched
 	})
@@ -376,7 +380,7 @@ func (t *UDPv4) RequestENR(n *enode.Node) (*enode.Node, error) {
 	if respN.Seq() < n.Seq() {
 		return n, nil // response record is older
 	}
-	if err := netutil.CheckRelayIP(addr.IP, respN.IP()); err != nil {
+	if err := netutil.CheckRelayIP(addr.Addr().AsSlice(), respN.IP()); err != nil {
 		return nil, fmt.Errorf("invalid IP in response record: %v", err)
 	}
 	return respN, nil
@@ -388,7 +392,7 @@ func (t *UDPv4) TableBuckets() [][]BucketNode {
 
 // pending adds a reply matcher to the pending reply queue.
 // see the documentation of type replyMatcher for a detailed explanation.
-func (t *UDPv4) pending(id enode.ID, ip net.IP, ptype byte, callback replyMatchFunc) *replyMatcher {
+func (t *UDPv4) pending(id enode.ID, ip netip.Addr, ptype byte, callback replyMatchFunc) *replyMatcher {
 	ch := make(chan error, 1)
 	p := &replyMatcher{from: id, ip: ip, ptype: ptype, callback: callback, errc: ch}
 	select {
@@ -402,7 +406,7 @@ func (t *UDPv4) pending(id enode.ID, ip net.IP, ptype byte, callback replyMatchF
 
 // handleReply dispatches a reply packet, invoking reply matchers. It returns
 // whether any matcher considered the packet acceptable.
-func (t *UDPv4) handleReply(from enode.ID, fromIP net.IP, req v4wire.Packet) bool {
+func (t *UDPv4) handleReply(from enode.ID, fromIP netip.Addr, req v4wire.Packet) bool {
 	matched := make(chan bool, 1)
 	select {
 	case t.gotreply <- reply{from, fromIP, req, matched}:
@@ -468,7 +472,7 @@ func (t *UDPv4) loop() {
 			var matched bool // whether any replyMatcher considered the reply acceptable.
 			for el := plist.Front(); el != nil; el = el.Next() {
 				p := el.Value.(*replyMatcher)
-				if p.from == r.from && p.ptype == r.data.Kind() && p.ip.Equal(r.ip) {
+				if p.from == r.from && p.ptype == r.data.Kind() && p.ip == r.ip {
 					ok, requestDone := p.callback(r.data)
 					matched = matched || ok
 					p.reply = r.data
@@ -507,7 +511,7 @@ func (t *UDPv4) loop() {
 	}
 }
 
-func (t *UDPv4) send(toaddr *net.UDPAddr, toid enode.ID, req v4wire.Packet) ([]byte, error) {
+func (t *UDPv4) send(toaddr netip.AddrPort, toid enode.ID, req v4wire.Packet) ([]byte, error) {
 	packet, hash, err := v4wire.Encode(t.priv, req)
 	if err != nil {
 		return hash, err
@@ -515,8 +519,8 @@ func (t *UDPv4) send(toaddr *net.UDPAddr, toid enode.ID, req v4wire.Packet) ([]b
 	return hash, t.write(toaddr, toid, req.Name(), packet)
 }
 
-func (t *UDPv4) write(toaddr *net.UDPAddr, toid enode.ID, what string, packet []byte) error {
-	_, err := t.conn.WriteToUDP(packet, toaddr)
+func (t *UDPv4) write(toaddr netip.AddrPort, toid enode.ID, what string, packet []byte) error {
+	_, err := t.conn.WriteToUDPAddrPort(packet, toaddr)
 	t.log.Trace(">> "+what, "id", toid, "addr", toaddr, "err", err)
 	return err
 }
@@ -530,7 +534,7 @@ func (t *UDPv4) readLoop(unhandled chan<- ReadPacket) {
 
 	buf := make([]byte, maxPacketSize)
 	for {
-		nbytes, from, err := t.conn.ReadFromUDP(buf)
+		nbytes, from, err := t.conn.ReadFromUDPAddrPort(buf)
 		if netutil.IsTemporaryError(err) {
 			// Ignore temporary read errors.
 			t.log.Debug("Temporary UDP read error", "err", err)
@@ -551,7 +555,7 @@ func (t *UDPv4) readLoop(unhandled chan<- ReadPacket) {
 	}
 }
 
-func (t *UDPv4) handlePacket(from *net.UDPAddr, buf []byte) error {
+func (t *UDPv4) handlePacket(from netip.AddrPort, buf []byte) error {
 	rawpacket, fromKey, hash, err := v4wire.Decode(buf)
 	if err != nil {
 		t.log.Debug("Bad discv4 packet", "addr", from, "err", err)
@@ -570,15 +574,16 @@ func (t *UDPv4) handlePacket(from *net.UDPAddr, buf []byte) error {
 }
 
 // checkBond checks if the given node has a recent enough endpoint proof.
-func (t *UDPv4) checkBond(id enode.ID, ip net.IP) bool {
-	return time.Since(t.db.LastPongReceived(id, ip)) < bondExpiration
+func (t *UDPv4) checkBond(id enode.ID, ip netip.AddrPort) bool {
+	return time.Since(t.db.LastPongReceived(id, ip.Addr().AsSlice())) < bondExpiration
 }
 
 // ensureBond solicits a ping from a node if we haven't seen a ping from it for a while.
 // This ensures there is a valid endpoint proof on the remote end.
-func (t *UDPv4) ensureBond(toid enode.ID, toaddr *net.UDPAddr) {
-	tooOld := time.Since(t.db.LastPingReceived(toid, toaddr.IP)) > bondExpiration
-	if tooOld || t.db.FindFails(toid, toaddr.IP) > maxFindnodeFailures {
+func (t *UDPv4) ensureBond(toid enode.ID, toaddr netip.AddrPort) {
+	ip := toaddr.Addr().AsSlice()
+	tooOld := time.Since(t.db.LastPingReceived(toid, ip)) > bondExpiration
+	if tooOld || t.db.FindFails(toid, ip) > maxFindnodeFailures {
 		rm := t.sendPing(toid, toaddr, nil)
 		<-rm.errc
 		// Wait for them to ping back and process our pong.
@@ -586,11 +591,11 @@ func (t *UDPv4) ensureBond(toid enode.ID, toaddr *net.UDPAddr) {
 	}
 }
 
-func (t *UDPv4) nodeFromRPC(sender *net.UDPAddr, rn v4wire.Node) (*enode.Node, error) {
+func (t *UDPv4) nodeFromRPC(sender netip.AddrPort, rn v4wire.Node) (*enode.Node, error) {
 	if rn.UDP <= 1024 {
 		return nil, errLowPort
 	}
-	if err := netutil.CheckRelayIP(sender.IP, rn.IP); err != nil {
+	if err := netutil.CheckRelayIP(sender.Addr().AsSlice(), rn.IP); err != nil {
 		return nil, err
 	}
 	if t.netrestrict != nil && !t.netrestrict.Contains(rn.IP) {
@@ -644,14 +649,14 @@ type packetHandlerV4 struct {
 	senderKey *ecdsa.PublicKey // used for ping
 
 	// preverify checks whether the packet is valid and should be handled at all.
-	preverify func(p *packetHandlerV4, from *net.UDPAddr, fromID enode.ID, fromKey v4wire.Pubkey) error
+	preverify func(p *packetHandlerV4, from netip.AddrPort, fromID enode.ID, fromKey v4wire.Pubkey) error
 	// handle handles the packet.
-	handle func(req *packetHandlerV4, from *net.UDPAddr, fromID enode.ID, mac []byte)
+	handle func(req *packetHandlerV4, from netip.AddrPort, fromID enode.ID, mac []byte)
 }
 
 // PING/v4
 
-func (t *UDPv4) verifyPing(h *packetHandlerV4, from *net.UDPAddr, fromID enode.ID, fromKey v4wire.Pubkey) error {
+func (t *UDPv4) verifyPing(h *packetHandlerV4, from netip.AddrPort, fromID enode.ID, fromKey v4wire.Pubkey) error {
 	req := h.Packet.(*v4wire.Ping)
 
 	if v4wire.Expired(req.Expiration) {
@@ -665,7 +670,7 @@ func (t *UDPv4) verifyPing(h *packetHandlerV4, from *net.UDPAddr, fromID enode.I
 	return nil
 }
 
-func (t *UDPv4) handlePing(h *packetHandlerV4, from *net.UDPAddr, fromID enode.ID, mac []byte) {
+func (t *UDPv4) handlePing(h *packetHandlerV4, from netip.AddrPort, fromID enode.ID, mac []byte) {
 	req := h.Packet.(*v4wire.Ping)
 
 	// Reply.
@@ -677,8 +682,9 @@ func (t *UDPv4) handlePing(h *packetHandlerV4, from *net.UDPAddr, fromID enode.I
 	})
 
 	// Ping back if our last pong on file is too far in the past.
-	n := enode.NewV4(h.senderKey, from.IP, int(req.From.TCP), from.Port)
-	if time.Since(t.db.LastPongReceived(n.ID(), from.IP)) > bondExpiration {
+	ip := from.Addr().AsSlice()
+	n := enode.NewV4(h.senderKey, ip, int(req.From.TCP), int(from.Port()))
+	if time.Since(t.db.LastPongReceived(n.ID(), ip)) > bondExpiration {
 		t.sendPing(fromID, from, func() {
 			t.tab.addInboundNode(n)
 		})
@@ -687,35 +693,40 @@ func (t *UDPv4) handlePing(h *packetHandlerV4, from *net.UDPAddr, fromID enode.I
 	}
 
 	// Update node database and endpoint predictor.
-	t.db.UpdateLastPingReceived(n.ID(), from.IP, time.Now())
-	t.localNode.UDPEndpointStatement(from, &net.UDPAddr{IP: req.To.IP, Port: int(req.To.UDP)})
+	t.db.UpdateLastPingReceived(n.ID(), ip, time.Now())
+	fromUDPAddr := &net.UDPAddr{IP: ip, Port: int(from.Port())}
+	toUDPAddr := &net.UDPAddr{IP: req.To.IP, Port: int(req.To.UDP)}
+	t.localNode.UDPEndpointStatement(fromUDPAddr, toUDPAddr)
 }
 
 // PONG/v4
 
-func (t *UDPv4) verifyPong(h *packetHandlerV4, from *net.UDPAddr, fromID enode.ID, fromKey v4wire.Pubkey) error {
+func (t *UDPv4) verifyPong(h *packetHandlerV4, from netip.AddrPort, fromID enode.ID, fromKey v4wire.Pubkey) error {
 	req := h.Packet.(*v4wire.Pong)
 
 	if v4wire.Expired(req.Expiration) {
 		return errExpired
 	}
-	if !t.handleReply(fromID, from.IP, req) {
+	if !t.handleReply(fromID, from.Addr(), req) {
 		return errUnsolicitedReply
 	}
-	t.localNode.UDPEndpointStatement(from, &net.UDPAddr{IP: req.To.IP, Port: int(req.To.UDP)})
-	t.db.UpdateLastPongReceived(fromID, from.IP, time.Now())
+	fromIP := from.Addr().AsSlice()
+	fromUDPAddr := &net.UDPAddr{IP: fromIP, Port: int(from.Port())}
+	toUDPAddr := &net.UDPAddr{IP: req.To.IP, Port: int(req.To.UDP)}
+	t.localNode.UDPEndpointStatement(fromUDPAddr, toUDPAddr)
+	t.db.UpdateLastPongReceived(fromID, fromIP, time.Now())
 	return nil
 }
 
 // FINDNODE/v4
 
-func (t *UDPv4) verifyFindnode(h *packetHandlerV4, from *net.UDPAddr, fromID enode.ID, fromKey v4wire.Pubkey) error {
+func (t *UDPv4) verifyFindnode(h *packetHandlerV4, from netip.AddrPort, fromID enode.ID, fromKey v4wire.Pubkey) error {
 	req := h.Packet.(*v4wire.Findnode)
 
 	if v4wire.Expired(req.Expiration) {
 		return errExpired
 	}
-	if !t.checkBond(fromID, from.IP) {
+	if !t.checkBond(fromID, from) {
 		// No endpoint proof pong exists, we don't process the packet. This prevents an
 		// attack vector where the discovery protocol could be used to amplify traffic in a
 		// DDOS attack. A malicious actor would send a findnode request with the IP address
@@ -727,7 +738,7 @@ func (t *UDPv4) verifyFindnode(h *packetHandlerV4, from *net.UDPAddr, fromID eno
 	return nil
 }
 
-func (t *UDPv4) handleFindnode(h *packetHandlerV4, from *net.UDPAddr, fromID enode.ID, mac []byte) {
+func (t *UDPv4) handleFindnode(h *packetHandlerV4, from netip.AddrPort, fromID enode.ID, mac []byte) {
 	req := h.Packet.(*v4wire.Findnode)
 
 	// Determine closest nodes.
@@ -739,7 +750,8 @@ func (t *UDPv4) handleFindnode(h *packetHandlerV4, from *net.UDPAddr, fromID eno
 	p := v4wire.Neighbors{Expiration: uint64(time.Now().Add(expiration).Unix())}
 	var sent bool
 	for _, n := range closest {
-		if netutil.CheckRelayIP(from.IP, n.IP()) == nil {
+		fromIP := from.Addr().AsSlice()
+		if netutil.CheckRelayIP(fromIP, n.IP()) == nil {
 			p.Nodes = append(p.Nodes, nodeToRPC(n))
 		}
 		if len(p.Nodes) == v4wire.MaxNeighbors {
@@ -755,13 +767,13 @@ func (t *UDPv4) handleFindnode(h *packetHandlerV4, from *net.UDPAddr, fromID eno
 
 // NEIGHBORS/v4
 
-func (t *UDPv4) verifyNeighbors(h *packetHandlerV4, from *net.UDPAddr, fromID enode.ID, fromKey v4wire.Pubkey) error {
+func (t *UDPv4) verifyNeighbors(h *packetHandlerV4, from netip.AddrPort, fromID enode.ID, fromKey v4wire.Pubkey) error {
 	req := h.Packet.(*v4wire.Neighbors)
 
 	if v4wire.Expired(req.Expiration) {
 		return errExpired
 	}
-	if !t.handleReply(fromID, from.IP, h.Packet) {
+	if !t.handleReply(fromID, from.Addr(), h.Packet) {
 		return errUnsolicitedReply
 	}
 	return nil
@@ -769,19 +781,19 @@ func (t *UDPv4) verifyNeighbors(h *packetHandlerV4, from *net.UDPAddr, fromID en
 
 // ENRREQUEST/v4
 
-func (t *UDPv4) verifyENRRequest(h *packetHandlerV4, from *net.UDPAddr, fromID enode.ID, fromKey v4wire.Pubkey) error {
+func (t *UDPv4) verifyENRRequest(h *packetHandlerV4, from netip.AddrPort, fromID enode.ID, fromKey v4wire.Pubkey) error {
 	req := h.Packet.(*v4wire.ENRRequest)
 
 	if v4wire.Expired(req.Expiration) {
 		return errExpired
 	}
-	if !t.checkBond(fromID, from.IP) {
+	if !t.checkBond(fromID, from) {
 		return errUnknownNode
 	}
 	return nil
 }
 
-func (t *UDPv4) handleENRRequest(h *packetHandlerV4, from *net.UDPAddr, fromID enode.ID, mac []byte) {
+func (t *UDPv4) handleENRRequest(h *packetHandlerV4, from netip.AddrPort, fromID enode.ID, mac []byte) {
 	t.send(from, fromID, &v4wire.ENRResponse{
 		ReplyTok: mac,
 		Record:   *t.localNode.Node().Record(),
@@ -790,8 +802,8 @@ func (t *UDPv4) handleENRRequest(h *packetHandlerV4, from *net.UDPAddr, fromID e
 
 // ENRRESPONSE/v4
 
-func (t *UDPv4) verifyENRResponse(h *packetHandlerV4, from *net.UDPAddr, fromID enode.ID, fromKey v4wire.Pubkey) error {
-	if !t.handleReply(fromID, from.IP, h.Packet) {
+func (t *UDPv4) verifyENRResponse(h *packetHandlerV4, from netip.AddrPort, fromID enode.ID, fromKey v4wire.Pubkey) error {
+	if !t.handleReply(fromID, from.Addr(), h.Packet) {
 		return errUnsolicitedReply
 	}
 	return nil

--- a/p2p/discover/v4_udp_test.go
+++ b/p2p/discover/v4_udp_test.go
@@ -393,8 +393,8 @@ func TestUDPv4_pingMatchIP(t *testing.T) {
 
 func TestUDPv4_successfulPing(t *testing.T) {
 	test := newUDPTest(t)
-	added := make(chan *node, 1)
-	test.table.nodeAddedHook = func(b *bucket, n *node) { added <- n }
+	added := make(chan *tableNode, 1)
+	test.table.nodeAddedHook = func(b *bucket, n *tableNode) { added <- n }
 	defer test.close()
 
 	// The remote side sends a ping packet to initiate the exchange.

--- a/p2p/discover/v4_udp_test.go
+++ b/p2p/discover/v4_udp_test.go
@@ -592,7 +592,7 @@ func newpipe() *dgramPipe {
 	}
 }
 
-// WriteToUDP queues a datagram.
+// WriteToUDPAddrPort queues a datagram.
 func (c *dgramPipe) WriteToUDPAddrPort(b []byte, to netip.AddrPort) (n int, err error) {
 	msg := make([]byte, len(b))
 	copy(msg, b)
@@ -606,7 +606,7 @@ func (c *dgramPipe) WriteToUDPAddrPort(b []byte, to netip.AddrPort) (n int, err 
 	return len(b), nil
 }
 
-// ReadFromUDP just hangs until the pipe is closed.
+// ReadFromUDPAddrPort just hangs until the pipe is closed.
 func (c *dgramPipe) ReadFromUDPAddrPort(b []byte) (n int, addr netip.AddrPort, err error) {
 	<-c.closing
 	return 0, netip.AddrPort{}, io.EOF

--- a/p2p/discover/v4_udp_test.go
+++ b/p2p/discover/v4_udp_test.go
@@ -416,7 +416,9 @@ func TestUDPv4_successfulPing(t *testing.T) {
 
 	// Remote is unknown, the table pings back.
 	test.waitPacketOut(func(p *v4wire.Ping, to netip.AddrPort, hash []byte) {
-		if !reflect.DeepEqual(p.From, test.udp.ourEndpoint()) {
+		wantFrom := test.udp.ourEndpoint()
+		wantFrom.IP = net.IP{}
+		if !reflect.DeepEqual(p.From, wantFrom) {
 			t.Errorf("got ping.From %#v, want %#v", p.From, test.udp.ourEndpoint())
 		}
 		// The mirrored UDP address is the UDP packet sender.

--- a/p2p/discover/v4wire/v4wire.go
+++ b/p2p/discover/v4wire/v4wire.go
@@ -25,6 +25,7 @@ import (
 	"fmt"
 	"math/big"
 	"net"
+	"net/netip"
 	"time"
 
 	"github.com/ethereum/go-ethereum/common/math"
@@ -150,14 +151,15 @@ type Endpoint struct {
 }
 
 // NewEndpoint creates an endpoint.
-func NewEndpoint(addr *net.UDPAddr, tcpPort uint16) Endpoint {
-	ip := net.IP{}
-	if ip4 := addr.IP.To4(); ip4 != nil {
-		ip = ip4
-	} else if ip6 := addr.IP.To16(); ip6 != nil {
-		ip = ip6
+func NewEndpoint(addr netip.AddrPort, tcpPort uint16) Endpoint {
+	var ip net.IP
+	if addr.Addr().Is4() || addr.Addr().Is4In6() {
+		ip4 := addr.Addr().As4()
+		ip = ip4[:]
+	} else {
+		ip = addr.Addr().AsSlice()
 	}
-	return Endpoint{IP: ip, UDP: uint16(addr.Port), TCP: tcpPort}
+	return Endpoint{IP: ip, UDP: addr.Port(), TCP: tcpPort}
 }
 
 type Packet interface {

--- a/p2p/discover/v5_udp.go
+++ b/p2p/discover/v5_udp.go
@@ -25,6 +25,7 @@ import (
 	"fmt"
 	"io"
 	"net"
+	"net/netip"
 	"slices"
 	"sync"
 	"time"
@@ -101,14 +102,14 @@ type UDPv5 struct {
 
 type sendRequest struct {
 	destID   enode.ID
-	destAddr *net.UDPAddr
+	destAddr netip.AddrPort
 	msg      v5wire.Packet
 }
 
 // callV5 represents a remote procedure call against another node.
 type callV5 struct {
 	id   enode.ID
-	addr *net.UDPAddr
+	addr netip.AddrPort
 	node *enode.Node // This is required to perform handshakes.
 
 	packet       v5wire.Packet
@@ -266,7 +267,7 @@ func (t *UDPv5) TalkRequest(n *enode.Node, protocol string, request []byte) ([]b
 }
 
 // TalkRequestToID sends a talk request to a node and waits for a response.
-func (t *UDPv5) TalkRequestToID(id enode.ID, addr *net.UDPAddr, protocol string, request []byte) ([]byte, error) {
+func (t *UDPv5) TalkRequestToID(id enode.ID, addr netip.AddrPort, protocol string, request []byte) ([]byte, error) {
 	req := &v5wire.TalkRequest{Protocol: protocol, Message: request}
 	resp := t.callToID(id, addr, v5wire.TalkResponseMsg, req)
 	defer t.callDone(resp)
@@ -427,7 +428,7 @@ func (t *UDPv5) verifyResponseNode(c *callV5, r *enr.Record, distances []uint, s
 	if err != nil {
 		return nil, err
 	}
-	if err := netutil.CheckRelayIP(c.addr.IP, node.IP()); err != nil {
+	if err := netutil.CheckRelayIP(c.addr.Addr().AsSlice(), node.IP()); err != nil {
 		return nil, err
 	}
 	if t.netrestrict != nil && !t.netrestrict.Contains(node.IP()) {
@@ -452,14 +453,14 @@ func (t *UDPv5) verifyResponseNode(c *callV5, r *enr.Record, distances []uint, s
 // callToNode sends the given call and sets up a handler for response packets (of message
 // type responseType). Responses are dispatched to the call's response channel.
 func (t *UDPv5) callToNode(n *enode.Node, responseType byte, req v5wire.Packet) *callV5 {
-	addr := &net.UDPAddr{IP: n.IP(), Port: n.UDP()}
+	addr, _ := n.UDPEndpoint()
 	c := &callV5{id: n.ID(), addr: addr, node: n}
 	t.initCall(c, responseType, req)
 	return c
 }
 
 // callToID is like callToNode, but for cases where the node record is not available.
-func (t *UDPv5) callToID(id enode.ID, addr *net.UDPAddr, responseType byte, req v5wire.Packet) *callV5 {
+func (t *UDPv5) callToID(id enode.ID, addr netip.AddrPort, responseType byte, req v5wire.Packet) *callV5 {
 	c := &callV5{id: id, addr: addr}
 	t.initCall(c, responseType, req)
 	return c
@@ -619,12 +620,12 @@ func (t *UDPv5) sendCall(c *callV5) {
 
 // sendResponse sends a response packet to the given node.
 // This doesn't trigger a handshake even if no keys are available.
-func (t *UDPv5) sendResponse(toID enode.ID, toAddr *net.UDPAddr, packet v5wire.Packet) error {
+func (t *UDPv5) sendResponse(toID enode.ID, toAddr netip.AddrPort, packet v5wire.Packet) error {
 	_, err := t.send(toID, toAddr, packet, nil)
 	return err
 }
 
-func (t *UDPv5) sendFromAnotherThread(toID enode.ID, toAddr *net.UDPAddr, packet v5wire.Packet) {
+func (t *UDPv5) sendFromAnotherThread(toID enode.ID, toAddr netip.AddrPort, packet v5wire.Packet) {
 	select {
 	case t.sendCh <- sendRequest{toID, toAddr, packet}:
 	case <-t.closeCtx.Done():
@@ -632,7 +633,7 @@ func (t *UDPv5) sendFromAnotherThread(toID enode.ID, toAddr *net.UDPAddr, packet
 }
 
 // send sends a packet to the given node.
-func (t *UDPv5) send(toID enode.ID, toAddr *net.UDPAddr, packet v5wire.Packet, c *v5wire.Whoareyou) (v5wire.Nonce, error) {
+func (t *UDPv5) send(toID enode.ID, toAddr netip.AddrPort, packet v5wire.Packet, c *v5wire.Whoareyou) (v5wire.Nonce, error) {
 	addr := toAddr.String()
 	t.logcontext = append(t.logcontext[:0], "id", toID, "addr", addr)
 	t.logcontext = packet.AppendLogInfo(t.logcontext)
@@ -644,7 +645,7 @@ func (t *UDPv5) send(toID enode.ID, toAddr *net.UDPAddr, packet v5wire.Packet, c
 		return nonce, err
 	}
 
-	_, err = t.conn.WriteToUDP(enc, toAddr)
+	_, err = t.conn.WriteToUDPAddrPort(enc, toAddr)
 	t.log.Trace(">> "+packet.Name(), t.logcontext...)
 	return nonce, err
 }
@@ -655,7 +656,7 @@ func (t *UDPv5) readLoop() {
 
 	buf := make([]byte, maxPacketSize)
 	for range t.readNextCh {
-		nbytes, from, err := t.conn.ReadFromUDP(buf)
+		nbytes, from, err := t.conn.ReadFromUDPAddrPort(buf)
 		if netutil.IsTemporaryError(err) {
 			// Ignore temporary read errors.
 			t.log.Debug("Temporary UDP read error", "err", err)
@@ -672,7 +673,7 @@ func (t *UDPv5) readLoop() {
 }
 
 // dispatchReadPacket sends a packet into the dispatch loop.
-func (t *UDPv5) dispatchReadPacket(from *net.UDPAddr, content []byte) bool {
+func (t *UDPv5) dispatchReadPacket(from netip.AddrPort, content []byte) bool {
 	select {
 	case t.packetInCh <- ReadPacket{content, from}:
 		return true
@@ -682,7 +683,7 @@ func (t *UDPv5) dispatchReadPacket(from *net.UDPAddr, content []byte) bool {
 }
 
 // handlePacket decodes and processes an incoming packet from the network.
-func (t *UDPv5) handlePacket(rawpacket []byte, fromAddr *net.UDPAddr) error {
+func (t *UDPv5) handlePacket(rawpacket []byte, fromAddr netip.AddrPort) error {
 	addr := fromAddr.String()
 	fromID, fromNode, packet, err := t.codec.Decode(rawpacket, addr)
 	if err != nil {
@@ -712,13 +713,13 @@ func (t *UDPv5) handlePacket(rawpacket []byte, fromAddr *net.UDPAddr) error {
 }
 
 // handleCallResponse dispatches a response packet to the call waiting for it.
-func (t *UDPv5) handleCallResponse(fromID enode.ID, fromAddr *net.UDPAddr, p v5wire.Packet) bool {
+func (t *UDPv5) handleCallResponse(fromID enode.ID, fromAddr netip.AddrPort, p v5wire.Packet) bool {
 	ac := t.activeCallByNode[fromID]
 	if ac == nil || !bytes.Equal(p.RequestID(), ac.reqid) {
 		t.log.Debug(fmt.Sprintf("Unsolicited/late %s response", p.Name()), "id", fromID, "addr", fromAddr)
 		return false
 	}
-	if !fromAddr.IP.Equal(ac.addr.IP) || fromAddr.Port != ac.addr.Port {
+	if fromAddr != ac.addr {
 		t.log.Debug(fmt.Sprintf("%s from wrong endpoint", p.Name()), "id", fromID, "addr", fromAddr)
 		return false
 	}
@@ -743,7 +744,7 @@ func (t *UDPv5) getNode(id enode.ID) *enode.Node {
 }
 
 // handle processes incoming packets according to their message type.
-func (t *UDPv5) handle(p v5wire.Packet, fromID enode.ID, fromAddr *net.UDPAddr) {
+func (t *UDPv5) handle(p v5wire.Packet, fromID enode.ID, fromAddr netip.AddrPort) {
 	switch p := p.(type) {
 	case *v5wire.Unknown:
 		t.handleUnknown(p, fromID, fromAddr)
@@ -753,7 +754,9 @@ func (t *UDPv5) handle(p v5wire.Packet, fromID enode.ID, fromAddr *net.UDPAddr) 
 		t.handlePing(p, fromID, fromAddr)
 	case *v5wire.Pong:
 		if t.handleCallResponse(fromID, fromAddr, p) {
-			t.localNode.UDPEndpointStatement(fromAddr, &net.UDPAddr{IP: p.ToIP, Port: int(p.ToPort)})
+			fromUDPAddr := &net.UDPAddr{IP: fromAddr.Addr().AsSlice(), Port: int(fromAddr.Port())}
+			toUDPAddr := &net.UDPAddr{IP: p.ToIP, Port: int(p.ToPort)}
+			t.localNode.UDPEndpointStatement(fromUDPAddr, toUDPAddr)
 		}
 	case *v5wire.Findnode:
 		t.handleFindnode(p, fromID, fromAddr)
@@ -767,7 +770,7 @@ func (t *UDPv5) handle(p v5wire.Packet, fromID enode.ID, fromAddr *net.UDPAddr) 
 }
 
 // handleUnknown initiates a handshake by responding with WHOAREYOU.
-func (t *UDPv5) handleUnknown(p *v5wire.Unknown, fromID enode.ID, fromAddr *net.UDPAddr) {
+func (t *UDPv5) handleUnknown(p *v5wire.Unknown, fromID enode.ID, fromAddr netip.AddrPort) {
 	challenge := &v5wire.Whoareyou{Nonce: p.Nonce}
 	crand.Read(challenge.IDNonce[:])
 	if n := t.getNode(fromID); n != nil {
@@ -783,7 +786,7 @@ var (
 )
 
 // handleWhoareyou resends the active call as a handshake packet.
-func (t *UDPv5) handleWhoareyou(p *v5wire.Whoareyou, fromID enode.ID, fromAddr *net.UDPAddr) {
+func (t *UDPv5) handleWhoareyou(p *v5wire.Whoareyou, fromID enode.ID, fromAddr netip.AddrPort) {
 	c, err := t.matchWithCall(fromID, p.Nonce)
 	if err != nil {
 		t.log.Debug("Invalid "+p.Name(), "addr", fromAddr, "err", err)
@@ -817,32 +820,35 @@ func (t *UDPv5) matchWithCall(fromID enode.ID, nonce v5wire.Nonce) (*callV5, err
 }
 
 // handlePing sends a PONG response.
-func (t *UDPv5) handlePing(p *v5wire.Ping, fromID enode.ID, fromAddr *net.UDPAddr) {
-	remoteIP := fromAddr.IP
-	// Handle IPv4 mapped IPv6 addresses in the
-	// event the local node is binded to an
-	// ipv6 interface.
-	if remoteIP.To4() != nil {
-		remoteIP = remoteIP.To4()
+func (t *UDPv5) handlePing(p *v5wire.Ping, fromID enode.ID, fromAddr netip.AddrPort) {
+	var remoteIP net.IP
+	// Handle IPv4 mapped IPv6 addresses in the event the local node is binded
+	// to an ipv6 interface.
+	if fromAddr.Addr().Is4() || fromAddr.Addr().Is4In6() {
+		ip4 := fromAddr.Addr().As4()
+		remoteIP = ip4[:]
+	} else {
+		remoteIP = fromAddr.Addr().AsSlice()
 	}
 	t.sendResponse(fromID, fromAddr, &v5wire.Pong{
 		ReqID:  p.ReqID,
 		ToIP:   remoteIP,
-		ToPort: uint16(fromAddr.Port),
+		ToPort: fromAddr.Port(),
 		ENRSeq: t.localNode.Node().Seq(),
 	})
 }
 
 // handleFindnode returns nodes to the requester.
-func (t *UDPv5) handleFindnode(p *v5wire.Findnode, fromID enode.ID, fromAddr *net.UDPAddr) {
-	nodes := t.collectTableNodes(fromAddr.IP, p.Distances, findnodeResultLimit)
+func (t *UDPv5) handleFindnode(p *v5wire.Findnode, fromID enode.ID, fromAddr netip.AddrPort) {
+	nodes := t.collectTableNodes(fromAddr.Addr(), p.Distances, findnodeResultLimit)
 	for _, resp := range packNodes(p.ReqID, nodes) {
 		t.sendResponse(fromID, fromAddr, resp)
 	}
 }
 
 // collectTableNodes creates a FINDNODE result set for the given distances.
-func (t *UDPv5) collectTableNodes(rip net.IP, distances []uint, limit int) []*enode.Node {
+func (t *UDPv5) collectTableNodes(rip netip.Addr, distances []uint, limit int) []*enode.Node {
+	ripSlice := rip.AsSlice()
 	var bn []*enode.Node
 	var nodes []*enode.Node
 	var processed = make(map[uint]struct{})
@@ -857,7 +863,7 @@ func (t *UDPv5) collectTableNodes(rip net.IP, distances []uint, limit int) []*en
 		for _, n := range t.tab.appendLiveNodes(dist, bn[:0]) {
 			// Apply some pre-checks to avoid sending invalid nodes.
 			// Note liveness is checked by appendLiveNodes.
-			if netutil.CheckRelayIP(rip, n.IP()) != nil {
+			if netutil.CheckRelayIP(ripSlice, n.IP()) != nil {
 				continue
 			}
 			nodes = append(nodes, n)

--- a/p2p/discover/v5_udp_test.go
+++ b/p2p/discover/v5_udp_test.go
@@ -776,7 +776,7 @@ func (test *udpV5Test) packetIn(packet v5wire.Packet) {
 	test.packetInFrom(test.remotekey, test.remoteaddr, packet)
 }
 
-// handles a packet as if it had been sent to the transport by the key/endpoint.
+// packetInFrom handles a packet as if it had been sent to the transport by the key/endpoint.
 func (test *udpV5Test) packetInFrom(key *ecdsa.PrivateKey, addr netip.AddrPort, packet v5wire.Packet) {
 	test.t.Helper()
 

--- a/p2p/server.go
+++ b/p2p/server.go
@@ -436,7 +436,7 @@ type sharedUDPConn struct {
 	unhandled chan discover.ReadPacket
 }
 
-// ReadFromUDP implements discover.UDPConn
+// ReadFromUDPAddrPort implements discover.UDPConn
 func (s *sharedUDPConn) ReadFromUDPAddrPort(b []byte) (n int, addr netip.AddrPort, err error) {
 	packet, ok := <-s.unhandled
 	if !ok {

--- a/p2p/server.go
+++ b/p2p/server.go
@@ -24,6 +24,7 @@ import (
 	"errors"
 	"fmt"
 	"net"
+	"net/netip"
 	"slices"
 	"sync"
 	"sync/atomic"
@@ -436,10 +437,10 @@ type sharedUDPConn struct {
 }
 
 // ReadFromUDP implements discover.UDPConn
-func (s *sharedUDPConn) ReadFromUDP(b []byte) (n int, addr *net.UDPAddr, err error) {
+func (s *sharedUDPConn) ReadFromUDPAddrPort(b []byte) (n int, addr netip.AddrPort, err error) {
 	packet, ok := <-s.unhandled
 	if !ok {
-		return 0, nil, errors.New("connection was closed")
+		return 0, netip.AddrPort{}, errors.New("connection was closed")
 	}
 	l := len(packet.Data)
 	if l > len(b) {


### PR DESCRIPTION
Here we clean up internal uses of type `discover.node`, converting most code to use `enode.Node` instead. The `discover.node` type used to be the canonical representation of network hosts before ENR was introduced. Most code worked with `*node` to avoid conversions when interacting with `Table` methods. Since `*node` also contains internal state of `Table` and is a mutable type, using `*node` outside of `Table` code is prone to data races. It's also cleaner not having to wrap/unwrap `*enode.Node` all the time.

`discover.node` has been renamed to `tableNode` to clarify its purpose.

While here, we also change most uses of `net.UDPAddr` into `netip.AddrPort`. While this is technically a separate refactoring from the `*node` -> `*enode.Node` change, it is more convenient because `*enode.Node` handles IP addresses as `netip.Addr`. The switch to package netip in discovery would've happened very soon anyway.

The change to `netip.AddrPort` stops at certain interface points. For example, since package p2p/netutil has not been converted to use `netip.Addr` yet, we still have to convert to `net.IP`/`net.UDPAddr` in a few places.
