### PR TITLE
core/txpool/blobpool: revert #29989, WLock on Nonce

### DIFF
--- a/core/txpool/blobpool/blobpool.go
+++ b/core/txpool/blobpool/blobpool.go
@@ -1598,8 +1598,9 @@ func (p *BlobPool) SubscribeTransactions(ch chan<- core.NewTxsEvent, reorgs bool
 // Nonce returns the next nonce of an account, with all transactions executable
 // by the pool already applied on top.
 func (p *BlobPool) Nonce(addr common.Address) uint64 {
-	p.lock.RLock()
-	defer p.lock.RUnlock()
+	// We need a write lock here, since state.GetNonce might write the cache.
+	p.lock.Lock()
+	defer p.lock.Unlock()
 
 	if txs, ok := p.index[addr]; ok {
 		return txs[len(txs)-1].nonce + 1


### PR DESCRIPTION
This PR reverts https://github.com/ethereum/go-ethereum/pull/29989/files which introduced a race condition between subsequent calls to blobpool.Nonce. 
The issue is that statedb.GetNonce can write to a cache.

Closes https://github.com/ethereum/go-ethereum/issues/30139