### PR TITLE
core: initialize developer genesis beacon root contract with 0 balance

### DIFF
--- a/core/genesis.go
+++ b/core/genesis.go
@@ -594,7 +594,7 @@ func DeveloperGenesisBlock(gasLimit uint64, faucet *common.Address) *Genesis {
 			common.BytesToAddress([]byte{8}): {Balance: big.NewInt(1)}, // ECPairing
 			common.BytesToAddress([]byte{9}): {Balance: big.NewInt(1)}, // BLAKE2b
 			// Pre-deploy EIP-4788 system contract
-			params.BeaconRootsAddress: {Nonce: 1, Code: params.BeaconRootsCode},
+			params.BeaconRootsAddress: {Nonce: 1, Code: params.BeaconRootsCode, Balance: common.Big0},
 		},
 	}
 	if faucet != nil {


### PR DESCRIPTION
closes https://github.com/ethereum/go-ethereum/issues/29955