### PR TITLE
p2p: prevent deadlock

### DIFF
--- a/p2p/peer.go
+++ b/p2p/peer.go
@@ -323,12 +323,18 @@ func (p *Peer) readLoop(errc chan<- error) {
 	for {
 		msg, err := p.rw.ReadMsg()
 		if err != nil {
-			errc <- err
+			select {
+			case <-p.closed:
+			case errc <- err:
+			}
 			return
 		}
 		msg.ReceivedAt = time.Now()
 		if err = p.handle(msg); err != nil {
-			errc <- err
+			select {
+			case <-p.closed:
+			case errc <- err:
+			}
 			return
 		}
 	}


### PR DESCRIPTION
This PR fixes a deadlock described here: https://github.com/ethereum/go-ethereum/issues/29857 . 

In 2018, @fjl stated that the deadlock cannot happen ( https://github.com/ethereum/go-ethereum/issues/17950#issuecomment-436965720 ) 

I'm not so sure. Maybe that is still correct, but if so, that looks mostly incidental. With the fix in this PR, the code becomes more robust and "trivially obvious" that the deadlock will not occur. 