### PR TITLE
internal/build: include git-date on detached head

### DIFF
--- a/internal/build/env.go
+++ b/internal/build/env.go
@@ -111,6 +111,7 @@ func LocalEnv() Environment {
 		commitRe, _ := regexp.Compile("^([0-9a-f]{40})$")
 		if commit := commitRe.FindString(head); commit != "" && env.Commit == "" {
 			env.Commit = commit
+			env.Date = getDate(env.Commit)
 		}
 		return env
 	}


### PR DESCRIPTION
When we are building in detached head, we cannot easily obtain the same information as we can if we're in non-detached head. 

However, one thing we _can_ obtain is the git-hash and git-date. Currently, we omit to include the git-date into the build-info, which causes problem for reproducable builds which are on a detached head. This PR should fix it. 

----

Can be tested locally by adding an early return in `ci.go` and then do `go run build/ci.go install` , check out a specific git commit and add some printouts to see the env. 
```
func doInstall(cmdline []string) {
	var (
		dlgo       = flag.Bool("dlgo", false, "Download Go and build with it")
		arch       = flag.String("arch", "", "Architecture to cross build for")
		cc         = flag.String("cc", "", "C compiler to cross build with")
		staticlink = flag.Bool("static", false, "Create statically-linked executable")
	)
	flag.CommandLine.Parse(cmdline)
	env := build.Env()
        return
```

HT to @vivi365 for finding