### PR TITLE
[Website]: fix cmd to access kurtosis shell

### DIFF
--- a/docs/fundamentals/kurtosis.md
+++ b/docs/fundamentals/kurtosis.md
@@ -142,7 +142,7 @@ The most straightforward to interact with any of the geth nodes is through JSON-
 In the end the kurtosis services are docker images. It is also possible to get shell access to them and poke around, e.g. load up the console. Kurtosis facilitates the shell access through a command:
 
 ```
-> kurtosis shell dusty-soil el-1-geth-lighthouse
+> kurtosis service shell dusty-soil el-1-geth-lighthouse
 No bash found on container; dropping down to sh shell...
 / # geth --datadir /data/geth/execution-data/ attach
 Welcome to the Geth JavaScript console!


### PR DESCRIPTION
# The command to access kurtosis shell needs to be fixed

The command ```kurtosis shell lucid-sky el-2-geth-lighthouse``` gives ```Error:  unknown command "shell" for "kurtosis```

Reason: The keyword **_service_** is missing from the command. 
Check official reference here: https://docs.kurtosis.com/service-shell

- I am using kurtosis cli version: 0.90.1  
- The command should be: ```kurtosis service shell $THE_ENCLAVE_IDENTIFIER $THE_SERVICE_IDENTIFIER```