### PR TITLE
eth/downloader, core/types: take withdrawals-size into account in downloader queue

### DIFF
--- a/core/types/withdrawal.go
+++ b/core/types/withdrawal.go
@@ -43,17 +43,17 @@ type withdrawalMarshaling struct {
 	Amount    hexutil.Uint64
 }
 
-var withdrawalSize = common.StorageSize(reflect.TypeOf(Withdrawal{}).Size())
-
-func (w Withdrawal) Size() common.StorageSize {
-	return common.StorageSize(withdrawalSize)
-}
-
 // Withdrawals implements DerivableList for withdrawals.
 type Withdrawals []*Withdrawal
 
 // Len returns the length of s.
 func (s Withdrawals) Len() int { return len(s) }
+
+var withdrawalSize = int(reflect.TypeOf(Withdrawal{}).Size())
+
+func (s Withdrawals) Size() int {
+	return withdrawalSize * len(s)
+}
 
 // EncodeIndex encodes the i'th withdrawal to w. Note that this does not check for errors
 // because we assume that *Withdrawal will only ever contain valid withdrawals that were either

--- a/core/types/withdrawal.go
+++ b/core/types/withdrawal.go
@@ -18,6 +18,7 @@ package types
 
 import (
 	"bytes"
+	"unsafe"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
@@ -40,6 +41,10 @@ type withdrawalMarshaling struct {
 	Index     hexutil.Uint64
 	Validator hexutil.Uint64
 	Amount    hexutil.Uint64
+}
+
+func (w Withdrawal) Size() common.StorageSize {
+	return common.StorageSize(unsafe.Sizeof(w))
 }
 
 // Withdrawals implements DerivableList for withdrawals.

--- a/core/types/withdrawal.go
+++ b/core/types/withdrawal.go
@@ -18,7 +18,7 @@ package types
 
 import (
 	"bytes"
-	"unsafe"
+	"reflect"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
@@ -43,8 +43,10 @@ type withdrawalMarshaling struct {
 	Amount    hexutil.Uint64
 }
 
+var withdrawalSize = common.StorageSize(reflect.TypeOf(Withdrawal{}).Size())
+
 func (w Withdrawal) Size() common.StorageSize {
-	return common.StorageSize(unsafe.Sizeof(w))
+	return common.StorageSize(withdrawalSize)
 }
 
 // Withdrawals implements DerivableList for withdrawals.

--- a/eth/downloader/queue.go
+++ b/eth/downloader/queue.go
@@ -385,9 +385,7 @@ func (q *queue) Results(block bool) []*fetchResult {
 		for _, tx := range result.Transactions {
 			size += common.StorageSize(tx.Size())
 		}
-		for _, withdrawal := range result.Withdrawals {
-			size += withdrawal.Size()
-		}
+		size += common.StorageSize(result.Withdrawals.Size())
 		q.resultSize = common.StorageSize(blockCacheSizeWeight)*size +
 			(1-common.StorageSize(blockCacheSizeWeight))*q.resultSize
 	}

--- a/eth/downloader/queue.go
+++ b/eth/downloader/queue.go
@@ -385,6 +385,9 @@ func (q *queue) Results(block bool) []*fetchResult {
 		for _, tx := range result.Transactions {
 			size += common.StorageSize(tx.Size())
 		}
+		for _, withdrawal := range result.Withdrawals {
+			size += withdrawal.Size()
+		}
 		q.resultSize = common.StorageSize(blockCacheSizeWeight)*size +
 			(1-common.StorageSize(blockCacheSizeWeight))*q.resultSize
 	}


### PR DESCRIPTION
This PR addresses an issue where the size of the downloader queue was not accurately measured. Previously, the size of withdrawals was not included in the queue size calculation, leading to an accumulation of more items than originally intended. This simple fix ensures that withdrawals are now considered, providing an accurate measurement of the queue size.