### PR TITLE
core/vm: remove panic when address is not present

### DIFF
--- a/core/vm/operations_acl.go
+++ b/core/vm/operations_acl.go
@@ -39,16 +39,10 @@ func makeGasSStoreFunc(clearingRefund uint64) gasFunc {
 			cost    = uint64(0)
 		)
 		// Check slot presence in the access list
-		if addrPresent, slotPresent := evm.StateDB.SlotInAccessList(contract.Address(), slot); !slotPresent {
+		if _, slotPresent := evm.StateDB.SlotInAccessList(contract.Address(), slot); !slotPresent {
 			cost = params.ColdSloadCostEIP2929
 			// If the caller cannot afford the cost, this change will be rolled back
 			evm.StateDB.AddSlotToAccessList(contract.Address(), slot)
-			if !addrPresent {
-				// Once we're done with YOLOv2 and schedule this for mainnet, might
-				// be good to remove this panic here, which is just really a
-				// canary to have during testing
-				panic("impossible case: address was not present in access list during sstore op")
-			}
 		}
 		value := common.Hash(y.Bytes32())
 


### PR DESCRIPTION
Remove redundant address presence check in `makeGasSStoreFunc`.

This PR simplifies the `makeGasSStoreFunc` function by removing the redundant check for address presence in the access list. The updated code now only checks for slot presence, streamlining the logic and eliminating unnecessary panic conditions.

This change removes the unnecessary address presence check, simplifying the code and improving maintainability without affecting functionality. The previous panic condition was intended as a canary during the testing phases (i.e. _YOLOv2_) and is no longer needed.