### PR TITLE
all: update math/rand to math/rand/v2

### DIFF
--- a/accounts/keystore/account_cache_test.go
+++ b/accounts/keystore/account_cache_test.go
@@ -19,7 +19,7 @@ package keystore
 import (
 	"errors"
 	"fmt"
-	"math/rand"
+	"math/rand/v2"
 	"os"
 	"path/filepath"
 	"reflect"

--- a/accounts/keystore/keystore_test.go
+++ b/accounts/keystore/keystore_test.go
@@ -17,7 +17,7 @@
 package keystore
 
 import (
-	"math/rand"
+	"math/rand/v2"
 	"os"
 	"runtime"
 	"slices"

--- a/beacon/light/test_helpers.go
+++ b/beacon/light/test_helpers.go
@@ -19,7 +19,7 @@ package light
 import (
 	"crypto/rand"
 	"crypto/sha256"
-	mrand "math/rand"
+	mrand "math/rand/v2"
 
 	"github.com/ethereum/go-ethereum/beacon/merkle"
 	"github.com/ethereum/go-ethereum/beacon/params"
@@ -74,7 +74,7 @@ func GenerateTestCheckpoint(period uint64, committee *types.SerializedSyncCommit
 
 func makeBitmask(signerCount int) (bitmask [params.SyncCommitteeBitmaskSize]byte) {
 	for i := 0; i < params.SyncCommitteeSize; i++ {
-		if mrand.Intn(params.SyncCommitteeSize-i) < signerCount {
+		if mrand.IntN(params.SyncCommitteeSize-i) < signerCount {
 			bitmask[i/8] += byte(1) << (i & 7)
 			signerCount--
 		}

--- a/cmd/devp2p/internal/ethtest/snap.go
+++ b/cmd/devp2p/internal/ethtest/snap.go
@@ -21,7 +21,7 @@ import (
 	"errors"
 	"fmt"
 	"math/big"
-	"math/rand"
+	"math/rand/v2"
 	"reflect"
 
 	"github.com/ethereum/go-ethereum/common"
@@ -758,7 +758,7 @@ func (s *Suite) snapGetAccountRange(t *utesting.T, tc *accRangeTest) error {
 	}
 	// write request
 	req := &snap.GetAccountRangePacket{
-		ID:     uint64(rand.Int63()),
+		ID:     uint64(rand.Int64()),
 		Root:   tc.root,
 		Origin: tc.startingHash,
 		Limit:  tc.limitHash,
@@ -828,7 +828,7 @@ func (s *Suite) snapGetStorageRanges(t *utesting.T, tc *stRangesTest) error {
 
 	// write request
 	req := &snap.GetStorageRangesPacket{
-		ID:       uint64(rand.Int63()),
+		ID:       uint64(rand.Int64()),
 		Root:     tc.root,
 		Accounts: tc.accounts,
 		Origin:   tc.origin,
@@ -882,7 +882,7 @@ func (s *Suite) snapGetByteCodes(t *utesting.T, tc *byteCodesTest) error {
 	}
 	// write request
 	req := &snap.GetByteCodesPacket{
-		ID:     uint64(rand.Int63()),
+		ID:     uint64(rand.Int64()),
 		Hashes: tc.hashes,
 		Bytes:  tc.nBytes,
 	}
@@ -942,7 +942,7 @@ func (s *Suite) snapGetTrieNodes(t *utesting.T, tc *trieNodesTest) error {
 
 	// write0 request
 	req := &snap.GetTrieNodesPacket{
-		ID:    uint64(rand.Int63()),
+		ID:    uint64(rand.Int64()),
 		Root:  tc.root,
 		Paths: tc.paths,
 		Bytes: tc.nBytes,

--- a/cmd/geth/logging_test.go
+++ b/cmd/geth/logging_test.go
@@ -24,7 +24,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"math/rand"
+	"math/rand/v2"
 	"os"
 	"os/exec"
 	"strings"
@@ -201,7 +201,7 @@ func TestFileOut(t *testing.T) {
 	var (
 		have, want []byte
 		err        error
-		path       = fmt.Sprintf("%s/test_file_out-%d", t.TempDir(), rand.Int63())
+		path       = fmt.Sprintf("%s/test_file_out-%d", t.TempDir(), rand.Int64())
 	)
 	if want, err = runSelf(fmt.Sprintf("--log.file=%s", path), "logtest"); err != nil {
 		t.Fatal(err)
@@ -221,7 +221,7 @@ func TestRotatingFileOut(t *testing.T) {
 	var (
 		have, want []byte
 		err        error
-		path       = fmt.Sprintf("%s/test_file_out-%d", t.TempDir(), rand.Int63())
+		path       = fmt.Sprintf("%s/test_file_out-%d", t.TempDir(), rand.Int64())
 	)
 	if want, err = runSelf(fmt.Sprintf("--log.file=%s", path), "--log.rotate", "logtest"); err != nil {
 		t.Fatal(err)

--- a/common/bitutil/compress_test.go
+++ b/common/bitutil/compress_test.go
@@ -19,7 +19,7 @@ package bitutil
 import (
 	"bytes"
 	"fmt"
-	"math/rand"
+	"math/rand/v2"
 	"testing"
 
 	"github.com/ethereum/go-ethereum/common/hexutil"
@@ -167,14 +167,14 @@ func BenchmarkEncoding4KBSaturated(b *testing.B) { benchmarkEncoding(b, 4096, 0.
 
 func benchmarkEncoding(b *testing.B, bytes int, fill float64) {
 	// Generate a random slice of bytes to compress
-	random := rand.NewSource(0) // reproducible and comparable
+	random := rand.New(rand.NewPCG(0, 0)) // reproducible and comparable
 
 	data := make([]byte, bytes)
 	bits := int(float64(bytes) * 8 * fill)
 
 	for i := 0; i < bits; i++ {
-		idx := random.Int63() % int64(len(data))
-		bit := uint(random.Int63() % 8)
+		idx := random.Int64() % int64(len(data))
+		bit := uint(random.Int64() % 8)
 		data[idx] |= 1 << bit
 	}
 	// Reset the benchmark and measure encoding/decoding

--- a/common/lru/basiclru_test.go
+++ b/common/lru/basiclru_test.go
@@ -20,7 +20,7 @@ import (
 	crand "crypto/rand"
 	"fmt"
 	"io"
-	"math/rand"
+	"math/rand/v2"
 	"testing"
 )
 
@@ -192,7 +192,7 @@ func BenchmarkLRU(b *testing.B) {
 		values   = make([][]byte, capacity)
 	)
 	for i := range indexes {
-		indexes[i] = rand.Intn(capacity)
+		indexes[i] = rand.IntN(capacity)
 	}
 	for i := range keys {
 		b := make([]byte, 32)

--- a/common/prque/lazyqueue_test.go
+++ b/common/prque/lazyqueue_test.go
@@ -17,7 +17,7 @@
 package prque
 
 import (
-	"math/rand"
+	"math/rand/v2"
 	"sync"
 	"testing"
 	"time"
@@ -65,7 +65,7 @@ func TestLazyQueue(t *testing.T) {
 	)
 
 	for i := range items[:] {
-		items[i].p = rand.Int63n(testPriorityStep * 10)
+		items[i].p = rand.Int64N(testPriorityStep * 10)
 		if items[i].p > maxPri {
 			maxPri = items[i].p
 		}
@@ -95,9 +95,9 @@ func TestLazyQueue(t *testing.T) {
 	}()
 
 	for c := 0; c < testSteps; c++ {
-		i := rand.Intn(testItems)
+		i := rand.IntN(testItems)
 		lock.Lock()
-		items[i].p += rand.Int63n(testPriorityStep*2-1) + 1
+		items[i].p += rand.Int64N(testPriorityStep*2-1) + 1
 		if items[i].p > maxPri {
 			maxPri = items[i].p
 		}
@@ -105,7 +105,7 @@ func TestLazyQueue(t *testing.T) {
 		if items[i].p > items[i].maxp {
 			q.Update(items[i].index)
 		}
-		if rand.Intn(100) == 0 {
+		if rand.IntN(100) == 0 {
 			p := q.PopItem().(*lazyItem)
 			if p.p != maxPri {
 				lock.Unlock()

--- a/common/prque/prque_test.go
+++ b/common/prque/prque_test.go
@@ -9,7 +9,7 @@
 package prque
 
 import (
-	"math/rand"
+	"math/rand/v2"
 	"testing"
 )
 
@@ -103,7 +103,7 @@ func BenchmarkPush(b *testing.B) {
 	prio := make([]int64, b.N)
 	for i := 0; i < len(data); i++ {
 		data[i] = rand.Int()
-		prio[i] = rand.Int63()
+		prio[i] = rand.Int64()
 	}
 	// Execute the benchmark
 	b.ResetTimer()
@@ -119,7 +119,7 @@ func BenchmarkPop(b *testing.B) {
 	prio := make([]int64, b.N)
 	for i := 0; i < len(data); i++ {
 		data[i] = rand.Int()
-		prio[i] = rand.Int63()
+		prio[i] = rand.Int64()
 	}
 	queue := New[int64, int](nil)
 	for i := 0; i < len(data); i++ {

--- a/common/prque/sstack_test.go
+++ b/common/prque/sstack_test.go
@@ -9,7 +9,7 @@
 package prque
 
 import (
-	"math/rand"
+	"math/rand/v2"
 	"sort"
 	"testing"
 )
@@ -19,7 +19,7 @@ func TestSstack(t *testing.T) {
 	size := 16 * blockSize
 	data := make([]*item[int64, int], size)
 	for i := 0; i < size; i++ {
-		data[i] = &item[int64, int]{rand.Int(), rand.Int63()}
+		data[i] = &item[int64, int]{rand.Int(), rand.Int64()}
 	}
 	stack := newSstack[int64, int](nil)
 	for rep := 0; rep < 2; rep++ {
@@ -74,7 +74,7 @@ func TestSstackReset(t *testing.T) {
 	size := 16 * blockSize
 	data := make([]*item[int64, int], size)
 	for i := 0; i < size; i++ {
-		data[i] = &item[int64, int]{rand.Int(), rand.Int63()}
+		data[i] = &item[int64, int]{rand.Int(), rand.Int64()}
 	}
 	stack := newSstack[int64, int](nil)
 	for rep := 0; rep < 2; rep++ {

--- a/common/types.go
+++ b/common/types.go
@@ -24,7 +24,7 @@ import (
 	"errors"
 	"fmt"
 	"math/big"
-	"math/rand"
+	"math/rand/v2"
 	"reflect"
 	"strconv"
 	"strings"
@@ -154,7 +154,7 @@ func (h *Hash) SetBytes(b []byte) {
 
 // Generate implements testing/quick.Generator.
 func (h Hash) Generate(rand *rand.Rand, size int) reflect.Value {
-	m := rand.Intn(len(h))
+	m := rand.IntN(len(h))
 	for i := len(h) - 1; i > m; i-- {
 		h[i] = byte(rand.Uint32())
 	}

--- a/consensus/clique/clique.go
+++ b/consensus/clique/clique.go
@@ -23,7 +23,7 @@ import (
 	"fmt"
 	"io"
 	"math/big"
-	"math/rand"
+	"math/rand/v2"
 	"sync"
 	"time"
 
@@ -534,7 +534,7 @@ func (c *Clique) Prepare(chain consensus.ChainHeaderReader, header *types.Header
 		}
 		// If there's pending proposals, cast a vote on them
 		if len(addresses) > 0 {
-			header.Coinbase = addresses[rand.Intn(len(addresses))]
+			header.Coinbase = addresses[rand.IntN(len(addresses))]
 			if c.proposals[header.Coinbase] {
 				copy(header.Nonce[:], nonceAuthVote)
 			} else {
@@ -651,7 +651,7 @@ func (c *Clique) Seal(chain consensus.ChainHeaderReader, block *types.Block, res
 	if header.Difficulty.Cmp(diffNoTurn) == 0 {
 		// It's not our turn explicitly to sign, delay it a bit
 		wiggle := time.Duration(len(snap.Signers)/2+1) * wiggleTime
-		delay += time.Duration(rand.Int63n(int64(wiggle)))
+		delay += time.Duration(rand.Int64N(int64(wiggle)))
 
 		log.Trace("Out-of-turn signing requested", "wiggle", common.PrettyDuration(wiggle))
 	}

--- a/consensus/ethash/consensus_test.go
+++ b/consensus/ethash/consensus_test.go
@@ -21,7 +21,7 @@ import (
 	"encoding/binary"
 	"encoding/json"
 	"math/big"
-	"math/rand"
+	"math/rand/v2"
 	"os"
 	"path/filepath"
 	"testing"

--- a/core/blockchain_test.go
+++ b/core/blockchain_test.go
@@ -20,7 +20,7 @@ import (
 	"errors"
 	"fmt"
 	"math/big"
-	"math/rand"
+	"math/rand/v2"
 	"os"
 	"path"
 	"sync"

--- a/core/bloombits/generator_test.go
+++ b/core/bloombits/generator_test.go
@@ -19,7 +19,7 @@ package bloombits
 import (
 	"bytes"
 	crand "crypto/rand"
-	"math/rand"
+	"math/rand/v2"
 	"testing"
 
 	"github.com/ethereum/go-ethereum/core/types"

--- a/core/bloombits/matcher_test.go
+++ b/core/bloombits/matcher_test.go
@@ -18,7 +18,7 @@ package bloombits
 
 import (
 	"context"
-	"math/rand"
+	"math/rand/v2"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -115,7 +115,7 @@ func makeRandomIndexes(lengths []int, max int) [][]bloomIndexes {
 		res[i] = make([]bloomIndexes, topics)
 		for j := 0; j < topics; j++ {
 			for k := 0; k < len(res[i][j]); k++ {
-				res[i][j][k] = uint(rand.Intn(max-1) + 2)
+				res[i][j][k] = uint(rand.IntN(max-1) + 2)
 			}
 		}
 	}

--- a/core/chain_indexer_test.go
+++ b/core/chain_indexer_test.go
@@ -21,7 +21,7 @@ import (
 	"errors"
 	"fmt"
 	"math/big"
-	"math/rand"
+	"math/rand/v2"
 	"testing"
 	"time"
 
@@ -56,8 +56,8 @@ func testChainIndexer(t *testing.T, count int) {
 	backends := make([]*testChainIndexBackend, count)
 	for i := 0; i < count; i++ {
 		var (
-			sectionSize = uint64(rand.Intn(100) + 1)
-			confirmsReq = uint64(rand.Intn(10))
+			sectionSize = uint64(rand.IntN(100) + 1)
+			confirmsReq = uint64(rand.IntN(10))
 		)
 		backends[i] = &testChainIndexBackend{t: t, processCh: make(chan uint64)}
 		backends[i].indexer = NewChainIndexer(db, rawdb.NewTable(db, string([]byte{byte(i)})), backends[i], sectionSize, confirmsReq, 0, fmt.Sprintf("indexer-%d", i))
@@ -92,7 +92,7 @@ func testChainIndexer(t *testing.T, count int) {
 	}
 	// inject inserts a new random canonical header into the database directly
 	inject := func(number uint64) {
-		header := &types.Header{Number: big.NewInt(int64(number)), Extra: big.NewInt(rand.Int63()).Bytes()}
+		header := &types.Header{Number: big.NewInt(int64(number)), Extra: big.NewInt(rand.Int64()).Bytes()}
 		if number > 0 {
 			header.ParentHash = rawdb.ReadCanonicalHash(db, number-1)
 		}

--- a/core/rawdb/accessors_chain_test.go
+++ b/core/rawdb/accessors_chain_test.go
@@ -21,7 +21,7 @@ import (
 	"encoding/hex"
 	"fmt"
 	"math/big"
-	"math/rand"
+	"math/rand/v2"
 	"os"
 	"reflect"
 	"testing"

--- a/core/rawdb/freezer_table_test.go
+++ b/core/rawdb/freezer_table_test.go
@@ -20,7 +20,7 @@ import (
 	"bytes"
 	"encoding/binary"
 	"fmt"
-	"math/rand"
+	"math/rand/v2"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -1205,7 +1205,7 @@ func (randTest) Generate(r *rand.Rand, size int) reflect.Value {
 				return nil
 			}
 			var ret []uint64
-			index := rand.Intn(length)
+			index := rand.IntN(length)
 			for i := index; len(ret) < n && i < length; i++ {
 				ret = append(ret, items[i])
 			}
@@ -1229,11 +1229,11 @@ func (randTest) Generate(r *rand.Rand, size int) reflect.Value {
 
 	var steps randTest
 	for i := 0; i < size; i++ {
-		step := randTestStep{op: r.Intn(opMax)}
+		step := randTestStep{op: r.IntN(opMax)}
 		switch step.op {
 		case opReload, opCheckAll:
 		case opAppend:
-			num := r.Intn(3)
+			num := r.IntN(3)
 			step.items = addItems(num)
 			if len(step.items) == 0 {
 				step.blobs = nil
@@ -1241,12 +1241,12 @@ func (randTest) Generate(r *rand.Rand, size int) reflect.Value {
 				step.blobs = getVals(step.items[0], num)
 			}
 		case opRetrieve:
-			step.items = getItems(r.Intn(3))
+			step.items = getItems(r.IntN(3))
 		case opTruncateHead:
 			if len(items) == 0 {
 				step.target = deleted
 			} else {
-				index := r.Intn(len(items))
+				index := r.IntN(len(items))
 				items = items[:index]
 				step.target = deleted + uint64(index)
 			}
@@ -1257,7 +1257,7 @@ func (randTest) Generate(r *rand.Rand, size int) reflect.Value {
 			if len(items) == 0 {
 				step.target = deleted
 			} else {
-				index := r.Intn(len(items))
+				index := r.IntN(len(items))
 				items = items[index:]
 				deleted += uint64(index)
 				step.target = deleted

--- a/core/rawdb/freezer_test.go
+++ b/core/rawdb/freezer_test.go
@@ -21,7 +21,7 @@ import (
 	"errors"
 	"fmt"
 	"math/big"
-	"math/rand"
+	"math/rand/v2"
 	"sync"
 	"testing"
 
@@ -166,7 +166,7 @@ func TestFreezerConcurrentModifyRetrieve(t *testing.T) {
 			defer wg.Done()
 			for frozen := range written {
 				for rc := 0; rc < 80; rc++ {
-					num := uint64(rand.Intn(int(frozen)))
+					num := uint64(rand.IntN(int(frozen)))
 					value, err := f.Ancient("test", num)
 					if err != nil {
 						panic(fmt.Errorf("error reading %d (frozen %d): %v", num, frozen, err))

--- a/core/state/snapshot/difflayer.go
+++ b/core/state/snapshot/difflayer.go
@@ -20,7 +20,7 @@ import (
 	"encoding/binary"
 	"fmt"
 	"math"
-	"math/rand"
+	"math/rand/v2"
 	"slices"
 	"sync"
 	"sync/atomic"
@@ -80,15 +80,15 @@ var (
 
 func init() {
 	// Init the bloom offsets in the range [0:24] (requires 8 bytes)
-	bloomDestructHasherOffset = rand.Intn(25)
-	bloomAccountHasherOffset = rand.Intn(25)
-	bloomStorageHasherOffset = rand.Intn(25)
+	bloomDestructHasherOffset = rand.IntN(25)
+	bloomAccountHasherOffset = rand.IntN(25)
+	bloomStorageHasherOffset = rand.IntN(25)
 
 	// The destruct and account blooms must be different, as the storage slots
 	// will check for destruction too for every bloom miss. It should not collide
 	// with modified accounts.
 	for bloomAccountHasherOffset == bloomDestructHasherOffset {
-		bloomAccountHasherOffset = rand.Intn(25)
+		bloomAccountHasherOffset = rand.IntN(25)
 	}
 }
 

--- a/core/state/snapshot/difflayer_test.go
+++ b/core/state/snapshot/difflayer_test.go
@@ -19,7 +19,7 @@ package snapshot
 import (
 	"bytes"
 	crand "crypto/rand"
-	"math/rand"
+	"math/rand/v2"
 	"testing"
 
 	"github.com/VictoriaMetrics/fastcache"
@@ -68,10 +68,10 @@ func TestMergeBasics(t *testing.T) {
 		data := randomAccount()
 
 		accounts[h] = data
-		if rand.Intn(4) == 0 {
+		if rand.IntN(4) == 0 {
 			destructs[h] = struct{}{}
 		}
-		if rand.Intn(2) == 0 {
+		if rand.IntN(2) == 0 {
 			accStorage := make(map[common.Hash][]byte)
 			value := make([]byte, 32)
 			crand.Read(value)

--- a/core/state/snapshot/iterator_test.go
+++ b/core/state/snapshot/iterator_test.go
@@ -21,7 +21,7 @@ import (
 	crand "crypto/rand"
 	"encoding/binary"
 	"fmt"
-	"math/rand"
+	"math/rand/v2"
 	"testing"
 
 	"github.com/VictoriaMetrics/fastcache"
@@ -42,10 +42,10 @@ func TestAccountIteratorBasics(t *testing.T) {
 		data := randomAccount()
 
 		accounts[h] = data
-		if rand.Intn(4) == 0 {
+		if rand.IntN(4) == 0 {
 			destructs[h] = struct{}{}
 		}
-		if rand.Intn(2) == 0 {
+		if rand.IntN(2) == 0 {
 			accStorage := make(map[common.Hash][]byte)
 			value := make([]byte, 32)
 			crand.Read(value)
@@ -81,7 +81,7 @@ func TestStorageIteratorBasics(t *testing.T) {
 		var nilstorage int
 		for i := 0; i < 100; i++ {
 			crand.Read(value)
-			if rand.Intn(2) == 0 {
+			if rand.IntN(2) == 0 {
 				accStorage[randomHash()] = common.CopyBytes(value)
 			} else {
 				accStorage[randomHash()] = nil // delete slot
@@ -1028,7 +1028,7 @@ func benchmarkAccountIteration(b *testing.B, iterator func(snap snapshot) Accoun
 		layers[i] = make(map[common.Hash][]byte)
 	}
 	for i := 0; i < b.N; i++ {
-		depth := rand.Intn(len(layers))
+		depth := rand.IntN(len(layers))
 		layers[depth][randomHash()] = randomAccount()
 	}
 	stack := snapshot(emptyLayer())

--- a/core/state/snapshot/snapshot_test.go
+++ b/core/state/snapshot/snapshot_test.go
@@ -20,7 +20,7 @@ import (
 	crand "crypto/rand"
 	"encoding/binary"
 	"fmt"
-	"math/rand"
+	"math/rand/v2"
 	"testing"
 	"time"
 

--- a/core/state/statedb_fuzz_test.go
+++ b/core/state/statedb_fuzz_test.go
@@ -22,7 +22,7 @@ import (
 	"errors"
 	"fmt"
 	"math"
-	"math/rand"
+	"math/rand/v2"
 	"reflect"
 	"strings"
 	"testing"
@@ -109,7 +109,7 @@ func newStateTestAction(addr common.Address, r *rand.Rand, index int) testAction
 	}
 	var nonRandom = index != -1
 	if index == -1 {
-		index = r.Intn(len(actions))
+		index = r.IntN(len(actions))
 	}
 	action := actions[index]
 	var names []string
@@ -118,9 +118,9 @@ func newStateTestAction(addr common.Address, r *rand.Rand, index int) testAction
 	}
 	for i := range action.args {
 		if nonRandom {
-			action.args[i] = rand.Int63n(10000) + 1 // set balance to non-zero
+			action.args[i] = rand.Int64N(10000) + 1 // set balance to non-zero
 		} else {
-			action.args[i] = rand.Int63n(10000)
+			action.args[i] = rand.Int64N(10000)
 		}
 		names = append(names, fmt.Sprint(action.args[i]))
 	}
@@ -135,7 +135,7 @@ func (*stateTest) Generate(r *rand.Rand, size int) reflect.Value {
 	for i := range addrs {
 		addrs[i][0] = byte(i)
 	}
-	actions := make([][]testAction, rand.Intn(5)+1)
+	actions := make([][]testAction, rand.IntN(5)+1)
 
 	for i := 0; i < len(actions); i++ {
 		actions[i] = make([]testAction, size)
@@ -146,7 +146,7 @@ func (*stateTest) Generate(r *rand.Rand, size int) reflect.Value {
 				actions[i][j] = newStateTestAction(common.HexToAddress("0xdeadbeef"), r, 0)
 				continue
 			}
-			actions[i][j] = newStateTestAction(addrs[r.Intn(len(addrs))], r, -1)
+			actions[i][j] = newStateTestAction(addrs[r.IntN(len(addrs))], r, -1)
 		}
 	}
 	chunk := int(math.Sqrt(float64(size)))
@@ -197,13 +197,13 @@ func (test *stateTest) run() bool {
 		}
 		disk      = rawdb.NewMemoryDatabase()
 		tdb       = triedb.NewDatabase(disk, &triedb.Config{PathDB: pathdb.Defaults})
-		byzantium = rand.Intn(2) == 0
+		byzantium = rand.IntN(2) == 0
 	)
 	defer disk.Close()
 	defer tdb.Close()
 
 	var snaps *snapshot.Tree
-	if rand.Intn(3) == 0 {
+	if rand.IntN(3) == 0 {
 		snaps, _ = snapshot.New(snapshot.Config{
 			CacheSize:  1,
 			Recovery:   false,

--- a/core/state/statedb_test.go
+++ b/core/state/statedb_test.go
@@ -22,7 +22,7 @@ import (
 	"fmt"
 	"maps"
 	"math"
-	"math/rand"
+	"math/rand/v2"
 	"reflect"
 	"slices"
 	"strings"
@@ -471,13 +471,13 @@ func newTestAction(addr common.Address, r *rand.Rand) testAction {
 			args: make([]int64, 2),
 		},
 	}
-	action := actions[r.Intn(len(actions))]
+	action := actions[r.IntN(len(actions))]
 	var nameargs []string
 	if !action.noAddr {
 		nameargs = append(nameargs, addr.Hex())
 	}
 	for i := range action.args {
-		action.args[i] = rand.Int63n(100)
+		action.args[i] = rand.Int64N(100)
 		nameargs = append(nameargs, fmt.Sprint(action.args[i]))
 	}
 	action.name += strings.Join(nameargs, ", ")
@@ -494,7 +494,7 @@ func (*snapshotTest) Generate(r *rand.Rand, size int) reflect.Value {
 	}
 	actions := make([]testAction, size)
 	for i := range actions {
-		addr := addrs[r.Intn(len(addrs))]
+		addr := addrs[r.IntN(len(addrs))]
 		actions[i] = newTestAction(addr, r)
 	}
 	// Generate snapshot indexes.
@@ -506,7 +506,7 @@ func (*snapshotTest) Generate(r *rand.Rand, size int) reflect.Value {
 	snaplen := len(actions) / nsnapshots
 	for i := range snapshots {
 		// Try to place the snapshots some number of actions apart from each other.
-		snapshots[i] = (i * snaplen) + r.Intn(snaplen)
+		snapshots[i] = (i * snaplen) + r.IntN(snaplen)
 	}
 	return reflect.ValueOf(&snapshotTest{addrs, actions, snapshots, nil})
 }

--- a/core/txpool/blobpool/evictheap_test.go
+++ b/core/txpool/blobpool/evictheap_test.go
@@ -18,7 +18,7 @@ package blobpool
 
 import (
 	"container/heap"
-	mrand "math/rand"
+	mrand "math/rand/v2"
 	"testing"
 
 	"github.com/ethereum/go-ethereum/common"
@@ -26,7 +26,7 @@ import (
 	"github.com/holiman/uint256"
 )
 
-var rand = mrand.New(mrand.NewSource(1))
+var rand = mrand.New(mrand.NewPCG(1, 1))
 
 // verifyHeapInternals verifies that all accounts present in the index are also
 // present in the heap and internals are consistent across various indices.
@@ -193,7 +193,15 @@ func benchmarkPriceHeapReinit(b *testing.B, datacap uint64) {
 	index := make(map[common.Address][]*blobTxMeta)
 	for i := 0; i < int(blobs); i++ {
 		var addr common.Address
-		rand.Read(addr[:])
+
+		addr.SetBytes(func() []byte {
+			ret := make([]byte, common.AddressLength)
+			randInts := rand.Perm(256)
+			for i, v := range randInts {
+				ret[i] = byte(v)
+			}
+			return ret
+		}())
 
 		var (
 			execTip = uint256.NewInt(rand.Uint64())
@@ -253,7 +261,14 @@ func benchmarkPriceHeapOverflow(b *testing.B, datacap uint64) {
 	index := make(map[common.Address][]*blobTxMeta)
 	for i := 0; i < int(blobs); i++ {
 		var addr common.Address
-		rand.Read(addr[:])
+		addr.SetBytes(func() []byte {
+			ret := make([]byte, common.AddressLength)
+			randInts := rand.Perm(256)
+			for i, v := range randInts {
+				ret[i] = byte(v)
+			}
+			return ret
+		}())
 
 		var (
 			execTip = uint256.NewInt(rand.Uint64())
@@ -284,7 +299,14 @@ func benchmarkPriceHeapOverflow(b *testing.B, datacap uint64) {
 		metas = make([]*blobTxMeta, b.N)
 	)
 	for i := 0; i < b.N; i++ {
-		rand.Read(addrs[i][:])
+		addrs[i].SetBytes(func() []byte {
+			ret := make([]byte, common.AddressLength)
+			randInts := rand.Perm(256)
+			for i, v := range randInts {
+				ret[i] = byte(v)
+			}
+			return ret
+		}())
 
 		var (
 			execTip = uint256.NewInt(rand.Uint64())

--- a/core/txpool/legacypool/legacypool_test.go
+++ b/core/txpool/legacypool/legacypool_test.go
@@ -22,7 +22,7 @@ import (
 	"errors"
 	"fmt"
 	"math/big"
-	"math/rand"
+	"math/rand/v2"
 	"os"
 	"sync"
 	"sync/atomic"
@@ -933,7 +933,7 @@ func testQueueGlobalLimiting(t *testing.T, nolocals bool) {
 
 	txs := make(types.Transactions, 0, 3*config.GlobalQueue)
 	for len(txs) < cap(txs) {
-		key := keys[rand.Intn(len(keys)-1)] // skip adding transactions with the local account
+		key := keys[rand.IntN(len(keys)-1)] // skip adding transactions with the local account
 		addr := crypto.PubkeyToAddress(key.PublicKey)
 
 		txs = append(txs, transaction(nonces[addr]+1, 100000, key))
@@ -1261,7 +1261,7 @@ func TestAllowedTxSize(t *testing.T) {
 		t.Fatalf("failed to add transaction of size %d, close to maximal: %v", int(tx.Size()), err)
 	}
 	// Try adding a transaction with random allowed size
-	if err := pool.addRemoteSync(pricedDataTransaction(1, pool.currentHead.Load().GasLimit, big.NewInt(1), key, uint64(rand.Intn(int(dataSize))))); err != nil {
+	if err := pool.addRemoteSync(pricedDataTransaction(1, pool.currentHead.Load().GasLimit, big.NewInt(1), key, uint64(rand.IntN(int(dataSize))))); err != nil {
 		t.Fatalf("failed to add transaction of random allowed size: %v", err)
 	}
 	// Try adding a transaction of minimal not allowed size
@@ -1269,7 +1269,7 @@ func TestAllowedTxSize(t *testing.T) {
 		t.Fatalf("expected rejection on slightly oversize transaction")
 	}
 	// Try adding a transaction of random not allowed size
-	if err := pool.addRemoteSync(pricedDataTransaction(2, pool.currentHead.Load().GasLimit, big.NewInt(1), key, dataSize+1+uint64(rand.Intn(10*txMaxSize)))); err == nil {
+	if err := pool.addRemoteSync(pricedDataTransaction(2, pool.currentHead.Load().GasLimit, big.NewInt(1), key, dataSize+1+uint64(rand.IntN(10*txMaxSize)))); err == nil {
 		t.Fatalf("expected rejection on oversize transaction")
 	}
 	// Run some sanity checks on the pool internals

--- a/core/txpool/legacypool/list_test.go
+++ b/core/txpool/legacypool/list_test.go
@@ -18,7 +18,7 @@ package legacypool
 
 import (
 	"math/big"
-	"math/rand"
+	"math/rand/v2"
 	"testing"
 
 	"github.com/ethereum/go-ethereum/common"

--- a/eth/catalyst/api_test.go
+++ b/eth/catalyst/api_test.go
@@ -22,7 +22,7 @@ import (
 	crand "crypto/rand"
 	"fmt"
 	"math/big"
-	"math/rand"
+	"math/rand/v2"
 	"reflect"
 	"sync"
 	"testing"

--- a/eth/downloader/queue_test.go
+++ b/eth/downloader/queue_test.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 	"log/slog"
 	"math/big"
-	"math/rand"
+	"math/rand/v2"
 	"os"
 	"sync"
 	"testing"
@@ -317,14 +317,14 @@ func XTestDelivery(t *testing.T) {
 		i := 4
 		for {
 			peer := dummyPeer(fmt.Sprintf("peer-%d", i))
-			f, _, _ := q.ReserveBodies(peer, rand.Intn(30))
+			f, _, _ := q.ReserveBodies(peer, rand.IntN(30))
 			if f != nil {
 				var (
 					emptyList []*types.Header
 					txset     [][]*types.Transaction
 					uncleset  [][]*types.Header
 				)
-				numToSkip := rand.Intn(len(f.Headers))
+				numToSkip := rand.IntN(len(f.Headers))
 				for _, hdr := range f.Headers[0 : len(f.Headers)-numToSkip] {
 					txset = append(txset, world.getTransactions(hdr.Number.Uint64()))
 					uncleset = append(uncleset, emptyList)
@@ -356,7 +356,7 @@ func XTestDelivery(t *testing.T) {
 		// reserve receiptfetch
 		peer := dummyPeer("peer-3")
 		for {
-			f, _, _ := q.ReserveReceipts(peer, rand.Intn(50))
+			f, _, _ := q.ReserveReceipts(peer, rand.IntN(50))
 			if f != nil {
 				var rcs [][]*types.Receipt
 				for _, hdr := range f.Headers {
@@ -384,7 +384,7 @@ func XTestDelivery(t *testing.T) {
 			time.Sleep(300 * time.Millisecond)
 			//world.tick()
 			//fmt.Printf("trying to progress\n")
-			world.progress(rand.Intn(100))
+			world.progress(rand.IntN(100))
 		}
 		for i := 0; i < 50; i++ {
 			time.Sleep(2990 * time.Millisecond)

--- a/eth/downloader/skeleton.go
+++ b/eth/downloader/skeleton.go
@@ -20,7 +20,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"math/rand"
+	"math/rand/v2"
 	"sort"
 	"time"
 
@@ -712,7 +712,7 @@ func (s *skeleton) assignTasks(success chan *headerResponse, fail chan *headerRe
 		// Matched a pending task to an idle peer, allocate a unique request id
 		var reqid uint64
 		for {
-			reqid = uint64(rand.Int63())
+			reqid = uint64(rand.Int64())
 			if reqid == 0 {
 				continue
 			}

--- a/eth/fetcher/tx_fetcher.go
+++ b/eth/fetcher/tx_fetcher.go
@@ -20,7 +20,7 @@ import (
 	"errors"
 	"fmt"
 	"math"
-	mrand "math/rand"
+	mrand "math/rand/v2"
 	"sort"
 	"time"
 
@@ -988,7 +988,7 @@ func (f *TxFetcher) forEachPeer(peers map[string]struct{}, do func(peer string))
 		list = append(list, peer)
 	}
 	sort.Strings(list)
-	rotateStrings(list, f.rand.Intn(len(list)))
+	rotateStrings(list, f.rand.IntN(len(list)))
 	for _, peer := range list {
 		do(peer)
 	}

--- a/eth/fetcher/tx_fetcher_test.go
+++ b/eth/fetcher/tx_fetcher_test.go
@@ -19,7 +19,7 @@ package fetcher
 import (
 	"errors"
 	"math/big"
-	"math/rand"
+	"math/rand/v2"
 	"slices"
 	"testing"
 	"time"
@@ -1292,7 +1292,7 @@ func TestTransactionFetcherUnderpricedDoSProtection(t *testing.T) {
 	// Create a slew of transactions to max out the underpriced set
 	var txs []*types.Transaction
 	for i := 0; i < maxTxUnderpricedSetSize+1; i++ {
-		txs = append(txs, types.NewTransaction(rand.Uint64(), common.Address{byte(rand.Intn(256))}, new(big.Int), 0, new(big.Int), nil))
+		txs = append(txs, types.NewTransaction(rand.Uint64(), common.Address{byte(rand.IntN(256))}, new(big.Int), 0, new(big.Int), nil))
 	}
 	var (
 		hashes []common.Hash
@@ -1842,7 +1842,7 @@ func testTransactionFetcher(t *testing.T, tt txFetcherTest) {
 	fetcher := tt.init()
 	fetcher.clock = clock
 	fetcher.step = wait
-	fetcher.rand = rand.New(rand.NewSource(0x3a29))
+	fetcher.rand = rand.New(rand.New(rand.NewPCG(uint64(0x3a29), uint64(0x3a29))))
 
 	fetcher.Start()
 	defer fetcher.Stop()

--- a/eth/filters/filter_system_test.go
+++ b/eth/filters/filter_system_test.go
@@ -20,7 +20,7 @@ import (
 	"context"
 	"errors"
 	"math/big"
-	"math/rand"
+	"math/rand/v2"
 	"reflect"
 	"runtime"
 	"testing"

--- a/eth/protocols/eth/handler_test.go
+++ b/eth/protocols/eth/handler_test.go
@@ -19,7 +19,7 @@ package eth
 import (
 	"math"
 	"math/big"
-	"math/rand"
+	"math/rand/v2"
 	"testing"
 
 	"github.com/ethereum/go-ethereum/common"
@@ -393,7 +393,7 @@ func testGetBlockBodies(t *testing.T, protocol uint) {
 		)
 		for j := 0; j < tt.random; j++ {
 			for {
-				num := rand.Int63n(int64(backend.chain.CurrentBlock().Number.Uint64()))
+				num := rand.Int64N(int64(backend.chain.CurrentBlock().Number.Uint64()))
 				if !seen[num] {
 					seen[num] = true
 

--- a/eth/protocols/eth/peer.go
+++ b/eth/protocols/eth/peer.go
@@ -18,7 +18,7 @@ package eth
 
 import (
 	"math/big"
-	"math/rand"
+	"math/rand/v2"
 	"sync"
 
 	mapset "github.com/deckarep/golang-set/v2"

--- a/eth/protocols/snap/gentrie_test.go
+++ b/eth/protocols/snap/gentrie_test.go
@@ -18,7 +18,7 @@ package snap
 
 import (
 	"bytes"
-	"math/rand"
+	"math/rand/v2"
 	"slices"
 	"testing"
 
@@ -163,12 +163,12 @@ func buildPartial(owner common.Hash, db ethdb.KeyValueReader, batch ethdb.Batch,
 func TestPartialGentree(t *testing.T) {
 	for round := 0; round < 100; round++ {
 		var (
-			n       = rand.Intn(1024) + 10
+			n       = rand.IntN(1024) + 10
 			entries []*kv
 		)
 		for i := 0; i < n; i++ {
 			var val []byte
-			if rand.Intn(3) == 0 {
+			if rand.IntN(3) == 0 {
 				val = testrand.Bytes(3)
 			} else {
 				val = testrand.Bytes(32)
@@ -223,8 +223,8 @@ func TestPartialGentree(t *testing.T) {
 				last  int
 			)
 			for {
-				first = rand.Intn(len(entries))
-				last = rand.Intn(len(entries))
+				first = rand.IntN(len(entries))
+				last = rand.IntN(len(entries))
 				if first <= last {
 					break
 				}
@@ -255,12 +255,12 @@ func TestPartialGentree(t *testing.T) {
 func TestGentreeDanglingClearing(t *testing.T) {
 	for round := 0; round < 100; round++ {
 		var (
-			n       = rand.Intn(1024) + 10
+			n       = rand.IntN(1024) + 10
 			entries []*kv
 		)
 		for i := 0; i < n; i++ {
 			var val []byte
-			if rand.Intn(3) == 0 {
+			if rand.IntN(3) == 0 {
 				val = testrand.Bytes(3)
 			} else {
 				val = testrand.Bytes(32)
@@ -332,8 +332,8 @@ func TestGentreeDanglingClearing(t *testing.T) {
 				last  int
 			)
 			for {
-				first = rand.Intn(len(entries))
-				last = rand.Intn(len(entries))
+				first = rand.IntN(len(entries))
+				last = rand.IntN(len(entries))
 				if first <= last {
 					break
 				}
@@ -365,7 +365,7 @@ func TestFlushPartialTree(t *testing.T) {
 	var entries []*kv
 	for i := 0; i < 1024; i++ {
 		var val []byte
-		if rand.Intn(3) == 0 {
+		if rand.IntN(3) == 0 {
 			val = testrand.Bytes(3)
 		} else {
 			val = testrand.Bytes(32)
@@ -410,7 +410,7 @@ func TestFlushPartialTree(t *testing.T) {
 		tr := newPathTrie(common.Hash{}, c.first != 0, db, batch)
 		for i := c.first; i <= c.last; i++ {
 			tr.update(entries[i].k, entries[i].v)
-			if rand.Intn(2) == 0 {
+			if rand.IntN(2) == 0 {
 				tr.commit(false)
 
 				batch.Replay(combined)
@@ -449,7 +449,7 @@ func TestBoundSplit(t *testing.T) {
 	var entries []*kv
 	for i := 0; i < 1024; i++ {
 		var val []byte
-		if rand.Intn(3) == 0 {
+		if rand.IntN(3) == 0 {
 			val = testrand.Bytes(3)
 		} else {
 			val = testrand.Bytes(32)
@@ -473,7 +473,7 @@ func TestBoundSplit(t *testing.T) {
 			if next == len(entries) {
 				break
 			}
-			last = rand.Intn(len(entries)-next) + next
+			last = rand.IntN(len(entries)-next) + next
 
 			r := buildPartial(common.Hash{}, db, db.NewBatch(), entries, next, last)
 			set := r.modifies()
@@ -523,7 +523,7 @@ func TestTinyPartialTree(t *testing.T) {
 	var entries []*kv
 	for i := 0; i < 1024; i++ {
 		var val []byte
-		if rand.Intn(3) == 0 {
+		if rand.IntN(3) == 0 {
 			val = testrand.Bytes(3)
 		} else {
 			val = testrand.Bytes(32)

--- a/eth/protocols/snap/sync.go
+++ b/eth/protocols/snap/sync.go
@@ -23,7 +23,7 @@ import (
 	"fmt"
 	gomath "math"
 	"math/big"
-	"math/rand"
+	"math/rand/v2"
 	"sort"
 	"sync"
 	"sync/atomic"
@@ -1046,7 +1046,7 @@ func (s *Syncer) assignAccountTasks(success chan *accountResponse, fail chan *ac
 		// Matched a pending task to an idle peer, allocate a unique request id
 		var reqid uint64
 		for {
-			reqid = uint64(rand.Int63())
+			reqid = uint64(rand.Int64())
 			if reqid == 0 {
 				continue
 			}
@@ -1147,7 +1147,7 @@ func (s *Syncer) assignBytecodeTasks(success chan *bytecodeResponse, fail chan *
 		// Matched a pending task to an idle peer, allocate a unique request id
 		var reqid uint64
 		for {
-			reqid = uint64(rand.Int63())
+			reqid = uint64(rand.Int64())
 			if reqid == 0 {
 				continue
 			}
@@ -1251,7 +1251,7 @@ func (s *Syncer) assignStorageTasks(success chan *storageResponse, fail chan *st
 		// Matched a pending task to an idle peer, allocate a unique request id
 		var reqid uint64
 		for {
-			reqid = uint64(rand.Int63())
+			reqid = uint64(rand.Int64())
 			if reqid == 0 {
 				continue
 			}
@@ -1419,7 +1419,7 @@ func (s *Syncer) assignTrienodeHealTasks(success chan *trienodeHealResponse, fai
 		// Matched a pending task to an idle peer, allocate a unique request id
 		var reqid uint64
 		for {
-			reqid = uint64(rand.Int63())
+			reqid = uint64(rand.Int64())
 			if reqid == 0 {
 				continue
 			}
@@ -1547,7 +1547,7 @@ func (s *Syncer) assignBytecodeHealTasks(success chan *bytecodeHealResponse, fai
 		// Matched a pending task to an idle peer, allocate a unique request id
 		var reqid uint64
 		for {
-			reqid = uint64(rand.Int63())
+			reqid = uint64(rand.Int64())
 			if reqid == 0 {
 				continue
 			}

--- a/eth/protocols/snap/sync_test.go
+++ b/eth/protocols/snap/sync_test.go
@@ -22,7 +22,7 @@ import (
 	"encoding/binary"
 	"fmt"
 	"math/big"
-	mrand "math/rand"
+	mrand "math/rand/v2"
 	"slices"
 	"sync"
 	"testing"
@@ -1797,7 +1797,7 @@ func makeUnevenStorageTrie(owner common.Hash, slots int, db *triedb.Database) (c
 	for i := 0; i < 3; i++ {
 		var n int
 		for {
-			n = mrand.Intn(15) // the last range is set empty deliberately
+			n = mrand.IntN(15) // the last range is set empty deliberately
 			if _, ok := chosen[byte(n)]; ok {
 				continue
 			}

--- a/ethclient/simulated/backend_test.go
+++ b/ethclient/simulated/backend_test.go
@@ -20,7 +20,7 @@ import (
 	"context"
 	"crypto/ecdsa"
 	"math/big"
-	"math/rand"
+	"math/rand/v2"
 	"testing"
 	"time"
 
@@ -161,7 +161,7 @@ func TestFork(t *testing.T) {
 	parent, _ := client.HeaderByNumber(ctx, nil)
 
 	// 2.
-	n := int(rand.Int31n(21))
+	n := int(rand.Int32N(21))
 	for i := 0; i < n; i++ {
 		sim.Commit()
 	}

--- a/event/event_test.go
+++ b/event/event_test.go
@@ -17,7 +17,7 @@
 package event
 
 import (
-	"math/rand"
+	"math/rand/v2"
 	"sync"
 	"testing"
 	"time"
@@ -113,7 +113,7 @@ func TestMuxConcurrent(t *testing.T) {
 		}
 	}
 	sub := func(i int) {
-		time.Sleep(time.Duration(rand.Intn(99)) * time.Millisecond)
+		time.Sleep(time.Duration(rand.IntN(99)) * time.Millisecond)
 		sub := mux.Subscribe(testEvent(0))
 		<-sub.Chan()
 		sub.Unsubscribe()

--- a/internal/jsre/jsre.go
+++ b/internal/jsre/jsre.go
@@ -23,7 +23,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"math/rand"
+	"math/rand/v2"
 	"os"
 	"time"
 
@@ -90,9 +90,7 @@ func randomSource() *rand.Rand {
 	if _, err := crand.Read(bytes); err == nil {
 		seed = int64(binary.LittleEndian.Uint64(bytes))
 	}
-
-	src := rand.NewSource(seed)
-	return rand.New(src)
+	return rand.New(rand.New(rand.NewPCG(uint64(seed), uint64(seed))))
 }
 
 // This function runs the main event loop from a goroutine that is started

--- a/internal/testrand/rand.go
+++ b/internal/testrand/rand.go
@@ -19,7 +19,7 @@ package testrand
 import (
 	crand "crypto/rand"
 	"encoding/binary"
-	mrand "math/rand"
+	mrand "math/rand/v2"
 
 	"github.com/ethereum/go-ethereum/common"
 )
@@ -31,14 +31,16 @@ var prng = initRand()
 func initRand() *mrand.Rand {
 	var seed [8]byte
 	crand.Read(seed[:])
-	rnd := mrand.New(mrand.NewSource(int64(binary.LittleEndian.Uint64(seed[:]))))
+	rnd := mrand.New(mrand.NewPCG(binary.LittleEndian.Uint64(seed[:]), binary.LittleEndian.Uint64(seed[:])))
 	return rnd
 }
 
 // Bytes generates a random byte slice with specified length.
 func Bytes(n int) []byte {
 	r := make([]byte, n)
-	prng.Read(r)
+	for i := range r {
+		r[i] = byte(mrand.Int())
+	}
 	return r
 }
 

--- a/log/format_test.go
+++ b/log/format_test.go
@@ -1,7 +1,7 @@
 package log
 
 import (
-	"math/rand"
+	"math/rand/v2"
 	"testing"
 )
 
@@ -11,7 +11,7 @@ func BenchmarkPrettyInt64Logfmt(b *testing.B) {
 	buf := make([]byte, 100)
 	b.ReportAllocs()
 	for i := 0; i < b.N; i++ {
-		sink = appendInt64(buf, rand.Int63())
+		sink = appendInt64(buf, rand.Int64())
 	}
 }
 

--- a/metrics/sample.go
+++ b/metrics/sample.go
@@ -2,7 +2,7 @@ package metrics
 
 import (
 	"math"
-	"math/rand"
+	"math/rand/v2"
 	"slices"
 	"sync"
 	"time"
@@ -359,9 +359,9 @@ func (s *UniformSample) Update(v int64) {
 	} else {
 		var r int64
 		if s.rand != nil {
-			r = s.rand.Int63n(s.count)
+			r = s.rand.Int64N(s.count)
 		} else {
-			r = rand.Int63n(s.count)
+			r = rand.Int64N(s.count)
 		}
 		if r < int64(len(s.values)) {
 			s.values[int(r)] = v

--- a/metrics/sample_test.go
+++ b/metrics/sample_test.go
@@ -2,7 +2,7 @@ package metrics
 
 import (
 	"math"
-	"math/rand"
+	"math/rand/v2"
 	"runtime"
 	"testing"
 	"time"
@@ -158,7 +158,7 @@ func TestExpDecaySampleRescale(t *testing.T) {
 
 func TestExpDecaySampleSnapshot(t *testing.T) {
 	now := time.Now()
-	s := NewExpDecaySample(100, 0.99).(*ExpDecaySample).SetRand(rand.New(rand.NewSource(1)))
+	s := NewExpDecaySample(100, 0.99).(*ExpDecaySample).SetRand(rand.New(rand.NewPCG(1, 1)))
 	for i := 1; i <= 10000; i++ {
 		s.(*ExpDecaySample).update(now.Add(time.Duration(i)), int64(i))
 	}
@@ -169,7 +169,7 @@ func TestExpDecaySampleSnapshot(t *testing.T) {
 
 func TestExpDecaySampleStatistics(t *testing.T) {
 	now := time.Now()
-	s := NewExpDecaySample(100, 0.99).(*ExpDecaySample).SetRand(rand.New(rand.NewSource(1)))
+	s := NewExpDecaySample(100, 0.99).(*ExpDecaySample).SetRand(rand.New(rand.NewPCG(1, 1)))
 	for i := 1; i <= 10000; i++ {
 		s.(*ExpDecaySample).update(now.Add(time.Duration(i)), int64(i))
 	}
@@ -219,7 +219,7 @@ func TestUniformSampleIncludesTail(t *testing.T) {
 }
 
 func TestUniformSampleSnapshot(t *testing.T) {
-	s := NewUniformSample(100).(*UniformSample).SetRand(rand.New(rand.NewSource(1)))
+	s := NewUniformSample(100).(*UniformSample).SetRand(rand.New(rand.NewPCG(1, 1)))
 	for i := 1; i <= 10000; i++ {
 		s.Update(int64(i))
 	}
@@ -229,7 +229,7 @@ func TestUniformSampleSnapshot(t *testing.T) {
 }
 
 func TestUniformSampleStatistics(t *testing.T) {
-	s := NewUniformSample(100).(*UniformSample).SetRand(rand.New(rand.NewSource(1)))
+	s := NewUniformSample(100).(*UniformSample).SetRand(rand.New(rand.NewPCG(1, 1)))
 	for i := 1; i <= 10000; i++ {
 		s.Update(int64(i))
 	}
@@ -327,7 +327,7 @@ func TestUniformSampleConcurrentUpdateCount(t *testing.T) {
 		for {
 			select {
 			case <-t.C:
-				s.Update(rand.Int63())
+				s.Update(rand.Int64())
 			case <-quit:
 				t.Stop()
 				return
@@ -345,7 +345,7 @@ func BenchmarkCalculatePercentiles(b *testing.B) {
 	pss := []float64{0.5, 0.75, 0.95, 0.99, 0.999, 0.9999}
 	var vals []int64
 	for i := 0; i < 1000; i++ {
-		vals = append(vals, int64(rand.Int31()))
+		vals = append(vals, int64(rand.Int32()))
 	}
 	v := make([]int64, len(vals))
 	b.ResetTimer()

--- a/miner/ordering_test.go
+++ b/miner/ordering_test.go
@@ -19,7 +19,7 @@ package miner
 import (
 	"crypto/ecdsa"
 	"math/big"
-	"math/rand"
+	"math/rand/v2"
 	"testing"
 	"time"
 
@@ -61,7 +61,7 @@ func testTransactionPriceNonceSort(t *testing.T, baseFee *big.Int) {
 		count := 25
 		for i := 0; i < 25; i++ {
 			var tx *types.Transaction
-			gasFeeCap := rand.Intn(50)
+			gasFeeCap := rand.IntN(50)
 			if baseFee == nil {
 				tx = types.NewTx(&types.LegacyTx{
 					Nonce:    uint64(start + i),
@@ -78,7 +78,7 @@ func testTransactionPriceNonceSort(t *testing.T, baseFee *big.Int) {
 					Value:     big.NewInt(100),
 					Gas:       100,
 					GasFeeCap: big.NewInt(int64(gasFeeCap)),
-					GasTipCap: big.NewInt(int64(rand.Intn(gasFeeCap + 1))),
+					GasTipCap: big.NewInt(int64(rand.IntN(gasFeeCap + 1))),
 					Data:      nil,
 				})
 				if count == 25 && int64(gasFeeCap) < baseFee.Int64() {

--- a/p2p/dial.go
+++ b/p2p/dial.go
@@ -22,7 +22,7 @@ import (
 	"encoding/binary"
 	"errors"
 	"fmt"
-	mrand "math/rand"
+	mrand "math/rand/v2"
 	"net"
 	"sync"
 	"sync/atomic"
@@ -150,8 +150,8 @@ func (cfg dialConfig) withDefaults() dialConfig {
 	if cfg.rand == nil {
 		seedb := make([]byte, 8)
 		crand.Read(seedb)
-		seed := int64(binary.BigEndian.Uint64(seedb))
-		cfg.rand = mrand.New(mrand.NewSource(seed))
+		seed := binary.BigEndian.Uint64(seedb)
+		cfg.rand = mrand.New(mrand.NewPCG(seed, seed))
 	}
 	return cfg
 }
@@ -397,7 +397,7 @@ func (d *dialScheduler) checkDial(n *enode.Node) error {
 // startStaticDials starts n static dial tasks.
 func (d *dialScheduler) startStaticDials(n int) (started int) {
 	for started = 0; started < n && len(d.staticPool) > 0; started++ {
-		idx := d.rand.Intn(len(d.staticPool))
+		idx := d.rand.IntN(len(d.staticPool))
 		task := d.staticPool[idx]
 		d.startDial(task)
 		d.removeFromStaticPool(idx)

--- a/p2p/dial_test.go
+++ b/p2p/dial_test.go
@@ -20,7 +20,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"math/rand"
+	"math/rand/v2"
 	"net"
 	"reflect"
 	"sync"
@@ -423,7 +423,7 @@ func runDialTest(t *testing.T, config dialConfig, rounds []dialTestRound) {
 	config.dialer = dialer
 	config.resolver = resolver
 	config.log = testlog.Logger(t, log.LvlTrace)
-	config.rand = rand.New(rand.NewSource(0x1111))
+	config.rand = rand.New(rand.NewPCG(0x1111, 0x1111))
 
 	// Set up the dialer. The setup function below runs on the dialTask
 	// goroutine and adds the peer.

--- a/p2p/discover/common.go
+++ b/p2p/discover/common.go
@@ -20,7 +20,7 @@ import (
 	"crypto/ecdsa"
 	crand "crypto/rand"
 	"encoding/binary"
-	"math/rand"
+	"math/rand/v2"
 	"net"
 	"net/netip"
 	"sync"
@@ -99,8 +99,8 @@ type ReadPacket struct {
 }
 
 type randomSource interface {
-	Intn(int) int
-	Int63n(int64) int64
+	IntN(int) int
+	Int64N(int64) int64
 	Shuffle(int, func(int, int))
 }
 
@@ -114,23 +114,23 @@ func (r *reseedingRandom) seed() {
 	var b [8]byte
 	crand.Read(b[:])
 	seed := binary.BigEndian.Uint64(b[:])
-	new := rand.New(rand.NewSource(int64(seed)))
+	new := rand.New(rand.NewPCG(seed, seed))
 
 	r.mu.Lock()
 	r.cur = new
 	r.mu.Unlock()
 }
 
-func (r *reseedingRandom) Intn(n int) int {
+func (r *reseedingRandom) IntN(n int) int {
 	r.mu.Lock()
 	defer r.mu.Unlock()
-	return r.cur.Intn(n)
+	return r.cur.IntN(n)
 }
 
-func (r *reseedingRandom) Int63n(n int64) int64 {
+func (r *reseedingRandom) Int64N(n int64) int64 {
 	r.mu.Lock()
 	defer r.mu.Unlock()
-	return r.cur.Int63n(n)
+	return r.cur.Int64N(n)
 }
 
 func (r *reseedingRandom) Shuffle(n int, swap func(i, j int)) {

--- a/p2p/discover/table.go
+++ b/p2p/discover/table.go
@@ -460,7 +460,7 @@ func (tab *Table) loadSeedNodes() {
 
 func (tab *Table) nextRefreshTime() time.Duration {
 	half := tab.cfg.RefreshInterval / 2
-	return half + time.Duration(tab.rand.Int63n(int64(half)))
+	return half + time.Duration(tab.rand.Int64N(int64(half)))
 }
 
 // bucket returns the bucket for the given node ID hash.
@@ -605,7 +605,7 @@ func (tab *Table) deleteInBucket(b *bucket, id enode.ID) *tableNode {
 		tab.log.Debug("Removed dead node", "b", b.index, "id", n.ID(), "ip", n.IPAddr())
 		return nil
 	}
-	rindex := tab.rand.Intn(len(b.replacements))
+	rindex := tab.rand.IntN(len(b.replacements))
 	rep := b.replacements[rindex]
 	b.replacements = slices.Delete(b.replacements, rindex, rindex+1)
 	b.entries = append(b.entries, rep)

--- a/p2p/discover/table_reval.go
+++ b/p2p/discover/table_reval.go
@@ -208,7 +208,7 @@ func (list *revalidationList) get(now mclock.AbsTime, rand randomSource, exclude
 		return nil
 	}
 	for i := 0; i < len(list.nodes)*3; i++ {
-		n := list.nodes[rand.Intn(len(list.nodes))]
+		n := list.nodes[rand.IntN(len(list.nodes))]
 		_, excluded := exclude[n.ID()]
 		if !excluded {
 			return n
@@ -218,7 +218,7 @@ func (list *revalidationList) get(now mclock.AbsTime, rand randomSource, exclude
 }
 
 func (list *revalidationList) schedule(now mclock.AbsTime, rand randomSource) {
-	list.nextTime = now.Add(time.Duration(rand.Int63n(int64(list.interval))))
+	list.nextTime = now.Add(time.Duration(rand.Int64N(int64(list.interval))))
 }
 
 func (list *revalidationList) push(n *tableNode, now mclock.AbsTime, rand randomSource) {

--- a/p2p/discover/table_test.go
+++ b/p2p/discover/table_test.go
@@ -19,7 +19,7 @@ package discover
 import (
 	"crypto/ecdsa"
 	"fmt"
-	"math/rand"
+	"math/rand/v2"
 	"net"
 	"reflect"
 	"slices"
@@ -264,7 +264,7 @@ func (*closeTest) Generate(rand *rand.Rand, size int) reflect.Value {
 	t := &closeTest{
 		Self:   gen(enode.ID{}, rand).(enode.ID),
 		Target: gen(enode.ID{}, rand).(enode.ID),
-		N:      rand.Intn(bucketSize),
+		N:      rand.IntN(bucketSize),
 	}
 	for _, id := range gen([]enode.ID{}, rand).([]enode.ID) {
 		r := new(enr.Record)
@@ -486,7 +486,7 @@ func gen(typ interface{}, rand *rand.Rand) interface{} {
 func quickcfg() *quick.Config {
 	return &quick.Config{
 		MaxCount: 5000,
-		Rand:     rand.New(rand.NewSource(time.Now().Unix())),
+		Rand:     rand.New(rand.NewPCG(uint64(time.Now().Unix()), uint64(time.Now().Unix()))),
 	}
 }
 

--- a/p2p/discover/table_util_test.go
+++ b/p2p/discover/table_util_test.go
@@ -22,7 +22,7 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
-	"math/rand"
+	"math/rand/v2"
 	"net"
 	"slices"
 	"sync"
@@ -96,7 +96,7 @@ func idAtDistance(a enode.ID, n int) (b enode.ID) {
 	}
 	b[pos] = a[pos]&^bit | ^a[pos]&bit // TODO: randomize end bits
 	for i := pos + 1; i < len(a); i++ {
-		b[i] = byte(rand.Intn(255))
+		b[i] = byte(rand.IntN(255))
 	}
 	return b
 }

--- a/p2p/discover/v4_udp_test.go
+++ b/p2p/discover/v4_udp_test.go
@@ -24,7 +24,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"math/rand"
+	"math/rand/v2"
 	"net"
 	"net/netip"
 	"reflect"
@@ -167,7 +167,7 @@ func TestUDPv4_responseTimeouts(t *testing.T) {
 	defer test.close()
 
 	randomDuration := func(max time.Duration) time.Duration {
-		return time.Duration(rand.Int63n(int64(max)))
+		return time.Duration(rand.Int64N(int64(max)))
 	}
 
 	var (
@@ -182,7 +182,7 @@ func TestUDPv4_responseTimeouts(t *testing.T) {
 		// For all other requests, a reply is scheduled to arrive
 		// within the timeout window.
 		p := &replyMatcher{
-			ptype:    byte(rand.Intn(255)),
+			ptype:    byte(rand.IntN(255)),
 			callback: func(v4wire.Packet) (bool, bool) { return true, true },
 		}
 		binary.BigEndian.PutUint64(p.from[:], uint64(i))

--- a/p2p/discover/v5_udp_test.go
+++ b/p2p/discover/v5_udp_test.go
@@ -21,7 +21,7 @@ import (
 	"crypto/ecdsa"
 	"encoding/binary"
 	"fmt"
-	"math/rand"
+	"math/rand/v2"
 	"net"
 	"net/netip"
 	"reflect"
@@ -56,7 +56,7 @@ func TestUDPv5_lookupE2E(t *testing.T) {
 		defer node.Close()
 	}
 	last := nodes[N-1]
-	target := nodes[rand.Intn(N-2)].Self()
+	target := nodes[rand.IntN(N-2)].Self()
 
 	// It is expected that all nodes can be found.
 	expectedResult := make([]*enode.Node, len(nodes))

--- a/p2p/dnsdisc/client.go
+++ b/p2p/dnsdisc/client.go
@@ -21,7 +21,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"math/rand"
+	"math/rand/v2"
 	"net"
 	"strings"
 	"sync"
@@ -312,7 +312,7 @@ func (it *randomIterator) pickTree() *clientTree {
 		switch {
 		case canSync:
 			// Pick a random tree.
-			return trees[rand.Intn(len(trees))]
+			return trees[rand.IntN(len(trees))]
 		case len(trees) > 0:
 			// No sync action can be performed on any tree right now. The only meaningful
 			// thing to do is waiting for any root record to get updated.

--- a/p2p/dnsdisc/sync.go
+++ b/p2p/dnsdisc/sync.go
@@ -18,7 +18,7 @@ package dnsdisc
 
 import (
 	"context"
-	"math/rand"
+	"math/rand/v2"
 	"time"
 
 	"github.com/ethereum/go-ethereum/common/mclock"
@@ -131,7 +131,7 @@ func (ct *clientTree) syncNextLink(ctx context.Context) error {
 }
 
 func (ct *clientTree) syncNextRandomENR(ctx context.Context) (*enode.Node, error) {
-	index := rand.Intn(len(ct.enrs.missing))
+	index := rand.IntN(len(ct.enrs.missing))
 	hash := ct.enrs.missing[index]
 	e, err := ct.enrs.resolveNext(ctx, hash)
 	if err != nil {

--- a/p2p/dnsdisc/sync_test.go
+++ b/p2p/dnsdisc/sync_test.go
@@ -17,7 +17,7 @@
 package dnsdisc
 
 import (
-	"math/rand"
+	"math/rand/v2"
 	"strconv"
 	"testing"
 )
@@ -67,7 +67,7 @@ func TestLinkCacheRandom(t *testing.T) {
 	var lc linkCache
 	var remove []string
 	for i := 0; i < 100; i++ {
-		a, b := tags[rand.Intn(len(tags))], tags[rand.Intn(len(tags))]
+		a, b := tags[rand.IntN(len(tags))], tags[rand.IntN(len(tags))]
 		lc.addLink(a, b)
 		remove = append(remove, a)
 	}

--- a/p2p/enode/localnode_test.go
+++ b/p2p/enode/localnode_test.go
@@ -17,7 +17,7 @@
 package enode
 
 import (
-	"math/rand"
+	"math/rand/v2"
 	"net"
 	"net/netip"
 	"testing"
@@ -90,7 +90,7 @@ func TestLocalNodeSeqPersist(t *testing.T) {
 // This test checks behavior of the endpoint predictor.
 func TestLocalNodeEndpoint(t *testing.T) {
 	var (
-		rng       = rand.New(rand.NewSource(4))
+		rng       = rand.New(rand.NewPCG(4, 4))
 		fallback  = &net.UDPAddr{IP: net.IP{127, 0, 0, 1}, Port: 80}
 		predicted = &net.UDPAddr{IP: net.IP{127, 0, 1, 2}, Port: 81}
 		staticIP  = net.IP{127, 0, 1, 2}

--- a/p2p/enr/enr_test.go
+++ b/p2p/enr/enr_test.go
@@ -20,7 +20,7 @@ import (
 	"bytes"
 	"encoding/binary"
 	"fmt"
-	"math/rand"
+	"math/rand/v2"
 	"testing"
 	"time"
 
@@ -29,11 +29,13 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-var rnd = rand.New(rand.NewSource(time.Now().UnixNano()))
+var rnd = rand.New(rand.NewPCG(uint64(time.Now().Unix()), uint64(time.Now().Unix())))
 
 func randomString(strlen int) string {
 	b := make([]byte, strlen)
-	rnd.Read(b)
+	for i := range b {
+		b[i] = byte(rand.Int())
+	}
 	return string(b)
 }
 

--- a/p2p/nat/natupnp.go
+++ b/p2p/nat/natupnp.go
@@ -20,7 +20,7 @@ import (
 	"errors"
 	"fmt"
 	"math"
-	"math/rand"
+	"math/rand/v2"
 	"net"
 	"strings"
 	"sync"
@@ -120,9 +120,10 @@ func (n *upnp) addAnyPortMapping(protocol string, extport, intport int, ip net.I
 
 func (n *upnp) randomPort() int {
 	if n.rand == nil {
-		n.rand = rand.New(rand.NewSource(time.Now().UnixNano()))
+		seed := uint64(time.Now().UnixNano())
+		n.rand = rand.New(rand.NewPCG(seed, seed))
 	}
-	return n.rand.Intn(math.MaxUint16-10000) + 10000
+	return n.rand.IntN(math.MaxUint16-10000) + 10000
 }
 
 func (n *upnp) internalAddress() (net.IP, error) {

--- a/p2p/netutil/addrutil.go
+++ b/p2p/netutil/addrutil.go
@@ -18,7 +18,7 @@ package netutil
 
 import (
 	"fmt"
-	"math/rand"
+	"math/rand/v2"
 	"net"
 	"net/netip"
 )
@@ -54,12 +54,14 @@ func IPToAddr(ip net.IP) netip.Addr {
 // RandomAddr creates a random IP address.
 func RandomAddr(rng *rand.Rand, ipv4 bool) netip.Addr {
 	var bytes []byte
-	if ipv4 || rng.Intn(2) == 0 {
+	if ipv4 || rng.IntN(2) == 0 {
 		bytes = make([]byte, 4)
 	} else {
 		bytes = make([]byte, 16)
 	}
-	rng.Read(bytes)
+	for i := range bytes {
+		bytes[i] = byte(rand.Int())
+	}
 	addr, ok := netip.AddrFromSlice(bytes)
 	if !ok {
 		panic(fmt.Errorf("BUG! invalid IP %v", bytes))

--- a/p2p/netutil/net_test.go
+++ b/p2p/netutil/net_test.go
@@ -18,7 +18,7 @@ package netutil
 
 import (
 	"fmt"
-	"math/rand"
+	"math/rand/v2"
 	"net"
 	"net/netip"
 	"reflect"
@@ -264,7 +264,7 @@ func TestDistinctNetSet(t *testing.T) {
 func TestDistinctNetSetAddRemove(t *testing.T) {
 	cfg := &quick.Config{
 		Values: func(s []reflect.Value, rng *rand.Rand) {
-			slice := make([]netip.Addr, rng.Intn(20)+1)
+			slice := make([]netip.Addr, rng.IntN(20)+1)
 			for i := range slice {
 				slice[i] = RandomAddr(rng, false)
 			}

--- a/p2p/peer_test.go
+++ b/p2p/peer_test.go
@@ -20,7 +20,7 @@ import (
 	"encoding/binary"
 	"errors"
 	"fmt"
-	"math/rand"
+	"math/rand/v2"
 	"net"
 	"reflect"
 	"strconv"
@@ -201,7 +201,7 @@ func TestPeerDisconnect(t *testing.T) {
 // This test is supposed to verify that Peer can reliably handle
 // multiple causes of disconnection occurring at the same time.
 func TestPeerDisconnectRace(t *testing.T) {
-	maybe := func() bool { return rand.Intn(2) == 1 }
+	maybe := func() bool { return rand.IntN(2) == 1 }
 
 	for i := 0; i < 1000; i++ {
 		protoclose := make(chan error)

--- a/p2p/rlpx/rlpx.go
+++ b/p2p/rlpx/rlpx.go
@@ -29,7 +29,7 @@ import (
 	"fmt"
 	"hash"
 	"io"
-	mrand "math/rand"
+	mrand "math/rand/v2"
 	"net"
 	"time"
 
@@ -635,7 +635,7 @@ func (h *handshakeState) sealEIP8(msg interface{}) ([]byte, error) {
 	}
 	// Pad with random amount of data. the amount needs to be at least 100 bytes to make
 	// the message distinguishable from pre-EIP-8 handshakes.
-	h.wbuf.appendZero(mrand.Intn(100) + 100)
+	h.wbuf.appendZero(mrand.IntN(100) + 100)
 
 	prefix := make([]byte, 2)
 	binary.BigEndian.PutUint16(prefix, uint16(len(h.wbuf.data)+eciesOverhead))

--- a/p2p/rlpx/rlpx_test.go
+++ b/p2p/rlpx/rlpx_test.go
@@ -22,7 +22,7 @@ import (
 	"encoding/hex"
 	"fmt"
 	"io"
-	"math/rand"
+	"math/rand/v2"
 	"net"
 	"reflect"
 	"strings"
@@ -392,9 +392,11 @@ func BenchmarkThroughput(b *testing.B) {
 		conn1, conn2  = NewConn(pipe1, nil), NewConn(pipe2, &keyA.PublicKey)
 		handshakeDone = make(chan error, 1)
 		msgdata       = make([]byte, 1024)
-		rand          = rand.New(rand.NewSource(1337))
+		rand          = rand.New(rand.NewPCG(1337, 1337))
 	)
-	rand.Read(msgdata)
+	for i := range msgdata {
+		msgdata[i] = byte(rand.Int())
+	}
 
 	// Server side.
 	go func() {

--- a/p2p/server_test.go
+++ b/p2p/server_test.go
@@ -21,7 +21,7 @@ import (
 	"crypto/sha256"
 	"errors"
 	"io"
-	"math/rand"
+	"math/rand/v2"
 	"net"
 	"reflect"
 	"strconv"
@@ -508,7 +508,7 @@ func newkey() *ecdsa.PrivateKey {
 
 func randomID() (id enode.ID) {
 	for i := range id {
-		id[i] = byte(rand.Intn(255))
+		id[i] = byte(rand.IntN(255))
 	}
 	return id
 }

--- a/rpc/client_test.go
+++ b/rpc/client_test.go
@@ -21,7 +21,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"math/rand"
+	"math/rand/v2"
 	"net"
 	"net/http"
 	"net/http/httptest"
@@ -357,7 +357,7 @@ func testClientCancel(transport string, t *testing.T) {
 			var (
 				ctx     context.Context
 				cancel  func()
-				timeout = time.Duration(rand.Int63n(int64(maxContextCancelTimeout)))
+				timeout = time.Duration(rand.Int64N(int64(maxContextCancelTimeout)))
 			)
 			if index < ncallers/2 {
 				// For half of the callers, create a context without deadline
@@ -899,7 +899,7 @@ func httpTestClient(srv *Server, transport string, fl *flakeyListener) (*Client,
 
 func ipcTestClient(srv *Server, fl *flakeyListener) (*Client, net.Listener) {
 	// Listen on a random endpoint.
-	endpoint := fmt.Sprintf("go-ethereum-test-ipc-%d-%d", os.Getpid(), rand.Int63())
+	endpoint := fmt.Sprintf("go-ethereum-test-ipc-%d-%d", os.Getpid(), rand.Int64())
 	if runtime.GOOS == "windows" {
 		endpoint = `\\.\pipe\` + endpoint
 	} else {
@@ -931,12 +931,12 @@ type flakeyListener struct {
 }
 
 func (l *flakeyListener) Accept() (net.Conn, error) {
-	delay := time.Duration(rand.Int63n(int64(l.maxAcceptDelay)))
+	delay := time.Duration(rand.Int64N(int64(l.maxAcceptDelay)))
 	time.Sleep(delay)
 
 	c, err := l.Listener.Accept()
 	if err == nil {
-		timeout := time.Duration(rand.Int63n(int64(l.maxKillTimeout)))
+		timeout := time.Duration(rand.Int64N(int64(l.maxKillTimeout)))
 		time.AfterFunc(timeout, func() {
 			log.Debug(fmt.Sprintf("killing conn %v after %v", c.LocalAddr(), timeout))
 			c.Close()

--- a/tests/block_test.go
+++ b/tests/block_test.go
@@ -17,7 +17,7 @@
 package tests
 
 import (
-	"math/rand"
+	"math/rand/v2"
 	"testing"
 
 	"github.com/ethereum/go-ethereum/common"

--- a/tests/fuzzers/txfetcher/txfetcher_fuzzer.go
+++ b/tests/fuzzers/txfetcher/txfetcher_fuzzer.go
@@ -20,7 +20,7 @@ import (
 	"bytes"
 	"fmt"
 	"math/big"
-	"math/rand"
+	"math/rand/v2"
 	"time"
 
 	"github.com/ethereum/go-ethereum/common"
@@ -36,7 +36,7 @@ var (
 
 func init() {
 	// Random is nice, but we need it deterministic
-	rand := rand.New(rand.NewSource(0x3a29))
+	rand := rand.New(rand.NewPCG(0x3a29, 0x3a29))
 
 	peers = make([]string, 10)
 	for i := 0; i < len(peers); i++ {
@@ -44,7 +44,7 @@ func init() {
 	}
 	txs = make([]*types.Transaction, 65536) // We need to bump enough to hit all the limits
 	for i := 0; i < len(txs); i++ {
-		txs[i] = types.NewTransaction(rand.Uint64(), common.Address{byte(rand.Intn(256))}, new(big.Int), 0, new(big.Int), nil)
+		txs[i] = types.NewTransaction(rand.Uint64(), common.Address{byte(rand.IntN(256))}, new(big.Int), 0, new(big.Int), nil)
 	}
 }
 
@@ -75,7 +75,7 @@ func fuzz(input []byte) int {
 	}
 	// Create a fetcher and hook into it's simulated fields
 	clock := new(mclock.Simulated)
-	rand := rand.New(rand.NewSource(0x3a29)) // Same used in package tests!!!
+	rand := rand.New(rand.NewPCG(0x3a29, 0x3a29)) // Same used in package tests!!!
 
 	f := fetcher.NewTxFetcherForTests(
 		func(common.Hash) bool { return false },

--- a/tests/state_test.go
+++ b/tests/state_test.go
@@ -21,7 +21,7 @@ import (
 	"bytes"
 	"fmt"
 	"math/big"
-	"math/rand"
+	"math/rand/v2"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -111,7 +111,7 @@ func execStateTest(t *testing.T, st *testMatcher, test *StateTest) {
 		// one.
 		executionMask := 0xf
 		if testing.Short() {
-			executionMask = (1 << (rand.Int63() & 4))
+			executionMask = (1 << (rand.Int64() & 4))
 		}
 		t.Run(key+"/hash/trie", func(t *testing.T) {
 			if executionMask&0x1 == 0 {

--- a/trie/encoding_test.go
+++ b/trie/encoding_test.go
@@ -20,7 +20,7 @@ import (
 	"bytes"
 	crand "crypto/rand"
 	"encoding/hex"
-	"math/rand"
+	"math/rand/v2"
 	"testing"
 )
 
@@ -95,7 +95,7 @@ func TestHexToCompactInPlace(t *testing.T) {
 
 func TestHexToCompactInPlaceRandom(t *testing.T) {
 	for i := 0; i < 10000; i++ {
-		l := rand.Intn(128)
+		l := rand.IntN(128)
 		key := make([]byte, l)
 		crand.Read(key)
 		hexBytes := keybytesToHex(key)

--- a/trie/iterator_test.go
+++ b/trie/iterator_test.go
@@ -19,7 +19,7 @@ package trie
 import (
 	"bytes"
 	"fmt"
-	"math/rand"
+	"math/rand/v2"
 	"testing"
 
 	"github.com/ethereum/go-ethereum/common"
@@ -413,14 +413,14 @@ func testIteratorContinueAfterError(t *testing.T, memonly bool, scheme string) {
 		)
 		for {
 			if memonly {
-				rpath = paths[rand.Intn(len(paths))]
+				rpath = paths[rand.IntN(len(paths))]
 				n := nodes.Nodes[string(rpath)]
 				if n == nil {
 					continue
 				}
 				rhash = n.Hash
 			} else {
-				index := rand.Intn(len(paths))
+				index := rand.IntN(len(paths))
 				rpath = paths[index]
 				rhash = hashes[index]
 			}

--- a/trie/sync_test.go
+++ b/trie/sync_test.go
@@ -20,7 +20,7 @@ import (
 	"bytes"
 	"fmt"
 	"maps"
-	"math/rand"
+	"math/rand/v2"
 	"testing"
 
 	"github.com/ethereum/go-ethereum/common"
@@ -589,7 +589,7 @@ func testIncompleteSync(t *testing.T, scheme string) {
 	}
 	// Sanity check that removing any node from the database is detected
 	for i, path := range addedKeys {
-		if rand.Int31n(100) > 5 {
+		if rand.Int32N(100) > 5 {
 			// Only check 5 percent of added keys as a sanity check
 			continue
 		}

--- a/triedb/pathdb/database_test.go
+++ b/triedb/pathdb/database_test.go
@@ -20,7 +20,7 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
-	"math/rand"
+	"math/rand/v2"
 	"testing"
 
 	"github.com/ethereum/go-ethereum/common"
@@ -58,7 +58,7 @@ func updateTrie(db *Database, stateRoot common.Hash, addrHash common.Hash, root 
 
 func generateAccount(storageRoot common.Hash) types.StateAccount {
 	return types.StateAccount{
-		Nonce:    uint64(rand.Intn(100)),
+		Nonce:    uint64(rand.IntN(100)),
 		Balance:  uint256.NewInt(rand.Uint64()),
 		CodeHash: testrand.Bytes(32),
 		Root:     storageRoot,
@@ -223,7 +223,7 @@ func (t *tester) generate(parent common.Hash) (common.Hash, *trienode.MergedNode
 		dirties = make(map[common.Hash]struct{})
 	)
 	for i := 0; i < 20; i++ {
-		switch rand.Intn(opLen) {
+		switch rand.IntN(opLen) {
 		case createAccountOp:
 			// account creation
 			addr := testrand.Address()


### PR DESCRIPTION
To ease the potential error and confusion among math/rand and crypto/rand. math/rand/v2 has been introduced from 1.22. This can avoid critical errors wehn calling rand.Read() in the security-sensitive places. Other improvement can refer the golang doc