### PR TITLE
metrics: add some missing test cases

### DIFF
--- a/metrics/counter_float_64_test.go
+++ b/metrics/counter_float_64_test.go
@@ -25,9 +25,16 @@ func BenchmarkCounterFloat64Parallel(b *testing.B) {
 			}
 			wg.Done()
 		}()
+		wg.Add(1)
+		go func() {
+			for i := 0; i < b.N; i++ {
+				c.Dec(1.0)
+			}
+			wg.Done()
+		}()
 	}
 	wg.Wait()
-	if have, want := c.Snapshot().Count(), 10.0*float64(b.N); have != want {
+	if have, want := c.Snapshot().Count(), float64(0); have != want {
 		b.Fatalf("have %f want %f", have, want)
 	}
 }

--- a/metrics/gauge_test.go
+++ b/metrics/gauge_test.go
@@ -1,6 +1,7 @@
 package metrics
 
 import (
+	"sync"
 	"testing"
 )
 
@@ -9,6 +10,65 @@ func BenchmarkGauge(b *testing.B) {
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		g.Update(int64(i))
+	}
+}
+
+func BenchmarkGaugeIncDecParallel(b *testing.B) {
+	g := NewGauge()
+	b.ResetTimer()
+	var wg sync.WaitGroup
+	for i := 0; i < 10; i++ {
+		wg.Add(1)
+		go func() {
+			for i := 0; i < b.N; i++ {
+				g.Inc(1)
+			}
+			wg.Done()
+		}()
+		wg.Add(1)
+		go func() {
+			for i := 0; i < b.N; i++ {
+				g.Dec(1)
+			}
+			wg.Done()
+		}()
+	}
+	wg.Wait()
+	if have, want := g.Snapshot().Value(), int64(0); have != want {
+		b.Fatalf("have %d want %d", have, want)
+	}
+}
+
+func TestGaugeUpdateIfGt(t *testing.T) {
+	g := NewGauge()
+	g.Update(int64(47))
+	g.UpdateIfGt(int64(0))
+	if v := g.Snapshot().Value(); v != 47 {
+		t.Errorf("g.Value(): 47 != %v\n", v)
+	}
+	g.UpdateIfGt(int64(58))
+	if v := g.Snapshot().Value(); v != 58 {
+		t.Errorf("g.Value(): 58 != %v\n", v)
+	}
+}
+
+func TestGaugeUpdateIfGtParallel(t *testing.T) {
+	g := NewGauge()
+	g.Update(int64(45))
+	if v := g.Snapshot().Value(); v != 45 {
+		t.Errorf("g.Value(): 45 != %v\n", v)
+	}
+	var wg sync.WaitGroup
+	for i := 50; i >= 40; i-- {
+		wg.Add(1)
+		go func(i int) {
+			g.UpdateIfGt(int64(i))
+			wg.Done()
+		}(i)
+	}
+	wg.Wait()
+	if v := g.Snapshot().Value(); v != 50 {
+		t.Errorf("g.Value(): 50 != %v\n", v)
 	}
 }
 


### PR DESCRIPTION
This PR adds some test cases for `metrics/counter` and `metrics/gauge`:

- For counter_float_64_test.go, add a test case for `func Dec`
- For counter_test.go, add a parallel test case for `func Inc` and `func Dec`
- For gauge_test.go, add a test case for `UpdateIfGt` and a parallel test case for `func Inc` and `func Dec`