### PR TITLE
tests: fix TransactionTest to actually run

### DIFF
--- a/tests/transaction_test.go
+++ b/tests/transaction_test.go
@@ -26,20 +26,14 @@ func TestTransaction(t *testing.T) {
 	t.Parallel()
 
 	txt := new(testMatcher)
-	// These can't be parsed, invalid hex in RLP
-	txt.skipLoad("^ttWrongRLP/.*")
 	// We don't allow more than uint64 in gas amount
 	// This is a pseudo-consensus vulnerability, but not in practice
 	// because of the gas limit
 	txt.skipLoad("^ttGasLimit/TransactionWithGasLimitxPriceOverflow.json")
 	// We _do_ allow more than uint64 in gas price, as opposed to the tests
 	// This is also not a concern, as long as tx.Cost() uses big.Int for
-	// calculating the final cozt
-	txt.skipLoad(".*TransactionWithGasPriceOverflow.*")
-
-	// The nonce is too large for uint64. Not a concern, it means geth won't
-	// accept transactions at a certain point in the distant future
-	txt.skipLoad("^ttNonce/TransactionWithHighNonce256.json")
+	// calculating the final cost
+	txt.skipLoad("^ttGasPrice/TransactionWithGasPriceOverflow.json")
 
 	// The maximum value of nonce is 2^64 - 1
 	txt.skipLoad("^ttNonce/TransactionWithHighNonce64Minus1.json")

--- a/tests/transaction_test.go
+++ b/tests/transaction_test.go
@@ -41,6 +41,9 @@ func TestTransaction(t *testing.T) {
 	// accept transactions at a certain point in the distant future
 	txt.skipLoad("^ttNonce/TransactionWithHighNonce256.json")
 
+	// The maximum value of nonce is 2^64 - 1
+	txt.skipLoad("^ttNonce/TransactionWithHighNonce64Minus1.json")
+
 	// The value is larger than uint64, which according to the test is invalid.
 	// Geth accepts it, which is not a consensus issue since we use big.Int's
 	// internally to calculate the cost

--- a/tests/transaction_test_util.go
+++ b/tests/transaction_test_util.go
@@ -29,7 +29,11 @@ import (
 
 // TransactionTest checks RLP decoding and sender derivation of transactions.
 type TransactionTest struct {
-	RLP            hexutil.Bytes `json:"rlp"`
+	Txbytes    hexutil.Bytes `json:"txbytes"`
+	Result ttResult
+}
+
+type ttResult struct {
 	Byzantium      ttFork
 	Constantinople ttFork
 	Istanbul       ttFork
@@ -73,15 +77,15 @@ func (tt *TransactionTest) Run(config *params.ChainConfig) error {
 		isHomestead bool
 		isIstanbul  bool
 	}{
-		{"Frontier", types.FrontierSigner{}, tt.Frontier, false, false},
-		{"Homestead", types.HomesteadSigner{}, tt.Homestead, true, false},
-		{"EIP150", types.HomesteadSigner{}, tt.EIP150, true, false},
-		{"EIP158", types.NewEIP155Signer(config.ChainID), tt.EIP158, true, false},
-		{"Byzantium", types.NewEIP155Signer(config.ChainID), tt.Byzantium, true, false},
-		{"Constantinople", types.NewEIP155Signer(config.ChainID), tt.Constantinople, true, false},
-		{"Istanbul", types.NewEIP155Signer(config.ChainID), tt.Istanbul, true, true},
+		{"Frontier", types.FrontierSigner{}, tt.Result.Frontier, false, false},
+		{"Homestead", types.HomesteadSigner{}, tt.Result.Homestead, true, false},
+		{"EIP150", types.HomesteadSigner{}, tt.Result.EIP150, true, false},
+		{"EIP158", types.NewEIP155Signer(config.ChainID), tt.Result.EIP158, true, false},
+		{"Byzantium", types.NewEIP155Signer(config.ChainID), tt.Result.Byzantium, true, false},
+		{"Constantinople", types.NewEIP155Signer(config.ChainID), tt.Result.Constantinople, true, false},
+		{"Istanbul", types.NewEIP155Signer(config.ChainID), tt.Result.Istanbul, true, true},
 	} {
-		sender, txhash, err := validateTx(tt.RLP, testcase.signer, testcase.isHomestead, testcase.isIstanbul)
+		sender, txhash, err := validateTx(tt.Txbytes, testcase.signer, testcase.isHomestead, testcase.isIstanbul)
 
 		if testcase.fork.Sender == (common.UnprefixedAddress{}) {
 			if err == nil {

--- a/tests/transaction_test_util.go
+++ b/tests/transaction_test_util.go
@@ -29,8 +29,8 @@ import (
 
 // TransactionTest checks RLP decoding and sender derivation of transactions.
 type TransactionTest struct {
-	Txbytes    hexutil.Bytes `json:"txbytes"`
-	Result ttResult
+	Txbytes hexutil.Bytes `json:"txbytes"`
+	Result  ttResult
 }
 
 type ttResult struct {


### PR DESCRIPTION
Due to https://github.com/ethereum/tests/releases/tag/v10.1, the format of the TransactionTest changed, but it was not properly addressed, causing the test to pass unexpectedly.

This PR follows the structural changes and corrects the TransactionTest to pass correctly.

For reference, a similar issue had occurred previously.
https://github.com/ethereum/go-ethereum/issues/19033