### PR TITLE
genesis: fix dev mode alloc

### DIFF
--- a/core/genesis.go
+++ b/core/genesis.go
@@ -180,6 +180,7 @@ func flushAlloc(ga *types.GenesisAlloc, triedb *triedb.Database) (common.Hash, e
 func getGenesisState(db ethdb.Database, blockhash common.Hash) (alloc types.GenesisAlloc, err error) {
 	blob := rawdb.ReadGenesisStateSpec(db, blockhash)
 	if len(blob) != 0 {
+		fmt.Printf("genesis json: %s\n", blob)
 		if err := alloc.UnmarshalJSON(blob); err != nil {
 			return nil, err
 		}
@@ -591,7 +592,7 @@ func DeveloperGenesisBlock(gasLimit uint64, faucet *common.Address) *Genesis {
 			// Pre-deploy EIP-4788 system contract
 			params.BeaconRootsAddress: {Nonce: 1, Code: params.BeaconRootsCode, Balance: common.Big0},
 			// Pre-deploy EIP-2935 history contract.
-			params.HistoryStorageAddress: {Nonce: 1, Code: params.HistoryStorageCode},
+			params.HistoryStorageAddress: {Nonce: 1, Code: params.HistoryStorageCode, Balance: common.Big0},
 		},
 	}
 	if faucet != nil {

--- a/core/genesis.go
+++ b/core/genesis.go
@@ -180,7 +180,6 @@ func flushAlloc(ga *types.GenesisAlloc, triedb *triedb.Database) (common.Hash, e
 func getGenesisState(db ethdb.Database, blockhash common.Hash) (alloc types.GenesisAlloc, err error) {
 	blob := rawdb.ReadGenesisStateSpec(db, blockhash)
 	if len(blob) != 0 {
-		fmt.Printf("genesis json: %s\n", blob)
 		if err := alloc.UnmarshalJSON(blob); err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
Balance being null causes `getGenesisState` to fail as the balance field is required in json marshaling of an account.