### PR TITLE
core/types: add hash check in transaction unmarshalling

### DIFF
--- a/core/types/transaction_marshalling.go
+++ b/core/types/transaction_marshalling.go
@@ -416,6 +416,9 @@ func (tx *Transaction) UnmarshalJSON(input []byte) error {
 	// Now set the inner transaction.
 	tx.setDecoded(inner, 0)
 
-	// TODO: check hash here?
+	if dec.Hash != tx.Hash() {
+		return errors.New("hash mismatch")
+	}
+
 	return nil
 }


### PR DESCRIPTION
Not sure why hash checking for decoding JSON is missing, added it back.