### PR TITLE
eth/protocols/snap: cleanup dangling account trie nodes due to incomplete storage

### DIFF
--- a/eth/protocols/snap/gentrie.go
+++ b/eth/protocols/snap/gentrie.go
@@ -31,6 +31,9 @@ type genTrie interface {
 	// update inserts the state item into generator trie.
 	update(key, value []byte) error
 
+	// delete removes the state item from the generator trie.
+	delete(key []byte) error
+
 	// commit flushes the right boundary nodes if complete flag is true. This
 	// function must be called before flushing the associated database batch.
 	commit(complete bool) common.Hash
@@ -113,7 +116,7 @@ func (t *pathTrie) onTrieNode(path []byte, hash common.Hash, blob []byte) {
 			// removed because it's a sibling of the nodes we want to commit, not
 			// the parent or ancestor.
 			for i := 0; i < len(path); i++ {
-				t.delete(path[:i], false)
+				t.deleteNode(path[:i], false)
 			}
 		}
 		return
@@ -136,7 +139,7 @@ func (t *pathTrie) onTrieNode(path []byte, hash common.Hash, blob []byte) {
 	// byte key. In either case, no gaps will be left in the path.
 	if t.last != nil && bytes.HasPrefix(t.last, path) && len(t.last)-len(path) > 1 {
 		for i := len(path) + 1; i < len(t.last); i++ {
-			t.delete(t.last[:i], true)
+			t.deleteNode(t.last[:i], true)
 		}
 	}
 	t.write(path, blob)
@@ -192,8 +195,8 @@ func (t *pathTrie) deleteStorageNode(path []byte, inner bool) {
 	rawdb.DeleteStorageTrieNode(t.batch, t.owner, path)
 }
 
-// delete commits the node deletion to provided database batch in path mode.
-func (t *pathTrie) delete(path []byte, inner bool) {
+// deleteNode commits the node deletion to provided database batch in path mode.
+func (t *pathTrie) deleteNode(path []byte, inner bool) {
 	if t.owner == (common.Hash{}) {
 		t.deleteAccountNode(path, inner)
 	} else {
@@ -205,6 +208,29 @@ func (t *pathTrie) delete(path []byte, inner bool) {
 // stack trie.
 func (t *pathTrie) update(key, value []byte) error {
 	return t.tr.Update(key, value)
+}
+
+// delete implements genTrie interface, deleting the item from the stack trie.
+func (t *pathTrie) delete(key []byte) error {
+	// reset the trie along with the trackers. Be aware that the last
+	// inserted item (potentially along with some internal trie nodes)
+	// will be silently discarded by trie resetting.
+	t.first = nil
+	t.last = nil
+	t.tr.Reset()
+
+	// explicitly mark the left boundary as incomplete, as the left-side
+	// item of the next one has been removed. Be aware that the next item
+	// to be inserted to will be ignored from committing as well.
+	t.skipLeftBoundary = true
+
+	// explicitly delete the potential leftover nodes on the specific
+	// path from the database.
+	tkey := t.tr.TrieKey(key)
+	for i := 0; i <= len(tkey); i++ {
+		t.deleteNode(tkey[:i], false)
+	}
+	return nil
 }
 
 // commit implements genTrie interface, flushing the right boundary if it's
@@ -255,7 +281,7 @@ func (t *pathTrie) commit(complete bool) common.Hash {
 	// with no issues as they are actually complete. Also, from a database
 	// perspective, first deleting and then rewriting is a valid data update.
 	for i := 0; i < len(t.last); i++ {
-		t.delete(t.last[:i], false)
+		t.deleteNode(t.last[:i], false)
 	}
 	return common.Hash{} // the hash is meaningless for incomplete commit
 }
@@ -277,6 +303,9 @@ func newHashTrie(batch ethdb.Batch) *hashTrie {
 func (t *hashTrie) update(key, value []byte) error {
 	return t.tr.Update(key, value)
 }
+
+// delete implements genTrie interface, ignoring the state item for deleting.
+func (t *hashTrie) delete(key []byte) error { return nil }
 
 // commit implements genTrie interface, committing the nodes on right boundary.
 func (t *hashTrie) commit(complete bool) common.Hash {

--- a/trie/stacktrie.go
+++ b/trie/stacktrie.go
@@ -64,8 +64,7 @@ func (t *StackTrie) Update(key, value []byte) error {
 	if len(value) == 0 {
 		return errors.New("trying to insert empty (deletion)")
 	}
-	k := keybytesToHex(key)
-	k = k[:len(k)-1] // chop the termination flag
+	k := t.TrieKey(key)
 	if bytes.Compare(t.last, k) >= 0 {
 		return errors.New("non-ascending key order")
 	}
@@ -82,6 +81,13 @@ func (t *StackTrie) Update(key, value []byte) error {
 func (t *StackTrie) Reset() {
 	t.root = stPool.Get().(*stNode)
 	t.last = nil
+}
+
+// TrieKey returns the internal key representation for the given user key.
+func (t *StackTrie) TrieKey(key []byte) []byte {
+	k := keybytesToHex(key)
+	k = k[:len(k)-1] // chop the termination flag
+	return k
 }
 
 // stNode represents a node within a StackTrie


### PR DESCRIPTION
This pull request fixes the https://github.com/ethereum/go-ethereum/issues/30229.
 
During the snap sync, large storage will be split into several pieces and synchronized
concurrently. Unfortunately, the tradeoff is that the respective merkle trie of each 
storage chunk will be incomplete due to the incomplete boundaries. The trie nodes 
on these boundaries will be discarded, and any dangling nodes on disk will also be 
removed if they fall on these paths, ensuring the state healer won't be blocked.

However, the dangling account trie nodes on the path from the root to the associated
account are left untouched. This means the dangling account trie nodes could 
potentially stop the state healing and break the assumption that the entire subtrie 
should exist if the subtrie root exists. We should consider the account trie node as 
the ancestor of the corresponding storage trie node. 

In the scenarios described in the above ticket, the state corruption could occur if 
there is a dangling account trie node while some storage trie nodes are removed
due to synchronization redo. 

---

The fixing idea is pretty straightforward, the trie nodes on the path from root
to account should all be explicitly removed if an incomplete storage trie occurs.
Therefore, a `delete` operation has been added into `gentrie` to explicitly clear
the account along with all nodes on this path. The special thing is that it's a 
cross-trie clearing. In theory, there may be a dangling node at any position on
this account key and we have to clear all of them. 

Specifically, in the diagram below, the *cross-trie-boundary* (from `[]` to `keyToNibbles(accountHash)`)
in account trie  should also be cleaned instead of the boundary nodes in storage trie only. 

![Untitled (Draft)-7](https://github.com/user-attachments/assets/f65eb047-b7ab-441a-baf2-655aa13e5606)


Besides, once the account is marked as deleted because of incomplete storage, 
the gentrie structure will be different with the full one, therefore, boundaries on 
both sides of the deleted account should be discarded as well, preventing committing
unexpected account trie nodes.

![1722830449248](https://github.com/user-attachments/assets/c20e23da-16c5-4dc0-b7b1-c8ab7ceac6c8)
![Untitled (Draft)-9](https://github.com/user-attachments/assets/dc1ef61f-591d-429e-8420-d3ab7aa2942f)
