### PR TITLE
crypto: remove hardcoded value for secp256k1.N

### DIFF
--- a/crypto/crypto.go
+++ b/crypto/crypto.go
@@ -45,7 +45,7 @@ const RecoveryIDOffset = 64
 const DigestLength = 32
 
 var (
-	secp256k1N, _  = new(big.Int).SetString("fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364141", 16)
+	secp256k1N     = S256().Params().N
 	secp256k1halfN = new(big.Int).Div(secp256k1N, big.NewInt(2))
 )
 


### PR DESCRIPTION
The same hardcoded value is already [there](https://github.com/ethereum/go-ethereum/blob/2d9d42376436cd275c28056cffd0eb97cb8daed8/crypto/secp256k1/curve.go#L287), so no need to do it twice.