### PR TITLE
core: remove withdrawal length check for state processor

### DIFF
--- a/core/state_processor.go
+++ b/core/state_processor.go
@@ -17,7 +17,6 @@
 package core
 
 import (
-	"errors"
 	"fmt"
 	"math/big"
 
@@ -92,11 +91,6 @@ func (p *StateProcessor) Process(block *types.Block, statedb *state.StateDB, cfg
 		}
 		receipts = append(receipts, receipt)
 		allLogs = append(allLogs, receipt.Logs...)
-	}
-	// Fail if Shanghai not enabled and len(withdrawals) is non-zero.
-	withdrawals := block.Withdrawals()
-	if len(withdrawals) > 0 && !p.config.IsShanghai(block.Number(), block.Time()) {
-		return nil, nil, 0, errors.New("withdrawals before shanghai")
 	}
 	// Finalize the block, applying any consensus engine specific extras (e.g. block rewards)
 	p.chain.engine.Finalize(p.chain, header, statedb, block.Body())


### PR DESCRIPTION
I thought the withdrawal length check should be placed in `BlockValidator.ValidateBody`

https://github.com/ethereum/go-ethereum/blob/32a1e0643ca5012bda851d65194fb5eb3d83591b/core/block_validator.go#L73-L84

the BlockValidator has the chain config field, and should be feasible to move the check to the ValidateBody.

but there is only a withdrawal root hash check.

and the verifyHeader func in the consensus package ensures a block that before shanghai fork doesn't have a withdrawal hash.

https://github.com/ethereum/go-ethereum/blob/32a1e0643ca5012bda851d65194fb5eb3d83591b/consensus/beacon/consensus.go#L267-L273

so I think the check in the processor is not required and can be removed.