### PR TITLE
core/state: pull the verkle trie from prefetcher for empty storage root

### DIFF
--- a/core/state/state_object.go
+++ b/core/state/state_object.go
@@ -143,7 +143,7 @@ func (s *stateObject) getTrie() (Trie, error) {
 func (s *stateObject) getPrefetchedTrie() Trie {
 	// If there's nothing to meaningfully return, let the user figure it out by
 	// pulling the trie from disk.
-	if s.data.Root == types.EmptyRootHash || s.db.prefetcher == nil {
+	if (s.data.Root == types.EmptyRootHash && !s.db.db.TrieDB().IsVerkle()) || s.db.prefetcher == nil {
 		return nil
 	}
 	// Attempt to retrieve the trie from the prefetcher


### PR DESCRIPTION
This pull request fixes a flaw in prefetcher.

In verkle tree world, both accounts and storage slots are committed into a single tree instance
for state hashing. If the prefetcher is activated, we will try to pull the trie for the prefetcher for
performance speedup. 

However, we had a special logic to skip pulling storage trie if the storage root is empty. While
it's true for merkle as we have nothing to do with an empty storage trie, it's totally wrong for
verkle. The consequences for skipping pulling is the storage changes are committed into trie
A, while the account changes are committed into trie B (pulled from the prefetcher), boom. 
