### PR TITLE
cmd/blsync: use debug.Setup for logging configuration

### DIFF
--- a/cmd/blsync/main.go
+++ b/cmd/blsync/main.go
@@ -19,39 +19,21 @@ package main
 import (
 	"context"
 	"fmt"
-	"io"
 	"os"
 
 	"github.com/ethereum/go-ethereum/beacon/blsync"
 	"github.com/ethereum/go-ethereum/cmd/utils"
+	"github.com/ethereum/go-ethereum/internal/debug"
 	"github.com/ethereum/go-ethereum/internal/flags"
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/node"
 	"github.com/ethereum/go-ethereum/rpc"
-	"github.com/mattn/go-colorable"
-	"github.com/mattn/go-isatty"
 	"github.com/urfave/cli/v2"
-)
-
-var (
-	verbosityFlag = &cli.IntFlag{
-		Name:     "verbosity",
-		Usage:    "Logging verbosity: 0=silent, 1=error, 2=warn, 3=info, 4=debug, 5=detail",
-		Value:    3,
-		Category: flags.LoggingCategory,
-	}
-	vmoduleFlag = &cli.StringFlag{
-		Name:     "vmodule",
-		Usage:    "Per-module verbosity: comma-separated list of <pattern>=<level> (e.g. eth/*=5,p2p=4)",
-		Value:    "",
-		Hidden:   true,
-		Category: flags.LoggingCategory,
-	}
 )
 
 func main() {
 	app := flags.NewApp("beacon light syncer tool")
-	app.Flags = []cli.Flag{
+	app.Flags = flags.Merge([]cli.Flag{
 		utils.BeaconApiFlag,
 		utils.BeaconApiHeaderFlag,
 		utils.BeaconThresholdFlag,
@@ -66,8 +48,16 @@ func main() {
 		utils.GoerliFlag,
 		utils.BlsyncApiFlag,
 		utils.BlsyncJWTSecretFlag,
-		verbosityFlag,
-		vmoduleFlag,
+	},
+		debug.Flags,
+	)
+	app.Before = func(ctx *cli.Context) error {
+		flags.MigrateGlobalFlags(ctx)
+		return debug.Setup(ctx)
+	}
+	app.After = func(ctx *cli.Context) error {
+		debug.Exit()
+		return nil
 	}
 	app.Action = sync
 
@@ -78,14 +68,6 @@ func main() {
 }
 
 func sync(ctx *cli.Context) error {
-	usecolor := (isatty.IsTerminal(os.Stderr.Fd()) || isatty.IsCygwinTerminal(os.Stderr.Fd())) && os.Getenv("TERM") != "dumb"
-	output := io.Writer(os.Stderr)
-	if usecolor {
-		output = colorable.NewColorable(os.Stderr)
-	}
-	verbosity := log.FromLegacyLevel(ctx.Int(verbosityFlag.Name))
-	log.SetDefault(log.NewLogger(log.NewTerminalHandlerWithLevel(output, verbosity, usecolor)))
-
 	// set up blsync
 	client := blsync.NewClient(ctx)
 	client.SetEngineRPC(makeRPCClient(ctx))


### PR DESCRIPTION
*Replaces #30042*

As @fjl mentioned, the correct way to have `blsync` handle the log configuration is to reuse `debug.Setup`.