### PR TITLE
core: split commit and flush in prep for witnesses

### DIFF
--- a/core/state/statedb_fuzz_test.go
+++ b/core/state/statedb_fuzz_test.go
@@ -236,15 +236,15 @@ func (test *stateTest) run() bool {
 		} else {
 			state.IntermediateRoot(true) // call intermediateRoot at the transaction boundary
 		}
-		ret, err := state.commitAndFlush(0, true) // call commit at the block boundary
+		_, err = state.Commit(0, true) // call commit at the block boundary
 		if err != nil {
 			panic(err)
 		}
-		if ret.empty() {
+		if state.commit.empty() {
 			return true
 		}
-		copyUpdate(ret)
-		roots = append(roots, ret.root)
+		copyUpdate(state.commit)
+		roots = append(roots, state.commit.root)
 	}
 	for i := 0; i < len(test.actions); i++ {
 		root := types.EmptyRootHash


### PR DESCRIPTION
The statedb.Commit does 2 things under the hood:

- Commit the changes *into* the tries and in-memory structs.
- Flush the minimally necessary diffs to the database.

In preparation for the stateless witnesses however, we need access to the in-between step. Committing the updates to the tries is necessary to produce the accurate access lists to know what's needed to cover all state deletes and updates (i.e. we need to call commit to get an accurate state witness). However, if we want to do cross validation against other clients, that should happen **before** we start pushing stuff to disk.

This PR retains the atomic Commit(), since that's what we expect most people to use (even ourselves most of the time). But for that one - stateless validation - use case, we also have the two steps callable independently, which our chain insertion will do. This way, cross client validation can be added after the state validator gets it's run but before we push things to disk.