### PR TITLE
core/vm: use stack arena

### DIFF
--- a/core/state_prefetcher.go
+++ b/core/state_prefetcher.go
@@ -93,6 +93,7 @@ func (p *statePrefetcher) Prefetch(block *types.Block, statedb *state.StateDB, c
 			}
 			// Execute the message to preload the implicit touched states
 			evm := vm.NewEVM(NewEVMBlockContext(header, p.chain, nil), stateCpy, p.config, cfg)
+			defer evm.Free()
 
 			// Convert the transaction into an executable message and pre-cache its sender
 			msg, err := TransactionToMessage(tx, signer, header.BaseFee)

--- a/core/state_processor.go
+++ b/core/state_processor.go
@@ -81,6 +81,7 @@ func (p *StateProcessor) Process(block *types.Block, statedb *state.StateDB, cfg
 	}
 	context = NewEVMBlockContext(header, p.chain, nil)
 	evm := vm.NewEVM(context, tracingStateDB, p.config, cfg)
+	defer evm.Free()
 
 	if beaconRoot := block.BeaconRoot(); beaconRoot != nil {
 		ProcessBeaconBlockRoot(*beaconRoot, evm)

--- a/core/vm/eips.go
+++ b/core/vm/eips.go
@@ -89,8 +89,7 @@ func enable1884(jt *JumpTable) {
 }
 
 func opSelfBalance(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([]byte, error) {
-	balance := interpreter.evm.StateDB.GetBalance(scope.Contract.Address())
-	scope.Stack.push(balance)
+	scope.Stack.get().Set(interpreter.evm.StateDB.GetBalance(scope.Contract.Address()))
 	return nil, nil
 }
 
@@ -108,8 +107,7 @@ func enable1344(jt *JumpTable) {
 
 // opChainID implements CHAINID opcode
 func opChainID(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([]byte, error) {
-	chainId, _ := uint256.FromBig(interpreter.evm.chainConfig.ChainID)
-	scope.Stack.push(chainId)
+	scope.Stack.get().SetFromBig(interpreter.evm.chainConfig.ChainID)
 	return nil, nil
 }
 
@@ -219,8 +217,7 @@ func opTstore(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([]b
 
 // opBaseFee implements BASEFEE opcode
 func opBaseFee(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([]byte, error) {
-	baseFee, _ := uint256.FromBig(interpreter.evm.Context.BaseFee)
-	scope.Stack.push(baseFee)
+	scope.Stack.get().SetFromBig(interpreter.evm.Context.BaseFee)
 	return nil, nil
 }
 
@@ -237,7 +234,7 @@ func enable3855(jt *JumpTable) {
 
 // opPush0 implements the PUSH0 opcode
 func opPush0(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([]byte, error) {
-	scope.Stack.push(new(uint256.Int))
+	scope.Stack.get().Clear()
 	return nil, nil
 }
 
@@ -288,8 +285,7 @@ func opBlobHash(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([
 
 // opBlobBaseFee implements BLOBBASEFEE opcode
 func opBlobBaseFee(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([]byte, error) {
-	blobBaseFee, _ := uint256.FromBig(interpreter.evm.Context.BlobBaseFee)
-	scope.Stack.push(blobBaseFee)
+	scope.Stack.get().SetFromBig(interpreter.evm.Context.BlobBaseFee)
 	return nil, nil
 }
 

--- a/core/vm/evm.go
+++ b/core/vm/evm.go
@@ -170,6 +170,12 @@ func (evm *EVM) Cancel() {
 	evm.abort.Store(true)
 }
 
+// Free returns some memory allocated by the EVM, should be called after the EVM was used
+// for the last time. Not necessary, but an improvement.
+func (evm *EVM) Free() {
+	returnStack(evm.arena)
+}
+
 // Cancelled returns true if Cancel has been called
 func (evm *EVM) Cancelled() bool {
 	return evm.abort.Load()

--- a/core/vm/evm.go
+++ b/core/vm/evm.go
@@ -125,6 +125,8 @@ type EVM struct {
 	// jumpDests is the aggregated result of JUMPDEST analysis made through
 	// the life cycle of EVM.
 	jumpDests map[common.Hash]bitvec
+
+	arena *stackArena
 }
 
 // NewEVM constructs an EVM instance with the supplied block context, state
@@ -139,6 +141,7 @@ func NewEVM(blockCtx BlockContext, statedb StateDB, chainConfig *params.ChainCon
 		chainConfig: chainConfig,
 		chainRules:  chainConfig.Rules(blockCtx.BlockNumber, blockCtx.Random != nil, blockCtx.Time),
 		jumpDests:   make(map[common.Hash]bitvec),
+		arena:       newArena(),
 	}
 	evm.precompiles = activePrecompiledContracts(evm.chainRules)
 	evm.interpreter = NewEVMInterpreter(evm)

--- a/core/vm/gas_table.go
+++ b/core/vm/gas_table.go
@@ -345,7 +345,7 @@ func gasCreate2Eip3860(evm *EVM, contract *Contract, stack *Stack, mem *Memory, 
 }
 
 func gasExpFrontier(evm *EVM, contract *Contract, stack *Stack, mem *Memory, memorySize uint64) (uint64, error) {
-	expByteLen := uint64((stack.data[stack.len()-2].BitLen() + 7) / 8)
+	expByteLen := uint64((stack.Back(1).BitLen() + 7) / 8)
 
 	var (
 		gas      = expByteLen * params.ExpByteFrontier // no overflow check required. Max is 256 * ExpByte gas
@@ -358,7 +358,7 @@ func gasExpFrontier(evm *EVM, contract *Contract, stack *Stack, mem *Memory, mem
 }
 
 func gasExpEIP158(evm *EVM, contract *Contract, stack *Stack, mem *Memory, memorySize uint64) (uint64, error) {
-	expByteLen := uint64((stack.data[stack.len()-2].BitLen() + 7) / 8)
+	expByteLen := uint64((stack.Back(1).BitLen() + 7) / 8)
 
 	var (
 		gas      = expByteLen * params.ExpByteEIP158 // no overflow check required. Max is 256 * ExpByte gas

--- a/core/vm/instructions.go
+++ b/core/vm/instructions.go
@@ -23,7 +23,6 @@ import (
 	"github.com/ethereum/go-ethereum/core/tracing"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/params"
-	"github.com/holiman/uint256"
 )
 
 func opAdd(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([]byte, error) {
@@ -246,7 +245,7 @@ func opKeccak256(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) (
 }
 
 func opAddress(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([]byte, error) {
-	scope.Stack.push(new(uint256.Int).SetBytes(scope.Contract.Address().Bytes()))
+	scope.Stack.get().SetBytes(scope.Contract.Address().Bytes())
 	return nil, nil
 }
 
@@ -258,17 +257,17 @@ func opBalance(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([]
 }
 
 func opOrigin(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([]byte, error) {
-	scope.Stack.push(new(uint256.Int).SetBytes(interpreter.evm.Origin.Bytes()))
+	scope.Stack.get().SetBytes(interpreter.evm.Origin.Bytes())
 	return nil, nil
 }
 
 func opCaller(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([]byte, error) {
-	scope.Stack.push(new(uint256.Int).SetBytes(scope.Contract.Caller().Bytes()))
+	scope.Stack.get().SetBytes(scope.Contract.Caller().Bytes())
 	return nil, nil
 }
 
 func opCallValue(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([]byte, error) {
-	scope.Stack.push(scope.Contract.value)
+	scope.Stack.get().Set(scope.Contract.value)
 	return nil, nil
 }
 
@@ -284,7 +283,7 @@ func opCallDataLoad(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext
 }
 
 func opCallDataSize(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([]byte, error) {
-	scope.Stack.push(new(uint256.Int).SetUint64(uint64(len(scope.Contract.Input))))
+	scope.Stack.get().SetUint64(uint64(len(scope.Contract.Input)))
 	return nil, nil
 }
 
@@ -307,7 +306,7 @@ func opCallDataCopy(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext
 }
 
 func opReturnDataSize(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([]byte, error) {
-	scope.Stack.push(new(uint256.Int).SetUint64(uint64(len(interpreter.returnData))))
+	scope.Stack.get().SetUint64(uint64(len(interpreter.returnData)))
 	return nil, nil
 }
 
@@ -340,7 +339,7 @@ func opExtCodeSize(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext)
 }
 
 func opCodeSize(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([]byte, error) {
-	scope.Stack.push(new(uint256.Int).SetUint64(uint64(len(scope.Contract.Code))))
+	scope.Stack.get().SetUint64(uint64(len(scope.Contract.Code)))
 	return nil, nil
 }
 
@@ -418,8 +417,7 @@ func opExtCodeHash(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext)
 }
 
 func opGasprice(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([]byte, error) {
-	v, _ := uint256.FromBig(interpreter.evm.GasPrice)
-	scope.Stack.push(v)
+	scope.Stack.get().SetFromBig(interpreter.evm.GasPrice)
 	return nil, nil
 }
 
@@ -454,35 +452,32 @@ func opBlockhash(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) (
 }
 
 func opCoinbase(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([]byte, error) {
-	scope.Stack.push(new(uint256.Int).SetBytes(interpreter.evm.Context.Coinbase.Bytes()))
+	scope.Stack.get().SetBytes(interpreter.evm.Context.Coinbase.Bytes())
 	return nil, nil
 }
 
 func opTimestamp(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([]byte, error) {
-	scope.Stack.push(new(uint256.Int).SetUint64(interpreter.evm.Context.Time))
+	scope.Stack.get().SetUint64(interpreter.evm.Context.Time)
 	return nil, nil
 }
 
 func opNumber(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([]byte, error) {
-	v, _ := uint256.FromBig(interpreter.evm.Context.BlockNumber)
-	scope.Stack.push(v)
+	scope.Stack.get().SetFromBig(interpreter.evm.Context.BlockNumber)
 	return nil, nil
 }
 
 func opDifficulty(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([]byte, error) {
-	v, _ := uint256.FromBig(interpreter.evm.Context.Difficulty)
-	scope.Stack.push(v)
+	scope.Stack.get().SetFromBig(interpreter.evm.Context.Difficulty)
 	return nil, nil
 }
 
 func opRandom(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([]byte, error) {
-	v := new(uint256.Int).SetBytes(interpreter.evm.Context.Random.Bytes())
-	scope.Stack.push(v)
+	scope.Stack.get().SetBytes(interpreter.evm.Context.Random.Bytes())
 	return nil, nil
 }
 
 func opGasLimit(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([]byte, error) {
-	scope.Stack.push(new(uint256.Int).SetUint64(interpreter.evm.Context.GasLimit))
+	scope.Stack.get().SetUint64(interpreter.evm.Context.GasLimit)
 	return nil, nil
 }
 
@@ -559,17 +554,17 @@ func opJumpdest(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([
 }
 
 func opPc(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([]byte, error) {
-	scope.Stack.push(new(uint256.Int).SetUint64(*pc))
+	scope.Stack.get().SetUint64(*pc)
 	return nil, nil
 }
 
 func opMsize(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([]byte, error) {
-	scope.Stack.push(new(uint256.Int).SetUint64(uint64(scope.Memory.Len())))
+	scope.Stack.get().SetUint64(uint64(scope.Memory.Len()))
 	return nil, nil
 }
 
 func opGas(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([]byte, error) {
-	scope.Stack.push(new(uint256.Int).SetUint64(scope.Contract.Gas))
+	scope.Stack.get().SetUint64(scope.Contract.Gas)
 	return nil, nil
 }
 

--- a/core/vm/instructions.go
+++ b/core/vm/instructions.go
@@ -991,13 +991,13 @@ func makePush(size uint64, pushByteSize int) executionFunc {
 			start   = min(codeLen, int(*pc+1))
 			end     = min(codeLen, start+pushByteSize)
 		)
-		a := new(uint256.Int).SetBytes(scope.Contract.Code[start:end])
+		a := scope.Stack.get()
+		a.SetBytes(scope.Contract.Code[start:end])
 
 		// Missing bytes: pushByteSize - len(pushData)
 		if missing := pushByteSize - (end - start); missing > 0 {
 			a.Lsh(a, uint(8*missing))
 		}
-		scope.Stack.push(a)
 		*pc += size
 		return nil, nil
 	}

--- a/core/vm/instructions.go
+++ b/core/vm/instructions.go
@@ -955,13 +955,13 @@ func makeLog(size int) executionFunc {
 func opPush1(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([]byte, error) {
 	var (
 		codeLen = uint64(len(scope.Contract.Code))
-		integer = new(uint256.Int)
+		elem    = scope.Stack.get()
 	)
 	*pc += 1
 	if *pc < codeLen {
-		scope.Stack.push(integer.SetUint64(uint64(scope.Contract.Code[*pc])))
+		elem.SetUint64(uint64(scope.Contract.Code[*pc]))
 	} else {
-		scope.Stack.push(integer.Clear())
+		elem.Clear()
 	}
 	return nil, nil
 }
@@ -970,14 +970,14 @@ func opPush1(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([]by
 func opPush2(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([]byte, error) {
 	var (
 		codeLen = uint64(len(scope.Contract.Code))
-		integer = new(uint256.Int)
+		elem    = scope.Stack.get()
 	)
 	if *pc+2 < codeLen {
-		scope.Stack.push(integer.SetBytes2(scope.Contract.Code[*pc+1 : *pc+3]))
+		elem.SetBytes2(scope.Contract.Code[*pc+1 : *pc+3])
 	} else if *pc+1 < codeLen {
-		scope.Stack.push(integer.SetUint64(uint64(scope.Contract.Code[*pc+1]) << 8))
+		elem.SetUint64(uint64(scope.Contract.Code[*pc+1]) << 8)
 	} else {
-		scope.Stack.push(integer.Clear())
+		elem.Clear()
 	}
 	*pc += 2
 	return nil, nil

--- a/core/vm/interpreter.go
+++ b/core/vm/interpreter.go
@@ -181,9 +181,9 @@ func (in *EVMInterpreter) Run(contract *Contract, input []byte, readOnly bool) (
 	}
 
 	var (
-		op          OpCode        // current opcode
-		mem         = NewMemory() // bound memory
-		stack       = newstack()  // local stack
+		op          OpCode                 // current opcode
+		mem         = NewMemory()          // bound memory
+		stack       = in.evm.arena.stack() // local stack
 		callContext = &ScopeContext{
 			Memory:   mem,
 			Stack:    stack,
@@ -205,7 +205,7 @@ func (in *EVMInterpreter) Run(contract *Contract, input []byte, readOnly bool) (
 	// so that it gets executed _after_: the OnOpcode needs the stacks before
 	// they are returned to the pools
 	defer func() {
-		returnStack(stack)
+		stack.release()
 		mem.Free()
 	}()
 	contract.Input = input

--- a/core/vm/runtime/runtime_test.go
+++ b/core/vm/runtime/runtime_test.go
@@ -952,7 +952,7 @@ func TestManyLargeStacks(t *testing.T) {
 	}...)
 
 	main := common.HexToAddress("0xbb")
-	statedb, _ := state.New(types.EmptyRootHash, state.NewDatabase(rawdb.NewMemoryDatabase()), nil)
+	statedb, _ := state.New(types.EmptyRootHash, state.NewDatabaseForTesting())
 	statedb.SetCode(main, code)
 
 	//tracer := logger.NewJSONLogger(nil, os.Stdout)

--- a/core/vm/stack.go
+++ b/core/vm/stack.go
@@ -28,10 +28,6 @@ type stackArena struct {
 	top  int // first free slot
 }
 
-func (sa *stackArena) push(value *uint256.Int) {
-
-}
-
 func newArena() *stackArena {
 	return &stackArena{
 		data: make([]uint256.Int, 1025),

--- a/core/vm/stack.go
+++ b/core/vm/stack.go
@@ -86,6 +86,8 @@ func (s *Stack) push(d *uint256.Int) {
 	s.size++
 }
 
+// get returns a pointer to a newly created element
+// on top of the stack
 func (s *Stack) get() *uint256.Int {
 	elem := &s.inner.data[s.inner.top]
 	s.inner.top++

--- a/core/vm/stack.go
+++ b/core/vm/stack.go
@@ -18,6 +18,7 @@ package vm
 
 import (
 	"slices"
+	"sync"
 
 	"github.com/holiman/uint256"
 )
@@ -29,9 +30,19 @@ type stackArena struct {
 }
 
 func newArena() *stackArena {
-	return &stackArena{
-		data: make([]uint256.Int, 1025),
-	}
+	return stackPool.New().(*stackArena)
+}
+
+var stackPool = sync.Pool{
+	New: func() any {
+		return &stackArena{
+			data: make([]uint256.Int, 1025),
+		}
+	},
+}
+
+func returnStack(arena *stackArena) {
+	stackPool.Put(arena)
 }
 
 // stack returns an instance of a stack which uses the underlying arena. The instance

--- a/core/vm/stack.go
+++ b/core/vm/stack.go
@@ -17,111 +17,155 @@
 package vm
 
 import (
-	"sync"
+	"slices"
 
 	"github.com/holiman/uint256"
 )
 
-var stackPool = sync.Pool{
-	New: func() interface{} {
-		return &Stack{data: make([]uint256.Int, 0, 16)}
-	},
+// stackArena is an arena which actual evm stacks use for data storage
+type stackArena struct {
+	data []uint256.Int
+	top  int // first free slot
+}
+
+func (sa *stackArena) push(value *uint256.Int) {
+	if len(sa.data) <= sa.top {
+		// we need to grow the arena
+		sa.data = slices.Grow(sa.data, 512)
+		sa.data = sa.data[:cap(sa.data)]
+	}
+	sa.data[sa.top] = *value
+	sa.top++
+}
+
+func (sa *stackArena) pop() {
+	sa.top--
+}
+
+func newArena() *stackArena {
+	return &stackArena{
+		data: make([]uint256.Int, 1024),
+	}
+}
+
+// stack returns an instance of a stack which uses the underlying arena. The instance
+// must be released by invoking the (*Stack).release() method
+func (sa *stackArena) stack() *Stack {
+	return &Stack{
+		bottom: sa.top,
+		size:   0,
+		inner:  sa,
+	}
+}
+
+// newStackForTesting is meant to be used solely for testing. It creates a stack
+// backed by a newly allocated arena.
+func newStackForTesting() *Stack {
+	arena := &stackArena{
+		data: make([]uint256.Int, 256),
+	}
+	return arena.stack()
 }
 
 // Stack is an object for basic stack operations. Items popped to the stack are
 // expected to be changed and modified. stack does not take care of adding newly
 // initialized objects.
 type Stack struct {
-	data []uint256.Int
+	bottom int // bottom is the index of the first element of this stack
+	size   int // size is the number of elements in this stack
+	inner  *stackArena
 }
 
-func newstack() *Stack {
-	return stackPool.Get().(*Stack)
-}
-
-func returnStack(s *Stack) {
-	s.data = s.data[:0]
-	stackPool.Put(s)
+// release un-claims the area of the arena which was claimed by the stack.
+func (s *Stack) release() {
+	// When the stack is returned, need to notify the arena that the new 'top' is
+	// the returned stack's bottom.
+	s.inner.top = s.bottom
 }
 
 // Data returns the underlying uint256.Int array.
-func (st *Stack) Data() []uint256.Int {
-	return st.data
+func (s *Stack) Data() []uint256.Int {
+	return s.inner.data[s.bottom : s.bottom+s.size]
 }
 
-func (st *Stack) push(d *uint256.Int) {
+func (s *Stack) push(d *uint256.Int) {
 	// NOTE push limit (1024) is checked in baseCheck
-	st.data = append(st.data, *d)
+	s.inner.push(d)
+	s.size++
 }
 
-func (st *Stack) pop() (ret uint256.Int) {
-	ret = st.data[len(st.data)-1]
-	st.data = st.data[:len(st.data)-1]
-	return
+func (s *Stack) pop() uint256.Int {
+	ret := s.inner.data[s.bottom+s.size-1]
+	s.inner.pop()
+	s.size--
+	return ret
 }
 
-func (st *Stack) len() int {
-	return len(st.data)
+func (s *Stack) len() int {
+	return s.size
 }
 
-func (st *Stack) swap1() {
-	st.data[st.len()-2], st.data[st.len()-1] = st.data[st.len()-1], st.data[st.len()-2]
+func (s *Stack) swap1() {
+	s.inner.data[s.bottom+s.size-2], s.inner.data[s.bottom+s.size-1] = s.inner.data[s.bottom+s.size-1], s.inner.data[s.bottom+s.size-2]
 }
-func (st *Stack) swap2() {
-	st.data[st.len()-3], st.data[st.len()-1] = st.data[st.len()-1], st.data[st.len()-3]
+func (s *Stack) swap2() {
+	s.inner.data[s.bottom+s.size-3], s.inner.data[s.bottom+s.size-1] = s.inner.data[s.bottom+s.size-1], s.inner.data[s.bottom+s.size-3]
 }
-func (st *Stack) swap3() {
-	st.data[st.len()-4], st.data[st.len()-1] = st.data[st.len()-1], st.data[st.len()-4]
+func (s *Stack) swap3() {
+	s.inner.data[s.bottom+s.size-4], s.inner.data[s.bottom+s.size-1] = s.inner.data[s.bottom+s.size-1], s.inner.data[s.bottom+s.size-4]
 }
-func (st *Stack) swap4() {
-	st.data[st.len()-5], st.data[st.len()-1] = st.data[st.len()-1], st.data[st.len()-5]
+func (s *Stack) swap4() {
+	s.inner.data[s.bottom+s.size-5], s.inner.data[s.bottom+s.size-1] = s.inner.data[s.bottom+s.size-1], s.inner.data[s.bottom+s.size-5]
 }
-func (st *Stack) swap5() {
-	st.data[st.len()-6], st.data[st.len()-1] = st.data[st.len()-1], st.data[st.len()-6]
+func (s *Stack) swap5() {
+	s.inner.data[s.bottom+s.size-6], s.inner.data[s.bottom+s.size-1] = s.inner.data[s.bottom+s.size-1], s.inner.data[s.bottom+s.size-6]
 }
-func (st *Stack) swap6() {
-	st.data[st.len()-7], st.data[st.len()-1] = st.data[st.len()-1], st.data[st.len()-7]
+func (s *Stack) swap6() {
+	s.inner.data[s.bottom+s.size-7], s.inner.data[s.bottom+s.size-1] = s.inner.data[s.bottom+s.size-1], s.inner.data[s.bottom+s.size-7]
 }
-func (st *Stack) swap7() {
-	st.data[st.len()-8], st.data[st.len()-1] = st.data[st.len()-1], st.data[st.len()-8]
+func (s *Stack) swap7() {
+	s.inner.data[s.bottom+s.size-8], s.inner.data[s.bottom+s.size-1] = s.inner.data[s.bottom+s.size-1], s.inner.data[s.bottom+s.size-8]
 }
-func (st *Stack) swap8() {
-	st.data[st.len()-9], st.data[st.len()-1] = st.data[st.len()-1], st.data[st.len()-9]
+func (s *Stack) swap8() {
+	s.inner.data[s.bottom+s.size-9], s.inner.data[s.bottom+s.size-1] = s.inner.data[s.bottom+s.size-1], s.inner.data[s.bottom+s.size-9]
 }
-func (st *Stack) swap9() {
-	st.data[st.len()-10], st.data[st.len()-1] = st.data[st.len()-1], st.data[st.len()-10]
+func (s *Stack) swap9() {
+	s.inner.data[s.bottom+s.size-10], s.inner.data[s.bottom+s.size-1] = s.inner.data[s.bottom+s.size-1], s.inner.data[s.bottom+s.size-10]
 }
-func (st *Stack) swap10() {
-	st.data[st.len()-11], st.data[st.len()-1] = st.data[st.len()-1], st.data[st.len()-11]
+func (s *Stack) swap10() {
+	s.inner.data[s.bottom+s.size-11], s.inner.data[s.bottom+s.size-1] = s.inner.data[s.bottom+s.size-1], s.inner.data[s.bottom+s.size-11]
 }
-func (st *Stack) swap11() {
-	st.data[st.len()-12], st.data[st.len()-1] = st.data[st.len()-1], st.data[st.len()-12]
+func (s *Stack) swap11() {
+	s.inner.data[s.bottom+s.size-12], s.inner.data[s.bottom+s.size-1] = s.inner.data[s.bottom+s.size-1], s.inner.data[s.bottom+s.size-12]
 }
-func (st *Stack) swap12() {
-	st.data[st.len()-13], st.data[st.len()-1] = st.data[st.len()-1], st.data[st.len()-13]
+func (s *Stack) swap12() {
+	s.inner.data[s.bottom+s.size-13], s.inner.data[s.bottom+s.size-1] = s.inner.data[s.bottom+s.size-1], s.inner.data[s.bottom+s.size-13]
 }
-func (st *Stack) swap13() {
-	st.data[st.len()-14], st.data[st.len()-1] = st.data[st.len()-1], st.data[st.len()-14]
+func (s *Stack) swap13() {
+	s.inner.data[s.bottom+s.size-14], s.inner.data[s.bottom+s.size-1] = s.inner.data[s.bottom+s.size-1], s.inner.data[s.bottom+s.size-14]
 }
-func (st *Stack) swap14() {
-	st.data[st.len()-15], st.data[st.len()-1] = st.data[st.len()-1], st.data[st.len()-15]
+func (s *Stack) swap14() {
+	s.inner.data[s.bottom+s.size-15], s.inner.data[s.bottom+s.size-1] = s.inner.data[s.bottom+s.size-1], s.inner.data[s.bottom+s.size-15]
 }
-func (st *Stack) swap15() {
-	st.data[st.len()-16], st.data[st.len()-1] = st.data[st.len()-1], st.data[st.len()-16]
+func (s *Stack) swap15() {
+	s.inner.data[s.bottom+s.size-16], s.inner.data[s.bottom+s.size-1] = s.inner.data[s.bottom+s.size-1], s.inner.data[s.bottom+s.size-16]
 }
-func (st *Stack) swap16() {
-	st.data[st.len()-17], st.data[st.len()-1] = st.data[st.len()-1], st.data[st.len()-17]
-}
-
-func (st *Stack) dup(n int) {
-	st.push(&st.data[st.len()-n])
+func (s *Stack) swap16() {
+	s.inner.data[s.bottom+s.size-17], s.inner.data[s.bottom+s.size-1] = s.inner.data[s.bottom+s.size-1], s.inner.data[s.bottom+s.size-17]
 }
 
-func (st *Stack) peek() *uint256.Int {
-	return &st.data[st.len()-1]
+func (s *Stack) dup(n int) {
+	// TODO: check size of inner
+	s.inner.data[s.bottom+s.size] = s.inner.data[s.bottom+s.size-n]
+	s.size++
+	s.inner.top++
+}
+
+func (s *Stack) peek() *uint256.Int {
+	return &s.inner.data[s.bottom+s.size-1]
 }
 
 // Back returns the n'th item in stack
-func (st *Stack) Back(n int) *uint256.Int {
-	return &st.data[st.len()-n-1]
+func (s *Stack) Back(n int) *uint256.Int {
+	return &s.inner.data[s.bottom+s.size-n-1]
 }


### PR DESCRIPTION
OBS, wip, this is nowhere near ready for merging

This is an experimental stack layout, using an underlying `arena` of `uint256.Int`. The actual stacks that are used during execution uses the stack-arena for storage. 

At this point, I'm still experimenting with who shoud hold what, e.g. if both the arena and stack-instances need to keep track of `top`. Right now the arena has a `top`, and the stacks have a `bottom` and a `size`. 

I have also not implemented the `grow`ing of the arena. Possibly, there will be an `ensureCapacity` method which ensures that there's room for at least `1` more item (any evm operation grows the stack at most by 1) - and the methods that expand the stack by `1` are the only ones that need ever invoke it.  

Since the elements are `uint256.Int`, we should avoid giving out pointers to the elements. The `peek` method does so, which is "unsafe", but the `peek` was only ever meant for evm operations to modify a stack item directly, without popping/pushing. The `peek`ed references are not held more than a very brief time, so it should be ok. 

Posting it here for eyes / suggestions / discussions. 
