### PR TITLE
gitignore: ignore build signatures

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,11 @@ build/_vendor/pkg
 
 # used by the build/ci.go archive + upload tool
 /geth*.tar.gz
+/geth*.tar.gz.sig
+/geth*.tar.gz.asc
+/geth*.zip.sig
+/geth*.zip.asc
+
 
 # travis
 profile.tmp


### PR DESCRIPTION
From https://app.travis-ci.com/github/ethereum/go-ethereum/jobs/625441424#L1332

```
$ git status --porcelain
?? geth-alltools-linux-amd64-1.14.9-unstable-0378dc83.tar.gz.asc
?? geth-alltools-linux-amd64-1.14.9-unstable-0378dc83.tar.gz.sig
?? geth-linux-amd64-1.14.9-unstable-0378dc83.tar.gz.asc
?? geth-linux-amd64-1.14.9-unstable-0378dc83.tar.gz.sig
```
These files are generated during signing of download-binaries, and the 'dirty' the vcs for subsequent builds. 