### PR TITLE
core, rlp: remove duplicated words

### DIFF
--- a/core/state/snapshot/iterator_test.go
+++ b/core/state/snapshot/iterator_test.go
@@ -815,7 +815,7 @@ func TestStorageIteratorDeletions(t *testing.T) {
 	verifyIterator(t, 2, snaps.Snapshot(common.HexToHash("0x06")).(*diffLayer).newBinaryStorageIterator(common.HexToHash("0xaa")), verifyStorage)
 }
 
-// BenchmarkAccountIteratorTraversal is a bit a bit notorious -- all layers contain the
+// BenchmarkAccountIteratorTraversal is a bit notorious -- all layers contain the
 // exact same 200 accounts. That means that we need to process 2000 items, but
 // only spit out 200 values eventually.
 //

--- a/rlp/decode.go
+++ b/rlp/decode.go
@@ -1064,7 +1064,7 @@ func (s *Stream) readKind() (kind Kind, size uint64, err error) {
 		return String, uint64(b - 0x80), nil
 	case b < 0xC0:
 		// If a string is more than 55 bytes long, the RLP encoding consists of a
-		// single byte with value 0xB7 plus the length of the length of the
+		// single byte with value 0xB7 plus the length of the
 		// string in binary form, followed by the length of the string, followed
 		// by the string. For example, a length-1024 string would be encoded as
 		// 0xB90400 followed by the string. The range of the first byte is thus

--- a/rlp/decode.go
+++ b/rlp/decode.go
@@ -1064,7 +1064,7 @@ func (s *Stream) readKind() (kind Kind, size uint64, err error) {
 		return String, uint64(b - 0x80), nil
 	case b < 0xC0:
 		// If a string is more than 55 bytes long, the RLP encoding consists of a
-		// single byte with value 0xB7 plus the length of the
+		// single byte with value 0xB7 plus the length of the length of the
 		// string in binary form, followed by the length of the string, followed
 		// by the string. For example, a length-1024 string would be encoded as
 		// 0xB90400 followed by the string. The range of the first byte is thus


### PR DESCRIPTION
remove duplicated words in comments to improve reading experience.