### PR TITLE
beacon/light: fix shutdown issues

### DIFF
--- a/beacon/light/api/light_api.go
+++ b/beacon/light/api/light_api.go
@@ -494,9 +494,6 @@ func (api *BeaconLightApi) StartHeadListener(listener HeadEventListener) func() 
 
 		for {
 			select {
-			case <-ctx.Done():
-				stream.Close()
-
 			case event, ok := <-stream.Events:
 				if !ok {
 					log.Trace("Event stream closed")

--- a/beacon/light/request/server.go
+++ b/beacon/light/request/server.go
@@ -230,13 +230,12 @@ func (s *serverWithTimeout) startTimeout(reqData RequestResponse) {
 // unsubscribe stops all goroutines associated with the server.
 func (s *serverWithTimeout) unsubscribe() {
 	s.lock.Lock()
-	defer s.lock.Unlock()
-
 	for _, timer := range s.timeouts {
 		if timer != nil {
 			timer.Stop()
 		}
 	}
+	s.lock.Unlock()
 	s.parent.Unsubscribe()
 }
 
@@ -354,13 +353,12 @@ func (s *serverWithLimits) sendRequest(request Request) (reqId ID) {
 // unsubscribe stops all goroutines associated with the server.
 func (s *serverWithLimits) unsubscribe() {
 	s.lock.Lock()
-	defer s.lock.Unlock()
-
 	if s.delayTimer != nil {
 		s.delayTimer.Stop()
 		s.delayTimer = nil
 	}
 	s.childEventCb = nil
+	s.lock.Unlock()
 	s.serverWithTimeout.unsubscribe()
 }
 

--- a/beacon/light/request/server_test.go
+++ b/beacon/light/request/server_test.go
@@ -51,6 +51,7 @@ func TestServerEvents(t *testing.T) {
 	expEvent(EvFail)
 	rs.eventCb(Event{Type: EvResponse, Data: RequestResponse{ID: 1, Request: testRequest, Response: testResponse}})
 	expEvent(nil)
+	srv.unsubscribe()
 }
 
 func TestServerParallel(t *testing.T) {
@@ -129,9 +130,7 @@ func TestServerEventRateLimit(t *testing.T) {
 	srv := NewServer(rs, clock)
 	var eventCount int
 	srv.subscribe(func(event Event) {
-		if !event.IsRequestEvent() {
-			eventCount++
-		}
+		eventCount++
 	})
 	expEvents := func(send, expAllowed int) {
 		eventCount = 0
@@ -147,6 +146,30 @@ func TestServerEventRateLimit(t *testing.T) {
 	expEvents(5, 1)
 	clock.Run(maxServerEventRate * maxServerEventBuffer * 2)
 	expEvents(maxServerEventBuffer+5, maxServerEventBuffer)
+	srv.unsubscribe()
+}
+
+func TestServerUnsubscribe(t *testing.T) {
+	rs := &testRequestServer{}
+	clock := &mclock.Simulated{}
+	srv := NewServer(rs, clock)
+	var eventCount int
+	srv.subscribe(func(event Event) {
+		eventCount++
+	})
+	eventCb := rs.eventCb
+	eventCb(Event{Type: testEventType})
+	if eventCount != 1 {
+		t.Errorf("Server event callback not called before unsubscribe")
+	}
+	srv.unsubscribe()
+	if rs.eventCb != nil {
+		t.Errorf("Server event callback not removed after unsubscribe")
+	}
+	eventCb(Event{Type: testEventType})
+	if eventCount != 1 {
+		t.Errorf("Server event callback called after unsubscribe")
+	}
 }
 
 type testRequestServer struct {
@@ -156,4 +179,4 @@ type testRequestServer struct {
 func (rs *testRequestServer) Name() string                  { return "" }
 func (rs *testRequestServer) Subscribe(eventCb func(Event)) { rs.eventCb = eventCb }
 func (rs *testRequestServer) SendRequest(ID, Request)       {}
-func (rs *testRequestServer) Unsubscribe()                  {}
+func (rs *testRequestServer) Unsubscribe()                  { rs.eventCb = nil }


### PR DESCRIPTION
This PR fixes shutdown/server disconnection issues in the beacon light syncer:

- as described in https://github.com/ethereum/go-ethereum/issues/29915 the server event stream crashed during shutdown; this issue was simply caused by a double call to `stream.Close()`.
- the server implementation in `beacon/light/request` did not handle server disconnection properly. If an event callback arrived after unsubscribing from server events (shutdown occured while a request was pending) the server called the removed (nil) callback function. Also, the unsubscription from the parent was called while the server mutex was locked, which was both unnecessary and wrong because it broke the normal locking order (`Scheduler` -> `serverWithLimits` -> `serverWithTimeout` -> `ApiServer`) sometimes causing a deadlock during shutdown.