### PR TITLE
trie: don't reset tracer at the end of Commit

### DIFF
--- a/trie/trie.go
+++ b/trie/trie.go
@@ -53,7 +53,6 @@ type Trie struct {
 	reader *trieReader
 
 	// tracer is the tool to track the trie changes.
-	// It will be reset after each commit operation.
 	tracer *tracer
 }
 

--- a/trie/trie.go
+++ b/trie/trie.go
@@ -609,7 +609,6 @@ func (t *Trie) Hash() common.Hash {
 // Once the trie is committed, it's not usable anymore. A new trie must
 // be created with new root and updated trie database for following usage
 func (t *Trie) Commit(collectLeaf bool) (common.Hash, *trienode.NodeSet) {
-	defer t.tracer.reset()
 	defer func() {
 		t.committed = true
 	}()


### PR DESCRIPTION
We will want the tracer access list available after calling `Commit` when building stateless witnesses.  There's no need to clear it as a trie should not be mutated again after calling `Commit`.