### PR TITLE
eth/catalyst: ensure period zero mode leaves no pending txs in pool

### DIFF
--- a/eth/catalyst/simulated_beacon.go
+++ b/eth/catalyst/simulated_beacon.go
@@ -30,6 +30,7 @@ import (
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/crypto/kzg4844"
 	"github.com/ethereum/go-ethereum/eth"
+	"github.com/ethereum/go-ethereum/event"
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/node"
 	"github.com/ethereum/go-ethereum/params"
@@ -41,36 +42,47 @@ const devEpochLength = 32
 // withdrawalQueue implements a FIFO queue which holds withdrawals that are
 // pending inclusion.
 type withdrawalQueue struct {
-	pending chan *types.Withdrawal
+	pending types.Withdrawals
+	mu      sync.Mutex
+	feed    event.Feed
+	subs    event.SubscriptionScope
 }
 
+type newWithdrawalsEvent struct{ Withdrawals types.Withdrawals }
+
 // add queues a withdrawal for future inclusion.
-func (w *withdrawalQueue) add(withdrawal *types.Withdrawal) error {
-	select {
-	case w.pending <- withdrawal:
-		break
-	default:
-		return errors.New("withdrawal queue full")
-	}
+func (w *withdrawalQueue) Add(withdrawal *types.Withdrawal) error {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+
+	w.pending = append(w.pending, withdrawal)
+	w.feed.Send(newWithdrawalsEvent{types.Withdrawals{withdrawal}})
+
 	return nil
 }
 
-// gatherPending returns a number of queued withdrawals up to a maximum count.
-func (w *withdrawalQueue) gatherPending(maxCount int) []*types.Withdrawal {
-	withdrawals := []*types.Withdrawal{}
-	for {
-		select {
-		case withdrawal := <-w.pending:
-			withdrawals = append(withdrawals, withdrawal)
-			if len(withdrawals) == maxCount {
-				return withdrawals
-			}
-		default:
-			return withdrawals
-		}
-	}
+// pop dequeues the specified number of withdrawals from the queue.
+func (w *withdrawalQueue) Pop(count int) types.Withdrawals {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+
+	count = min(count, len(w.pending))
+	popped := w.pending[0:count]
+	w.pending = w.pending[count:]
+
+	return popped
 }
 
+// subscribe allows a listener to be updated when new withdrawals are added to
+// the queue.
+func (w *withdrawalQueue) Subscribe(ch chan<- newWithdrawalsEvent) event.Subscription {
+	sub := w.feed.Subscribe(ch)
+	return w.subs.Track(sub)
+}
+
+// SimulatedBeacon drives an Ethereum instance as if it were a real beacon
+// client. It can run in period mode where it mines a new block every period
+// (seconds) or on every transaction via Commit, Fork and AdjustTime.
 type SimulatedBeacon struct {
 	shutdownCh  chan struct{}
 	eth         *eth.Ethereum
@@ -86,10 +98,6 @@ type SimulatedBeacon struct {
 }
 
 // NewSimulatedBeacon constructs a new simulated beacon chain.
-// Period sets the period in which blocks should be produced.
-//
-//   - If period is set to 0, a block is produced on every transaction.
-//     via Commit, Fork and AdjustTime.
 func NewSimulatedBeacon(period uint64, eth *eth.Ethereum) (*SimulatedBeacon, error) {
 	block := eth.BlockChain().CurrentBlock()
 	current := engine.ForkchoiceStateV1{
@@ -112,7 +120,6 @@ func NewSimulatedBeacon(period uint64, eth *eth.Ethereum) (*SimulatedBeacon, err
 		engineAPI:          engineAPI,
 		lastBlockTime:      block.Time,
 		curForkchoiceState: current,
-		withdrawals:        withdrawalQueue{make(chan *types.Withdrawal, 20)},
 	}, nil
 }
 
@@ -171,6 +178,7 @@ func (c *SimulatedBeacon) sealBlock(withdrawals []*types.Withdrawal, timestamp u
 	if fcResponse == engine.STATUS_SYNCING {
 		return errors.New("chain rewind prevented invocation of payload creation")
 	}
+
 	envelope, err := c.engineAPI.getPayload(*fcResponse.PayloadID, true)
 	if err != nil {
 		return err
@@ -223,8 +231,7 @@ func (c *SimulatedBeacon) loop() {
 		case <-c.shutdownCh:
 			return
 		case <-timer.C:
-			withdrawals := c.withdrawals.gatherPending(10)
-			if err := c.sealBlock(withdrawals, uint64(time.Now().Unix())); err != nil {
+			if err := c.sealBlock(c.withdrawals.Pop(10), uint64(time.Now().Unix())); err != nil {
 				log.Warn("Error performing sealing work", "err", err)
 			} else {
 				timer.Reset(time.Second * time.Duration(c.period))
@@ -260,7 +267,7 @@ func (c *SimulatedBeacon) setCurrentState(headHash, finalizedHash common.Hash) {
 
 // Commit seals a block on demand.
 func (c *SimulatedBeacon) Commit() common.Hash {
-	withdrawals := c.withdrawals.gatherPending(10)
+	withdrawals := c.withdrawals.Pop(10)
 	if err := c.sealBlock(withdrawals, uint64(time.Now().Unix())); err != nil {
 		log.Warn("Error performing sealing work", "err", err)
 	}
@@ -301,12 +308,14 @@ func (c *SimulatedBeacon) AdjustTime(adjustment time.Duration) error {
 	if parent == nil {
 		return errors.New("parent not found")
 	}
-	withdrawals := c.withdrawals.gatherPending(10)
+	withdrawals := c.withdrawals.Pop(10)
 	return c.sealBlock(withdrawals, parent.Time+uint64(adjustment/time.Second))
 }
 
+// RegisterSimulatedBeaconAPIs registers the simulated beacon's API with the
+// stack.
 func RegisterSimulatedBeaconAPIs(stack *node.Node, sim *SimulatedBeacon) {
-	api := &api{sim}
+	api := &simulatedBeaconAPI{sim: sim, doCommit: make(chan struct{}, 1)}
 	if sim.period == 0 {
 		// mine on demand if period is set to 0
 		go api.loop()

--- a/eth/catalyst/simulated_beacon.go
+++ b/eth/catalyst/simulated_beacon.go
@@ -54,11 +54,10 @@ type newWithdrawalsEvent struct{ Withdrawals types.Withdrawals }
 // add queues a withdrawal for future inclusion.
 func (w *withdrawalQueue) add(withdrawal *types.Withdrawal) error {
 	w.mu.Lock()
-	defer w.mu.Unlock()
-
 	w.pending = append(w.pending, withdrawal)
-	w.feed.Send(newWithdrawalsEvent{types.Withdrawals{withdrawal}})
+	w.mu.Unlock()
 
+	w.feed.Send(newWithdrawalsEvent{types.Withdrawals{withdrawal}})
 	return nil
 }
 

--- a/eth/catalyst/simulated_beacon_api.go
+++ b/eth/catalyst/simulated_beacon_api.go
@@ -60,7 +60,10 @@ func (a *simulatedBeaconAPI) loop() {
 		for _ = range doCommit {
 			a.sim.Commit()
 			a.sim.eth.TxPool().Sync()
-			if executable, _ := a.sim.eth.TxPool().Stats(); executable > 0 {
+			for {
+				if executable, _ := a.sim.eth.TxPool().Stats(); executable == 0 {
+					break
+				}
 				a.sim.Commit()
 			}
 		}

--- a/eth/catalyst/simulated_beacon_api.go
+++ b/eth/catalyst/simulated_beacon_api.go
@@ -54,7 +54,8 @@ func (a *simulatedBeaconAPI) loop() {
 	)
 	defer newTxsSub.Unsubscribe()
 	defer newWxsSub.Unsubscribe()
-	// a background thread which signals to the simulator when to commit
+
+	// A background thread which signals to the simulator when to commit
 	// based on messages over doCommit.
 	go func() {
 		for _ = range doCommit {

--- a/eth/catalyst/simulated_beacon_api.go
+++ b/eth/catalyst/simulated_beacon_api.go
@@ -58,14 +58,14 @@ func (a *simulatedBeaconAPI) loop() {
 	// A background thread which signals to the simulator when to commit
 	// based on messages over doCommit.
 	go func() {
-		for _ = range doCommit {
+		for range doCommit {
 			a.sim.Commit()
 			a.sim.eth.TxPool().Sync()
 
 			// It's worth noting that in case a tx ends up in the pool listed as
 			// "executable", but for whatever reason the miner does not include it in
 			// a block -- maybe the miner is enforcing a higher tip than the pool --
-			// this code will spinloop.
+			// this code will spinloopk.
 			for {
 				if executable, _ := a.sim.eth.TxPool().Stats(); executable == 0 {
 					break

--- a/eth/catalyst/simulated_beacon_api.go
+++ b/eth/catalyst/simulated_beacon_api.go
@@ -65,7 +65,7 @@ func (a *simulatedBeaconAPI) loop() {
 			// It's worth noting that in case a tx ends up in the pool listed as
 			// "executable", but for whatever reason the miner does not include it in
 			// a block -- maybe the miner is enforcing a higher tip than the pool --
-			// this code will spinloopk.
+			// this code will spinloop.
 			for {
 				if executable, _ := a.sim.eth.TxPool().Stats(); executable == 0 {
 					break

--- a/eth/catalyst/simulated_beacon_api.go
+++ b/eth/catalyst/simulated_beacon_api.go
@@ -61,6 +61,11 @@ func (a *simulatedBeaconAPI) loop() {
 		for _ = range doCommit {
 			a.sim.Commit()
 			a.sim.eth.TxPool().Sync()
+
+			// It's worth noting that in case a tx ends up in the pool listed as
+			// "executable", but for whatever reason the miner does not include it in
+			// a block -- maybe the miner is enforcing a higher tip than the pool --
+			// this code will spinloop.
 			for {
 				if executable, _ := a.sim.eth.TxPool().Stats(); executable == 0 {
 					break

--- a/eth/catalyst/simulated_beacon_test.go
+++ b/eth/catalyst/simulated_beacon_test.go
@@ -35,7 +35,7 @@ import (
 	"github.com/ethereum/go-ethereum/params"
 )
 
-func startSimulatedBeaconEthService(t *testing.T, genesis *core.Genesis) (*node.Node, *eth.Ethereum, *SimulatedBeacon) {
+func startSimulatedBeaconEthService(t *testing.T, genesis *core.Genesis, period uint64) (*node.Node, *eth.Ethereum, *SimulatedBeacon) {
 	t.Helper()
 
 	n, err := node.New(&node.Config{
@@ -55,7 +55,7 @@ func startSimulatedBeaconEthService(t *testing.T, genesis *core.Genesis) (*node.
 		t.Fatal("can't create eth service:", err)
 	}
 
-	simBeacon, err := NewSimulatedBeacon(1, ethservice)
+	simBeacon, err := NewSimulatedBeacon(period, ethservice)
 	if err != nil {
 		t.Fatal("can't create simulated beacon:", err)
 	}
@@ -87,7 +87,7 @@ func TestSimulatedBeaconSendWithdrawals(t *testing.T) {
 	// short period (1 second) for testing purposes
 	var gasLimit uint64 = 10_000_000
 	genesis := core.DeveloperGenesisBlock(gasLimit, &testAddr)
-	node, ethService, mock := startSimulatedBeaconEthService(t, genesis)
+	node, ethService, mock := startSimulatedBeaconEthService(t, genesis, 1)
 	_ = mock
 	defer node.Close()
 
@@ -98,7 +98,7 @@ func TestSimulatedBeaconSendWithdrawals(t *testing.T) {
 	// generate some withdrawals
 	for i := 0; i < 20; i++ {
 		withdrawals = append(withdrawals, types.Withdrawal{Index: uint64(i)})
-		if err := mock.withdrawals.add(&withdrawals[i]); err != nil {
+		if err := mock.withdrawals.Add(&withdrawals[i]); err != nil {
 			t.Fatal("addWithdrawal failed", err)
 		}
 	}
@@ -137,6 +137,71 @@ func TestSimulatedBeaconSendWithdrawals(t *testing.T) {
 			}
 		case <-timer.C:
 			t.Fatal("timed out without including all withdrawals/txs")
+		}
+	}
+}
+
+// Tests that zero-period dev mode can handle a lot of simultaneous
+// transactions/withdrawals
+func TestOnDemandSpam(t *testing.T) {
+	var (
+		withdrawals     []types.Withdrawal
+		txs                    = make(map[common.Hash]*types.Transaction)
+		testKey, _             = crypto.HexToECDSA("b71c71a67e1177ad4e901695e1b4b9ee17ae16c6668d313eac2f96dbcda3f291")
+		testAddr               = crypto.PubkeyToAddress(testKey.PublicKey)
+		gasLimit        uint64 = 10_000_000
+		genesis                = core.DeveloperGenesisBlock(gasLimit, &testAddr)
+		node, eth, mock        = startSimulatedBeaconEthService(t, genesis, 0)
+		signer                 = types.LatestSigner(eth.BlockChain().Config())
+		chainHeadCh            = make(chan core.ChainHeadEvent, 100)
+		sub                    = eth.BlockChain().SubscribeChainHeadEvent(chainHeadCh)
+	)
+	defer node.Close()
+	defer sub.Unsubscribe()
+
+	// start simulated beacon
+	api := &simulatedBeaconAPI{sim: mock, doCommit: make(chan struct{}, 1)}
+	go api.loop()
+
+	// generate some withdrawals
+	for i := 0; i < 20; i++ {
+		withdrawals = append(withdrawals, types.Withdrawal{Index: uint64(i)})
+		if err := mock.withdrawals.Add(&withdrawals[i]); err != nil {
+			t.Fatal("addWithdrawal failed", err)
+		}
+	}
+
+	// generate a bunch of transactions
+	for i := 0; i < 20000; i++ {
+		tx, err := types.SignTx(types.NewTransaction(uint64(i), common.Address{byte(i), byte(1)}, big.NewInt(1000), params.TxGas, big.NewInt(params.InitialBaseFee*2), nil), signer, testKey)
+		if err != nil {
+			t.Fatal("error signing transaction", err)
+		}
+		txs[tx.Hash()] = tx
+		if err := eth.APIBackend.SendTx(context.Background(), tx); err != nil {
+			t.Fatal("error adding txs to pool", err)
+		}
+	}
+
+	var (
+		includedTxs = make(map[common.Hash]struct{})
+		includedWxs []uint64
+	)
+	for {
+		select {
+		case evt := <-chainHeadCh:
+			for _, itx := range evt.Block.Transactions() {
+				includedTxs[itx.Hash()] = struct{}{}
+			}
+			for _, iwx := range evt.Block.Withdrawals() {
+				includedWxs = append(includedWxs, iwx.Index)
+			}
+			// ensure all withdrawals/txs included. this will take two blocks b/c number of withdrawals > 10
+			if len(includedTxs) == len(txs) && len(includedWxs) == len(withdrawals) {
+				return
+			}
+		case <-time.After(10 * time.Second):
+			t.Fatalf("timed out without including all withdrawals/txs: have txs %d, want %d, have wxs %d, want %d", len(includedTxs), len(txs), len(includedWxs), len(withdrawals))
 		}
 	}
 }

--- a/eth/catalyst/simulated_beacon_test.go
+++ b/eth/catalyst/simulated_beacon_test.go
@@ -98,7 +98,7 @@ func TestSimulatedBeaconSendWithdrawals(t *testing.T) {
 	// generate some withdrawals
 	for i := 0; i < 20; i++ {
 		withdrawals = append(withdrawals, types.Withdrawal{Index: uint64(i)})
-		if err := mock.withdrawals.Add(&withdrawals[i]); err != nil {
+		if err := mock.withdrawals.add(&withdrawals[i]); err != nil {
 			t.Fatal("addWithdrawal failed", err)
 		}
 	}
@@ -152,6 +152,7 @@ func TestOnDemandSpam(t *testing.T) {
 		gasLimit        uint64 = 10_000_000
 		genesis                = core.DeveloperGenesisBlock(gasLimit, &testAddr)
 		node, eth, mock        = startSimulatedBeaconEthService(t, genesis, 0)
+		_                      = newSimulatedBeaconAPI(mock)
 		signer                 = types.LatestSigner(eth.BlockChain().Config())
 		chainHeadCh            = make(chan core.ChainHeadEvent, 100)
 		sub                    = eth.BlockChain().SubscribeChainHeadEvent(chainHeadCh)
@@ -159,14 +160,10 @@ func TestOnDemandSpam(t *testing.T) {
 	defer node.Close()
 	defer sub.Unsubscribe()
 
-	// start simulated beacon
-	api := &simulatedBeaconAPI{sim: mock, doCommit: make(chan struct{}, 1)}
-	go api.loop()
-
 	// generate some withdrawals
 	for i := 0; i < 20; i++ {
 		withdrawals = append(withdrawals, types.Withdrawal{Index: uint64(i)})
-		if err := mock.withdrawals.Add(&withdrawals[i]); err != nil {
+		if err := mock.withdrawals.add(&withdrawals[i]); err != nil {
 			t.Fatal("addWithdrawal failed", err)
 		}
 	}


### PR DESCRIPTION
closes #29475, replaces #29657, #30104 

The original problem noted in #29475 was a deadlock where `runReorg` was trying to write to `newTxs` subscription, but the reader was already waiting for `runReorg` to finish in a call to `txpool.Sync()`. This PR solves that issue by creating a worker thread in the simulated beacon API which allows the API's main event handler to never block. Instead, when a new tx or withdrawal event is received it notifies the worker thread to begin constructing a block. It uses a buffered channel to ensure that while the worker is building a block, additional requests to construct a block are not dropped nor blocked on.

Although this was also solved by spawning a new goroutine on each `newTxs` event #29657, an additional issue around handling txs [was noticed](https://github.com/ethereum/go-ethereum/pull/29657#issuecomment-2196832615). It's possible for a `newTxs` event to have more txs than can be included in a single block. Because we only called `Commit` once, these txs would be left dangling in the pool. This PR also fixes this issue by calling `txpool.Sync()` to ensure the reorg has happened to account for the recently produced block, followed by `txpool.Stats()` to check if there are any remaining executable txs.

There is a concern here is that the relationship between the miner determining if the pending txs can be included and the result of `txpool.Stats()` is sort of weak. It's possible that if those get out-of-whack the simulated beacon api could go into an infinite loop of block production. Since the miner only checks if txs can 1) pay the appropriate miner tip, 2) afford the base fee, and 3) fit within the gas limit. Currently I can't see how this would happen unless maybe a local tx submits a base below the theoretical floor (7 wei). Open to suggestions on improving that.

The PR #30104 did not have this issue, because it would build blocks until it got an empty block. Originally I felt this was rather crude and polluted the separation of `sealBlock` with the concept of `allowEmpty`. It still feels hacky to me, but given the complexity of the subsystems (miner, txpool, sim), it may actually be the cleanest way to ensure we get the desired outcome. One scenario the current PR can handle that #30104 cannot though is if there are pending txs which cannot pay the base fee due to a previous iteration pushing the base fee too high. Th

--

I also tacked on a commit to move the call for `txpool.Sync()` out of `forkchoiceUpdated` and into the simulated beacon. @karalabe originally added it into fcu, would be curious to know if there was a reason for adding there versus in the simulator. By adding it to the simulator we can simplify the parameters for `forkchoiceUpdated` slightly.

If it seems better to go down the path set by #30104 I can adjust this PR to just check the resulting block's tx count and stop the loop once it receives an empty block. I still think there are some worth while renamings / improvements in this PR.