### PR TITLE
beacon/light: add missing json tag

### DIFF
--- a/beacon/light/api/light_api.go
+++ b/beacon/light/api/light_api.go
@@ -201,7 +201,7 @@ func (api *BeaconLightApi) GetOptimisticUpdate() (types.OptimisticUpdate, error)
 
 func decodeOptimisticUpdate(enc []byte) (types.OptimisticUpdate, error) {
 	var data struct {
-		Version string
+		Version string `json:"Version"`
 		Data    struct {
 			Attested      jsonHeaderWithExecProof `json:"attested_header"`
 			Aggregate     types.SyncAggregate     `json:"sync_aggregate"`
@@ -254,7 +254,7 @@ func (api *BeaconLightApi) GetFinalityUpdate() (types.FinalityUpdate, error) {
 
 func decodeFinalityUpdate(enc []byte) (types.FinalityUpdate, error) {
 	var data struct {
-		Version string
+		Version string `json:"Version"`
 		Data    struct {
 			Attested       jsonHeaderWithExecProof `json:"attested_header"`
 			Finalized      jsonHeaderWithExecProof `json:"finalized_header"`
@@ -390,7 +390,7 @@ func (api *BeaconLightApi) GetBeaconBlock(blockRoot common.Hash) (*types.BeaconB
 	}
 
 	var beaconBlockMessage struct {
-		Version string
+		Version string `json:"Version"`
 		Data    struct {
 			Message json.RawMessage `json:"message"`
 		}

--- a/beacon/light/sync/test_helpers.go
+++ b/beacon/light/sync/test_helpers.go
@@ -193,9 +193,9 @@ func (t *TestCommitteeChain) NextSyncPeriod() (uint64, bool) {
 	return t.nsp, t.init
 }
 
-func (tc *TestCommitteeChain) ExpInit(t *testing.T, ExpInit bool) {
-	if tc.init != ExpInit {
-		t.Errorf("Incorrect init flag (expected %v, got %v)", ExpInit, tc.init)
+func (tc *TestCommitteeChain) ExpInit(t *testing.T, expInit bool) {
+	if tc.init != expInit {
+		t.Errorf("Incorrect init flag (expected %v, got %v)", expInit, tc.init)
 	}
 }
 


### PR DESCRIPTION
1. Explicitly setting the JSON tag
2. Update param name `ExpInit` to `expInit`, avoid to be the same with the function name `ExpInit`