### PR TITLE
core/vm/runtime: ensure tracer benchmark calls `OnTxStart`

### DIFF
--- a/core/vm/runtime/runtime_test.go
+++ b/core/vm/runtime/runtime_test.go
@@ -38,7 +38,6 @@ import (
 
 	// force-load js tracers to trigger registration
 	_ "github.com/ethereum/go-ethereum/eth/tracers/js"
-	"github.com/holiman/uint256"
 )
 
 func TestDefaults(t *testing.T) {
@@ -339,11 +338,7 @@ func benchmarkNonModifyingCode(gas uint64, code []byte, name string, tracerCode 
 			Tracer: tracer.Hooks,
 		}
 	}
-	var (
-		destination = common.BytesToAddress([]byte("contract"))
-		vmenv       = NewEnv(cfg)
-		sender      = vm.AccountRef(cfg.Origin)
-	)
+	destination := common.BytesToAddress([]byte("contract"))
 	cfg.State.CreateAccount(destination)
 	eoa := common.HexToAddress("E0")
 	{
@@ -363,12 +358,12 @@ func benchmarkNonModifyingCode(gas uint64, code []byte, name string, tracerCode 
 	//cfg.State.CreateAccount(cfg.Origin)
 	// set the receiver's (the executing contract) code for execution.
 	cfg.State.SetCode(destination, code)
-	vmenv.Call(sender, destination, nil, gas, uint256.MustFromBig(cfg.Value))
+	Call(destination, nil, cfg)
 
 	b.Run(name, func(b *testing.B) {
 		b.ReportAllocs()
 		for i := 0; i < b.N; i++ {
-			vmenv.Call(sender, destination, nil, gas, uint256.MustFromBig(cfg.Value))
+			Call(destination, nil, cfg)
 		}
 	})
 }


### PR DESCRIPTION
The struct-based tracing added in #29189 seems to have caused an issue with the benchmark `BenchmarkTracerStepVsCallFrame`. On master we see the following panic: 

```console
$ go test -v ./core/vm/runtime -bench=BenchmarkTracerStepVsCallFrame -run=^#
goos: darwin
goarch: arm64
pkg: github.com/ethereum/go-ethereum/core/vm/runtime
BenchmarkTracerStepVsCallFrame
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x2 addr=0x40 pc=0x1019782f0]

goroutine 37 [running]:
github.com/ethereum/go-ethereum/eth/tracers/js.(*jsTracer).OnOpcode(0x140004c4000, 0x0, 0x10?, 0x989680, 0x1, {0x101ea2298, 0x1400000e258}, {0x1400000e258?, 0x14000155928?, 0x10173020c?}, ...)
        /Users/matt/dev/go-ethereum/eth/tracers/js/goja.go:328 +0x140
github.com/ethereum/go-ethereum/core/vm.(*EVMInterpreter).Run(0x14000307da0, 0x140003cc0d0, {0x0, 0x0, 0x0}, 0x0)
        /Users/matt/dev/go-ethereum/core/vm/interpreter.go:297 +0x8f8
github.com/ethereum/go-ethereum/core/vm.(*EVM).Call(0x140004a28c0, {0x101e94998, 0x14000141248}, {0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, ...}, ...)
        /Users/matt/dev/go-ethereum/core/vm/evm.go:245 +0x760
github.com/ethereum/go-ethereum/core/vm/runtime.benchmarkNonModifyingCode(0x989680, {0x14000010110, 0xa, 0xa}, {0x101a24bfd, 0xf}, {0x101a569be, 0x4b}, 0x140000daa08)
        /Users/matt/dev/go-ethereum/core/vm/runtime/runtime_test.go:366 +0x424
github.com/ethereum/go-ethereum/core/vm/runtime.BenchmarkTracerStepVsCallFrame(0x140000daa08)
        /Users/matt/dev/go-ethereum/core/vm/runtime/runtime_test.go:913 +0x7c
testing.(*B).runN(0x140000daa08, 0x1)
        /opt/homebrew/Cellar/go/1.22.5/libexec/src/testing/benchmark.go:193 +0x130
testing.(*B).run1.func1()
        /opt/homebrew/Cellar/go/1.22.5/libexec/src/testing/benchmark.go:215 +0x50
created by testing.(*B).run1 in goroutine 1
        /opt/homebrew/Cellar/go/1.22.5/libexec/src/testing/benchmark.go:208 +0x90
exit status 2
FAIL    github.com/ethereum/go-ethereum/core/vm/runtime 0.420s
FAIL
```

The issue seems to be that `OnOpcode` expects that `OnTxStart` has already been called to initialize the `env` value in the tracer. The JS tracer uses it in `OnOpcode` for the `GetRefund()` method.

This patch resolves the issue by reusing the `Call` method already defined in `runtime_test.go` which correctly calls `OnTxStart`.

After the patch:

```console
$ go test -v ./core/vm/runtime -bench=BenchmarkTracerStepVs
CallFrame -run=^#
goos: darwin
goarch: arm64
pkg: github.com/ethereum/go-ethereum/core/vm/runtime
BenchmarkTracerStepVsCallFrame
BenchmarkTracerStepVsCallFrame/tracer-step-10M
BenchmarkTracerStepVsCallFrame/tracer-step-10M-10                      3         493126958 ns/op    5
09117562 B/op    6363899 allocs/op
BenchmarkTracerStepVsCallFrame/tracer-call-frame-10M
BenchmarkTracerStepVsCallFrame/tracer-call-frame-10M-10               32          36011997 ns/op
  14804 B/op         188 allocs/op
PASS
ok      github.com/ethereum/go-ethereum/core/vm/runtime 5.130s
```