### PR TITLE
core/types: more easily extensible tx signing

### DIFF
--- a/core/types/transaction_signing.go
+++ b/core/types/transaction_signing.go
@@ -64,21 +64,20 @@ func MakeSigner(config *params.ChainConfig, blockNumber *big.Int, blockTime uint
 // Use this in transaction-handling code where the current block number is unknown. If you
 // have the current block number available, use MakeSigner instead.
 func LatestSigner(config *params.ChainConfig) Signer {
+	var signer Signer = HomesteadSigner{}
 	if config.ChainID != nil {
-		if config.CancunTime != nil {
-			return NewCancunSigner(config.ChainID)
-		}
-		if config.LondonBlock != nil {
-			return NewLondonSigner(config.ChainID)
-		}
-		if config.BerlinBlock != nil {
-			return NewEIP2930Signer(config.ChainID)
-		}
-		if config.EIP155Block != nil {
-			return NewEIP155Signer(config.ChainID)
+		switch {
+		case config.CancunTime != nil:
+			signer = NewCancunSigner(config.ChainID)
+		case config.LondonBlock != nil:
+			signer = NewLondonSigner(config.ChainID)
+		case config.BerlinBlock != nil:
+			signer = NewEIP2930Signer(config.ChainID)
+		case config.EIP155Block != nil:
+			signer = NewEIP155Signer(config.ChainID)
 		}
 	}
-	return HomesteadSigner{}
+	return signer
 }
 
 // LatestSignerForChainID returns the 'most permissive' Signer available. Specifically,
@@ -89,10 +88,11 @@ func LatestSigner(config *params.ChainConfig) Signer {
 // configuration are unknown. If you have a ChainConfig, use LatestSigner instead.
 // If you have a ChainConfig and know the current block number, use MakeSigner instead.
 func LatestSignerForChainID(chainID *big.Int) Signer {
-	if chainID == nil {
-		return HomesteadSigner{}
+	var signer Signer = HomesteadSigner{}
+	if chainID != nil {
+		signer = NewCancunSigner(chainID)
 	}
-	return NewCancunSigner(chainID)
+	return signer
 }
 
 // SignTx signs the transaction using the given signer and private key.

--- a/core/types/transaction_signing.go
+++ b/core/types/transaction_signing.go
@@ -64,7 +64,7 @@ func MakeSigner(config *params.ChainConfig, blockNumber *big.Int, blockTime uint
 // Use this in transaction-handling code where the current block number is unknown. If you
 // have the current block number available, use MakeSigner instead.
 func LatestSigner(config *params.ChainConfig) Signer {
-	var signer Signer = HomesteadSigner{}
+	var signer Signer
 	if config.ChainID != nil {
 		switch {
 		case config.CancunTime != nil:
@@ -75,7 +75,11 @@ func LatestSigner(config *params.ChainConfig) Signer {
 			signer = NewEIP2930Signer(config.ChainID)
 		case config.EIP155Block != nil:
 			signer = NewEIP155Signer(config.ChainID)
+		default:
+			signer = HomesteadSigner{}
 		}
+	} else {
+		signer = HomesteadSigner{}
 	}
 	return signer
 }
@@ -88,9 +92,11 @@ func LatestSigner(config *params.ChainConfig) Signer {
 // configuration are unknown. If you have a ChainConfig, use LatestSigner instead.
 // If you have a ChainConfig and know the current block number, use MakeSigner instead.
 func LatestSignerForChainID(chainID *big.Int) Signer {
-	var signer Signer = HomesteadSigner{}
+	var signer Signer
 	if chainID != nil {
 		signer = NewCancunSigner(chainID)
+	} else {
+		signer = HomesteadSigner{}
 	}
 	return signer
 }


### PR DESCRIPTION
Having just a single return point in methods that build signers makes it easier for forks of go ethereum to add their own signers that delegate to the underlying signer chain, since they can intercept the signer chain at a single point.

At celo we are currently transitioning to be an L2 based on the optimism codebase and we have a number of additional transaction types that we have extended vanilla ethereum with, these transaction types require custom signing therefore requiring us to modify the signer creation functions.

In order to lessen the burden of being a fork of op-geth and consequently go-ethereum we are trying to ensure that our changes are minimally invasive to the codebase, we've partially achieved that for transaction signing by having an overlay signer that handles our added transactions and delegates to the existing signer chain for all other cases. 

In the case of `MakeSigner`(see below) we are able to cleanly add this since we can delegate to the `signer` variable, however for `LatestSigner` and `LatestSignerForChainId` this is not possible due to the multiple return points.

```go
// MakeSigner returns a Signer based on the given chain config and block number.
func MakeSigner(config *params.ChainConfig, blockNumber *big.Int, blockTime uint64) Signer {
	var signer Signer
	switch {
	case config.IsCancun(blockNumber, blockTime) && !config.IsOptimism():
		signer = NewCancunSigner(config.ChainID)
	case config.IsLondon(blockNumber):
		signer = NewLondonSigner(config.ChainID)
	case config.IsBerlin(blockNumber):
		signer = NewEIP2930Signer(config.ChainID)
	case config.IsEIP155(blockNumber):
		signer = NewEIP155Signer(config.ChainID)
	case config.IsHomestead(blockNumber):
		signer = HomesteadSigner{}
	default:
		signer = FrontierSigner{}
	}

	// Apply the celo overlay signer, if no celo forks have been enabled then the given signer is returned.
	signer = makeCeloSigner(config, blockTime, signer)

	return signer
}
```

Having multiple return points requires us to handle potentially every return point inside the switch case or if ladder, which further introduces conflicts when forks with new signing are introduced.

I'm aware that this change doesn't bring any direct benefit for the go-ethereum codebase, but also I don't think it is further complicating the codebase and should help to simplify the lives of fork maintainers.