### PR TITLE
node: fix flaky jwt-test

### DIFF
--- a/node/rpcstack_test.go
+++ b/node/rpcstack_test.go
@@ -383,7 +383,7 @@ func TestJWT(t *testing.T) {
 	expFail := []func() string{
 		// future
 		func() string {
-			return fmt.Sprintf("Bearer %v", issueToken(secret, nil, testClaim{"iat": time.Now().Unix() + int64(jwtExpiryTimeout.Seconds()) + 1}))
+			return fmt.Sprintf("Bearer %v", issueToken(secret, nil, testClaim{"iat": time.Now().Unix() + int64(jwtExpiryTimeout.Seconds()) + 60}))
 		},
 		// stale
 		func() string {


### PR DESCRIPTION
This PR fixes a flaky jwt-test. 

The test is a jwt "from one second in the future". The test passes; the reason for this is that the CI-system is slow, and by the time the jwt is actually evaluated, that second has passed, and it's no longer future.

Alternative to #30380