### PR TITLE
core: allow rewinding to block 0

### DIFF
--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -454,7 +454,7 @@ func NewBlockChain(db ethdb.Database, cacheConfig *CacheConfig, genesis *Genesis
 		if compat.RewindToTime > 0 {
 			bc.SetHeadWithTimestamp(compat.RewindToTime)
 		} else {
-			bc.SetHead(compat.RewindToBlock)
+			bc.SetHead(uint64(compat.RewindToBlock))
 		}
 		rawdb.WriteChainConfig(db, genesisHash, chainConfig)
 	}

--- a/core/genesis.go
+++ b/core/genesis.go
@@ -354,7 +354,7 @@ func SetupGenesisBlockWithOverride(db ethdb.Database, triedb *triedb.Database, g
 		return newcfg, stored, errors.New("missing head header")
 	}
 	compatErr := storedcfg.CheckCompatible(newcfg, head.Number.Uint64(), head.Time)
-	if compatErr != nil && ((head.Number.Uint64() != 0 && compatErr.RewindByBlock) || (head.Time != 0 && compatErr.RewindToTime != 0)) {
+	if compatErr != nil && ((head.Number.Uint64() != 0 && compatErr.IsRewindByBlock()) || (head.Time != 0 && compatErr.RewindToTime != 0)) {
 		return newcfg, stored, compatErr
 	}
 	// Don't overwrite if the old is identical to the new

--- a/core/genesis.go
+++ b/core/genesis.go
@@ -354,7 +354,7 @@ func SetupGenesisBlockWithOverride(db ethdb.Database, triedb *triedb.Database, g
 		return newcfg, stored, errors.New("missing head header")
 	}
 	compatErr := storedcfg.CheckCompatible(newcfg, head.Number.Uint64(), head.Time)
-	if compatErr != nil && ((head.Number.Uint64() != 0 && compatErr.RewindToBlock != 0) || (head.Time != 0 && compatErr.RewindToTime != 0)) {
+	if compatErr != nil && ((head.Number.Uint64() != 0 && compatErr.RewindByBlock) || (head.Time != 0 && compatErr.RewindToTime != 0)) {
 		return newcfg, stored, compatErr
 	}
 	// Don't overwrite if the old is identical to the new

--- a/core/genesis_test.go
+++ b/core/genesis_test.go
@@ -148,7 +148,6 @@ func testSetupGenesis(t *testing.T, scheme string) {
 				What:          "Homestead fork block",
 				StoredBlock:   big.NewInt(2),
 				NewBlock:      big.NewInt(3),
-				RewindByBlock: true,
 				RewindToBlock: 1,
 			},
 		},

--- a/core/genesis_test.go
+++ b/core/genesis_test.go
@@ -148,6 +148,7 @@ func testSetupGenesis(t *testing.T, scheme string) {
 				What:          "Homestead fork block",
 				StoredBlock:   big.NewInt(2),
 				NewBlock:      big.NewInt(3),
+				RewindByBlock: true,
 				RewindToBlock: 1,
 			},
 		},

--- a/params/config.go
+++ b/params/config.go
@@ -843,6 +843,9 @@ type ConfigCompatError struct {
 	// the block number to which the local chain must be rewound to correct the error
 	RewindToBlock uint64
 
+	// the flag to tell whether it's rewinding by block or time
+	RewindByBlock bool
+
 	// the timestamp to which the local chain must be rewound to correct the error
 	RewindToTime uint64
 }
@@ -862,6 +865,7 @@ func newBlockCompatError(what string, storedblock, newblock *big.Int) *ConfigCom
 		StoredBlock:   storedblock,
 		NewBlock:      newblock,
 		RewindToBlock: 0,
+		RewindByBlock: true,
 	}
 	if rew != nil && rew.Sign() > 0 {
 		err.RewindToBlock = rew.Uint64() - 1

--- a/params/config_test.go
+++ b/params/config_test.go
@@ -52,7 +52,6 @@ func TestCheckCompatible(t *testing.T) {
 				StoredBlock:   big.NewInt(0),
 				NewBlock:      nil,
 				RewindToBlock: 0,
-				RewindByBlock: true,
 			},
 		},
 		{
@@ -64,7 +63,6 @@ func TestCheckCompatible(t *testing.T) {
 				StoredBlock:   big.NewInt(0),
 				NewBlock:      big.NewInt(1),
 				RewindToBlock: 0,
-				RewindByBlock: true,
 			},
 		},
 		{
@@ -76,7 +74,6 @@ func TestCheckCompatible(t *testing.T) {
 				StoredBlock:   big.NewInt(10),
 				NewBlock:      big.NewInt(20),
 				RewindToBlock: 9,
-				RewindByBlock: true,
 			},
 		},
 		{
@@ -94,7 +91,6 @@ func TestCheckCompatible(t *testing.T) {
 				StoredBlock:   nil,
 				NewBlock:      big.NewInt(31),
 				RewindToBlock: 30,
-				RewindByBlock: true,
 			},
 		},
 		{
@@ -108,18 +104,19 @@ func TestCheckCompatible(t *testing.T) {
 			new:           &ChainConfig{ShanghaiTime: newUint64(20)},
 			headTimestamp: 25,
 			wantErr: &ConfigCompatError{
-				What:         "Shanghai fork timestamp",
-				StoredTime:   newUint64(10),
-				NewTime:      newUint64(20),
-				RewindToTime: 9,
+				What:          "Shanghai fork timestamp",
+				StoredTime:    newUint64(10),
+				NewTime:       newUint64(20),
+				RewindToTime:  9,
+				RewindToBlock: -1,
 			},
 		},
 	}
 
-	for _, test := range tests {
+	for i, test := range tests {
 		err := test.stored.CheckCompatible(test.new, test.headBlock, test.headTimestamp)
 		if !reflect.DeepEqual(err, test.wantErr) {
-			t.Errorf("error mismatch:\nstored: %v\nnew: %v\nheadBlock: %v\nheadTimestamp: %v\nerr: %v\nwant: %v", test.stored, test.new, test.headBlock, test.headTimestamp, err, test.wantErr)
+			t.Errorf("error mismatch:\nstored: %v\nnew: %v\nheadBlock: %v\nheadTimestamp: %v\nerr: %v\nwant: %v\nindex:%d", test.stored, test.new, test.headBlock, test.headTimestamp, err, test.wantErr, i)
 		}
 	}
 }

--- a/params/config_test.go
+++ b/params/config_test.go
@@ -52,6 +52,7 @@ func TestCheckCompatible(t *testing.T) {
 				StoredBlock:   big.NewInt(0),
 				NewBlock:      nil,
 				RewindToBlock: 0,
+				RewindByBlock: true,
 			},
 		},
 		{
@@ -63,6 +64,7 @@ func TestCheckCompatible(t *testing.T) {
 				StoredBlock:   big.NewInt(0),
 				NewBlock:      big.NewInt(1),
 				RewindToBlock: 0,
+				RewindByBlock: true,
 			},
 		},
 		{
@@ -74,6 +76,7 @@ func TestCheckCompatible(t *testing.T) {
 				StoredBlock:   big.NewInt(10),
 				NewBlock:      big.NewInt(20),
 				RewindToBlock: 9,
+				RewindByBlock: true,
 			},
 		},
 		{
@@ -91,6 +94,7 @@ func TestCheckCompatible(t *testing.T) {
 				StoredBlock:   nil,
 				NewBlock:      big.NewInt(31),
 				RewindToBlock: 30,
+				RewindByBlock: true,
 			},
 		},
 		{


### PR DESCRIPTION
`0` is a possible value for block number, but impossible for block time.

This PR tries to allow explicitly rewinding to block `0` by adding `ConfigCompatError.RewindByBlock` field.

Previously there's no way to explicitly rewind to block `0` according to [this condition](https://github.com/ethereum/go-ethereum/blob/cc22e0cdf0468947265883921b0c29119ca0327a/core/genesis.go#L357).