### PR TITLE
performing a exhaustive clean-up on the unused parameters

### DIFF
--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -1239,7 +1239,7 @@ func setIPC(ctx *cli.Context, cfg *node.Config) {
 }
 
 // setLes shows the deprecation warnings for LES flags.
-func setLes(ctx *cli.Context, cfg *ethconfig.Config) {
+func setLes(ctx *cli.Context) {
 	if ctx.IsSet(LightServeFlag.Name) {
 		log.Warn("The light server has been deprecated, please remove this flag", "flag", LightServeFlag.Name)
 	}
@@ -1648,7 +1648,7 @@ func SetEthConfig(ctx *cli.Context, stack *node.Node, cfg *ethconfig.Config) {
 	setTxPool(ctx, &cfg.TxPool)
 	setMiner(ctx, &cfg.Miner)
 	setRequiredBlocks(ctx, cfg)
-	setLes(ctx, cfg)
+	setLes(ctx)
 
 	// Cap the cache allowance and tune the garbage collector
 	mem, err := gopsutil.VirtualMemory()

--- a/consensus/clique/clique.go
+++ b/consensus/clique/clique.go
@@ -378,7 +378,7 @@ func (c *Clique) verifyCascadingFields(chain consensus.ChainHeaderReader, header
 		}
 	}
 	// All basic checks passed, verify the seal and return
-	return c.verifySeal(snap, header, parents)
+	return c.verifySeal(snap, header)
 }
 
 // snapshot retrieves the authorization snapshot at a given point in time.
@@ -388,7 +388,7 @@ func (c *Clique) snapshot(chain consensus.ChainHeaderReader, number uint64, hash
 		headers []*types.Header
 		snap    *Snapshot
 	)
-	for snap == nil {
+	for {
 		// If an in-memory snapshot was found, use that
 		if s, ok := c.recents.Get(hash); ok {
 			snap = s
@@ -475,7 +475,7 @@ func (c *Clique) VerifyUncles(chain consensus.ChainReader, block *types.Block) e
 // consensus protocol requirements. The method accepts an optional list of parent
 // headers that aren't yet part of the local blockchain to generate the snapshots
 // from.
-func (c *Clique) verifySeal(snap *Snapshot, header *types.Header, parents []*types.Header) error {
+func (c *Clique) verifySeal(snap *Snapshot, header *types.Header) error {
 	// Verifying the genesis block is not supported
 	number := header.Number.Uint64()
 	if number == 0 {

--- a/core/blockchain_test.go
+++ b/core/blockchain_test.go
@@ -2182,10 +2182,10 @@ func testInsertKnownChainData(t *testing.T, typ string, scheme string) {
 	genDb, blocks, receipts := GenerateChainWithGenesis(genesis, engine, 32, func(i int, b *BlockGen) { b.SetCoinbase(common.Address{1}) })
 
 	// A longer chain but total difficulty is lower.
-	blocks2, _ := GenerateChain(genesis.Config, blocks[len(blocks)-1], engine, genDb, 65, func(i int, b *BlockGen) { b.SetCoinbase(common.Address{1}) })
+	blocks2, receipts2 := GenerateChain(genesis.Config, blocks[len(blocks)-1], engine, genDb, 65, func(i int, b *BlockGen) { b.SetCoinbase(common.Address{1}) })
 
 	// A shorter chain but total difficulty is higher.
-	blocks3, _ := GenerateChain(genesis.Config, blocks[len(blocks)-1], engine, genDb, 64, func(i int, b *BlockGen) {
+	blocks3, receipts3 := GenerateChain(genesis.Config, blocks[len(blocks)-1], engine, genDb, 64, func(i int, b *BlockGen) {
 		b.SetCoinbase(common.Address{1})
 		b.OffsetTime(-9) // A higher difficulty
 	})
@@ -2203,11 +2203,11 @@ func testInsertKnownChainData(t *testing.T, typ string, scheme string) {
 	defer chain.Stop()
 
 	var (
-		inserter func(blocks []*types.Block) error
+		inserter func(blocks []*types.Block, receipts []types.Receipts) error
 		asserter func(t *testing.T, block *types.Block)
 	)
 	if typ == "headers" {
-		inserter = func(blocks []*types.Block) error {
+		inserter = func(blocks []*types.Block, receipts []types.Receipts) error {
 			headers := make([]*types.Header, 0, len(blocks))
 			for _, block := range blocks {
 				headers = append(headers, block.Header())
@@ -2221,7 +2221,7 @@ func testInsertKnownChainData(t *testing.T, typ string, scheme string) {
 			}
 		}
 	} else if typ == "receipts" {
-		inserter = func(blocks []*types.Block) error {
+		inserter = func(blocks []*types.Block, receipts []types.Receipts) error {
 			headers := make([]*types.Header, 0, len(blocks))
 			for _, block := range blocks {
 				headers = append(headers, block.Header())
@@ -2239,7 +2239,7 @@ func testInsertKnownChainData(t *testing.T, typ string, scheme string) {
 			}
 		}
 	} else {
-		inserter = func(blocks []*types.Block) error {
+		inserter = func(blocks []*types.Block, receipts []types.Receipts) error {
 			_, err := chain.InsertChain(blocks)
 			return err
 		}
@@ -2250,13 +2250,13 @@ func testInsertKnownChainData(t *testing.T, typ string, scheme string) {
 		}
 	}
 
-	if err := inserter(blocks); err != nil {
+	if err := inserter(blocks, receipts); err != nil {
 		t.Fatalf("failed to insert chain data: %v", err)
 	}
 
 	// Reimport the chain data again. All the imported
 	// chain data are regarded "known" data.
-	if err := inserter(blocks); err != nil {
+	if err := inserter(blocks, receipts); err != nil {
 		t.Fatalf("failed to insert chain data: %v", err)
 	}
 	asserter(t, blocks[len(blocks)-1])
@@ -2265,19 +2265,19 @@ func testInsertKnownChainData(t *testing.T, typ string, scheme string) {
 	rollback := blocks[len(blocks)/2].NumberU64()
 
 	chain.SetHead(rollback - 1)
-	if err := inserter(append(blocks, blocks2...)); err != nil {
+	if err := inserter(append(blocks, blocks2...), append(receipts, receipts2...)); err != nil {
 		t.Fatalf("failed to insert chain data: %v", err)
 	}
 	asserter(t, blocks2[len(blocks2)-1])
 
 	// Import a heavier shorter but higher total difficulty chain with some known data as prefix.
-	if err := inserter(append(blocks, blocks3...)); err != nil {
+	if err := inserter(append(blocks, blocks3...), append(receipts, receipts3...)); err != nil {
 		t.Fatalf("failed to insert chain data: %v", err)
 	}
 	asserter(t, blocks3[len(blocks3)-1])
 
 	// Import a longer but lower total difficulty chain with some known data as prefix.
-	if err := inserter(append(blocks, blocks2...)); err != nil {
+	if err := inserter(append(blocks, blocks2...), append(receipts, receipts2...)); err != nil {
 		t.Fatalf("failed to insert chain data: %v", err)
 	}
 	// The head shouldn't change.
@@ -2285,7 +2285,7 @@ func testInsertKnownChainData(t *testing.T, typ string, scheme string) {
 
 	// Rollback the heavier chain and re-insert the longer chain again
 	chain.SetHead(rollback - 1)
-	if err := inserter(append(blocks, blocks2...)); err != nil {
+	if err := inserter(append(blocks, blocks2...), append(receipts, receipts2...)); err != nil {
 		t.Fatalf("failed to insert chain data: %v", err)
 	}
 	asserter(t, blocks2[len(blocks2)-1])
@@ -2347,13 +2347,13 @@ func testInsertKnownChainDataWithMerging(t *testing.T, typ string, mergeHeight i
 		mergeBlock = uint64(len(blocks))
 	}
 	// Longer chain and shorter chain
-	blocks2, _ := GenerateChain(genesis.Config, blocks[len(blocks)-1], engine, genDb, 65, func(i int, b *BlockGen) {
+	blocks2, receipts2 := GenerateChain(genesis.Config, blocks[len(blocks)-1], engine, genDb, 65, func(i int, b *BlockGen) {
 		b.SetCoinbase(common.Address{1})
 		if b.header.Number.Uint64() >= mergeBlock {
 			b.SetPoS()
 		}
 	})
-	blocks3, _ := GenerateChain(genesis.Config, blocks[len(blocks)-1], engine, genDb, 64, func(i int, b *BlockGen) {
+	blocks3, receipts3 := GenerateChain(genesis.Config, blocks[len(blocks)-1], engine, genDb, 64, func(i int, b *BlockGen) {
 		b.SetCoinbase(common.Address{1})
 		b.OffsetTime(-9) // Time shifted, difficulty shouldn't be changed
 		if b.header.Number.Uint64() >= mergeBlock {
@@ -2374,11 +2374,11 @@ func testInsertKnownChainDataWithMerging(t *testing.T, typ string, mergeHeight i
 	defer chain.Stop()
 
 	var (
-		inserter func(blocks []*types.Block) error
+		inserter func(blocks []*types.Block, receipts []types.Receipts) error
 		asserter func(t *testing.T, block *types.Block)
 	)
 	if typ == "headers" {
-		inserter = func(blocks []*types.Block) error {
+		inserter = func(blocks []*types.Block, receipts []types.Receipts) error {
 			headers := make([]*types.Header, 0, len(blocks))
 			for _, block := range blocks {
 				headers = append(headers, block.Header())
@@ -2395,7 +2395,7 @@ func testInsertKnownChainDataWithMerging(t *testing.T, typ string, mergeHeight i
 			}
 		}
 	} else if typ == "receipts" {
-		inserter = func(blocks []*types.Block) error {
+		inserter = func(blocks []*types.Block, receipts []types.Receipts) error {
 			headers := make([]*types.Header, 0, len(blocks))
 			for _, block := range blocks {
 				headers = append(headers, block.Header())
@@ -2413,7 +2413,7 @@ func testInsertKnownChainDataWithMerging(t *testing.T, typ string, mergeHeight i
 			}
 		}
 	} else {
-		inserter = func(blocks []*types.Block) error {
+		inserter = func(blocks []*types.Block, receipts []types.Receipts) error {
 			i, err := chain.InsertChain(blocks)
 			if err != nil {
 				return fmt.Errorf("index %d: %w", i, err)
@@ -2426,13 +2426,13 @@ func testInsertKnownChainDataWithMerging(t *testing.T, typ string, mergeHeight i
 			}
 		}
 	}
-	if err := inserter(blocks); err != nil {
+	if err := inserter(blocks, receipts); err != nil {
 		t.Fatalf("failed to insert chain data: %v", err)
 	}
 
 	// Reimport the chain data again. All the imported
 	// chain data are regarded "known" data.
-	if err := inserter(blocks); err != nil {
+	if err := inserter(blocks, receipts); err != nil {
 		t.Fatalf("failed to insert chain data: %v", err)
 	}
 	asserter(t, blocks[len(blocks)-1])
@@ -2440,13 +2440,13 @@ func testInsertKnownChainDataWithMerging(t *testing.T, typ string, mergeHeight i
 	// Import a long canonical chain with some known data as prefix.
 	rollback := blocks[len(blocks)/2].NumberU64()
 	chain.SetHead(rollback - 1)
-	if err := inserter(blocks); err != nil {
+	if err := inserter(blocks, receipts); err != nil {
 		t.Fatalf("failed to insert chain data: %v", err)
 	}
 	asserter(t, blocks[len(blocks)-1])
 
 	// Import a longer chain with some known data as prefix.
-	if err := inserter(append(blocks, blocks2...)); err != nil {
+	if err := inserter(append(blocks, blocks2...), append(receipts, receipts2...)); err != nil {
 		t.Fatalf("failed to insert chain data: %v", err)
 	}
 	asserter(t, blocks2[len(blocks2)-1])
@@ -2454,7 +2454,7 @@ func testInsertKnownChainDataWithMerging(t *testing.T, typ string, mergeHeight i
 	// Import a shorter chain with some known data as prefix.
 	// The reorg is expected since the fork choice rule is
 	// already changed.
-	if err := inserter(append(blocks, blocks3...)); err != nil {
+	if err := inserter(append(blocks, blocks3...), append(receipts, receipts3...)); err != nil {
 		t.Fatalf("failed to insert chain data: %v", err)
 	}
 	// The head shouldn't change.
@@ -2462,7 +2462,7 @@ func testInsertKnownChainDataWithMerging(t *testing.T, typ string, mergeHeight i
 
 	// Reimport the longer chain again, the reorg is still expected
 	chain.SetHead(rollback - 1)
-	if err := inserter(append(blocks, blocks2...)); err != nil {
+	if err := inserter(append(blocks, blocks2...), append(receipts, receipts2...)); err != nil {
 		t.Fatalf("failed to insert chain data: %v", err)
 	}
 	asserter(t, blocks2[len(blocks2)-1])
@@ -2618,7 +2618,7 @@ func testReorgToShorterRemovesCanonMappingHeaderChain(t *testing.T, scheme strin
 }
 
 // Benchmarks large blocks with value transfers to non-existing accounts
-func benchmarkLargeNumberOfValueToNonexisting(b *testing.B, numTxs, numBlocks int, recipientFn func(uint64) common.Address) {
+func benchmarkLargeNumberOfValueToNonexisting(b *testing.B, numTxs, numBlocks int, recipientFn func(uint64) common.Address, dataFn func(uint64) []byte) {
 	var (
 		signer          = types.HomesteadSigner{}
 		testBankKey, _  = crypto.HexToECDSA("b71c71a67e1177ad4e901695e1b4b9ee17ae16c6668d313eac2f96dbcda3f291")
@@ -2681,8 +2681,10 @@ func BenchmarkBlockChain_1x1000ValueTransferToNonexisting(b *testing.B) {
 	recipientFn := func(nonce uint64) common.Address {
 		return common.BigToAddress(new(big.Int).SetUint64(1337 + nonce))
 	}
-
-	benchmarkLargeNumberOfValueToNonexisting(b, numTxs, numBlocks, recipientFn)
+	dataFn := func(nonce uint64) []byte {
+		return nil
+	}
+	benchmarkLargeNumberOfValueToNonexisting(b, numTxs, numBlocks, recipientFn, dataFn)
 }
 
 func BenchmarkBlockChain_1x1000ValueTransferToExisting(b *testing.B) {
@@ -2696,8 +2698,10 @@ func BenchmarkBlockChain_1x1000ValueTransferToExisting(b *testing.B) {
 	recipientFn := func(nonce uint64) common.Address {
 		return common.BigToAddress(new(big.Int).SetUint64(1337))
 	}
-
-	benchmarkLargeNumberOfValueToNonexisting(b, numTxs, numBlocks, recipientFn)
+	dataFn := func(nonce uint64) []byte {
+		return nil
+	}
+	benchmarkLargeNumberOfValueToNonexisting(b, numTxs, numBlocks, recipientFn, dataFn)
 }
 
 func BenchmarkBlockChain_1x1000Executions(b *testing.B) {
@@ -2711,7 +2715,10 @@ func BenchmarkBlockChain_1x1000Executions(b *testing.B) {
 	recipientFn := func(nonce uint64) common.Address {
 		return common.BigToAddress(new(big.Int).SetUint64(0xc0de))
 	}
-	benchmarkLargeNumberOfValueToNonexisting(b, numTxs, numBlocks, recipientFn)
+	dataFn := func(nonce uint64) []byte {
+		return nil
+	}
+	benchmarkLargeNumberOfValueToNonexisting(b, numTxs, numBlocks, recipientFn, dataFn)
 }
 
 // Tests that importing a some old blocks, where all blocks are before the

--- a/core/state/sync.go
+++ b/core/state/sync.go
@@ -29,7 +29,7 @@ func NewStateSync(root common.Hash, database ethdb.KeyValueReader, onLeaf func(k
 	// Register the storage slot callback if the external callback is specified.
 	var onSlot func(keys [][]byte, path []byte, leaf []byte, parent common.Hash, parentPath []byte) error
 	if onLeaf != nil {
-		onSlot = func(keys [][]byte, path []byte, leaf []byte, parent common.Hash, parentPath []byte) error {
+		onSlot = func(keys [][]byte, _ []byte, leaf []byte, _ common.Hash, _ []byte) error {
 			return onLeaf(keys, leaf)
 		}
 	}

--- a/core/state_prefetcher.go
+++ b/core/state_prefetcher.go
@@ -68,7 +68,7 @@ func (p *statePrefetcher) Prefetch(block *types.Block, statedb *state.StateDB, c
 			return // Also invalid block, bail out
 		}
 		statedb.SetTxContext(tx.Hash(), i)
-		if err := precacheTransaction(msg, p.config, gaspool, statedb, header, evm); err != nil {
+		if err := precacheTransaction(msg, gaspool, statedb, evm); err != nil {
 			return // Ugh, something went horribly wrong, bail out
 		}
 		// If we're pre-byzantium, pre-load trie nodes for the intermediate root
@@ -85,7 +85,7 @@ func (p *statePrefetcher) Prefetch(block *types.Block, statedb *state.StateDB, c
 // precacheTransaction attempts to apply a transaction to the given state database
 // and uses the input parameters for its environment. The goal is not to execute
 // the transaction successfully, rather to warm up touched data slots.
-func precacheTransaction(msg *Message, config *params.ChainConfig, gaspool *GasPool, statedb *state.StateDB, header *types.Header, evm *vm.EVM) error {
+func precacheTransaction(msg *Message, gaspool *GasPool, statedb *state.StateDB, evm *vm.EVM) error {
 	// Update the evm with the new transaction context.
 	evm.Reset(NewEVMTxContext(msg), statedb)
 	// Add addresses to access list if applicable

--- a/core/txpool/legacypool/legacypool.go
+++ b/core/txpool/legacypool/legacypool.go
@@ -624,7 +624,7 @@ func (pool *LegacyPool) validateTxBasics(tx *types.Transaction, local bool) erro
 
 // validateTx checks whether a transaction is valid according to the consensus
 // rules and adheres to some heuristic limits of the local node (price and size).
-func (pool *LegacyPool) validateTx(tx *types.Transaction, local bool) error {
+func (pool *LegacyPool) validateTx(tx *types.Transaction) error {
 	opts := &txpool.ValidationOptionsWithState{
 		State: pool.currentState,
 
@@ -680,7 +680,7 @@ func (pool *LegacyPool) add(tx *types.Transaction, local bool) (replaced bool, e
 	isLocal := local || pool.locals.containsTx(tx)
 
 	// If the transaction fails basic validation, discard it
-	if err := pool.validateTx(tx, isLocal); err != nil {
+	if err := pool.validateTx(tx); err != nil {
 		log.Trace("Discarding invalid transaction", "hash", hash, "err", err)
 		invalidTxMeter.Mark(1)
 		return false, err

--- a/eth/tracers/js/goja.go
+++ b/eth/tracers/js/goja.go
@@ -273,7 +273,7 @@ func (t *jsTracer) OnTxEnd(receipt *types.Receipt, err error) {
 }
 
 // onStart implements the Tracer interface to initialize the tracing operation.
-func (t *jsTracer) onStart(from common.Address, to common.Address, create bool, input []byte, gas uint64, value *big.Int) {
+func (t *jsTracer) onStart(from common.Address, to common.Address, create bool, input []byte, value *big.Int) {
 	if t.err != nil {
 		return
 	}
@@ -346,7 +346,7 @@ func (t *jsTracer) OnFault(pc uint64, op byte, gas, cost uint64, scope tracing.O
 }
 
 // onEnd is called after the call finishes to finalize the tracing.
-func (t *jsTracer) onEnd(output []byte, gasUsed uint64, err error, reverted bool) {
+func (t *jsTracer) onEnd(output []byte, err error) {
 	if t.err != nil {
 		return
 	}
@@ -367,7 +367,7 @@ func (t *jsTracer) OnEnter(depth int, typ byte, from common.Address, to common.A
 		return
 	}
 	if depth == 0 {
-		t.onStart(from, to, vm.OpCode(typ) == vm.CREATE, input, gas, value)
+		t.onStart(from, to, vm.OpCode(typ) == vm.CREATE, input, value)
 		return
 	}
 	if !t.traceFrame {
@@ -396,7 +396,7 @@ func (t *jsTracer) OnExit(depth int, output []byte, gasUsed uint64, err error, r
 		return
 	}
 	if depth == 0 {
-		t.onEnd(output, gasUsed, err, reverted)
+		t.onEnd(output, err)
 		return
 	}
 	if !t.traceFrame {

--- a/eth/tracers/native/call.go
+++ b/eth/tracers/native/call.go
@@ -126,7 +126,7 @@ type callTracerConfig struct {
 // newCallTracer returns a native go tracer which tracks
 // call frames of a tx, and implements vm.EVMLogger.
 func newCallTracer(ctx *tracers.Context, cfg json.RawMessage) (*tracers.Tracer, error) {
-	t, err := newCallTracerObject(ctx, cfg)
+	t, err := newCallTracerObject(cfg)
 	if err != nil {
 		return nil, err
 	}
@@ -143,7 +143,7 @@ func newCallTracer(ctx *tracers.Context, cfg json.RawMessage) (*tracers.Tracer, 
 	}, nil
 }
 
-func newCallTracerObject(ctx *tracers.Context, cfg json.RawMessage) (*callTracer, error) {
+func newCallTracerObject(cfg json.RawMessage) (*callTracer, error) {
 	var config callTracerConfig
 	if cfg != nil {
 		if err := json.Unmarshal(cfg, &config); err != nil {
@@ -185,7 +185,7 @@ func (t *callTracer) OnEnter(depth int, typ byte, from common.Address, to common
 // execute any code.
 func (t *callTracer) OnExit(depth int, output []byte, gasUsed uint64, err error, reverted bool) {
 	if depth == 0 {
-		t.captureEnd(output, gasUsed, err, reverted)
+		t.captureEnd(output, err, reverted)
 		return
 	}
 
@@ -209,7 +209,7 @@ func (t *callTracer) OnExit(depth int, output []byte, gasUsed uint64, err error,
 	t.callstack[size-1].Calls = append(t.callstack[size-1].Calls, call)
 }
 
-func (t *callTracer) captureEnd(output []byte, gasUsed uint64, err error, reverted bool) {
+func (t *callTracer) captureEnd(output []byte, err error, reverted bool) {
 	if len(t.callstack) != 1 {
 		return
 	}

--- a/eth/tracers/native/call_flat.go
+++ b/eth/tracers/native/call_flat.go
@@ -135,7 +135,7 @@ func newFlatCallTracer(ctx *tracers.Context, cfg json.RawMessage) (*tracers.Trac
 
 	// Create inner call tracer with default configuration, don't forward
 	// the OnlyTopCall or WithLog to inner for now
-	t, err := newCallTracerObject(ctx, nil)
+	t, err := newCallTracerObject(nil)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -1284,7 +1284,7 @@ func RPCMarshalBlock(block *types.Block, inclTx bool, fullTx bool, config *param
 			return tx.Hash()
 		}
 		if fullTx {
-			formatTx = func(idx int, tx *types.Transaction) interface{} {
+			formatTx = func(idx int, _ *types.Transaction) interface{} {
 				return newRPCTransactionFromBlockIndex(block, uint64(idx), config)
 			}
 		}

--- a/internal/ethapi/transaction_args.go
+++ b/internal/ethapi/transaction_args.go
@@ -97,7 +97,7 @@ func (args *TransactionArgs) data() []byte {
 
 // setDefaults fills in default values for unspecified tx fields.
 func (args *TransactionArgs) setDefaults(ctx context.Context, b Backend, skipGasEstimation bool) error {
-	if err := args.setBlobTxSidecar(ctx); err != nil {
+	if err := args.setBlobTxSidecar(); err != nil {
 		return err
 	}
 	if err := args.setFeeDefaults(ctx, b); err != nil {
@@ -189,7 +189,7 @@ func (args *TransactionArgs) setFeeDefaults(ctx context.Context, b Backend) erro
 	if args.BlobFeeCap != nil && args.BlobFeeCap.ToInt().Sign() == 0 {
 		return errors.New("maxFeePerBlobGas, if specified, must be non-zero")
 	}
-	if err := args.setCancunFeeDefaults(ctx, head, b); err != nil {
+	if err := args.setCancunFeeDefaults(head); err != nil {
 		return err
 	}
 	// If both gasPrice and at least one of the EIP-1559 fee parameters are specified, error.
@@ -243,7 +243,7 @@ func (args *TransactionArgs) setFeeDefaults(ctx context.Context, b Backend) erro
 }
 
 // setCancunFeeDefaults fills in reasonable default fee values for unspecified fields.
-func (args *TransactionArgs) setCancunFeeDefaults(ctx context.Context, head *types.Header, b Backend) error {
+func (args *TransactionArgs) setCancunFeeDefaults(head *types.Header) error {
 	// Set maxFeePerBlobGas if it is missing.
 	if args.BlobHashes != nil && args.BlobFeeCap == nil {
 		var excessBlobGas uint64
@@ -290,7 +290,7 @@ func (args *TransactionArgs) setLondonFeeDefaults(ctx context.Context, head *typ
 }
 
 // setBlobTxSidecar adds the blob tx
-func (args *TransactionArgs) setBlobTxSidecar(ctx context.Context) error {
+func (args *TransactionArgs) setBlobTxSidecar() error {
 	// No blobs, we're done.
 	if args.Blobs == nil {
 		return nil

--- a/internal/jsre/jsre.go
+++ b/internal/jsre/jsre.go
@@ -289,7 +289,7 @@ func (re *JSRE) Evaluate(code string, w io.Writer) {
 	re.Do(func(vm *goja.Runtime) {
 		val, err := vm.RunString(code)
 		if err != nil {
-			prettyError(vm, err, w)
+			prettyError(err, w)
 		} else {
 			prettyPrint(vm, val, w)
 		}

--- a/internal/jsre/pretty.go
+++ b/internal/jsre/pretty.go
@@ -58,7 +58,7 @@ func prettyPrint(vm *goja.Runtime, value goja.Value, w io.Writer) {
 }
 
 // prettyError writes err to standard output.
-func prettyError(vm *goja.Runtime, err error, w io.Writer) {
+func prettyError(err error, w io.Writer) {
 	failure := err.Error()
 	if gojaErr, ok := err.(*goja.Exception); ok {
 		failure = gojaErr.String()

--- a/log/format.go
+++ b/log/format.go
@@ -79,7 +79,7 @@ func (h *TerminalHandler) format(buf []byte, r slog.Record, usecolor bool) []byt
 }
 
 func (h *TerminalHandler) formatAttributes(buf *bytes.Buffer, r slog.Record, color string) {
-	writeAttr := func(attr slog.Attr, first, last bool) {
+	writeAttr := func(attr slog.Attr, last bool) {
 		buf.WriteByte(' ')
 
 		if color != "" {
@@ -107,11 +107,11 @@ func (h *TerminalHandler) formatAttributes(buf *bytes.Buffer, r slog.Record, col
 	var n = 0
 	var nAttrs = len(h.attrs) + r.NumAttrs()
 	for _, attr := range h.attrs {
-		writeAttr(attr, n == 0, n == nAttrs-1)
+		writeAttr(attr, n == nAttrs-1)
 		n++
 	}
 	r.Attrs(func(attr slog.Attr) bool {
-		writeAttr(attr, n == 0, n == nAttrs-1)
+		writeAttr(attr, n == nAttrs-1)
 		n++
 		return true
 	})

--- a/p2p/discover/v5_udp.go
+++ b/p2p/discover/v5_udp.go
@@ -753,7 +753,7 @@ func (t *UDPv5) handle(p v5wire.Packet, fromID enode.ID, fromAddr netip.AddrPort
 	case *v5wire.Unknown:
 		t.handleUnknown(p, fromID, fromAddr)
 	case *v5wire.Whoareyou:
-		t.handleWhoareyou(p, fromID, fromAddr)
+		t.handleWhoareyou(p, fromAddr)
 	case *v5wire.Ping:
 		t.handlePing(p, fromID, fromAddr)
 	case *v5wire.Pong:
@@ -789,8 +789,8 @@ var (
 )
 
 // handleWhoareyou resends the active call as a handshake packet.
-func (t *UDPv5) handleWhoareyou(p *v5wire.Whoareyou, fromID enode.ID, fromAddr netip.AddrPort) {
-	c, err := t.matchWithCall(fromID, p.Nonce)
+func (t *UDPv5) handleWhoareyou(p *v5wire.Whoareyou, fromAddr netip.AddrPort) {
+	c, err := t.matchWithCall(p.Nonce)
 	if err != nil {
 		t.log.Debug("Invalid "+p.Name(), "addr", fromAddr, "err", err)
 		return
@@ -811,7 +811,7 @@ func (t *UDPv5) handleWhoareyou(p *v5wire.Whoareyou, fromID enode.ID, fromAddr n
 }
 
 // matchWithCall checks whether a handshake attempt matches the active call.
-func (t *UDPv5) matchWithCall(fromID enode.ID, nonce v5wire.Nonce) (*callV5, error) {
+func (t *UDPv5) matchWithCall(nonce v5wire.Nonce) (*callV5, error) {
 	c := t.activeCallByAuth[nonce]
 	if c == nil {
 		return nil, errChallengeNoCall

--- a/p2p/simulations/mocker.go
+++ b/p2p/simulations/mocker.go
@@ -52,7 +52,7 @@ func GetMockerList() []string {
 }
 
 // The boot mockerFn only connects the node in a ring and doesn't do anything else
-func boot(net *Network, quit chan struct{}, nodeCount int) {
+func boot(net *Network, _ chan struct{}, nodeCount int) {
 	_, err := connectNodesInRing(net, nodeCount)
 	if err != nil {
 		panic("Could not startup node network for mocker")


### PR DESCRIPTION
Two main points in this MR:

1. Performing a clean-up on the unused parameters in the project. After running [mvdan/unparam](https://github.com/mvdan/unparam) on the project, it can be noticed that there are several methods declaring parameters that are not used later. 

```
unparam ./... | grep "is unused"

core/state/sync.go:32:32: NewStateSync$1 - path is unused
core/state/sync.go:32:58: NewStateSync$1 - parent is unused
core/state/sync.go:32:78: NewStateSync$1 - parentPath is unused
core/txpool/legacypool/legacypool.go:627:59: (*LegacyPool).validateTx - local is unused
eth/tracers/js/goja.go:276:95: (*jsTracer).onStart - gas is unused
eth/tracers/js/goja.go:349:41: (*jsTracer).onEnd - gasUsed is unused
eth/tracers/js/goja.go:349:68: (*jsTracer).onEnd - reverted is unused
eth/tracers/native/call.go:146:26: newCallTracerObject - ctx is unused
eth/tracers/native/call.go:212:48: (*callTracer).captureEnd - gasUsed is unused
internal/ethapi/transaction_args.go:246:51: (*TransactionArgs).setCancunFeeDefaults - ctx is unused
internal/ethapi/transaction_args.go:246:92: (*TransactionArgs).setCancunFeeDefaults - b is unused
internal/ethapi/transaction_args.go:293:47: (*TransactionArgs).setBlobTxSidecar - ctx is unused
internal/jsre/pretty.go:61:18: prettyError - vm is unused
log/format.go:82:36: (*TerminalHandler).formatAttributes$1 - first is unused
p2p/discover/v5_udp.go:814:31: (*UDPv5).matchWithCall - fromID is unused
p2p/discover/v5wire/encoding.go:256:28: (*Codec).makeHeader - toID is unused
p2p/discover/v5wire/encoding.go:362:50: (*Codec).makeHandshakeAuth - addr is unused
p2p/simulations/mocker.go:55:25: boot - quit is unused

```

Some of these unused parameters are declared to complain with a type definition, like in the case of `core/state/sync.go:32:32: NewStateSync$1 - path is unused`, in those cases, I just used `_` for the naming of the parameter.

2. On [consensus/clique/clique.go:391](https://github.com/ethereum/go-ethereum/blob/1098d148a51c929fd9829328fe60ca1214f3c7b5/consensus/clique/clique.go#L391), the iteration:

```go
var (
	headers []*types.Header
	snap    *Snapshot
)

for snap == nil {
    // later in the only cases where snap is set to a different value than the original(nil)
   // we automatically break the loop, hence there's no point on declaring a loop with a continue condition
  //  that is always true
}
```
On this iteration the snap value is always nil, the only points where this snap is changed, we automatically break the loop.
 
