### PR TITLE
core/rawdb: reset freezer recheck timer before select

### DIFF
--- a/core/rawdb/chain_freezer.go
+++ b/core/rawdb/chain_freezer.go
@@ -165,10 +165,11 @@ func (f *chainFreezer) freeze(db ethdb.KeyValueStore) {
 				triggered <- struct{}{}
 				triggered = nil
 			}
+			timer.Reset(freezerRecheckInterval)
 			select {
 			case <-timer.C:
 				backoff = false
-				timer.Reset(freezerRecheckInterval)
+
 			case triggered = <-f.trigger:
 				backoff = false
 			case <-f.quit:

--- a/core/rawdb/chain_freezer.go
+++ b/core/rawdb/chain_freezer.go
@@ -169,7 +169,6 @@ func (f *chainFreezer) freeze(db ethdb.KeyValueStore) {
 			select {
 			case <-timer.C:
 				backoff = false
-
 			case triggered = <-f.trigger:
 				backoff = false
 			case <-f.quit:


### PR DESCRIPTION
As noted in #30054, it appears the timer should actually be reset before the select kicks off so that the backoff actually backs off for `freezerRecheckInterval`.