### PR TITLE
  eth/downloader: correct sync mode logging to show old mode

### DIFF
--- a/eth/downloader/beaconsync.go
+++ b/eth/downloader/beaconsync.go
@@ -123,7 +123,8 @@ func (b *beaconBackfiller) resume() {
 func (b *beaconBackfiller) setMode(mode SyncMode) {
 	// Update the old sync mode and track if it was changed
 	b.lock.Lock()
-	updated := b.syncMode != mode
+	oldMode := b.syncMode
+	updated := oldMode != mode
 	filling := b.filling
 	b.syncMode = mode
 	b.lock.Unlock()
@@ -133,8 +134,8 @@ func (b *beaconBackfiller) setMode(mode SyncMode) {
 	if !updated || !filling {
 		return
 	}
-	log.Error("Downloader sync mode changed mid-run", "old", mode.String(), "new", mode.String())
-	b.suspend()
+	log.Error("Downloader sync mode changed mid-run", "old", oldMode.String(), "new", mode.String())
+	b.suspend()	
 	b.resume()
 }
 


### PR DESCRIPTION
This pull request fixes an issue in the setMode function of the beaconBackfiller where the sync mode change log was not displaying the previous mode correctly. This issue was discovered while exploring [issue #29817](https://github.com/ethereum/go-ethereum/issues/29817).

After the change, the log message now correctly shows both the old and new sync modes.

Modified the setMode function to store the previous sync mode and display it in the log message.
___________________________________

Additionally, I have a question about the implementation of the **setMode** function. In the current code, the sync mode is updated before checking for errors. Shouldn't we check for errors first, and then update `b.syncMode = mode` if there are no issues?