### PR TITLE
all: remove all database's duplicated words

### DIFF
--- a/crypto/secp256k1/libsecp256k1/sage/group_prover.sage
+++ b/crypto/secp256k1/libsecp256k1/sage/group_prover.sage
@@ -3,7 +3,7 @@
 # to independently set assumptions on input or intermediary variables.
 #
 # The general approach is:
-# * A constraint is a tuple of two sets of of symbolic expressions:
+# * A constraint is a tuple of two sets of symbolic expressions:
 #   the first of which are required to evaluate to zero, the second of which
 #   are required to evaluate to nonzero.
 #   - A constraint is said to be conflicting if any of its nonzero expressions

--- a/crypto/secp256k1/libsecp256k1/src/tests_exhaustive.c
+++ b/crypto/secp256k1/libsecp256k1/src/tests_exhaustive.c
@@ -262,7 +262,7 @@ void test_exhaustive_sign(const secp256k1_context *ctx, const secp256k1_ge *grou
 
                 secp256k1_ecdsa_signature_load(ctx, &r, &s, &sig);
                 /* Note that we compute expected_r *after* signing -- this is important
-                 * because our nonce-computing function function might change k during
+                 * because our nonce-computing function might change k during
                  * signing. */
                 r_from_k(&expected_r, group, k);
                 CHECK(r == expected_r);
@@ -335,7 +335,7 @@ void test_exhaustive_recovery_sign(const secp256k1_context *ctx, const secp256k1
                 secp256k1_ecdsa_recoverable_signature_convert(ctx, &sig, &rsig);
                 secp256k1_ecdsa_signature_load(ctx, &r, &s, &sig);
                 /* Note that we compute expected_r *after* signing -- this is important
-                 * because our nonce-computing function function might change k during
+                 * because our nonce-computing function might change k during
                  * signing. */
                 r_from_k(&expected_r, group, k);
                 CHECK(r == expected_r);


### PR DESCRIPTION
follow https://github.com/ethereum/go-ethereum/pull/29964
checked whole codebase, fix all possible duplicated words and exclude some typical false positive case,eg:

```shell
.//rlp/raw_test.go:01 01
.//common/prque/lazyqueue_test.go:chan chan
.//accounts/accounts.go:Wallet Wallet
.//accounts/usbwallet/hub.go:chan chan
.//accounts/usbwallet/hub.go:chan chan
.//accounts/usbwallet/wallet.go:driver driver
```