### PR TITLE
core/vm: add micro-optimization

### DIFF
--- a/common/types.go
+++ b/common/types.go
@@ -30,6 +30,7 @@ import (
 	"strings"
 
 	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/holiman/uint256"
 	"golang.org/x/crypto/sha3"
 )
 
@@ -247,6 +248,9 @@ func (a Address) Bytes() []byte { return a[:] }
 
 // Big converts an address to a big integer.
 func (a Address) Big() *big.Int { return new(big.Int).SetBytes(a[:]) }
+
+// Big converts an address to a uint256.
+func (a Address) Uint256() *uint256.Int { return new(uint256.Int).SetBytes20(a[:]) }
 
 // Hex returns an EIP55-compliant hex string representation of the address.
 func (a Address) Hex() string {

--- a/core/vm/instructions.go
+++ b/core/vm/instructions.go
@@ -251,7 +251,7 @@ func opKeccak256(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) (
 }
 
 func opAddress(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([]byte, error) {
-	scope.Stack.push(new(uint256.Int).SetBytes(scope.Contract.Address().Bytes()))
+	scope.Stack.push(scope.Contract.Address().Uint256())
 	return nil, nil
 }
 
@@ -263,12 +263,12 @@ func opBalance(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([]
 }
 
 func opOrigin(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([]byte, error) {
-	scope.Stack.push(new(uint256.Int).SetBytes(interpreter.evm.Origin.Bytes()))
+	scope.Stack.push(interpreter.evm.Origin.Uint256())
 	return nil, nil
 }
 
 func opCaller(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([]byte, error) {
-	scope.Stack.push(new(uint256.Int).SetBytes(scope.Contract.Caller().Bytes()))
+	scope.Stack.push(scope.Contract.Caller().Uint256())
 	return nil, nil
 }
 
@@ -463,7 +463,7 @@ func opBlockhash(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) (
 }
 
 func opCoinbase(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([]byte, error) {
-	scope.Stack.push(new(uint256.Int).SetBytes(interpreter.evm.Context.Coinbase.Bytes()))
+	scope.Stack.push(interpreter.evm.Context.Coinbase.Uint256())
 	return nil, nil
 }
 
@@ -485,8 +485,7 @@ func opDifficulty(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) 
 }
 
 func opRandom(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([]byte, error) {
-	v := new(uint256.Int).SetBytes(interpreter.evm.Context.Random.Bytes())
-	scope.Stack.push(v)
+	scope.Stack.push(new(uint256.Int).SetBytes(interpreter.evm.Context.Random.Bytes()))
 	return nil, nil
 }
 

--- a/core/vm/instructions_test.go
+++ b/core/vm/instructions_test.go
@@ -580,6 +580,25 @@ func BenchmarkOpMstore(bench *testing.B) {
 	}
 }
 
+func BenchmarkOpAddress(bench *testing.B) {
+	var (
+		env            = NewEVM(BlockContext{}, TxContext{}, nil, params.TestChainConfig, Config{})
+		stack          = newstack()
+		evmInterpreter = NewEVMInterpreter(env)
+	)
+
+	env.interpreter = evmInterpreter
+	pc := uint64(0)
+	contract := Contract{
+		self: contractRef{addr: common.Address{}},
+	}
+
+	bench.ResetTimer()
+	for i := 0; i < bench.N; i++ {
+		opAddress(&pc, evmInterpreter, &ScopeContext{nil, stack, &contract})
+	}
+}
+
 func TestOpTstore(t *testing.T) {
 	var (
 		statedb, _     = state.New(types.EmptyRootHash, state.NewDatabase(rawdb.NewMemoryDatabase()), nil)


### PR DESCRIPTION
This PR adds `Uint256()` to the Address type, to create a uint256 from an address. 
Since we know that the address type is 20 bytes, we can use setBytes20 instead of setBytes which saves us one switch.

Benchmarks:
```
Master:
//BenchmarkOpAddress-24        31233150            38.22 ns/op         183 B/op           0 allocs/op
Pr:
//BenchmarkOpAddress-24        33228558            35.39 ns/op         172 B/op           0 allocs/op
```