### PR TITLE
p2p/discover: add missing lock when calling tab.handleAddNode

### DIFF
--- a/p2p/discover/table.go
+++ b/p2p/discover/table.go
@@ -452,7 +452,9 @@ func (tab *Table) loadSeedNodes() {
 			addr, _ := seed.UDPEndpoint()
 			tab.log.Trace("Found seed node in database", "id", seed.ID(), "addr", addr, "age", age)
 		}
+		tab.mutex.Lock()
 		tab.handleAddNode(addNodeOp{node: seed, isInbound: false})
+		tab.mutex.Unlock()
 	}
 }
 


### PR DESCRIPTION
According to the documentation of the method [`handleAddNode`](https://github.com/ethereum/go-ethereum/blob/1098d148a51c929fd9829328fe60ca1214f3c7b5/p2p/discover/table.go#L506),
> // The caller must hold tab.mutex.

 This required call to `tab.mutex.Lock`, and `tab.mutex.Unlock` is missing on the method `loadSeedNodes`.