### PR TITLE
core: use buffered ch for subscription

### DIFF
--- a/core/txindexer.go
+++ b/core/txindexer.go
@@ -132,7 +132,7 @@ func (indexer *txIndexer) loop(chain *BlockChain) {
 		lastHead uint64                              // The latest announced chain head (whose tx indexes are assumed created)
 		lastTail = rawdb.ReadTxIndexTail(indexer.db) // The oldest indexed block, nil means nothing indexed
 
-		headCh = make(chan ChainHeadEvent)
+		headCh = make(chan ChainHeadEvent, 5)
 		sub    = chain.SubscribeChainHeadEvent(headCh)
 	)
 	defer sub.Unsubscribe()


### PR DESCRIPTION
After the [refactor](https://github.com/ethereum/go-ethereum/pull/28857) the channel changed from buffered to unbuffered. The comment said `Buffered to avoid locking up the event feed`, if that's the case (it seems like can be) should the channel be kept buffered and even with the the buffer capacity >1? 