### PR TITLE
accounts/keystore: fix flaky test `TestWalletNotifications`

### DIFF
--- a/accounts/keystore/account_cache.go
+++ b/accounts/keystore/account_cache.go
@@ -284,9 +284,11 @@ func (ac *accountCache) scanAccounts() error {
 	start := time.Now()
 
 	for _, path := range creates.ToSlice() {
+		ac.fileC.mu.Lock()
 		if a := readAccount(path); a != nil {
 			ac.add(*a)
 		}
+		ac.fileC.mu.Unlock()
 	}
 	for _, path := range deletes.ToSlice() {
 		ac.deleteByFile(path)

--- a/accounts/keystore/file_cache.go
+++ b/accounts/keystore/file_cache.go
@@ -39,15 +39,14 @@ type fileCache struct {
 func (fc *fileCache) scan(keyDir string) (mapset.Set[string], mapset.Set[string], mapset.Set[string], error) {
 	t0 := time.Now()
 
+	fc.mu.Lock()
+	defer fc.mu.Unlock()
 	// List all the files from the keystore folder
 	files, err := os.ReadDir(keyDir)
 	if err != nil {
 		return nil, nil, nil, err
 	}
 	t1 := time.Now()
-
-	fc.mu.Lock()
-	defer fc.mu.Unlock()
 
 	// Iterate all the files and gather their metadata
 	all := mapset.NewThreadUnsafeSet[string]()

--- a/accounts/keystore/keystore.go
+++ b/accounts/keystore/keystore.go
@@ -228,6 +228,8 @@ func (ks *KeyStore) Accounts() []accounts.Account {
 // Delete deletes the key matched by account if the passphrase is correct.
 // If the account contains no filename, the address must match a unique key.
 func (ks *KeyStore) Delete(a accounts.Account, passphrase string) error {
+	ks.cache.fileC.mu.Lock()
+	defer ks.cache.fileC.mu.Unlock()
 	// Decrypting the key isn't really necessary, but we do
 	// it anyway to check the password and zero out the key
 	// immediately afterwards.

--- a/accounts/keystore/keystore_test.go
+++ b/accounts/keystore/keystore_test.go
@@ -311,7 +311,7 @@ func TestWalletNotifications(t *testing.T) {
 		live       = make(map[common.Address]accounts.Account)
 		wantEvents []walletEvent
 	)
-	for i := 0; i < 1024; i++ {
+	for i := 0; i < 500; i++ {
 		if create := len(live) == 0 || rand.Int()%4 > 0; create {
 			// Add a new account and ensure wallet notifications arrives
 			account, err := ks.NewAccount("")

--- a/accounts/keystore/keystore_test.go
+++ b/accounts/keystore/keystore_test.go
@@ -311,7 +311,7 @@ func TestWalletNotifications(t *testing.T) {
 		live       = make(map[common.Address]accounts.Account)
 		wantEvents []walletEvent
 	)
-	for i := 0; i < 500; i++ {
+	for i := 0; i < 1024; i++ {
 		if create := len(live) == 0 || rand.Int()%4 > 0; create {
 			// Add a new account and ensure wallet notifications arrives
 			account, err := ks.NewAccount("")


### PR DESCRIPTION
This PR fixes the `checkEvents` part of the flaky test `TestWalletNotifications`. There is another flaky failure for `checkAccounts`.

```go
// checkEvents checks that all events in 'want' are present in 'have'. Events may be present multiple times.
func checkEvents(t *testing.T, want []walletEvent, have []walletEvent) {}
```

The original logic of `checkEvents` seems to ask for both `wantEvents` and `haveEvents` to keep a consistent order so that this function could work correctly.

But actually, the order of both is not consistent. See the failed log comment on #29830 
```shell
keystore_test.go:455: can't find event with Kind=2 for 56fe5c503fb7f1850298b7d6896cfd8019b525e1
```

Before this patch, the stress test of `TestWalletNotifications`  failed by `checkAccounts` and `checkEvents`
```shell
5s: 237 runs so far, 0 failures

/tmp/go-stress-20240623T163016-2051068115
--- FAIL: TestWalletNotifications (0.55s)
    keystore_test.go:427: wallet list doesn't match required accounts: have 519, want 518
    keystore_test.go:455: can't find event with Kind=0 for bd535fefc07673125b61b29febbc0cc078046a54
FAIL


ERROR: exit status 1

10s: 490 runs so far, 1 failures (0.20%)
15s: 745 runs so far, 1 failures (0.13%)
20s: 997 runs so far, 1 failures (0.10%)
25s: 1253 runs so far, 1 failures (0.08%)
30s: 1489 runs so far, 1 failures (0.07%)
35s: 1708 runs so far, 1 failures (0.06%)
40s: 1925 runs so far, 1 failures (0.05%)

/tmp/go-stress-20240623T163016-1363815113
--- FAIL: TestWalletNotifications (0.52s)
    keystore_test.go:427: wallet list doesn't match required accounts: have 539, want 538
    keystore_test.go:455: can't find event with Kind=0 for d96d2f8b7d825b01038487e904fda016b8a47a9a
FAIL
```

After this patch, the stress test of `TestWalletNotifications` only failed by `checkAccounts`.
```shell
halimao@Galaxy:keystore$ stress ./keystore.test -test.run=TestWalletNotifications -test.cpu=5
5s: 241 runs so far, 0 failures
10s: 493 runs so far, 0 failures
15s: 741 runs so far, 0 failures
20s: 988 runs so far, 0 failures
25s: 1238 runs so far, 0 failures
30s: 1467 runs so far, 0 failures
35s: 1679 runs so far, 0 failures

/tmp/go-stress-20240623T155222-1929018433
--- FAIL: TestWalletNotifications (0.65s)
    keystore_test.go:428: wallet list doesn't match required accounts: have 517, want 516
FAIL


ERROR: exit status 1

40s: 1879 runs so far, 1 failures (0.05%)
45s: 2092 runs so far, 1 failures (0.05%)
50s: 2302 runs so far, 1 failures (0.04%)
55s: 2517 runs so far, 1 failures (0.04%)
1m0s: 2728 runs so far, 1 failures (0.04%)
1m5s: 2934 runs so far, 1 failures (0.03%)

/tmp/go-stress-20240623T155222-687466893
--- FAIL: TestWalletNotifications (0.81s)
    keystore_test.go:428: wallet list doesn't match required accounts: have 531, want 530
FAIL
```