### PR TITLE
p2p/nat: return correct port for ExtIP NAT

### DIFF
--- a/p2p/nat/nat.go
+++ b/p2p/nat/nat.go
@@ -138,8 +138,10 @@ func (n ExtIP) String() string              { return fmt.Sprintf("ExtIP(%v)", ne
 
 // These do nothing.
 
-func (ExtIP) AddMapping(string, int, int, string, time.Duration) (uint16, error) { return 0, nil }
-func (ExtIP) DeleteMapping(string, int, int) error                               { return nil }
+func (ExtIP) AddMapping(protocol string, extport, intport int, name string, lifetime time.Duration) (uint16, error) {
+	return uint16(extport), nil
+}
+func (ExtIP) DeleteMapping(string, int, int) error { return nil }
 
 // Any returns a port mapper that tries to discover any supported
 // mechanism on the local network.


### PR DESCRIPTION
Return the actually requested external port instead of `0` for the `AddMapping` implementation for `--nat extip:<IP>`.

Returning `0` causes various trouble, as we now treat this as our externally reachable port. For example, a zero port is treated in some parts of the code as missing value, like when we send a discv4 ping: https://github.com/ethereum/go-ethereum/blob/f94baab238a64895e78034522092e935628c6c74/p2p/discover/v4_udp.go#L204-L211

As `node.UDPEndpoint` returns `ok == false` when our port is `0`, this causes us to generate an invalid ping packet.

This PR aims to fix this issue and possibly other related issues.