### PR TITLE
[WIP] Verkle pathdb rollback

### DIFF
--- a/cmd/evm/internal/t8ntool/execution.go
+++ b/cmd/evm/internal/t8ntool/execution.go
@@ -346,7 +346,7 @@ func (pre *Prestate) Apply(vmConfig vm.Config, chainConfig *params.ChainConfig,
 		statedb.AddBalance(w.Address, uint256.MustFromBig(amount), tracing.BalanceIncreaseWithdrawal)
 	}
 	// Commit block
-	root, err := statedb.Commit(vmContext.BlockNumber.Uint64(), chainConfig.IsEIP158(vmContext.BlockNumber))
+	root, err := statedb.Commit(vmContext.BlockNumber.Uint64(), chainConfig.IsEIP158(vmContext.BlockNumber), chainConfig.IsCancun(vmContext.BlockNumber, vmContext.Time))
 	if err != nil {
 		return nil, nil, nil, NewError(ErrorEVM, fmt.Errorf("could not commit state: %v", err))
 	}
@@ -392,7 +392,7 @@ func MakePreState(db ethdb.Database, accounts types.GenesisAlloc) *state.StateDB
 		}
 	}
 	// Commit and re-open to start with a clean state.
-	root, _ := statedb.Commit(0, false)
+	root, _ := statedb.Commit(0, false, false)
 	statedb, _ = state.New(root, sdb, nil)
 	return statedb
 }

--- a/cmd/evm/runner.go
+++ b/cmd/evm/runner.go
@@ -272,7 +272,7 @@ func runCmd(ctx *cli.Context) error {
 	output, leftOverGas, stats, err := timedExec(bench, execFunc)
 
 	if ctx.Bool(DumpFlag.Name) {
-		root, err := statedb.Commit(genesisConfig.Number, true)
+		root, err := statedb.Commit(genesisConfig.Number, true, false)
 		if err != nil {
 			fmt.Printf("Failed to commit changes %v\n", err)
 			return err

--- a/cmd/geth/dbcmd.go
+++ b/cmd/geth/dbcmd.go
@@ -829,8 +829,7 @@ func inspectAccount(db *triedb.Database, start uint64, end uint64, address commo
 func inspectStorage(db *triedb.Database, start uint64, end uint64, address common.Address, slot common.Hash, raw bool) error {
 	// The hash of storage slot key is utilized in the history
 	// rather than the raw slot key, make the conversion.
-	slotHash := crypto.Keccak256Hash(slot.Bytes())
-	stats, err := db.StorageHistory(address, slotHash, start, end)
+	stats, err := db.StorageHistory(address, slot, start, end)
 	if err != nil {
 		return err
 	}

--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -1474,7 +1474,7 @@ func (bc *BlockChain) writeBlockWithState(block *types.Block, receipts []*types.
 		log.Crit("Failed to write block into disk", "err", err)
 	}
 	// Commit all cached state changes into underlying memory database.
-	root, err := statedb.Commit(block.NumberU64(), bc.chainConfig.IsEIP158(block.Number()))
+	root, err := statedb.Commit(block.NumberU64(), bc.chainConfig.IsEIP158(block.Number()), bc.chainConfig.IsCancun(block.Number(), block.Time()))
 	if err != nil {
 		return err
 	}

--- a/core/blockchain_test.go
+++ b/core/blockchain_test.go
@@ -176,7 +176,7 @@ func testBlockChainImport(chain types.Blocks, blockchain *BlockChain) error {
 		blockchain.chainmu.MustLock()
 		rawdb.WriteTd(blockchain.db, block.Hash(), block.NumberU64(), new(big.Int).Add(block.Difficulty(), blockchain.GetTd(block.ParentHash(), block.NumberU64()-1)))
 		rawdb.WriteBlock(blockchain.db, block)
-		statedb.Commit(block.NumberU64(), false)
+		statedb.Commit(block.NumberU64(), false, false)
 		blockchain.chainmu.Unlock()
 	}
 	return nil

--- a/core/chain_makers.go
+++ b/core/chain_makers.go
@@ -353,7 +353,7 @@ func GenerateChain(config *params.ChainConfig, parent *types.Block, engine conse
 		}
 
 		// Write state changes to db
-		root, err := statedb.Commit(b.header.Number.Uint64(), config.IsEIP158(b.header.Number))
+		root, err := statedb.Commit(b.header.Number.Uint64(), config.IsEIP158(b.header.Number), config.IsCancun(b.header.Number, b.header.Time))
 		if err != nil {
 			panic(fmt.Sprintf("state write error: %v", err))
 		}
@@ -459,7 +459,7 @@ func GenerateVerkleChain(config *params.ChainConfig, parent *types.Block, engine
 		}
 
 		// Write state changes to db
-		root, err := statedb.Commit(b.header.Number.Uint64(), config.IsEIP158(b.header.Number))
+		root, err := statedb.Commit(b.header.Number.Uint64(), config.IsEIP158(b.header.Number), config.IsCancun(b.header.Number, b.header.Time))
 		if err != nil {
 			panic(fmt.Sprintf("state write error: %v", err))
 		}

--- a/core/genesis.go
+++ b/core/genesis.go
@@ -142,7 +142,7 @@ func hashAlloc(ga *types.GenesisAlloc, isVerkle bool) (common.Hash, error) {
 			statedb.SetState(addr, key, value)
 		}
 	}
-	return statedb.Commit(0, false)
+	return statedb.Commit(0, false, false)
 }
 
 // flushAlloc is very similar with hash, but the main difference is all the generated
@@ -165,7 +165,7 @@ func flushAlloc(ga *types.GenesisAlloc, db ethdb.Database, triedb *triedb.Databa
 			statedb.SetState(addr, key, value)
 		}
 	}
-	root, err := statedb.Commit(0, false)
+	root, err := statedb.Commit(0, false, false)
 	if err != nil {
 		return err
 	}

--- a/core/state/state_object.go
+++ b/core/state/state_object.go
@@ -440,10 +440,16 @@ func (s *stateObject) commitStorage(op *accountUpdate) {
 			op.storages = make(map[common.Hash][]byte)
 		}
 		op.storages[hash] = encode(val)
-		if op.storagesOrigin == nil {
-			op.storagesOrigin = make(map[common.Hash][]byte)
+
+		if op.storagesOriginByKey == nil {
+			op.storagesOriginByKey = make(map[common.Hash][]byte)
 		}
-		op.storagesOrigin[hash] = encode(s.originStorage[key])
+		if op.storagesOriginByHash == nil {
+			op.storagesOriginByHash = make(map[common.Hash][]byte)
+		}
+		origin := encode(s.originStorage[key])
+		op.storagesOriginByKey[key] = origin
+		op.storagesOriginByHash[hash] = origin
 
 		// Overwrite the clean value of storage slots
 		s.originStorage[key] = val

--- a/core/state/state_test.go
+++ b/core/state/state_test.go
@@ -59,7 +59,7 @@ func TestDump(t *testing.T) {
 	// write some of them to the trie
 	s.state.updateStateObject(obj1)
 	s.state.updateStateObject(obj2)
-	root, _ := s.state.Commit(0, false)
+	root, _ := s.state.Commit(0, false, false)
 
 	// check that DumpToCollector contains the state objects that are in trie
 	s.state, _ = New(root, tdb, nil)
@@ -118,7 +118,7 @@ func TestIterativeDump(t *testing.T) {
 	// write some of them to the trie
 	s.state.updateStateObject(obj1)
 	s.state.updateStateObject(obj2)
-	root, _ := s.state.Commit(0, false)
+	root, _ := s.state.Commit(0, false, false)
 	s.state, _ = New(root, tdb, nil)
 
 	b := &bytes.Buffer{}
@@ -144,7 +144,7 @@ func TestNull(t *testing.T) {
 	var value common.Hash
 
 	s.state.SetState(address, common.Hash{}, value)
-	s.state.Commit(0, false)
+	s.state.Commit(0, false, false)
 
 	if value := s.state.GetState(address, common.Hash{}); value != (common.Hash{}) {
 		t.Errorf("expected empty current value, got %x", value)

--- a/core/state/statedb.go
+++ b/core/state/statedb.go
@@ -1119,7 +1119,7 @@ func (s *StateDB) deleteStorage(addr common.Address, addrHash common.Hash, root 
 // with their values be tracked as original value.
 // In case (d), **original** account along with its storages should be deleted,
 // with their values be tracked as original value.
-func (s *StateDB) handleDestruction() (map[common.Hash]*accountDelete, []*trienode.NodeSet, error) {
+func (s *StateDB) handleDestruction(noStorageWiping bool) (map[common.Hash]*accountDelete, []*trienode.NodeSet, error) {
 	var (
 		nodes   []*trienode.NodeSet
 		buf     = crypto.NewKeccakState()
@@ -1148,6 +1148,9 @@ func (s *StateDB) handleDestruction() (map[common.Hash]*accountDelete, []*trieno
 		if prev.Root == types.EmptyRootHash {
 			continue
 		}
+		if noStorageWiping {
+			return nil, nil, fmt.Errorf("unexpected storage wiping, %x", addr)
+		}
 		// Remove storage slots belonging to the account.
 		slots, set, err := s.deleteStorage(addr, addrHash, prev.Root)
 		if err != nil {
@@ -1168,7 +1171,7 @@ func (s *StateDB) GetTrie() Trie {
 
 // commit gathers the state mutations accumulated along with the associated
 // trie changes, resetting all internal flags with the new state as the base.
-func (s *StateDB) commit(deleteEmptyObjects bool) (*stateUpdate, error) {
+func (s *StateDB) commit(deleteEmptyObjects bool, noStorageWiping bool) (*stateUpdate, error) {
 	// Short circuit in case any database failure occurred earlier.
 	if s.dbErr != nil {
 		return nil, fmt.Errorf("commit aborted due to earlier error: %v", s.dbErr)
@@ -1218,7 +1221,7 @@ func (s *StateDB) commit(deleteEmptyObjects bool) (*stateUpdate, error) {
 	// the same block, account deletions must be processed first. This ensures
 	// that the storage trie nodes deleted during destruction and recreated
 	// during subsequent resurrection can be combined correctly.
-	deletes, delNodes, err := s.handleDestruction()
+	deletes, delNodes, err := s.handleDestruction(noStorageWiping)
 	if err != nil {
 		return nil, err
 	}
@@ -1310,13 +1313,14 @@ func (s *StateDB) commit(deleteEmptyObjects bool) (*stateUpdate, error) {
 
 	origin := s.originalRoot
 	s.originalRoot = root
-	return newStateUpdate(origin, root, deletes, updates, nodes), nil
+
+	return newStateUpdate(noStorageWiping, origin, root, deletes, updates, nodes), nil
 }
 
 // commitAndFlush is a wrapper of commit which also commits the state mutations
 // to the configured data stores.
-func (s *StateDB) commitAndFlush(block uint64, deleteEmptyObjects bool) (*stateUpdate, error) {
-	ret, err := s.commit(deleteEmptyObjects)
+func (s *StateDB) commitAndFlush(block uint64, deleteEmptyObjects bool, noStorageWiping bool) (*stateUpdate, error) {
+	ret, err := s.commit(deleteEmptyObjects, noStorageWiping)
 	if err != nil {
 		return nil, err
 	}
@@ -1351,7 +1355,7 @@ func (s *StateDB) commitAndFlush(block uint64, deleteEmptyObjects bool) (*stateU
 		// If trie database is enabled, commit the state update as a new layer
 		if db := s.db.TrieDB(); db != nil {
 			start := time.Now()
-			set := triestate.New(ret.accountsOrigin, ret.storagesOrigin)
+			set := triestate.New(ret.accountsOrigin, ret.storagesOrigin, ret.rawStorageKey)
 			if err := db.Update(ret.root, ret.originRoot, block, ret.nodes, set); err != nil {
 				return nil, err
 			}
@@ -1370,8 +1374,13 @@ func (s *StateDB) commitAndFlush(block uint64, deleteEmptyObjects bool) (*stateU
 //
 // The associated block number of the state transition is also provided
 // for more chain context.
-func (s *StateDB) Commit(block uint64, deleteEmptyObjects bool) (common.Hash, error) {
-	ret, err := s.commitAndFlush(block, deleteEmptyObjects)
+//
+// noStorageWiping is a flag indicating whether storage wiping is permitted.
+// Since self-destruction was deprecated with the Cancun fork and there are
+// no empty accounts left that could be deleted by EIP-158, storage wiping
+// should not occur.
+func (s *StateDB) Commit(block uint64, deleteEmptyObjects bool, noStorageWiping bool) (common.Hash, error) {
+	ret, err := s.commitAndFlush(block, deleteEmptyObjects, noStorageWiping)
 	if err != nil {
 		return common.Hash{}, err
 	}

--- a/core/state/statedb_fuzz_test.go
+++ b/core/state/statedb_fuzz_test.go
@@ -236,7 +236,7 @@ func (test *stateTest) run() bool {
 		} else {
 			state.IntermediateRoot(true) // call intermediateRoot at the transaction boundary
 		}
-		ret, err := state.commitAndFlush(0, true) // call commit at the block boundary
+		ret, err := state.commitAndFlush(0, true, false) // call commit at the block boundary
 		if err != nil {
 			panic(err)
 		}

--- a/core/state/stateupdate.go
+++ b/core/state/stateupdate.go
@@ -30,34 +30,54 @@ type contractCode struct {
 
 // accountDelete represents an operation for deleting an Ethereum account.
 type accountDelete struct {
-	address        common.Address         // address is the unique account identifier
-	origin         []byte                 // origin is the original value of account data in slim-RLP encoding.
-	storagesOrigin map[common.Hash][]byte // storagesOrigin stores the original values of mutated slots in prefix-zero-trimmed RLP format.
+	address common.Address // address is the unique account identifier
+	origin  []byte         // origin is the original value of account data in slim-RLP encoding.
+
+	// storagesOrigin stores the original values of mutated slots in
+	// prefix-zero-trimmed RLP format. The map key refers to the **HASH**
+	// of the raw storage slot key.
+	storagesOrigin map[common.Hash][]byte
 }
 
 // accountUpdate represents an operation for updating an Ethereum account.
 type accountUpdate struct {
-	address        common.Address         // address is the unique account identifier
-	data           []byte                 // data is the slim-RLP encoded account data.
-	origin         []byte                 // origin is the original value of account data in slim-RLP encoding.
-	code           *contractCode          // code represents mutated contract code; nil means it's not modified.
-	storages       map[common.Hash][]byte // storages stores mutated slots in prefix-zero-trimmed RLP format.
-	storagesOrigin map[common.Hash][]byte // storagesOrigin stores the original values of mutated slots in prefix-zero-trimmed RLP format.
+	address  common.Address         // address is the unique account identifier
+	data     []byte                 // data is the slim-RLP encoded account data.
+	origin   []byte                 // origin is the original value of account data in slim-RLP encoding.
+	code     *contractCode          // code represents mutated contract code; nil means it's not modified.
+	storages map[common.Hash][]byte // storages stores mutated slots in prefix-zero-trimmed RLP format.
+
+	// storagesOriginByKey and storagesOriginByHash both store the original values
+	// of mutated slots in prefix-zero-trimmed RLP format. The difference is that
+	// storagesOriginByKey uses the **raw** storage slot key as the map ID, while
+	// storagesOriginByHash uses the **hash** of the storage slot key instead.
+	storagesOriginByKey  map[common.Hash][]byte
+	storagesOriginByHash map[common.Hash][]byte
 }
 
 // stateUpdate represents the difference between two states resulting from state
 // execution. It contains information about mutated contract codes, accounts,
 // and storage slots, along with their original values.
 type stateUpdate struct {
-	originRoot     common.Hash                               // hash of the state before applying mutation
-	root           common.Hash                               // hash of the state after applying mutation
-	destructs      map[common.Hash]struct{}                  // destructs contains the list of destructed accounts
-	accounts       map[common.Hash][]byte                    // accounts stores mutated accounts in 'slim RLP' encoding
-	accountsOrigin map[common.Address][]byte                 // accountsOrigin stores the original values of mutated accounts in 'slim RLP' encoding
-	storages       map[common.Hash]map[common.Hash][]byte    // storages stores mutated slots in 'prefix-zero-trimmed' RLP format
-	storagesOrigin map[common.Address]map[common.Hash][]byte // storagesOrigin stores the original values of mutated slots in 'prefix-zero-trimmed' RLP format
-	codes          map[common.Address]contractCode           // codes contains the set of dirty codes
-	nodes          *trienode.MergedNodeSet                   // Aggregated dirty nodes caused by state changes
+	originRoot     common.Hash               // hash of the state before applying mutation
+	root           common.Hash               // hash of the state after applying mutation
+	destructs      map[common.Hash]struct{}  // destructs contains the list of destructed accounts
+	accounts       map[common.Hash][]byte    // accounts stores mutated accounts in 'slim RLP' encoding
+	accountsOrigin map[common.Address][]byte // accountsOrigin stores the original values of mutated accounts in 'slim RLP' encoding
+
+	// storages stores mutated slots in 'prefix-zero-trimmed' RLP format.
+	// The value is keyed by account hash and **storage slot key hash**.
+	storages map[common.Hash]map[common.Hash][]byte
+
+	// storagesOrigin stores the original values of mutated slots in
+	// 'prefix-zero-trimmed' RLP format.
+	// (a) the value is keyed by account hash and **storage slot key** if rawStorageKey is true;
+	// (b) the value is keyed by account hash and **storage slot key hash** if rawStorageKey is false;
+	storagesOrigin map[common.Address]map[common.Hash][]byte
+	rawStorageKey  bool
+
+	codes map[common.Address]contractCode // codes contains the set of dirty codes
+	nodes *trienode.MergedNodeSet         // Aggregated dirty nodes caused by state changes
 }
 
 // empty returns a flag indicating the state transition is empty or not.
@@ -65,10 +85,13 @@ func (sc *stateUpdate) empty() bool {
 	return sc.originRoot == sc.root
 }
 
-// newStateUpdate constructs a state update object, representing the differences
-// between two states by performing state execution. It aggregates the given
-// account deletions and account updates to form a comprehensive state update.
-func newStateUpdate(originRoot common.Hash, root common.Hash, deletes map[common.Hash]*accountDelete, updates map[common.Hash]*accountUpdate, nodes *trienode.MergedNodeSet) *stateUpdate {
+// newStateUpdate constructs a state update object by identifying the differences
+// between two states through state execution. It combines the specified account
+// deletions and account updates to create a complete state update.
+//
+// rawStorageKey is a flag indicating whether to use the raw storage slot key or
+// the hash of the slot key for constructing state update object.
+func newStateUpdate(rawStorageKey bool, originRoot common.Hash, root common.Hash, deletes map[common.Hash]*accountDelete, updates map[common.Hash]*accountUpdate, nodes *trienode.MergedNodeSet) *stateUpdate {
 	var (
 		destructs      = make(map[common.Hash]struct{})
 		accounts       = make(map[common.Hash][]byte)
@@ -77,12 +100,14 @@ func newStateUpdate(originRoot common.Hash, root common.Hash, deletes map[common
 		storagesOrigin = make(map[common.Address]map[common.Hash][]byte)
 		codes          = make(map[common.Address]contractCode)
 	)
-	// Due to the fact that some accounts could be destructed and resurrected
-	// within the same block, the deletions must be aggregated first.
+	// Since some accounts might be destroyed and recreated within the same
+	// block, deletions must be aggregated first.
 	for addrHash, op := range deletes {
 		addr := op.address
 		destructs[addrHash] = struct{}{}
 		accountsOrigin[addr] = op.origin
+
+		// If storage wiping exists, the hash of the storage slot key must be used
 		if len(op.storagesOrigin) > 0 {
 			storagesOrigin[addr] = op.storagesOrigin
 		}
@@ -105,13 +130,17 @@ func newStateUpdate(originRoot common.Hash, root common.Hash, deletes map[common
 		if len(op.storages) > 0 {
 			storages[addrHash] = op.storages
 		}
-		if len(op.storagesOrigin) > 0 {
+		storageOriginSet := op.storagesOriginByHash
+		if rawStorageKey {
+			storageOriginSet = op.storagesOriginByKey
+		}
+		if len(storageOriginSet) > 0 {
 			origin := storagesOrigin[addr]
 			if origin == nil {
-				storagesOrigin[addr] = op.storagesOrigin
+				storagesOrigin[addr] = storageOriginSet
 				continue
 			}
-			for key, slot := range op.storagesOrigin {
+			for key, slot := range storageOriginSet {
 				if _, found := origin[key]; !found {
 					origin[key] = slot
 				}
@@ -127,6 +156,7 @@ func newStateUpdate(originRoot common.Hash, root common.Hash, deletes map[common
 		accountsOrigin: accountsOrigin,
 		storages:       storages,
 		storagesOrigin: storagesOrigin,
+		rawStorageKey:  rawStorageKey,
 		codes:          codes,
 		nodes:          nodes,
 	}

--- a/core/state/sync_test.go
+++ b/core/state/sync_test.go
@@ -80,7 +80,7 @@ func makeTestState(scheme string) (ethdb.Database, Database, *triedb.Database, c
 		}
 		accounts = append(accounts, acc)
 	}
-	root, _ := state.Commit(0, false)
+	root, _ := state.Commit(0, false, false)
 
 	// Return the generated state
 	return db, sdb, nodeDb, root, accounts

--- a/core/txpool/blobpool/blobpool_test.go
+++ b/core/txpool/blobpool/blobpool_test.go
@@ -559,7 +559,7 @@ func TestOpenDrops(t *testing.T) {
 	statedb.AddBalance(crypto.PubkeyToAddress(overcapper.PublicKey), uint256.NewInt(10000000), tracing.BalanceChangeUnspecified)
 	statedb.AddBalance(crypto.PubkeyToAddress(duplicater.PublicKey), uint256.NewInt(1000000), tracing.BalanceChangeUnspecified)
 	statedb.AddBalance(crypto.PubkeyToAddress(repeater.PublicKey), uint256.NewInt(1000000), tracing.BalanceChangeUnspecified)
-	statedb.Commit(0, true)
+	statedb.Commit(0, true, false)
 
 	chain := &testBlockChain{
 		config:  testChainConfig,
@@ -678,7 +678,7 @@ func TestOpenIndex(t *testing.T) {
 	// Create a blob pool out of the pre-seeded data
 	statedb, _ := state.New(types.EmptyRootHash, state.NewDatabase(rawdb.NewDatabase(memorydb.New())), nil)
 	statedb.AddBalance(addr, uint256.NewInt(1_000_000_000), tracing.BalanceChangeUnspecified)
-	statedb.Commit(0, true)
+	statedb.Commit(0, true, false)
 
 	chain := &testBlockChain{
 		config:  testChainConfig,
@@ -780,7 +780,7 @@ func TestOpenHeap(t *testing.T) {
 	statedb.AddBalance(addr1, uint256.NewInt(1_000_000_000), tracing.BalanceChangeUnspecified)
 	statedb.AddBalance(addr2, uint256.NewInt(1_000_000_000), tracing.BalanceChangeUnspecified)
 	statedb.AddBalance(addr3, uint256.NewInt(1_000_000_000), tracing.BalanceChangeUnspecified)
-	statedb.Commit(0, true)
+	statedb.Commit(0, true, false)
 
 	chain := &testBlockChain{
 		config:  testChainConfig,
@@ -860,7 +860,7 @@ func TestOpenCap(t *testing.T) {
 		statedb.AddBalance(addr1, uint256.NewInt(1_000_000_000), tracing.BalanceChangeUnspecified)
 		statedb.AddBalance(addr2, uint256.NewInt(1_000_000_000), tracing.BalanceChangeUnspecified)
 		statedb.AddBalance(addr3, uint256.NewInt(1_000_000_000), tracing.BalanceChangeUnspecified)
-		statedb.Commit(0, true)
+		statedb.Commit(0, true, false)
 
 		chain := &testBlockChain{
 			config:  testChainConfig,
@@ -1283,7 +1283,7 @@ func TestAdd(t *testing.T) {
 				store.Put(blob)
 			}
 		}
-		statedb.Commit(0, true)
+		statedb.Commit(0, true, false)
 		store.Close()
 
 		// Create a blob pool out of the pre-seeded dats
@@ -1356,7 +1356,7 @@ func benchmarkPoolPending(b *testing.B, datacap uint64) {
 		statedb.AddBalance(addr, uint256.NewInt(1_000_000_000), tracing.BalanceChangeUnspecified)
 		pool.add(tx)
 	}
-	statedb.Commit(0, true)
+	statedb.Commit(0, true, false)
 	defer pool.Close()
 
 	// Benchmark assembling the pending

--- a/eth/api_debug_test.go
+++ b/eth/api_debug_test.go
@@ -81,7 +81,7 @@ func TestAccountRange(t *testing.T) {
 			m[addr] = true
 		}
 	}
-	root, _ := sdb.Commit(0, true)
+	root, _ := sdb.Commit(0, true, false)
 	sdb, _ = state.New(root, statedb, nil)
 
 	trie, err := statedb.OpenTrie(root)
@@ -139,7 +139,7 @@ func TestEmptyAccountRange(t *testing.T) {
 		st, _   = state.New(types.EmptyRootHash, statedb, nil)
 	)
 	// Commit(although nothing to flush) and re-init the statedb
-	st.Commit(0, true)
+	st.Commit(0, true, false)
 	st, _ = state.New(types.EmptyRootHash, statedb, nil)
 
 	results := st.RawDump(&state.DumpConfig{
@@ -180,7 +180,7 @@ func TestStorageRangeAt(t *testing.T) {
 	for _, entry := range storage {
 		sdb.SetState(addr, *entry.Key, entry.Value)
 	}
-	root, _ := sdb.Commit(0, false)
+	root, _ := sdb.Commit(0, false, false)
 	sdb, _ = state.New(root, db, nil)
 
 	// Check a few combinations of limit and start/end.

--- a/eth/state_accessor.go
+++ b/eth/state_accessor.go
@@ -151,7 +151,7 @@ func (eth *Ethereum) hashState(ctx context.Context, block *types.Block, reexec u
 			return nil, nil, fmt.Errorf("processing block %d failed: %v", current.NumberU64(), err)
 		}
 		// Finalize the state so any modifications are written to the trie
-		root, err := statedb.Commit(current.NumberU64(), eth.blockchain.Config().IsEIP158(current.Number()))
+		root, err := statedb.Commit(current.NumberU64(), eth.blockchain.Config().IsEIP158(current.Number()), eth.blockchain.Config().IsCancun(current.Number(), current.Time()))
 		if err != nil {
 			return nil, nil, fmt.Errorf("stateAtBlock commit failed, number %d root %v: %w",
 				current.NumberU64(), current.Root().Hex(), err)

--- a/tests/state_test_util.go
+++ b/tests/state_test_util.go
@@ -319,7 +319,7 @@ func (t *StateTest) RunNoVerify(subtest StateSubtest, vmconfig vm.Config, snapsh
 	st.StateDB.AddBalance(block.Coinbase(), new(uint256.Int), tracing.BalanceChangeUnspecified)
 
 	// Commit state mutations into database.
-	root, _ = st.StateDB.Commit(block.NumberU64(), config.IsEIP158(block.Number()))
+	root, _ = st.StateDB.Commit(block.NumberU64(), config.IsEIP158(block.Number()), config.IsCancun(block.Number(), block.Time()))
 	return st, root, err
 }
 
@@ -471,7 +471,7 @@ func MakePreState(db ethdb.Database, accounts types.GenesisAlloc, snapshotter bo
 		}
 	}
 	// Commit and re-open to start with a clean state.
-	root, _ := statedb.Commit(0, false)
+	root, _ := statedb.Commit(0, false, false)
 
 	// If snapshot is requested, initialize the snapshotter and use it in state.
 	var snaps *snapshot.Tree

--- a/trie/triestate/state.go
+++ b/trie/triestate/state.go
@@ -22,16 +22,18 @@ import "github.com/ethereum/go-ethereum/common"
 // The value refers to the original content of state before the transition
 // is made. Nil means that the state was not present previously.
 type Set struct {
-	Accounts map[common.Address][]byte                 // Mutated account set, nil means the account was not present
-	Storages map[common.Address]map[common.Hash][]byte // Mutated storage set, nil means the slot was not present
-	size     common.StorageSize                        // Approximate size of set
+	Accounts      map[common.Address][]byte                 // Mutated account set, nil means the account was not present
+	Storages      map[common.Address]map[common.Hash][]byte // Mutated storage set, nil means the slot was not present
+	RawStorageKey bool                                      // Flag whether the storage set uses the raw slot key or the hash
+	size          common.StorageSize                        // Approximate size of set
 }
 
 // New constructs the state set with provided data.
-func New(accounts map[common.Address][]byte, storages map[common.Address]map[common.Hash][]byte) *Set {
+func New(accounts map[common.Address][]byte, storages map[common.Address]map[common.Hash][]byte, rawStorageKey bool) *Set {
 	return &Set{
-		Accounts: accounts,
-		Storages: storages,
+		Accounts:      accounts,
+		Storages:      storages,
+		RawStorageKey: rawStorageKey,
 	}
 }
 

--- a/triedb/pathdb/disklayer.go
+++ b/triedb/pathdb/disklayer.go
@@ -229,7 +229,7 @@ func (dl *diskLayer) revert(h *history) (*diskLayer, error) {
 	// Apply the reverse state changes upon the current state. This must
 	// be done before holding the lock in order to access state in "this"
 	// layer.
-	nodes, err := apply(dl.db, h.meta.parent, h.meta.root, h.accounts, h.storages)
+	nodes, err := apply(dl.db, h.meta.parent, h.meta.root, h.meta.version != stateHistoryV0, h.accounts, h.storages)
 	if err != nil {
 		return nil, err
 	}

--- a/triedb/pathdb/execute.go
+++ b/triedb/pathdb/execute.go
@@ -22,175 +22,374 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/rlp"
 	"github.com/ethereum/go-ethereum/trie"
 	"github.com/ethereum/go-ethereum/trie/trienode"
-	"github.com/ethereum/go-ethereum/triedb/database"
+	"github.com/ethereum/go-ethereum/trie/utils"
 )
+
+// stateHasher wraps the necessary methods for state hashing.
+type stateHasher interface {
+	// hasAccount returns a flag indicating if the account with specified
+	// address is existent in the state.
+	hasAccount(addr common.Address) (bool, error)
+
+	// updateAccount updates the account with the specified address in state.
+	updateAccount(addr common.Address, account *types.StateAccount) error
+
+	// deleteAccount removes the account with the specified address from the state.
+	deleteAccount(addr common.Address) error
+
+	// updateStorage inserts the storage slot with the specified account address
+	// and storage key into state.
+	updateStorage(addr common.Address, key []byte, val []byte) error
+
+	// deleteStorage removes the storage slot with the specified account address
+	// and storage key from state.
+	deleteStorage(addr common.Address, key []byte) error
+
+	// commitStorage commits the storage changes and compares if the new state
+	// root is equal to the target.
+	commitStorage(addr common.Address, expectRoot common.Hash) error
+
+	// commit recomputes the state root and returns the dirty trie nodes caused
+	// by state rehashing.
+	commit() (common.Hash, *trienode.MergedNodeSet, error)
+}
+
+// merkleHasher implements stateHasher interface, hashing the state in merkle manner.
+type merkleHasher struct {
+	db            *Database
+	root          common.Hash
+	rawStorageKey bool
+	buff          crypto.KeccakState
+	accountTrie   *trie.Trie
+	storageTries  map[common.Address]*trie.Trie
+	nodes         *trienode.MergedNodeSet
+}
+
+// newMerkleHasher initializes the merkle hasher.
+func newMerkleHasher(db *Database, root common.Hash, rawStorageKey bool) (*merkleHasher, error) {
+	tr, err := trie.New(trie.TrieID(root), db)
+	if err != nil {
+		return nil, err
+	}
+	return &merkleHasher{
+		db:            db,
+		root:          root,
+		rawStorageKey: rawStorageKey,
+		buff:          crypto.NewKeccakState(),
+		accountTrie:   tr,
+		storageTries:  make(map[common.Address]*trie.Trie),
+		nodes:         trienode.NewMergedNodeSet(),
+	}, nil
+}
+
+// getAccount implements the stateHasher, retrieving the account with specified
+// account address from state. Nil is returned if the account is not existent.
+func (m *merkleHasher) getAccount(addr common.Address) (*types.StateAccount, error) {
+	addrHash := crypto.HashData(m.buff, addr.Bytes()).Bytes()
+	blob, err := m.accountTrie.Get(addrHash)
+	if err != nil {
+		return nil, err
+	}
+	if len(blob) == 0 {
+		return nil, nil
+	}
+	var account types.StateAccount
+	if err := rlp.DecodeBytes(blob, &account); err != nil {
+		return nil, err
+	}
+	return &account, nil
+}
+
+// hasAccount implements stateHasher, returning a flag indicating if the account
+// with specified address is existent in the state.
+func (m *merkleHasher) hasAccount(addr common.Address) (bool, error) {
+	addrHash := crypto.HashData(m.buff, addr.Bytes()).Bytes()
+	blob, err := m.accountTrie.Get(addrHash)
+	if err != nil {
+		return false, err
+	}
+	return len(blob) > 0, nil
+}
+
+// updateStorage implements stateHasher, updating the account data with specified
+// account address in the state.
+func (m *merkleHasher) updateAccount(addr common.Address, account *types.StateAccount) error {
+	blob, err := rlp.EncodeToBytes(account)
+	if err != nil {
+		return err
+	}
+	return m.accountTrie.Update(crypto.HashData(m.buff, addr.Bytes()).Bytes(), blob)
+}
+
+// deleteAccount implements stateHasher, removing the account with specified
+// account address from the state.
+func (m *merkleHasher) deleteAccount(addr common.Address) error {
+	return m.accountTrie.Delete(crypto.HashData(m.buff, addr.Bytes()).Bytes())
+}
+
+// updateStorage implements stateHasher, updating the storage with specified
+// account address and storage key in the state.
+func (m *merkleHasher) updateStorage(addr common.Address, key []byte, val []byte) error {
+	tr, ok := m.storageTries[addr]
+	if !ok {
+		acct, err := m.getAccount(addr)
+		if err != nil {
+			return err
+		}
+		root := types.EmptyRootHash
+		if acct != nil {
+			root = acct.Root
+		}
+		tr, err = trie.New(trie.StorageTrieID(m.root, crypto.HashData(m.buff, addr.Bytes()), root), m.db)
+		if err != nil {
+			return err
+		}
+		m.storageTries[addr] = tr
+	}
+	if m.rawStorageKey {
+		return tr.Update(crypto.HashData(m.buff, key).Bytes(), val)
+	}
+	return tr.Update(key, val)
+}
+
+// deleteStorage implements stateHasher, removing the storage with specified
+// account address and storage key from the state.
+func (m *merkleHasher) deleteStorage(addr common.Address, key []byte) error {
+	tr, ok := m.storageTries[addr]
+	if !ok {
+		acct, err := m.getAccount(addr)
+		if err != nil {
+			return err
+		}
+		if acct == nil {
+			return fmt.Errorf("account %x is not found", addr)
+		}
+		tr, err = trie.New(trie.StorageTrieID(m.root, crypto.HashData(m.buff, addr.Bytes()), acct.Root), m.db)
+		if err != nil {
+			return err
+		}
+		m.storageTries[addr] = tr
+	}
+	if m.rawStorageKey {
+		return tr.Delete(crypto.HashData(m.buff, key).Bytes())
+	}
+	return tr.Delete(key)
+}
+
+// commitStorage implements stateHasher, recomputing the storage trie root and
+// ensuring it is equal to the target. Additionally, it aggregates the dirty
+// trie nodes into a global set for the final commit.
+func (m *merkleHasher) commitStorage(addr common.Address, expectRoot common.Hash) error {
+	tr, ok := m.storageTries[addr]
+	if !ok {
+		return errors.New("the storage trie is not initialized yet")
+	}
+	root, nodes := tr.Commit(false)
+	if nodes == nil {
+		return errors.New("the storage trie change is empty")
+	}
+	expectRoot = types.TrieRootHash(expectRoot)
+	if root != expectRoot {
+		return fmt.Errorf("expected root %s, got %s", expectRoot, root)
+	}
+	if err := m.nodes.Merge(nodes); err != nil {
+		return err
+	}
+	return nil
+}
+
+// commit implements stateHasher, committing the changes made and returning the
+// new state root along with the dirty trie nodes caused by rehashing.
+func (m *merkleHasher) commit() (common.Hash, *trienode.MergedNodeSet, error) {
+	root, nodes := m.accountTrie.Commit(false)
+	if nodes == nil {
+		return common.Hash{}, nil, errors.New("the account trie change is empty")
+	}
+	if err := m.nodes.Merge(nodes); err != nil {
+		return common.Hash{}, nil, err
+	}
+	return root, m.nodes, nil
+}
+
+// verkleHasher implements stateHasher, hashing the state in verkle manner.
+type verkleHasher struct {
+	root common.Hash
+	db   *Database
+	tr   *trie.VerkleTrie
+}
+
+// newVerkleHasher initializes the verkle hasher.
+func newVerkleHasher(db *Database, root common.Hash) (*verkleHasher, error) {
+	tr, err := trie.NewVerkleTrie(root, db, utils.NewPointCache(4096))
+	if err != nil {
+		return nil, err
+	}
+	return &verkleHasher{root: root, db: db, tr: tr}, nil
+}
+
+// hasAccount implements stateHasher, returning a flag indicating if the account
+// with specified address is existent in the state.
+func (v *verkleHasher) hasAccount(addr common.Address) (bool, error) {
+	acct, err := v.tr.GetAccount(addr)
+	if err != nil {
+		return false, err
+	}
+	return acct != nil, nil
+}
+
+// updateStorage implements stateHasher, updating the account data with specified
+// account address in the state.
+func (v *verkleHasher) updateAccount(addr common.Address, account *types.StateAccount) error {
+	return v.tr.UpdateAccount(addr, account)
+}
+
+// deleteAccount implements stateHasher, removing the account with specified
+// account address from the state.
+func (v *verkleHasher) deleteAccount(addr common.Address) error {
+	return v.tr.RollBackAccount(addr)
+}
+
+// updateStorage implements stateHasher, updating the storage with specified
+// account address and storage key in the state.
+func (v *verkleHasher) updateStorage(addr common.Address, key []byte, val []byte) error {
+	return v.tr.UpdateStorage(addr, key, val)
+}
+
+// deleteStorage implements stateHasher, removing the storage with specified
+// account address and storage key from the state.
+func (v *verkleHasher) deleteStorage(addr common.Address, key []byte) error {
+	return v.tr.DeleteStorage(addr, key)
+}
+
+// commitStorage implements stateHasher, it's an noop in verkle hasher.
+func (v *verkleHasher) commitStorage(addr common.Address, expectRoot common.Hash) error {
+	return nil
+}
+
+// commit implements stateHasher, committing the changes made and returning the
+// new state root along with the dirty trie nodes caused by rehashing.
+func (v *verkleHasher) commit() (common.Hash, *trienode.MergedNodeSet, error) {
+	root, nodes := v.tr.Commit(false)
+	if nodes == nil {
+		return common.Hash{}, nil, errors.New("the trie change is empty")
+	}
+	return root, trienode.NewWithNodeSet(nodes), nil
+}
+
+func newStateHasher(db *Database, root common.Hash, rawStorageKey bool) (stateHasher, error) {
+	if db.isVerkle {
+		if !rawStorageKey {
+			return nil, errors.New("incompatible state history for verkle rollback")
+		}
+		return newVerkleHasher(db, root)
+	}
+	return newMerkleHasher(db, root, rawStorageKey)
+}
 
 // context wraps all fields for executing state diffs.
 type context struct {
-	prevRoot      common.Hash
-	postRoot      common.Hash
-	accounts      map[common.Address][]byte
-	storages      map[common.Address]map[common.Hash][]byte
-	nodes         *trienode.MergedNodeSet
-	rawStorageKey bool
-
-	// TODO (rjl493456442) abstract out the state hasher
-	// for supporting verkle tree.
-	accountTrie *trie.Trie
+	prevRoot common.Hash
+	postRoot common.Hash
+	accounts map[common.Address][]byte
+	storages map[common.Address]map[common.Hash][]byte
+	hasher   stateHasher
 }
 
 // apply processes the given state diffs, updates the corresponding post-state
 // and returns the trie nodes that have been modified.
-func apply(db database.Database, prevRoot common.Hash, postRoot common.Hash, rawStorageKey bool, accounts map[common.Address][]byte, storages map[common.Address]map[common.Hash][]byte) (map[common.Hash]map[string]*trienode.Node, error) {
-	tr, err := trie.New(trie.TrieID(postRoot), db)
+func apply(db *Database, prevRoot common.Hash, postRoot common.Hash, rawStorageKey bool, accounts map[common.Address][]byte, storages map[common.Address]map[common.Hash][]byte) (map[common.Hash]map[string]*trienode.Node, error) {
+	h, err := newStateHasher(db, postRoot, rawStorageKey)
 	if err != nil {
 		return nil, err
 	}
 	ctx := &context{
-		prevRoot:      prevRoot,
-		postRoot:      postRoot,
-		accounts:      accounts,
-		storages:      storages,
-		accountTrie:   tr,
-		rawStorageKey: rawStorageKey,
-		nodes:         trienode.NewMergedNodeSet(),
+		prevRoot: prevRoot,
+		postRoot: postRoot,
+		accounts: accounts,
+		storages: storages,
+		hasher:   h,
 	}
 	for addr, account := range accounts {
 		var err error
 		if len(account) == 0 {
-			err = deleteAccount(ctx, db, addr)
+			err = deleteAccount(ctx, addr)
 		} else {
-			err = updateAccount(ctx, db, addr)
+			err = updateAccount(ctx, addr)
 		}
 		if err != nil {
 			return nil, fmt.Errorf("failed to revert state, err: %w", err)
 		}
 	}
-	root, result := tr.Commit(false)
+	root, nodes, err := h.commit()
 	if root != prevRoot {
 		return nil, fmt.Errorf("failed to revert state, want %#x, got %#x", prevRoot, root)
 	}
-	if err := ctx.nodes.Merge(result); err != nil {
+	if err != nil {
 		return nil, err
 	}
-	return ctx.nodes.Flatten(), nil
+	return nodes.Flatten(), nil
 }
 
 // updateAccount the account was present in prev-state, and may or may not
 // existent in post-state. Apply the reverse diff and verify if the storage
 // root matches the one in prev-state account.
-func updateAccount(ctx *context, db database.Database, addr common.Address) error {
+func updateAccount(ctx *context, addr common.Address) error {
 	// The account was present in prev-state, decode it from the
 	// 'slim-rlp' format bytes.
-	h := newHasher()
-	defer h.release()
-
-	addrHash := h.hash(addr.Bytes())
 	prev, err := types.FullAccount(ctx.accounts[addr])
 	if err != nil {
 		return err
 	}
-	// The account may or may not existent in post-state, try to
-	// load it and decode if it's found.
-	blob, err := ctx.accountTrie.Get(addrHash.Bytes())
-	if err != nil {
-		return err
-	}
-	post := types.NewEmptyStateAccount()
-	if len(blob) != 0 {
-		if err := rlp.DecodeBytes(blob, &post); err != nil {
-			return err
-		}
-	}
-	// Apply all storage changes into the post-state storage trie.
-	st, err := trie.New(trie.StorageTrieID(ctx.postRoot, addrHash, post.Root), db)
-	if err != nil {
-		return err
-	}
+	// Apply all storage changes into the hasher
 	for key, val := range ctx.storages[addr] {
-		tkey := key
-		if ctx.rawStorageKey {
-			tkey = h.hash(key.Bytes())
-		}
 		var err error
 		if len(val) == 0 {
-			err = st.Delete(tkey.Bytes())
+			err = ctx.hasher.deleteStorage(addr, key.Bytes())
 		} else {
-			err = st.Update(tkey.Bytes(), val)
+			err = ctx.hasher.updateStorage(addr, key.Bytes(), val)
 		}
 		if err != nil {
 			return err
 		}
 	}
-	root, result := st.Commit(false)
-	if root != prev.Root {
-		return errors.New("failed to reset storage trie")
-	}
-	// The returned set can be nil if storage trie is not changed
-	// at all.
-	if result != nil {
-		if err := ctx.nodes.Merge(result); err != nil {
+	if len(ctx.storages[addr]) > 0 {
+		if err := ctx.hasher.commitStorage(addr, prev.Root); err != nil {
 			return err
 		}
 	}
 	// Write the prev-state account into the main trie
-	full, err := rlp.EncodeToBytes(prev)
-	if err != nil {
-		return err
-	}
-	return ctx.accountTrie.Update(addrHash.Bytes(), full)
+	return ctx.hasher.updateAccount(addr, prev)
 }
 
 // deleteAccount the account was not present in prev-state, and is expected
 // to be existent in post-state. Apply the reverse diff and verify if the
 // account and storage is wiped out correctly.
-func deleteAccount(ctx *context, db database.Database, addr common.Address) error {
-	// The account must be existent in post-state, load the account.
-	h := newHasher()
-	defer h.release()
-
-	addrHash := h.hash(addr.Bytes())
-	blob, err := ctx.accountTrie.Get(addrHash.Bytes())
+func deleteAccount(ctx *context, addr common.Address) error {
+	// Ensure the account was indeed existent in the post-state.
+	exists, err := ctx.hasher.hasAccount(addr)
 	if err != nil {
 		return err
 	}
-	if len(blob) == 0 {
-		return fmt.Errorf("account is non-existent %#x", addrHash)
-	}
-	var post types.StateAccount
-	if err := rlp.DecodeBytes(blob, &post); err != nil {
-		return err
-	}
-	st, err := trie.New(trie.StorageTrieID(ctx.postRoot, addrHash, post.Root), db)
-	if err != nil {
-		return err
+	if !exists {
+		return fmt.Errorf("account is non-existent %#x", addr)
 	}
 	for key, val := range ctx.storages[addr] {
 		if len(val) != 0 {
 			return errors.New("expect storage deletion")
 		}
-		tkey := key
-		if ctx.rawStorageKey {
-			tkey = h.hash(key.Bytes())
-		}
-		if err := st.Delete(tkey.Bytes()); err != nil {
+		if err := ctx.hasher.deleteStorage(addr, key.Bytes()); err != nil {
 			return err
 		}
 	}
-	root, result := st.Commit(false)
-	if root != types.EmptyRootHash {
-		return errors.New("failed to clear storage trie")
-	}
-	// The returned set can be nil if storage trie is not changed
-	// at all.
-	if result != nil {
-		if err := ctx.nodes.Merge(result); err != nil {
+	if len(ctx.storages[addr]) > 0 {
+		if err := ctx.hasher.commitStorage(addr, common.Hash{}); err != nil {
 			return err
 		}
 	}
 	// Delete the post-state account from the main trie.
-	return ctx.accountTrie.Delete(addrHash.Bytes())
+	return ctx.hasher.deleteAccount(addr)
 }

--- a/triedb/pathdb/execute.go
+++ b/triedb/pathdb/execute.go
@@ -30,11 +30,12 @@ import (
 
 // context wraps all fields for executing state diffs.
 type context struct {
-	prevRoot common.Hash
-	postRoot common.Hash
-	accounts map[common.Address][]byte
-	storages map[common.Address]map[common.Hash][]byte
-	nodes    *trienode.MergedNodeSet
+	prevRoot      common.Hash
+	postRoot      common.Hash
+	accounts      map[common.Address][]byte
+	storages      map[common.Address]map[common.Hash][]byte
+	nodes         *trienode.MergedNodeSet
+	rawStorageKey bool
 
 	// TODO (rjl493456442) abstract out the state hasher
 	// for supporting verkle tree.
@@ -43,18 +44,19 @@ type context struct {
 
 // apply processes the given state diffs, updates the corresponding post-state
 // and returns the trie nodes that have been modified.
-func apply(db database.Database, prevRoot common.Hash, postRoot common.Hash, accounts map[common.Address][]byte, storages map[common.Address]map[common.Hash][]byte) (map[common.Hash]map[string]*trienode.Node, error) {
+func apply(db database.Database, prevRoot common.Hash, postRoot common.Hash, rawStorageKey bool, accounts map[common.Address][]byte, storages map[common.Address]map[common.Hash][]byte) (map[common.Hash]map[string]*trienode.Node, error) {
 	tr, err := trie.New(trie.TrieID(postRoot), db)
 	if err != nil {
 		return nil, err
 	}
 	ctx := &context{
-		prevRoot:    prevRoot,
-		postRoot:    postRoot,
-		accounts:    accounts,
-		storages:    storages,
-		accountTrie: tr,
-		nodes:       trienode.NewMergedNodeSet(),
+		prevRoot:      prevRoot,
+		postRoot:      postRoot,
+		accounts:      accounts,
+		storages:      storages,
+		accountTrie:   tr,
+		rawStorageKey: rawStorageKey,
+		nodes:         trienode.NewMergedNodeSet(),
 	}
 	for addr, account := range accounts {
 		var err error
@@ -109,11 +111,15 @@ func updateAccount(ctx *context, db database.Database, addr common.Address) erro
 		return err
 	}
 	for key, val := range ctx.storages[addr] {
+		tkey := key
+		if ctx.rawStorageKey {
+			tkey = h.hash(key.Bytes())
+		}
 		var err error
 		if len(val) == 0 {
-			err = st.Delete(key.Bytes())
+			err = st.Delete(tkey.Bytes())
 		} else {
-			err = st.Update(key.Bytes(), val)
+			err = st.Update(tkey.Bytes(), val)
 		}
 		if err != nil {
 			return err
@@ -166,7 +172,11 @@ func deleteAccount(ctx *context, db database.Database, addr common.Address) erro
 		if len(val) != 0 {
 			return errors.New("expect storage deletion")
 		}
-		if err := st.Delete(key.Bytes()); err != nil {
+		tkey := key
+		if ctx.rawStorageKey {
+			tkey = h.hash(key.Bytes())
+		}
+		if err := st.Delete(tkey.Bytes()); err != nil {
 			return err
 		}
 	}

--- a/triedb/pathdb/history.go
+++ b/triedb/pathdb/history.go
@@ -69,7 +69,8 @@ const (
 	slotIndexSize    = common.HashLength + 5     // The length of encoded slot index
 	historyMetaSize  = 9 + 2*common.HashLength   // The length of encoded history meta
 
-	stateHistoryVersion = uint8(0) // initial version of state history structure.
+	stateHistoryV0 = uint8(0) // initial version of state history structure
+	stateHistoryV1 = uint8(1) // use the storage slot raw key as the identifier instead of the key hash
 )
 
 // Each state history entry is consisted of five elements:
@@ -170,15 +171,18 @@ func (i *accountIndex) decode(blob []byte) {
 
 // slotIndex describes the metadata belonging to a storage slot.
 type slotIndex struct {
-	hash   common.Hash // The hash of slot key
-	length uint8       // The length of storage slot, up to 32 bytes defined in protocol
-	offset uint32      // The offset of item in storage slot data table
+	// the identifier of the storage slot. Specifically
+	// in v0, it's the hash of the raw storage slot key (32 bytes);
+	// in v1, it's the raw storage slot key (32 bytes);
+	id     common.Hash
+	length uint8  // The length of storage slot, up to 32 bytes defined in protocol
+	offset uint32 // The offset of item in storage slot data table
 }
 
 // encode packs slot index into byte stream.
 func (i *slotIndex) encode() []byte {
 	var buf [slotIndexSize]byte
-	copy(buf[:common.HashLength], i.hash.Bytes())
+	copy(buf[:common.HashLength], i.id.Bytes())
 	buf[common.HashLength] = i.length
 	binary.BigEndian.PutUint32(buf[common.HashLength+1:], i.offset)
 	return buf[:]
@@ -186,7 +190,7 @@ func (i *slotIndex) encode() []byte {
 
 // decode unpack slot index from the byte stream.
 func (i *slotIndex) decode(blob []byte) {
-	i.hash = common.BytesToHash(blob[:common.HashLength])
+	i.id = common.BytesToHash(blob[:common.HashLength])
 	i.length = blob[common.HashLength]
 	i.offset = binary.BigEndian.Uint32(blob[common.HashLength+1:])
 }
@@ -215,7 +219,7 @@ func (m *meta) decode(blob []byte) error {
 		return errors.New("no version tag")
 	}
 	switch blob[0] {
-	case stateHistoryVersion:
+	case stateHistoryV0, stateHistoryV1:
 		if len(blob) != historyMetaSize {
 			return fmt.Errorf("invalid state history meta, len: %d", len(blob))
 		}
@@ -255,9 +259,13 @@ func newHistory(root common.Hash, parent common.Hash, block uint64, states *trie
 		slices.SortFunc(slist, common.Hash.Cmp)
 		storageList[addr] = slist
 	}
+	version := stateHistoryV0
+	if states.RawStorageKey {
+		version = stateHistoryV1
+	}
 	return &history{
 		meta: &meta{
-			version: stateHistoryVersion,
+			version: version,
 			parent:  parent,
 			root:    root,
 			block:   block,
@@ -290,7 +298,7 @@ func (h *history) encode() ([]byte, []byte, []byte, []byte) {
 			// Encode storage slots in order
 			for _, slotHash := range h.storageList[addr] {
 				sIndex := slotIndex{
-					hash:   slotHash,
+					id:     slotHash,
 					length: uint8(len(slots[slotHash])),
 					offset: uint32(len(storageData)),
 				}
@@ -378,7 +386,7 @@ func (r *decoder) readAccount(pos int) (accountIndex, []byte, error) {
 // readStorage parses the storage slots from the byte stream with specified account.
 func (r *decoder) readStorage(accIndex accountIndex) ([]common.Hash, map[common.Hash][]byte, error) {
 	var (
-		last    common.Hash
+		last    *common.Hash
 		count   = int(accIndex.storageSlots)
 		list    = make([]common.Hash, 0, count)
 		storage = make(map[common.Hash][]byte, count)
@@ -403,8 +411,10 @@ func (r *decoder) readStorage(accIndex accountIndex) ([]common.Hash, map[common.
 		}
 		index.decode(r.storageIndexes[start:end])
 
-		if bytes.Compare(last.Bytes(), index.hash.Bytes()) >= 0 {
-			return nil, nil, errors.New("storage slot is not in order")
+		if last != nil {
+			if bytes.Compare(last.Bytes(), index.id.Bytes()) >= 0 {
+				return nil, nil, fmt.Errorf("storage slot is not in order, last: %x, current: %x", *last, index.id)
+			}
 		}
 		if index.offset != r.lastSlotDataRead {
 			return nil, nil, errors.New("storage data buffer is gapped")
@@ -413,10 +423,10 @@ func (r *decoder) readStorage(accIndex accountIndex) ([]common.Hash, map[common.
 		if uint32(len(r.storageData)) < sEnd {
 			return nil, nil, errors.New("storage data buffer is corrupted")
 		}
-		storage[index.hash] = r.storageData[r.lastSlotDataRead:sEnd]
-		list = append(list, index.hash)
+		storage[index.id] = r.storageData[r.lastSlotDataRead:sEnd]
+		list = append(list, index.id)
 
-		last = index.hash
+		last = &index.id
 		r.lastSlotIndexRead = end
 		r.lastSlotDataRead = sEnd
 	}

--- a/triedb/pathdb/history_inspect.go
+++ b/triedb/pathdb/history_inspect.go
@@ -21,6 +21,7 @@ import (
 	"time"
 
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/ethdb"
 	"github.com/ethereum/go-ethereum/log"
 )
@@ -109,12 +110,17 @@ func accountHistory(freezer ethdb.AncientReader, address common.Address, start, 
 
 // storageHistory inspects the storage history within the range.
 func storageHistory(freezer ethdb.AncientReader, address common.Address, slot common.Hash, start uint64, end uint64) (*HistoryStats, error) {
+	slotHash := crypto.Keccak256Hash(slot.Bytes())
 	return inspectHistory(freezer, start, end, func(h *history, stats *HistoryStats) {
 		slots, exists := h.storages[address]
 		if !exists {
 			return
 		}
-		blob, exists := slots[slot]
+		key := slotHash
+		if h.meta.version != stateHistoryV0 {
+			key = slot
+		}
+		blob, exists := slots[key]
 		if !exists {
 			return
 		}

--- a/triedb/pathdb/history_test.go
+++ b/triedb/pathdb/history_test.go
@@ -47,7 +47,7 @@ func randomStateSet(n int) *triestate.Set {
 		account := generateAccount(types.EmptyRootHash)
 		accounts[addr] = types.SlimAccountRLP(account)
 	}
-	return triestate.New(accounts, storages)
+	return triestate.New(accounts, storages, false)
 }
 
 func makeHistory() *history {


### PR DESCRIPTION
TODO:

Verkle tree differentiates between zero values and empty values . For instance, a zero storage slot and an empty storage slot are distinct notions in Verkle manner. 

Unfortunately, our current state history is insufficient to distinguish between zero and empty values during state rollbacks. The pull request to add this extra information should be merged before this one.