### PR TITLE
eth/catalyst: ensure TxPool is synced in Fork

### DIFF
--- a/eth/catalyst/simulated_beacon.go
+++ b/eth/catalyst/simulated_beacon.go
@@ -279,9 +279,12 @@ func (c *SimulatedBeacon) Rollback() {
 
 // Fork sets the head to the provided hash.
 func (c *SimulatedBeacon) Fork(parentHash common.Hash) error {
+	// Ensure no pending transactions.
+	c.eth.TxPool().Sync()
 	if len(c.eth.TxPool().Pending(txpool.PendingFilter{})) != 0 {
 		return errors.New("pending block dirty")
 	}
+
 	parent := c.eth.BlockChain().GetBlockByHash(parentHash)
 	if parent == nil {
 		return errors.New("parent not found")


### PR DESCRIPTION
This should fix an occasional test failure in ethclient/simulated.TestForkResendTx. Inspection of logs revealed the cause of the failure being that txpool was not done reorganizing by the time Fork is called.

```
~/d/e/go-ethereum >> go test -run TestForkResendTx -count 200 ./ethclient/simulated 
ok  	github.com/ethereum/go-ethereum/ethclient/simulated	3.645s
~/d/e/go-ethereum >> go test -run TestForkResendTx -count 200 -race ./ethclient/simulated 
ok  	github.com/ethereum/go-ethereum/ethclient/simulated	11.669s
```