### PR TITLE
p2p/discover: fix flaky test TestTable_revalidateSyncRecord

### DIFF
--- a/p2p/discover/table_test.go
+++ b/p2p/discover/table_test.go
@@ -135,7 +135,7 @@ func waitForRevalidationPing(t *testing.T, transport *pingRecorder, tab *Table, 
 		simclock.Run(tab.cfg.PingInterval * slowRevalidationFactor)
 		p := transport.waitPing(2 * time.Second)
 		if p == nil {
-			t.Fatal("Table did not send revalidation ping")
+			continue
 		}
 		if id == (enode.ID{}) || p.ID() == id {
 			return p
@@ -423,9 +423,7 @@ func TestTable_revalidateSyncRecord(t *testing.T) {
 
 	// Wait for revalidation. We wait for the node to be revalidated two times
 	// in order to synchronize with the update in the table.
-	time.Sleep(5 * time.Millisecond)
 	waitForRevalidationPing(t, transport, tab, n2.ID())
-	time.Sleep(5 * time.Millisecond)
 	waitForRevalidationPing(t, transport, tab, n2.ID())
 
 	intable := tab.getNode(id)

--- a/p2p/discover/table_test.go
+++ b/p2p/discover/table_test.go
@@ -423,7 +423,9 @@ func TestTable_revalidateSyncRecord(t *testing.T) {
 
 	// Wait for revalidation. We wait for the node to be revalidated two times
 	// in order to synchronize with the update in the table.
+	time.Sleep(5 * time.Millisecond)
 	waitForRevalidationPing(t, transport, tab, n2.ID())
+	time.Sleep(5 * time.Millisecond)
 	waitForRevalidationPing(t, transport, tab, n2.ID())
 
 	intable := tab.getNode(id)


### PR DESCRIPTION
This pull request fixes a flaky test TestTable_revalidateSyncRecord in #29830

BTW, there is also an issue with the first `waitForRevalidationPing`
```shell
/tmp/go-stress-20240618T231835-3046585152
--- FAIL: TestTable_revalidateSyncRecord (2.00s)
    table_test.go:426: Table did not send revalidation ping
FAIL
```


## Problem Statement:
1. First `time.Sleep` ensures `fast revalidationList` can return non-nil fast node from `func (list *revalidationList) get(now mclock.AbsTime, rand randomSource, exclude map[enode.ID]struct{}) *tableNode`, so that we can send `ping request`
2. Second `time.Sleep` ensures `fast revalidationList` moves to `slow revalidationList`, and can return non-nil slow node from `func (list *revalidationList) get(now mclock.AbsTime, rand randomSource, exclude map[enode.ID]struct{}) *tableNode`, so that we can send `ping request`

Since `now < nextTime` inner the function `revalidationList.get`, we cannot get a non-nil node so we couldn't send the ping request, and waiting ping response would time out.

## Stress test results screenshot:
![image](https://github.com/ethereum/go-ethereum/assets/25278203/f0b81013-6164-4bf2-a50a-ce250ba90ec6)
