### PR TITLE
node: fix TestJWT

### DIFF
--- a/node/rpcstack_test.go
+++ b/node/rpcstack_test.go
@@ -445,6 +445,7 @@ func TestJWT(t *testing.T) {
 		if resp.StatusCode != http.StatusUnauthorized {
 			t.Errorf("tc %d-http, token '%v': expected not to allow,  got %v", i, token, resp.StatusCode)
 		}
+		time.Sleep(50 * time.Millisecond)
 	}
 	srv.stop()
 }


### PR DESCRIPTION
This pull request fixes the flaky test TestJWT in https://github.com/ethereum/go-ethereum/issues/29830


Fail cases:
```  
rpcstack_test.go:440: tc 0-ws, token 'Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpYXQiOjE3MjUyNzMwOTR9.xTDOYphuc2Wx9nlglGnGwLba30TNCTmuntwlh1T5DJI': expected not to allow,  got ok
```

The fail case is that the request with expired time still passed. When run flaky test, the server cannot handle all request in time, some requests are delayed. So when the delayed request are handled, server time is behind the client time and when the time difference is over 1s, the server would not take it as expired, then  it passed. 

This PR try to reduce the traffic and it works better now.  

``` 
$ stress ./node.test -test.run=TestJWT -test.cpu=4 

5s: 36 runs so far, 0 failures, 12 active
10s: 84 runs so far, 0 failures, 12 active
15s: 132 runs so far, 0 failures, 12 active
20s: 180 runs so far, 0 failures, 12 active
25s: 228 runs so far, 0 failures, 12 active
30s: 290 runs so far, 0 failures, 12 active
35s: 332 runs so far, 0 failures, 12 active
40s: 374 runs so far, 0 failures, 12 active
45s: 422 runs so far, 0 failures, 12 active
50s: 461 runs so far, 0 failures, 12 active
55s: 500 runs so far, 0 failures, 12 active
1m0s: 542 runs so far, 0 failures, 12 active
```

Not sure if it's a good way to fix the flaky test, please give some suggestions. 