### PR TITLE
common/math: fix out of bounds access in json unmarshalling

### DIFF
--- a/common/math/big.go
+++ b/common/math/big.go
@@ -54,7 +54,7 @@ func NewHexOrDecimal256(x int64) *HexOrDecimal256 {
 // It is similar to UnmarshalText, but allows parsing real decimals too, not just
 // quoted decimal strings.
 func (i *HexOrDecimal256) UnmarshalJSON(input []byte) error {
-	if len(input) > 2 && input[0] == '"' {
+	if len(input) > 1 && input[0] == '"' {
 		input = input[1 : len(input)-1]
 	}
 	return i.UnmarshalText(input)

--- a/common/math/big.go
+++ b/common/math/big.go
@@ -54,7 +54,7 @@ func NewHexOrDecimal256(x int64) *HexOrDecimal256 {
 // It is similar to UnmarshalText, but allows parsing real decimals too, not just
 // quoted decimal strings.
 func (i *HexOrDecimal256) UnmarshalJSON(input []byte) error {
-	if len(input) > 0 && input[0] == '"' {
+	if len(input) > 2 && input[0] == '"' {
 		input = input[1 : len(input)-1]
 	}
 	return i.UnmarshalText(input)

--- a/common/math/integer.go
+++ b/common/math/integer.go
@@ -46,7 +46,7 @@ type HexOrDecimal64 uint64
 // It is similar to UnmarshalText, but allows parsing real decimals too, not just
 // quoted decimal strings.
 func (i *HexOrDecimal64) UnmarshalJSON(input []byte) error {
-	if len(input) > 0 && input[0] == '"' {
+	if len(input) > 1 && input[0] == '"' {
 		input = input[1 : len(input)-1]
 	}
 	return i.UnmarshalText(input)


### PR DESCRIPTION
Fixes a potential panic if `len(input) == 1`

```
input = input[1 : len(input)-1]
```