### PR TITLE
eth/filters: prevent concurrent access in test

### DIFF
--- a/eth/filters/filter_system_test.go
+++ b/eth/filters/filter_system_test.go
@@ -601,7 +601,9 @@ func TestPendingTxFilterDeadlock(t *testing.T) {
 	subs := make([]*Subscription, 20)
 	for i := 0; i < len(subs); i++ {
 		fid := api.NewPendingTransactionFilter(nil)
+		api.filtersMu.Lock()
 		f, ok := api.filters[fid]
+		api.filtersMu.Unlock()
 		if !ok {
 			t.Fatalf("Filter %s should exist", fid)
 		}


### PR DESCRIPTION
Hi, during a CI run I observed the following:
```
fatal error: concurrent map read and map write

goroutine 88 [running]:
github.com/ava-labs/subnet-evm/eth/filters.TestPendingTxFilterDeadlock(0xc0061ef860)
	/home/runner/work/subnet-evm/subnet-evm/eth/filters/filter_system_test.go:[84]
```

seems this access in the test should be protected like the other accesses in `api.go`