### PR TITLE
.github: add release maintainers to params/ CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -20,5 +20,6 @@ les/                            @zsfelfoldi @rjl493456442
 light/                          @zsfelfoldi @rjl493456442
 node/                           @fjl
 p2p/                            @fjl @zsfelfoldi
+params/                         @fjl @holiman @karalabe @gballet @rjl493456442 @zsfelfoldi
 rpc/                            @fjl @holiman
 signer/                         @holiman


### PR DESCRIPTION
In order to make the release process smoother, grant merge access to the `params/` directory to all team members who volunteered to do releases.