### PR TITLE
miner: lower default min miner tip from 1 gwei to 0.001 gwei

### DIFF
--- a/miner/miner.go
+++ b/miner/miner.go
@@ -53,7 +53,7 @@ type Config struct {
 // DefaultConfig contains default settings for miner.
 var DefaultConfig = Config{
 	GasCeil:  30_000_000,
-	GasPrice: big.NewInt(params.GWei),
+	GasPrice: big.NewInt(params.GWei / 1000),
 
 	// The default recommit time is chosen as two seconds since
 	// consensus-layer usually will wait a half slot of time(6s)


### PR DESCRIPTION
This PR is the result of a long debate as to what the default minimum miner tip expectation of Geth should be. It's important to highlight here that this is *just* a CLI flag that miners can change, but still people felt strongly that the default should be more reasonable (https://github.com/ethereum/go-ethereum/issues/29771).

The 1 gwei was originally meant as an opportunity cost for doing more computation on the block + propagating a larger block, which could have someone beat the miner to producing a block. With PoS, there's no opportunity cost wrt someone producing a better block, so it makes sense to reduce the minimum needed price.

Whilst in theory we could also just completely remove it, I feel that miners should still be rewarded *something* for adding transactions to their blocks, and with 0.001 gwei we're already under the rounding error category. I don't really see a reason to go below this point in the current climate. Maybe in the future if something changes, this can be revisited.

cc @dataalways