### PR TITLE
triedb/pathdb: fix flaky test in pathdb

### DIFF
--- a/triedb/pathdb/database.go
+++ b/triedb/pathdb/database.go
@@ -310,6 +310,10 @@ func (db *Database) Enable(root common.Hash) error {
 	stored := types.EmptyRootHash
 	if blob := rawdb.ReadAccountTrieNode(db.diskdb, nil); len(blob) > 0 {
 		stored = crypto.Keccak256Hash(blob)
+	} else {
+		has, err := db.diskdb.Has(nil)
+		fmt.Println("len(blob) == 0", has, err)
+		fmt.Printf("state root mismatch: stored %x, synced %x\n", stored, root)
 	}
 	if stored != root {
 		return fmt.Errorf("state root mismatch: stored %x, synced %x", stored, root)

--- a/triedb/pathdb/database.go
+++ b/triedb/pathdb/database.go
@@ -310,10 +310,6 @@ func (db *Database) Enable(root common.Hash) error {
 	stored := types.EmptyRootHash
 	if blob := rawdb.ReadAccountTrieNode(db.diskdb, nil); len(blob) > 0 {
 		stored = crypto.Keccak256Hash(blob)
-	} else {
-		has, err := db.diskdb.Has(nil)
-		fmt.Println("len(blob) == 0", has, err)
-		fmt.Printf("state root mismatch: stored %x, synced %x\n", stored, root)
 	}
 	if stored != root {
 		return fmt.Errorf("state root mismatch: stored %x, synced %x", stored, root)

--- a/triedb/pathdb/database_test.go
+++ b/triedb/pathdb/database_test.go
@@ -121,7 +121,7 @@ func newTester(t *testing.T, historyLimit uint64) *tester {
 			snapStorages: make(map[common.Hash]map[common.Hash]map[common.Hash][]byte),
 		}
 	)
-	for i := 0; i < 8; i++ {
+	for i := 0; i < 20; i++ {
 		var parent = types.EmptyRootHash
 		if len(obj.roots) != 0 {
 			parent = obj.roots[len(obj.roots)-1]

--- a/triedb/pathdb/database_test.go
+++ b/triedb/pathdb/database_test.go
@@ -476,6 +476,13 @@ func TestDatabaseRecoverable(t *testing.T) {
 	}
 }
 
+func TestDisableManyTimes(t *testing.T) {
+	for i := 0; i < 1000; i++ {
+		t.Log(i)
+		TestDisable(t)
+	}
+}
+
 func TestDisable(t *testing.T) {
 	// Redefine the diff layer depth allowance for faster testing.
 	maxDiffLayers = 4
@@ -486,13 +493,14 @@ func TestDisable(t *testing.T) {
 	tester := newTester(t, 0)
 	defer tester.release()
 
-	stored := crypto.Keccak256Hash(rawdb.ReadAccountTrieNode(tester.db.diskdb, nil))
 	if err := tester.db.Disable(); err != nil {
 		t.Fatalf("Failed to deactivate database: %v", err)
 	}
+	fmt.Println(tester.db.diskdb.Has(nil))
 	if err := tester.db.Enable(types.EmptyRootHash); err == nil {
 		t.Fatal("Invalid activation should be rejected")
 	}
+	stored := crypto.Keccak256Hash(rawdb.ReadAccountTrieNode(tester.db.diskdb, nil))
 	if err := tester.db.Enable(stored); err != nil {
 		t.Fatalf("Failed to activate database: %v", err)
 	}

--- a/triedb/pathdb/database_test.go
+++ b/triedb/pathdb/database_test.go
@@ -121,7 +121,7 @@ func newTester(t *testing.T, historyLimit uint64) *tester {
 			snapStorages: make(map[common.Hash]map[common.Hash]map[common.Hash][]byte),
 		}
 	)
-	for i := 0; i < 20; i++ {
+	for i := 0; i < 12; i++ {
 		var parent = types.EmptyRootHash
 		if len(obj.roots) != 0 {
 			parent = obj.roots[len(obj.roots)-1]

--- a/triedb/pathdb/database_test.go
+++ b/triedb/pathdb/database_test.go
@@ -476,13 +476,6 @@ func TestDatabaseRecoverable(t *testing.T) {
 	}
 }
 
-func TestDisableManyTimes(t *testing.T) {
-	for i := 0; i < 1000; i++ {
-		t.Log(i)
-		TestDisable(t)
-	}
-}
-
 func TestDisable(t *testing.T) {
 	// Redefine the diff layer depth allowance for faster testing.
 	maxDiffLayers = 4
@@ -493,14 +486,13 @@ func TestDisable(t *testing.T) {
 	tester := newTester(t, 0)
 	defer tester.release()
 
+	stored := crypto.Keccak256Hash(rawdb.ReadAccountTrieNode(tester.db.diskdb, nil))
 	if err := tester.db.Disable(); err != nil {
 		t.Fatalf("Failed to deactivate database: %v", err)
 	}
-	fmt.Println(tester.db.diskdb.Has(nil))
 	if err := tester.db.Enable(types.EmptyRootHash); err == nil {
 		t.Fatal("Invalid activation should be rejected")
 	}
-	stored := crypto.Keccak256Hash(rawdb.ReadAccountTrieNode(tester.db.diskdb, nil))
 	if err := tester.db.Enable(stored); err != nil {
 		t.Fatalf("Failed to activate database: %v", err)
 	}


### PR DESCRIPTION
Refer to #29830 [comment](https://github.com/ethereum/go-ethereum/issues/29830#issuecomment-2143240316)

Larger `maxDiffLayers` causes a higher probability of failing. If maxDiffLayers >= 7, it always fails.

I think it's due to the round times of init data in `newTester`.

After adjusting round times to 12 and stress test `TestNewTester` for 2 minutes, no failed again

```go
// TestNewTester is a temp test for quickly check
func TestNewTester(t *testing.T) {
	// Redefine the diff layer depth allowance for faster testing.
	maxDiffLayers = 4
	defer func() {
		maxDiffLayers = 128
	}()
	tester := newTester(t, 0)
	defer tester.release()
	if ok, err := tester.db.diskdb.Has(rawdb.TrieNodeAccountPrefix); !ok {
		panic(fmt.Sprintf("missing key %v %v", ok, err))
	}
}
```
```shell
stress ./pathdb.test TestNewTester

5s: 0 runs so far, 0 failures
10s: 16 runs so far, 0 failures
15s: 32 runs so far, 0 failures
20s: 48 runs so far, 0 failures
25s: 64 runs so far, 0 failures
30s: 80 runs so far, 0 failures
35s: 96 runs so far, 0 failures
40s: 112 runs so far, 0 failures
45s: 128 runs so far, 0 failures
50s: 144 runs so far, 0 failures
55s: 160 runs so far, 0 failures
1m0s: 176 runs so far, 0 failures
1m5s: 192 runs so far, 0 failures
1m10s: 208 runs so far, 0 failures
1m15s: 224 runs so far, 0 failures
1m20s: 240 runs so far, 0 failures
1m25s: 256 runs so far, 0 failures
1m30s: 272 runs so far, 0 failures
1m35s: 288 runs so far, 0 failures
1m40s: 304 runs so far, 0 failures
1m45s: 320 runs so far, 0 failures
1m50s: 336 runs so far, 0 failures
1m55s: 352 runs so far, 0 failures
2m0s: 368 runs so far, 0 failures
```