### PR TITLE
vm: simplify error handling in `vm.EVM.create()`

### DIFF
--- a/core/vm/evm.go
+++ b/core/vm/evm.go
@@ -537,8 +537,8 @@ func (evm *EVM) create(caller ContractRef, codeAndHash *codeAndHash, gas uint64,
 	return ret, address, contract.Gas, err
 }
 
-// initNewContract perform initialization checks and actions on code for a newly
-// create()d contract.
+// initNewContract runs a new contract's creation code, performs checks on the
+// resulting code that is to be deployed, and consumes necessary gas.
 func (evm *EVM) initNewContract(contract *Contract, address common.Address) ([]byte, error) {
 	ret, err := evm.interpreter.Run(contract, nil, false)
 	if err != nil {

--- a/core/vm/evm.go
+++ b/core/vm/evm.go
@@ -518,6 +518,7 @@ func (evm *EVM) create(caller ContractRef, codeAndHash *codeAndHash, gas uint64,
 			evm.StateDB.RevertToSnapshot(snapshot)
 			if err != ErrExecutionReverted {
 				contract.UseGas(contract.Gas, evm.Config.Tracer, tracing.GasChangeCallFailedExecution)
+				leftOverGas = 0
 			}
 		}
 	}()


### PR DESCRIPTION
### Reason for this PR

To allow all error paths in `vm.EVM.create()` to consume the necessary gas, there is currently a pattern of gating code on `if err == nil` instead of returning as soon as the error occurs. The same behaviour can be achieved by abstracting the gated code into a method that returns immediately on error, improving readability and thus making it easier to understand and maintain.

### Summary of changes

1. There is no new logic. Other than a single new method signature, all code is original.
2. All actions and checks that were previously gated by `if err == nil` are moved to a new `EVM.initNewContract()` method that removes the gating and instead returns immediately on error—this is functionally equivalent but more idiomatic and reduces cognitive load because the reader knows that it's a terminal statement.

### Alternatives considered

An [earlier commit](https://github.com/ethereum/go-ethereum/pull/30292/commits/1cdf3052b2c1872bc843f930451d103036e2de30) used a `defer` statement for consuming all gas on error. Although this allowed error paths to remain in `EVM.create()` it made for non-linear code that was harder to understand.