### PR TITLE
core, trie: prealloc capacity for maps

### DIFF
--- a/core/stateless/witness.go
+++ b/core/stateless/witness.go
@@ -101,9 +101,7 @@ func (w *Witness) AddState(nodes map[string]struct{}) {
 	w.lock.Lock()
 	defer w.lock.Unlock()
 
-	for node := range nodes {
-		w.State[node] = struct{}{}
-	}
+	maps.Copy(w.State, nodes)
 }
 
 // Copy deep-copies the witness object.  Witness.Block isn't deep-copied as it

--- a/core/txpool/blobpool/blobpool.go
+++ b/core/txpool/blobpool/blobpool.go
@@ -566,7 +566,7 @@ func (p *BlobPool) recheck(addr common.Address, inclusions map[common.Hash]uint6
 			ids    []uint64
 			nonces []uint64
 		)
-		for txs[0].nonce < next {
+		for ; len(txs) > 0 && txs[0].nonce < next; txs = txs[1:] {
 			ids = append(ids, txs[0].id)
 			nonces = append(nonces, txs[0].nonce)
 
@@ -578,7 +578,6 @@ func (p *BlobPool) recheck(addr common.Address, inclusions map[common.Hash]uint6
 			if inclusions != nil {
 				p.offload(addr, txs[0].nonce, txs[0].id, inclusions)
 			}
-			txs = txs[1:]
 		}
 		log.Trace("Dropping overlapped blob transactions", "from", addr, "overlapped", nonces, "ids", ids, "left", len(txs))
 		dropOverlappedMeter.Mark(int64(len(ids)))

--- a/core/txpool/blobpool/blobpool.go
+++ b/core/txpool/blobpool/blobpool.go
@@ -939,7 +939,7 @@ func (p *BlobPool) reorg(oldHead, newHead *types.Header) (map[common.Address][]*
 	}
 	// Generate the set of transactions per address to pull back into the pool,
 	// also updating the rest along the way
-	reinject := make(map[common.Address][]*types.Transaction)
+	reinject := make(map[common.Address][]*types.Transaction, len(transactors))
 	for addr := range transactors {
 		// Generate the set that was lost to reinject into the pool
 		lost := make([]*types.Transaction, 0, len(discarded[addr]))
@@ -948,7 +948,9 @@ func (p *BlobPool) reorg(oldHead, newHead *types.Header) (map[common.Address][]*
 				lost = append(lost, tx)
 			}
 		}
-		reinject[addr] = lost
+		if len(lost) > 0 {
+			reinject[addr] = lost
+		}
 
 		// Update the set that was already reincluded to track the blocks in limbo
 		for _, tx := range types.TxDifference(included[addr], discarded[addr]) {

--- a/core/types/transaction.go
+++ b/core/types/transaction.go
@@ -560,7 +560,7 @@ func (s Transactions) EncodeIndex(i int, w *bytes.Buffer) {
 func TxDifference(a, b Transactions) Transactions {
 	keep := make(Transactions, 0, len(a))
 
-	remove := make(map[common.Hash]struct{})
+	remove := make(map[common.Hash]struct{}, b.Len())
 	for _, tx := range b {
 		remove[tx.Hash()] = struct{}{}
 	}

--- a/trie/trie.go
+++ b/trie/trie.go
@@ -666,7 +666,7 @@ func (t *Trie) Witness() map[string]struct{} {
 	if len(t.tracer.accessList) == 0 {
 		return nil
 	}
-	witness := make(map[string]struct{})
+	witness := make(map[string]struct{}, len(t.tracer.accessList))
 	for _, node := range t.tracer.accessList {
 		witness[string(node)] = struct{}{}
 	}


### PR DESCRIPTION
- preallocate capacity for map
- avoid `reinject` adding empty value
- use `maps.Copy`