### PR TITLE
all:  support multi-database of ethereum data

### DIFF
--- a/cmd/geth/chaincmd.go
+++ b/cmd/geth/chaincmd.go
@@ -229,6 +229,15 @@ func initGenesis(ctx *cli.Context) error {
 		}
 		defer chaindb.Close()
 
+		// if the trie data dir has been set, new trie db with a new state database
+		if ctx.IsSet(utils.SeparateDBFlag.Name) {
+			statediskdb, dbErr := stack.OpenDatabaseWithFreezer(name+"/state", 0, 0, "", "", false)
+			if dbErr != nil {
+				utils.Fatalf("Failed to open separate trie database: %v", dbErr)
+			}
+			chaindb.SetStateStore(statediskdb)
+		}
+
 		triedb := utils.MakeTrieDatabase(ctx, chaindb, ctx.Bool(utils.CachePreimagesFlag.Name), false, genesis.IsVerkle())
 		defer triedb.Close()
 

--- a/cmd/geth/config.go
+++ b/cmd/geth/config.go
@@ -179,9 +179,6 @@ func makeFullNode(ctx *cli.Context) *node.Node {
 		cfg.Eth.OverrideVerkle = &v
 	}
 
-	if ctx.IsSet(utils.SeparateDBFlag.Name) && !stack.IsSeparatedDB() {
-		utils.Fatalf("Failed to locate separate database subdirectory when separatedb parameter has been set")
-	}
 	backend, eth := utils.RegisterEthService(stack, &cfg.Eth)
 
 	// Create gauge with geth system and build information

--- a/cmd/geth/config.go
+++ b/cmd/geth/config.go
@@ -179,6 +179,9 @@ func makeFullNode(ctx *cli.Context) *node.Node {
 		cfg.Eth.OverrideVerkle = &v
 	}
 
+	if ctx.IsSet(utils.SeparateDBFlag.Name) && !stack.IsSeparatedDB() {
+		utils.Fatalf("Failed to locate separate database subdirectory when separatedb parameter has been set")
+	}
 	backend, eth := utils.RegisterEthService(stack, &cfg.Eth)
 
 	// Create gauge with geth system and build information

--- a/cmd/geth/snapshot.go
+++ b/cmd/geth/snapshot.go
@@ -545,6 +545,7 @@ func dumpState(ctx *cli.Context) error {
 	if err != nil {
 		return err
 	}
+	defer db.Close()
 	triedb := utils.MakeTrieDatabase(ctx, db, false, true, false)
 	defer triedb.Close()
 

--- a/cmd/geth/snapshot.go
+++ b/cmd/geth/snapshot.go
@@ -174,9 +174,6 @@ func pruneState(ctx *cli.Context) error {
 	chaindb := utils.MakeChainDatabase(ctx, stack, false)
 	defer chaindb.Close()
 
-	if rawdb.ReadStateScheme(chaindb) != rawdb.HashScheme {
-		log.Crit("Offline pruning is not required for path scheme")
-	}
 	prunerconfig := pruner.Config{
 		Datadir:   stack.ResolvePath(""),
 		BloomSize: ctx.Uint64(utils.BloomFilterSizeFlag.Name),

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -94,6 +94,12 @@ var (
 		Value:    flags.DirectoryString(node.DefaultDataDir()),
 		Category: flags.EthCategory,
 	}
+	SeparateDBFlag = &cli.BoolFlag{
+		Name: "separatedb",
+		Usage: "Enable a separated trie database, it will be created within a subdirectory called state, " +
+			"Users can copy this state directory to another directory or disk, and then create a symbolic link to the state directory under the chaindata",
+		Category: flags.EthCategory,
+	}
 	RemoteDBFlag = &cli.StringFlag{
 		Name:     "remotedb",
 		Usage:    "URL for remote database",
@@ -974,6 +980,7 @@ var (
 		DBEngineFlag,
 		StateSchemeFlag,
 		HttpHeaderFlag,
+		SeparateDBFlag,
 	}
 )
 
@@ -2070,11 +2077,27 @@ func MakeChainDatabase(ctx *cli.Context, stack *node.Node, readonly bool) ethdb.
 		chainDb, err = stack.OpenDatabase("lightchaindata", cache, handles, "", readonly)
 	default:
 		chainDb, err = stack.OpenDatabaseWithFreezer("chaindata", cache, handles, ctx.String(AncientFlag.Name), "", readonly)
+		// set the separate state database
+		if stack.IsSeparatedDB() && err == nil {
+			stateDiskDb := MakeStateDataBase(ctx, stack, readonly, false)
+			chainDb.SetStateStore(stateDiskDb)
+		}
 	}
 	if err != nil {
 		Fatalf("Could not open database: %v", err)
 	}
 	return chainDb
+}
+
+// MakeStateDataBase open a separate state database using the flags passed to the client and will hard crash if it fails.
+func MakeStateDataBase(ctx *cli.Context, stack *node.Node, readonly, disableFreeze bool) ethdb.Database {
+	cache := ctx.Int(CacheFlag.Name) * ctx.Int(CacheDatabaseFlag.Name) / 100
+	handles := MakeDatabaseHandles(ctx.Int(FDLimitFlag.Name)) / 2
+	statediskdb, err := stack.OpenDatabaseWithFreezer("chaindata/state", cache, handles, "", "", readonly)
+	if err != nil {
+		Fatalf("Failed to open separate trie database: %v", err)
+	}
+	return statediskdb
 }
 
 // tryMakeReadOnlyDatabase try to open the chain database in read-only mode,

--- a/core/blockchain_reader.go
+++ b/core/blockchain_reader.go
@@ -214,7 +214,7 @@ func (bc *BlockChain) GetReceiptsByHash(hash common.Hash) types.Receipts {
 	if receipts, ok := bc.receiptsCache.Get(hash); ok {
 		return receipts
 	}
-	number := rawdb.ReadHeaderNumber(bc.db, hash)
+	number := rawdb.ReadHeaderNumber(bc.db.BlockStore(), hash)
 	if number == nil {
 		return nil
 	}

--- a/core/chain_indexer.go
+++ b/core/chain_indexer.go
@@ -227,8 +227,8 @@ func (c *ChainIndexer) eventLoop(currentHeader *types.Header, events chan ChainH
 				// Reorg to the common ancestor if needed (might not exist in light sync mode, skip reorg then)
 				// TODO(karalabe, zsfelfoldi): This seems a bit brittle, can we detect this case explicitly?
 
-				if rawdb.ReadCanonicalHash(c.chainDb, prevHeader.Number.Uint64()) != prevHash {
-					if h := rawdb.FindCommonAncestor(c.chainDb, prevHeader, header); h != nil {
+				if rawdb.ReadCanonicalHash(c.chainDb.BlockStore(), prevHeader.Number.Uint64()) != prevHash {
+					if h := rawdb.FindCommonAncestor(c.chainDb.BlockStore(), prevHeader, header); h != nil {
 						c.newHead(h.Number.Uint64(), true)
 					}
 				}

--- a/core/genesis.go
+++ b/core/genesis.go
@@ -502,13 +502,13 @@ func (g *Genesis) Commit(db ethdb.Database, triedb *triedb.Database) (*types.Blo
 	if err := flushAlloc(&g.Alloc, db, triedb, block.Hash()); err != nil {
 		return nil, err
 	}
-	rawdb.WriteTd(db, block.Hash(), block.NumberU64(), block.Difficulty())
-	rawdb.WriteBlock(db, block)
-	rawdb.WriteReceipts(db, block.Hash(), block.NumberU64(), nil)
-	rawdb.WriteCanonicalHash(db, block.Hash(), block.NumberU64())
-	rawdb.WriteHeadBlockHash(db, block.Hash())
+	rawdb.WriteTd(db.BlockStore(), block.Hash(), block.NumberU64(), block.Difficulty())
+	rawdb.WriteBlock(db.BlockStore(), block)
+	rawdb.WriteReceipts(db.BlockStore(), block.Hash(), block.NumberU64(), nil)
+	rawdb.WriteCanonicalHash(db.BlockStore(), block.Hash(), block.NumberU64())
+	rawdb.WriteHeadBlockHash(db.BlockStore(), block.Hash())
 	rawdb.WriteHeadFastBlockHash(db, block.Hash())
-	rawdb.WriteHeadHeaderHash(db, block.Hash())
+	rawdb.WriteHeadHeaderHash(db.BlockStore(), block.Hash())
 	rawdb.WriteChainConfig(db, block.Hash(), config)
 	return block, nil
 }

--- a/core/rawdb/accessors_indexes.go
+++ b/core/rawdb/accessors_indexes.go
@@ -42,7 +42,7 @@ func ReadTxLookupEntry(db ethdb.Reader, hash common.Hash) *uint64 {
 	}
 	// Database v4-v5 tx lookup format just stores the hash
 	if len(data) == common.HashLength {
-		return ReadHeaderNumber(db, common.BytesToHash(data))
+		return ReadHeaderNumber(db.BlockStoreReader(), common.BytesToHash(data))
 	}
 	// Finally try database v3 tx lookup format
 	var entry LegacyTxLookupEntry

--- a/core/rawdb/accessors_trie.go
+++ b/core/rawdb/accessors_trie.go
@@ -247,12 +247,12 @@ func DeleteTrieNode(db ethdb.KeyValueWriter, owner common.Hash, path []byte, has
 // if the state is not present in database.
 func ReadStateScheme(db ethdb.Reader) string {
 	// Check if state in path-based scheme is present.
-	if HasAccountTrieNode(db, nil) {
+	if HasAccountTrieNode(db.StateStoreReader(), nil) {
 		return PathScheme
 	}
 	// The root node might be deleted during the initial snap sync, check
 	// the persistent state id then.
-	if id := ReadPersistentStateID(db); id != 0 {
+	if id := ReadPersistentStateID(db.StateStoreReader()); id != 0 {
 		return PathScheme
 	}
 	// In a hash-based scheme, the genesis state is consistently stored
@@ -262,7 +262,7 @@ func ReadStateScheme(db ethdb.Reader) string {
 	if header == nil {
 		return "" // empty datadir
 	}
-	if !HasLegacyTrieNode(db, header.Root) {
+	if !HasLegacyTrieNode(db.StateStoreReader(), header.Root) {
 		return "" // no state in disk
 	}
 	return HashScheme

--- a/core/rawdb/ancient_utils.go
+++ b/core/rawdb/ancient_utils.go
@@ -89,6 +89,9 @@ func inspectFreezers(db ethdb.Database) ([]freezerInfo, error) {
 			infos = append(infos, info)
 
 		case StateFreezerName:
+			if db.StateStore() != nil {
+				continue
+			}
 			datadir, err := db.AncientDatadir()
 			if err != nil {
 				return nil, err

--- a/core/rawdb/ancient_utils.go
+++ b/core/rawdb/ancient_utils.go
@@ -119,16 +119,25 @@ func inspectFreezers(db ethdb.Database) ([]freezerInfo, error) {
 // ancient indicates the path of root ancient directory where the chain freezer can
 // be opened. Start and end specify the range for dumping out indexes.
 // Note this function can only be used for debugging purposes.
-func InspectFreezerTable(ancient string, freezerName string, tableName string, start, end int64) error {
+func InspectFreezerTable(ancient string, freezerName string, tableName string, start, end int64, multiDatabase bool) error {
 	var (
 		path   string
 		tables map[string]bool
 	)
 	switch freezerName {
 	case ChainFreezerName:
-		path, tables = resolveChainFreezerDir(ancient), chainFreezerNoSnappy
+		if multiDatabase {
+			path, tables = resolveChainFreezerDir(filepath.Dir(ancient)+"/block/ancient"), chainFreezerNoSnappy
+		} else {
+			path, tables = resolveChainFreezerDir(ancient), chainFreezerNoSnappy
+		}
+
 	case StateFreezerName:
-		path, tables = filepath.Join(ancient, freezerName), stateFreezerNoSnappy
+		if multiDatabase {
+			path, tables = filepath.Join(filepath.Dir(ancient)+"/state/ancient", freezerName), stateFreezerNoSnappy
+		} else {
+			path, tables = filepath.Join(ancient, freezerName), stateFreezerNoSnappy
+		}
 	default:
 		return fmt.Errorf("unknown freezer, supported ones: %v", freezers)
 	}

--- a/core/rawdb/chain_iterator.go
+++ b/core/rawdb/chain_iterator.go
@@ -78,7 +78,7 @@ func InitDatabaseFromFreezer(db ethdb.Database) {
 	}
 	batch.Reset()
 
-	WriteHeadHeaderHash(db, hash)
+	WriteHeadHeaderHash(db.BlockStore(), hash)
 	WriteHeadFastBlockHash(db, hash)
 	log.Info("Initialized database from freezer", "blocks", frozen, "elapsed", common.PrettyDuration(time.Since(start)))
 }
@@ -117,7 +117,7 @@ func iterateTransactions(db ethdb.Database, from uint64, to uint64, reverse bool
 		}
 		defer close(rlpCh)
 		for n != end {
-			data := ReadCanonicalBodyRLP(db, n)
+			data := ReadCanonicalBodyRLP(db.BlockStore(), n)
 			// Feed the block to the aggregator, or abort on interrupt
 			select {
 			case rlpCh <- &numberRlp{n, data}:

--- a/core/rawdb/table.go
+++ b/core/rawdb/table.go
@@ -43,6 +43,10 @@ func (t *table) SetBlockStore(block ethdb.Database) {
 	panic("not implement")
 }
 
+func (t *table) HasSeparateBlockStore() bool {
+	panic("not implement")
+}
+
 // NewTable returns a database object that prefixes all keys with a given string.
 func NewTable(db ethdb.Database, prefix string) ethdb.Database {
 	return &table{

--- a/core/rawdb/table.go
+++ b/core/rawdb/table.go
@@ -27,6 +27,22 @@ type table struct {
 	prefix string
 }
 
+func (t *table) BlockStoreReader() ethdb.Reader {
+	return t
+}
+
+func (t *table) BlockStoreWriter() ethdb.Writer {
+	return t
+}
+
+func (t *table) BlockStore() ethdb.Database {
+	return t
+}
+
+func (t *table) SetBlockStore(block ethdb.Database) {
+	panic("not implement")
+}
+
 // NewTable returns a database object that prefixes all keys with a given string.
 func NewTable(db ethdb.Database, prefix string) ethdb.Database {
 	return &table{

--- a/core/rawdb/table.go
+++ b/core/rawdb/table.go
@@ -195,6 +195,18 @@ func (t *table) NewBatch() ethdb.Batch {
 	return &tableBatch{t.db.NewBatch(), t.prefix}
 }
 
+func (t *table) StateStore() ethdb.Database {
+	return nil
+}
+
+func (t *table) SetStateStore(state ethdb.Database) {
+	panic("not implement")
+}
+
+func (t *table) StateStoreReader() ethdb.Reader {
+	return nil
+}
+
 // NewBatchWithSize creates a write-only database batch with pre-allocated buffer.
 func (t *table) NewBatchWithSize(size int) ethdb.Batch {
 	return &tableBatch{t.db.NewBatchWithSize(size), t.prefix}

--- a/core/state/pruner/pruner.go
+++ b/core/state/pruner/pruner.go
@@ -125,13 +125,19 @@ func prune(snaptree *snapshot.Tree, root common.Hash, maindb ethdb.Database, sta
 	// that the false-positive is low enough(~0.05%). The probability of the
 	// dangling node is the state root is super low. So the dangling nodes in
 	// theory will never ever be visited again.
+	var pruneDB ethdb.Database
+	if maindb != nil && maindb.StateStore() != nil {
+		pruneDB = maindb.StateStore()
+	} else {
+		pruneDB = maindb
+	}
 	var (
 		skipped, count int
 		size           common.StorageSize
 		pstart         = time.Now()
 		logged         = time.Now()
-		batch          = maindb.NewBatch()
-		iter           = maindb.NewIterator(nil, nil)
+		batch          = pruneDB.NewBatch()
+		iter           = pruneDB.NewIterator(nil, nil)
 	)
 	for iter.Next() {
 		key := iter.Key()
@@ -178,7 +184,7 @@ func prune(snaptree *snapshot.Tree, root common.Hash, maindb ethdb.Database, sta
 				batch.Reset()
 
 				iter.Release()
-				iter = maindb.NewIterator(nil, key)
+				iter = pruneDB.NewIterator(nil, key)
 			}
 		}
 	}
@@ -221,7 +227,7 @@ func prune(snaptree *snapshot.Tree, root common.Hash, maindb ethdb.Database, sta
 				end = nil
 			}
 			log.Info("Compacting database", "range", fmt.Sprintf("%#x-%#x", start, end), "elapsed", common.PrettyDuration(time.Since(cstart)))
-			if err := maindb.Compact(start, end); err != nil {
+			if err := pruneDB.Compact(start, end); err != nil {
 				log.Error("Database compaction failed", "error", err)
 				return err
 			}
@@ -266,10 +272,17 @@ func (p *Pruner) Prune(root common.Hash) error {
 		// Use the bottom-most diff layer as the target
 		root = layers[len(layers)-1].Root()
 	}
+	// if the separated state db has been set, use this db to prune data
+	var trienodedb ethdb.Database
+	if p.db != nil && p.db.StateStore() != nil {
+		trienodedb = p.db.StateStore()
+	} else {
+		trienodedb = p.db
+	}
 	// Ensure the root is really present. The weak assumption
 	// is the presence of root can indicate the presence of the
 	// entire trie.
-	if !rawdb.HasLegacyTrieNode(p.db, root) {
+	if !rawdb.HasLegacyTrieNode(trienodedb, root) {
 		// The special case is for clique based networks(goerli
 		// and some other private networks), it's possible that two
 		// consecutive blocks will have same root. In this case snapshot
@@ -283,7 +296,7 @@ func (p *Pruner) Prune(root common.Hash) error {
 		// as the pruning target.
 		var found bool
 		for i := len(layers) - 2; i >= 2; i-- {
-			if rawdb.HasLegacyTrieNode(p.db, layers[i].Root()) {
+			if rawdb.HasLegacyTrieNode(trienodedb, layers[i].Root()) {
 				root = layers[i].Root()
 				found = true
 				log.Info("Selecting middle-layer as the pruning target", "root", root, "depth", i)

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -59,6 +59,10 @@ import (
 	"github.com/ethereum/go-ethereum/rpc"
 )
 
+const (
+	ChainDBNamespace = "eth/db/chaindata/"
+)
+
 // Config contains the configuration options of the ETH protocol.
 // Deprecated: use ethconfig.Config instead.
 type Config = ethconfig.Config
@@ -127,7 +131,8 @@ func New(stack *node.Node, config *ethconfig.Config) (*Ethereum, error) {
 	log.Info("Allocated trie memory caches", "clean", common.StorageSize(config.TrieCleanCache)*1024*1024, "dirty", common.StorageSize(config.TrieDirtyCache)*1024*1024)
 
 	// Assemble the Ethereum object
-	chainDb, err := stack.OpenDatabaseWithFreezer("chaindata", config.DatabaseCache, config.DatabaseHandles, config.DatabaseFreezer, "eth/db/chaindata/", false)
+	chainDb, err := stack.OpenAndMergeDatabase("chaindata", config.DatabaseCache, config.DatabaseHandles,
+		config.DatabaseFreezer, ChainDBNamespace, false)
 	if err != nil {
 		return nil, err
 	}

--- a/ethdb/database.go
+++ b/ethdb/database.go
@@ -160,6 +160,7 @@ type StateStoreReader interface {
 type BlockStore interface {
 	BlockStore() Database
 	SetBlockStore(block Database)
+	HasSeparateBlockStore() bool
 }
 
 type BlockStoreReader interface {

--- a/ethdb/database.go
+++ b/ethdb/database.go
@@ -153,11 +153,16 @@ type AncientStater interface {
 	AncientDatadir() (string, error)
 }
 
+type StateStoreReader interface {
+	StateStoreReader() Reader
+}
+
 // Reader contains the methods required to read data from both key-value as well as
 // immutable ancient data.
 type Reader interface {
 	KeyValueReader
 	AncientReader
+	StateStoreReader
 }
 
 // Writer contains the methods required to write data to both key-value as well as
@@ -190,11 +195,17 @@ type ResettableAncientStore interface {
 	Reset() error
 }
 
+type StateStore interface {
+	StateStore() Database
+	SetStateStore(state Database)
+}
+
 // Database contains all the methods required by the high level database to not
 // only access the key-value data store but also the ancient chain store.
 type Database interface {
 	Reader
 	Writer
+	StateStore
 	Batcher
 	Iteratee
 	Stater

--- a/ethdb/database.go
+++ b/ethdb/database.go
@@ -157,12 +157,26 @@ type StateStoreReader interface {
 	StateStoreReader() Reader
 }
 
+type BlockStore interface {
+	BlockStore() Database
+	SetBlockStore(block Database)
+}
+
+type BlockStoreReader interface {
+	BlockStoreReader() Reader
+}
+
+type BlockStoreWriter interface {
+	BlockStoreWriter() Writer
+}
+
 // Reader contains the methods required to read data from both key-value as well as
 // immutable ancient data.
 type Reader interface {
 	KeyValueReader
 	AncientReader
 	StateStoreReader
+	BlockStoreReader
 }
 
 // Writer contains the methods required to write data to both key-value as well as
@@ -170,6 +184,7 @@ type Reader interface {
 type Writer interface {
 	KeyValueWriter
 	AncientWriter
+	BlockStoreWriter
 }
 
 // Stater contains the methods required to retrieve states from both key-value as well as
@@ -206,6 +221,7 @@ type Database interface {
 	Reader
 	Writer
 	StateStore
+	BlockStore
 	Batcher
 	Iteratee
 	Stater

--- a/ethdb/remotedb/remotedb.go
+++ b/ethdb/remotedb/remotedb.go
@@ -44,6 +44,10 @@ func (db *Database) BlockStore() ethdb.Database {
 	return db
 }
 
+func (db *Database) HasSeparateBlockStore() bool {
+	return false
+}
+
 func (db *Database) SetBlockStore(block ethdb.Database) {
 	panic("not supported")
 }

--- a/ethdb/remotedb/remotedb.go
+++ b/ethdb/remotedb/remotedb.go
@@ -82,6 +82,18 @@ func (db *Database) AncientSize(kind string) (uint64, error) {
 	panic("not supported")
 }
 
+func (db *Database) StateStore() ethdb.Database {
+	panic("not supported")
+}
+
+func (db *Database) SetStateStore(state ethdb.Database) {
+	panic("not supported")
+}
+
+func (db *Database) StateStoreReader() ethdb.Reader {
+	return db
+}
+
 func (db *Database) ReadAncients(fn func(op ethdb.AncientReaderOp) error) (err error) {
 	return fn(db)
 }

--- a/ethdb/remotedb/remotedb.go
+++ b/ethdb/remotedb/remotedb.go
@@ -32,6 +32,22 @@ type Database struct {
 	remote *rpc.Client
 }
 
+func (db *Database) BlockStoreReader() ethdb.Reader {
+	return db
+}
+
+func (db *Database) BlockStoreWriter() ethdb.Writer {
+	return db
+}
+
+func (db *Database) BlockStore() ethdb.Database {
+	return db
+}
+
+func (db *Database) SetBlockStore(block ethdb.Database) {
+	panic("not supported")
+}
+
 func (db *Database) Has(key []byte) (bool, error) {
 	if _, err := db.Get(key); err != nil {
 		return false, nil

--- a/node/errors.go
+++ b/node/errors.go
@@ -24,10 +24,11 @@ import (
 )
 
 var (
-	ErrDatadirUsed    = errors.New("datadir already used by another process")
-	ErrNodeStopped    = errors.New("node not started")
-	ErrNodeRunning    = errors.New("node already running")
-	ErrServiceUnknown = errors.New("unknown service")
+	ErrDatadirUsed      = errors.New("datadir already used by another process")
+	ErrNodeStopped      = errors.New("node not started")
+	ErrNodeRunning      = errors.New("node already running")
+	ErrServiceUnknown   = errors.New("unknown service")
+	ErrSeprateDBDatadir = errors.New("datadir is not configured when using separate trie")
 
 	datadirInUseErrnos = map[uint]bool{11: true, 32: true, 35: true}
 )

--- a/triedb/database.go
+++ b/triedb/database.go
@@ -90,16 +90,23 @@ type Database struct {
 // the legacy hash-based scheme is used by default.
 func NewDatabase(diskdb ethdb.Database, config *Config) *Database {
 	// Sanitize the config and use the default one if it's not specified.
+	var triediskdb ethdb.Database
+	if diskdb != nil && diskdb.StateStore() != nil {
+		triediskdb = diskdb.StateStore()
+	} else {
+		triediskdb = diskdb
+	}
+
 	if config == nil {
 		config = HashDefaults
 	}
 	var preimages *preimageStore
 	if config.Preimages {
-		preimages = newPreimageStore(diskdb)
+		preimages = newPreimageStore(triediskdb)
 	}
 	db := &Database{
 		config:    config,
-		diskdb:    diskdb,
+		diskdb:    triediskdb,
 		preimages: preimages,
 	}
 	if config.HashDB != nil && config.PathDB != nil {


### PR DESCRIPTION
This PR implements a feature which can improve the performance and maintainability by splitting blockchain data into multi-databases based on data patterns.  

Currently, the chaindata except for historical block and state data, is stored in a single key-value database instance. The chaindata will be divided into BlockStore, TrieStore, and OriginalStore with this feature enabled. 

1. TrieStore: All trie nodes of the current state and historical state data of nearly 9w blocks are stored here.
2. BlockStore: Block-related data is stored in this store, including headers, bodies, receipts, difficulties, number-to-hash indexes, hash-to-number indexes, and historical block data. 
3. Original Database: The remaining data will be stored in this store, including snapshot, txIndex, contract code, and other metadata, etc.

The independent db can process compaction with a more simplified LSM hierarchy, which would reduce the read/write latency of the entire database and improve the performance.

**Major changes:**

-  add the stateStore and the blockStore to the freezerdb database wrapper and each db can work independently
-  users can set the --multidatabase flag to enable this feature . The original database is located within the chaindata/ folder, and new block/ and state/ folders have been introduced to store block and trie data .
- adapted cmd code to support this feature
