### PR TITLE
beacon/types, cmd/devp2p, p2p/enr: clean up uses of fmt.Errorf

### DIFF
--- a/beacon/types/beacon_block.go
+++ b/beacon/types/beacon_block.go
@@ -48,7 +48,7 @@ func BlockFromJSON(forkName string, data []byte) (*BeaconBlock, error) {
 	case "capella":
 		obj = new(capella.BeaconBlock)
 	default:
-		return nil, fmt.Errorf("unsupported fork: " + forkName)
+		return nil, fmt.Errorf("unsupported fork: %s", forkName)
 	}
 	if err := json.Unmarshal(data, obj); err != nil {
 		return nil, err

--- a/beacon/types/exec_header.go
+++ b/beacon/types/exec_header.go
@@ -46,7 +46,7 @@ func ExecutionHeaderFromJSON(forkName string, data []byte) (*ExecutionHeader, er
 	case "deneb":
 		obj = new(deneb.ExecutionPayloadHeader)
 	default:
-		return nil, fmt.Errorf("unsupported fork: " + forkName)
+		return nil, fmt.Errorf("unsupported fork: %s", forkName)
 	}
 	if err := json.Unmarshal(data, obj); err != nil {
 		return nil, err

--- a/cmd/devp2p/rlpxcmd.go
+++ b/cmd/devp2p/rlpxcmd.go
@@ -79,7 +79,7 @@ func rlpxPing(ctx *cli.Context) error {
 	n := getNodeArg(ctx)
 	tcpEndpoint, ok := n.TCPEndpoint()
 	if !ok {
-		return fmt.Errorf("node has no TCP endpoint")
+		return errors.New("node has no TCP endpoint")
 	}
 	fd, err := net.Dial("tcp", tcpEndpoint.String())
 	if err != nil {

--- a/p2p/enr/entries.go
+++ b/p2p/enr/entries.go
@@ -177,7 +177,7 @@ func (v IPv4Addr) ENRKey() string { return "ip" }
 func (v IPv4Addr) EncodeRLP(w io.Writer) error {
 	addr := netip.Addr(v)
 	if !addr.Is4() {
-		return fmt.Errorf("address is not IPv4")
+		return errors.New("address is not IPv4")
 	}
 	enc := rlp.NewEncoderBuffer(w)
 	bytes := addr.As4()
@@ -204,7 +204,7 @@ func (v IPv6Addr) ENRKey() string { return "ip6" }
 func (v IPv6Addr) EncodeRLP(w io.Writer) error {
 	addr := netip.Addr(v)
 	if !addr.Is6() {
-		return fmt.Errorf("address is not IPv6")
+		return errors.New("address is not IPv6")
 	}
 	enc := rlp.NewEncoderBuffer(w)
 	bytes := addr.As16()


### PR DESCRIPTION
1. Replace `fmt.Errorf` with `errors.New` when there is no parameter
2. Use `%` format instead of `+` to concat error message