### PR TITLE
core/txpool/blobpool: simplify the drop txs logic in blobpool module.

### DIFF
--- a/core/txpool/blobpool/blobpool.go
+++ b/core/txpool/blobpool/blobpool.go
@@ -1035,7 +1035,7 @@ func (p *BlobPool) SetGasTip(tip *big.Int) {
 						nonces  = make([]uint64, len(dropTxs))
 					)
 					for j, tx := range dropTxs {
-						p.spent[addr] = new(uint256.Int).Sub(p.spent[addr], txs[i].costCap)
+						p.spent[addr] = new(uint256.Int).Sub(p.spent[addr], tx.costCap)
 						p.stored -= uint64(tx.size)
 						delete(p.lookup, tx.hash)
 						ids[j], nonces[j] = tx.id, tx.nonce

--- a/core/txpool/blobpool/blobpool.go
+++ b/core/txpool/blobpool/blobpool.go
@@ -1028,7 +1028,7 @@ func (p *BlobPool) SetGasTip(tip *big.Int) {
 		for addr, txs := range p.index {
 			for i, tx := range txs {
 				if tx.execTipCap.Cmp(p.gasTip) < 0 {
-					// Drop the offending transaction
+					// Drop the offending transaction and everything afterwards, no gaps allowed
 					var (
 						dropTxs = txs[i:]
 						ids     = make([]uint64, len(dropTxs))

--- a/core/txpool/blobpool/blobpool.go
+++ b/core/txpool/blobpool/blobpool.go
@@ -1039,6 +1039,7 @@ func (p *BlobPool) SetGasTip(tip *big.Int) {
 						p.stored -= uint64(tx.size)
 						delete(p.lookup, tx.hash)
 						ids[j], nonces[j] = tx.id, tx.nonce
+						txs[i+j] = nil
 					}
 					// Clear out the dropped transactions from the index
 					if i > 0 {


### PR DESCRIPTION
- Prealloc capacity for `ids` and `nonces`.
- Simplify the logic of dropping offend transactions.