### PR TITLE
eth/tracers: avoid panic if nil-receipt passed to OnTxEnd

### DIFF
--- a/eth/tracers/js/goja.go
+++ b/eth/tracers/js/goja.go
@@ -275,7 +275,9 @@ func (t *jsTracer) OnTxEnd(receipt *types.Receipt, err error) {
 		}
 		return
 	}
-	t.ctx["gasUsed"] = t.vm.ToValue(receipt.GasUsed)
+	if receipt != nil {
+		t.ctx["gasUsed"] = t.vm.ToValue(receipt.GasUsed)
+	}
 }
 
 // onStart implements the Tracer interface to initialize the tracing operation.

--- a/eth/tracers/logger/logger.go
+++ b/eth/tracers/logger/logger.go
@@ -268,7 +268,9 @@ func (l *StructLogger) OnTxEnd(receipt *types.Receipt, err error) {
 		}
 		return
 	}
-	l.usedGas = receipt.GasUsed
+	if receipt != nil {
+		l.usedGas = receipt.GasUsed
+	}
 }
 
 // StructLogs returns the captured log entries.

--- a/eth/tracers/native/call.go
+++ b/eth/tracers/native/call.go
@@ -225,7 +225,9 @@ func (t *callTracer) OnTxEnd(receipt *types.Receipt, err error) {
 	if err != nil {
 		return
 	}
-	t.callstack[0].GasUsed = receipt.GasUsed
+	if receipt != nil {
+		t.callstack[0].GasUsed = receipt.GasUsed
+	}
 	if t.config.WithLog {
 		// Logs are not emitted when the call fails
 		clearFailedLogs(&t.callstack[0], false)


### PR DESCRIPTION
Make tracers more robust by handling `nil` as input. Closes https://github.com/ethereum/go-ethereum/issues/30117 