### PR TITLE
core: attempt at alternative tx-level prefetcher

### DIFF
--- a/core/state_prefetcher.go
+++ b/core/state_prefetcher.go
@@ -53,8 +53,10 @@ func (p *statePrefetcher) Prefetch(block *types.Block, statedb *state.StateDB, c
 		signer       = types.MakeSigner(p.config, header.Number, header.Time)
 	)
 	// Iterate over and process the individual transactions
-	byzantium := p.config.IsByzantium(block.Number())
-	for i, tx := range block.Transactions() {
+	txs := block.Transactions()
+	// Skip the first third of transactions, prefetch the latter two thirds of the transactions
+	for i := (len(txs) * 2) / 3; i < len(txs); i++ {
+		tx := txs[i]
 		// If block precaching was interrupted, abort
 		if interrupt != nil && interrupt.Load() {
 			return
@@ -68,14 +70,6 @@ func (p *statePrefetcher) Prefetch(block *types.Block, statedb *state.StateDB, c
 		if err := precacheTransaction(msg, p.config, gaspool, statedb, header, evm); err != nil {
 			return // Ugh, something went horribly wrong, bail out
 		}
-		// If we're pre-byzantium, pre-load trie nodes for the intermediate root
-		if !byzantium {
-			statedb.IntermediateRoot(true)
-		}
-	}
-	// If were post-byzantium, pre-load trie nodes for the final root hash
-	if byzantium {
-		statedb.IntermediateRoot(true)
 	}
 }
 


### PR DESCRIPTION
This is a proof-of-concept test of an idea based off a discussion with @rjl493456442 . We can try to prefetch transcations _in the current block_. 

Current, prior to this PR, we have

1. Prefetcher which executes _the next block_ opportunistically.  This is not used in regular operations, since we usually don't have the next block -- only while catching up. 
2. Prefetching the trie. This happens post-execution: after executing `tx 1`, we try to prefetch the trie so we later on can do the `commit` faster. 

This PR changes the `1.` prefetcher, so that instead of pre-executing the next block, we skip ahead across a third of the transactions in the block, and (opportunistically) execute it in order to pre-load stuff into caches. 