### PR TITLE
p2p: use package slices to sort in PeersInfo

### DIFF
--- a/p2p/server.go
+++ b/p2p/server.go
@@ -26,6 +26,7 @@ import (
 	"net"
 	"net/netip"
 	"slices"
+	"sort"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -1140,12 +1141,9 @@ func (srv *Server) PeersInfo() []*PeerInfo {
 		}
 	}
 	// Sort the result array alphabetically by node identifier
-	for i := 0; i < len(infos); i++ {
-		for j := i + 1; j < len(infos); j++ {
-			if infos[i].ID > infos[j].ID {
-				infos[i], infos[j] = infos[j], infos[i]
-			}
-		}
-	}
+	sort.Slice(infos, func(i, j int) bool {
+		return infos[i].ID < infos[j].ID
+	})
+
 	return infos
 }

--- a/p2p/server.go
+++ b/p2p/server.go
@@ -19,6 +19,7 @@ package p2p
 
 import (
 	"bytes"
+	"cmp"
 	"crypto/ecdsa"
 	"encoding/hex"
 	"errors"
@@ -26,7 +27,6 @@ import (
 	"net"
 	"net/netip"
 	"slices"
-	"sort"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -1141,8 +1141,8 @@ func (srv *Server) PeersInfo() []*PeerInfo {
 		}
 	}
 	// Sort the result array alphabetically by node identifier
-	sort.Slice(infos, func(i, j int) bool {
-		return infos[i].ID < infos[j].ID
+	slices.SortFunc(infos, func(a, b *PeerInfo) int {
+		return cmp.Compare(a.ID, b.ID)
 	})
 
 	return infos


### PR DESCRIPTION
Replacing bubble sort in `p2p/server.go` on `PeersInfo` method by standard library method [ `slices.SortFunc`](https://pkg.go.dev/slices#SortFunc).