### PR TITLE
core/tracing, core/vm: add ContractCode to the OpContext

### DIFF
--- a/core/tracing/hooks.go
+++ b/core/tracing/hooks.go
@@ -34,6 +34,7 @@ type OpContext interface {
 	Address() common.Address
 	CallValue() *uint256.Int
 	CallInput() []byte
+	ContractCode() []byte
 }
 
 // StateDB gives tracers access to the whole state.

--- a/core/vm/interpreter.go
+++ b/core/vm/interpreter.go
@@ -83,6 +83,11 @@ func (ctx *ScopeContext) CallInput() []byte {
 	return ctx.Contract.Input
 }
 
+// ContractCode returns the code of the contract being executed.
+func (ctx *ScopeContext) ContractCode() []byte {
+	return ctx.Contract.Code
+}
+
 // EVMInterpreter represents an EVM interpreter
 type EVMInterpreter struct {
 	evm   *EVM


### PR DESCRIPTION
Extending the `OpContext` interface:
- adding `ContractCode` - returns the code of the contract being executed.

Previous implementation of tracing had access to the contract code in Scope, the current one does not. And it was important in the context of custom tracers(e.g., in my case 👀).

So in reference to the conversation on discord (#tracing channel), I add such functionality.

I tried to follow the current naming convention, lmk if i should fix/change something!