### PR TITLE
cmd/evm: don't overwrite sender account

### DIFF
--- a/cmd/evm/runner.go
+++ b/cmd/evm/runner.go
@@ -162,7 +162,6 @@ func runCmd(ctx *cli.Context) error {
 	if ctx.String(SenderFlag.Name) != "" {
 		sender = common.HexToAddress(ctx.String(SenderFlag.Name))
 	}
-	statedb.CreateAccount(sender)
 
 	if ctx.String(ReceiverFlag.Name) != "" {
 		receiver = common.HexToAddress(ctx.String(ReceiverFlag.Name))


### PR DESCRIPTION
fixes #30254 

It seems like this line is [very old](https://github.com/ethereum/go-ethereum/blame/67b81371008d147aa2ccebd3fa9655fe042b0f14/cmd/evm/runner.go#L165) and is not needed anymore. After removing it, setting a sender that does not exist in the state doesn't seem to cause an issue.

This is the result of the command in the issue, you can see that `BALANCE` now returns the expected value:

```console
$ go run ./cmd/evm --debug --sender 0x1c7cd2d37ffd63856a5bd56a9af1643f2bcf545f --gas 0xffffff --nomemory=false --json --code 731c7cd2d37ffd63856a5bd56a9af1643f2bcf545f3160005260406000f3 --prestate ./genesis.json run
INFO [08-01|21:17:49.233] Persisted trie from memory database      nodes=1 size=142.00B time="2.208µs" gcnodes=0 gcsize=0.00B gctime=0s livenodes=0 livesize=0.00B
{"pc":0,"op":115,"gas":"0xffffff","gasCost":"0x3","memSize":0,"stack":[],"depth":1,"refund":0,"opName":"PUSH20"}
{"pc":21,"op":49,"gas":"0xfffffc","gasCost":"0x64","memSize":0,"stack":["0x1c7cd2d37ffd63856a5bd56a9af1643f2bcf545f"],"depth":1,"refund":0,"opName":"BALANCE"}
{"pc":22,"op":96,"gas":"0xffff98","gasCost":"0x3","memSize":0,"stack":["0x1234"],"depth":1,"refund":0,"opName":"PUSH1"}
{"pc":24,"op":82,"gas":"0xffff95","gasCost":"0x6","memSize":0,"stack":["0x1234","0x0"],"depth":1,"refund":0,"opName":"MSTORE"}
{"pc":25,"op":96,"gas":"0xffff8f","gasCost":"0x3","memory":"0x0000000000000000000000000000000000000000000000000000000000001234","memSize":32,"stack":[],"depth":1,"refund":0,"opName":"PUSH1"}
{"pc":27,"op":96,"gas":"0xffff8c","gasCost":"0x3","memory":"0x0000000000000000000000000000000000000000000000000000000000001234","memSize":32,"stack":["0x40"],"depth":1,"refund":0,"opName":"PUSH1"}
{"pc":29,"op":243,"gas":"0xffff89","gasCost":"0x3","memory":"0x0000000000000000000000000000000000000000000000000000000000001234","memSize":32,"stack":["0x40","0x0"],"depth":1,"refund":0,"opName":"RETURN"}
{"output":"00000000000000000000000000000000000000000000000000000000000012340000000000000000000000000000000000000000000000000000000000000000","gasUsed":"0x79"}
#### LOGS ####