### PR TITLE
core/vm: specify concurrent tasks to 1 for bls msm precompiles

### DIFF
--- a/core/vm/contracts.go
+++ b/core/vm/contracts.go
@@ -805,7 +805,7 @@ func (c *bls12381G1MultiExp) Run(input []byte) ([]byte, error) {
 
 	// Compute r = e_0 * p_0 + e_1 * p_1 + ... + e_(k-1) * p_(k-1)
 	r := new(bls12381.G1Affine)
-	r.MultiExp(points, scalars, ecc.MultiExpConfig{})
+	r.MultiExp(points, scalars, ecc.MultiExpConfig{NbTasks: 1})
 
 	// Encode the G1 point to 128 bytes
 	return encodePointG1(r), nil
@@ -940,7 +940,7 @@ func (c *bls12381G2MultiExp) Run(input []byte) ([]byte, error) {
 
 	// Compute r = e_0 * p_0 + e_1 * p_1 + ... + e_(k-1) * p_(k-1)
 	r := new(bls12381.G2Affine)
-	r.MultiExp(points, scalars, ecc.MultiExpConfig{})
+	r.MultiExp(points, scalars, ecc.MultiExpConfig{NbTasks: 1})
 
 	// Encode the G2 point to 256 bytes.
 	return encodePointG2(r), nil


### PR DESCRIPTION
We've discussed that these should not be performed concurrently.  Unfortunately, even with specifying `NbTasks: 1`, the implementation still uses goroutines.

Ultimately, it's unclear if we will use the current gnark MSM implementation, or there is some other MSM algorithm more amenable to single-threaded execution.

Overall, restricting `NbTasks: 1` decreases performance of the MSM precompiles by ~40% in the worst case on my machine.  Executing benchmarks with `NbTasks: 1` becomes marginally better when `GOMAXPROCS=1` is specified.

#### Performance for random inputs, ran on my M2 MBP (from the benchmarks I've put together [here](https://github.com/jwasinger/eip2537-benchmarks)):

**Edit:** Made a mistake.  re-running benchmarks and will post them again.