### PR TITLE
log: remove unnecessary log level

### DIFF
--- a/internal/debug/flags.go
+++ b/internal/debug/flags.go
@@ -231,9 +231,9 @@ func Setup(ctx *cli.Context) error {
 	case ctx.Bool(logjsonFlag.Name):
 		// Retain backwards compatibility with `--log.json` flag if `--log.format` not set
 		defer log.Warn("The flag '--log.json' is deprecated, please use '--log.format=json' instead")
-		handler = log.JSONHandlerWithLevel(output, log.LevelInfo)
+		handler = log.JSONHandler(output)
 	case logFmtFlag == "json":
-		handler = log.JSONHandlerWithLevel(output, log.LevelInfo)
+		handler = log.JSONHandler(output)
 	case logFmtFlag == "logfmt":
 		handler = log.LogfmtHandler(output)
 	case logFmtFlag == "", logFmtFlag == "terminal":


### PR DESCRIPTION
log level is specified in [L259](https://github.com/amiremohamadi/go-ethereum/blob/2fcb90b5bbefc4c5525d8664ad363d2593e4e739/internal/debug/flags.go#L259) so it's unnecessary to specify it for `handler` ([L234](https://github.com/amiremohamadi/go-ethereum/blob/2fcb90b5bbefc4c5525d8664ad363d2593e4e739/internal/debug/flags.go#L234), [L236](https://github.com/amiremohamadi/go-ethereum/blob/2fcb90b5bbefc4c5525d8664ad363d2593e4e739/internal/debug/flags.go#L236))