### PR TITLE
tests: re-enable blockchain GeneralStateTests (state tests converted to blockchain test format).  Disable VMTests VMPerformance suite.

### DIFF
--- a/tests/block_test.go
+++ b/tests/block_test.go
@@ -26,7 +26,6 @@ import (
 
 func TestBlockchain(t *testing.T) {
 	bt := new(testMatcher)
-	bt.skipLoad(`^GeneralStateTests/VMTests/vmPerformance`)
 
 	// Skip random failures due to selfish mining test
 	bt.skipLoad(`.*bcForgedTest/bcForkUncle\.json`)
@@ -38,6 +37,7 @@ func TestBlockchain(t *testing.T) {
 	bt.slow(`.*/bcForkStressTest/`)
 	bt.slow(`.*/bcGasPricerTest/RPC_API_Test.json`)
 	bt.slow(`.*/bcWalletTest/`)
+	bt.skipLoad(`^GeneralStateTests/VMTests/vmPerformance`)
 
 	// Very slow test
 	bt.skipLoad(`.*/stTimeConsuming/.*`)

--- a/tests/block_test.go
+++ b/tests/block_test.go
@@ -26,11 +26,7 @@ import (
 
 func TestBlockchain(t *testing.T) {
 	bt := new(testMatcher)
-	// General state tests are 'exported' as blockchain tests, but we can run them natively.
-	// For speedier CI-runs, the line below can be uncommented, so those are skipped.
-	// For now, in hardfork-times (Berlin), we run the tests both as StateTests and
-	// as blockchain tests, since the latter also covers things like receipt root
-	bt.skipLoad(`^GeneralStateTests/`)
+	bt.skipLoad(`^GeneralStateTests/VMTests/vmPerformance`)
 
 	// Skip random failures due to selfish mining test
 	bt.skipLoad(`.*bcForgedTest/bcForkUncle\.json`)


### PR DESCRIPTION
These will certainly be useful for stateless witness construction/verification test coverage.  After disabling the `VMTests/vmPerformance` suite, the test suite runtime only takes 110 seconds.

From my machine:

Blockchain tests without vmPerformance - 110.071s
Blockchain tests with vmPerformance - 594.565s
Blockchain tests without GeneralStatetests (master) - 32.120s

State tests (master) - 59.723s