### PR TITLE
p2p/simulations: fix flaky test TestHTTPNodeRPC

### DIFF
--- a/p2p/simulations/http_test.go
+++ b/p2p/simulations/http_test.go
@@ -237,8 +237,8 @@ type TestAPI struct {
 	state               *atomic.Value
 	peerCount           *int64
 	counter             int64
-	feed                event.Feed
 	activeSubscriptions int64
+	feed                event.Feed
 }
 
 func (t *TestAPI) PeerCount() int64 {


### PR DESCRIPTION
There is a race condition between subscribing and generating an event in the test. This PR extends the `TestAPI` to expose the number of active subscriptions, allowing clients to wait until their subscription becomes active.

Tested via
```
cd p2p/simulations
go test -c
stress ./simulations.test -test.run=TestHTTPNodeRPC
...
10m0s: 156026 runs so far, 0 failures
```

See issue #29830