### PR TITLE
Added a custom field to the ethconfig.Config to test deserialisation

### DIFF
--- a/custom-config.toml
+++ b/custom-config.toml
@@ -1,0 +1,80 @@
+[Eth]
+NetworkId = 15003
+SyncMode = "full"
+EthDiscoveryURLs = []
+SnapDiscoveryURLs = []
+NoPruning = true
+NoPrefetch = false
+TxLookupLimit = 2350000
+TransactionHistory = 2350000
+StateScheme = "hash"
+DatabaseCache = 512
+DatabaseFreezer = ""
+TrieCleanCache = 256
+TrieDirtyCache = 256
+TrieTimeout = 3600000000000
+SnapshotCache = 0
+Preimages = false
+FilterLogCacheSize = 32
+EnablePreimageRecording = false
+RPCGasCap = 50000000
+RPCEVMTimeout = 5000000000
+RPCTxFeeCap = 0e+00
+CustomField = "Some value"
+
+[Eth.Miner]
+GasCeil = 30000000
+GasPrice = 10000000000
+Recommit = 999999999000000000
+NewPayloadTimeout = 2000000000
+
+[Eth.TxPool]
+Locals = []
+NoLocals = true
+Journal = "transactions.rlp"
+Rejournal = 3600000000000
+PriceLimit = 10000000000
+PriceBump = 10
+AccountSlots = 16
+GlobalSlots = 5120
+AccountQueue = 64
+GlobalQueue = 1024
+Lifetime = 3600000000000
+
+[Eth.BlobPool]
+Datadir = "blobpool"
+Datacap = 1
+PriceBump = 100
+
+[Eth.GPO]
+Blocks = 120
+Percentile = 60
+MaxHeaderHistory = 1024
+MaxBlockHistory = 1024
+MaxPrice = 500000000000
+IgnorePrice = 2
+
+[Node]
+DataDir = ""
+IPCPath = "geth.ipc"
+HTTPHost = ""
+HTTPModules = []
+WSHost = ""
+WSModules = []
+AllowUnprotectedTxs = true
+
+[Node.P2P]
+MaxPeers = 100
+NoDiscovery = false
+BootstrapNodes = []
+StaticNodes = []
+TrustedNodes = []
+ListenAddr = ""
+DiscAddr = ""
+EnableMsgEvents = false
+
+[Node.HTTPTimeouts]
+ReadTimeout = 0
+ReadHeaderTimeout = 0
+WriteTimeout = 0
+IdleTimeout = 0

--- a/eth/ethconfig/config.go
+++ b/eth/ethconfig/config.go
@@ -159,6 +159,8 @@ type Config struct {
 
 	// OverrideVerkle (TODO: remove after the fork)
 	OverrideVerkle *uint64 `toml:",omitempty"`
+
+        CustomField string     `toml:",omitempty"`
 }
 
 // CreateConsensusEngine creates a consensus engine for the given chain config.


### PR DESCRIPTION
To test, run:
```
make all
 ./build/bin/geth --config custom-config.toml 
```

Expected behaviour: toml file is deserialised successfully.

Actual behaviour:
```
./build/bin/geth --config custom-config.toml
INFO [09-05|12:43:39.710] Starting Geth on Ethereum mainnet...
INFO [09-05|12:43:39.711] Bumping default cache on mainnet         provided=1024 updated=4096
Fatal: custom-config.toml, line 23: field 'CustomField' is not defined in ethconfig.Config, see https://godoc.org/github.com/ethereum/go-ethereum/eth/ethconfig#Config for available fields
```