### PR TITLE
accounts/abi/bind: return rawTx when signer is not preset and noSend is true

### DIFF
--- a/accounts/abi/bind/base.go
+++ b/accounts/abi/bind/base.go
@@ -414,6 +414,10 @@ func (c *BoundContract) transact(opts *TransactOpts, contract *common.Address, i
 	}
 	// Sign the transaction and schedule it for execution
 	if opts.Signer == nil {
+		if opts.NoSend {
+			// If no signer is provided, return the raw transaction
+			return rawTx, nil
+		}
 		return nil, errors.New("no signer to authorize the transaction with")
 	}
 	signedTx, err := opts.Signer(opts.From, rawTx)


### PR DESCRIPTION
Fixes #30233 

Please check the issue for more details on why this is needed

- Return Raw Transaction if `Signer` is not present and `noSend` is true