### PR TITLE
beacon/engine/types: remove PayloadV4

### DIFF
--- a/beacon/engine/types.go
+++ b/beacon/engine/types.go
@@ -36,7 +36,6 @@ var (
 	PayloadV1 PayloadVersion = 0x1
 	PayloadV2 PayloadVersion = 0x2
 	PayloadV3 PayloadVersion = 0x3
-	PayloadV4 PayloadVersion = 0x4
 )
 
 //go:generate go run github.com/fjl/gencodec -type PayloadAttributes -field-override payloadAttributesMarshaling -out gen_blockparams.go

--- a/eth/catalyst/api.go
+++ b/eth/catalyst/api.go
@@ -449,7 +449,7 @@ func (api *ConsensusAPI) GetPayloadV3(payloadID engine.PayloadID) (*engine.Execu
 
 // GetPayloadV4 returns a cached payload by id.
 func (api *ConsensusAPI) GetPayloadV4(payloadID engine.PayloadID) (*engine.ExecutionPayloadEnvelope, error) {
-	if !payloadID.Is(engine.PayloadV4) {
+	if !payloadID.Is(engine.PayloadV3) {
 		return nil, engine.UnsupportedFork
 	}
 	return api.getPayload(payloadID, false)


### PR DESCRIPTION
h/t @MariusVanDerWijden for finding and fixing this on devnet 3.

I made the mistake of thinking `PayloadVersion` was correlated with the `GetPayloadVX` method, but it actually tracks which version of `PayloadAttributes` were passed to `forkchoiceUpdated`. So far, Prague does not necessitate a new version of fcu, so there is no need for `PayloadV4`. 