### PR TITLE
Added a method for jsonError struct that always returns data from errors

### DIFF
--- a/rpc/client.go
+++ b/rpc/client.go
@@ -364,7 +364,7 @@ func (c *Client) CallContext(ctx context.Context, result interface{}, method str
 	resp := batchresp[0]
 	switch {
 	case resp.Error != nil:
-		return resp.Error
+		return resp.Error.FullError()
 	case len(resp.Result) == 0:
 		return ErrNoResult
 	default:

--- a/rpc/json.go
+++ b/rpc/json.go
@@ -157,6 +157,10 @@ func (err *jsonError) ErrorData() interface{} {
 	return err.Data
 }
 
+func (err *jsonError) FullError() error {
+	return fmt.Errorf("message: %v, code: %v, data: %v", err.Message, err.Code, err.Data)
+}
+
 // Conn is a subset of the methods of net.Conn which are sufficient for ServerCodec.
 type Conn interface {
 	io.ReadWriteCloser


### PR DESCRIPTION
For some reason, when I try to estimate gas for the following transaction to the EntryPoint v0.6.0 contract in Sepolia network, it reverts, but it does not return the revert reason string.

So, I added a method to jsonError, so that it will always revert the reason, even though it is empty (`FullError`).

The encoded transaction I tried to estiamate gas:
```
1fad948c0000000000000000000000000000000000000000000000000000000000000040000000000000000000000000db074b3c323a7ad418ebbe66bad231f43f68056300000000000000000000000000000000000000000000000000000000000000010000000000000000000000000000000000000000000000000000000000000020000000000000000000000000e67ec3303b9c00683c388e8bd9b9dafa752fcd8d000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000001600000000000000000000000000000000000000000000000000000000000000260000000000000000000000000000000000000000000000000000000000009113d0000000000000000000000000000000000000000000000000000000000080faa000000000000000000000000000000000000000000000000000000000001019300000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000028000000000000000000000000000000000000000000000000000000000000002a000000000000000000000000000000000000000000000000000000000000000d85102aa0ea1f1a88a6125b74adf673891eb6393cef1f7da844e4f4781c6cbaffc339fb30062adfd79b6e98c59b68af18c255185794500404e0000000000000000000000000000000000000000000000000000000000000040000000000000000000000000000000000000000000000000000000000000004110d9f5d4d16333f4573ec2c19dc9746186c94e37de17dd410c5ba9b02d1afbfb3d17e9e94da29e1125e1c2c307bd66db5db84562ec08939337acf2db4f252aee1c00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000004e000000000000000000000000001e2ee958709929f32c77eced08f13644385c70e55f0f05e63c0f2038e4ec8cf0475d14f3acc0ca640f9a18fa0ed8fba59f13692e0d2a533ac9be805a4454dbb81c000000000000000000000000000000000000
```

It should return the following data (`FailedOp["0","AA24 signature error"]`):
```
0x220266b600000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000040000000000000000000000000000000000000000000000000000000000000001441413234207369676e6174757265206572726f72000000000000000000000000
```
as shown in this [Tenderly simulation](https://www.tdly.co/shared/simulation/c87db996-93fe-4f80-bf19-dd8a8a3b8151), but it only returns `execution reverted`.
