### PR TITLE
miner: fix TestBuildPayload sporadic failure

### DIFF
--- a/miner/payload_building_test.go
+++ b/miner/payload_building_test.go
@@ -141,7 +141,7 @@ func (b *testWorkerBackend) TxPool() *txpool.TxPool       { return b.txPool }
 
 func newTestWorker(t *testing.T, chainConfig *params.ChainConfig, engine consensus.Engine, db ethdb.Database, blocks int) (*Miner, *testWorkerBackend) {
 	backend := newTestWorkerBackend(t, chainConfig, engine, db, blocks)
-	backend.txPool.Add(pendingTxs, true, false)
+	backend.txPool.Add(pendingTxs, true, true)
 	w := New(backend, testConfig, engine)
 	return w, backend
 }


### PR DESCRIPTION
Regarding #29830
Due to the large transaction churn,  adding tx to txpool may postpone fully integrating the tx to a later point to batch multiple ones together. 
If a block resolution occurs before a mock transaction is added to the transaction pool, the block won't contain any transactions. This sporadically causes TestBuildPayload to fail.
The solution is to set the sync flag to true, delaying block resolution until the addition is completed.