### PR TITLE
refactor `config` in `TestStateProcessorErrors`

### DIFF
--- a/core/state_processor_test.go
+++ b/core/state_processor_test.go
@@ -62,8 +62,8 @@ func TestStateProcessorErrors(t *testing.T) {
 			Ethash:                        new(params.EthashConfig),
 			TerminalTotalDifficulty:       big.NewInt(0),
 			TerminalTotalDifficultyPassed: true,
-			ShanghaiTime:                  new(uint64),
-			CancunTime:                    new(uint64),
+			ShanghaiTime:                  u64(0),
+			CancunTime:                    u64(0),
 		}
 		signer  = types.LatestSigner(config)
 		key1, _ = crypto.HexToECDSA("b71c71a67e1177ad4e901695e1b4b9ee17ae16c6668d313eac2f96dbcda3f291")


### PR DESCRIPTION
refactor `config` in `TestStateProcessorErrors`, to make its code style more consistent with other places