### PR TITLE
core/state/snapshot: acquire the lock on Release

### DIFF
--- a/core/state/snapshot/snapshot.go
+++ b/core/state/snapshot/snapshot.go
@@ -666,8 +666,8 @@ func diffToDisk(bottom *diffLayer) *diskLayer {
 
 // Release releases resources
 func (t *Tree) Release() {
-	t.lock.Lock()
-	defer t.lock.Unlock()
+	t.lock.RLock()
+	defer t.lock.RUnlock()
 
 	if dl := t.disklayer(); dl != nil {
 		dl.Release()
@@ -851,8 +851,8 @@ func (t *Tree) diskRoot() common.Hash {
 // generating is an internal helper function which reports whether the snapshot
 // is still under the construction.
 func (t *Tree) generating() (bool, error) {
-	t.lock.Lock()
-	defer t.lock.Unlock()
+	t.lock.RLock()
+	defer t.lock.RUnlock()
 
 	layer := t.disklayer()
 	if layer == nil {
@@ -865,8 +865,8 @@ func (t *Tree) generating() (bool, error) {
 
 // DiskRoot is a external helper function to return the disk layer root.
 func (t *Tree) DiskRoot() common.Hash {
-	t.lock.Lock()
-	defer t.lock.Unlock()
+	t.lock.RLock()
+	defer t.lock.RUnlock()
 
 	return t.diskRoot()
 }

--- a/core/state/snapshot/snapshot.go
+++ b/core/state/snapshot/snapshot.go
@@ -666,6 +666,9 @@ func diffToDisk(bottom *diffLayer) *diskLayer {
 
 // Release releases resources
 func (t *Tree) Release() {
+	t.lock.Lock()
+	defer t.lock.Unlock()
+
 	if dl := t.disklayer(); dl != nil {
 		dl.Release()
 	}


### PR DESCRIPTION
Make sure that all operations are done with the snaptree if we call Release on it