### PR TITLE
cmd/devp2p: require dns:read, dns:edit permissions for cloudflare deploy 

### DIFF
--- a/cmd/devp2p/dns_cloudflare.go
+++ b/cmd/devp2p/dns_cloudflare.go
@@ -88,7 +88,8 @@ func (c *cloudflareClient) checkZone(name string) error {
 	if !strings.HasSuffix(name, "."+zone.Name) {
 		return fmt.Errorf("CloudFlare zone name %q does not match name %q to be deployed", zone.Name, name)
 	}
-	needPerms := map[string]bool{"#zone:edit": false, "#zone:read": false}
+	// Necessary permissions for Cloudlare management - Zone:Read, DNS:Read, Zone:Edit, DNS:Edit
+	needPerms := map[string]bool{"#zone:edit": false, "#zone:read": false, "#dns_records:read": false, "#dns_records:edit": false}
 	for _, perm := range zone.Permissions {
 		if _, ok := needPerms[perm]; ok {
 			needPerms[perm] = true


### PR DESCRIPTION
This PR adds the `dns:read` and `dns:edit` permissions to the required set of permissions checked before deploying an ENR tree to Cloudflare. These permissions are necessary for a successful publish.

**Background**:
The current logic for `devp2p dns to-cloudflare` checks for `zone:edit` and `zone:read` permissions. However, when running the command with only these two permissions, the following error occurs:
```
wrong permissions on zone REMOVED-ZONE: map[#zone:edit:false #zone:read:true]
```

Adding `zone:read` and `zone:edit` to the API token led to a different error:
```
INFO [08-19|14:06:16.782] Retrieving existing TXT records on pos-nodes.hardfork.dev
Authentication error (10000)
```

This suggested that additional permissions were required. I added `dns:read`, but encountered another error:
```
INFO [08-19|14:11:42.342] Retrieving existing TXT records on pos-nodes.hardfork.dev
INFO [08-19|14:11:42.851] Updating DNS entries
failed to publish REMOVED.pos-nodes.hardfork.dev: Authentication error (10000)
```

Finally, after adding both `dns:read` and `dns:edit` permissions, the command executed successfully with the following output:
```
INFO [08-19|14:13:07.677] Checking Permissions on zone REMOVED-ZONE
INFO [08-19|14:13:08.014] Retrieving existing TXT records on pos-nodes.hardfork.dev
INFO [08-19|14:13:08.440] Updating DNS entries
INFO [08-19|14:13:08.440] "Updating pos-nodes.hardfork.dev from \"enrtree-root:v1 e=FSED3EDKEKRDDFMCLP746QY6CY l=FDXN3SN67NA5DKA4J2GOK7BVQI seq=1 sig=Glja2c9RviRqOpaaHR0MnHsQwU76nJXadJwFeiXpp8MRTVIhvL0LIireT0yE3ETZArGEmY5Ywz3FVHZ3LR5JTAE\" to \"enrtree-root:v1 e=AB66M4ULYD5OYN4XFFCPVZRLUM l=FDXN3SN67NA5DKA4J2GOK7BVQI seq=1 sig=H8cqDzu0FAzBplK4g3yudhSaNtszIebc2aj4oDm5a5ZE5PAg-xpCnQgVE_53CsgsqQpalD9byafx_FrUT61sagA\""
INFO [08-19|14:13:16.932] Updated DNS entries                      new=32 updated=1 untouched=100
INFO [08-19|14:13:16.932] Deleting stale DNS entries
INFO [08-19|14:13:24.663] Deleted stale DNS entries                count=31
```

With this PR, the required permissions for deploying an ENR tree to Cloudflare now include `zone:read`, `zone:edit`, `dns:read`, and `dns:edit`. The initial check now includes all of the necessary permissions and indicates in the error message which permissions are missing:
```
INFO [08-19|14:17:20.339] Checking Permissions on zone REMOVED-ZONE
wrong permissions on zone REMOVED-ZONE: map[#dns_records:edit:false #dns_records:read:false #zone:edit:false #zone:read:true]
```