### PR TITLE
common/math: rename variable name `int` to `in`

### DIFF
--- a/common/math/big_test.go
+++ b/common/math/big_test.go
@@ -180,9 +180,9 @@ func BenchmarkByteAtOld(b *testing.B) {
 func TestReadBits(t *testing.T) {
 	check := func(input string) {
 		want, _ := hex.DecodeString(input)
-		int, _ := new(big.Int).SetString(input, 16)
+		in, _ := new(big.Int).SetString(input, 16)
 		buf := make([]byte, len(want))
-		ReadBits(int, buf)
+		ReadBits(in, buf)
 		if !bytes.Equal(buf, want) {
 			t.Errorf("have: %x\nwant: %x", buf, want)
 		}

--- a/common/math/big_test.go
+++ b/common/math/big_test.go
@@ -180,9 +180,9 @@ func BenchmarkByteAtOld(b *testing.B) {
 func TestReadBits(t *testing.T) {
 	check := func(input string) {
 		want, _ := hex.DecodeString(input)
-		in, _ := new(big.Int).SetString(input, 16)
+		n, _ := new(big.Int).SetString(input, 16)
 		buf := make([]byte, len(want))
-		ReadBits(in, buf)
+		ReadBits(n, buf)
 		if !bytes.Equal(buf, want) {
 			t.Errorf("have: %x\nwant: %x", buf, want)
 		}

--- a/common/math/integer.go
+++ b/common/math/integer.go
@@ -54,11 +54,11 @@ func (i *HexOrDecimal64) UnmarshalJSON(input []byte) error {
 
 // UnmarshalText implements encoding.TextUnmarshaler.
 func (i *HexOrDecimal64) UnmarshalText(input []byte) error {
-	int, ok := ParseUint64(string(input))
+	in, ok := ParseUint64(string(input))
 	if !ok {
 		return fmt.Errorf("invalid hex or decimal integer %q", input)
 	}
-	*i = HexOrDecimal64(int)
+	*i = HexOrDecimal64(in)
 	return nil
 }
 

--- a/common/math/integer.go
+++ b/common/math/integer.go
@@ -54,11 +54,11 @@ func (i *HexOrDecimal64) UnmarshalJSON(input []byte) error {
 
 // UnmarshalText implements encoding.TextUnmarshaler.
 func (i *HexOrDecimal64) UnmarshalText(input []byte) error {
-	in, ok := ParseUint64(string(input))
+	n, ok := ParseUint64(string(input))
 	if !ok {
 		return fmt.Errorf("invalid hex or decimal integer %q", input)
 	}
-	*i = HexOrDecimal64(in)
+	*i = HexOrDecimal64(n)
 	return nil
 }
 


### PR DESCRIPTION
It's odd to use the keyword `int` as variable name, I think it's better to use `in`