### PR TITLE
core/state: prefetch account trie while starting a prefetcher

### DIFF
--- a/core/state/statedb.go
+++ b/core/state/statedb.go
@@ -219,7 +219,7 @@ func (s *StateDB) StartPrefetcher(namespace string) {
 		// the prefetcher is constructed. For more details, see:
 		// https://github.com/ethereum/go-ethereum/issues/29880
 		if err := s.prefetcher.prefetch(common.Hash{}, s.originalRoot, common.Address{}, nil); err != nil {
-			log.Error("Failed to prefetch account trie", "root", s.originalRoot.String(), "err", err)
+			log.Error("Failed to prefetch account trie", "root", s.originalRoot, "err", err)
 		}
 	}
 }

--- a/core/state/statedb.go
+++ b/core/state/statedb.go
@@ -208,6 +208,9 @@ func (s *StateDB) StartPrefetcher(namespace string) {
 	}
 	if s.snap != nil {
 		s.prefetcher = newTriePrefetcher(s.db, s.originalRoot, namespace)
+		if err := s.prefetcher.prefetch(common.Hash{}, s.originalRoot, common.Address{}, [][]byte{}); err != nil {
+			log.Error("Failed to prefetch account trie", "pre-state root", s.originalRoot.String(), "err", err)
+		}
 	}
 }
 

--- a/core/state/statedb.go
+++ b/core/state/statedb.go
@@ -208,8 +208,18 @@ func (s *StateDB) StartPrefetcher(namespace string) {
 	}
 	if s.snap != nil {
 		s.prefetcher = newTriePrefetcher(s.db, s.originalRoot, namespace)
-		if err := s.prefetcher.prefetch(common.Hash{}, s.originalRoot, common.Address{}, [][]byte{}); err != nil {
-			log.Error("Failed to prefetch account trie", "pre-state root", s.originalRoot.String(), "err", err)
+
+		// With the switch to the Proof-of-Stake consensus algorithm, block production
+		// rewards are now handled at the consensus layer. Consequently, a block may
+		// have no state transitions if it contains no transactions and no withdrawals.
+		// In such cases, the account trie won't be scheduled for prefetching, leading
+		// to unnecessary error logs.
+		//
+		// To prevent this, the account trie is always scheduled for prefetching once
+		// the prefetcher is constructed. For more details, see:
+		// https://github.com/ethereum/go-ethereum/issues/29880
+		if err := s.prefetcher.prefetch(common.Hash{}, s.originalRoot, common.Address{}, nil); err != nil {
+			log.Error("Failed to prefetch account trie", "root", s.originalRoot.String(), "err", err)
 		}
 	}
 }


### PR DESCRIPTION
Fix #29880 

Always prefetch the account trie while starting the prefetcher.