### PR TITLE
secp256k1: update badge

### DIFF
--- a/crypto/secp256k1/libsecp256k1/README.md
+++ b/crypto/secp256k1/libsecp256k1/README.md
@@ -1,7 +1,7 @@
 libsecp256k1
 ============
 
-[![Build Status](https://travis-ci.org/bitcoin-core/secp256k1.svg?branch=master)](https://travis-ci.org/bitcoin-core/secp256k1)
+[![Build Status](https://img.shields.io/badge/irc.libera.chat-%23secp256k1-success)](https://web.libera.chat/#secp256k1)
 
 Optimized C library for EC operations on curve secp256k1.
 


### PR DESCRIPTION
The original badge links is expired, I found this new link from [bitcoin-core](https://github.com/bitcoin-core/secp256k1/blob/master/README.md?plain=1#L5C55-L5C60)