### PR TITLE
core/state: check db error after intermediate call

### DIFF
--- a/core/state/statedb.go
+++ b/core/state/statedb.go
@@ -1172,6 +1172,10 @@ func (s *StateDB) commit(deleteEmptyObjects bool) (*stateUpdate, error) {
 	// Finalize any pending changes and merge everything into the tries
 	s.IntermediateRoot(deleteEmptyObjects)
 
+	// Short circuit if any error occurs within the IntermediateRoot.
+	if s.dbErr != nil {
+		return nil, fmt.Errorf("commit aborted due to database error: %v", s.dbErr)
+	}
 	// Commit objects to the trie, measuring the elapsed time
 	var (
 		accountTrieNodesUpdated int


### PR DESCRIPTION
This pull request adds an additional error check after statedb.IntermediateRoot, ensuring that no errors occur during this call. This step is essential, as the call might encounter database errors.