### PR TITLE
.github: add lightclient as codeowner to relevant packages

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,14 +4,18 @@
 accounts/usbwallet              @karalabe
 accounts/scwallet               @gballet
 accounts/abi                    @gballet @MariusVanDerWijden
+beacon/engine                   @lightclient
 cmd/clef                        @holiman
+cmd/evm                         @holiman @MariusVanDerWijden @lightclient
 consensus                       @karalabe
 core/                           @karalabe @holiman @rjl493456442
 eth/                            @karalabe @holiman @rjl493456442
-eth/catalyst/                   @gballet
+eth/catalyst/                   @gballet @lightclient
 eth/tracers/                    @s1na
 core/tracing/                   @s1na
 graphql/                        @s1na
+internal/ethapi                 @lightclient
+internal/era                    @lightclient
 les/                            @zsfelfoldi @rjl493456442
 light/                          @zsfelfoldi @rjl493456442
 node/                           @fjl


### PR DESCRIPTION
In an effort to lower the number of open PRs, I am proposing to add myself to a few packages that I have contributed to over the past few years that I feel comfortable with helping maintain.

Obviously open to reducing or increasing the scope of code ownership depending on how people feel. Just hoping this will decrease some of the busy work for those with merge rights.