### PR TITLE
pathdb: No more new diskLayers will be generated

### DIFF
--- a/triedb/pathdb/database.go
+++ b/triedb/pathdb/database.go
@@ -371,8 +371,7 @@ func (db *Database) Recover(root common.Hash, loader triestate.TrieLoader) error
 		if err != nil {
 			return err
 		}
-		dl, err = dl.revert(h, loader)
-		if err != nil {
+		if err = dl.revert(h, loader); err != nil {
 			return err
 		}
 		// reset layer with newly created disk layer. It must be

--- a/triedb/pathdb/difflayer.go
+++ b/triedb/pathdb/difflayer.go
@@ -152,5 +152,8 @@ func diffToDisk(layer *diffLayer, force bool) (layer, error) {
 	if !ok {
 		panic(fmt.Sprintf("unknown layer type: %T", layer.parentLayer()))
 	}
-	return disk.commit(layer, force)
+	if err := disk.commit(layer, force); err != nil {
+		return nil, err
+	}
+	return disk, nil
 }


### PR DESCRIPTION
The purpose of this PR is to simplify the `layerTree.bottom` function.