### PR TITLE
eth/catalyst: fix (*SimulatedBeacon).AdjustTime() conversion

### DIFF
--- a/eth/catalyst/simulated_beacon.go
+++ b/eth/catalyst/simulated_beacon.go
@@ -302,7 +302,7 @@ func (c *SimulatedBeacon) AdjustTime(adjustment time.Duration) error {
 		return errors.New("parent not found")
 	}
 	withdrawals := c.withdrawals.gatherPending(10)
-	return c.sealBlock(withdrawals, parent.Time+uint64(adjustment))
+	return c.sealBlock(withdrawals, parent.Time+uint64(adjustment/1e9))
 }
 
 func RegisterSimulatedBeaconAPIs(stack *node.Node, sim *SimulatedBeacon) {

--- a/eth/catalyst/simulated_beacon.go
+++ b/eth/catalyst/simulated_beacon.go
@@ -302,7 +302,7 @@ func (c *SimulatedBeacon) AdjustTime(adjustment time.Duration) error {
 		return errors.New("parent not found")
 	}
 	withdrawals := c.withdrawals.gatherPending(10)
-	return c.sealBlock(withdrawals, parent.Time+uint64(adjustment/1e9))
+	return c.sealBlock(withdrawals, parent.Time+uint64(adjustment/time.Second))
 }
 
 func RegisterSimulatedBeaconAPIs(stack *node.Node, sim *SimulatedBeacon) {

--- a/ethclient/simulated/backend_test.go
+++ b/ethclient/simulated/backend_test.go
@@ -106,7 +106,7 @@ func TestAdjustTime(t *testing.T) {
 	block2, _ := client.BlockByNumber(context.Background(), nil)
 	prevTime := block1.Time()
 	newTime := block2.Time()
-	if newTime-prevTime != uint64(time.Minute) {
+	if newTime-prevTime != 60 {
 		t.Errorf("adjusted time not equal to 60 seconds. prev: %v, new: %v", prevTime, newTime)
 	}
 }


### PR DESCRIPTION
This PR fixes a conversion in `(*SimulatedBeacon).AdjustTime()` which was adding a raw _nanosecond_ duration to a unix timestamp value (_seconds_).  The corresponding test `TestAdjustTime` was making the same mistake.