### PR TITLE
build: increase go test timeout

### DIFF
--- a/build/ci.go
+++ b/build/ci.go
@@ -298,7 +298,7 @@ func doTest(cmdline []string) {
 	gotest := tc.Go("test")
 
 	// CI needs a bit more time for the statetests (default 10m).
-	gotest.Args = append(gotest.Args, "-timeout=20m")
+	gotest.Args = append(gotest.Args, "-timeout=30m")
 
 	// Enable CKZG backend in CI.
 	gotest.Args = append(gotest.Args, "-tags=ckzg")


### PR DESCRIPTION
This increases the timeout for the go tests on ci, this should prevent travis from erroring.

see: https://app.travis-ci.com/github/ethereum/go-ethereum/jobs/625803693
