### PR TITLE
trie/utils: remove useless `SetZero` for verkle

### DIFF
--- a/trie/utils/verkle.go
+++ b/trie/utils/verkle.go
@@ -156,10 +156,6 @@ func GetTreeKey(address []byte, treeIndex *uint256.Int, subIndex byte) []byte {
 func GetTreeKeyWithEvaluatedAddress(evaluated *verkle.Point, treeIndex *uint256.Int, subIndex byte) []byte {
 	var poly [5]fr.Element
 
-	poly[0].SetZero()
-	poly[1].SetZero()
-	poly[2].SetZero()
-
 	// little-endian, 32-byte aligned treeIndex
 	var index [32]byte
 	for i := 0; i < len(treeIndex); i++ {
@@ -284,8 +280,6 @@ func evaluateAddressPoint(address []byte) *verkle.Point {
 		address = append(aligned[:32-len(address)], address...)
 	}
 	var poly [3]fr.Element
-
-	poly[0].SetZero()
 
 	// 32-byte address, interpreted as two little endian
 	// 16-byte numbers.


### PR DESCRIPTION
The default value of `fr.Element` is already zero, you can see the evidence in `go-verkle` here:

1. https://github.com/ethereum/go-verkle/blob/dffa7562dbe971a9776f43795d49177a18ecb5c8/tree.go#L273

2. https://github.com/ethereum/go-verkle/blob/dffa7562dbe971a9776f43795d49177a18ecb5c8/tree.go#L294

It doesn't call `SetZero` for those already zeroed `fr.Element`s.

