### PR TITLE
signer/core/apitypes: support fixed size arrays for EIP-712 typed data

### DIFF
--- a/signer/core/apitypes/signed_data_internal_test.go
+++ b/signer/core/apitypes/signed_data_internal_test.go
@@ -240,3 +240,49 @@ func TestConvertAddressDataToSlice(t *testing.T) {
 		t.Fatal(err)
 	}
 }
+
+func TestTypedDataArrayValidate(t *testing.T) {
+	t.Parallel()
+
+	typedData := TypedData{
+		Types: Types{
+			"BulkOrder": []Type{
+				// Should be able to accept fixed size arrays
+				{Name: "tree", Type: "OrderComponents[2][2]"},
+			},
+			"OrderComponents": []Type{
+				{Name: "offerer", Type: "address"},
+				{Name: "amount", Type: "uint8"},
+			},
+			"EIP712Domain": []Type{
+				{Name: "name", Type: "string"},
+				{Name: "version", Type: "string"},
+				{Name: "chainId", Type: "uint8"},
+				{Name: "verifyingContract", Type: "address"},
+			},
+		},
+		PrimaryType: "BulkOrder",
+		Domain: TypedDataDomain{
+			VerifyingContract: "0xCcCCccccCCCCcCCCCCCcCcCccCcCCCcCcccccccC",
+		},
+		Message: TypedDataMessage{},
+	}
+
+	if err := typedData.validate(); err != nil {
+		t.Errorf("expected typed data to pass validation, got: %v", err)
+	}
+
+	// Should be able to accept dynamic arrays
+	typedData.Types["BulkOrder"][0].Type = "OrderComponents[]"
+
+	if err := typedData.validate(); err != nil {
+		t.Errorf("expected typed data to pass validation, got: %v", err)
+	}
+
+	// Should be able to accept standard types
+	typedData.Types["BulkOrder"][0].Type = "OrderComponents"
+
+	if err := typedData.validate(); err != nil {
+		t.Errorf("expected typed data to pass validation, got: %v", err)
+	}
+}

--- a/signer/core/apitypes/types.go
+++ b/signer/core/apitypes/types.go
@@ -36,7 +36,7 @@ import (
 	"github.com/ethereum/go-ethereum/crypto"
 )
 
-var typedDataReferenceTypeRegexp = regexp.MustCompile(`^[A-Za-z](\w*)(\[\])?$`)
+var typedDataReferenceTypeRegexp = regexp.MustCompile(`^[A-Za-z](\w*)(\[\d*\])*$`)
 
 type ValidationInfo struct {
 	Typ     string `json:"type"`
@@ -216,8 +216,9 @@ func (t *Type) isArray() bool {
 // typeName returns the canonical name of the type. If the type is 'Person[]', then
 // this method returns 'Person'
 func (t *Type) typeName() string {
-	if strings.HasSuffix(t.Type, "[]") {
-		return strings.TrimSuffix(t.Type, "[]")
+	if strings.Contains(t.Type, "[") {
+		re := regexp.MustCompile(`\[\d*\]`)
+		return re.ReplaceAllString(t.Type, "")
 	}
 	return t.Type
 }


### PR DESCRIPTION
`resolves`: https://github.com/ethereum/go-ethereum/issues/30183

When attempting to hash a typed data struct that includes a type reference with a fixed-size array, the validation process fails. According to EIP-712, arrays can be either fixed-size or dynamic, denoted by `Type[n]` or `Type[]` respectively, although it appears this currently isn't supported.

This PR introduces a change to the validation logic to accommodate types containing fixed-size arrays.