### PR TITLE
core/state: read from snap error should continue to read from db

### DIFF
--- a/core/state/state_object.go
+++ b/core/state/state_object.go
@@ -206,11 +206,13 @@ func (s *stateObject) GetCommittedState(key common.Hash) common.Hash {
 		s.db.SnapshotStorageReads += time.Since(start)
 
 		if len(enc) > 0 {
-			_, content, _, err := rlp.Split(enc)
+			var content []byte
+			_, content, _, err = rlp.Split(enc)
 			if err != nil {
 				s.db.setError(err)
+			} else {
+				value.SetBytes(content)
 			}
-			value.SetBytes(content)
 		}
 	}
 	// If the snapshot is unavailable or reading from it fails, load from the database.


### PR DESCRIPTION
``` go
// If the snapshot is unavailable or reading from it fails, load from the database.
if s.db.snap == nil || err != nil {
```

If I understood the comment correctly, we should cover the original err with `_, content, _, err = rlp.Split(enc)`.


If not, I think it would be fine to return `common.Hash{}` when there is an error with `rlp.Split(enc)`.
```go
_, content, _, err := rlp.Split(enc)
if err != nil {
	s.db.setError(err)
        return common.Hash{}
}
```