### PR TITLE
eth/catalyst: avoid copy the whole slice

### DIFF
--- a/eth/catalyst/queue.go
+++ b/eth/catalyst/queue.go
@@ -79,7 +79,8 @@ func (q *payloadQueue) get(id engine.PayloadID, full bool) *engine.ExecutionPayl
 	q.lock.RLock()
 	defer q.lock.RUnlock()
 
-	for _, item := range q.payloads {
+	for i := len(q.payloads) - 1; i >= 0; i-- {
+		item := q.payloads[i]
 		if item.id == id {
 			if !full {
 				return item.payload.Resolve()
@@ -95,7 +96,8 @@ func (q *payloadQueue) has(id engine.PayloadID) bool {
 	q.lock.RLock()
 	defer q.lock.RUnlock()
 
-	for _, item := range q.payloads {
+	for i := len(q.payloads) - 1; i >= 0; i-- {
+		item := q.payloads[i]
 		if item.id == id {
 			return true
 		}
@@ -144,7 +146,8 @@ func (q *headerQueue) get(hash common.Hash) *types.Header {
 	q.lock.RLock()
 	defer q.lock.RUnlock()
 
-	for _, item := range q.headers {
+	for i := len(q.headers) - 1; i >= 0; i-- {
+		item := q.headers[i]
 		if item.hash == hash {
 			return item.header
 		}

--- a/eth/catalyst/queue.go
+++ b/eth/catalyst/queue.go
@@ -134,11 +134,11 @@ func (q *headerQueue) put(hash common.Hash, data *types.Header) {
 	q.lock.Lock()
 	defer q.lock.Unlock()
 
-	copy(q.headers[1:], q.headers)
-	q.headers[0] = &headerQueueItem{
+	q.headers = append(q.headers, &headerQueueItem{
 		hash:   hash,
 		header: data,
-	}
+	})
+	q.headers = q.headers[1:]
 }
 
 // get retrieves a previously stored header item or nil if it does not exist.
@@ -146,7 +146,8 @@ func (q *headerQueue) get(hash common.Hash) *types.Header {
 	q.lock.RLock()
 	defer q.lock.RUnlock()
 
-	for _, item := range q.headers {
+	for i := len(q.headers) - 1; i >= 0; i-- {
+		item := q.headers[i]
 		if item == nil {
 			return nil // no more items
 		}


### PR DESCRIPTION
This PR aims to avoid copying the entire slice, if the length is bigger than `maxTrackedHeaders` discard the oldest one.
At first `headers` length is zero and the capacity is `maxTrackedHeaders`, so we don't need to check `item == nil`.