### PR TITLE
Include tracerConfig in created tracing test

### DIFF
--- a/eth/tracers/internal/tracetest/makeTest.js
+++ b/eth/tracers/internal/tracetest/makeTest.js
@@ -49,5 +49,6 @@ var makeTest = function(tx, traceConfig) {
         context: context,
         input:  eth.getRawTransaction(tx),
         result: result,
+        tracerConfig: traceConfig.tracerConfig,
     }, null, 2));
 }


### PR DESCRIPTION
When creating prestate tracer tests in diff mode, the diff mode flag has to be included in the resulting test JSON. This change makes sure the flag is included in the JSON when it is passed to makeTest.