### PR TITLE
eth/tracers: implement trace live filter

### DIFF
--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -2222,7 +2222,7 @@ func MakeChain(ctx *cli.Context, stack *node.Node, readonly bool) (*core.BlockCh
 			if ctx.IsSet(VMTraceJsonConfigFlag.Name) {
 				config = json.RawMessage(ctx.String(VMTraceJsonConfigFlag.Name))
 			}
-			t, err := tracers.LiveDirectory.New(name, config)
+			t, _, err := tracers.LiveDirectory.New(name, config)
 			if err != nil {
 				Fatalf("Failed to create tracer %q: %v", name, err)
 			}

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -203,11 +203,14 @@ func New(stack *node.Node, config *ethconfig.Config) (*Ethereum, error) {
 		if config.VMTraceJsonConfig != "" {
 			traceConfig = json.RawMessage(config.VMTraceJsonConfig)
 		}
-		t, err := tracers.LiveDirectory.New(config.VMTrace, traceConfig)
+		t, apis, err := tracers.LiveDirectory.New(config.VMTrace, traceConfig)
 		if err != nil {
 			return nil, fmt.Errorf("failed to create tracer %s: %v", config.VMTrace, err)
 		}
 		vmConfig.Tracer = t
+
+		// Register live trace JSON-APIs
+		stack.RegisterAPIs(apis)
 	}
 	// Override the chain config with provided settings.
 	var overrides core.ChainOverrides

--- a/eth/tracers/internal/tracetest/supply_test.go
+++ b/eth/tracers/internal/tracetest/supply_test.go
@@ -552,7 +552,7 @@ func testSupplyTracer(t *testing.T, genesis *core.Genesis, gen func(*core.BlockG
 	traceOutputFilename := path.Join(traceOutputPath, "supply.jsonl")
 
 	// Load supply tracer
-	tracer, err := tracers.LiveDirectory.New("supply", json.RawMessage(fmt.Sprintf(`{"path":"%s"}`, traceOutputPath)))
+	tracer, _, err := tracers.LiveDirectory.New("supply", json.RawMessage(fmt.Sprintf(`{"path":"%s"}`, traceOutputPath)))
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to create call tracer: %v", err)
 	}

--- a/eth/tracers/live.go
+++ b/eth/tracers/live.go
@@ -5,9 +5,10 @@ import (
 	"errors"
 
 	"github.com/ethereum/go-ethereum/core/tracing"
+	"github.com/ethereum/go-ethereum/rpc"
 )
 
-type ctorFunc func(config json.RawMessage) (*tracing.Hooks, error)
+type ctorFunc func(config json.RawMessage) (*tracing.Hooks, []rpc.API, error)
 
 // LiveDirectory is the collection of tracers which can be used
 // during normal block import operations.
@@ -23,9 +24,9 @@ func (d *liveDirectory) Register(name string, f ctorFunc) {
 }
 
 // New instantiates a tracer by name.
-func (d *liveDirectory) New(name string, config json.RawMessage) (*tracing.Hooks, error) {
+func (d *liveDirectory) New(name string, config json.RawMessage) (*tracing.Hooks, []rpc.API, error) {
 	if f, ok := d.elems[name]; ok {
 		return f(config)
 	}
-	return nil, errors.New("not found")
+	return nil, nil, errors.New("not found")
 }

--- a/eth/tracers/live/filter.go
+++ b/eth/tracers/live/filter.go
@@ -159,7 +159,8 @@ func (f *filter) OnBlockStart(ev tracing.BlockEvent) {
 	})
 
 	// truncate the freezer db if the block number is less than the latest
-	if blknum >= f.latest {
+	if blknum <= f.latest {
+		log.Info("Reorg detected", "number", blknum, "latest", f.latest, "offset", f.offset)
 		if _, err := f.db.TruncateHead(blknum - f.offset); err != nil {
 			log.Error("Failed to truncate filter tracer db", "error", err)
 			// TODO: how to handle this error?

--- a/eth/tracers/live/filter.go
+++ b/eth/tracers/live/filter.go
@@ -88,7 +88,7 @@ func newFilter(cfg json.RawMessage) (*tracing.Hooks, []rpc.API, error) {
 	}
 
 	f.offset = uint64(offset)
-	return &tracing.Hooks{
+	hooks := &tracing.Hooks{
 		OnBlockStart:   f.OnBlockStart,
 		OnBlockEnd:     f.OnBlockEnd,
 		OnGenesisBlock: f.OnGenesisBlock,
@@ -106,7 +106,14 @@ func newFilter(cfg json.RawMessage) (*tracing.Hooks, []rpc.API, error) {
 		OnCodeChange:    t.OnCodeChange,
 		OnStorageChange: t.OnStorageChange,
 		OnLog:           t.OnLog,
-	}, nil, nil
+	}
+	apis := []rpc.API{
+		{
+			Namespace: "trace",
+			Service:   &filterAPI{filter: f},
+		},
+	}
+	return hooks, apis, nil
 }
 
 func (f *filter) OnBlockStart(ev tracing.BlockEvent) {

--- a/eth/tracers/live/filter.go
+++ b/eth/tracers/live/filter.go
@@ -113,6 +113,7 @@ func newFilter(cfg json.RawMessage) (*tracing.Hooks, []rpc.API, error) {
 	}
 	log.Info("Open filter tracer", "path", config.Path, "offset", offset, "tables", tables)
 
+	f.latest += uint64(offset)
 	f.offset = uint64(offset)
 	hooks := &tracing.Hooks{
 		OnBlockStart: f.OnBlockStart,

--- a/eth/tracers/live/filter.go
+++ b/eth/tracers/live/filter.go
@@ -25,8 +25,7 @@ func init() {
 }
 
 const (
-	tracersTable = "tracers"
-	tableSize    = 2 * 1024 * 1024 * 1024
+	tableSize = 2 * 1024 * 1024 * 1024
 )
 
 type traceResult struct {
@@ -37,8 +36,9 @@ type traceResult struct {
 
 type filter struct {
 	db         *rawdb.Freezer
-	traces     []*traceResult
-	tracer     *tracers.Tracer
+	tables     map[string]bool
+	traces     map[string][]*traceResult
+	tracer     *native.MuxTracer
 	latest     uint64
 	offset     uint64
 	once       sync.Once
@@ -48,6 +48,10 @@ type filter struct {
 type filterTracerConfig struct {
 	Path   string          `json:"path"` // Path to the directory where the tracer logs will be stored
 	Config json.RawMessage `json:"config"`
+}
+
+func toTraceTable(name string) string {
+	return name + "_tracers"
 }
 
 func newFilter(cfg json.RawMessage) (*tracing.Hooks, []rpc.API, error) {
@@ -61,14 +65,22 @@ func newFilter(cfg json.RawMessage) (*tracing.Hooks, []rpc.API, error) {
 		return nil, nil, errors.New("filter tracer output path is required")
 	}
 
-	db, err := rawdb.NewFreezer(config.Path, "trace", false, tableSize, map[string]bool{tracersTable: false})
-	if err != nil {
-		return nil, nil, fmt.Errorf("failed to create trace freezer db: %v", err)
-	}
-
-	t, err := native.NewMuxTracer(nil, config.Config)
+	t, err := native.NewMuxTracer(config.Config)
 	if err != nil {
 		return nil, nil, err
+	}
+
+	muxTracers := t.Tracers()
+	tables := make(map[string]bool, len(muxTracers))
+	traces := make(map[string][]*traceResult, len(muxTracers))
+	for name := range muxTracers {
+		tables[toTraceTable(name)] = false
+		traces[name] = nil
+	}
+
+	db, err := rawdb.NewFreezer(config.Path, "trace", false, tableSize, tables)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to create trace freezer db: %v", err)
 	}
 
 	tail, err := db.Tail()
@@ -80,7 +92,14 @@ func newFilter(cfg json.RawMessage) (*tracing.Hooks, []rpc.API, error) {
 		return nil, nil, fmt.Errorf("failed to read the frozen block numbers from the freezer db: %v", err)
 	}
 
-	f := &filter{db: db, tracer: t, latest: tail + frozen, offsetFile: path.Join(config.Path, "OFFSET")}
+	f := &filter{
+		db:         db,
+		tables:     tables,
+		traces:     traces,
+		tracer:     t,
+		latest:     tail + frozen,
+		offsetFile: path.Join(config.Path, "OFFSET"),
+	}
 	offset := 0
 	if _, err := os.Stat(f.offsetFile); err == nil || os.IsExist(err) {
 		data, err := os.ReadFile(f.offsetFile)
@@ -92,14 +111,14 @@ func newFilter(cfg json.RawMessage) (*tracing.Hooks, []rpc.API, error) {
 			return nil, nil, fmt.Errorf("failed to convert offset: %v", err)
 		}
 	}
+	log.Info("Open filter tracer", "path", config.Path, "offset", offset, "tables", tables)
 
 	f.offset = uint64(offset)
 	hooks := &tracing.Hooks{
-		OnBlockStart:   f.OnBlockStart,
-		OnBlockEnd:     f.OnBlockEnd,
-		OnGenesisBlock: f.OnGenesisBlock,
-		OnTxStart:      f.OnTxStart,
-		OnTxEnd:        f.OnTxEnd,
+		OnBlockStart: f.OnBlockStart,
+		OnBlockEnd:   f.OnBlockEnd,
+		OnTxStart:    f.OnTxStart,
+		OnTxEnd:      f.OnTxEnd,
 
 		// reuse the mux's hooks
 		OnEnter:         t.OnEnter,
@@ -124,7 +143,11 @@ func newFilter(cfg json.RawMessage) (*tracing.Hooks, []rpc.API, error) {
 
 func (f *filter) OnBlockStart(ev tracing.BlockEvent) {
 	// reset local cache
-	f.traces = make([]*traceResult, 0, ev.Block.Transactions().Len())
+	txs := ev.Block.Transactions().Len()
+	for name := range f.traces {
+		f.traces[name] = make([]*traceResult, 0, txs)
+	}
+
 	blknum := ev.Block.NumberU64()
 
 	// save the earliest arrived blknum as the offset
@@ -138,7 +161,7 @@ func (f *filter) OnBlockStart(ev tracing.BlockEvent) {
 	// truncate the freezer db if the block number is less than the latest
 	if blknum >= f.latest {
 		if _, err := f.db.TruncateHead(blknum - f.offset); err != nil {
-			log.Error("failed to truncate filter tracer db", "error", err)
+			log.Error("Failed to truncate filter tracer db", "error", err)
 			// TODO: how to handle this error?
 			return
 		}
@@ -154,36 +177,48 @@ func (f *filter) OnTxStart(env *tracing.VMContext, tx *types.Transaction, from c
 func (f *filter) OnTxEnd(receipt *types.Receipt, err error) {
 	f.tracer.OnTxEnd(receipt, err)
 
-	trace := &traceResult{TxHash: receipt.TxHash}
-	result, err := f.tracer.GetResult()
-	if err != nil {
-		log.Error("failed to get tracer results", "number", f.latest, "error", err)
-		trace.Error = err.Error()
-	} else {
-		trace.Result = result
+	for name, tt := range f.tracer.Tracers() {
+		trace := &traceResult{TxHash: receipt.TxHash}
+		result, err := tt.GetResult()
+		if err != nil {
+			log.Error("Failed to get tracer results", "number", f.latest, "error", err)
+			trace.Error = err.Error()
+		} else {
+			trace.Result = result
+		}
+		f.traces[name] = append(f.traces[name], trace)
 	}
-	f.traces = append(f.traces, trace)
 }
 
 func (f *filter) OnBlockEnd(err error) {
-	data, _ := json.Marshal(f.traces)
-	f.appendData(data)
-}
-
-func (f *filter) OnGenesisBlock(b *types.Block, alloc types.GenesisAlloc) {
-	f.appendData([]byte{})
-}
-
-func (f *filter) appendData(data []byte) {
-	_, err := f.db.ModifyAncients(func(w ethdb.AncientWriteOp) error {
-		return w.AppendRaw(tracersTable, f.latest-f.offset, data)
+	f.db.ModifyAncients(func(w ethdb.AncientWriteOp) error {
+		number := f.latest - f.offset
+		for name, traces := range f.traces {
+			data, err := json.Marshal(traces)
+			if err != nil {
+				log.Error("Failed to marshal traces", "error", err)
+			}
+			if f.db == nil {
+				log.Crit("Failed to write block traces", "error", "f.db is null")
+			}
+			if w == nil {
+				log.Crit("Failed to write block traces", "error", "2 is null")
+			}
+			table := toTraceTable(name)
+			if err := w.AppendRaw(table, number, data); err != nil {
+				log.Error("Failed to write block traces", "number", f.latest, "table", table, "error", err)
+			}
+		}
+		return nil
 	})
-	if err != nil {
-		log.Error("write to freezer db failed", "error", err)
-	}
 }
 
-func (f *filter) readBlockTraces(blknum uint64) ([]*traceResult, error) {
+func (f *filter) readBlockTraces(name string, blknum uint64) ([]*traceResult, error) {
+	table := toTraceTable(name)
+	if _, ok := f.tables[table]; !ok {
+		return nil, errors.New("tracer not found")
+	}
+
 	if blknum < f.offset || blknum > f.latest {
 		return nil, nil
 	}
@@ -191,7 +226,7 @@ func (f *filter) readBlockTraces(blknum uint64) ([]*traceResult, error) {
 	var data []byte
 	err := f.db.ReadAncients(func(reader ethdb.AncientReaderOp) error {
 		var err error
-		data, err = reader.Ancient(tracersTable, blknum-f.offset)
+		data, err = reader.Ancient(table, blknum-f.offset)
 		return err
 	})
 	if err != nil {

--- a/eth/tracers/live/filter.go
+++ b/eth/tracers/live/filter.go
@@ -29,9 +29,15 @@ const (
 	tableSize    = 2 * 1024 * 1024 * 1024
 )
 
+type traceResult struct {
+	TxHash common.Hash `json:"txHash,omitempty"` // transaction hash
+	Result interface{} `json:"result,omitempty"` // Trace results produced by the tracer
+	Error  string      `json:"error,omitempty"`  // Trace failure produced by the tracer
+}
+
 type filter struct {
 	db         *rawdb.Freezer
-	traces     []json.RawMessage
+	traces     []*traceResult
 	tracer     *tracers.Tracer
 	latest     uint64
 	offset     uint64
@@ -117,6 +123,8 @@ func newFilter(cfg json.RawMessage) (*tracing.Hooks, []rpc.API, error) {
 }
 
 func (f *filter) OnBlockStart(ev tracing.BlockEvent) {
+	// reset local cache
+	f.traces = make([]*traceResult, 0, ev.Block.Transactions().Len())
 	blknum := ev.Block.NumberU64()
 
 	// save the earliest arrived blknum as the offset
@@ -137,7 +145,6 @@ func (f *filter) OnBlockStart(ev tracing.BlockEvent) {
 	}
 
 	f.latest = blknum
-	f.traces = make([]json.RawMessage, ev.Block.Transactions().Len())
 }
 
 func (f *filter) OnTxStart(env *tracing.VMContext, tx *types.Transaction, from common.Address) {
@@ -147,12 +154,15 @@ func (f *filter) OnTxStart(env *tracing.VMContext, tx *types.Transaction, from c
 func (f *filter) OnTxEnd(receipt *types.Receipt, err error) {
 	f.tracer.OnTxEnd(receipt, err)
 
+	trace := &traceResult{TxHash: receipt.TxHash}
 	result, err := f.tracer.GetResult()
 	if err != nil {
 		log.Error("failed to get tracer results", "number", f.latest, "error", err)
-		return
+		trace.Error = err.Error()
+	} else {
+		trace.Result = result
 	}
-	f.traces = append(f.traces, result)
+	f.traces = append(f.traces, trace)
 }
 
 func (f *filter) OnBlockEnd(err error) {
@@ -171,4 +181,23 @@ func (f *filter) appendData(data []byte) {
 	if err != nil {
 		log.Error("write to freezer db failed", "error", err)
 	}
+}
+
+func (f *filter) readBlockTraces(blknum uint64) ([]*traceResult, error) {
+	if blknum < f.offset || blknum > f.latest {
+		return nil, nil
+	}
+
+	var data []byte
+	err := f.db.ReadAncients(func(reader ethdb.AncientReaderOp) error {
+		var err error
+		data, err = reader.Ancient(tracersTable, blknum-f.offset)
+		return err
+	})
+	if err != nil {
+		return nil, err
+	}
+	var traces []*traceResult
+	err = json.Unmarshal(data, &traces)
+	return traces, err
 }

--- a/eth/tracers/live/filter.go
+++ b/eth/tracers/live/filter.go
@@ -1,0 +1,166 @@
+package live
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path"
+	"strconv"
+	"sync"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/rawdb"
+	"github.com/ethereum/go-ethereum/core/tracing"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/eth/tracers"
+	"github.com/ethereum/go-ethereum/eth/tracers/native"
+	"github.com/ethereum/go-ethereum/ethdb"
+	"github.com/ethereum/go-ethereum/log"
+)
+
+func init() {
+	tracers.LiveDirectory.Register("filter", newFilter)
+}
+
+const (
+	tracersTable = "tracers"
+	tableSize    = 2 * 1024 * 1024 * 1024
+)
+
+type filter struct {
+	db         *rawdb.Freezer
+	traces     []json.RawMessage
+	tracer     *tracers.Tracer
+	latest     uint64
+	offset     uint64
+	once       sync.Once
+	offsetFile string
+}
+
+type filterTracerConfig struct {
+	Path   string          `json:"path"` // Path to the directory where the tracer logs will be stored
+	Config json.RawMessage `json:"config"`
+}
+
+func newFilter(cfg json.RawMessage) (*tracing.Hooks, error) {
+	var config filterTracerConfig
+	if cfg != nil {
+		if err := json.Unmarshal(cfg, &config); err != nil {
+			return nil, fmt.Errorf("failed to parse config: %v", err)
+		}
+	}
+	if config.Path == "" {
+		return nil, errors.New("filter tracer output path is required")
+	}
+
+	db, err := rawdb.NewFreezer(config.Path, "trace", false, tableSize, map[string]bool{tracersTable: false})
+	if err != nil {
+		return nil, fmt.Errorf("failed to create trace freezer db: %v", err)
+	}
+
+	t, err := native.NewMuxTracer(nil, config.Config)
+	if err != nil {
+		return nil, err
+	}
+
+	tail, err := db.Tail()
+	if err != nil {
+		return nil, fmt.Errorf("failed to read the tail block number from the freezer db: %v", err)
+	}
+	frozen, err := db.Ancients()
+	if err != nil {
+		return nil, fmt.Errorf("failed to read the frozen block numbers from the freezer db: %v", err)
+	}
+
+	f := &filter{db: db, tracer: t, latest: tail + frozen, offsetFile: path.Join(config.Path, "OFFSET")}
+	offset := 0
+	if _, err := os.Stat(f.offsetFile); err == nil || os.IsExist(err) {
+		data, err := os.ReadFile(f.offsetFile)
+		if err != nil {
+			return nil, fmt.Errorf("failed to read the offset from the freezer db: %v", err)
+		}
+		offset, err = strconv.Atoi(string(data))
+		if err != nil {
+			return nil, fmt.Errorf("failed to convert offset: %v", err)
+		}
+	}
+
+	f.offset = uint64(offset)
+	return &tracing.Hooks{
+		OnBlockStart:   f.OnBlockStart,
+		OnBlockEnd:     f.OnBlockEnd,
+		OnGenesisBlock: f.OnGenesisBlock,
+		OnTxStart:      f.OnTxStart,
+		OnTxEnd:        f.OnTxEnd,
+
+		// reuse the mux's hooks
+		OnEnter:         t.OnEnter,
+		OnExit:          t.OnExit,
+		OnOpcode:        t.OnOpcode,
+		OnFault:         t.OnFault,
+		OnGasChange:     t.OnGasChange,
+		OnBalanceChange: t.OnBalanceChange,
+		OnNonceChange:   t.OnNonceChange,
+		OnCodeChange:    t.OnCodeChange,
+		OnStorageChange: t.OnStorageChange,
+		OnLog:           t.OnLog,
+	}, nil
+}
+
+func (f *filter) OnBlockStart(ev tracing.BlockEvent) {
+	blknum := ev.Block.NumberU64()
+
+	// save the earliest arrived blknum as the offset
+	f.once.Do(func() {
+		if _, err := os.Stat(f.offsetFile); err != nil && os.IsNotExist(err) {
+			f.offset = blknum
+			os.WriteFile(f.offsetFile, []byte(fmt.Sprintf("%d", blknum)), 0666)
+		}
+	})
+
+	// truncate the freezer db if the block number is less than the latest
+	if blknum >= f.latest {
+		if _, err := f.db.TruncateHead(blknum - f.offset); err != nil {
+			log.Error("failed to truncate filter tracer db", "error", err)
+			// TODO: how to handle this error?
+			return
+		}
+	}
+
+	f.latest = blknum
+	f.traces = make([]json.RawMessage, ev.Block.Transactions().Len())
+}
+
+func (f *filter) OnTxStart(env *tracing.VMContext, tx *types.Transaction, from common.Address) {
+	f.tracer.OnTxStart(env, tx, from)
+}
+
+func (f *filter) OnTxEnd(receipt *types.Receipt, err error) {
+	f.tracer.OnTxEnd(receipt, err)
+
+	result, err := f.tracer.GetResult()
+	if err != nil {
+		log.Error("failed to get tracer results", "number", f.latest, "error", err)
+		return
+	}
+	f.traces = append(f.traces, result)
+}
+
+func (f *filter) OnBlockEnd(err error) {
+	data, _ := json.Marshal(f.traces)
+	f.appendData(data)
+}
+
+func (f *filter) OnGenesisBlock(b *types.Block, alloc types.GenesisAlloc) {
+	f.appendData([]byte{})
+}
+
+func (f *filter) appendData(data []byte) {
+	_, err := f.db.ModifyAncients(func(w ethdb.AncientWriteOp) error {
+		return w.AppendRaw(tracersTable, f.latest-f.offset, data)
+	})
+	if err != nil {
+		log.Error("write to freezer db failed", "error", err)
+	}
+}

--- a/eth/tracers/live/filter.go
+++ b/eth/tracers/live/filter.go
@@ -149,7 +149,10 @@ func (f *filter) OnBlockStart(ev tracing.BlockEvent) {
 		f.traces[name] = make([]*traceResult, 0, txs)
 	}
 
+	// track the latest block number
 	blknum := ev.Block.NumberU64()
+	latest := f.latest
+	f.latest = blknum
 
 	// save the earliest arrived blknum as the offset
 	f.once.Do(func() {
@@ -160,17 +163,15 @@ func (f *filter) OnBlockStart(ev tracing.BlockEvent) {
 	})
 
 	// truncate the freezer db if the block number is less than the latest
-	if blknum < f.latest {
+	if blknum < latest {
 		frozen, _ := f.db.Ancients()
-		log.Info("Reorg detected", "number", blknum, "latest", f.latest, "offset", f.offset, "frozen", frozen)
+		log.Info("Reorg detected", "number", blknum, "latest", latest, "offset", f.offset, "frozen", frozen)
 		if _, err := f.db.TruncateHead(blknum - f.offset); err != nil {
 			log.Error("Failed to truncate filter tracer db", "error", err)
 			// TODO: how to handle this error?
 			return
 		}
 	}
-
-	f.latest = blknum
 }
 
 func (f *filter) OnTxStart(env *tracing.VMContext, tx *types.Transaction, from common.Address) {

--- a/eth/tracers/live/filter.go
+++ b/eth/tracers/live/filter.go
@@ -159,8 +159,9 @@ func (f *filter) OnBlockStart(ev tracing.BlockEvent) {
 	})
 
 	// truncate the freezer db if the block number is less than the latest
-	if blknum <= f.latest {
-		log.Info("Reorg detected", "number", blknum, "latest", f.latest, "offset", f.offset)
+	if blknum < f.latest {
+		frozen, _ := f.db.Ancients()
+		log.Info("Reorg detected", "number", blknum, "latest", f.latest, "offset", f.offset, "frozen", frozen)
 		if _, err := f.db.TruncateHead(blknum - f.offset); err != nil {
 			log.Error("Failed to truncate filter tracer db", "error", err)
 			// TODO: how to handle this error?

--- a/eth/tracers/live/filter.go
+++ b/eth/tracers/live/filter.go
@@ -17,6 +17,7 @@ import (
 	"github.com/ethereum/go-ethereum/eth/tracers/native"
 	"github.com/ethereum/go-ethereum/ethdb"
 	"github.com/ethereum/go-ethereum/log"
+	"github.com/ethereum/go-ethereum/rpc"
 )
 
 func init() {
@@ -43,34 +44,34 @@ type filterTracerConfig struct {
 	Config json.RawMessage `json:"config"`
 }
 
-func newFilter(cfg json.RawMessage) (*tracing.Hooks, error) {
+func newFilter(cfg json.RawMessage) (*tracing.Hooks, []rpc.API, error) {
 	var config filterTracerConfig
 	if cfg != nil {
 		if err := json.Unmarshal(cfg, &config); err != nil {
-			return nil, fmt.Errorf("failed to parse config: %v", err)
+			return nil, nil, fmt.Errorf("failed to parse config: %v", err)
 		}
 	}
 	if config.Path == "" {
-		return nil, errors.New("filter tracer output path is required")
+		return nil, nil, errors.New("filter tracer output path is required")
 	}
 
 	db, err := rawdb.NewFreezer(config.Path, "trace", false, tableSize, map[string]bool{tracersTable: false})
 	if err != nil {
-		return nil, fmt.Errorf("failed to create trace freezer db: %v", err)
+		return nil, nil, fmt.Errorf("failed to create trace freezer db: %v", err)
 	}
 
 	t, err := native.NewMuxTracer(nil, config.Config)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	tail, err := db.Tail()
 	if err != nil {
-		return nil, fmt.Errorf("failed to read the tail block number from the freezer db: %v", err)
+		return nil, nil, fmt.Errorf("failed to read the tail block number from the freezer db: %v", err)
 	}
 	frozen, err := db.Ancients()
 	if err != nil {
-		return nil, fmt.Errorf("failed to read the frozen block numbers from the freezer db: %v", err)
+		return nil, nil, fmt.Errorf("failed to read the frozen block numbers from the freezer db: %v", err)
 	}
 
 	f := &filter{db: db, tracer: t, latest: tail + frozen, offsetFile: path.Join(config.Path, "OFFSET")}
@@ -78,11 +79,11 @@ func newFilter(cfg json.RawMessage) (*tracing.Hooks, error) {
 	if _, err := os.Stat(f.offsetFile); err == nil || os.IsExist(err) {
 		data, err := os.ReadFile(f.offsetFile)
 		if err != nil {
-			return nil, fmt.Errorf("failed to read the offset from the freezer db: %v", err)
+			return nil, nil, fmt.Errorf("failed to read the offset from the freezer db: %v", err)
 		}
 		offset, err = strconv.Atoi(string(data))
 		if err != nil {
-			return nil, fmt.Errorf("failed to convert offset: %v", err)
+			return nil, nil, fmt.Errorf("failed to convert offset: %v", err)
 		}
 	}
 
@@ -105,7 +106,7 @@ func newFilter(cfg json.RawMessage) (*tracing.Hooks, error) {
 		OnCodeChange:    t.OnCodeChange,
 		OnStorageChange: t.OnStorageChange,
 		OnLog:           t.OnLog,
-	}, nil
+	}, nil, nil
 }
 
 func (f *filter) OnBlockStart(ev tracing.BlockEvent) {

--- a/eth/tracers/live/filter_api.go
+++ b/eth/tracers/live/filter_api.go
@@ -1,0 +1,22 @@
+package live
+
+import (
+	"context"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/rpc"
+)
+
+type filterAPI struct {
+	filter *filter
+}
+
+type txTraceResult struct {
+	TxHash common.Hash `json:"txHash"`           // transaction hash
+	Result interface{} `json:"result,omitempty"` // Trace results produced by the tracer
+	Error  string      `json:"error,omitempty"`  // Trace failure produced by the tracer
+}
+
+func (api *filterAPI) Block(ctx context.Context, blockNr rpc.BlockNumber) ([]*txTraceResult, error) {
+	return nil, nil
+}

--- a/eth/tracers/live/filter_api.go
+++ b/eth/tracers/live/filter_api.go
@@ -3,7 +3,6 @@ package live
 import (
 	"context"
 
-	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/rpc"
 )
 
@@ -11,12 +10,11 @@ type filterAPI struct {
 	filter *filter
 }
 
-type txTraceResult struct {
-	TxHash common.Hash `json:"txHash"`           // transaction hash
-	Result interface{} `json:"result,omitempty"` // Trace results produced by the tracer
-	Error  string      `json:"error,omitempty"`  // Trace failure produced by the tracer
-}
+func (api *filterAPI) Block(ctx context.Context, blockNr rpc.BlockNumber) ([]*traceResult, error) {
+	blknum := uint64(blockNr.Int64())
+	if blockNr == rpc.LatestBlockNumber {
+		blknum = api.filter.latest
+	}
 
-func (api *filterAPI) Block(ctx context.Context, blockNr rpc.BlockNumber) ([]*txTraceResult, error) {
-	return nil, nil
+	return api.filter.readBlockTraces(blknum)
 }

--- a/eth/tracers/live/filter_api.go
+++ b/eth/tracers/live/filter_api.go
@@ -10,11 +10,24 @@ type filterAPI struct {
 	filter *filter
 }
 
-func (api *filterAPI) Block(ctx context.Context, blockNr rpc.BlockNumber) ([]*traceResult, error) {
+type traceConfig struct {
+	Tracer string `json:"tracer"`
+}
+
+var defaultTraceConfig = &traceConfig{
+	Tracer: "callTracer",
+}
+
+func (api *filterAPI) Block(ctx context.Context, blockNr rpc.BlockNumber, cfg *traceConfig) ([]*traceResult, error) {
 	blknum := uint64(blockNr.Int64())
 	if blockNr == rpc.LatestBlockNumber {
 		blknum = api.filter.latest
 	}
 
-	return api.filter.readBlockTraces(blknum)
+	tracer := defaultTraceConfig.Tracer
+	if cfg != nil {
+		tracer = cfg.Tracer
+	}
+
+	return api.filter.readBlockTraces(tracer, blknum)
 }

--- a/eth/tracers/live/noop.go
+++ b/eth/tracers/live/noop.go
@@ -9,6 +9,7 @@ import (
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/eth/tracers"
 	"github.com/ethereum/go-ethereum/params"
+	"github.com/ethereum/go-ethereum/rpc"
 )
 
 func init() {
@@ -21,7 +22,7 @@ func init() {
 // as soon as we have a real live tracer.
 type noop struct{}
 
-func newNoopTracer(_ json.RawMessage) (*tracing.Hooks, error) {
+func newNoopTracer(_ json.RawMessage) (*tracing.Hooks, []rpc.API, error) {
 	t := &noop{}
 	return &tracing.Hooks{
 		OnTxStart:        t.OnTxStart,
@@ -41,7 +42,7 @@ func newNoopTracer(_ json.RawMessage) (*tracing.Hooks, error) {
 		OnCodeChange:     t.OnCodeChange,
 		OnStorageChange:  t.OnStorageChange,
 		OnLog:            t.OnLog,
-	}, nil
+	}, nil, nil
 }
 
 func (t *noop) OnOpcode(pc uint64, op byte, gas, cost uint64, scope tracing.OpContext, rData []byte, depth int, err error) {

--- a/eth/tracers/live/supply.go
+++ b/eth/tracers/live/supply.go
@@ -15,11 +15,15 @@ import (
 	"github.com/ethereum/go-ethereum/core/vm"
 	"github.com/ethereum/go-ethereum/eth/tracers"
 	"github.com/ethereum/go-ethereum/log"
+	"github.com/ethereum/go-ethereum/rpc"
 	"gopkg.in/natefinch/lumberjack.v2"
 )
 
 func init() {
-	tracers.LiveDirectory.Register("supply", newSupply)
+	tracers.LiveDirectory.Register("supply", func(cfg json.RawMessage) (*tracing.Hooks, []rpc.API, error) {
+		t, err := newSupply(cfg)
+		return t, nil, err
+	})
 }
 
 type supplyInfoIssuance struct {

--- a/eth/tracers/native/call.go
+++ b/eth/tracers/native/call.go
@@ -217,6 +217,7 @@ func (t *callTracer) captureEnd(output []byte, gasUsed uint64, err error, revert
 }
 
 func (t *callTracer) OnTxStart(env *tracing.VMContext, tx *types.Transaction, from common.Address) {
+	t.callstack = nil
 	t.gasLimit = tx.Gas()
 }
 

--- a/eth/tracers/native/mux.go
+++ b/eth/tracers/native/mux.go
@@ -27,36 +27,21 @@ import (
 )
 
 func init() {
-	tracers.DefaultDirectory.Register("muxTracer", NewMuxTracer, false)
+	tracers.DefaultDirectory.Register("muxTracer", newMuxTracer, false)
 }
 
-// muxTracer is a go implementation of the Tracer interface which
+// MuxTracer is a go implementation of the Tracer interface which
 // runs multiple tracers in one go.
-type muxTracer struct {
-	names   []string
-	tracers []*tracers.Tracer
+type MuxTracer struct {
+	tracers map[string]*tracers.Tracer
 }
 
-// NewMuxTracer returns a new mux tracer.
-func NewMuxTracer(ctx *tracers.Context, cfg json.RawMessage) (*tracers.Tracer, error) {
-	var config map[string]json.RawMessage
-	if cfg != nil {
-		if err := json.Unmarshal(cfg, &config); err != nil {
-			return nil, err
-		}
+// newMuxTracer returns a new mux tracer.
+func newMuxTracer(ctx *tracers.Context, cfg json.RawMessage) (*tracers.Tracer, error) {
+	t, err := NewMuxTracer(cfg)
+	if err != nil {
+		return nil, err
 	}
-	objects := make([]*tracers.Tracer, 0, len(config))
-	names := make([]string, 0, len(config))
-	for k, v := range config {
-		t, err := tracers.DefaultDirectory.New(k, ctx, v)
-		if err != nil {
-			return nil, err
-		}
-		objects = append(objects, t)
-		names = append(names, k)
-	}
-
-	t := &muxTracer{names: names, tracers: objects}
 	return &tracers.Tracer{
 		Hooks: &tracing.Hooks{
 			OnTxStart:       t.OnTxStart,
@@ -77,7 +62,27 @@ func NewMuxTracer(ctx *tracers.Context, cfg json.RawMessage) (*tracers.Tracer, e
 	}, nil
 }
 
-func (t *muxTracer) OnOpcode(pc uint64, op byte, gas, cost uint64, scope tracing.OpContext, rData []byte, depth int, err error) {
+// NewMuxTracer returns a new mux tracer.
+func NewMuxTracer(cfg json.RawMessage) (*MuxTracer, error) {
+	var config map[string]json.RawMessage
+	if cfg != nil {
+		if err := json.Unmarshal(cfg, &config); err != nil {
+			return nil, err
+		}
+	}
+	objects := make(map[string]*tracers.Tracer, len(config))
+	for k, v := range config {
+		t, err := tracers.DefaultDirectory.New(k, nil, v)
+		if err != nil {
+			return nil, err
+		}
+		objects[k] = t
+	}
+
+	return &MuxTracer{tracers: objects}, nil
+}
+
+func (t *MuxTracer) OnOpcode(pc uint64, op byte, gas, cost uint64, scope tracing.OpContext, rData []byte, depth int, err error) {
 	for _, t := range t.tracers {
 		if t.OnOpcode != nil {
 			t.OnOpcode(pc, op, gas, cost, scope, rData, depth, err)
@@ -85,7 +90,7 @@ func (t *muxTracer) OnOpcode(pc uint64, op byte, gas, cost uint64, scope tracing
 	}
 }
 
-func (t *muxTracer) OnFault(pc uint64, op byte, gas, cost uint64, scope tracing.OpContext, depth int, err error) {
+func (t *MuxTracer) OnFault(pc uint64, op byte, gas, cost uint64, scope tracing.OpContext, depth int, err error) {
 	for _, t := range t.tracers {
 		if t.OnFault != nil {
 			t.OnFault(pc, op, gas, cost, scope, depth, err)
@@ -93,7 +98,7 @@ func (t *muxTracer) OnFault(pc uint64, op byte, gas, cost uint64, scope tracing.
 	}
 }
 
-func (t *muxTracer) OnGasChange(old, new uint64, reason tracing.GasChangeReason) {
+func (t *MuxTracer) OnGasChange(old, new uint64, reason tracing.GasChangeReason) {
 	for _, t := range t.tracers {
 		if t.OnGasChange != nil {
 			t.OnGasChange(old, new, reason)
@@ -101,7 +106,7 @@ func (t *muxTracer) OnGasChange(old, new uint64, reason tracing.GasChangeReason)
 	}
 }
 
-func (t *muxTracer) OnEnter(depth int, typ byte, from common.Address, to common.Address, input []byte, gas uint64, value *big.Int) {
+func (t *MuxTracer) OnEnter(depth int, typ byte, from common.Address, to common.Address, input []byte, gas uint64, value *big.Int) {
 	for _, t := range t.tracers {
 		if t.OnEnter != nil {
 			t.OnEnter(depth, typ, from, to, input, gas, value)
@@ -109,7 +114,7 @@ func (t *muxTracer) OnEnter(depth int, typ byte, from common.Address, to common.
 	}
 }
 
-func (t *muxTracer) OnExit(depth int, output []byte, gasUsed uint64, err error, reverted bool) {
+func (t *MuxTracer) OnExit(depth int, output []byte, gasUsed uint64, err error, reverted bool) {
 	for _, t := range t.tracers {
 		if t.OnExit != nil {
 			t.OnExit(depth, output, gasUsed, err, reverted)
@@ -117,7 +122,7 @@ func (t *muxTracer) OnExit(depth int, output []byte, gasUsed uint64, err error, 
 	}
 }
 
-func (t *muxTracer) OnTxStart(env *tracing.VMContext, tx *types.Transaction, from common.Address) {
+func (t *MuxTracer) OnTxStart(env *tracing.VMContext, tx *types.Transaction, from common.Address) {
 	for _, t := range t.tracers {
 		if t.OnTxStart != nil {
 			t.OnTxStart(env, tx, from)
@@ -125,7 +130,7 @@ func (t *muxTracer) OnTxStart(env *tracing.VMContext, tx *types.Transaction, fro
 	}
 }
 
-func (t *muxTracer) OnTxEnd(receipt *types.Receipt, err error) {
+func (t *MuxTracer) OnTxEnd(receipt *types.Receipt, err error) {
 	for _, t := range t.tracers {
 		if t.OnTxEnd != nil {
 			t.OnTxEnd(receipt, err)
@@ -133,7 +138,7 @@ func (t *muxTracer) OnTxEnd(receipt *types.Receipt, err error) {
 	}
 }
 
-func (t *muxTracer) OnBalanceChange(a common.Address, prev, new *big.Int, reason tracing.BalanceChangeReason) {
+func (t *MuxTracer) OnBalanceChange(a common.Address, prev, new *big.Int, reason tracing.BalanceChangeReason) {
 	for _, t := range t.tracers {
 		if t.OnBalanceChange != nil {
 			t.OnBalanceChange(a, prev, new, reason)
@@ -141,7 +146,7 @@ func (t *muxTracer) OnBalanceChange(a common.Address, prev, new *big.Int, reason
 	}
 }
 
-func (t *muxTracer) OnNonceChange(a common.Address, prev, new uint64) {
+func (t *MuxTracer) OnNonceChange(a common.Address, prev, new uint64) {
 	for _, t := range t.tracers {
 		if t.OnNonceChange != nil {
 			t.OnNonceChange(a, prev, new)
@@ -149,7 +154,7 @@ func (t *muxTracer) OnNonceChange(a common.Address, prev, new uint64) {
 	}
 }
 
-func (t *muxTracer) OnCodeChange(a common.Address, prevCodeHash common.Hash, prev []byte, codeHash common.Hash, code []byte) {
+func (t *MuxTracer) OnCodeChange(a common.Address, prevCodeHash common.Hash, prev []byte, codeHash common.Hash, code []byte) {
 	for _, t := range t.tracers {
 		if t.OnCodeChange != nil {
 			t.OnCodeChange(a, prevCodeHash, prev, codeHash, code)
@@ -157,7 +162,7 @@ func (t *muxTracer) OnCodeChange(a common.Address, prevCodeHash common.Hash, pre
 	}
 }
 
-func (t *muxTracer) OnStorageChange(a common.Address, k, prev, new common.Hash) {
+func (t *MuxTracer) OnStorageChange(a common.Address, k, prev, new common.Hash) {
 	for _, t := range t.tracers {
 		if t.OnStorageChange != nil {
 			t.OnStorageChange(a, k, prev, new)
@@ -165,7 +170,7 @@ func (t *muxTracer) OnStorageChange(a common.Address, k, prev, new common.Hash) 
 	}
 }
 
-func (t *muxTracer) OnLog(log *types.Log) {
+func (t *MuxTracer) OnLog(log *types.Log) {
 	for _, t := range t.tracers {
 		if t.OnLog != nil {
 			t.OnLog(log)
@@ -174,14 +179,14 @@ func (t *muxTracer) OnLog(log *types.Log) {
 }
 
 // GetResult returns an empty json object.
-func (t *muxTracer) GetResult() (json.RawMessage, error) {
+func (t *MuxTracer) GetResult() (json.RawMessage, error) {
 	resObject := make(map[string]json.RawMessage)
-	for i, tt := range t.tracers {
+	for n, tt := range t.tracers {
 		r, err := tt.GetResult()
 		if err != nil {
 			return nil, err
 		}
-		resObject[t.names[i]] = r
+		resObject[n] = r
 	}
 	res, err := json.Marshal(resObject)
 	if err != nil {
@@ -191,8 +196,12 @@ func (t *muxTracer) GetResult() (json.RawMessage, error) {
 }
 
 // Stop terminates execution of the tracer at the first opportune moment.
-func (t *muxTracer) Stop(err error) {
+func (t *MuxTracer) Stop(err error) {
 	for _, t := range t.tracers {
 		t.Stop(err)
 	}
+}
+
+func (t *MuxTracer) Tracers() map[string]*tracers.Tracer {
+	return t.tracers
 }

--- a/eth/tracers/native/mux.go
+++ b/eth/tracers/native/mux.go
@@ -27,7 +27,7 @@ import (
 )
 
 func init() {
-	tracers.DefaultDirectory.Register("muxTracer", newMuxTracer, false)
+	tracers.DefaultDirectory.Register("muxTracer", NewMuxTracer, false)
 }
 
 // muxTracer is a go implementation of the Tracer interface which
@@ -37,8 +37,8 @@ type muxTracer struct {
 	tracers []*tracers.Tracer
 }
 
-// newMuxTracer returns a new mux tracer.
-func newMuxTracer(ctx *tracers.Context, cfg json.RawMessage) (*tracers.Tracer, error) {
+// NewMuxTracer returns a new mux tracer.
+func NewMuxTracer(ctx *tracers.Context, cfg json.RawMessage) (*tracers.Tracer, error) {
 	var config map[string]json.RawMessage
 	if cfg != nil {
 		if err := json.Unmarshal(cfg, &config); err != nil {


### PR DESCRIPTION
Hi @s1na,

This is a poc version of the trace_xxx RPC. I primarily use the freezer database to store the block traces and register the RPC in stack with a callback (which may be refactored later). In this branch, I attempt to implement a simple version of the trace_filter, trace_block, and trace_transaction RPC methods. I then run these changes locally to verify the correctness of the data produced.

Here are some areas that need further refactoring:

1. Dependency Injection: We need to pass an `eth.Backend` or a similar object to the filter_tracer to fetch the chain’s inner services. For example, trace_transaction requires the transaction-to-block number mapping.
2. Tracer Compatibility: We need to adjust some aspects of the prestate and call tracers to be compatible with both live and debug traces. For instance, in live tracing, the block context is passed via the `OnBlockStart` hook, whereas in debug tracing, it is provided during the initialization of tracing.
3. RPC Design: We aim to maintain compatibility with Parity’s RPC. For example:

```json
{
  "jsonrpc": "2.0",
  "method": "trace_block",
  "id": 67,
  "params": [
    "0x5990",
    {"tracer": "callTracer"}  // Added in our implementation
  ]
}
```

Should the default tracer be parity? In Parity’s case, the response should also be the same as Parity’s(need more redesign). For other tracers (e.g., callTracer, prestateTracer), the response format should be consistent with the debug_traceXXX methods.

Looking forward to your feedback and suggestions.
