### PR TITLE
core: don't modify signature param V when reading chainId

### DIFF
--- a/core/types/transaction_signing.go
+++ b/core/types/transaction_signing.go
@@ -572,6 +572,6 @@ func deriveChainId(v *big.Int) *big.Int {
 		}
 		return new(big.Int).SetUint64((v - 35) / 2)
 	}
-	v.Sub(v, big.NewInt(35))
-	return v.Rsh(v, 1)
+	vCopy := new(big.Int).Sub(v, big.NewInt(35))
+	return vCopy.Rsh(vCopy, 1)
 }


### PR DESCRIPTION
### Description
For large chain IDs calling `ChainId()` on legacy transactions results in the v param of the signature being modified. This was introduced by removing the copy in this [PR](https://github.com/ethereum/go-ethereum/pull/29911/files#diff-58204a02692cd9ef1cf0767b18dbc4df99eb678126c8982350e5b727af075b5eR574-R576). 

This PR reintroduces the copy of the V param and adds a test.