### PR TITLE
core/state/snapshot: tiny fixes

### DIFF
--- a/core/state/snapshot/generate.go
+++ b/core/state/snapshot/generate.go
@@ -634,16 +634,10 @@ func generateAccounts(ctx *generatorContext, dl *diskLayer, accMarker []byte) er
 		accMarker = nil
 		return nil
 	}
-	// Always reset the initial account range as 1 whenever recover from the
-	// interruption. TODO(rjl493456442) can we remove it?
-	var accountRange = accountCheckRange
-	if len(accMarker) > 0 {
-		accountRange = 1
-	}
 	origin := common.CopyBytes(accMarker)
 	for {
 		id := trie.StateTrieID(dl.root)
-		exhausted, last, err := dl.generateRange(ctx, id, rawdb.SnapshotAccountPrefix, snapAccount, origin, accountRange, onAccount, types.FullAccountRLP)
+		exhausted, last, err := dl.generateRange(ctx, id, rawdb.SnapshotAccountPrefix, snapAccount, origin, accountCheckRange, onAccount, types.FullAccountRLP)
 		if err != nil {
 			return err // The procedure it aborted, either by external signal or internal error.
 		}
@@ -655,7 +649,6 @@ func generateAccounts(ctx *generatorContext, dl *diskLayer, accMarker []byte) er
 			ctx.removeStorageLeft()
 			break
 		}
-		accountRange = accountCheckRange
 	}
 	return nil
 }

--- a/core/state/snapshot/snapshot.go
+++ b/core/state/snapshot/snapshot.go
@@ -258,14 +258,6 @@ func (t *Tree) Disable() {
 	for _, layer := range t.layers {
 		switch layer := layer.(type) {
 		case *diskLayer:
-
-			layer.lock.RLock()
-			generating := layer.genMarker != nil
-			layer.lock.RUnlock()
-			if !generating {
-				// Generator is already aborted or finished
-				break
-			}
 			// If the base layer is generating, abort it
 			if layer.genAbort != nil {
 				abort := make(chan *generatorStats)
@@ -276,6 +268,7 @@ func (t *Tree) Disable() {
 			layer.lock.Lock()
 			layer.stale = true
 			layer.lock.Unlock()
+			layer.Release()
 
 		case *diffLayer:
 			// If the layer is a simple diff, simply mark as stale
@@ -737,6 +730,7 @@ func (t *Tree) Rebuild(root common.Hash) {
 			layer.lock.Lock()
 			layer.stale = true
 			layer.lock.Unlock()
+			layer.Release()
 
 		case *diffLayer:
 			// If the layer is a simple diff, simply mark as stale


### PR DESCRIPTION
This pull request improves and fixes some tiny issues:

---

Originally, the first account range after an interruption was limited to a single account. The rationale was that mutations might occur at the interruption point, making it more likely to detect inconsistencies. However, since mutations can occur anywhere, this special handling was unnecessary and overly complex. Therefore, it has been removed in this pull request.

---

Besides, this pull request also fixes a tiny issue, by releasing the clean cache if the whole snapshot is disabled, preventing memory leak.