### PR TITLE
p2p/discover: unwrap 4-in-6 UDP source addresses

### DIFF
--- a/p2p/discover/v4_udp.go
+++ b/p2p/discover/v4_udp.go
@@ -557,6 +557,11 @@ func (t *UDPv4) readLoop(unhandled chan<- ReadPacket) {
 }
 
 func (t *UDPv4) handlePacket(from netip.AddrPort, buf []byte) error {
+	// Unwrap IPv4-in-6 source address.
+	if from.Addr().Is4In6() {
+		from = netip.AddrPortFrom(netip.AddrFrom4(from.Addr().As4()), from.Port())
+	}
+
 	rawpacket, fromKey, hash, err := v4wire.Decode(buf)
 	if err != nil {
 		t.log.Debug("Bad discv4 packet", "addr", from, "err", err)

--- a/p2p/discover/v5_udp.go
+++ b/p2p/discover/v5_udp.go
@@ -674,6 +674,10 @@ func (t *UDPv5) readLoop() {
 
 // dispatchReadPacket sends a packet into the dispatch loop.
 func (t *UDPv5) dispatchReadPacket(from netip.AddrPort, content []byte) bool {
+	// Unwrap IPv4-in-6 source address.
+	if from.Addr().Is4In6() {
+		from = netip.AddrPortFrom(netip.AddrFrom4(from.Addr().As4()), from.Port())
+	}
 	select {
 	case t.packetInCh <- ReadPacket{content, from}:
 		return true


### PR DESCRIPTION
Fixes an issue where discovery responses were not recognized.