### PR TITLE
core/state, eth/protocols, trie, triedb/pathdb:  remove unused error from trie Commit

### DIFF
--- a/core/state/database.go
+++ b/core/state/database.go
@@ -123,7 +123,7 @@ type Trie interface {
 	// The returned nodeset can be nil if the trie is clean(nothing to commit).
 	// Once the trie is committed, it's not usable anymore. A new trie must
 	// be created with new root and updated trie database for following usage
-	Commit(collectLeaf bool) (common.Hash, *trienode.NodeSet, error)
+	Commit(collectLeaf bool) (common.Hash, *trienode.NodeSet)
 
 	// NodeIterator returns an iterator that returns nodes of the trie. Iteration
 	// starts at the key after the given start key. And error will be returned

--- a/core/state/snapshot/generate.go
+++ b/core/state/snapshot/generate.go
@@ -360,10 +360,7 @@ func (dl *diskLayer) generateRange(ctx *generatorContext, trieId *trie.ID, prefi
 		for i, key := range result.keys {
 			snapTrie.Update(key, result.vals[i])
 		}
-		root, nodes, err := snapTrie.Commit(false)
-		if err != nil {
-			return false, nil, err
-		}
+		root, nodes := snapTrie.Commit(false)
 		if nodes != nil {
 			tdb.Update(root, types.EmptyRootHash, 0, trienode.NewWithNodeSet(nodes), nil)
 			tdb.Commit(root, false)

--- a/core/state/snapshot/generate_test.go
+++ b/core/state/snapshot/generate_test.go
@@ -210,7 +210,7 @@ func (t *testHelper) makeStorageTrie(owner common.Hash, keys []string, vals []st
 	if !commit {
 		return stTrie.Hash()
 	}
-	root, nodes, _ := stTrie.Commit(false)
+	root, nodes := stTrie.Commit(false)
 	if nodes != nil {
 		t.nodes.Merge(nodes)
 	}
@@ -218,7 +218,7 @@ func (t *testHelper) makeStorageTrie(owner common.Hash, keys []string, vals []st
 }
 
 func (t *testHelper) Commit() common.Hash {
-	root, nodes, _ := t.accTrie.Commit(true)
+	root, nodes := t.accTrie.Commit(true)
 	if nodes != nil {
 		t.nodes.Merge(nodes)
 	}

--- a/core/state/state_object.go
+++ b/core/state/state_object.go
@@ -462,10 +462,7 @@ func (s *stateObject) commit() (*accountUpdate, *trienode.NodeSet, error) {
 		s.origin = s.data.Copy()
 		return op, nil, nil
 	}
-	root, nodes, err := s.trie.Commit(false)
-	if err != nil {
-		return nil, nil, err
-	}
+	root, nodes := s.trie.Commit(false)
 	s.data.Root = root
 	s.origin = s.data.Copy()
 	return op, nodes, nil

--- a/core/state/statedb.go
+++ b/core/state/statedb.go
@@ -1159,6 +1159,7 @@ func (s *StateDB) commit(deleteEmptyObjects bool) (*stateUpdate, error) {
 		start   = time.Now()
 		root    common.Hash
 		workers errgroup.Group
+		set     *trienode.NodeSet
 	)
 	// Schedule the account trie first since that will be the biggest, so give
 	// it the most time to crunch.
@@ -1171,11 +1172,7 @@ func (s *StateDB) commit(deleteEmptyObjects bool) (*stateUpdate, error) {
 	// code didn't anticipate for.
 	workers.Go(func() error {
 		// Write the account trie changes, measuring the amount of wasted time
-		newroot, set, err := s.trie.Commit(true)
-		if err != nil {
-			return err
-		}
-		root = newroot
+		root, set = s.trie.Commit(true)
 
 		if err := merge(set); err != nil {
 			return err

--- a/core/state/statedb.go
+++ b/core/state/statedb.go
@@ -1159,7 +1159,6 @@ func (s *StateDB) commit(deleteEmptyObjects bool) (*stateUpdate, error) {
 		start   = time.Now()
 		root    common.Hash
 		workers errgroup.Group
-		set     *trienode.NodeSet
 	)
 	// Schedule the account trie first since that will be the biggest, so give
 	// it the most time to crunch.
@@ -1172,7 +1171,8 @@ func (s *StateDB) commit(deleteEmptyObjects bool) (*stateUpdate, error) {
 	// code didn't anticipate for.
 	workers.Go(func() error {
 		// Write the account trie changes, measuring the amount of wasted time
-		root, set = s.trie.Commit(true)
+		newroot, set := s.trie.Commit(true)
+		root = newroot
 
 		if err := merge(set); err != nil {
 			return err

--- a/eth/protocols/snap/sync_test.go
+++ b/eth/protocols/snap/sync_test.go
@@ -1525,7 +1525,7 @@ func makeAccountTrieNoStorage(n int, scheme string) (string, *trie.Trie, []*kv) 
 
 	// Commit the state changes into db and re-create the trie
 	// for accessing later.
-	root, nodes, _ := accTrie.Commit(false)
+	root, nodes := accTrie.Commit(false)
 	db.Update(root, types.EmptyRootHash, 0, trienode.NewWithNodeSet(nodes), nil)
 
 	accTrie, _ = trie.New(trie.StateTrieID(root), db)
@@ -1587,7 +1587,7 @@ func makeBoundaryAccountTrie(scheme string, n int) (string, *trie.Trie, []*kv) {
 
 	// Commit the state changes into db and re-create the trie
 	// for accessing later.
-	root, nodes, _ := accTrie.Commit(false)
+	root, nodes := accTrie.Commit(false)
 	db.Update(root, types.EmptyRootHash, 0, trienode.NewWithNodeSet(nodes), nil)
 
 	accTrie, _ = trie.New(trie.StateTrieID(root), db)
@@ -1633,7 +1633,7 @@ func makeAccountTrieWithStorageWithUniqueStorage(scheme string, accounts, slots 
 	slices.SortFunc(entries, (*kv).cmp)
 
 	// Commit account trie
-	root, set, _ := accTrie.Commit(true)
+	root, set := accTrie.Commit(true)
 	nodes.Merge(set)
 
 	// Commit gathered dirty nodes into database
@@ -1700,7 +1700,7 @@ func makeAccountTrieWithStorage(scheme string, accounts, slots int, code, bounda
 	slices.SortFunc(entries, (*kv).cmp)
 
 	// Commit account trie
-	root, set, _ := accTrie.Commit(true)
+	root, set := accTrie.Commit(true)
 	nodes.Merge(set)
 
 	// Commit gathered dirty nodes into database
@@ -1742,7 +1742,7 @@ func makeStorageTrieWithSeed(owner common.Hash, n, seed uint64, db *triedb.Datab
 		entries = append(entries, elem)
 	}
 	slices.SortFunc(entries, (*kv).cmp)
-	root, nodes, _ := trie.Commit(false)
+	root, nodes := trie.Commit(false)
 	return root, nodes, entries
 }
 
@@ -1793,7 +1793,7 @@ func makeBoundaryStorageTrie(owner common.Hash, n int, db *triedb.Database) (com
 		entries = append(entries, elem)
 	}
 	slices.SortFunc(entries, (*kv).cmp)
-	root, nodes, _ := trie.Commit(false)
+	root, nodes := trie.Commit(false)
 	return root, nodes, entries
 }
 
@@ -1825,7 +1825,7 @@ func makeUnevenStorageTrie(owner common.Hash, slots int, db *triedb.Database) (c
 		}
 	}
 	slices.SortFunc(entries, (*kv).cmp)
-	root, nodes, _ := tr.Commit(false)
+	root, nodes := tr.Commit(false)
 	return root, nodes, entries
 }
 

--- a/trie/iterator_test.go
+++ b/trie/iterator_test.go
@@ -59,7 +59,7 @@ func TestIterator(t *testing.T) {
 		all[val.k] = val.v
 		trie.MustUpdate([]byte(val.k), []byte(val.v))
 	}
-	root, nodes, _ := trie.Commit(false)
+	root, nodes := trie.Commit(false)
 	db.Update(root, types.EmptyRootHash, trienode.NewWithNodeSet(nodes))
 
 	trie, _ = New(TrieID(root), db)
@@ -257,7 +257,7 @@ func TestDifferenceIterator(t *testing.T) {
 	for _, val := range testdata1 {
 		triea.MustUpdate([]byte(val.k), []byte(val.v))
 	}
-	rootA, nodesA, _ := triea.Commit(false)
+	rootA, nodesA := triea.Commit(false)
 	dba.Update(rootA, types.EmptyRootHash, trienode.NewWithNodeSet(nodesA))
 	triea, _ = New(TrieID(rootA), dba)
 
@@ -266,7 +266,7 @@ func TestDifferenceIterator(t *testing.T) {
 	for _, val := range testdata2 {
 		trieb.MustUpdate([]byte(val.k), []byte(val.v))
 	}
-	rootB, nodesB, _ := trieb.Commit(false)
+	rootB, nodesB := trieb.Commit(false)
 	dbb.Update(rootB, types.EmptyRootHash, trienode.NewWithNodeSet(nodesB))
 	trieb, _ = New(TrieID(rootB), dbb)
 
@@ -299,7 +299,7 @@ func TestUnionIterator(t *testing.T) {
 	for _, val := range testdata1 {
 		triea.MustUpdate([]byte(val.k), []byte(val.v))
 	}
-	rootA, nodesA, _ := triea.Commit(false)
+	rootA, nodesA := triea.Commit(false)
 	dba.Update(rootA, types.EmptyRootHash, trienode.NewWithNodeSet(nodesA))
 	triea, _ = New(TrieID(rootA), dba)
 
@@ -308,7 +308,7 @@ func TestUnionIterator(t *testing.T) {
 	for _, val := range testdata2 {
 		trieb.MustUpdate([]byte(val.k), []byte(val.v))
 	}
-	rootB, nodesB, _ := trieb.Commit(false)
+	rootB, nodesB := trieb.Commit(false)
 	dbb.Update(rootB, types.EmptyRootHash, trienode.NewWithNodeSet(nodesB))
 	trieb, _ = New(TrieID(rootB), dbb)
 
@@ -371,7 +371,7 @@ func testIteratorContinueAfterError(t *testing.T, memonly bool, scheme string) {
 	for _, val := range testdata1 {
 		tr.MustUpdate([]byte(val.k), []byte(val.v))
 	}
-	root, nodes, _ := tr.Commit(false)
+	root, nodes := tr.Commit(false)
 	tdb.Update(root, types.EmptyRootHash, trienode.NewWithNodeSet(nodes))
 	if !memonly {
 		tdb.Commit(root)
@@ -481,7 +481,7 @@ func testIteratorContinueAfterSeekError(t *testing.T, memonly bool, scheme strin
 	for _, val := range testdata1 {
 		ctr.MustUpdate([]byte(val.k), []byte(val.v))
 	}
-	root, nodes, _ := ctr.Commit(false)
+	root, nodes := ctr.Commit(false)
 	for path, n := range nodes.Nodes {
 		if n.Hash == barNodeHash {
 			barNodePath = []byte(path)
@@ -561,7 +561,7 @@ func testIteratorNodeBlob(t *testing.T, scheme string) {
 		all[val.k] = val.v
 		trie.MustUpdate([]byte(val.k), []byte(val.v))
 	}
-	root, nodes, _ := trie.Commit(false)
+	root, nodes := trie.Commit(false)
 	triedb.Update(root, types.EmptyRootHash, trienode.NewWithNodeSet(nodes))
 	triedb.Commit(root)
 

--- a/trie/secure_trie.go
+++ b/trie/secure_trie.go
@@ -221,7 +221,7 @@ func (t *StateTrie) GetKey(shaKey []byte) []byte {
 // All cached preimages will be also flushed if preimages recording is enabled.
 // Once the trie is committed, it's not usable anymore. A new trie must
 // be created with new root and updated trie database for following usage
-func (t *StateTrie) Commit(collectLeaf bool) (common.Hash, *trienode.NodeSet, error) {
+func (t *StateTrie) Commit(collectLeaf bool) (common.Hash, *trienode.NodeSet) {
 	// Write all the pre-images to the actual disk database
 	if len(t.getSecKeyCache()) > 0 {
 		preimages := make(map[common.Hash][]byte)

--- a/trie/secure_trie_test.go
+++ b/trie/secure_trie_test.go
@@ -60,7 +60,7 @@ func makeTestStateTrie() (*testDb, *StateTrie, map[string][]byte) {
 			trie.MustUpdate(key, val)
 		}
 	}
-	root, nodes, _ := trie.Commit(false)
+	root, nodes := trie.Commit(false)
 	if err := triedb.Update(root, types.EmptyRootHash, trienode.NewWithNodeSet(nodes)); err != nil {
 		panic(fmt.Errorf("failed to commit db %v", err))
 	}

--- a/trie/stacktrie_fuzzer_test.go
+++ b/trie/stacktrie_fuzzer_test.go
@@ -79,10 +79,7 @@ func fuzz(data []byte, debugging bool) {
 		return
 	}
 	// Flush trie -> database
-	rootA, nodes, err := trieA.Commit(false)
-	if err != nil {
-		panic(err)
-	}
+	rootA, nodes := trieA.Commit(false)
 	if nodes != nil {
 		dbA.Update(rootA, types.EmptyRootHash, trienode.NewWithNodeSet(nodes))
 	}

--- a/trie/sync_test.go
+++ b/trie/sync_test.go
@@ -58,7 +58,7 @@ func makeTestTrie(scheme string) (ethdb.Database, *testDb, *StateTrie, map[strin
 			trie.MustUpdate(key, val)
 		}
 	}
-	root, nodes, _ := trie.Commit(false)
+	root, nodes := trie.Commit(false)
 	if err := triedb.Update(root, types.EmptyRootHash, trienode.NewWithNodeSet(nodes)); err != nil {
 		panic(fmt.Errorf("failed to commit db %v", err))
 	}
@@ -771,7 +771,7 @@ func testSyncMovingTarget(t *testing.T, scheme string) {
 		srcTrie.MustUpdate(key, val)
 		diff[string(key)] = val
 	}
-	root, nodes, _ := srcTrie.Commit(false)
+	root, nodes := srcTrie.Commit(false)
 	if err := srcDb.Update(root, preRoot, trienode.NewWithNodeSet(nodes)); err != nil {
 		panic(err)
 	}
@@ -796,7 +796,7 @@ func testSyncMovingTarget(t *testing.T, scheme string) {
 		srcTrie.MustUpdate([]byte(k), val)
 		reverted[k] = val
 	}
-	root, nodes, _ = srcTrie.Commit(false)
+	root, nodes = srcTrie.Commit(false)
 	if err := srcDb.Update(root, preRoot, trienode.NewWithNodeSet(nodes)); err != nil {
 		panic(err)
 	}
@@ -847,7 +847,7 @@ func testPivotMove(t *testing.T, scheme string, tiny bool) {
 	writeFn([]byte{0x02, 0x34}, nil, srcTrie, stateA)
 	writeFn([]byte{0x13, 0x44}, nil, srcTrie, stateA)
 
-	rootA, nodesA, _ := srcTrie.Commit(false)
+	rootA, nodesA := srcTrie.Commit(false)
 	if err := srcTrieDB.Update(rootA, types.EmptyRootHash, trienode.NewWithNodeSet(nodesA)); err != nil {
 		panic(err)
 	}
@@ -866,7 +866,7 @@ func testPivotMove(t *testing.T, scheme string, tiny bool) {
 	deleteFn([]byte{0x13, 0x44}, srcTrie, stateB)
 	writeFn([]byte{0x01, 0x24}, nil, srcTrie, stateB)
 
-	rootB, nodesB, _ := srcTrie.Commit(false)
+	rootB, nodesB := srcTrie.Commit(false)
 	if err := srcTrieDB.Update(rootB, rootA, trienode.NewWithNodeSet(nodesB)); err != nil {
 		panic(err)
 	}
@@ -884,7 +884,7 @@ func testPivotMove(t *testing.T, scheme string, tiny bool) {
 	writeFn([]byte{0x02, 0x34}, nil, srcTrie, stateC)
 	writeFn([]byte{0x13, 0x44}, nil, srcTrie, stateC)
 
-	rootC, nodesC, _ := srcTrie.Commit(false)
+	rootC, nodesC := srcTrie.Commit(false)
 	if err := srcTrieDB.Update(rootC, rootB, trienode.NewWithNodeSet(nodesC)); err != nil {
 		panic(err)
 	}
@@ -946,7 +946,7 @@ func testSyncAbort(t *testing.T, scheme string) {
 	}
 	writeFn(key, val, srcTrie, stateA)
 
-	rootA, nodesA, _ := srcTrie.Commit(false)
+	rootA, nodesA := srcTrie.Commit(false)
 	if err := srcTrieDB.Update(rootA, types.EmptyRootHash, trienode.NewWithNodeSet(nodesA)); err != nil {
 		panic(err)
 	}
@@ -963,7 +963,7 @@ func testSyncAbort(t *testing.T, scheme string) {
 	srcTrie, _ = New(TrieID(rootA), srcTrieDB)
 	deleteFn(key, srcTrie, stateB)
 
-	rootB, nodesB, _ := srcTrie.Commit(false)
+	rootB, nodesB := srcTrie.Commit(false)
 	if err := srcTrieDB.Update(rootB, rootA, trienode.NewWithNodeSet(nodesB)); err != nil {
 		panic(err)
 	}
@@ -990,7 +990,7 @@ func testSyncAbort(t *testing.T, scheme string) {
 	srcTrie, _ = New(TrieID(rootB), srcTrieDB)
 
 	writeFn(key, val, srcTrie, stateC)
-	rootC, nodesC, _ := srcTrie.Commit(false)
+	rootC, nodesC := srcTrie.Commit(false)
 	if err := srcTrieDB.Update(rootC, rootB, trienode.NewWithNodeSet(nodesC)); err != nil {
 		panic(err)
 	}

--- a/trie/tracer_test.go
+++ b/trie/tracer_test.go
@@ -70,7 +70,7 @@ func testTrieTracer(t *testing.T, vals []struct{ k, v string }) {
 	}
 	insertSet := copySet(trie.tracer.inserts) // copy before commit
 	deleteSet := copySet(trie.tracer.deletes) // copy before commit
-	root, nodes, _ := trie.Commit(false)
+	root, nodes := trie.Commit(false)
 	db.Update(root, types.EmptyRootHash, trienode.NewWithNodeSet(nodes))
 
 	seen := setKeys(iterNodes(db, root))
@@ -137,7 +137,7 @@ func testAccessList(t *testing.T, vals []struct{ k, v string }) {
 	for _, val := range vals {
 		trie.MustUpdate([]byte(val.k), []byte(val.v))
 	}
-	root, nodes, _ := trie.Commit(false)
+	root, nodes := trie.Commit(false)
 	db.Update(root, types.EmptyRootHash, trienode.NewWithNodeSet(nodes))
 
 	trie, _ = New(TrieID(root), db)
@@ -152,7 +152,7 @@ func testAccessList(t *testing.T, vals []struct{ k, v string }) {
 	for _, val := range vals {
 		trie.MustUpdate([]byte(val.k), randBytes(32))
 	}
-	root, nodes, _ = trie.Commit(false)
+	root, nodes = trie.Commit(false)
 	db.Update(root, parent, trienode.NewWithNodeSet(nodes))
 
 	trie, _ = New(TrieID(root), db)
@@ -170,7 +170,7 @@ func testAccessList(t *testing.T, vals []struct{ k, v string }) {
 		keys = append(keys, string(key))
 		trie.MustUpdate(key, randBytes(32))
 	}
-	root, nodes, _ = trie.Commit(false)
+	root, nodes = trie.Commit(false)
 	db.Update(root, parent, trienode.NewWithNodeSet(nodes))
 
 	trie, _ = New(TrieID(root), db)
@@ -185,7 +185,7 @@ func testAccessList(t *testing.T, vals []struct{ k, v string }) {
 	for _, key := range keys {
 		trie.MustUpdate([]byte(key), nil)
 	}
-	root, nodes, _ = trie.Commit(false)
+	root, nodes = trie.Commit(false)
 	db.Update(root, parent, trienode.NewWithNodeSet(nodes))
 
 	trie, _ = New(TrieID(root), db)
@@ -200,7 +200,7 @@ func testAccessList(t *testing.T, vals []struct{ k, v string }) {
 	for _, val := range vals {
 		trie.MustUpdate([]byte(val.k), nil)
 	}
-	root, nodes, _ = trie.Commit(false)
+	root, nodes = trie.Commit(false)
 	db.Update(root, parent, trienode.NewWithNodeSet(nodes))
 
 	trie, _ = New(TrieID(root), db)
@@ -219,7 +219,7 @@ func TestAccessListLeak(t *testing.T) {
 	for _, val := range standard {
 		trie.MustUpdate([]byte(val.k), []byte(val.v))
 	}
-	root, nodes, _ := trie.Commit(false)
+	root, nodes := trie.Commit(false)
 	db.Update(root, types.EmptyRootHash, trienode.NewWithNodeSet(nodes))
 
 	var cases = []struct {
@@ -269,7 +269,7 @@ func TestTinyTree(t *testing.T) {
 	for _, val := range tiny {
 		trie.MustUpdate([]byte(val.k), randBytes(32))
 	}
-	root, set, _ := trie.Commit(false)
+	root, set := trie.Commit(false)
 	db.Update(root, types.EmptyRootHash, trienode.NewWithNodeSet(set))
 
 	parent := root
@@ -278,7 +278,7 @@ func TestTinyTree(t *testing.T) {
 	for _, val := range tiny {
 		trie.MustUpdate([]byte(val.k), []byte(val.v))
 	}
-	root, set, _ = trie.Commit(false)
+	root, set = trie.Commit(false)
 	db.Update(root, parent, trienode.NewWithNodeSet(set))
 
 	trie, _ = New(TrieID(root), db)

--- a/trie/trie.go
+++ b/trie/trie.go
@@ -608,7 +608,7 @@ func (t *Trie) Hash() common.Hash {
 // The returned nodeset can be nil if the trie is clean (nothing to commit).
 // Once the trie is committed, it's not usable anymore. A new trie must
 // be created with new root and updated trie database for following usage
-func (t *Trie) Commit(collectLeaf bool) (common.Hash, *trienode.NodeSet, error) {
+func (t *Trie) Commit(collectLeaf bool) (common.Hash, *trienode.NodeSet) {
 	defer t.tracer.reset()
 	defer func() {
 		t.committed = true
@@ -620,13 +620,13 @@ func (t *Trie) Commit(collectLeaf bool) (common.Hash, *trienode.NodeSet, error) 
 	if t.root == nil {
 		paths := t.tracer.deletedNodes()
 		if len(paths) == 0 {
-			return types.EmptyRootHash, nil, nil // case (a)
+			return types.EmptyRootHash, nil // case (a)
 		}
 		nodes := trienode.NewNodeSet(t.owner)
 		for _, path := range paths {
 			nodes.AddNode([]byte(path), trienode.NewDeleted())
 		}
-		return types.EmptyRootHash, nodes, nil // case (b)
+		return types.EmptyRootHash, nodes // case (b)
 	}
 	// Derive the hash for all dirty nodes first. We hold the assumption
 	// in the following procedure that all nodes are hashed.
@@ -638,14 +638,14 @@ func (t *Trie) Commit(collectLeaf bool) (common.Hash, *trienode.NodeSet, error) 
 		// Replace the root node with the origin hash in order to
 		// ensure all resolved nodes are dropped after the commit.
 		t.root = hashedNode
-		return rootHash, nil, nil
+		return rootHash, nil
 	}
 	nodes := trienode.NewNodeSet(t.owner)
 	for _, path := range t.tracer.deletedNodes() {
 		nodes.AddNode([]byte(path), trienode.NewDeleted())
 	}
 	t.root = newCommitter(nodes, t.tracer, collectLeaf).Commit(t.root)
-	return rootHash, nodes, nil
+	return rootHash, nodes
 }
 
 // hashRoot calculates the root hash of the given trie

--- a/trie/trie_test.go
+++ b/trie/trie_test.go
@@ -95,7 +95,7 @@ func testMissingNode(t *testing.T, memonly bool, scheme string) {
 	trie := NewEmpty(triedb)
 	updateString(trie, "120000", "qwerqwerqwerqwerqwerqwerqwerqwer")
 	updateString(trie, "123456", "asdfasdfasdfasdfasdfasdfasdfasdf")
-	root, nodes, _ := trie.Commit(false)
+	root, nodes := trie.Commit(false)
 	triedb.Update(root, types.EmptyRootHash, trienode.NewWithNodeSet(nodes))
 
 	if !memonly {
@@ -184,7 +184,7 @@ func TestInsert(t *testing.T) {
 	updateString(trie, "A", "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
 
 	exp = common.HexToHash("d23786fb4a010da3ce639d66d5e904a11dbc02746d1ce25029e53290cabf28ab")
-	root, _, _ = trie.Commit(false)
+	root, _ = trie.Commit(false)
 	if root != exp {
 		t.Errorf("case 2: exp %x got %x", exp, root)
 	}
@@ -209,7 +209,7 @@ func TestGet(t *testing.T) {
 		if i == 1 {
 			return
 		}
-		root, nodes, _ := trie.Commit(false)
+		root, nodes := trie.Commit(false)
 		db.Update(root, types.EmptyRootHash, trienode.NewWithNodeSet(nodes))
 		trie, _ = New(TrieID(root), db)
 	}
@@ -282,7 +282,7 @@ func TestReplication(t *testing.T) {
 	for _, val := range vals {
 		updateString(trie, val.k, val.v)
 	}
-	root, nodes, _ := trie.Commit(false)
+	root, nodes := trie.Commit(false)
 	db.Update(root, types.EmptyRootHash, trienode.NewWithNodeSet(nodes))
 
 	// create a new trie on top of the database and check that lookups work.
@@ -295,7 +295,7 @@ func TestReplication(t *testing.T) {
 			t.Errorf("trie2 doesn't have %q => %q", kv.k, kv.v)
 		}
 	}
-	hash, nodes, _ := trie2.Commit(false)
+	hash, nodes := trie2.Commit(false)
 	if hash != root {
 		t.Errorf("root failure. expected %x got %x", root, hash)
 	}
@@ -531,7 +531,7 @@ func runRandTest(rt randTest) error {
 		case opHash:
 			tr.Hash()
 		case opCommit:
-			root, nodes, _ := tr.Commit(true)
+			root, nodes := tr.Commit(true)
 			if nodes != nil {
 				triedb.Update(root, origin, trienode.NewWithNodeSet(nodes))
 			}
@@ -768,7 +768,7 @@ func TestCommitAfterHash(t *testing.T) {
 	if exp != root {
 		t.Errorf("got %x, exp %x", root, exp)
 	}
-	root, _, _ = trie.Commit(false)
+	root, _ = trie.Commit(false)
 	if exp != root {
 		t.Errorf("got %x, exp %x", root, exp)
 	}
@@ -894,7 +894,7 @@ func TestCommitSequence(t *testing.T) {
 			trie.MustUpdate(crypto.Keccak256(addresses[i][:]), accounts[i])
 		}
 		// Flush trie -> database
-		root, nodes, _ := trie.Commit(false)
+		root, nodes := trie.Commit(false)
 		db.Update(root, types.EmptyRootHash, trienode.NewWithNodeSet(nodes))
 		// Flush memdb -> disk (sponge)
 		db.Commit(root)
@@ -935,7 +935,7 @@ func TestCommitSequenceRandomBlobs(t *testing.T) {
 			trie.MustUpdate(key, val)
 		}
 		// Flush trie -> database
-		root, nodes, _ := trie.Commit(false)
+		root, nodes := trie.Commit(false)
 		db.Update(root, types.EmptyRootHash, trienode.NewWithNodeSet(nodes))
 		// Flush memdb -> disk (sponge)
 		db.Commit(root)
@@ -984,7 +984,7 @@ func TestCommitSequenceStackTrie(t *testing.T) {
 			stTrie.Update(key, val)
 		}
 		// Flush trie -> database
-		root, nodes, _ := trie.Commit(false)
+		root, nodes := trie.Commit(false)
 		// Flush memdb -> disk (sponge)
 		db.Update(root, types.EmptyRootHash, trienode.NewWithNodeSet(nodes))
 		db.Commit(root)
@@ -1042,7 +1042,7 @@ func TestCommitSequenceSmallRoot(t *testing.T) {
 	stTrie.Update(key, []byte{0x1})
 
 	// Flush trie -> database
-	root, nodes, _ := trie.Commit(false)
+	root, nodes := trie.Commit(false)
 	// Flush memdb -> disk (sponge)
 	db.Update(root, types.EmptyRootHash, trienode.NewWithNodeSet(nodes))
 	db.Commit(root)

--- a/trie/triestate/state.go
+++ b/trie/triestate/state.go
@@ -42,7 +42,7 @@ type Trie interface {
 
 	// Commit the trie and returns a set of dirty nodes generated along with
 	// the new root hash.
-	Commit(collectLeaf bool) (common.Hash, *trienode.NodeSet, error)
+	Commit(collectLeaf bool) (common.Hash, *trienode.NodeSet)
 }
 
 // TrieLoader wraps functions to load tries.
@@ -125,10 +125,7 @@ func Apply(prevRoot common.Hash, postRoot common.Hash, accounts map[common.Addre
 			return nil, fmt.Errorf("failed to revert state, err: %w", err)
 		}
 	}
-	root, result, err := tr.Commit(false)
-	if err != nil {
-		return nil, err
-	}
+	root, result := tr.Commit(false)
 	if root != prevRoot {
 		return nil, fmt.Errorf("failed to revert state, want %#x, got %#x", prevRoot, root)
 	}
@@ -180,10 +177,7 @@ func updateAccount(ctx *context, loader TrieLoader, addr common.Address) error {
 			return err
 		}
 	}
-	root, result, err := st.Commit(false)
-	if err != nil {
-		return err
-	}
+	root, result := st.Commit(false)
 	if root != prev.Root {
 		return errors.New("failed to reset storage trie")
 	}
@@ -234,10 +228,7 @@ func deleteAccount(ctx *context, loader TrieLoader, addr common.Address) error {
 			return err
 		}
 	}
-	root, result, err := st.Commit(false)
-	if err != nil {
-		return err
-	}
+	root, result := st.Commit(false)
 	if root != types.EmptyRootHash {
 		return errors.New("failed to clear storage trie")
 	}

--- a/trie/verkle.go
+++ b/trie/verkle.go
@@ -221,13 +221,13 @@ func (t *VerkleTrie) Commit(_ bool) (common.Hash, *trienode.NodeSet) {
 	root := t.root.(*verkle.InternalNode)
 	nodes, err := root.BatchSerialize()
 	if err != nil {
-		// error return from this function indicates error in the code logic
+		// Error return from this function indicates error in the code logic
 		// of BatchSerialize, and we fail catastrophically if this is the case.
 		panic(fmt.Errorf("BatchSerialize failed: %v", err))
 	}
 	nodeset := trienode.NewNodeSet(common.Hash{})
 	for _, node := range nodes {
-		// hash parameter is not used in pathdb
+		// Hash parameter is not used in pathdb
 		nodeset.AddNode(node.Path, trienode.New(common.Hash{}, node.SerializedBytes))
 	}
 	// Serialize root commitment form

--- a/trie/verkle.go
+++ b/trie/verkle.go
@@ -219,7 +219,12 @@ func (t *VerkleTrie) Hash() common.Hash {
 // Commit writes all nodes to the tree's memory database.
 func (t *VerkleTrie) Commit(_ bool) (common.Hash, *trienode.NodeSet) {
 	root := t.root.(*verkle.InternalNode)
-	nodes, _ := root.BatchSerialize()
+	nodes, err := root.BatchSerialize()
+	if err != nil {
+		// error return from this function indicates error in the code logic
+		// of BatchSerialize, and we fail catastrophically if this is the case.
+		panic(fmt.Errorf("BatchSerialize failed: %v", err))
+	}
 	nodeset := trienode.NewNodeSet(common.Hash{})
 	for _, node := range nodes {
 		// hash parameter is not used in pathdb

--- a/trie/verkle.go
+++ b/trie/verkle.go
@@ -217,22 +217,16 @@ func (t *VerkleTrie) Hash() common.Hash {
 }
 
 // Commit writes all nodes to the tree's memory database.
-func (t *VerkleTrie) Commit(_ bool) (common.Hash, *trienode.NodeSet, error) {
-	root, ok := t.root.(*verkle.InternalNode)
-	if !ok {
-		return common.Hash{}, nil, errors.New("unexpected root node type")
-	}
-	nodes, err := root.BatchSerialize()
-	if err != nil {
-		return common.Hash{}, nil, fmt.Errorf("serializing tree nodes: %s", err)
-	}
+func (t *VerkleTrie) Commit(_ bool) (common.Hash, *trienode.NodeSet) {
+	root := t.root.(*verkle.InternalNode)
+	nodes, _ := root.BatchSerialize()
 	nodeset := trienode.NewNodeSet(common.Hash{})
 	for _, node := range nodes {
 		// hash parameter is not used in pathdb
 		nodeset.AddNode(node.Path, trienode.New(common.Hash{}, node.SerializedBytes))
 	}
 	// Serialize root commitment form
-	return t.Hash(), nodeset, nil
+	return t.Hash(), nodeset
 }
 
 // NodeIterator implements state.Trie, returning an iterator that returns

--- a/triedb/pathdb/database_test.go
+++ b/triedb/pathdb/database_test.go
@@ -46,8 +46,7 @@ func updateTrie(addrHash common.Hash, root common.Hash, dirties, cleans map[comm
 			h.Update(key.Bytes(), val)
 		}
 	}
-	root, nodes := h.Commit(false)
-	return root, nodes
+	return h.Commit(false)
 }
 
 func generateAccount(storageRoot common.Hash) types.StateAccount {

--- a/triedb/pathdb/database_test.go
+++ b/triedb/pathdb/database_test.go
@@ -46,10 +46,7 @@ func updateTrie(addrHash common.Hash, root common.Hash, dirties, cleans map[comm
 			h.Update(key.Bytes(), val)
 		}
 	}
-	root, nodes, err := h.Commit(false)
-	if err != nil {
-		panic(fmt.Errorf("failed to commit hasher, err: %w", err))
-	}
+	root, nodes := h.Commit(false)
 	return root, nodes
 }
 

--- a/triedb/pathdb/testutils.go
+++ b/triedb/pathdb/testutils.go
@@ -80,7 +80,7 @@ func (h *testHasher) Delete(key []byte) error {
 
 // Commit computes the new hash of the states and returns the set with all
 // state changes.
-func (h *testHasher) Commit(collectLeaf bool) (common.Hash, *trienode.NodeSet, error) {
+func (h *testHasher) Commit(collectLeaf bool) (common.Hash, *trienode.NodeSet) {
 	var (
 		nodes = make(map[common.Hash][]byte)
 		set   = trienode.NewNodeSet(h.owner)
@@ -111,7 +111,7 @@ func (h *testHasher) Commit(collectLeaf bool) (common.Hash, *trienode.NodeSet, e
 	if root == types.EmptyRootHash && h.root != types.EmptyRootHash {
 		set.AddNode(nil, trienode.NewDeleted())
 	}
-	return root, set, nil
+	return root, set
 }
 
 // hash performs the hash computation upon the provided states.


### PR DESCRIPTION
The `Commit` operation performs the commitment computation, computing the changed node-set, internal intermediate roots, and new state root.  There's no reason that it should fail and return an error.