### PR TITLE
core: add metrics for state access

### DIFF
--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -1957,9 +1957,12 @@ func (bc *BlockChain) processBlock(block *types.Block, statedb *state.StateDB, s
 
 	accountRead := statedb.SnapshotAccountReads + statedb.AccountReads // The time spent on account read
 	storageRead := statedb.SnapshotStorageReads + statedb.StorageReads // The time spent on storage read
-	accountReadSingleTimer.Update(accountRead / time.Duration(statedb.AccountLoaded))
-	storageReadSingleTimer.Update(storageRead / time.Duration(statedb.StorageLoaded))
-
+	if statedb.AccountLoaded != 0 {
+		accountReadSingleTimer.Update(accountRead / time.Duration(statedb.AccountLoaded))
+	}
+	if statedb.StorageLoaded != 0 {
+		storageReadSingleTimer.Update(storageRead / time.Duration(statedb.StorageLoaded))
+	}
 	accountUpdateTimer.Update(statedb.AccountUpdates)               // Account updates are complete(in validation)
 	storageUpdateTimer.Update(statedb.StorageUpdates)               // Storage updates are complete(in validation)
 	accountHashTimer.Update(statedb.AccountHashes)                  // Account hashes are complete(in validation)

--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -76,6 +76,9 @@ var (
 	snapshotStorageReadTimer = metrics.NewRegisteredResettingTimer("chain/snapshot/storage/reads", nil)
 	snapshotCommitTimer      = metrics.NewRegisteredResettingTimer("chain/snapshot/commits", nil)
 
+	accountReadSingleTimer = metrics.NewRegisteredResettingTimer("chain/account/reads/single", nil)
+	storageReadSingleTimer = metrics.NewRegisteredResettingTimer("chain/storage/reads/single", nil)
+
 	triedbCommitTimer = metrics.NewRegisteredResettingTimer("chain/triedb/commits", nil)
 
 	blockInsertTimer     = metrics.NewRegisteredResettingTimer("chain/inserts", nil)
@@ -1947,18 +1950,22 @@ func (bc *BlockChain) processBlock(block *types.Block, statedb *state.StateDB, s
 	proctime := time.Since(start) // processing + validation
 
 	// Update the metrics touched during block processing and validation
-	accountReadTimer.Update(statedb.AccountReads)                   // Account reads are complete(in processing)
-	storageReadTimer.Update(statedb.StorageReads)                   // Storage reads are complete(in processing)
-	snapshotAccountReadTimer.Update(statedb.SnapshotAccountReads)   // Account reads are complete(in processing)
-	snapshotStorageReadTimer.Update(statedb.SnapshotStorageReads)   // Storage reads are complete(in processing)
+	accountReadTimer.Update(statedb.AccountReads)                 // Account reads are complete(in processing)
+	storageReadTimer.Update(statedb.StorageReads)                 // Storage reads are complete(in processing)
+	snapshotAccountReadTimer.Update(statedb.SnapshotAccountReads) // Account reads are complete(in processing)
+	snapshotStorageReadTimer.Update(statedb.SnapshotStorageReads) // Storage reads are complete(in processing)
+
+	accountRead := statedb.SnapshotAccountReads + statedb.AccountReads // The time spent on account read
+	storageRead := statedb.SnapshotStorageReads + statedb.StorageReads // The time spent on storage read
+	accountReadSingleTimer.Update(accountRead / time.Duration(statedb.AccountLoaded))
+	storageReadSingleTimer.Update(storageRead / time.Duration(statedb.StorageLoaded))
+
 	accountUpdateTimer.Update(statedb.AccountUpdates)               // Account updates are complete(in validation)
 	storageUpdateTimer.Update(statedb.StorageUpdates)               // Storage updates are complete(in validation)
 	accountHashTimer.Update(statedb.AccountHashes)                  // Account hashes are complete(in validation)
 	triehash := statedb.AccountHashes                               // The time spent on tries hashing
 	trieUpdate := statedb.AccountUpdates + statedb.StorageUpdates   // The time spent on tries update
-	trieRead := statedb.SnapshotAccountReads + statedb.AccountReads // The time spent on account read
-	trieRead += statedb.SnapshotStorageReads + statedb.StorageReads // The time spent on storage read
-	blockExecutionTimer.Update(ptime - trieRead)                    // The time spent on EVM processing
+	blockExecutionTimer.Update(ptime - (accountRead + storageRead)) // The time spent on EVM processing
 	blockValidationTimer.Update(vtime - (triehash + trieUpdate))    // The time spent on block validation
 
 	// Write the block to the chain and get the status.

--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -76,8 +76,8 @@ var (
 	snapshotStorageReadTimer = metrics.NewRegisteredResettingTimer("chain/snapshot/storage/reads", nil)
 	snapshotCommitTimer      = metrics.NewRegisteredResettingTimer("chain/snapshot/commits", nil)
 
-	accountReadSingleTimer = metrics.NewRegisteredResettingTimer("chain/account/reads/single", nil)
-	storageReadSingleTimer = metrics.NewRegisteredResettingTimer("chain/storage/reads/single", nil)
+	accountReadSingleTimer = metrics.NewRegisteredResettingTimer("chain/account/single/reads", nil)
+	storageReadSingleTimer = metrics.NewRegisteredResettingTimer("chain/storage/single/reads", nil)
 
 	triedbCommitTimer = metrics.NewRegisteredResettingTimer("chain/triedb/commits", nil)
 

--- a/core/state/metrics.go
+++ b/core/state/metrics.go
@@ -19,6 +19,8 @@ package state
 import "github.com/ethereum/go-ethereum/metrics"
 
 var (
+	accountReadMeters        = metrics.NewRegisteredMeter("state/read/accounts", nil)
+	storageReadMeters        = metrics.NewRegisteredMeter("state/read/storage", nil)
 	accountUpdatedMeter      = metrics.NewRegisteredMeter("state/update/account", nil)
 	storageUpdatedMeter      = metrics.NewRegisteredMeter("state/update/storage", nil)
 	accountDeletedMeter      = metrics.NewRegisteredMeter("state/delete/account", nil)

--- a/core/state/state_object.go
+++ b/core/state/state_object.go
@@ -239,6 +239,7 @@ func (s *stateObject) GetCommittedState(key common.Hash) common.Hash {
 		}
 	}
 	s.originStorage[key] = value
+	s.db.StorageLoaded++
 	return value
 }
 

--- a/triedb/pathdb/disklayer.go
+++ b/triedb/pathdb/disklayer.go
@@ -139,7 +139,6 @@ func (dl *diskLayer) node(owner common.Hash, path []byte, depth int) ([]byte, co
 		dl.cleans.Set(key, blob)
 		cleanWriteMeter.Mark(int64(len(blob)))
 	}
-
 	return blob, h.hash(blob), &nodeLoc{loc: locDiskLayer, depth: depth}, nil
 }
 


### PR DESCRIPTION
This pull request adds a few more performance metrics, specifically:

- The average time cost of an account read
- The average time cost of a storage read
- The rate of account reads
- The rate of storage reads