### PR TITLE
types: add `to` field to `Receipts`

### DIFF
--- a/core/types/gen_receipt_json.go
+++ b/core/types/gen_receipt_json.go
@@ -16,21 +16,22 @@ var _ = (*receiptMarshaling)(nil)
 // MarshalJSON marshals as JSON.
 func (r Receipt) MarshalJSON() ([]byte, error) {
 	type Receipt struct {
-		Type              hexutil.Uint64 `json:"type,omitempty"`
-		PostState         hexutil.Bytes  `json:"root"`
-		Status            hexutil.Uint64 `json:"status"`
-		CumulativeGasUsed hexutil.Uint64 `json:"cumulativeGasUsed" gencodec:"required"`
-		Bloom             Bloom          `json:"logsBloom"         gencodec:"required"`
-		Logs              []*Log         `json:"logs"              gencodec:"required"`
-		TxHash            common.Hash    `json:"transactionHash" gencodec:"required"`
-		ContractAddress   common.Address `json:"contractAddress"`
-		GasUsed           hexutil.Uint64 `json:"gasUsed" gencodec:"required"`
-		EffectiveGasPrice *hexutil.Big   `json:"effectiveGasPrice"`
-		BlobGasUsed       hexutil.Uint64 `json:"blobGasUsed,omitempty"`
-		BlobGasPrice      *hexutil.Big   `json:"blobGasPrice,omitempty"`
-		BlockHash         common.Hash    `json:"blockHash,omitempty"`
-		BlockNumber       *hexutil.Big   `json:"blockNumber,omitempty"`
-		TransactionIndex  hexutil.Uint   `json:"transactionIndex"`
+		Type              hexutil.Uint64  `json:"type,omitempty"`
+		PostState         hexutil.Bytes   `json:"root"`
+		Status            hexutil.Uint64  `json:"status"`
+		CumulativeGasUsed hexutil.Uint64  `json:"cumulativeGasUsed" gencodec:"required"`
+		Bloom             Bloom           `json:"logsBloom"         gencodec:"required"`
+		Logs              []*Log          `json:"logs"              gencodec:"required"`
+		TxHash            common.Hash     `json:"transactionHash" gencodec:"required"`
+		ContractAddress   common.Address  `json:"contractAddress"`
+		GasUsed           hexutil.Uint64  `json:"gasUsed" gencodec:"required"`
+		EffectiveGasPrice *hexutil.Big    `json:"effectiveGasPrice"`
+		BlobGasUsed       hexutil.Uint64  `json:"blobGasUsed,omitempty"`
+		BlobGasPrice      *hexutil.Big    `json:"blobGasPrice,omitempty"`
+		BlockHash         common.Hash     `json:"blockHash,omitempty"`
+		BlockNumber       *hexutil.Big    `json:"blockNumber,omitempty"`
+		TransactionIndex  hexutil.Uint    `json:"transactionIndex"`
+		To                *common.Address `json:"to"`
 	}
 	var enc Receipt
 	enc.Type = hexutil.Uint64(r.Type)
@@ -48,6 +49,7 @@ func (r Receipt) MarshalJSON() ([]byte, error) {
 	enc.BlockHash = r.BlockHash
 	enc.BlockNumber = (*hexutil.Big)(r.BlockNumber)
 	enc.TransactionIndex = hexutil.Uint(r.TransactionIndex)
+	enc.To = r.To
 	return json.Marshal(&enc)
 }
 
@@ -69,6 +71,7 @@ func (r *Receipt) UnmarshalJSON(input []byte) error {
 		BlockHash         *common.Hash    `json:"blockHash,omitempty"`
 		BlockNumber       *hexutil.Big    `json:"blockNumber,omitempty"`
 		TransactionIndex  *hexutil.Uint   `json:"transactionIndex"`
+		To                *common.Address `json:"to"`
 	}
 	var dec Receipt
 	if err := json.Unmarshal(input, &dec); err != nil {
@@ -123,6 +126,9 @@ func (r *Receipt) UnmarshalJSON(input []byte) error {
 	}
 	if dec.TransactionIndex != nil {
 		r.TransactionIndex = uint(*dec.TransactionIndex)
+	}
+	if dec.To != nil {
+		r.To = dec.To
 	}
 	return nil
 }

--- a/core/types/receipt.go
+++ b/core/types/receipt.go
@@ -68,10 +68,10 @@ type Receipt struct {
 
 	// Inclusion information: These fields provide information about the inclusion of the
 	// transaction corresponding to this receipt.
-	BlockHash        common.Hash    `json:"blockHash,omitempty"`
-	BlockNumber      *big.Int       `json:"blockNumber,omitempty"`
-	TransactionIndex uint           `json:"transactionIndex"`
-	To               common.Address `json:"to,omitempty"`
+	BlockHash        common.Hash     `json:"blockHash,omitempty"`
+	BlockNumber      *big.Int        `json:"blockNumber,omitempty"`
+	TransactionIndex uint            `json:"transactionIndex"`
+	To               *common.Address `json:"to"`
 }
 
 type receiptMarshaling struct {
@@ -85,6 +85,7 @@ type receiptMarshaling struct {
 	BlobGasPrice      *hexutil.Big
 	BlockNumber       *hexutil.Big
 	TransactionIndex  hexutil.Uint
+	To                *common.Address
 }
 
 // receiptRLP is the consensus encoding of a receipt.


### PR DESCRIPTION
On a request to Geth node, with payload like this:
```json
{
  "method": "eth_getBlockReceipts",
  "params": [
    "0x13319c1"
  ],
  "id": 1,
  "jsonrpc": "2.0"
}
```

We can get some response like this:

```json
{
    "jsonrpc": "2.0",
    "id": 1,
    "result": [
        {
            "blockHash": "0x900987e9f470efc07906159ed38333146984c2930643e847136305f77eb7e48a",
            "blockNumber": "0x13319c1",
            "contractAddress": null,
            "cumulativeGasUsed": "0x7a55b",
            "effectiveGasPrice": "0x26fcf5f41",
            "from": "0xae2fc483527b8ef99eb5d9b44875f005ba1fae13",
            "gasUsed": "0x7a55b",
            "logs": [
...
            ],
            "logsBloom": "0x0020000000000000000010008000000000000000000000200000000000000000000000800000002000000000000000000220000008002000000000102100000010800000000400481000000c000001200000000200000400000000000000000002000200000000000000000000020000000000000000000080000010000840000400000008000000000000400000020080000000000000080000006000000000000000000200000000000000000000020000004000000000000000020000000000000002010000000000080000010000000000000000021000000000000000000000200000000000000001000000001000000000000000000000000020000000",
            "status": "0x1",
            "to": "0x6b75d8af000000e20b7a7ddf000ba900b4009a80",
            "transactionHash": "0xd3d76c5247775e73aca4624680086b071c2f8d980976fff504e3aa68638e0073",
            "transactionIndex": "0x0",
            "type": "0x2"
        },
]
}
```

Note that there's a `to` field there, so we can find out all transactions for specific contract address for just one call(`eth_getBlockReceipts`).
For example, I'd like to exam whether this block contains failed txns (with `status` of value `0x0`).

However in the current Geth implementation, the Receipt is defined as below:
```go
type Receipt struct {
	// Consensus fields: These fields are defined by the Yellow Paper
	Type              uint8  `json:"type,omitempty"`
	PostState         []byte `json:"root"`
	Status            uint64 `json:"status"`
	CumulativeGasUsed uint64 `json:"cumulativeGasUsed" gencodec:"required"`
	Bloom             Bloom  `json:"logsBloom"         gencodec:"required"`
	Logs              []*Log `json:"logs"              gencodec:"required"`

	// Implementation fields: These fields are added by geth when processing a transaction.
	TxHash            common.Hash    `json:"transactionHash" gencodec:"required"`
	ContractAddress   common.Address `json:"contractAddress"`
	GasUsed           uint64         `json:"gasUsed" gencodec:"required"`
	EffectiveGasPrice *big.Int       `json:"effectiveGasPrice"` // required, but tag omitted for backwards compatibility
	BlobGasUsed       uint64         `json:"blobGasUsed,omitempty"`
	BlobGasPrice      *big.Int       `json:"blobGasPrice,omitempty"`

	// Inclusion information: These fields provide information about the inclusion of the
	// transaction corresponding to this receipt.
	BlockHash        common.Hash     `json:"blockHash,omitempty"`
	BlockNumber      *big.Int        `json:"blockNumber,omitempty"`
	TransactionIndex uint            `json:"transactionIndex"`
}
```

We have no access to the `to` field, thus making the need described above impossible, this PR tries to add this field to `BlockReceipts` method.