### PR TITLE
p2p/enode: add quic ENR entry

### DIFF
--- a/p2p/enode/localnode.go
+++ b/p2p/enode/localnode.go
@@ -298,7 +298,7 @@ func (ln *LocalNode) sign() {
 		panic(fmt.Errorf("enode: can't verify local record: %v", err))
 	}
 	ln.cur.Store(n)
-	log.Info("New local node record", "seq", ln.seq, "id", n.ID(), "ip", n.IPAddr(), "udp", n.UDP(), "tcp", n.TCP(), "quic", n.QUIC())
+	log.Info("New local node record", "seq", ln.seq, "id", n.ID(), "ip", n.IPAddr(), "udp", n.UDP(), "tcp", n.TCP())
 }
 
 func (ln *LocalNode) bumpSeq() {

--- a/p2p/enode/localnode.go
+++ b/p2p/enode/localnode.go
@@ -298,7 +298,7 @@ func (ln *LocalNode) sign() {
 		panic(fmt.Errorf("enode: can't verify local record: %v", err))
 	}
 	ln.cur.Store(n)
-	log.Info("New local node record", "seq", ln.seq, "id", n.ID(), "ip", n.IPAddr(), "udp", n.UDP(), "tcp", n.TCP())
+	log.Info("New local node record", "seq", ln.seq, "id", n.ID(), "ip", n.IPAddr(), "udp", n.UDP(), "tcp", n.TCP(), "quic", n.QUIC())
 }
 
 func (ln *LocalNode) bumpSeq() {

--- a/p2p/enode/node.go
+++ b/p2p/enode/node.go
@@ -38,10 +38,9 @@ type Node struct {
 	r  enr.Record
 	id ID
 	// endpoint information
-	ip   netip.Addr
-	udp  uint16
-	tcp  uint16
-	quic uint16
+	ip  netip.Addr
+	udp uint16
+	tcp uint16
 }
 
 // New wraps a node record. The record must be valid according to the given
@@ -106,7 +105,6 @@ func (n *Node) setIP4(ip netip.Addr) {
 	n.ip = ip
 	n.Load((*enr.UDP)(&n.udp))
 	n.Load((*enr.TCP)(&n.tcp))
-	n.Load((*enr.QUIC)(&n.quic))
 }
 
 func (n *Node) setIP6(ip netip.Addr) {
@@ -120,9 +118,6 @@ func (n *Node) setIP6(ip netip.Addr) {
 	}
 	if err := n.Load((*enr.TCP6)(&n.tcp)); err != nil {
 		n.Load((*enr.TCP)(&n.tcp))
-	}
-	if err := n.Load((*enr.QUIC6)(&n.quic)); err != nil {
-		n.Load((*enr.QUIC)(&n.quic))
 	}
 }
 
@@ -189,11 +184,6 @@ func (n *Node) TCP() int {
 	return int(n.tcp)
 }
 
-// QUIC returns the QUIC port of the node.
-func (n *Node) QUIC() int {
-	return int(n.quic)
-}
-
 // UDPEndpoint returns the announced UDP endpoint.
 func (n *Node) UDPEndpoint() (netip.AddrPort, bool) {
 	if !n.ip.IsValid() || n.ip.IsUnspecified() || n.udp == 0 {
@@ -212,10 +202,12 @@ func (n *Node) TCPEndpoint() (netip.AddrPort, bool) {
 
 // QUICEndpoint returns the announced QUIC endpoint.
 func (n *Node) QUICEndpoint() (netip.AddrPort, bool) {
-	if !n.ip.IsValid() || n.ip.IsUnspecified() || n.quic == 0 {
+	var quic enr.QUIC
+	n.Load(&quic)
+	if !n.ip.IsValid() || n.ip.IsUnspecified() || quic == 0 {
 		return netip.AddrPort{}, false
 	}
-	return netip.AddrPortFrom(n.ip, n.quic), true
+	return netip.AddrPortFrom(n.ip, uint16(quic)), true
 }
 
 // Pubkey returns the secp256k1 public key of the node, if present.

--- a/p2p/enode/node.go
+++ b/p2p/enode/node.go
@@ -38,9 +38,10 @@ type Node struct {
 	r  enr.Record
 	id ID
 	// endpoint information
-	ip  netip.Addr
-	udp uint16
-	tcp uint16
+	ip   netip.Addr
+	udp  uint16
+	tcp  uint16
+	quic uint16
 }
 
 // New wraps a node record. The record must be valid according to the given
@@ -105,6 +106,7 @@ func (n *Node) setIP4(ip netip.Addr) {
 	n.ip = ip
 	n.Load((*enr.UDP)(&n.udp))
 	n.Load((*enr.TCP)(&n.tcp))
+	n.Load((*enr.QUIC)(&n.quic))
 }
 
 func (n *Node) setIP6(ip netip.Addr) {
@@ -118,6 +120,9 @@ func (n *Node) setIP6(ip netip.Addr) {
 	}
 	if err := n.Load((*enr.TCP6)(&n.tcp)); err != nil {
 		n.Load((*enr.TCP)(&n.tcp))
+	}
+	if err := n.Load((*enr.QUIC6)(&n.quic)); err != nil {
+		n.Load((*enr.QUIC)(&n.quic))
 	}
 }
 
@@ -184,6 +189,11 @@ func (n *Node) TCP() int {
 	return int(n.tcp)
 }
 
+// QUIC returns the QUIC port of the node.
+func (n *Node) QUIC() int {
+	return int(n.quic)
+}
+
 // UDPEndpoint returns the announced UDP endpoint.
 func (n *Node) UDPEndpoint() (netip.AddrPort, bool) {
 	if !n.ip.IsValid() || n.ip.IsUnspecified() || n.udp == 0 {
@@ -198,6 +208,14 @@ func (n *Node) TCPEndpoint() (netip.AddrPort, bool) {
 		return netip.AddrPort{}, false
 	}
 	return netip.AddrPortFrom(n.ip, n.tcp), true
+}
+
+// QUICEndpoint returns the announced QUIC endpoint.
+func (n *Node) QUICEndpoint() (netip.AddrPort, bool) {
+	if !n.ip.IsValid() || n.ip.IsUnspecified() || n.quic == 0 {
+		return netip.AddrPort{}, false
+	}
+	return netip.AddrPortFrom(n.ip, n.quic), true
 }
 
 // Pubkey returns the secp256k1 public key of the node, if present.

--- a/p2p/enode/node.go
+++ b/p2p/enode/node.go
@@ -202,12 +202,16 @@ func (n *Node) TCPEndpoint() (netip.AddrPort, bool) {
 
 // QUICEndpoint returns the announced QUIC endpoint.
 func (n *Node) QUICEndpoint() (netip.AddrPort, bool) {
-	var quic enr.QUIC
-	n.Load(&quic)
+	var quic uint16
+	if n.ip.Is4() || n.ip.Is4In6() {
+		n.Load((*enr.QUIC)(&quic))
+	} else if n.ip.Is6() {
+		n.Load((*enr.QUIC6)(&quic))
+	}
 	if !n.ip.IsValid() || n.ip.IsUnspecified() || quic == 0 {
 		return netip.AddrPort{}, false
 	}
-	return netip.AddrPortFrom(n.ip, uint16(quic)), true
+	return netip.AddrPortFrom(n.ip, quic), true
 }
 
 // Pubkey returns the secp256k1 public key of the node, if present.

--- a/p2p/enode/node_test.go
+++ b/p2p/enode/node_test.go
@@ -68,12 +68,11 @@ func TestPythonInterop(t *testing.T) {
 func TestNodeEndpoints(t *testing.T) {
 	id := HexID("00000000000000806ad9b61fa5ae014307ebdc964253adcd9f2c0a392aa11abc")
 	type endpointTest struct {
-		name     string
-		node     *Node
-		wantIP   netip.Addr
-		wantUDP  int
-		wantTCP  int
-		wantQUIC int
+		name    string
+		node    *Node
+		wantIP  netip.Addr
+		wantUDP int
+		wantTCP int
 	}
 	tests := []endpointTest{
 		{
@@ -230,9 +229,6 @@ func TestNodeEndpoints(t *testing.T) {
 			}
 			if test.wantTCP != test.node.TCP() {
 				t.Errorf("node has wrong TCP port %d, want %d", test.node.TCP(), test.wantTCP)
-			}
-			if test.wantQUIC != test.node.QUIC() {
-				t.Errorf("node has wrong QUIC port %d, want %d", test.node.QUIC(), test.wantQUIC)
 			}
 		})
 	}

--- a/p2p/enode/node_test.go
+++ b/p2p/enode/node_test.go
@@ -68,11 +68,12 @@ func TestPythonInterop(t *testing.T) {
 func TestNodeEndpoints(t *testing.T) {
 	id := HexID("00000000000000806ad9b61fa5ae014307ebdc964253adcd9f2c0a392aa11abc")
 	type endpointTest struct {
-		name    string
-		node    *Node
-		wantIP  netip.Addr
-		wantUDP int
-		wantTCP int
+		name     string
+		node     *Node
+		wantIP   netip.Addr
+		wantUDP  int
+		wantTCP  int
+		wantQUIC int
 	}
 	tests := []endpointTest{
 		{
@@ -95,6 +96,14 @@ func TestNodeEndpoints(t *testing.T) {
 			node: func() *Node {
 				var r enr.Record
 				r.Set(enr.TCP(9000))
+				return SignNull(&r, id)
+			}(),
+		},
+		{
+			name: "quic-only",
+			node: func() *Node {
+				var r enr.Record
+				r.Set(enr.QUIC(9000))
 				return SignNull(&r, id)
 			}(),
 		},
@@ -221,6 +230,9 @@ func TestNodeEndpoints(t *testing.T) {
 			}
 			if test.wantTCP != test.node.TCP() {
 				t.Errorf("node has wrong TCP port %d, want %d", test.node.TCP(), test.wantTCP)
+			}
+			if test.wantQUIC != test.node.QUIC() {
+				t.Errorf("node has wrong QUIC port %d, want %d", test.node.QUIC(), test.wantQUIC)
 			}
 		})
 	}

--- a/p2p/enode/node_test.go
+++ b/p2p/enode/node_test.go
@@ -68,11 +68,12 @@ func TestPythonInterop(t *testing.T) {
 func TestNodeEndpoints(t *testing.T) {
 	id := HexID("00000000000000806ad9b61fa5ae014307ebdc964253adcd9f2c0a392aa11abc")
 	type endpointTest struct {
-		name    string
-		node    *Node
-		wantIP  netip.Addr
-		wantUDP int
-		wantTCP int
+		name     string
+		node     *Node
+		wantIP   netip.Addr
+		wantUDP  int
+		wantTCP  int
+		wantQUIC int
 	}
 	tests := []endpointTest{
 		{
@@ -103,6 +104,14 @@ func TestNodeEndpoints(t *testing.T) {
 			node: func() *Node {
 				var r enr.Record
 				r.Set(enr.QUIC(9000))
+				return SignNull(&r, id)
+			}(),
+		},
+		{
+			name: "quic6-only",
+			node: func() *Node {
+				var r enr.Record
+				r.Set(enr.QUIC6(9000))
 				return SignNull(&r, id)
 			}(),
 		},
@@ -217,6 +226,48 @@ func TestNodeEndpoints(t *testing.T) {
 			wantIP:  netip.MustParseAddr("192.168.2.2"),
 			wantUDP: 30304,
 		},
+		{
+			name: "ipv4-quic",
+			node: func() *Node {
+				var r enr.Record
+				r.Set(enr.IPv4Addr(netip.MustParseAddr("99.22.33.1")))
+				r.Set(enr.QUIC(9001))
+				return SignNull(&r, id)
+			}(),
+			wantIP:   netip.MustParseAddr("99.22.33.1"),
+			wantQUIC: 9001,
+		},
+		{ // Because the node is IPv4, the quic6 entry won't be loaded.
+			name: "ipv4-quic6",
+			node: func() *Node {
+				var r enr.Record
+				r.Set(enr.IPv4Addr(netip.MustParseAddr("99.22.33.1")))
+				r.Set(enr.QUIC6(9001))
+				return SignNull(&r, id)
+			}(),
+			wantIP: netip.MustParseAddr("99.22.33.1"),
+		},
+		{
+			name: "ipv6-quic",
+			node: func() *Node {
+				var r enr.Record
+				r.Set(enr.IPv6Addr(netip.MustParseAddr("2001::ff00:0042:8329")))
+				r.Set(enr.QUIC(9001))
+				return SignNull(&r, id)
+			}(),
+			wantIP: netip.MustParseAddr("2001::ff00:0042:8329"),
+		},
+		{
+			name: "ipv6-quic6",
+			node: func() *Node {
+				var r enr.Record
+				r.Set(enr.IPv6Addr(netip.MustParseAddr("2001::ff00:0042:8329")))
+				r.Set(enr.QUIC6(9001))
+				return SignNull(&r, id)
+			}(),
+			wantIP:   netip.MustParseAddr("2001::ff00:0042:8329"),
+			wantQUIC: 9001,
+		},
 	}
 
 	for _, test := range tests {
@@ -229,6 +280,9 @@ func TestNodeEndpoints(t *testing.T) {
 			}
 			if test.wantTCP != test.node.TCP() {
 				t.Errorf("node has wrong TCP port %d, want %d", test.node.TCP(), test.wantTCP)
+			}
+			if quic, _ := test.node.QUICEndpoint(); test.wantQUIC != int(quic.Port()) {
+				t.Errorf("node has wrong QUIC port %d, want %d", quic.Port(), test.wantQUIC)
 			}
 		})
 	}

--- a/p2p/enr/entries.go
+++ b/p2p/enr/entries.go
@@ -77,6 +77,16 @@ type UDP6 uint16
 
 func (v UDP6) ENRKey() string { return "udp6" }
 
+// QUIC is the "quic" key, which holds the QUIC port of the node.
+type QUIC uint16
+
+func (v QUIC) ENRKey() string { return "quic" }
+
+// QUIC6 is the "quic6" key, which holds the IPv6-specific quic6 port of the node.
+type QUIC6 uint16
+
+func (v QUIC6) ENRKey() string { return "quic6" }
+
 // ID is the "id" key, which holds the name of the identity scheme.
 type ID string
 


### PR DESCRIPTION
Add `quic` entry to the ENR as proposed in https://github.com/ethereum/consensus-specs/pull/3644

Allowing to read [Lighthouse `quic` port](https://github.com/sigp/lighthouse/blob/d6ba8c397557f5c977b70f0d822a9228e98ca214/book/src/developers.md?plain=1#L20-L26) from ENR.