### PR TITLE
p2p: fix ip change log parameter

### DIFF
--- a/p2p/server_nat.go
+++ b/p2p/server_nat.go
@@ -125,7 +125,7 @@ func (srv *Server) portMappingLoop() {
 			if err != nil {
 				log.Debug("Couldn't get external IP", "err", err, "interface", srv.NAT)
 			} else if !ip.Equal(lastExtIP) {
-				log.Debug("External IP changed", "ip", extip, "interface", srv.NAT)
+				log.Debug("External IP changed", "ip", ip, "interface", srv.NAT)
 			} else {
 				continue
 			}


### PR DESCRIPTION
`extip` is a `*mclock.Alarm`, so this log prints `ip="&{ch:0x1400797efc0 clock:{} timer:0x1400786c0a0 deadline:239748684632166}"`.

Fix to print changed ip address `ip=121.166.24.7`.