### PR TITLE
accounts: remove duplicate `sub.Unsubsribe` in test

### DIFF
--- a/accounts/keystore/keystore_test.go
+++ b/accounts/keystore/keystore_test.go
@@ -314,6 +314,8 @@ func TestWalletNotifications(t *testing.T) {
 			// Add a new account and ensure wallet notifications arrives
 			account, err := ks.NewAccount("")
 			if err != nil {
+				// Shut down the event collector and check events.
+				sub.Unsubscribe()
 				t.Fatalf("failed to create test account: %v", err)
 			}
 			live[account.Address] = account
@@ -326,6 +328,8 @@ func TestWalletNotifications(t *testing.T) {
 				break
 			}
 			if err := ks.Delete(account, ""); err != nil {
+				// Shut down the event collector and check events.
+				sub.Unsubscribe()
 				t.Fatalf("failed to delete test account: %v", err)
 			}
 			delete(live, account.Address)

--- a/accounts/keystore/keystore_test.go
+++ b/accounts/keystore/keystore_test.go
@@ -292,7 +292,6 @@ func TestWalletNotifications(t *testing.T) {
 		updates = make(chan accounts.WalletEvent)
 		sub     = ks.Subscribe(updates)
 	)
-	defer sub.Unsubscribe()
 	go func() {
 		for {
 			select {


### PR DESCRIPTION
As there is `sub.Unsubscribe` called after `for range`, there is no need to use `defer sub.Unsubscribe` again