### PR TITLE
build: attempt at reproducible builds

### DIFF
--- a/build/ci.go
+++ b/build/ci.go
@@ -251,7 +251,11 @@ func buildFlags(env build.Environment, staticLinking bool, buildTags []string) (
 	if runtime.GOOS == "linux" {
 		// Enforce the stacksize to 8M, which is the case on most platforms apart from
 		// alpine Linux.
-		extld := []string{"-Wl,-z,stack-size=0x800000"}
+		// See https://sourceware.org/binutils/docs-2.23.1/ld/Options.html#Options
+		// regarding the options --build-id=none and --strip-all. It is needed for
+		// reproducible builds; removing references to temporary files in C-land, and
+		// making build-id reproducably absent.
+		extld := []string{"-Wl,-z,stack-size=0x800000,--build-id=none,--strip-all"}
 		if staticLinking {
 			extld = append(extld, "-static")
 			// Under static linking, use of certain glibc features must be


### PR DESCRIPTION
This PR implements the conclusions from https://github.com/ethereum/go-ethereum/issues/28987#issuecomment-2296075028, that is: 

Building with `--strip-all` as  a ld-flag to the cgo linker, to remove symbols. Without that, some spurious reference to a temporary file is included into the kzg-related library. 

Building with `--build-id=none`, to avoid putting a `build id` into the file. 


cc @vivi365