### PR TITLE
accounts/abi, accounts/scwallet: avoid duplicate regex compilation

### DIFF
--- a/accounts/abi/type.go
+++ b/accounts/abi/type.go
@@ -64,6 +64,9 @@ type Type struct {
 var (
 	// typeRegex parses the abi sub types
 	typeRegex = regexp.MustCompile("([a-zA-Z]+)(([0-9]+)(x([0-9]+))?)?")
+
+	// sliceSizeRegex grab the slice size
+	sliceSizeRegex = regexp.MustCompile("[0-9]+")
 )
 
 // NewType creates a new reflection type of abi type given in t.
@@ -91,8 +94,7 @@ func NewType(t string, internalType string, components []ArgumentMarshaling) (ty
 		// grab the last cell and create a type from there
 		sliced := t[i:]
 		// grab the slice size with regexp
-		re := regexp.MustCompile("[0-9]+")
-		intz := re.FindAllString(sliced, -1)
+		intz := sliceSizeRegex.FindAllString(sliced, -1)
 
 		if len(intz) == 0 {
 			// is a slice

--- a/accounts/scwallet/wallet.go
+++ b/accounts/scwallet/wallet.go
@@ -77,8 +77,8 @@ var (
 	// PinRegexp is the regular expression used to validate PIN codes.
 	PinRegexp = regexp.MustCompile(`^[0-9]{6,}$`)
 
-	// PunRegexp is the regular expression used to validate PUN codes.
-	PunRegexp = regexp.MustCompile(`^[0-9]{12,}$`)
+	// PukRegexp is the regular expression used to validate PUK codes.
+	PukRegexp = regexp.MustCompile(`^[0-9]{12,}$`)
 )
 
 // List of APDU command-related constants
@@ -396,7 +396,7 @@ func (w *Wallet) Open(passphrase string) error {
 			return err
 		}
 	default:
-		if !PunRegexp.MatchString(passphrase) {
+		if !PukRegexp.MatchString(passphrase) {
 			w.log.Error("PUK needs to be at least 12 digits")
 			return ErrPINUnblockNeeded
 		}

--- a/accounts/scwallet/wallet.go
+++ b/accounts/scwallet/wallet.go
@@ -73,6 +73,14 @@ var (
 	DerivationSignatureHash = sha256.Sum256(common.Hash{}.Bytes())
 )
 
+var (
+	// PinRegexp is the regular expression used to validate PIN codes.
+	PinRegexp = regexp.MustCompile(`^[0-9]{6,}$`)
+
+	// PunRegexp is the regular expression used to validate PUN codes.
+	PunRegexp = regexp.MustCompile(`^[0-9]{12,}$`)
+)
+
 // List of APDU command-related constants
 const (
 	claISO7816  = 0
@@ -380,7 +388,7 @@ func (w *Wallet) Open(passphrase string) error {
 	case passphrase == "":
 		return ErrPINUnblockNeeded
 	case status.PinRetryCount > 0:
-		if !regexp.MustCompile(`^[0-9]{6,}$`).MatchString(passphrase) {
+		if !PinRegexp.MatchString(passphrase) {
 			w.log.Error("PIN needs to be at least 6 digits")
 			return ErrPINNeeded
 		}
@@ -388,7 +396,7 @@ func (w *Wallet) Open(passphrase string) error {
 			return err
 		}
 	default:
-		if !regexp.MustCompile(`^[0-9]{12,}$`).MatchString(passphrase) {
+		if !PunRegexp.MatchString(passphrase) {
 			w.log.Error("PUK needs to be at least 12 digits")
 			return ErrPINUnblockNeeded
 		}

--- a/accounts/scwallet/wallet.go
+++ b/accounts/scwallet/wallet.go
@@ -75,10 +75,10 @@ var (
 
 var (
 	// PinRegexp is the regular expression used to validate PIN codes.
-	PinRegexp = regexp.MustCompile(`^[0-9]{6,}$`)
+	pinRegexp = regexp.MustCompile(`^[0-9]{6,}$`)
 
 	// PukRegexp is the regular expression used to validate PUK codes.
-	PukRegexp = regexp.MustCompile(`^[0-9]{12,}$`)
+	pukRegexp = regexp.MustCompile(`^[0-9]{12,}$`)
 )
 
 // List of APDU command-related constants
@@ -388,7 +388,7 @@ func (w *Wallet) Open(passphrase string) error {
 	case passphrase == "":
 		return ErrPINUnblockNeeded
 	case status.PinRetryCount > 0:
-		if !PinRegexp.MatchString(passphrase) {
+		if !pinRegexp.MatchString(passphrase) {
 			w.log.Error("PIN needs to be at least 6 digits")
 			return ErrPINNeeded
 		}
@@ -396,7 +396,7 @@ func (w *Wallet) Open(passphrase string) error {
 			return err
 		}
 	default:
-		if !PukRegexp.MatchString(passphrase) {
+		if !pukRegexp.MatchString(passphrase) {
 			w.log.Error("PUK needs to be at least 12 digits")
 			return ErrPINUnblockNeeded
 		}


### PR DESCRIPTION
every time function **NewType** and **wallet.Open** execute, these regexp are initialized. which situation reduce the performance.