### PR TITLE
triedb/pathdb, eth: use double-buffer mechanism in pathdb

### DIFF
--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -152,9 +152,10 @@ const (
 // BlockChainConfig contains the configuration of the BlockChain object.
 type BlockChainConfig struct {
 	// Trie database related options
-	TrieCleanLimit int           // Memory allowance (MB) to use for caching trie nodes in memory
-	TrieDirtyLimit int           // Memory limit (MB) at which to start flushing dirty trie nodes to disk
-	TrieTimeLimit  time.Duration // Time limit after which to flush the current in-memory trie to disk
+	TrieCleanLimit   int           // Memory allowance (MB) to use for caching trie nodes in memory
+	TrieDirtyLimit   int           // Memory limit (MB) at which to start flushing dirty trie nodes to disk
+	TrieTimeLimit    time.Duration // Time limit after which to flush the current in-memory trie to disk
+	TrieNoAsyncFlush bool          // Whether the asynchronous buffer flushing is disallowed
 
 	Preimages    bool   // Whether to store preimage of trie key to the disk
 	StateHistory uint64 // Number of blocks from head whose state histories are reserved.
@@ -200,7 +201,7 @@ func DefaultConfig() *BlockChainConfig {
 	}
 }
 
-// WithArchive enabled/disables archive mode on the config.
+// WithArchive enables/disables archive mode on the config.
 func (cfg BlockChainConfig) WithArchive(on bool) *BlockChainConfig {
 	cfg.ArchiveMode = on
 	return &cfg
@@ -209,6 +210,12 @@ func (cfg BlockChainConfig) WithArchive(on bool) *BlockChainConfig {
 // WithStateScheme sets the state storage scheme on the config.
 func (cfg BlockChainConfig) WithStateScheme(scheme string) *BlockChainConfig {
 	cfg.StateScheme = scheme
+	return &cfg
+}
+
+// WithNoAsyncFlush enables/disables asynchronous buffer flushing mode on the config.
+func (cfg BlockChainConfig) WithNoAsyncFlush(on bool) *BlockChainConfig {
+	cfg.TrieNoAsyncFlush = on
 	return &cfg
 }
 
@@ -233,6 +240,7 @@ func (cfg *BlockChainConfig) triedbConfig(isVerkle bool) *triedb.Config {
 			// for flushing both trie data and state data to disk. The config name
 			// should be updated to eliminate the confusion.
 			WriteBufferSize: cfg.TrieDirtyLimit * 1024 * 1024,
+			NoAsyncFlush:    cfg.TrieNoAsyncFlush,
 		}
 	}
 	return config

--- a/core/blockchain_snapshot_test.go
+++ b/core/blockchain_snapshot_test.go
@@ -81,7 +81,7 @@ func (basic *snapshotTestBasic) prepare(t *testing.T) (*BlockChain, []*types.Blo
 		}
 		engine = ethash.NewFullFaker()
 	)
-	chain, err := NewBlockChain(db, gspec, engine, DefaultConfig().WithStateScheme(basic.scheme))
+	chain, err := NewBlockChain(db, gspec, engine, DefaultConfig().WithStateScheme(basic.scheme).WithNoAsyncFlush(true))
 	if err != nil {
 		t.Fatalf("Failed to create chain: %v", err)
 	}
@@ -572,7 +572,7 @@ func TestHighCommitCrashWithNewSnapshot(t *testing.T) {
 	//
 	// Expected head header    : C8
 	// Expected head fast block: C8
-	// Expected head block     : G (Hash mode), C6 (Hash mode)
+	// Expected head block     : G (Hash mode), C6 (Path mode)
 	// Expected snapshot disk  : C4 (Hash mode)
 	for _, scheme := range []string{rawdb.HashScheme, rawdb.PathScheme} {
 		expHead := uint64(0)

--- a/core/genesis_test.go
+++ b/core/genesis_test.go
@@ -256,7 +256,9 @@ func newDbConfig(scheme string) *triedb.Config {
 	if scheme == rawdb.HashScheme {
 		return triedb.HashDefaults
 	}
-	return &triedb.Config{PathDB: pathdb.Defaults}
+	config := *pathdb.Defaults
+	config.NoAsyncFlush = true
+	return &triedb.Config{PathDB: &config}
 }
 
 func TestVerkleGenesisCommit(t *testing.T) {
@@ -313,7 +315,14 @@ func TestVerkleGenesisCommit(t *testing.T) {
 	}
 
 	db := rawdb.NewMemoryDatabase()
-	triedb := triedb.NewDatabase(db, triedb.VerkleDefaults)
+
+	config := *pathdb.Defaults
+	config.NoAsyncFlush = true
+
+	triedb := triedb.NewDatabase(db, &triedb.Config{
+		IsVerkle: true,
+		PathDB:   &config,
+	})
 	block := genesis.MustCommit(db, triedb)
 	if !bytes.Equal(block.Root().Bytes(), expected) {
 		t.Fatalf("invalid genesis state root, expected %x, got %x", expected, block.Root())

--- a/core/state/snapshot/generate_test.go
+++ b/core/state/snapshot/generate_test.go
@@ -168,6 +168,7 @@ func newHelper(scheme string) *testHelper {
 	if scheme == rawdb.PathScheme {
 		config.PathDB = &pathdb.Config{
 			SnapshotNoBuild: true,
+			NoAsyncFlush:    true,
 		} // disable caching
 	} else {
 		config.HashDB = &hashdb.Config{} // disable caching
@@ -242,18 +243,6 @@ func (t *testHelper) Commit() common.Hash {
 	}
 	t.triedb.Update(root, types.EmptyRootHash, 0, t.nodes, t.states)
 	t.triedb.Commit(root, false)
-
-	// re-open the trie database to ensure the frozen buffer
-	// is not referenced
-	//config := &triedb.Config{}
-	//if t.triedb.Scheme() == rawdb.PathScheme {
-	//	config.PathDB = &pathdb.Config{
-	//		SnapshotNoBuild: true,
-	//	} // disable caching
-	//} else {
-	//	config.HashDB = &hashdb.Config{} // disable caching
-	//}
-	//t.triedb = triedb.NewDatabase(t.triedb.Disk(), config)
 	return root
 }
 

--- a/core/state/snapshot/generate_test.go
+++ b/core/state/snapshot/generate_test.go
@@ -242,6 +242,18 @@ func (t *testHelper) Commit() common.Hash {
 	}
 	t.triedb.Update(root, types.EmptyRootHash, 0, t.nodes, t.states)
 	t.triedb.Commit(root, false)
+
+	// re-open the trie database to ensure the frozen buffer
+	// is not referenced
+	//config := &triedb.Config{}
+	//if t.triedb.Scheme() == rawdb.PathScheme {
+	//	config.PathDB = &pathdb.Config{
+	//		SnapshotNoBuild: true,
+	//	} // disable caching
+	//} else {
+	//	config.HashDB = &hashdb.Config{} // disable caching
+	//}
+	//t.triedb = triedb.NewDatabase(t.triedb.Disk(), config)
 	return root
 }
 

--- a/core/state/statedb_test.go
+++ b/core/state/statedb_test.go
@@ -974,20 +974,23 @@ func TestMissingTrieNodes(t *testing.T) {
 func testMissingTrieNodes(t *testing.T, scheme string) {
 	// Create an initial state with a few accounts
 	var (
-		tdb   *triedb.Database
-		memDb = rawdb.NewMemoryDatabase()
+		tdb    *triedb.Database
+		memDb  = rawdb.NewMemoryDatabase()
+		openDb = func() *triedb.Database {
+			if scheme == rawdb.PathScheme {
+				return triedb.NewDatabase(memDb, &triedb.Config{PathDB: &pathdb.Config{
+					TrieCleanSize:   0,
+					StateCleanSize:  0,
+					WriteBufferSize: 0,
+				}}) // disable caching
+			} else {
+				return triedb.NewDatabase(memDb, &triedb.Config{HashDB: &hashdb.Config{
+					CleanCacheSize: 0,
+				}}) // disable caching
+			}
+		}
 	)
-	if scheme == rawdb.PathScheme {
-		tdb = triedb.NewDatabase(memDb, &triedb.Config{PathDB: &pathdb.Config{
-			TrieCleanSize:   0,
-			StateCleanSize:  0,
-			WriteBufferSize: 0,
-		}}) // disable caching
-	} else {
-		tdb = triedb.NewDatabase(memDb, &triedb.Config{HashDB: &hashdb.Config{
-			CleanCacheSize: 0,
-		}}) // disable caching
-	}
+	tdb = openDb()
 	db := NewDatabase(tdb, nil)
 
 	var root common.Hash
@@ -1005,17 +1008,27 @@ func testMissingTrieNodes(t *testing.T, scheme string) {
 		tdb.Commit(root, false)
 	}
 	// Create a new state on the old root
-	state, _ = New(root, db)
 	// Now we clear out the memdb
 	it := memDb.NewIterator(nil, nil)
 	for it.Next() {
 		k := it.Key()
-		// Leave the root intact
-		if !bytes.Equal(k, root[:]) {
-			t.Logf("key: %x", k)
-			memDb.Delete(k)
+		if scheme == rawdb.HashScheme {
+			if !bytes.Equal(k, root[:]) {
+				t.Logf("key: %x", k)
+				memDb.Delete(k)
+			}
+		}
+		if scheme == rawdb.PathScheme {
+			rk := k[len(rawdb.TrieNodeAccountPrefix):]
+			if len(rk) != 0 {
+				t.Logf("key: %x", k)
+				memDb.Delete(k)
+			}
 		}
 	}
+	tdb = openDb()
+	db = NewDatabase(tdb, nil)
+	state, _ = New(root, db)
 	balance := state.GetBalance(addr)
 	// The removed elem should lead to it returning zero balance
 	if exp, got := uint64(0), balance.Uint64(); got != exp {

--- a/core/state/sync_test.go
+++ b/core/state/sync_test.go
@@ -46,7 +46,9 @@ func makeTestState(scheme string) (ethdb.Database, Database, *triedb.Database, c
 	// Create an empty state
 	config := &triedb.Config{Preimages: true}
 	if scheme == rawdb.PathScheme {
-		config.PathDB = pathdb.Defaults
+		pconfig := *pathdb.Defaults
+		pconfig.NoAsyncFlush = true
+		config.PathDB = &pconfig
 	} else {
 		config.HashDB = hashdb.Defaults
 	}

--- a/triedb/pathdb/buffer.go
+++ b/triedb/pathdb/buffer.go
@@ -17,6 +17,7 @@
 package pathdb
 
 import (
+	"errors"
 	"fmt"
 	"time"
 
@@ -37,6 +38,9 @@ type buffer struct {
 	limit  uint64    // The maximum memory allowance in bytes
 	nodes  *nodeSet  // Aggregated trie node set
 	states *stateSet // Aggregated state set
+
+	done     chan struct{} // notifier whether the content in buffer has been flushed or not
+	flushErr error         // error if any exception occurs during flushing
 }
 
 // newBuffer initializes the buffer with the provided states and trie nodes.
@@ -124,43 +128,74 @@ func (b *buffer) size() uint64 {
 
 // flush persists the in-memory dirty trie node into the disk if the configured
 // memory threshold is reached. Note, all data must be written atomically.
-func (b *buffer) flush(root common.Hash, db ethdb.KeyValueStore, freezer ethdb.AncientWriter, progress []byte, nodesCache, statesCache *fastcache.Cache, id uint64) error {
-	// Ensure the target state id is aligned with the internal counter.
-	head := rawdb.ReadPersistentStateID(db)
-	if head+b.layers != id {
-		return fmt.Errorf("buffer layers (%d) cannot be applied on top of persisted state id (%d) to reach requested state id (%d)", b.layers, head, id)
+func (b *buffer) flush(root common.Hash, db ethdb.KeyValueStore, freezer ethdb.AncientWriter, progress []byte, nodesCache, statesCache *fastcache.Cache, id uint64, postFlush func()) {
+	if b.done != nil {
+		panic("duplicated flush operation")
 	}
-	// Terminate the state snapshot generation if it's active
-	var (
-		start = time.Now()
-		batch = db.NewBatchWithSize((b.nodes.dbsize() + b.states.dbsize()) * 11 / 10) // extra 10% for potential pebble internal stuff
-	)
-	// Explicitly sync the state freezer to ensure all written data is persisted to disk
-	// before updating the key-value store.
-	//
-	// This step is crucial to guarantee that the corresponding state history remains
-	// available for state rollback.
-	if freezer != nil {
-		if err := freezer.SyncAncient(); err != nil {
-			return err
-		}
-	}
-	nodes := b.nodes.write(batch, nodesCache)
-	accounts, slots := b.states.write(batch, progress, statesCache)
-	rawdb.WritePersistentStateID(batch, id)
-	rawdb.WriteSnapshotRoot(batch, root)
+	b.done = make(chan struct{}) // allocate the channel for notification
 
-	// Flush all mutations in a single batch
-	size := batch.ValueSize()
-	if err := batch.Write(); err != nil {
-		return err
+	go func() {
+		defer func() {
+			if postFlush != nil {
+				postFlush()
+			}
+			close(b.done)
+		}()
+
+		// Ensure the target state id is aligned with the internal counter.
+		head := rawdb.ReadPersistentStateID(db)
+		if head+b.layers != id {
+			b.flushErr = fmt.Errorf("buffer layers (%d) cannot be applied on top of persisted state id (%d) to reach requested state id (%d)", b.layers, head, id)
+			return
+		}
+
+		// Terminate the state snapshot generation if it's active
+		var (
+			start = time.Now()
+			batch = db.NewBatchWithSize((b.nodes.dbsize() + b.states.dbsize()) * 11 / 10) // extra 10% for potential pebble internal stuff
+		)
+		// Explicitly sync the state freezer to ensure all written data is persisted to disk
+		// before updating the key-value store.
+		//
+		// This step is crucial to guarantee that the corresponding state history remains
+		// available for state rollback.
+		if freezer != nil {
+			if err := freezer.SyncAncient(); err != nil {
+				b.flushErr = err
+				return
+			}
+		}
+		nodes := b.nodes.write(batch, nodesCache)
+		accounts, slots := b.states.write(batch, progress, statesCache)
+		rawdb.WritePersistentStateID(batch, id)
+		rawdb.WriteSnapshotRoot(batch, root)
+
+		// Flush all mutations in a single batch
+		size := batch.ValueSize()
+		if err := batch.Write(); err != nil {
+			b.flushErr = err
+			return
+		}
+		commitBytesMeter.Mark(int64(size))
+		commitNodesMeter.Mark(int64(nodes))
+		commitAccountsMeter.Mark(int64(accounts))
+		commitStoragesMeter.Mark(int64(slots))
+		commitTimeTimer.UpdateSince(start)
+
+		// The content in the frozen buffer is kept for consequent state access,
+		// TODO (rjl493456442) measure the gc overhead for holding this struct.
+		// TODO (rjl493456442) can we somehow get rid of it after flushing??
+		b.reset()
+		log.Debug("Persisted buffer content", "nodes", nodes, "accounts", accounts, "slots", slots, "bytes", common.StorageSize(size), "elapsed", common.PrettyDuration(time.Since(start)))
+	}()
+}
+
+// waitFlush blocks until the buffer has been fully flushed and returns any
+// stored errors that occurred during the process.
+func (b *buffer) waitFlush() error {
+	if b.done == nil {
+		return errors.New("the buffer is not frozen")
 	}
-	commitBytesMeter.Mark(int64(size))
-	commitNodesMeter.Mark(int64(nodes))
-	commitAccountsMeter.Mark(int64(accounts))
-	commitStoragesMeter.Mark(int64(slots))
-	commitTimeTimer.UpdateSince(start)
-	b.reset()
-	log.Debug("Persisted buffer content", "nodes", nodes, "accounts", accounts, "slots", slots, "bytes", common.StorageSize(size), "elapsed", common.PrettyDuration(time.Since(start)))
-	return nil
+	<-b.done
+	return b.flushErr
 }

--- a/triedb/pathdb/database.go
+++ b/triedb/pathdb/database.go
@@ -437,11 +437,8 @@ func (db *Database) Disable() error {
 	// Terminate the state generator if it's active and mark the disk layer
 	// as stale to prevent access to persistent state.
 	disk := db.tree.bottom()
-	if err := disk.waitFlush(); err != nil {
+	if err := disk.terminate(); err != nil {
 		return err
-	}
-	if disk.generator != nil {
-		disk.generator.stop()
 	}
 	disk.markStale()
 
@@ -602,12 +599,8 @@ func (db *Database) Close() error {
 	// be done before terminating the potential background snapshot
 	// generator.
 	dl := db.tree.bottom()
-	if err := dl.waitFlush(); err != nil {
+	if err := dl.terminate(); err != nil {
 		return err
-	}
-	// Terminate the background generation if it's active
-	if dl.generator != nil {
-		dl.generator.stop()
 	}
 	dl.resetCache() // release the memory held by clean cache
 
@@ -677,6 +670,9 @@ func (db *Database) HistoryRange() (uint64, uint64, error) {
 // waitGeneration waits until the background generation is finished. It assumes
 // that the generation is permitted; otherwise, it will block indefinitely.
 func (db *Database) waitGeneration() {
+	db.lock.RLock()
+	defer db.lock.RUnlock()
+
 	gen := db.tree.bottom().generator
 	if gen == nil || gen.completed() {
 		return
@@ -693,7 +689,7 @@ func (db *Database) AccountIterator(root common.Hash, seek common.Hash) (Account
 	if wait {
 		return nil, errDatabaseWaitSync
 	}
-	if gen := db.tree.bottom().generator; gen != nil && !gen.completed() {
+	if !db.tree.bottom().genComplete() {
 		return nil, errNotConstructed
 	}
 	return newFastAccountIterator(db, root, seek)
@@ -708,7 +704,7 @@ func (db *Database) StorageIterator(root common.Hash, account common.Hash, seek 
 	if wait {
 		return nil, errDatabaseWaitSync
 	}
-	if gen := db.tree.bottom().generator; gen != nil && !gen.completed() {
+	if !db.tree.bottom().genComplete() {
 		return nil, errNotConstructed
 	}
 	return newFastStorageIterator(db, root, account, seek)

--- a/triedb/pathdb/database_test.go
+++ b/triedb/pathdb/database_test.go
@@ -129,6 +129,7 @@ func newTester(t *testing.T, historyLimit uint64, isVerkle bool, layers int) *te
 			TrieCleanSize:   256 * 1024,
 			StateCleanSize:  256 * 1024,
 			WriteBufferSize: 256 * 1024,
+			NoAsyncFlush:    true,
 		}, isVerkle)
 
 		obj = &tester{

--- a/triedb/pathdb/disklayer.go
+++ b/triedb/pathdb/disklayer.go
@@ -581,6 +581,17 @@ func (dl *diskLayer) genComplete() bool {
 	return dl.genMarker() == nil
 }
 
+// waitFlush blocks until the background buffer flush is completed.
+func (dl *diskLayer) waitFlush() error {
+	dl.lock.RLock()
+	defer dl.lock.RUnlock()
+
+	if dl.frozen == nil {
+		return nil
+	}
+	return dl.frozen.waitFlush()
+}
+
 // terminate releases the frozen buffer if it's not nil and terminates the
 // background state generator.
 func (dl *diskLayer) terminate() error {

--- a/triedb/pathdb/generate.go
+++ b/triedb/pathdb/generate.go
@@ -186,7 +186,7 @@ func generateSnapshot(triedb *Database, root common.Hash, noBuild bool) *diskLay
 		stats     = &generatorStats{start: time.Now()}
 		genMarker = []byte{} // Initialized but empty!
 	)
-	dl := newDiskLayer(root, 0, triedb, nil, nil, newBuffer(triedb.config.WriteBufferSize, nil, nil, 0))
+	dl := newDiskLayer(root, 0, triedb, nil, nil, newBuffer(triedb.config.WriteBufferSize, nil, nil, 0), nil)
 	dl.setGenerator(newGenerator(triedb.diskdb, noBuild, genMarker, stats))
 
 	if !noBuild {

--- a/triedb/pathdb/generate_test.go
+++ b/triedb/pathdb/generate_test.go
@@ -49,6 +49,7 @@ func newGenTester() *genTester {
 	disk := rawdb.NewMemoryDatabase()
 	config := *Defaults
 	config.SnapshotNoBuild = true // no background generation
+	config.NoAsyncFlush = true    // no async flush
 	db := New(disk, &config, false)
 	tr, _ := trie.New(trie.StateTrieID(types.EmptyRootHash), db)
 	return &genTester{

--- a/triedb/pathdb/iterator_binary.go
+++ b/triedb/pathdb/iterator_binary.go
@@ -45,6 +45,10 @@ type binaryIterator struct {
 // accounts in a slow, but easily verifiable way. Note this function is used
 // for initialization, use `newBinaryAccountIterator` as the API.
 func (dl *diskLayer) initBinaryAccountIterator(seek common.Hash) *binaryIterator {
+	// Block until the frozen buffer flushing is completed.
+	if err := dl.waitFlush(); err != nil {
+		panic(err)
+	}
 	// The state set in the disk layer is mutable, hold the lock before obtaining
 	// the account list to prevent concurrent map iteration and write.
 	dl.lock.RLock()
@@ -113,6 +117,10 @@ func (dl *diffLayer) initBinaryAccountIterator(seek common.Hash) *binaryIterator
 // storage slots in a slow, but easily verifiable way. Note this function is used
 // for initialization, use `newBinaryStorageIterator` as the API.
 func (dl *diskLayer) initBinaryStorageIterator(account common.Hash, seek common.Hash) *binaryIterator {
+	// Block until the frozen buffer flushing is completed.
+	if err := dl.waitFlush(); err != nil {
+		panic(err)
+	}
 	// The state set in the disk layer is mutable, hold the lock before obtaining
 	// the storage list to prevent concurrent map iteration and write.
 	dl.lock.RLock()

--- a/triedb/pathdb/iterator_fast.go
+++ b/triedb/pathdb/iterator_fast.go
@@ -76,6 +76,11 @@ func newFastIterator(db *Database, root common.Hash, account common.Hash, seek c
 		if accountIterator {
 			switch dl := current.(type) {
 			case *diskLayer:
+				// Ensure no active background buffer flush is in progress, otherwise,
+				// part of the state data may become invisible.
+				if err := dl.waitFlush(); err != nil {
+					return nil, err
+				}
 				// The state set in the disk layer is mutable, hold the lock before obtaining
 				// the account list to prevent concurrent map iteration and write.
 				dl.lock.RLock()
@@ -113,6 +118,11 @@ func newFastIterator(db *Database, root common.Hash, account common.Hash, seek c
 		} else {
 			switch dl := current.(type) {
 			case *diskLayer:
+				// Ensure no active background buffer flush is in progress, otherwise,
+				// part of the state data may become invisible.
+				if err := dl.waitFlush(); err != nil {
+					return nil, err
+				}
 				// The state set in the disk layer is mutable, hold the lock before obtaining
 				// the storage list to prevent concurrent map iteration and write.
 				dl.lock.RLock()

--- a/triedb/pathdb/iterator_test.go
+++ b/triedb/pathdb/iterator_test.go
@@ -254,11 +254,9 @@ func TestFastIteratorBasics(t *testing.T) {
 // TestAccountIteratorTraversal tests some simple multi-layer iteration.
 func TestAccountIteratorTraversal(t *testing.T) {
 	config := &Config{
-		WriteBufferSize: 0,
-		NoAsyncFlush:    true,
+		NoAsyncGeneration: true,
 	}
 	db := New(rawdb.NewMemoryDatabase(), config, false)
-	db.waitGeneration()
 
 	// Stack three diff layers on top with various overlaps
 	db.Update(common.HexToHash("0x02"), types.EmptyRootHash, 0, trienode.NewMergedNodeSet(),
@@ -299,11 +297,9 @@ func TestAccountIteratorTraversal(t *testing.T) {
 
 func TestStorageIteratorTraversal(t *testing.T) {
 	config := &Config{
-		WriteBufferSize: 0,
-		NoAsyncFlush:    true,
+		NoAsyncGeneration: true,
 	}
 	db := New(rawdb.NewMemoryDatabase(), config, false)
-	db.waitGeneration()
 
 	// Stack three diff layers on top with various overlaps
 	db.Update(common.HexToHash("0x02"), types.EmptyRootHash, 0, trienode.NewMergedNodeSet(),
@@ -313,14 +309,14 @@ func TestStorageIteratorTraversal(t *testing.T) {
 		NewStateSetWithOrigin(randomAccountSet("0xaa"), randomStorageSet([]string{"0xaa"}, [][]string{{"0x04", "0x05", "0x06"}}, nil), nil, nil, false))
 
 	db.Update(common.HexToHash("0x04"), common.HexToHash("0x03"), 0, trienode.NewMergedNodeSet(),
-		NewStateSetWithOrigin(randomAccountSet("0xaa"), randomStorageSet([]string{"0xaa"}, [][]string{{"0x01", "0x02", "0x03"}}, nil), nil, nil, false))
+		NewStateSetWithOrigin(randomAccountSet("0xaa"), randomStorageSet([]string{"0xaa"}, [][]string{{"0x01", "0x02"}}, nil), nil, nil, false))
 
 	// Verify the single and multi-layer iterators
 	head := db.tree.get(common.HexToHash("0x04"))
 
 	// singleLayer: 0x1, 0x2, 0x3
 	diffIter := newDiffStorageIterator(common.HexToHash("0xaa"), common.Hash{}, head.(*diffLayer).states.stateSet.storageList(common.HexToHash("0xaa")), nil)
-	verifyIterator(t, 3, diffIter, verifyNothing)
+	verifyIterator(t, 2, diffIter, verifyNothing)
 
 	// binaryIterator: 0x1, 0x2, 0x3, 0x4, 0x5, 0x6
 	verifyIterator(t, 6, head.(*diffLayer).newBinaryStorageIterator(common.HexToHash("0xaa"), common.Hash{}), verifyStorage)
@@ -344,11 +340,9 @@ func TestStorageIteratorTraversal(t *testing.T) {
 // also expect the correct values to show up.
 func TestAccountIteratorTraversalValues(t *testing.T) {
 	config := &Config{
-		WriteBufferSize: 0,
-		NoAsyncFlush:    true,
+		NoAsyncGeneration: true,
 	}
 	db := New(rawdb.NewMemoryDatabase(), config, false)
-	db.waitGeneration()
 
 	// Create a batch of account sets to seed subsequent layers with
 	var (
@@ -461,11 +455,9 @@ func TestAccountIteratorTraversalValues(t *testing.T) {
 
 func TestStorageIteratorTraversalValues(t *testing.T) {
 	config := &Config{
-		WriteBufferSize: 0,
-		NoAsyncFlush:    true,
+		NoAsyncGeneration: true,
 	}
 	db := New(rawdb.NewMemoryDatabase(), config, false)
-	db.waitGeneration()
 
 	wrapStorage := func(storage map[common.Hash][]byte) map[common.Hash]map[common.Hash][]byte {
 		return map[common.Hash]map[common.Hash][]byte{
@@ -595,11 +587,9 @@ func TestAccountIteratorLargeTraversal(t *testing.T) {
 	}
 	// Build up a large stack of snapshots
 	config := &Config{
-		WriteBufferSize: 0,
-		NoAsyncFlush:    true,
+		NoAsyncGeneration: true,
 	}
 	db := New(rawdb.NewMemoryDatabase(), config, false)
-	db.waitGeneration()
 
 	for i := 1; i < 128; i++ {
 		parent := types.EmptyRootHash
@@ -635,10 +625,10 @@ func TestAccountIteratorLargeTraversal(t *testing.T) {
 // - continues iterating
 func TestAccountIteratorFlattening(t *testing.T) {
 	config := &Config{
-		WriteBufferSize: 10 * 1024,
+		WriteBufferSize:   10 * 1024,
+		NoAsyncGeneration: true,
 	}
 	db := New(rawdb.NewMemoryDatabase(), config, false)
-	db.waitGeneration()
 
 	// Create a stack of diffs on top
 	db.Update(common.HexToHash("0x02"), types.EmptyRootHash, 1, trienode.NewMergedNodeSet(),
@@ -667,12 +657,24 @@ func TestAccountIteratorFlattening(t *testing.T) {
 }
 
 func TestAccountIteratorSeek(t *testing.T) {
+	t.Run("fast", func(t *testing.T) {
+		testAccountIteratorSeek(t, func(db *Database, root, seek common.Hash) AccountIterator {
+			it, _ := db.AccountIterator(root, seek)
+			return it
+		})
+	})
+	t.Run("binary", func(t *testing.T) {
+		testAccountIteratorSeek(t, func(db *Database, root, seek common.Hash) AccountIterator {
+			return db.tree.get(root).(*diffLayer).newBinaryAccountIterator(seek)
+		})
+	})
+}
+
+func testAccountIteratorSeek(t *testing.T, newIterator func(db *Database, root, seek common.Hash) AccountIterator) {
 	config := &Config{
-		WriteBufferSize: 0,
-		NoAsyncFlush:    true,
+		NoAsyncGeneration: true,
 	}
 	db := New(rawdb.NewMemoryDatabase(), config, false)
-	db.waitGeneration()
 
 	db.Update(common.HexToHash("0x02"), types.EmptyRootHash, 1, trienode.NewMergedNodeSet(),
 		NewStateSetWithOrigin(randomAccountSet("0xaa", "0xee", "0xff", "0xf0"), nil, nil, nil, false))
@@ -688,39 +690,39 @@ func TestAccountIteratorSeek(t *testing.T) {
 	// 03: aa, bb, dd, ee, f0 (, f0), ff
 	// 04: aa, bb, cc, dd, ee, f0 (, f0), ff (, ff)
 	// Construct various iterators and ensure their traversal is correct
-	it, _ := db.AccountIterator(common.HexToHash("0x02"), common.HexToHash("0xdd"))
+	it := newIterator(db, common.HexToHash("0x02"), common.HexToHash("0xdd"))
 	defer it.Release()
 	verifyIterator(t, 3, it, verifyAccount) // expected: ee, f0, ff
 
-	it, _ = db.AccountIterator(common.HexToHash("0x02"), common.HexToHash("0xaa"))
+	it = newIterator(db, common.HexToHash("0x02"), common.HexToHash("0xaa"))
 	defer it.Release()
 	verifyIterator(t, 4, it, verifyAccount) // expected: aa, ee, f0, ff
 
-	it, _ = db.AccountIterator(common.HexToHash("0x02"), common.HexToHash("0xff"))
+	it = newIterator(db, common.HexToHash("0x02"), common.HexToHash("0xff"))
 	defer it.Release()
 	verifyIterator(t, 1, it, verifyAccount) // expected: ff
 
-	it, _ = db.AccountIterator(common.HexToHash("0x02"), common.HexToHash("0xff1"))
+	it = newIterator(db, common.HexToHash("0x02"), common.HexToHash("0xff1"))
 	defer it.Release()
 	verifyIterator(t, 0, it, verifyAccount) // expected: nothing
 
-	it, _ = db.AccountIterator(common.HexToHash("0x04"), common.HexToHash("0xbb"))
+	it = newIterator(db, common.HexToHash("0x04"), common.HexToHash("0xbb"))
 	defer it.Release()
 	verifyIterator(t, 6, it, verifyAccount) // expected: bb, cc, dd, ee, f0, ff
 
-	it, _ = db.AccountIterator(common.HexToHash("0x04"), common.HexToHash("0xef"))
+	it = newIterator(db, common.HexToHash("0x04"), common.HexToHash("0xef"))
 	defer it.Release()
 	verifyIterator(t, 2, it, verifyAccount) // expected: f0, ff
 
-	it, _ = db.AccountIterator(common.HexToHash("0x04"), common.HexToHash("0xf0"))
+	it = newIterator(db, common.HexToHash("0x04"), common.HexToHash("0xf0"))
 	defer it.Release()
 	verifyIterator(t, 2, it, verifyAccount) // expected: f0, ff
 
-	it, _ = db.AccountIterator(common.HexToHash("0x04"), common.HexToHash("0xff"))
+	it = newIterator(db, common.HexToHash("0x04"), common.HexToHash("0xff"))
 	defer it.Release()
 	verifyIterator(t, 1, it, verifyAccount) // expected: ff
 
-	it, _ = db.AccountIterator(common.HexToHash("0x04"), common.HexToHash("0xff1"))
+	it = newIterator(db, common.HexToHash("0x04"), common.HexToHash("0xff1"))
 	defer it.Release()
 	verifyIterator(t, 0, it, verifyAccount) // expected: nothing
 }
@@ -741,11 +743,9 @@ func TestStorageIteratorSeek(t *testing.T) {
 
 func testStorageIteratorSeek(t *testing.T, newIterator func(db *Database, root, account, seek common.Hash) StorageIterator) {
 	config := &Config{
-		WriteBufferSize: 0,
-		NoAsyncFlush:    true,
+		NoAsyncGeneration: true,
 	}
 	db := New(rawdb.NewMemoryDatabase(), config, false)
-	db.waitGeneration()
 
 	// Stack three diff layers on top with various overlaps
 	db.Update(common.HexToHash("0x02"), types.EmptyRootHash, 1, trienode.NewMergedNodeSet(),
@@ -814,11 +814,9 @@ func TestAccountIteratorDeletions(t *testing.T) {
 
 func testAccountIteratorDeletions(t *testing.T, newIterator func(db *Database, root, seek common.Hash) AccountIterator) {
 	config := &Config{
-		WriteBufferSize: 0,
-		NoAsyncFlush:    true,
+		NoAsyncGeneration: true,
 	}
 	db := New(rawdb.NewMemoryDatabase(), config, false)
-	db.waitGeneration()
 
 	// Stack three diff layers on top with various overlaps
 	db.Update(common.HexToHash("0x02"), types.EmptyRootHash, 1, trienode.NewMergedNodeSet(),
@@ -855,11 +853,9 @@ func testAccountIteratorDeletions(t *testing.T, newIterator func(db *Database, r
 
 func TestStorageIteratorDeletions(t *testing.T) {
 	config := &Config{
-		WriteBufferSize: 0,
-		NoAsyncFlush:    true,
+		NoAsyncGeneration: true,
 	}
 	db := New(rawdb.NewMemoryDatabase(), config, false)
-	db.waitGeneration()
 
 	// Stack three diff layers on top with various overlaps
 	db.Update(common.HexToHash("0x02"), types.EmptyRootHash, 1, trienode.NewMergedNodeSet(),
@@ -924,11 +920,10 @@ func TestStaleIterator(t *testing.T) {
 
 func testStaleIterator(t *testing.T, newIter func(db *Database, hash common.Hash) Iterator) {
 	config := &Config{
-		WriteBufferSize: 16 * 1024 * 1024,
-		NoAsyncFlush:    true,
+		WriteBufferSize:   16 * 1024 * 1024,
+		NoAsyncGeneration: true,
 	}
 	db := New(rawdb.NewMemoryDatabase(), config, false)
-	db.waitGeneration()
 
 	// [02 (disk), 03]
 	db.Update(common.HexToHash("0x02"), types.EmptyRootHash, 1, trienode.NewMergedNodeSet(),
@@ -980,11 +975,9 @@ func BenchmarkAccountIteratorTraversal(b *testing.B) {
 		return accounts
 	}
 	config := &Config{
-		WriteBufferSize: 0,
-		NoAsyncFlush:    true,
+		NoAsyncGeneration: true,
 	}
 	db := New(rawdb.NewMemoryDatabase(), config, false)
-	db.waitGeneration()
 
 	for i := 1; i <= 100; i++ {
 		parent := types.EmptyRootHash
@@ -1076,11 +1069,9 @@ func BenchmarkAccountIteratorLargeBaselayer(b *testing.B) {
 		return accounts
 	}
 	config := &Config{
-		WriteBufferSize: 0,
-		NoAsyncFlush:    true,
+		NoAsyncGeneration: true,
 	}
 	db := New(rawdb.NewMemoryDatabase(), config, false)
-	db.waitGeneration()
 
 	db.Update(common.HexToHash("0x02"), types.EmptyRootHash, 1, trienode.NewMergedNodeSet(), NewStateSetWithOrigin(makeAccounts(2000), nil, nil, nil, false))
 	for i := 2; i <= 100; i++ {

--- a/triedb/pathdb/iterator_test.go
+++ b/triedb/pathdb/iterator_test.go
@@ -255,6 +255,7 @@ func TestFastIteratorBasics(t *testing.T) {
 func TestAccountIteratorTraversal(t *testing.T) {
 	config := &Config{
 		WriteBufferSize: 0,
+		NoAsyncFlush:    true,
 	}
 	db := New(rawdb.NewMemoryDatabase(), config, false)
 	db.waitGeneration()
@@ -299,6 +300,7 @@ func TestAccountIteratorTraversal(t *testing.T) {
 func TestStorageIteratorTraversal(t *testing.T) {
 	config := &Config{
 		WriteBufferSize: 0,
+		NoAsyncFlush:    true,
 	}
 	db := New(rawdb.NewMemoryDatabase(), config, false)
 	db.waitGeneration()
@@ -343,6 +345,7 @@ func TestStorageIteratorTraversal(t *testing.T) {
 func TestAccountIteratorTraversalValues(t *testing.T) {
 	config := &Config{
 		WriteBufferSize: 0,
+		NoAsyncFlush:    true,
 	}
 	db := New(rawdb.NewMemoryDatabase(), config, false)
 	db.waitGeneration()
@@ -459,6 +462,7 @@ func TestAccountIteratorTraversalValues(t *testing.T) {
 func TestStorageIteratorTraversalValues(t *testing.T) {
 	config := &Config{
 		WriteBufferSize: 0,
+		NoAsyncFlush:    true,
 	}
 	db := New(rawdb.NewMemoryDatabase(), config, false)
 	db.waitGeneration()
@@ -592,6 +596,7 @@ func TestAccountIteratorLargeTraversal(t *testing.T) {
 	// Build up a large stack of snapshots
 	config := &Config{
 		WriteBufferSize: 0,
+		NoAsyncFlush:    true,
 	}
 	db := New(rawdb.NewMemoryDatabase(), config, false)
 	db.waitGeneration()
@@ -664,6 +669,7 @@ func TestAccountIteratorFlattening(t *testing.T) {
 func TestAccountIteratorSeek(t *testing.T) {
 	config := &Config{
 		WriteBufferSize: 0,
+		NoAsyncFlush:    true,
 	}
 	db := New(rawdb.NewMemoryDatabase(), config, false)
 	db.waitGeneration()
@@ -736,6 +742,7 @@ func TestStorageIteratorSeek(t *testing.T) {
 func testStorageIteratorSeek(t *testing.T, newIterator func(db *Database, root, account, seek common.Hash) StorageIterator) {
 	config := &Config{
 		WriteBufferSize: 0,
+		NoAsyncFlush:    true,
 	}
 	db := New(rawdb.NewMemoryDatabase(), config, false)
 	db.waitGeneration()
@@ -808,6 +815,7 @@ func TestAccountIteratorDeletions(t *testing.T) {
 func testAccountIteratorDeletions(t *testing.T, newIterator func(db *Database, root, seek common.Hash) AccountIterator) {
 	config := &Config{
 		WriteBufferSize: 0,
+		NoAsyncFlush:    true,
 	}
 	db := New(rawdb.NewMemoryDatabase(), config, false)
 	db.waitGeneration()
@@ -848,6 +856,7 @@ func testAccountIteratorDeletions(t *testing.T, newIterator func(db *Database, r
 func TestStorageIteratorDeletions(t *testing.T) {
 	config := &Config{
 		WriteBufferSize: 0,
+		NoAsyncFlush:    true,
 	}
 	db := New(rawdb.NewMemoryDatabase(), config, false)
 	db.waitGeneration()
@@ -916,6 +925,7 @@ func TestStaleIterator(t *testing.T) {
 func testStaleIterator(t *testing.T, newIter func(db *Database, hash common.Hash) Iterator) {
 	config := &Config{
 		WriteBufferSize: 16 * 1024 * 1024,
+		NoAsyncFlush:    true,
 	}
 	db := New(rawdb.NewMemoryDatabase(), config, false)
 	db.waitGeneration()
@@ -971,6 +981,7 @@ func BenchmarkAccountIteratorTraversal(b *testing.B) {
 	}
 	config := &Config{
 		WriteBufferSize: 0,
+		NoAsyncFlush:    true,
 	}
 	db := New(rawdb.NewMemoryDatabase(), config, false)
 	db.waitGeneration()
@@ -1066,6 +1077,7 @@ func BenchmarkAccountIteratorLargeBaselayer(b *testing.B) {
 	}
 	config := &Config{
 		WriteBufferSize: 0,
+		NoAsyncFlush:    true,
 	}
 	db := New(rawdb.NewMemoryDatabase(), config, false)
 	db.waitGeneration()

--- a/triedb/pathdb/journal.go
+++ b/triedb/pathdb/journal.go
@@ -304,12 +304,8 @@ func (db *Database) Journal(root common.Hash) error {
 	// Block until the background flushing is finished. It must
 	// be done before terminating the potential background snapshot
 	// generator.
-	if err := disk.waitFlush(); err != nil {
+	if err := disk.terminate(); err != nil {
 		return err
-	}
-	// Terminate the background state generation if it's active
-	if disk.generator != nil {
-		disk.generator.stop()
 	}
 	start := time.Now()
 

--- a/triedb/pathdb/journal.go
+++ b/triedb/pathdb/journal.go
@@ -160,7 +160,7 @@ func (db *Database) loadLayers() layer {
 		log.Info("Failed to load journal, discard it", "err", err)
 	}
 	// Return single layer with persistent state.
-	return newDiskLayer(root, rawdb.ReadPersistentStateID(db.diskdb), db, nil, nil, newBuffer(db.config.WriteBufferSize, nil, nil, 0))
+	return newDiskLayer(root, rawdb.ReadPersistentStateID(db.diskdb), db, nil, nil, newBuffer(db.config.WriteBufferSize, nil, nil, 0), nil)
 }
 
 // loadDiskLayer reads the binary blob from the layer journal, reconstructing
@@ -192,7 +192,7 @@ func (db *Database) loadDiskLayer(r *rlp.Stream) (layer, error) {
 	if err := states.decode(r); err != nil {
 		return nil, err
 	}
-	return newDiskLayer(root, id, db, nil, nil, newBuffer(db.config.WriteBufferSize, &nodes, &states, id-stored)), nil
+	return newDiskLayer(root, id, db, nil, nil, newBuffer(db.config.WriteBufferSize, &nodes, &states, id-stored), nil), nil
 }
 
 // loadDiffLayer reads the next sections of a layer journal, reconstructing a new
@@ -300,6 +300,12 @@ func (db *Database) Journal(root common.Hash) error {
 		log.Info("Persisting dirty state to disk", "head", l.block, "root", root, "layers", l.id-disk.id+disk.buffer.layers)
 	} else { // disk layer only on noop runs (likely) or deep reorgs (unlikely)
 		log.Info("Persisting dirty state to disk", "root", root, "layers", disk.buffer.layers)
+	}
+	// Block until the background flushing is finished. It must
+	// be done before terminating the potential background snapshot
+	// generator.
+	if err := disk.waitFlush(); err != nil {
+		return err
 	}
 	// Terminate the background state generation if it's active
 	if disk.generator != nil {

--- a/triedb/pathdb/journal.go
+++ b/triedb/pathdb/journal.go
@@ -301,9 +301,8 @@ func (db *Database) Journal(root common.Hash) error {
 	} else { // disk layer only on noop runs (likely) or deep reorgs (unlikely)
 		log.Info("Persisting dirty state to disk", "root", root, "layers", disk.buffer.layers)
 	}
-	// Block until the background flushing is finished. It must
-	// be done before terminating the potential background snapshot
-	// generator.
+	// Block until the background flushing is finished and terminate
+	// the potential active state generator.
 	if err := disk.terminate(); err != nil {
 		return err
 	}

--- a/triedb/pathdb/layertree.go
+++ b/triedb/pathdb/layertree.go
@@ -195,6 +195,10 @@ func (tree *layerTree) cap(root common.Hash, layers int) error {
 		}
 		tree.base = base
 
+		// Block until the frozen buffer is fully flushed
+		if err := base.waitFlush(); err != nil {
+			return err
+		}
 		// Reset the layer tree with the single new disk layer
 		tree.layers = map[common.Hash]layer{
 			base.rootHash(): base,

--- a/triedb/pathdb/layertree.go
+++ b/triedb/pathdb/layertree.go
@@ -195,10 +195,6 @@ func (tree *layerTree) cap(root common.Hash, layers int) error {
 		}
 		tree.base = base
 
-		// Block until the frozen buffer is fully flushed
-		if err := base.waitFlush(); err != nil {
-			return err
-		}
 		// Reset the layer tree with the single new disk layer
 		tree.layers = map[common.Hash]layer{
 			base.rootHash(): base,

--- a/triedb/pathdb/layertree_test.go
+++ b/triedb/pathdb/layertree_test.go
@@ -27,7 +27,7 @@ import (
 
 func newTestLayerTree() *layerTree {
 	db := New(rawdb.NewMemoryDatabase(), nil, false)
-	l := newDiskLayer(common.Hash{0x1}, 0, db, nil, nil, newBuffer(0, nil, nil, 0))
+	l := newDiskLayer(common.Hash{0x1}, 0, db, nil, nil, newBuffer(0, nil, nil, 0), nil)
 	t := newLayerTree(l)
 	return t
 }


### PR DESCRIPTION
Previously, PathDB used a single buffer to aggregate database writes, which needed to be flushed atomically. However, flushing large amounts of data (e.g., 256MB) caused significant overhead, often blocking the system for around 3 seconds during the flush.

To mitigate this overhead and reduce performance spikes, a double-buffer mechanism is introduced. When the active buffer fills up, it is marked as frozen and a background flushing process is triggered. Meanwhile, a new buffer is allocated for incoming writes, allowing operations to continue uninterrupted.

This approach reduces system blocking times and provides flexibility in adjusting buffer parameters for improved performance.

TODO:
- [ ] release the content in the frozen buffer after flushing