### PR TITLE
cmd/evm:  benchmarking via `statetest` command + filter by name, index and fork

### DIFF
--- a/cmd/evm/runner.go
+++ b/cmd/evm/runner.go
@@ -96,7 +96,6 @@ func timedExec(bench bool, execFunc func() ([]byte, uint64, error)) (output []by
 		stats.BytesAllocated = result.AllocedBytesPerOp()
 		stats.GasUsed = gasUsed
 	} else {
-		g
 		var memStatsBefore, memStatsAfter goruntime.MemStats
 		goruntime.ReadMemStats(&memStatsBefore)
 		startTime := time.Now()

--- a/cmd/evm/runner.go
+++ b/cmd/evm/runner.go
@@ -74,14 +74,14 @@ func readGenesis(genesisPath string) *core.Genesis {
 	return genesis
 }
 
-type ExecStats struct {
+type execStats struct {
 	Time           time.Duration `json:"time"`           // The execution Time.
 	Allocs         int64         `json:"allocs"`         // The number of heap allocations during execution.
 	BytesAllocated int64         `json:"bytesAllocated"` // The cumulative number of bytes allocated during execution.
 	GasUsed        uint64        `json:"gasUsed"`        // the amount of gas used during execution
 }
 
-func timedExec(bench bool, execFunc func() ([]byte, uint64, error)) (output []byte, stats ExecStats, err error) {
+func timedExec(bench bool, execFunc func() ([]byte, uint64, error)) (output []byte, stats execStats, err error) {
 	var gasUsed uint64
 	if bench {
 		result := testing.Benchmark(func(b *testing.B) {

--- a/cmd/evm/staterunner.go
+++ b/cmd/evm/staterunner.go
@@ -118,8 +118,7 @@ type stateTestCase struct {
 
 // collectMatchedSubtests returns test cases which match against provided filtering CLI parameters
 func collectMatchedSubtests(ctx *cli.Context, testsByName map[string]tests.StateTest) []stateTestCase {
-	res := []stateTestCase{}
-
+	var res []stateTestCase
 	subtestName := ctx.String(TestNameFlag.Name)
 	if subtestName != "" {
 		if subtest, ok := testsByName[subtestName]; ok {

--- a/cmd/evm/staterunner.go
+++ b/cmd/evm/staterunner.go
@@ -20,6 +20,8 @@ import (
 	"bufio"
 	"encoding/json"
 	"fmt"
+	"os"
+
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/rawdb"
 	"github.com/ethereum/go-ethereum/core/state"
@@ -28,7 +30,6 @@ import (
 	"github.com/ethereum/go-ethereum/internal/flags"
 	"github.com/ethereum/go-ethereum/tests"
 	"github.com/urfave/cli/v2"
-	"os"
 )
 
 var (

--- a/cmd/evm/staterunner.go
+++ b/cmd/evm/staterunner.go
@@ -187,12 +187,5 @@ func runStateTest(ctx *cli.Context, fname string, cfg vm.Config, dump bool, benc
 	}
 	out, _ := json.MarshalIndent(results, "", "  ")
 	fmt.Println(string(out))
-
-	if !bench {
-		return nil
-	} else if len(matchingTests) != 1 {
-		return fmt.Errorf("can only benchmark single state test case (more than one matching params)")
-	}
-
 	return nil
 }

--- a/cmd/evm/staterunner.go
+++ b/cmd/evm/staterunner.go
@@ -24,13 +24,12 @@ import (
 	"testing"
 	"time"
 
-	"github.com/ethereum/go-ethereum/internal/flags"
-
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/rawdb"
 	"github.com/ethereum/go-ethereum/core/state"
 	"github.com/ethereum/go-ethereum/core/vm"
 	"github.com/ethereum/go-ethereum/eth/tracers/logger"
+	"github.com/ethereum/go-ethereum/internal/flags"
 	"github.com/ethereum/go-ethereum/tests"
 	"github.com/urfave/cli/v2"
 )

--- a/cmd/evm/staterunner.go
+++ b/cmd/evm/staterunner.go
@@ -183,11 +183,14 @@ func runStateTest(ctx *cli.Context, fname string, cfg vm.Config, dump bool, benc
 
 	if !bench {
 		return nil
+	} else if len(matchingTests) != 1 {
+		return fmt.Errorf("can only benchmark single state test case (more than one matching params)")
 	}
+	var gasUsed uint64
 	result := testing.Benchmark(func(b *testing.B) {
 		for i := 0; i < b.N; i++ {
 			for _, test := range matchingTests {
-				test.test.Run(test.st, cfg, false, rawdb.HashScheme, func(err error, tstate *tests.StateTestState) {})
+				_, _, gasUsed, _ = test.test.RunNoVerify(test.st, cfg, false, rawdb.HashScheme)
 			}
 		}
 	})
@@ -201,6 +204,6 @@ func runStateTest(ctx *cli.Context, fname string, cfg vm.Config, dump bool, benc
 execution time:  %v
 allocations:     %d
 allocated bytes: %d
-`, 0, stats.time, stats.allocs, stats.bytesAllocated)
+`, gasUsed, stats.time, stats.allocs, stats.bytesAllocated)
 	return nil
 }

--- a/cmd/evm/staterunner.go
+++ b/cmd/evm/staterunner.go
@@ -71,7 +71,7 @@ type StatetestResult struct {
 	Fork       string       `json:"fork"`
 	Error      string       `json:"error,omitempty"`
 	State      *state.Dump  `json:"state,omitempty"`
-	BenchStats *ExecStats   `json:"benchStats,omitempty"`
+	BenchStats *execStats   `json:"benchStats,omitempty"`
 }
 
 func stateTestCmd(ctx *cli.Context) error {

--- a/cmd/evm/staterunner.go
+++ b/cmd/evm/staterunner.go
@@ -35,18 +35,18 @@ import (
 )
 
 var (
-	ForkFlag = &cli.StringFlag{
+	forkFlag = &cli.StringFlag{
 		Name:     "statetest.fork",
 		Usage:    "The hard-fork to run the test against",
 		Category: flags.VMCategory,
 	}
-	IdxFlag = &cli.IntFlag{
+	idxFlag = &cli.IntFlag{
 		Name:     "statetest.index",
 		Usage:    "The index of the subtest to run",
 		Category: flags.VMCategory,
 		Value:    -1, // default to select all subtest indices
 	}
-	TestNameFlag = &cli.StringFlag{
+	testNameFlag = &cli.StringFlag{
 		Name:     "statetest.name",
 		Usage:    "The name of the state test to run",
 		Category: flags.VMCategory,
@@ -58,9 +58,9 @@ var stateTestCommand = &cli.Command{
 	Usage:     "Executes the given state tests. Filenames can be fed via standard input (batch mode) or as an argument (one-off execution).",
 	ArgsUsage: "<file>",
 	Flags: []cli.Flag{
-		ForkFlag,
-		IdxFlag,
-		TestNameFlag,
+		forkFlag,
+		idxFlag,
+		testNameFlag,
 	},
 }
 
@@ -118,15 +118,15 @@ type stateTestCase struct {
 // collectMatchedSubtests returns test cases which match against provided filtering CLI parameters
 func collectMatchedSubtests(ctx *cli.Context, testsByName map[string]tests.StateTest) []stateTestCase {
 	var res []stateTestCase
-	subtestName := ctx.String(TestNameFlag.Name)
+	subtestName := ctx.String(testNameFlag.Name)
 	if subtestName != "" {
 		if subtest, ok := testsByName[subtestName]; ok {
 			testsByName := make(map[string]tests.StateTest)
 			testsByName[subtestName] = subtest
 		}
 	}
-	idx := ctx.Int(IdxFlag.Name)
-	fork := ctx.String(ForkFlag.Name)
+	idx := ctx.Int(idxFlag.Name)
+	fork := ctx.String(forkFlag.Name)
 
 	for key, test := range testsByName {
 		for _, st := range test.Subtests() {

--- a/cmd/evm/staterunner.go
+++ b/cmd/evm/staterunner.go
@@ -20,10 +20,11 @@ import (
 	"bufio"
 	"encoding/json"
 	"fmt"
-	"github.com/ethereum/go-ethereum/internal/flags"
 	"os"
 	"testing"
 	"time"
+
+	"github.com/ethereum/go-ethereum/internal/flags"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/rawdb"
@@ -36,19 +37,19 @@ import (
 
 var (
 	ForkFlag = &cli.StringFlag{
-		Name:     "subtest.fork",
+		Name:     "statetest.fork",
 		Usage:    "The hard-fork to run the test against",
 		Category: flags.VMCategory,
 	}
 	IdxFlag = &cli.IntFlag{
-		Name:     "subtest.index",
+		Name:     "statetest.index",
 		Usage:    "The index of the subtest to run",
 		Category: flags.VMCategory,
 		Value:    -1, // default to select all subtest indices
 	}
 	TestNameFlag = &cli.StringFlag{
-		Name:     "subtest.name",
-		Usage:    "The hard-fork to run the test against",
+		Name:     "statetest.name",
+		Usage:    "The name of the state test to run",
 		Category: flags.VMCategory,
 	}
 )
@@ -157,7 +158,7 @@ func runStateTest(ctx *cli.Context, fname string, cfg vm.Config, dump bool, benc
 	matchingTests := collectMatchedSubtests(ctx, testsByName)
 
 	// Iterate over all the tests, run them and aggregate the results
-	results := make([]StatetestResult, 0, len(testsByName))
+	var results []StatetestResult
 	for _, test := range matchingTests {
 		// Run the test and aggregate the result
 		result := &StatetestResult{Name: test.name, Fork: test.st.Fork, Pass: true}


### PR DESCRIPTION
When `evm statetest --bench` is specified, benchmark the execution similarly to `evm run`.  It will explicitly error if there is more than one matched subtest to be executed (new `statetest` flags are added to filter which tests are ran).

Breaks the state test runner API.  But I figure that we are the only consumers of this API, so it's not a big problem?