### PR TITLE
cmd/evm: fix evm basefee

### DIFF
--- a/cmd/evm/runner.go
+++ b/cmd/evm/runner.go
@@ -221,6 +221,7 @@ func runCmd(ctx *cli.Context) error {
 		Time:        genesisConfig.Timestamp,
 		Coinbase:    genesisConfig.Coinbase,
 		BlockNumber: new(big.Int).SetUint64(genesisConfig.Number),
+		BaseFee:     genesisConfig.BaseFee,
 		BlobHashes:  blobHashes,
 		BlobBaseFee: blobBaseFee,
 		EVMConfig: vm.Config{


### PR DESCRIPTION
This PR fixes #30279

We did not use the basefee from the genesis, and instead the defaults were used from `runtime.go/setDefaults`-function
```golang
	if cfg.BaseFee == nil {
		cfg.BaseFee = big.NewInt(params.InitialBaseFee)
	}
```
That method will still be used if it's not provided in genesis. 

----------

With this PR

```
[user@work go-ethereum]$ go run ./cmd/evm  --debug --gas 0xffffff --nomemory=false --json --code 4860005260406000f3 --prestate ./genesis.json run
INFO [08-08|15:55:21.436] Persisted trie from memory database      nodes=1 size=142.00B time="6.577µs" gcnodes=0 gcsize=0.00B gctime=0s livenodes=0 livesize=0.00B
{"pc":0,"op":72,"gas":"0xffffff","gasCost":"0x2","memSize":0,"stack":[],"depth":1,"refund":0,"opName":"BASEFEE"}
{"pc":1,"op":96,"gas":"0xfffffd","gasCost":"0x3","memSize":0,"stack":["0x3b9aca00"],"depth":1,"refund":0,"opName":"PUSH1"}
{"pc":3,"op":82,"gas":"0xfffffa","gasCost":"0x6","memSize":0,"stack":["0x3b9aca00","0x0"],"depth":1,"refund":0,"opName":"MSTORE"}
{"pc":4,"op":96,"gas":"0xfffff4","gasCost":"0x3","memory":"0x000000000000000000000000000000000000000000000000000000003b9aca00","memSize":32,"stack":[],"depth":1,"refund":0,"opName":"PUSH1"}
{"pc":6,"op":96,"gas":"0xfffff1","gasCost":"0x3","memory":"0x000000000000000000000000000000000000000000000000000000003b9aca00","memSize":32,"stack":["0x40"],"depth":1,"refund":0,"opName":"PUSH1"}
{"pc":8,"op":243,"gas":"0xffffee","gasCost":"0x3","memory":"0x000000000000000000000000000000000000000000000000000000003b9aca00","memSize":32,"stack":["0x40","0x0"],"depth":1,"refund":0,"opName":"RETURN"}
{"output":"000000000000000000000000000000000000000000000000000000003b9aca000000000000000000000000000000000000000000000000000000000000000000","gasUsed":"0x14"}
#### LOGS ####
```
