### PR TITLE
build: set buildid once more

### DIFF
--- a/build/ci.go
+++ b/build/ci.go
@@ -237,6 +237,10 @@ func doInstall(cmdline []string) {
 // buildFlags returns the go tool flags for building.
 func buildFlags(env build.Environment, staticLinking bool, buildTags []string) (flags []string) {
 	var ld []string
+	// See https://github.com/golang/go/issues/33772#issuecomment-528176001
+	// We need to set --buildid to the linker here, and also pass --build-id to the
+	// cgo-linker further down.
+	ld = append(ld, "--buildid=none")
 	if env.Commit != "" {
 		ld = append(ld, "-X", "github.com/ethereum/go-ethereum/internal/version.gitCommit="+env.Commit)
 		ld = append(ld, "-X", "github.com/ethereum/go-ethereum/internal/version.gitDate="+env.Date)


### PR DESCRIPTION
The previous clearing of buildid did fully work, turns out we need to set it in `ldflags` 

The go buildid is the only remaining hurdle for reproducible builds, see https://github.com/ethereum/go-ethereum/issues/28987#issuecomment-2306412590 

This PR changes the go build id application note to say literally `none` 

https://github.com/golang/go/issues/33772#issuecomment-528176001:

> This difference is due to the .note.go.buildid section added by the linker. It can be set to something static e.g. -ldflags=-buildid= (empty string) to gain reproducibility.
