### PR TITLE
core/state: remove useless metrics

### DIFF
--- a/core/state/metrics.go
+++ b/core/state/metrics.go
@@ -27,10 +27,4 @@ var (
 	storageTriesUpdatedMeter = metrics.NewRegisteredMeter("state/update/storagenodes", nil)
 	accountTrieDeletedMeter  = metrics.NewRegisteredMeter("state/delete/accountnodes", nil)
 	storageTriesDeletedMeter = metrics.NewRegisteredMeter("state/delete/storagenodes", nil)
-
-	slotDeletionMaxCount = metrics.NewRegisteredGauge("state/delete/storage/max/slot", nil)
-	slotDeletionMaxSize  = metrics.NewRegisteredGauge("state/delete/storage/max/size", nil)
-	slotDeletionTimer    = metrics.NewRegisteredResettingTimer("state/delete/storage/timer", nil)
-	slotDeletionCount    = metrics.NewRegisteredMeter("state/delete/storage/slot", nil)
-	slotDeletionSize     = metrics.NewRegisteredMeter("state/delete/storage/size", nil)
 )


### PR DESCRIPTION
This pull request removes a few outdated metrics for simplification.

Originally, these metrics were added to track the largest storage wiping. 
Since account self-destruction was deprecated with the Cancun fork, 
these metrics have become meaningless.