### PR TITLE
core/txpool/blobpool: avoid use *map as parameter.

### DIFF
--- a/core/txpool/blobpool/blobpool.go
+++ b/core/txpool/blobpool/blobpool.go
@@ -407,7 +407,7 @@ func (p *BlobPool) Init(gasTip uint64, head *types.Header, reserve txpool.Addres
 	if p.head.ExcessBlobGas != nil {
 		blobfee = uint256.MustFromBig(eip4844.CalcBlobFee(*p.head.ExcessBlobGas))
 	}
-	p.evict = newPriceHeap(basefee, blobfee, &p.index)
+	p.evict = newPriceHeap(basefee, blobfee, p.index)
 
 	// Pool initialized, attach the blob limbo to it to track blobs included
 	// recently but not yet finalized

--- a/core/txpool/blobpool/evictheap.go
+++ b/core/txpool/blobpool/evictheap.go
@@ -35,7 +35,7 @@ import (
 // The goal of the heap is to decide which account has the worst bottleneck to
 // evict transactions from.
 type evictHeap struct {
-	metas *map[common.Address][]*blobTxMeta // Pointer to the blob pool's index for price retrievals
+	metas map[common.Address][]*blobTxMeta // Pointer to the blob pool's index for price retrievals
 
 	basefeeJumps float64 // Pre-calculated absolute dynamic fee jumps for the base fee
 	blobfeeJumps float64 // Pre-calculated absolute dynamic fee jumps for the blob fee
@@ -46,7 +46,7 @@ type evictHeap struct {
 
 // newPriceHeap creates a new heap of cheapest accounts in the blob pool to evict
 // from in case of over saturation.
-func newPriceHeap(basefee *uint256.Int, blobfee *uint256.Int, index *map[common.Address][]*blobTxMeta) *evictHeap {
+func newPriceHeap(basefee *uint256.Int, blobfee *uint256.Int, index map[common.Address][]*blobTxMeta) *evictHeap {
 	heap := &evictHeap{
 		metas: index,
 		index: make(map[common.Address]int),
@@ -54,8 +54,8 @@ func newPriceHeap(basefee *uint256.Int, blobfee *uint256.Int, index *map[common.
 	// Populate the heap in account sort order. Not really needed in practice,
 	// but it makes the heap initialization deterministic and less annoying to
 	// test in unit tests.
-	addrs := make([]common.Address, 0, len(*index))
-	for addr := range *index {
+	addrs := make([]common.Address, 0, len(index))
+	for addr := range index {
 		addrs = append(addrs, addr)
 	}
 	sort.Slice(addrs, func(i, j int) bool { return bytes.Compare(addrs[i][:], addrs[j][:]) < 0 })
@@ -94,8 +94,8 @@ func (h *evictHeap) Len() int {
 // Less implements sort.Interface as part of heap.Interface, returning which of
 // the two requested accounts has a cheaper bottleneck.
 func (h *evictHeap) Less(i, j int) bool {
-	txsI := (*(h.metas))[h.addrs[i]]
-	txsJ := (*(h.metas))[h.addrs[j]]
+	txsI := (h.metas)[h.addrs[i]]
+	txsJ := (h.metas)[h.addrs[j]]
 
 	lastI := txsI[len(txsI)-1]
 	lastJ := txsJ[len(txsJ)-1]

--- a/core/txpool/blobpool/evictheap.go
+++ b/core/txpool/blobpool/evictheap.go
@@ -94,8 +94,8 @@ func (h *evictHeap) Len() int {
 // Less implements sort.Interface as part of heap.Interface, returning which of
 // the two requested accounts has a cheaper bottleneck.
 func (h *evictHeap) Less(i, j int) bool {
-	txsI := (h.metas)[h.addrs[i]]
-	txsJ := (h.metas)[h.addrs[j]]
+	txsI := h.metas[h.addrs[i]]
+	txsJ := h.metas[h.addrs[j]]
 
 	lastI := txsI[len(txsI)-1]
 	lastJ := txsJ[len(txsJ)-1]

--- a/core/txpool/blobpool/evictheap_test.go
+++ b/core/txpool/blobpool/evictheap_test.go
@@ -37,17 +37,17 @@ func verifyHeapInternals(t *testing.T, evict *evictHeap) {
 	seen := make(map[common.Address]struct{})
 	for i, addr := range evict.addrs {
 		seen[addr] = struct{}{}
-		if _, ok := (*evict.metas)[addr]; !ok {
+		if _, ok := evict.metas[addr]; !ok {
 			t.Errorf("heap contains unexpected address at slot %d: %v", i, addr)
 		}
 	}
-	for addr := range *evict.metas {
+	for addr := range evict.metas {
 		if _, ok := seen[addr]; !ok {
 			t.Errorf("heap is missing required address %v", addr)
 		}
 	}
-	if len(evict.addrs) != len(*evict.metas) {
-		t.Errorf("heap size %d mismatches metadata size %d", len(evict.addrs), len(*evict.metas))
+	if len(evict.addrs) != len(evict.metas) {
+		t.Errorf("heap size %d mismatches metadata size %d", len(evict.addrs), len(evict.metas))
 	}
 	// Ensure that all accounts are present in the heap order index and no extras
 	have := make([]common.Address, len(evict.index))
@@ -159,7 +159,7 @@ func TestPriceHeapSorting(t *testing.T) {
 			}}
 		}
 		// Create a price heap and check the pop order
-		priceheap := newPriceHeap(uint256.NewInt(tt.basefee), uint256.NewInt(tt.blobfee), &index)
+		priceheap := newPriceHeap(uint256.NewInt(tt.basefee), uint256.NewInt(tt.blobfee), index)
 		verifyHeapInternals(t, priceheap)
 
 		for j := 0; j < len(tt.order); j++ {
@@ -218,7 +218,7 @@ func benchmarkPriceHeapReinit(b *testing.B, datacap uint64) {
 		}}
 	}
 	// Create a price heap and reinit it over and over
-	heap := newPriceHeap(uint256.NewInt(rand.Uint64()), uint256.NewInt(rand.Uint64()), &index)
+	heap := newPriceHeap(uint256.NewInt(rand.Uint64()), uint256.NewInt(rand.Uint64()), index)
 
 	basefees := make([]*uint256.Int, b.N)
 	blobfees := make([]*uint256.Int, b.N)
@@ -278,7 +278,7 @@ func benchmarkPriceHeapOverflow(b *testing.B, datacap uint64) {
 		}}
 	}
 	// Create a price heap and overflow it over and over
-	evict := newPriceHeap(uint256.NewInt(rand.Uint64()), uint256.NewInt(rand.Uint64()), &index)
+	evict := newPriceHeap(uint256.NewInt(rand.Uint64()), uint256.NewInt(rand.Uint64()), index)
 	var (
 		addrs = make([]common.Address, b.N)
 		metas = make([]*blobTxMeta, b.N)


### PR DESCRIPTION
Map types are reference types, we can use them as pointers.