### PR TITLE
p2p: fix flaky test TestServerPortMapping

### DIFF
--- a/p2p/server_nat_test.go
+++ b/p2p/server_nat_test.go
@@ -36,6 +36,7 @@ func TestServerPortMapping(t *testing.T) {
 			PrivateKey: newkey(),
 			NoDial:     true,
 			ListenAddr: ":0",
+			DiscAddr:   ":0",
 			NAT:        mockNAT,
 			Logger:     testlog.Logger(t, log.LvlTrace),
 			clock:      clock,


### PR DESCRIPTION
The test specifies `ListenAddr: ":0"`, which means a random ephemeral port will be chosen for the TCP listener by the OS. Additionally, since no `DiscAddr` was specified, the same port that is chosen automatically by the OS will also be used for the UDP listener in the discovery UDP setup. This sometimes leads to test failures if the TCP listener picks a free TCP port that is already taken for UDP. By specifying `DiscAddr: ":0"`, the UDP port will be chosen independently from the TCP port, fixing the random failure.

See issue #29830.

Verified using
```
cd p2p
go test -c -race
stress ./p2p.test -test.run=TestServerPortMapping
...
5m0s: 4556 runs so far, 0 failures
```

The issue described above can technically lead to sporadic failures on systems that specify a listen address via the `--port` flag of 0 while not setting `--discovery.port`. Since the default is using port `30303` and using a random ephemeral port is likely not used much to begin with, not addressing the root cause might be acceptable.