### PR TITLE
cmd/clef, cmd/evm: fix markdown issues in README

### DIFF
--- a/cmd/clef/README.md
+++ b/cmd/clef/README.md
@@ -225,8 +225,8 @@ Response
      - `value` [number:optional]: amount of Wei to send with the transaction
      - `data` [data:optional]:  input data
      - `nonce` [number]: account nonce
-  1. method signature [string:optional]
-     - The method signature, if present, is to aid decoding the calldata. Should consist of `methodname(paramtype,...)`, e.g. `transfer(uint256,address)`. The signer may use this data to parse the supplied calldata, and show the user. The data, however, is considered totally untrusted, and reliability is not expected.
+  2. method signature [string:optional]
+       - The method signature, if present, is to aid decoding the calldata. Should consist of `methodname(paramtype,...)`, e.g. `transfer(uint256,address)`. The signer may use this data to parse the supplied calldata, and show the user. The data, however, is considered totally untrusted, and reliability is not expected.
 
 
 #### Result

--- a/cmd/evm/README.md
+++ b/cmd/evm/README.md
@@ -14,15 +14,15 @@ The `evm t8n` tool is a stateless state transition utility. It is a utility
 which can
 
 1. Take a prestate, including
-  - Accounts,
-  - Block context information,
-  - Previous blockshashes (*optional)
+   - Accounts,
+   - Block context information,
+   - Previous blockshashes (*optional)
 2. Apply a set of transactions,
 3. Apply a mining-reward (*optional),
 4. And generate a post-state, including
-  - State root, transaction root, receipt root,
-  - Information about rejected transactions,
-  - Optionally: a full or partial post-state dump
+   - State root, transaction root, receipt root,
+   - Information about rejected transactions,
+   - Optionally: a full or partial post-state dump
 
 ### Specification
 


### PR DESCRIPTION
Update README docs.

In `cmd/evm/README.md`, tab isn't applied because of an incorrect entry and in `cmd/clef/README.md`, the numbering is incorrect.