### PR TITLE
p2p/discover, cmd/devp2p: use `int64` as `Expiration` type to avoid type conversion

### DIFF
--- a/cmd/devp2p/internal/v4test/discv4tests.go
+++ b/cmd/devp2p/internal/v4test/discv4tests.go
@@ -48,7 +48,7 @@ var (
 type pingWithJunk struct {
 	Version    uint
 	From, To   v4wire.Endpoint
-	Expiration uint64
+	Expiration int64
 	JunkData1  uint
 	JunkData2  []byte
 }
@@ -59,14 +59,14 @@ func (req *pingWithJunk) Kind() byte   { return v4wire.PingPacket }
 type pingWrongType struct {
 	Version    uint
 	From, To   v4wire.Endpoint
-	Expiration uint64
+	Expiration int64
 }
 
 func (req *pingWrongType) Name() string { return "WRONG/v4" }
 func (req *pingWrongType) Kind() byte   { return wrongPacket }
 
-func futureExpiration() uint64 {
-	return uint64(time.Now().Add(expiration).Unix())
+func futureExpiration() int64 {
+	return time.Now().Add(expiration).Unix()
 }
 
 // BasicPing just sends a PING packet and expects a response.

--- a/p2p/discover/v4_udp.go
+++ b/p2p/discover/v4_udp.go
@@ -261,7 +261,7 @@ func (t *UDPv4) makePing(toaddr netip.AddrPort) *v4wire.Ping {
 		Version:    4,
 		From:       t.ourEndpoint(),
 		To:         v4wire.NewEndpoint(toaddr, 0),
-		Expiration: uint64(time.Now().Add(expiration).Unix()),
+		Expiration: time.Now().Add(expiration).Unix(),
 		ENRSeq:     t.localNode.Node().Seq(),
 	}
 }
@@ -334,7 +334,7 @@ func (t *UDPv4) findnode(toid enode.ID, toAddrPort netip.AddrPort, target v4wire
 	})
 	t.send(toAddrPort, toid, &v4wire.Findnode{
 		Target:     target,
-		Expiration: uint64(time.Now().Add(expiration).Unix()),
+		Expiration: time.Now().Add(expiration).Unix(),
 	})
 	// Ensure that callers don't see a timeout if the node actually responded. Since
 	// findnode can receive more than one neighbors response, the reply matcher will be
@@ -354,7 +354,7 @@ func (t *UDPv4) RequestENR(n *enode.Node) (*enode.Node, error) {
 	t.ensureBond(n.ID(), addr)
 
 	req := &v4wire.ENRRequest{
-		Expiration: uint64(time.Now().Add(expiration).Unix()),
+		Expiration: time.Now().Add(expiration).Unix(),
 	}
 	packet, hash, err := v4wire.Encode(t.priv, req)
 	if err != nil {
@@ -680,7 +680,7 @@ func (t *UDPv4) handlePing(h *packetHandlerV4, from netip.AddrPort, fromID enode
 	t.send(from, fromID, &v4wire.Pong{
 		To:         v4wire.NewEndpoint(from, req.From.TCP),
 		ReplyTok:   mac,
-		Expiration: uint64(time.Now().Add(expiration).Unix()),
+		Expiration: time.Now().Add(expiration).Unix(),
 		ENRSeq:     t.localNode.Node().Seq(),
 	})
 
@@ -750,7 +750,7 @@ func (t *UDPv4) handleFindnode(h *packetHandlerV4, from netip.AddrPort, fromID e
 
 	// Send neighbors in chunks with at most maxNeighbors per packet
 	// to stay below the packet size limit.
-	p := v4wire.Neighbors{Expiration: uint64(time.Now().Add(expiration).Unix())}
+	p := v4wire.Neighbors{Expiration: time.Now().Add(expiration).Unix()}
 	var sent bool
 	for _, n := range closest {
 		fromIP := from.Addr().AsSlice()

--- a/p2p/discover/v4_udp_test.go
+++ b/p2p/discover/v4_udp_test.go
@@ -41,7 +41,7 @@ import (
 
 // shared test variables
 var (
-	futureExp          = uint64(time.Now().Add(10 * time.Hour).Unix())
+	futureExp          = time.Now().Add(10 * time.Hour).Unix()
 	testTarget         = v4wire.Pubkey{0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1}
 	testRemote         = v4wire.Endpoint{IP: net.ParseIP("1.1.1.1").To4(), UDP: 1, TCP: 2}
 	testLocalAnnounced = v4wire.Endpoint{IP: net.ParseIP("2.2.2.2").To4(), UDP: 3, TCP: 4}

--- a/p2p/discover/v4wire/v4wire.go
+++ b/p2p/discover/v4wire/v4wire.go
@@ -50,7 +50,7 @@ type (
 	Ping struct {
 		Version    uint
 		From, To   Endpoint
-		Expiration uint64
+		Expiration int64
 		ENRSeq     uint64 `rlp:"optional"` // Sequence number of local record, added by EIP-868.
 
 		// Ignore additional fields (for forward compatibility).
@@ -64,7 +64,7 @@ type (
 		// external address (after NAT).
 		To         Endpoint
 		ReplyTok   []byte // This contains the hash of the ping packet.
-		Expiration uint64 // Absolute timestamp at which the packet becomes invalid.
+		Expiration int64  // Absolute timestamp at which the packet becomes invalid.
 		ENRSeq     uint64 `rlp:"optional"` // Sequence number of local record, added by EIP-868.
 
 		// Ignore additional fields (for forward compatibility).
@@ -74,7 +74,7 @@ type (
 	// Findnode is a query for nodes close to the given target.
 	Findnode struct {
 		Target     Pubkey
-		Expiration uint64
+		Expiration int64
 		// Ignore additional fields (for forward compatibility).
 		Rest []rlp.RawValue `rlp:"tail"`
 	}
@@ -82,14 +82,14 @@ type (
 	// Neighbors is the reply to findnode.
 	Neighbors struct {
 		Nodes      []Node
-		Expiration uint64
+		Expiration int64
 		// Ignore additional fields (for forward compatibility).
 		Rest []rlp.RawValue `rlp:"tail"`
 	}
 
 	// ENRRequest queries for the remote node's record.
 	ENRRequest struct {
-		Expiration uint64
+		Expiration int64
 		// Ignore additional fields (for forward compatibility).
 		Rest []rlp.RawValue `rlp:"tail"`
 	}
@@ -105,27 +105,6 @@ type (
 
 // MaxNeighbors is the maximum number of neighbor nodes in a Neighbors packet.
 const MaxNeighbors = 12
-
-// This code computes the MaxNeighbors constant value.
-
-// func init() {
-// 	var maxNeighbors int
-// 	p := Neighbors{Expiration: ^uint64(0)}
-// 	maxSizeNode := Node{IP: make(net.IP, 16), UDP: ^uint16(0), TCP: ^uint16(0)}
-// 	for n := 0; ; n++ {
-// 		p.Nodes = append(p.Nodes, maxSizeNode)
-// 		size, _, err := rlp.EncodeToReader(p)
-// 		if err != nil {
-// 			// If this ever happens, it will be caught by the unit tests.
-// 			panic("cannot encode: " + err.Error())
-// 		}
-// 		if headSize+size+1 >= 1280 {
-// 			maxNeighbors = n
-// 			break
-// 		}
-// 	}
-// 	fmt.Println("maxNeighbors", maxNeighbors)
-// }
 
 // Pubkey represents an encoded 64-byte secp256k1 public key.
 type Pubkey [64]byte
@@ -188,8 +167,8 @@ func (req *ENRResponse) Name() string { return "ENRRESPONSE/v4" }
 func (req *ENRResponse) Kind() byte   { return ENRResponsePacket }
 
 // Expired checks whether the given UNIX time stamp is in the past.
-func Expired(ts uint64) bool {
-	return time.Unix(int64(ts), 0).Before(time.Now())
+func Expired(ts int64) bool {
+	return time.Unix(ts, 0).Before(time.Now())
 }
 
 // Encoder/decoder.


### PR DESCRIPTION
- use `int64` as `Expiration` type to avoid type conversion
- chore: remove unused code