### PR TITLE
miner: remove outdated comment

### DIFF
--- a/miner/worker.go
+++ b/miner/worker.go
@@ -205,8 +205,7 @@ func (miner *Miner) prepareWork(genParams *generateParams) (*environment, error)
 
 // makeEnv creates a new environment for the sealing block.
 func (miner *Miner) makeEnv(parent *types.Header, header *types.Header, coinbase common.Address) (*environment, error) {
-	// Retrieve the parent state to execute on top and start a prefetcher for
-	// the miner to speed block sealing up a bit.
+	// Retrieve the parent state to execute on top.
 	state, err := miner.chain.StateAt(parent.Root)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Hi, it seems the prefetcher was intentionally removed from the miner (per this [comment](https://github.com/ethereum/go-ethereum/pull/28623/files#r1514228528)) so it is more clear if the comment does not reference it.