### PR TITLE
beacon/blsync: better error information in test

### DIFF
--- a/beacon/blsync/block_sync_test.go
+++ b/beacon/blsync/block_sync_test.go
@@ -70,7 +70,10 @@ func TestBlockSync(t *testing.T) {
 		t.Helper()
 		var expNumber, headNumber uint64
 		if expHead != nil {
-			p, _ := expHead.ExecutionPayload()
+			p, err := expHead.ExecutionPayload()
+			if err != nil {
+				t.Fatalf("expHead.ExecutionPayload() failed: %v", err)
+			}
 			expNumber = p.NumberU64()
 		}
 		select {


### PR DESCRIPTION
I managed to run into this error case and was unsure about the reason until I added this error handling. So I think it is worth it to spend the extra three lines to get a proper error message.