### PR TITLE
trie: only copy the preimages if necessary

### DIFF
--- a/trie/secure_trie.go
+++ b/trie/secure_trie.go
@@ -250,11 +250,11 @@ func (t *StateTrie) Witness() map[string]struct{} {
 func (t *StateTrie) Commit(collectLeaf bool) (common.Hash, *trienode.NodeSet) {
 	// Write all the pre-images to the actual disk database
 	if len(t.getSecKeyCache()) > 0 {
-		preimages := make(map[common.Hash][]byte, len(t.secKeyCache))
-		for hk, key := range t.secKeyCache {
-			preimages[common.BytesToHash([]byte(hk))] = key
-		}
 		if t.preimages != nil {
+			preimages := make(map[common.Hash][]byte, len(t.secKeyCache))
+			for hk, key := range t.secKeyCache {
+				preimages[common.BytesToHash([]byte(hk))] = key
+			}
 			t.preimages.InsertPreimage(preimages)
 		}
 		t.secKeyCache = make(map[string][]byte)


### PR DESCRIPTION
This pull request enhances the stateTrie a bit, by avoiding the unnecessary map copy
if the preimage recording is not enabled.