### PR TITLE
p2p/nat: remove forceful port mapping in upnp

### DIFF
--- a/p2p/nat/natpmp.go
+++ b/p2p/nat/natpmp.go
@@ -49,6 +49,9 @@ func (n *pmp) AddMapping(protocol string, extport, intport int, name string, lif
 	if lifetime <= 0 {
 		return 0, errors.New("lifetime must not be <= 0")
 	}
+	if extport == 0 {
+		extport = intport
+	}
 	// Note order of port arguments is switched between our
 	// AddMapping and the client's AddPortMapping.
 	res, err := n.c.AddPortMapping(strings.ToLower(protocol), intport, extport, int(lifetime/time.Second))

--- a/p2p/nat/natupnp.go
+++ b/p2p/nat/natupnp.go
@@ -87,6 +87,13 @@ func (n *upnp) AddMapping(protocol string, extport, intport int, desc string, li
 	protocol = strings.ToUpper(protocol)
 	lifetimeS := uint32(lifetime / time.Second)
 
+	if extport == 0 {
+		extport = intport
+	} else {
+		// Only delete port mapping if the external port was already used by geth.
+		n.DeleteMapping(protocol, extport, intport)
+	}
+
 	err = n.withRateLimit(func() error {
 		return n.client.AddPortMapping("", uint16(extport), protocol, uint16(intport), ip.String(), true, desc, lifetimeS)
 	})

--- a/p2p/nat/natupnp.go
+++ b/p2p/nat/natupnp.go
@@ -94,13 +94,7 @@ func (n *upnp) AddMapping(protocol string, extport, intport int, desc string, li
 		n.DeleteMapping(protocol, extport, intport)
 	}
 
-	err = n.withRateLimit(func() error {
-		return n.client.AddPortMapping("", uint16(extport), protocol, uint16(intport), ip.String(), true, desc, lifetimeS)
-	})
-	if err == nil {
-		return uint16(extport), nil
-	}
-	// Try addAnyPortMapping if mapping specified port didn't work.
+	// Try to add port mapping, preferring the specified external port.
 	err = n.withRateLimit(func() error {
 		p, err := n.addAnyPortMapping(protocol, extport, intport, ip, desc, lifetimeS)
 		if err == nil {

--- a/p2p/server_nat.go
+++ b/p2p/server_nat.go
@@ -150,11 +150,9 @@ func (srv *Server) portMappingLoop() {
 					continue
 				}
 
-				external := m.extPort
-				log := newLogger(m.protocol, external, m.port)
-
+				log := newLogger(m.protocol, m.extPort, m.port)
 				log.Trace("Attempting port mapping")
-				p, err := srv.NAT.AddMapping(m.protocol, external, m.port, m.name, portMapDuration)
+				p, err := srv.NAT.AddMapping(m.protocol, m.extPort, m.port, m.name, portMapDuration)
 				if err != nil {
 					log.Debug("Couldn't add port mapping", "err", err)
 					m.extPort = 0
@@ -164,8 +162,8 @@ func (srv *Server) portMappingLoop() {
 				// It was mapped!
 				m.extPort = int(p)
 				m.nextTime = srv.clock.Now().Add(portMapRefreshInterval)
+				log = newLogger(m.protocol, m.extPort, m.port)
 				if m.port != m.extPort {
-					log = newLogger(m.protocol, m.extPort, m.port)
 					log.Info("NAT mapped alternative port")
 				} else {
 					log.Info("NAT mapped port")

--- a/p2p/server_nat.go
+++ b/p2p/server_nat.go
@@ -164,7 +164,7 @@ func (srv *Server) portMappingLoop() {
 				// It was mapped!
 				m.extPort = int(p)
 				m.nextTime = srv.clock.Now().Add(portMapRefreshInterval)
-				if external != m.extPort {
+				if m.port != m.extPort {
 					log = newLogger(m.protocol, m.extPort, m.port)
 					log.Info("NAT mapped alternative port")
 				} else {

--- a/p2p/server_nat.go
+++ b/p2p/server_nat.go
@@ -150,10 +150,7 @@ func (srv *Server) portMappingLoop() {
 					continue
 				}
 
-				external := m.port
-				if m.extPort != 0 {
-					external = m.extPort
-				}
+				external := m.extPort
 				log := newLogger(m.protocol, external, m.port)
 
 				log.Trace("Attempting port mapping")


### PR DESCRIPTION
Since `addAnyPortMapping` is implemented, we don't need `DeleteMapping` to remove an existing port mapping and make a forceful port mapping (which somewhat goes against the concept of upnp).

Also there is some chance `n.randomPort()` in `addAnyPortMapping` returns an occupied port, so it's safer to try it couple of times. Three looks like  enough according to [libp2p](https://github.com/libp2p/go-nat/blob/01a3d9956ae145b41d9a72bb1e3a2bdad57a7606/upnp.go#L265).

Edit: Fixed so it would only delete port mapping only if the external port was originally used by geth.