### PR TITLE
feat(build): docker image with delve debugger support

### DIFF
--- a/Dockerfile.alltools
+++ b/Dockerfile.alltools
@@ -8,6 +8,9 @@ FROM golang:1.23-alpine as builder
 
 RUN apk add --no-cache gcc musl-dev linux-headers git
 
+# Install Delve debugger
+RUN go install github.com/go-delve/delve/cmd/dlv@latest
+
 # Get dependencies - will also be cached if we won't change go.mod/go.sum
 COPY go.mod /go-ethereum/
 COPY go.sum /go-ethereum/
@@ -22,7 +25,10 @@ FROM alpine:latest
 RUN apk add --no-cache ca-certificates
 COPY --from=builder /go-ethereum/build/bin/* /usr/local/bin/
 
-EXPOSE 8545 8546 30303 30303/udp
+# Copy Delve debugger executable to current stage
+COPY --from=builder /go/bin/dlv /
+
+EXPOSE 4000 8545 8546 30303 30303/udp
 
 # Add some metadata labels to help programmatic image consumption
 ARG COMMIT=""


### PR DESCRIPTION
Adds a new optional docker image tag to `build/ci.go`.  
In order to enable [Delve](https://github.com/go-delve/delve) to debug test environments remotely, the following build args are needed: 
```
GOFLAGS="-gcflags=all=-N -gcflags=all=-l"
```

For convenience, the `dlv` executable was added to `Dockerfile.alltools` ( and its default network port exposed ).