### PR TITLE
eth/catalyst: remove unnecessary continue

### DIFF
--- a/eth/catalyst/api.go
+++ b/eth/catalyst/api.go
@@ -811,7 +811,6 @@ func (api *ConsensusAPI) heartbeat() {
 			}
 			offlineLogged = time.Now()
 		}
-		continue
 	}
 }
 


### PR DESCRIPTION
I think put a continue at the end of a for loop was an accident.