### PR TITLE
core/state: don't compute verkle storage tree roots

### DIFF
--- a/core/state/statedb.go
+++ b/core/state/statedb.go
@@ -860,12 +860,16 @@ func (s *StateDB) IntermediateRoot(deleteEmptyObjects bool) common.Hash {
 		}
 		obj := s.stateObjects[addr] // closure for the task runner below
 		workers.Go(func() error {
-			obj.updateRoot()
+			if s.db.TrieDB().IsVerkle() {
+				obj.updateTrie()
+			} else {
+				obj.updateRoot()
 
-			// If witness building is enabled and the state object has a trie,
-			// gather the witnesses for its specific storage trie
-			if s.witness != nil && obj.trie != nil {
-				s.witness.AddState(obj.trie.Witness())
+				// If witness building is enabled and the state object has a trie,
+				// gather the witnesses for its specific storage trie
+				if s.witness != nil && obj.trie != nil {
+					s.witness.AddState(obj.trie.Witness())
+				}
 			}
 			return nil
 		})


### PR DESCRIPTION
In verkle trees, accounts and storage slots all end up in a single tree. Also, computing the root is quite computationally-intensive, and it is more efficient to compute all hashes/commitments at the same time, than sequentially.

This PR skips root computation of the "storage" trie in verkle, since it would amount to recomputing the root sequentially, over and over again, for each account that has its storage updated.