### PR TITLE
consensus/beacon, core/types: add verkle witness builder

### DIFF
--- a/beacon/engine/gen_ed.go
+++ b/beacon/engine/gen_ed.go
@@ -17,23 +17,24 @@ var _ = (*executableDataMarshaling)(nil)
 // MarshalJSON marshals as JSON.
 func (e ExecutableData) MarshalJSON() ([]byte, error) {
 	type ExecutableData struct {
-		ParentHash    common.Hash         `json:"parentHash"    gencodec:"required"`
-		FeeRecipient  common.Address      `json:"feeRecipient"  gencodec:"required"`
-		StateRoot     common.Hash         `json:"stateRoot"     gencodec:"required"`
-		ReceiptsRoot  common.Hash         `json:"receiptsRoot"  gencodec:"required"`
-		LogsBloom     hexutil.Bytes       `json:"logsBloom"     gencodec:"required"`
-		Random        common.Hash         `json:"prevRandao"    gencodec:"required"`
-		Number        hexutil.Uint64      `json:"blockNumber"   gencodec:"required"`
-		GasLimit      hexutil.Uint64      `json:"gasLimit"      gencodec:"required"`
-		GasUsed       hexutil.Uint64      `json:"gasUsed"       gencodec:"required"`
-		Timestamp     hexutil.Uint64      `json:"timestamp"     gencodec:"required"`
-		ExtraData     hexutil.Bytes       `json:"extraData"     gencodec:"required"`
-		BaseFeePerGas *hexutil.Big        `json:"baseFeePerGas" gencodec:"required"`
-		BlockHash     common.Hash         `json:"blockHash"     gencodec:"required"`
-		Transactions  []hexutil.Bytes     `json:"transactions"  gencodec:"required"`
-		Withdrawals   []*types.Withdrawal `json:"withdrawals"`
-		BlobGasUsed   *hexutil.Uint64     `json:"blobGasUsed"`
-		ExcessBlobGas *hexutil.Uint64     `json:"excessBlobGas"`
+		ParentHash       common.Hash             `json:"parentHash"    gencodec:"required"`
+		FeeRecipient     common.Address          `json:"feeRecipient"  gencodec:"required"`
+		StateRoot        common.Hash             `json:"stateRoot"     gencodec:"required"`
+		ReceiptsRoot     common.Hash             `json:"receiptsRoot"  gencodec:"required"`
+		LogsBloom        hexutil.Bytes           `json:"logsBloom"     gencodec:"required"`
+		Random           common.Hash             `json:"prevRandao"    gencodec:"required"`
+		Number           hexutil.Uint64          `json:"blockNumber"   gencodec:"required"`
+		GasLimit         hexutil.Uint64          `json:"gasLimit"      gencodec:"required"`
+		GasUsed          hexutil.Uint64          `json:"gasUsed"       gencodec:"required"`
+		Timestamp        hexutil.Uint64          `json:"timestamp"     gencodec:"required"`
+		ExtraData        hexutil.Bytes           `json:"extraData"     gencodec:"required"`
+		BaseFeePerGas    *hexutil.Big            `json:"baseFeePerGas" gencodec:"required"`
+		BlockHash        common.Hash             `json:"blockHash"     gencodec:"required"`
+		Transactions     []hexutil.Bytes         `json:"transactions"  gencodec:"required"`
+		Withdrawals      []*types.Withdrawal     `json:"withdrawals"`
+		BlobGasUsed      *hexutil.Uint64         `json:"blobGasUsed"`
+		ExcessBlobGas    *hexutil.Uint64         `json:"excessBlobGas"`
+		ExecutionWitness *types.ExecutionWitness `json:"executionWitness,omitempty"`
 	}
 	var enc ExecutableData
 	enc.ParentHash = e.ParentHash
@@ -58,29 +59,31 @@ func (e ExecutableData) MarshalJSON() ([]byte, error) {
 	enc.Withdrawals = e.Withdrawals
 	enc.BlobGasUsed = (*hexutil.Uint64)(e.BlobGasUsed)
 	enc.ExcessBlobGas = (*hexutil.Uint64)(e.ExcessBlobGas)
+	enc.ExecutionWitness = e.ExecutionWitness
 	return json.Marshal(&enc)
 }
 
 // UnmarshalJSON unmarshals from JSON.
 func (e *ExecutableData) UnmarshalJSON(input []byte) error {
 	type ExecutableData struct {
-		ParentHash    *common.Hash        `json:"parentHash"    gencodec:"required"`
-		FeeRecipient  *common.Address     `json:"feeRecipient"  gencodec:"required"`
-		StateRoot     *common.Hash        `json:"stateRoot"     gencodec:"required"`
-		ReceiptsRoot  *common.Hash        `json:"receiptsRoot"  gencodec:"required"`
-		LogsBloom     *hexutil.Bytes      `json:"logsBloom"     gencodec:"required"`
-		Random        *common.Hash        `json:"prevRandao"    gencodec:"required"`
-		Number        *hexutil.Uint64     `json:"blockNumber"   gencodec:"required"`
-		GasLimit      *hexutil.Uint64     `json:"gasLimit"      gencodec:"required"`
-		GasUsed       *hexutil.Uint64     `json:"gasUsed"       gencodec:"required"`
-		Timestamp     *hexutil.Uint64     `json:"timestamp"     gencodec:"required"`
-		ExtraData     *hexutil.Bytes      `json:"extraData"     gencodec:"required"`
-		BaseFeePerGas *hexutil.Big        `json:"baseFeePerGas" gencodec:"required"`
-		BlockHash     *common.Hash        `json:"blockHash"     gencodec:"required"`
-		Transactions  []hexutil.Bytes     `json:"transactions"  gencodec:"required"`
-		Withdrawals   []*types.Withdrawal `json:"withdrawals"`
-		BlobGasUsed   *hexutil.Uint64     `json:"blobGasUsed"`
-		ExcessBlobGas *hexutil.Uint64     `json:"excessBlobGas"`
+		ParentHash       *common.Hash            `json:"parentHash"    gencodec:"required"`
+		FeeRecipient     *common.Address         `json:"feeRecipient"  gencodec:"required"`
+		StateRoot        *common.Hash            `json:"stateRoot"     gencodec:"required"`
+		ReceiptsRoot     *common.Hash            `json:"receiptsRoot"  gencodec:"required"`
+		LogsBloom        *hexutil.Bytes          `json:"logsBloom"     gencodec:"required"`
+		Random           *common.Hash            `json:"prevRandao"    gencodec:"required"`
+		Number           *hexutil.Uint64         `json:"blockNumber"   gencodec:"required"`
+		GasLimit         *hexutil.Uint64         `json:"gasLimit"      gencodec:"required"`
+		GasUsed          *hexutil.Uint64         `json:"gasUsed"       gencodec:"required"`
+		Timestamp        *hexutil.Uint64         `json:"timestamp"     gencodec:"required"`
+		ExtraData        *hexutil.Bytes          `json:"extraData"     gencodec:"required"`
+		BaseFeePerGas    *hexutil.Big            `json:"baseFeePerGas" gencodec:"required"`
+		BlockHash        *common.Hash            `json:"blockHash"     gencodec:"required"`
+		Transactions     []hexutil.Bytes         `json:"transactions"  gencodec:"required"`
+		Withdrawals      []*types.Withdrawal     `json:"withdrawals"`
+		BlobGasUsed      *hexutil.Uint64         `json:"blobGasUsed"`
+		ExcessBlobGas    *hexutil.Uint64         `json:"excessBlobGas"`
+		ExecutionWitness *types.ExecutionWitness `json:"executionWitness,omitempty"`
 	}
 	var dec ExecutableData
 	if err := json.Unmarshal(input, &dec); err != nil {
@@ -153,6 +156,9 @@ func (e *ExecutableData) UnmarshalJSON(input []byte) error {
 	}
 	if dec.ExcessBlobGas != nil {
 		e.ExcessBlobGas = (*uint64)(dec.ExcessBlobGas)
+	}
+	if dec.ExecutionWitness != nil {
+		e.ExecutionWitness = dec.ExecutionWitness
 	}
 	return nil
 }

--- a/beacon/engine/types.go
+++ b/beacon/engine/types.go
@@ -59,23 +59,24 @@ type payloadAttributesMarshaling struct {
 
 // ExecutableData is the data necessary to execute an EL payload.
 type ExecutableData struct {
-	ParentHash    common.Hash         `json:"parentHash"    gencodec:"required"`
-	FeeRecipient  common.Address      `json:"feeRecipient"  gencodec:"required"`
-	StateRoot     common.Hash         `json:"stateRoot"     gencodec:"required"`
-	ReceiptsRoot  common.Hash         `json:"receiptsRoot"  gencodec:"required"`
-	LogsBloom     []byte              `json:"logsBloom"     gencodec:"required"`
-	Random        common.Hash         `json:"prevRandao"    gencodec:"required"`
-	Number        uint64              `json:"blockNumber"   gencodec:"required"`
-	GasLimit      uint64              `json:"gasLimit"      gencodec:"required"`
-	GasUsed       uint64              `json:"gasUsed"       gencodec:"required"`
-	Timestamp     uint64              `json:"timestamp"     gencodec:"required"`
-	ExtraData     []byte              `json:"extraData"     gencodec:"required"`
-	BaseFeePerGas *big.Int            `json:"baseFeePerGas" gencodec:"required"`
-	BlockHash     common.Hash         `json:"blockHash"     gencodec:"required"`
-	Transactions  [][]byte            `json:"transactions"  gencodec:"required"`
-	Withdrawals   []*types.Withdrawal `json:"withdrawals"`
-	BlobGasUsed   *uint64             `json:"blobGasUsed"`
-	ExcessBlobGas *uint64             `json:"excessBlobGas"`
+	ParentHash       common.Hash             `json:"parentHash"    gencodec:"required"`
+	FeeRecipient     common.Address          `json:"feeRecipient"  gencodec:"required"`
+	StateRoot        common.Hash             `json:"stateRoot"     gencodec:"required"`
+	ReceiptsRoot     common.Hash             `json:"receiptsRoot"  gencodec:"required"`
+	LogsBloom        []byte                  `json:"logsBloom"     gencodec:"required"`
+	Random           common.Hash             `json:"prevRandao"    gencodec:"required"`
+	Number           uint64                  `json:"blockNumber"   gencodec:"required"`
+	GasLimit         uint64                  `json:"gasLimit"      gencodec:"required"`
+	GasUsed          uint64                  `json:"gasUsed"       gencodec:"required"`
+	Timestamp        uint64                  `json:"timestamp"     gencodec:"required"`
+	ExtraData        []byte                  `json:"extraData"     gencodec:"required"`
+	BaseFeePerGas    *big.Int                `json:"baseFeePerGas" gencodec:"required"`
+	BlockHash        common.Hash             `json:"blockHash"     gencodec:"required"`
+	Transactions     [][]byte                `json:"transactions"  gencodec:"required"`
+	Withdrawals      []*types.Withdrawal     `json:"withdrawals"`
+	BlobGasUsed      *uint64                 `json:"blobGasUsed"`
+	ExcessBlobGas    *uint64                 `json:"excessBlobGas"`
+	ExecutionWitness *types.ExecutionWitness `json:"executionWitness,omitempty"`
 }
 
 // JSON type overrides for executableData.
@@ -250,6 +251,7 @@ func ExecutableDataToBlock(data ExecutableData, versionedHashes []common.Hash, b
 		ExcessBlobGas:    data.ExcessBlobGas,
 		BlobGasUsed:      data.BlobGasUsed,
 		ParentBeaconRoot: beaconRoot,
+		ExecutionWitness: params.ExecutionWitness,
 	}
 	block := types.NewBlockWithHeader(header).WithBody(types.Body{Transactions: txs, Uncles: nil, Withdrawals: data.Withdrawals})
 	if block.Hash() != data.BlockHash {
@@ -262,23 +264,24 @@ func ExecutableDataToBlock(data ExecutableData, versionedHashes []common.Hash, b
 // fields from the given block. It assumes the given block is post-merge block.
 func BlockToExecutableData(block *types.Block, fees *big.Int, sidecars []*types.BlobTxSidecar) *ExecutionPayloadEnvelope {
 	data := &ExecutableData{
-		BlockHash:     block.Hash(),
-		ParentHash:    block.ParentHash(),
-		FeeRecipient:  block.Coinbase(),
-		StateRoot:     block.Root(),
-		Number:        block.NumberU64(),
-		GasLimit:      block.GasLimit(),
-		GasUsed:       block.GasUsed(),
-		BaseFeePerGas: block.BaseFee(),
-		Timestamp:     block.Time(),
-		ReceiptsRoot:  block.ReceiptHash(),
-		LogsBloom:     block.Bloom().Bytes(),
-		Transactions:  encodeTransactions(block.Transactions()),
-		Random:        block.MixDigest(),
-		ExtraData:     block.Extra(),
-		Withdrawals:   block.Withdrawals(),
-		BlobGasUsed:   block.BlobGasUsed(),
-		ExcessBlobGas: block.ExcessBlobGas(),
+		BlockHash:        block.Hash(),
+		ParentHash:       block.ParentHash(),
+		FeeRecipient:     block.Coinbase(),
+		StateRoot:        block.Root(),
+		Number:           block.NumberU64(),
+		GasLimit:         block.GasLimit(),
+		GasUsed:          block.GasUsed(),
+		BaseFeePerGas:    block.BaseFee(),
+		Timestamp:        block.Time(),
+		ReceiptsRoot:     block.ReceiptHash(),
+		LogsBloom:        block.Bloom().Bytes(),
+		Transactions:     encodeTransactions(block.Transactions()),
+		Random:           block.MixDigest(),
+		ExtraData:        block.Extra(),
+		Withdrawals:      block.Withdrawals(),
+		BlobGasUsed:      block.BlobGasUsed(),
+		ExcessBlobGas:    block.ExcessBlobGas(),
+		ExecutionWitness: block.ExecutionWitness(),
 	}
 	bundle := BlobsBundleV1{
 		Commitments: make([]hexutil.Bytes, 0),

--- a/beacon/engine/types.go
+++ b/beacon/engine/types.go
@@ -251,9 +251,8 @@ func ExecutableDataToBlock(data ExecutableData, versionedHashes []common.Hash, b
 		ExcessBlobGas:    data.ExcessBlobGas,
 		BlobGasUsed:      data.BlobGasUsed,
 		ParentBeaconRoot: beaconRoot,
-		ExecutionWitness: params.ExecutionWitness,
 	}
-	block := types.NewBlockWithHeader(header).WithBody(types.Body{Transactions: txs, Uncles: nil, Withdrawals: data.Withdrawals})
+	block := types.NewBlockWithHeader(header).WithBody(types.Body{Transactions: txs, Uncles: nil, Withdrawals: data.Withdrawals, Witness: data.ExecutionWitness})
 	if block.Hash() != data.BlockHash {
 		return nil, fmt.Errorf("blockhash mismatch, want %x, got %x", data.BlockHash, block.Hash())
 	}

--- a/beacon/engine/types.go
+++ b/beacon/engine/types.go
@@ -252,7 +252,9 @@ func ExecutableDataToBlock(data ExecutableData, versionedHashes []common.Hash, b
 		BlobGasUsed:      data.BlobGasUsed,
 		ParentBeaconRoot: beaconRoot,
 	}
-	block := types.NewBlockWithHeader(header).WithBody(types.Body{Transactions: txs, Uncles: nil, Withdrawals: data.Withdrawals, Witness: data.ExecutionWitness})
+	block := types.NewBlockWithHeader(header)
+	block = block.WithBody(types.Body{Transactions: txs, Uncles: nil, Withdrawals: data.Withdrawals})
+	block = block.WithWitness(data.ExecutionWitness)
 	if block.Hash() != data.BlockHash {
 		return nil, fmt.Errorf("blockhash mismatch, want %x, got %x", data.BlockHash, block.Hash())
 	}

--- a/consensus/beacon/consensus.go
+++ b/consensus/beacon/consensus.go
@@ -408,7 +408,7 @@ func (beacon *Beacon) FinalizeAndAssemble(chain consensus.ChainHeaderReader, hea
 		vtrpost, okpost := state.GetTrie().(*trie.VerkleTrie)
 		if okpre && okpost {
 			if len(keys) > 0 {
-				p, k, err := trie.ProveAndSerialize(vtrpre, vtrpost, keys, vtrpre.FlatdbNodeResolver)
+				p, k, err := vtrpre.Proof(vtrpost, keys, vtrpre.FlatdbNodeResolver)
 				if err != nil {
 					return nil, fmt.Errorf("error generating verkle proof for block %d: %w", header.Number, err)
 				}

--- a/consensus/beacon/consensus.go
+++ b/consensus/beacon/consensus.go
@@ -404,15 +404,15 @@ func (beacon *Beacon) FinalizeAndAssemble(chain consensus.ChainHeaderReader, hea
 			return nil, fmt.Errorf("error opening pre-state tree root: %w", err)
 		}
 
-		vtrpre, okpre := preTrie.(*trie.VerkleTrie)
-		vtrpost, okpost := state.GetTrie().(*trie.VerkleTrie)
+		vktPreTrie, okpre := preTrie.(*trie.VerkleTrie)
+		vktPostTrie, okpost := state.GetTrie().(*trie.VerkleTrie)
 		if okpre && okpost {
 			if len(keys) > 0 {
-				p, k, err := vtrpre.Proof(vtrpost, keys, vtrpre.FlatdbNodeResolver)
+				verkleProof, stateDiff, err := vktPreTrie.Proof(vktPostTrie, keys, vktPreTrie.FlatdbNodeResolver)
 				if err != nil {
 					return nil, fmt.Errorf("error generating verkle proof for block %d: %w", header.Number, err)
 				}
-				block.SetVerkleProof(p, k)
+				return block.WithWitness(&types.ExecutionWitness{StateDiff: stateDiff, VerkleProof: verkleProof}), nil
 			}
 		}
 	}

--- a/core/chain_makers.go
+++ b/core/chain_makers.go
@@ -467,9 +467,8 @@ func GenerateVerkleChain(config *params.ChainConfig, parent *types.Block, engine
 			panic(fmt.Sprintf("trie write error: %v", err))
 		}
 
-		// TODO uncomment when proof generation is merged
-		// proofs = append(proofs, block.ExecutionWitness().VerkleProof)
-		// keyvals = append(keyvals, block.ExecutionWitness().StateDiff)
+		proofs = append(proofs, block.ExecutionWitness().VerkleProof)
+		keyvals = append(keyvals, block.ExecutionWitness().StateDiff)
 
 		return block, b.receipts
 	}

--- a/core/state/statedb.go
+++ b/core/state/statedb.go
@@ -713,6 +713,9 @@ func (s *StateDB) Copy() *StateDB {
 	if s.witness != nil {
 		state.witness = s.witness.Copy()
 	}
+	if s.accessEvents != nil {
+		state.accessEvents = s.accessEvents.Copy()
+	}
 	// Deep copy cached state objects.
 	for addr, obj := range s.stateObjects {
 		state.stateObjects[addr] = obj.deepCopy(state)
@@ -1466,8 +1469,5 @@ func (s *StateDB) NewAccessEvents() *AccessEvents {
 }
 
 func (s *StateDB) AccessEvents() *AccessEvents {
-	if s.accessEvents == nil {
-		s.accessEvents = s.NewAccessEvents()
-	}
 	return s.accessEvents
 }

--- a/core/state/statedb.go
+++ b/core/state/statedb.go
@@ -186,7 +186,7 @@ func New(root common.Hash, db Database, snaps *snapshot.Tree) (*StateDB, error) 
 		hasher:               crypto.NewKeccakState(),
 	}
 	if db.TrieDB().IsVerkle() {
-		sdb.accessEvents = sdb.NewAccessEvents()
+		sdb.accessEvents = NewAccessEvents(db.(*cachingDB).pointCache)
 	}
 	if sdb.snaps != nil {
 		sdb.snap = sdb.snaps.Snapshot(root)
@@ -1458,14 +1458,6 @@ func (s *StateDB) PointCache() *utils.PointCache {
 // Witness retrieves the current state witness being collected.
 func (s *StateDB) Witness() *stateless.Witness {
 	return s.witness
-}
-
-func (s *StateDB) NewAccessEvents() *AccessEvents {
-	return &AccessEvents{
-		branches:   make(map[branchAccessKey]mode),
-		chunks:     make(map[chunkAccessKey]mode),
-		pointCache: utils.NewPointCache(100),
-	}
 }
 
 func (s *StateDB) AccessEvents() *AccessEvents {

--- a/core/state_processor.go
+++ b/core/state_processor.go
@@ -155,7 +155,9 @@ func ApplyTransactionWithEVM(msg *Message, config *params.ChainConfig, gp *GasPo
 
 	// Merge the tx-local access event into the "block-local" one, in order to collect
 	// all values, so that the witness can be built.
-	statedb.AccessEvents().Merge(evm.AccessEvents)
+	if statedb.GetTrie().IsVerkle() {
+		statedb.AccessEvents().Merge(evm.AccessEvents)
+	}
 
 	// Set the receipt logs and create the bloom filter.
 	receipt.Logs = statedb.GetLogs(tx.Hash(), blockNumber.Uint64(), blockHash)

--- a/core/state_processor.go
+++ b/core/state_processor.go
@@ -153,6 +153,10 @@ func ApplyTransactionWithEVM(msg *Message, config *params.ChainConfig, gp *GasPo
 		receipt.ContractAddress = crypto.CreateAddress(evm.TxContext.Origin, tx.Nonce())
 	}
 
+	// Merge the tx-local access event into the "block-local" one, in order to collect
+	// all values, so that the witness can be built.
+	statedb.AccessEvents().Merge(evm.AccessEvents)
+
 	// Set the receipt logs and create the bloom filter.
 	receipt.Logs = statedb.GetLogs(tx.Hash(), blockNumber.Uint64(), blockHash)
 	receipt.Bloom = types.CreateBloom(types.Receipts{receipt})

--- a/core/state_processor_test.go
+++ b/core/state_processor_test.go
@@ -38,6 +38,7 @@ import (
 	"github.com/ethereum/go-ethereum/params"
 	"github.com/ethereum/go-ethereum/trie"
 	"github.com/ethereum/go-ethereum/triedb"
+	"github.com/ethereum/go-verkle"
 	"github.com/holiman/uint256"
 	"golang.org/x/crypto/sha3"
 )
@@ -491,7 +492,7 @@ func TestProcessVerkle(t *testing.T) {
 		txCost1*2 + txCost2,
 		txCost1*2 + txCost2 + contractCreationCost + codeWithExtCodeCopyGas,
 	}
-	_, chain, _, _, _ := GenerateVerkleChainWithGenesis(gspec, beacon.New(ethash.NewFaker()), 2, func(i int, gen *BlockGen) {
+	_, chain, _, proofs, statediffs := GenerateVerkleChainWithGenesis(gspec, beacon.New(ethash.NewFaker()), 2, func(i int, gen *BlockGen) {
 		gen.SetPoS()
 
 		// TODO need to check that the tx cost provided is the exact amount used (no remaining left-over)
@@ -512,7 +513,12 @@ func TestProcessVerkle(t *testing.T) {
 		}
 	})
 
-	t.Log("inserting blocks into the chain")
+	err := verkle.Verify(proofs[1], chain[0].Root().Bytes(), chain[1].Root().Bytes(), statediffs[1])
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	t.Log("verified verkle proof, inserting blocks into the chain")
 
 	endnum, err := blockchain.InsertChain(chain)
 	if err != nil {

--- a/core/state_processor_test.go
+++ b/core/state_processor_test.go
@@ -513,7 +513,12 @@ func TestProcessVerkle(t *testing.T) {
 		}
 	})
 
-	err := verkle.Verify(proofs[1], chain[0].Root().Bytes(), chain[1].Root().Bytes(), statediffs[1])
+	// Check proof for both blocks
+	err := verkle.Verify(proofs[0], gspec.ToBlock().Root().Bytes(), chain[0].Root().Bytes(), statediffs[0])
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = verkle.Verify(proofs[1], chain[0].Root().Bytes(), chain[1].Root().Bytes(), statediffs[1])
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/core/types/block.go
+++ b/core/types/block.go
@@ -179,8 +179,7 @@ func (h *Header) EmptyReceipts() bool {
 type Body struct {
 	Transactions []*Transaction
 	Uncles       []*Header
-	Withdrawals  []*Withdrawal     `rlp:"optional"`
-	Witness      *ExecutionWitness `rlp:"-"`
+	Withdrawals  []*Withdrawal `rlp:"optional"`
 }
 
 // Block represents an Ethereum block.
@@ -341,7 +340,7 @@ func (b *Block) EncodeRLP(w io.Writer) error {
 // Body returns the non-header content of the block.
 // Note the returned data is not an independent copy.
 func (b *Block) Body() *Body {
-	return &Body{b.transactions, b.uncles, b.withdrawals, b.witness}
+	return &Body{b.transactions, b.uncles, b.withdrawals}
 }
 
 // Accessors for body data. These do not return a copy because the content
@@ -473,10 +472,24 @@ func (b *Block) WithBody(body Body) *Block {
 		transactions: slices.Clone(body.Transactions),
 		uncles:       make([]*Header, len(body.Uncles)),
 		withdrawals:  slices.Clone(body.Withdrawals),
-		witness:      body.Witness,
 	}
 	for i := range body.Uncles {
 		block.uncles[i] = CopyHeader(body.Uncles[i])
+	}
+	return block
+}
+
+func (b *Block) WithWitness(witness *ExecutionWitness) *Block {
+
+	block := &Block{
+		header:       b.header,
+		transactions: slices.Clone(b.transactions),
+		uncles:       make([]*Header, len(b.uncles)),
+		withdrawals:  slices.Clone(b.withdrawals),
+		witness:      witness,
+	}
+	for i := range b.uncles {
+		block.uncles[i] = CopyHeader(b.uncles[i])
 	}
 	return block
 }

--- a/core/types/block.go
+++ b/core/types/block.go
@@ -483,13 +483,13 @@ func (b *Block) WithWitness(witness *ExecutionWitness) *Block {
 
 	block := &Block{
 		header:       b.header,
-		transactions: slices.Clone(b.transactions),
+		transactions: b.transactions,
 		uncles:       make([]*Header, len(b.uncles)),
-		withdrawals:  slices.Clone(b.withdrawals),
+		withdrawals:  b.withdrawals,
 		witness:      witness,
 	}
 	for i := range b.uncles {
-		block.uncles[i] = CopyHeader(b.uncles[i])
+		block.uncles[i] = b.uncles[i]
 	}
 	return block
 }

--- a/core/types/block.go
+++ b/core/types/block.go
@@ -505,19 +505,6 @@ func (b *Block) Hash() common.Hash {
 	return h
 }
 
-// SetVerkleProof attaches an execution witness + proof to the block in a verkle context.
-func (b *Block) SetVerkleProof(vp *verkle.VerkleProof, statediff verkle.StateDiff) {
-	b.witness = &ExecutionWitness{statediff, vp}
-	if statediff == nil {
-		b.witness.StateDiff = []verkle.StemStateDiff{}
-	}
-	if vp == nil {
-		b.witness.VerkleProof = &verkle.VerkleProof{
-			IPAProof: &verkle.IPAProof{},
-		}
-	}
-}
-
 type Blocks []*Block
 
 // HeaderParentHashFromRLP returns the parentHash of an RLP-encoded

--- a/core/types/block.go
+++ b/core/types/block.go
@@ -205,6 +205,9 @@ type Block struct {
 	transactions Transactions
 	withdrawals  Withdrawals
 
+	// witness is not an encoded part of the block body.
+	// It is held in Block in order for easy relaying to the places
+	// that process it.
 	witness *ExecutionWitness
 
 	// caches
@@ -461,6 +464,7 @@ func (b *Block) WithSeal(header *Header) *Block {
 		transactions: b.transactions,
 		uncles:       b.uncles,
 		withdrawals:  b.withdrawals,
+		witness:      b.witness,
 	}
 }
 
@@ -472,6 +476,7 @@ func (b *Block) WithBody(body Body) *Block {
 		transactions: slices.Clone(body.Transactions),
 		uncles:       make([]*Header, len(body.Uncles)),
 		withdrawals:  slices.Clone(body.Withdrawals),
+		witness:      b.witness,
 	}
 	for i := range body.Uncles {
 		block.uncles[i] = CopyHeader(body.Uncles[i])
@@ -480,18 +485,13 @@ func (b *Block) WithBody(body Body) *Block {
 }
 
 func (b *Block) WithWitness(witness *ExecutionWitness) *Block {
-
-	block := &Block{
+	return &Block{
 		header:       b.header,
 		transactions: b.transactions,
-		uncles:       make([]*Header, len(b.uncles)),
+		uncles:       b.uncles,
 		withdrawals:  b.withdrawals,
 		witness:      witness,
 	}
-	for i := range b.uncles {
-		block.uncles[i] = b.uncles[i]
-	}
-	return block
 }
 
 // Hash returns the keccak256 hash of b's header.

--- a/core/types/gen_header_json.go
+++ b/core/types/gen_header_json.go
@@ -16,28 +16,27 @@ var _ = (*headerMarshaling)(nil)
 // MarshalJSON marshals as JSON.
 func (h Header) MarshalJSON() ([]byte, error) {
 	type Header struct {
-		ParentHash       common.Hash       `json:"parentHash"       gencodec:"required"`
-		UncleHash        common.Hash       `json:"sha3Uncles"       gencodec:"required"`
-		Coinbase         common.Address    `json:"miner"`
-		Root             common.Hash       `json:"stateRoot"        gencodec:"required"`
-		TxHash           common.Hash       `json:"transactionsRoot" gencodec:"required"`
-		ReceiptHash      common.Hash       `json:"receiptsRoot"     gencodec:"required"`
-		Bloom            Bloom             `json:"logsBloom"        gencodec:"required"`
-		Difficulty       *hexutil.Big      `json:"difficulty"       gencodec:"required"`
-		Number           *hexutil.Big      `json:"number"           gencodec:"required"`
-		GasLimit         hexutil.Uint64    `json:"gasLimit"         gencodec:"required"`
-		GasUsed          hexutil.Uint64    `json:"gasUsed"          gencodec:"required"`
-		Time             hexutil.Uint64    `json:"timestamp"        gencodec:"required"`
-		Extra            hexutil.Bytes     `json:"extraData"        gencodec:"required"`
-		MixDigest        common.Hash       `json:"mixHash"`
-		Nonce            BlockNonce        `json:"nonce"`
-		BaseFee          *hexutil.Big      `json:"baseFeePerGas" rlp:"optional"`
-		WithdrawalsHash  *common.Hash      `json:"withdrawalsRoot" rlp:"optional"`
-		BlobGasUsed      *hexutil.Uint64   `json:"blobGasUsed" rlp:"optional"`
-		ExcessBlobGas    *hexutil.Uint64   `json:"excessBlobGas" rlp:"optional"`
-		ParentBeaconRoot *common.Hash      `json:"parentBeaconBlockRoot" rlp:"optional"`
-		ExecutionWitness *ExecutionWitness `json:"executionWitness,omitempty" rlp:"-"`
-		Hash             common.Hash       `json:"hash"`
+		ParentHash       common.Hash     `json:"parentHash"       gencodec:"required"`
+		UncleHash        common.Hash     `json:"sha3Uncles"       gencodec:"required"`
+		Coinbase         common.Address  `json:"miner"`
+		Root             common.Hash     `json:"stateRoot"        gencodec:"required"`
+		TxHash           common.Hash     `json:"transactionsRoot" gencodec:"required"`
+		ReceiptHash      common.Hash     `json:"receiptsRoot"     gencodec:"required"`
+		Bloom            Bloom           `json:"logsBloom"        gencodec:"required"`
+		Difficulty       *hexutil.Big    `json:"difficulty"       gencodec:"required"`
+		Number           *hexutil.Big    `json:"number"           gencodec:"required"`
+		GasLimit         hexutil.Uint64  `json:"gasLimit"         gencodec:"required"`
+		GasUsed          hexutil.Uint64  `json:"gasUsed"          gencodec:"required"`
+		Time             hexutil.Uint64  `json:"timestamp"        gencodec:"required"`
+		Extra            hexutil.Bytes   `json:"extraData"        gencodec:"required"`
+		MixDigest        common.Hash     `json:"mixHash"`
+		Nonce            BlockNonce      `json:"nonce"`
+		BaseFee          *hexutil.Big    `json:"baseFeePerGas" rlp:"optional"`
+		WithdrawalsHash  *common.Hash    `json:"withdrawalsRoot" rlp:"optional"`
+		BlobGasUsed      *hexutil.Uint64 `json:"blobGasUsed" rlp:"optional"`
+		ExcessBlobGas    *hexutil.Uint64 `json:"excessBlobGas" rlp:"optional"`
+		ParentBeaconRoot *common.Hash    `json:"parentBeaconBlockRoot" rlp:"optional"`
+		Hash             common.Hash     `json:"hash"`
 	}
 	var enc Header
 	enc.ParentHash = h.ParentHash
@@ -60,7 +59,6 @@ func (h Header) MarshalJSON() ([]byte, error) {
 	enc.BlobGasUsed = (*hexutil.Uint64)(h.BlobGasUsed)
 	enc.ExcessBlobGas = (*hexutil.Uint64)(h.ExcessBlobGas)
 	enc.ParentBeaconRoot = h.ParentBeaconRoot
-	enc.ExecutionWitness = h.ExecutionWitness
 	enc.Hash = h.Hash()
 	return json.Marshal(&enc)
 }
@@ -68,27 +66,26 @@ func (h Header) MarshalJSON() ([]byte, error) {
 // UnmarshalJSON unmarshals from JSON.
 func (h *Header) UnmarshalJSON(input []byte) error {
 	type Header struct {
-		ParentHash       *common.Hash      `json:"parentHash"       gencodec:"required"`
-		UncleHash        *common.Hash      `json:"sha3Uncles"       gencodec:"required"`
-		Coinbase         *common.Address   `json:"miner"`
-		Root             *common.Hash      `json:"stateRoot"        gencodec:"required"`
-		TxHash           *common.Hash      `json:"transactionsRoot" gencodec:"required"`
-		ReceiptHash      *common.Hash      `json:"receiptsRoot"     gencodec:"required"`
-		Bloom            *Bloom            `json:"logsBloom"        gencodec:"required"`
-		Difficulty       *hexutil.Big      `json:"difficulty"       gencodec:"required"`
-		Number           *hexutil.Big      `json:"number"           gencodec:"required"`
-		GasLimit         *hexutil.Uint64   `json:"gasLimit"         gencodec:"required"`
-		GasUsed          *hexutil.Uint64   `json:"gasUsed"          gencodec:"required"`
-		Time             *hexutil.Uint64   `json:"timestamp"        gencodec:"required"`
-		Extra            *hexutil.Bytes    `json:"extraData"        gencodec:"required"`
-		MixDigest        *common.Hash      `json:"mixHash"`
-		Nonce            *BlockNonce       `json:"nonce"`
-		BaseFee          *hexutil.Big      `json:"baseFeePerGas" rlp:"optional"`
-		WithdrawalsHash  *common.Hash      `json:"withdrawalsRoot" rlp:"optional"`
-		BlobGasUsed      *hexutil.Uint64   `json:"blobGasUsed" rlp:"optional"`
-		ExcessBlobGas    *hexutil.Uint64   `json:"excessBlobGas" rlp:"optional"`
-		ParentBeaconRoot *common.Hash      `json:"parentBeaconBlockRoot" rlp:"optional"`
-		ExecutionWitness *ExecutionWitness `json:"executionWitness,omitempty" rlp:"-"`
+		ParentHash       *common.Hash    `json:"parentHash"       gencodec:"required"`
+		UncleHash        *common.Hash    `json:"sha3Uncles"       gencodec:"required"`
+		Coinbase         *common.Address `json:"miner"`
+		Root             *common.Hash    `json:"stateRoot"        gencodec:"required"`
+		TxHash           *common.Hash    `json:"transactionsRoot" gencodec:"required"`
+		ReceiptHash      *common.Hash    `json:"receiptsRoot"     gencodec:"required"`
+		Bloom            *Bloom          `json:"logsBloom"        gencodec:"required"`
+		Difficulty       *hexutil.Big    `json:"difficulty"       gencodec:"required"`
+		Number           *hexutil.Big    `json:"number"           gencodec:"required"`
+		GasLimit         *hexutil.Uint64 `json:"gasLimit"         gencodec:"required"`
+		GasUsed          *hexutil.Uint64 `json:"gasUsed"          gencodec:"required"`
+		Time             *hexutil.Uint64 `json:"timestamp"        gencodec:"required"`
+		Extra            *hexutil.Bytes  `json:"extraData"        gencodec:"required"`
+		MixDigest        *common.Hash    `json:"mixHash"`
+		Nonce            *BlockNonce     `json:"nonce"`
+		BaseFee          *hexutil.Big    `json:"baseFeePerGas" rlp:"optional"`
+		WithdrawalsHash  *common.Hash    `json:"withdrawalsRoot" rlp:"optional"`
+		BlobGasUsed      *hexutil.Uint64 `json:"blobGasUsed" rlp:"optional"`
+		ExcessBlobGas    *hexutil.Uint64 `json:"excessBlobGas" rlp:"optional"`
+		ParentBeaconRoot *common.Hash    `json:"parentBeaconBlockRoot" rlp:"optional"`
 	}
 	var dec Header
 	if err := json.Unmarshal(input, &dec); err != nil {
@@ -165,9 +162,6 @@ func (h *Header) UnmarshalJSON(input []byte) error {
 	}
 	if dec.ParentBeaconRoot != nil {
 		h.ParentBeaconRoot = dec.ParentBeaconRoot
-	}
-	if dec.ExecutionWitness != nil {
-		h.ExecutionWitness = dec.ExecutionWitness
 	}
 	return nil
 }

--- a/core/types/gen_header_json.go
+++ b/core/types/gen_header_json.go
@@ -16,27 +16,28 @@ var _ = (*headerMarshaling)(nil)
 // MarshalJSON marshals as JSON.
 func (h Header) MarshalJSON() ([]byte, error) {
 	type Header struct {
-		ParentHash       common.Hash     `json:"parentHash"       gencodec:"required"`
-		UncleHash        common.Hash     `json:"sha3Uncles"       gencodec:"required"`
-		Coinbase         common.Address  `json:"miner"`
-		Root             common.Hash     `json:"stateRoot"        gencodec:"required"`
-		TxHash           common.Hash     `json:"transactionsRoot" gencodec:"required"`
-		ReceiptHash      common.Hash     `json:"receiptsRoot"     gencodec:"required"`
-		Bloom            Bloom           `json:"logsBloom"        gencodec:"required"`
-		Difficulty       *hexutil.Big    `json:"difficulty"       gencodec:"required"`
-		Number           *hexutil.Big    `json:"number"           gencodec:"required"`
-		GasLimit         hexutil.Uint64  `json:"gasLimit"         gencodec:"required"`
-		GasUsed          hexutil.Uint64  `json:"gasUsed"          gencodec:"required"`
-		Time             hexutil.Uint64  `json:"timestamp"        gencodec:"required"`
-		Extra            hexutil.Bytes   `json:"extraData"        gencodec:"required"`
-		MixDigest        common.Hash     `json:"mixHash"`
-		Nonce            BlockNonce      `json:"nonce"`
-		BaseFee          *hexutil.Big    `json:"baseFeePerGas" rlp:"optional"`
-		WithdrawalsHash  *common.Hash    `json:"withdrawalsRoot" rlp:"optional"`
-		BlobGasUsed      *hexutil.Uint64 `json:"blobGasUsed" rlp:"optional"`
-		ExcessBlobGas    *hexutil.Uint64 `json:"excessBlobGas" rlp:"optional"`
-		ParentBeaconRoot *common.Hash    `json:"parentBeaconBlockRoot" rlp:"optional"`
-		Hash             common.Hash     `json:"hash"`
+		ParentHash       common.Hash       `json:"parentHash"       gencodec:"required"`
+		UncleHash        common.Hash       `json:"sha3Uncles"       gencodec:"required"`
+		Coinbase         common.Address    `json:"miner"`
+		Root             common.Hash       `json:"stateRoot"        gencodec:"required"`
+		TxHash           common.Hash       `json:"transactionsRoot" gencodec:"required"`
+		ReceiptHash      common.Hash       `json:"receiptsRoot"     gencodec:"required"`
+		Bloom            Bloom             `json:"logsBloom"        gencodec:"required"`
+		Difficulty       *hexutil.Big      `json:"difficulty"       gencodec:"required"`
+		Number           *hexutil.Big      `json:"number"           gencodec:"required"`
+		GasLimit         hexutil.Uint64    `json:"gasLimit"         gencodec:"required"`
+		GasUsed          hexutil.Uint64    `json:"gasUsed"          gencodec:"required"`
+		Time             hexutil.Uint64    `json:"timestamp"        gencodec:"required"`
+		Extra            hexutil.Bytes     `json:"extraData"        gencodec:"required"`
+		MixDigest        common.Hash       `json:"mixHash"`
+		Nonce            BlockNonce        `json:"nonce"`
+		BaseFee          *hexutil.Big      `json:"baseFeePerGas" rlp:"optional"`
+		WithdrawalsHash  *common.Hash      `json:"withdrawalsRoot" rlp:"optional"`
+		BlobGasUsed      *hexutil.Uint64   `json:"blobGasUsed" rlp:"optional"`
+		ExcessBlobGas    *hexutil.Uint64   `json:"excessBlobGas" rlp:"optional"`
+		ParentBeaconRoot *common.Hash      `json:"parentBeaconBlockRoot" rlp:"optional"`
+		ExecutionWitness *ExecutionWitness `json:"executionWitness,omitempty" rlp:"-"`
+		Hash             common.Hash       `json:"hash"`
 	}
 	var enc Header
 	enc.ParentHash = h.ParentHash
@@ -59,6 +60,7 @@ func (h Header) MarshalJSON() ([]byte, error) {
 	enc.BlobGasUsed = (*hexutil.Uint64)(h.BlobGasUsed)
 	enc.ExcessBlobGas = (*hexutil.Uint64)(h.ExcessBlobGas)
 	enc.ParentBeaconRoot = h.ParentBeaconRoot
+	enc.ExecutionWitness = h.ExecutionWitness
 	enc.Hash = h.Hash()
 	return json.Marshal(&enc)
 }
@@ -66,26 +68,27 @@ func (h Header) MarshalJSON() ([]byte, error) {
 // UnmarshalJSON unmarshals from JSON.
 func (h *Header) UnmarshalJSON(input []byte) error {
 	type Header struct {
-		ParentHash       *common.Hash    `json:"parentHash"       gencodec:"required"`
-		UncleHash        *common.Hash    `json:"sha3Uncles"       gencodec:"required"`
-		Coinbase         *common.Address `json:"miner"`
-		Root             *common.Hash    `json:"stateRoot"        gencodec:"required"`
-		TxHash           *common.Hash    `json:"transactionsRoot" gencodec:"required"`
-		ReceiptHash      *common.Hash    `json:"receiptsRoot"     gencodec:"required"`
-		Bloom            *Bloom          `json:"logsBloom"        gencodec:"required"`
-		Difficulty       *hexutil.Big    `json:"difficulty"       gencodec:"required"`
-		Number           *hexutil.Big    `json:"number"           gencodec:"required"`
-		GasLimit         *hexutil.Uint64 `json:"gasLimit"         gencodec:"required"`
-		GasUsed          *hexutil.Uint64 `json:"gasUsed"          gencodec:"required"`
-		Time             *hexutil.Uint64 `json:"timestamp"        gencodec:"required"`
-		Extra            *hexutil.Bytes  `json:"extraData"        gencodec:"required"`
-		MixDigest        *common.Hash    `json:"mixHash"`
-		Nonce            *BlockNonce     `json:"nonce"`
-		BaseFee          *hexutil.Big    `json:"baseFeePerGas" rlp:"optional"`
-		WithdrawalsHash  *common.Hash    `json:"withdrawalsRoot" rlp:"optional"`
-		BlobGasUsed      *hexutil.Uint64 `json:"blobGasUsed" rlp:"optional"`
-		ExcessBlobGas    *hexutil.Uint64 `json:"excessBlobGas" rlp:"optional"`
-		ParentBeaconRoot *common.Hash    `json:"parentBeaconBlockRoot" rlp:"optional"`
+		ParentHash       *common.Hash      `json:"parentHash"       gencodec:"required"`
+		UncleHash        *common.Hash      `json:"sha3Uncles"       gencodec:"required"`
+		Coinbase         *common.Address   `json:"miner"`
+		Root             *common.Hash      `json:"stateRoot"        gencodec:"required"`
+		TxHash           *common.Hash      `json:"transactionsRoot" gencodec:"required"`
+		ReceiptHash      *common.Hash      `json:"receiptsRoot"     gencodec:"required"`
+		Bloom            *Bloom            `json:"logsBloom"        gencodec:"required"`
+		Difficulty       *hexutil.Big      `json:"difficulty"       gencodec:"required"`
+		Number           *hexutil.Big      `json:"number"           gencodec:"required"`
+		GasLimit         *hexutil.Uint64   `json:"gasLimit"         gencodec:"required"`
+		GasUsed          *hexutil.Uint64   `json:"gasUsed"          gencodec:"required"`
+		Time             *hexutil.Uint64   `json:"timestamp"        gencodec:"required"`
+		Extra            *hexutil.Bytes    `json:"extraData"        gencodec:"required"`
+		MixDigest        *common.Hash      `json:"mixHash"`
+		Nonce            *BlockNonce       `json:"nonce"`
+		BaseFee          *hexutil.Big      `json:"baseFeePerGas" rlp:"optional"`
+		WithdrawalsHash  *common.Hash      `json:"withdrawalsRoot" rlp:"optional"`
+		BlobGasUsed      *hexutil.Uint64   `json:"blobGasUsed" rlp:"optional"`
+		ExcessBlobGas    *hexutil.Uint64   `json:"excessBlobGas" rlp:"optional"`
+		ParentBeaconRoot *common.Hash      `json:"parentBeaconBlockRoot" rlp:"optional"`
+		ExecutionWitness *ExecutionWitness `json:"executionWitness,omitempty" rlp:"-"`
 	}
 	var dec Header
 	if err := json.Unmarshal(input, &dec); err != nil {
@@ -162,6 +165,9 @@ func (h *Header) UnmarshalJSON(input []byte) error {
 	}
 	if dec.ParentBeaconRoot != nil {
 		h.ParentBeaconRoot = dec.ParentBeaconRoot
+	}
+	if dec.ExecutionWitness != nil {
+		h.ExecutionWitness = dec.ExecutionWitness
 	}
 	return nil
 }

--- a/go.mod
+++ b/go.mod
@@ -24,7 +24,7 @@ require (
 	github.com/donovanhide/eventsource v0.0.0-20210830082556-c59027999da0
 	github.com/dop251/goja v0.0.0-20230605162241-28ee0ee714f3
 	github.com/ethereum/c-kzg-4844 v1.0.0
-	github.com/ethereum/go-verkle v0.1.1-0.20240726143912-7dc5142667fa
+	github.com/ethereum/go-verkle v0.1.1-0.20240829091221-dffa7562dbe9
 	github.com/fatih/color v1.16.0
 	github.com/ferranbt/fastssz v0.1.2
 	github.com/fjl/gencodec v0.0.0-20230517082657-f9840df7b83e

--- a/go.sum
+++ b/go.sum
@@ -170,8 +170,8 @@ github.com/envoyproxy/go-control-plane v0.9.4/go.mod h1:6rpuAdCZL397s3pYoYcLgu1m
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
 github.com/ethereum/c-kzg-4844 v1.0.0 h1:0X1LBXxaEtYD9xsyj9B9ctQEZIpnvVDeoBx8aHEwTNA=
 github.com/ethereum/c-kzg-4844 v1.0.0/go.mod h1:VewdlzQmpT5QSrVhbBuGoCdFJkpaJlO1aQputP83wc0=
-github.com/ethereum/go-verkle v0.1.1-0.20240726143912-7dc5142667fa h1:mXkPoR07WlPVAClNzWuGAQNqmhxLqQILXhm73J5d9Ew=
-github.com/ethereum/go-verkle v0.1.1-0.20240726143912-7dc5142667fa/go.mod h1:D9AJLVXSyZQXJQVk8oh1EwjISE+sJTn2duYIZC0dy3w=
+github.com/ethereum/go-verkle v0.1.1-0.20240829091221-dffa7562dbe9 h1:8NfxH2iXvJ60YRB8ChToFTUzl8awsc3cJ8CbLjGIl/A=
+github.com/ethereum/go-verkle v0.1.1-0.20240829091221-dffa7562dbe9/go.mod h1:M3b90YRnzqKyyzBEWJGqj8Qff4IDeXnzFw0P9bFw3uk=
 github.com/fatih/color v1.16.0 h1:zmkK9Ngbjj+K0yRhTVONQh1p/HknKYSlNT+vZCzyokM=
 github.com/fatih/color v1.16.0/go.mod h1:fL2Sau1YI5c0pdGEVCbKQbLXB6edEj1ZgiY4NijnWvE=
 github.com/ferranbt/fastssz v0.1.2 h1:Dky6dXlngF6Qjc+EfDipAkE83N5I5DE68bY6O0VLNPk=

--- a/trie/verkle.go
+++ b/trie/verkle.go
@@ -69,8 +69,8 @@ func NewVerkleTrie(root common.Hash, db database.Database, cache *utils.PointCac
 	}, nil
 }
 
-func (trie *VerkleTrie) FlatdbNodeResolver(path []byte) ([]byte, error) {
-	return trie.reader.node(path, common.Hash{})
+func (t *VerkleTrie) FlatdbNodeResolver(path []byte) ([]byte, error) {
+	return t.reader.node(path, common.Hash{})
 }
 
 // GetKey returns the sha3 preimage of a hashed key that was previously used

--- a/trie/verkle.go
+++ b/trie/verkle.go
@@ -307,12 +307,15 @@ func (t *VerkleTrie) IsVerkle() bool {
 	return true
 }
 
-func ProveAndSerialize(pretrie, posttrie *VerkleTrie, keys [][]byte, resolver verkle.NodeResolverFn) (*verkle.VerkleProof, verkle.StateDiff, error) {
+// Proof builds and returns the verkle multiproof for keys, built against
+// the pre tree. The post tree is passed in order to add the post values
+// to that proof.
+func (t *VerkleTrie) Proof(posttrie *VerkleTrie, keys [][]byte, resolver verkle.NodeResolverFn) (*verkle.VerkleProof, verkle.StateDiff, error) {
 	var postroot verkle.VerkleNode
 	if posttrie != nil {
 		postroot = posttrie.root
 	}
-	proof, _, _, _, err := verkle.MakeVerkleMultiProof(pretrie.root, postroot, keys, resolver)
+	proof, _, _, _, err := verkle.MakeVerkleMultiProof(t.root, postroot, keys, resolver)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/trie/verkle.go
+++ b/trie/verkle.go
@@ -69,6 +69,10 @@ func NewVerkleTrie(root common.Hash, db database.Database, cache *utils.PointCac
 	}, nil
 }
 
+func (trie *VerkleTrie) FlatdbNodeResolver(path []byte) ([]byte, error) {
+	return trie.reader.node(path, common.Hash{})
+}
+
 // GetKey returns the sha3 preimage of a hashed key that was previously used
 // to store a value.
 func (t *VerkleTrie) GetKey(key []byte) []byte {
@@ -301,6 +305,24 @@ func (t *VerkleTrie) Copy() *VerkleTrie {
 // IsVerkle indicates if the trie is a Verkle trie.
 func (t *VerkleTrie) IsVerkle() bool {
 	return true
+}
+
+func ProveAndSerialize(pretrie, posttrie *VerkleTrie, keys [][]byte, resolver verkle.NodeResolverFn) (*verkle.VerkleProof, verkle.StateDiff, error) {
+	var postroot verkle.VerkleNode
+	if posttrie != nil {
+		postroot = posttrie.root
+	}
+	proof, _, _, _, err := verkle.MakeVerkleMultiProof(pretrie.root, postroot, keys, resolver)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	p, kvps, err := verkle.SerializeProof(proof)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return p, kvps, nil
 }
 
 // ChunkedCode represents a sequence of 32-bytes chunks of code (31 bytes of which


### PR DESCRIPTION
This PR adds the bulk verkle witness+proof production at the end of block production. It reads all the data from the tree in one swoop.

For the PR to work, we still need:

 - [x] fixing the call to `updateRoot` in `statedb.go` done in #30130
 - [x] getting Gary's verkle db changes in.
 - [x] check if implemeting `(Trie).Witness()` makes sense -> it doesn't
 - [x] enhance verkle tests to check proofs