### PR TITLE
cmd/devp2p: fix `node.TCP` to `node.UDP()`

### DIFF
--- a/cmd/devp2p/internal/v4test/framework.go
+++ b/cmd/devp2p/internal/v4test/framework.go
@@ -62,7 +62,7 @@ func newTestEnv(remote string, listen1, listen2 string) *testenv {
 		if tcpPort = node.TCP(); tcpPort == 0 {
 			tcpPort = 30303
 		}
-		if udpPort = node.TCP(); udpPort == 0 {
+		if udpPort = node.UDP(); udpPort == 0 {
 			udpPort = 30303
 		}
 		node = enode.NewV4(node.Pubkey(), ip, tcpPort, udpPort)


### PR DESCRIPTION
fix: node.TCP() => node.UDP()