### PR TITLE
beacon/light: handle endpoint URL more gracefully

### DIFF
--- a/beacon/light/api/light_api.go
+++ b/beacon/light/api/light_api.go
@@ -122,7 +122,7 @@ func NewBeaconLightApi(url string, customHeaders map[string]string) *BeaconLight
 }
 
 func (api *BeaconLightApi) httpGet(path string) ([]byte, error) {
-	uri, err := url.JoinPath(api.url, path)
+	uri, err := api.buildURL(path, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -550,9 +550,8 @@ func (api *BeaconLightApi) StartHeadListener(listener HeadEventListener) func() 
 // established. It can only return nil when the context is canceled.
 func (api *BeaconLightApi) startEventStream(ctx context.Context, listener *HeadEventListener) *eventsource.Stream {
 	for retry := true; retry; retry = ctxSleep(ctx, 5*time.Second) {
-		path := "/eth/v1/events?topics=head&topics=light_client_finality_update&topics=light_client_optimistic_update"
 		log.Trace("Sending event subscription request")
-		uri, err := url.JoinPath(api.url, path)
+		uri, err := api.buildURL("/eth/v1/events", map[string][]string{"topics": {"head", "light_client_finality_update", "light_client_optimistic_update"}})
 		if err != nil {
 			listener.OnError(fmt.Errorf("error creating event subscription URL: %v", err))
 			continue
@@ -585,4 +584,16 @@ func ctxSleep(ctx context.Context, timeout time.Duration) (ok bool) {
 	case <-ctx.Done():
 		return false
 	}
+}
+
+func (api *BeaconLightApi) buildURL(path string, params url.Values) (string, error) {
+	uri, err := url.Parse(api.url)
+	if err != nil {
+		return "", err
+	}
+	uri = uri.JoinPath(path)
+	if params != nil {
+		uri.RawQuery = params.Encode()
+	}
+	return uri.String(), nil
 }


### PR DESCRIPTION
blsync was failing if the light endpoint it was provided ended with a `/`. This change should handle the joining more gracefully.