### PR TITLE
internal/ethapi: fix state override test

### DIFF
--- a/internal/ethapi/api_test.go
+++ b/internal/ethapi/api_test.go
@@ -979,7 +979,7 @@ func TestCall(t *testing.T) {
 			},
 			overrides: StateOverride{
 				dad: OverrideAccount{
-					State: &map[common.Hash]common.Hash{},
+					State: map[common.Hash]common.Hash{},
 				},
 			},
 			want: "0x0000000000000000000000000000000000000000000000000000000000000000",


### PR DESCRIPTION
Looks like #30094 became a bit stale after #30185 was merged and now we have a stale ref to a state override object causing CI to fail on master.