### PR TITLE
p2p/discover: fix Write method in metered connection

### DIFF
--- a/p2p/discover/metrics.go
+++ b/p2p/discover/metrics.go
@@ -18,6 +18,7 @@ package discover
 
 import (
 	"fmt"
+	"net"
 	"net/netip"
 
 	"github.com/ethereum/go-ethereum/metrics"
@@ -47,7 +48,7 @@ func init() {
 // meteredUdpConn is a wrapper around a net.UDPConn that meters both the
 // inbound and outbound network traffic.
 type meteredUdpConn struct {
-	UDPConn
+	udpConn UDPConn
 }
 
 func newMeteredConn(conn UDPConn) UDPConn {
@@ -55,19 +56,27 @@ func newMeteredConn(conn UDPConn) UDPConn {
 	if !metrics.Enabled {
 		return conn
 	}
-	return &meteredUdpConn{UDPConn: conn}
+	return &meteredUdpConn{udpConn: conn}
+}
+
+func (c *meteredUdpConn) Close() error {
+	return c.udpConn.Close()
+}
+
+func (c *meteredUdpConn) LocalAddr() net.Addr {
+	return c.udpConn.LocalAddr()
 }
 
 // ReadFromUDPAddrPort delegates a network read to the underlying connection, bumping the udp ingress traffic meter along the way.
 func (c *meteredUdpConn) ReadFromUDPAddrPort(b []byte) (n int, addr netip.AddrPort, err error) {
-	n, addr, err = c.UDPConn.ReadFromUDPAddrPort(b)
+	n, addr, err = c.udpConn.ReadFromUDPAddrPort(b)
 	ingressTrafficMeter.Mark(int64(n))
 	return n, addr, err
 }
 
-// WriteToUDP delegates a network write to the underlying connection, bumping the udp egress traffic meter along the way.
-func (c *meteredUdpConn) WriteToUDP(b []byte, addr netip.AddrPort) (n int, err error) {
-	n, err = c.UDPConn.WriteToUDPAddrPort(b, addr)
+// WriteToUDPAddrPort delegates a network write to the underlying connection, bumping the udp egress traffic meter along the way.
+func (c *meteredUdpConn) WriteToUDPAddrPort(b []byte, addr netip.AddrPort) (n int, err error) {
+	n, err = c.udpConn.WriteToUDPAddrPort(b, addr)
 	egressTrafficMeter.Mark(int64(n))
 	return n, err
 }


### PR DESCRIPTION
`WriteToUDP` was never called, since `meteredUdpConn` exposed directly all the methods from the underlying `UDPConn` interface.

This fixes the `discover/egress` metric never being updated.