### PR TITLE
.github/workflows: disable cache

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -16,6 +16,7 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version: 1.21.4
+          cache: false
       - name: Run tests
         run: go test -short ./...
         env:


### PR DESCRIPTION
disable the dependency cache so that they are not uploaded to github's servers, which is just as slow as downloading all the dependencies in the first place.