### PR TITLE
cmd/evm: fix random in runtime config

### DIFF
--- a/cmd/evm/runner.go
+++ b/cmd/evm/runner.go
@@ -227,6 +227,7 @@ func runCmd(ctx *cli.Context) error {
 		EVMConfig: vm.Config{
 			Tracer: tracer,
 		},
+		Random: &genesisConfig.Mixhash,
 	}
 
 	if chainConfig != nil {


### PR DESCRIPTION
Otherwise, the EVM command will never enter the fork version after London.

This is due to the commit in v1.13.13: https://github.com/ethereum/go-ethereum/pull/29023/files