### PR TITLE
build: remove mantic from ppa builds

### DIFF
--- a/build/ci.go
+++ b/build/ci.go
@@ -126,8 +126,6 @@ var (
 		"focal",  // 20.04, EOL: 04/2030
 		"jammy",  // 22.04, EOL: 04/2032
 		"noble",  // 24.04, EOL: 04/2034
-
-		"mantic", // 23.10, EOL: 07/2024
 	}
 
 	// This is where the tests should be unpacked.


### PR DESCRIPTION
Our ppa-uploads for mantic are rejected, so might aswell skip attempting it
```
Rejected:
mantic is obsolete and will not accept new uploads.

ethereum-unstable (1.14.9+build30173+mantic) mantic; urgency=low

  * git build of 710c3f32ac8e4e5829a6a631dcfb1e0e13a49220
```