### PR TITLE
eth/tracers/js: add coinbase addr to ctx

### DIFF
--- a/eth/tracers/js/goja.go
+++ b/eth/tracers/js/goja.go
@@ -254,6 +254,12 @@ func (t *jsTracer) OnTxStart(env *tracing.VMContext, tx *types.Transaction, from
 		return
 	}
 	t.ctx["gasPrice"] = gasPriceBig
+	coinbase, err := t.toBuf(t.vm, env.Coinbase.Bytes())
+	if err != nil {
+		t.err = err
+		return
+	}
+	t.ctx["coinbase"] = t.vm.ToValue(coinbase)
 }
 
 // OnTxEnd implements the Tracer interface and is invoked at the end of

--- a/eth/tracers/js/tracer_test.go
+++ b/eth/tracers/js/tracer_test.go
@@ -154,6 +154,9 @@ func TestTracer(t *testing.T) {
 			want:     "",
 			fail:     "reached limit for padding memory slice: 1049568 at step (<eval>:1:83(20))    in server-side tracer function 'step'",
 			contract: []byte{byte(vm.PUSH1), byte(0xff), byte(vm.PUSH1), byte(0x00), byte(vm.MSTORE8), byte(vm.STOP)},
+		}, { // tests ctx.coinbase
+			code: "{lengths: [], step: function(log) { }, fault: function() {}, result: function(ctx) { var coinbase = ctx.coinbase; return toAddress(coinbase); }}",
+			want: `{"0":0,"1":0,"2":0,"3":0,"4":0,"5":0,"6":0,"7":0,"8":0,"9":0,"10":0,"11":0,"12":0,"13":0,"14":0,"15":0,"16":0,"17":0,"18":0,"19":0}`,
 		},
 	} {
 		if have, err := execTracer(tt.code, tt.contract); tt.want != string(have) || tt.fail != err {


### PR DESCRIPTION
Add coinbase address to javascript tracer context.

This PR adds the `coinbase` address to `jsTracer.ctx`, allowing access to the coinbase address (fee receipient) in custom JavaScript tracers. 

Example usage:

```javascript
result: function(ctx) {
  return toAddress(ctx.coinbase);
}
```

This change enables custom tracers to access coinbase address, previously unavailable, enhancing their capabilities to match built-in tracers.