### PR TITLE
gitignore: ignore upload-artefacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,9 @@ build/_vendor/pkg
 /build/bin/
 /geth*.zip
 
+# used by the build/ci.go archive + upload tool
+/geth*.tar.gz
+
 # travis
 profile.tmp
 profile.cov


### PR DESCRIPTION
Closes https://github.com/ethereum/go-ethereum/issues/30324

Our `WriteArchive`, used by ci builder, creates files in the repo root, in order to upload.

https://github.com/ethereum/go-ethereum/blob/master/internal/build/archive.go#L80

After we've built the amd64-builds, we go on building remaining architectures. The repo is now flagged as dirty. 

There are more complicated ways to solve this, but the by far simplest is just to fix the gitignore. 