### PR TITLE
rpc: truncate call error data logs

### DIFF
--- a/rpc/handler.go
+++ b/rpc/handler.go
@@ -478,7 +478,7 @@ func (h *handler) handleCallMsg(ctx *callProc, msg *jsonrpcMessage) *jsonrpcMess
 			logCtx = append(logCtx, "err", resp.Error.Message)
 			if resp.Error.Data != nil {
 				errDataStr := fmt.Sprintf("%v", resp.Error.Data)
-				// Truncate the error data as string if it is too long. Otherwise, preserve the original data.
+				// Truncate the error data if it is too long. Otherwise, preserve the original data.
 				if len(errDataStr) > callErrorDataLogTruncateLimit {
 					remaining := len(errDataStr) - callErrorDataLogTruncateLimit
 					errDataStr = fmt.Sprintf("%s... (truncated remaining %d chars)", errDataStr[:callErrorDataLogTruncateLimit], remaining)

--- a/rpc/handler.go
+++ b/rpc/handler.go
@@ -29,7 +29,7 @@ import (
 	"github.com/ethereum/go-ethereum/log"
 )
 
-// callErrorDataLogDTruncateLimit is the before truncation limit of the error data field in the log.
+// callErrorDataLogTruncateLimit is the before truncation limit of the error data field in the log.
 const callErrorDataLogTruncateLimit = 1024
 
 // handler handles JSON-RPC messages. There is one handler per connection. Note that


### PR DESCRIPTION
Currently a user with the ability to use the `eth_call` RPC can cause the node to log a large amount of data (depending on the `RPCGasCap`).

This PR truncates rpc call message's returned error data after 1024 chars.   