### PR TITLE
rpc: show more error detail for `invalidMessageError`

### DIFF
--- a/rpc/server.go
+++ b/rpc/server.go
@@ -18,6 +18,7 @@ package rpc
 
 import (
 	"context"
+	"fmt"
 	"io"
 	"sync"
 	"sync/atomic"
@@ -152,7 +153,7 @@ func (s *Server) serveSingleRequest(ctx context.Context, codec ServerCodec) {
 	reqs, batch, err := codec.readBatch()
 	if err != nil {
 		if err != io.EOF {
-			resp := errorMessage(&invalidMessageError{"parse error"})
+			resp := errorMessage(&invalidMessageError{fmt.Sprintf("parse error: %s", err.Error())})
 			codec.writeJSON(ctx, resp, true)
 		}
 		return


### PR DESCRIPTION
The error detail may help the client debug the problem.

An example error detail is like the following:

![image](https://github.com/user-attachments/assets/ff84e08c-293a-41ea-b702-d6f7ee236f4b)
