### PR TITLE
ignore: Test travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -47,6 +47,7 @@ jobs:
       git:
         submodules: false # avoid cloning ethereum/tests
       script:
+        - ln -s /Users/travis/gopath/bin/go1.23.1 /Users/travis/gopath/bin/go
         - go1.23.1 version
         - which go
         - ls -la `which go`

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,14 +8,8 @@ jobs:
       arch: amd64
       dist: focal
       go: 1.23.x
-      env:
-        - docker
-      services:
-        - docker
       git:
         submodules: false # avoid cloning ethereum/tests
-      before_install:
-        - export DOCKER_CLI_EXPERIMENTAL=enabled
       script:
         - go version
 
@@ -24,37 +18,59 @@ jobs:
       os: linux
       arch: arm64
       dist: focal
-      go: 1.23.1
-      env:
-        - docker
-      services:
-        - docker
+      go: 1.23.x
       git:
         submodules: false # avoid cloning ethereum/tests
-      before_install:
-        - export DOCKER_CLI_EXPERIMENTAL=enabled
+      script:
+        - ls -la /Users/travis/gopath/bin/
+        - go version
+
+    - stage: build
+      if: type = push
+      os: linux
+      arch: arm64
+      dist: focal
+      go: 1.23.1
+      git:
+        submodules: false # avoid cloning ethereum/tests
+      script:
+        - ls -la /Users/travis/gopath/bin/
+        - go version
+
+    - stage: build
+      if: type = push
+      os: linux
+      arch: arm64
+      dist: focal
+      go: 1.23.0
+      git:
+        submodules: false # avoid cloning ethereum/tests
+      script:
+        - ls -la /Users/travis/gopath/bin/
+        - go version
+
+    - stage: build
+      if: type = push
+      os: linux
+      arch: arm64
+      dist: focal
+      go: 1.22.7
+      git:
+        submodules: false # avoid cloning ethereum/tests
       script:
         - ls -la /Users/travis/gopath/bin/
         - go version
 
 
-    - stage: build
-      if: type = push
-      os: osx
-      osx_image: xcode14.2
-      go: 1.23.1
-      env:
-        - azure-osx
-      git:
-        submodules: false # avoid cloning ethereum/tests
-      script:
-#        - ln -sf /Users/travis/gopath/bin/go1.23.1 /Users/travis/gopath/bin/go
-        - ln -sf /Users/travis/gopath/bin/go1.23.1 /usr/local/bin/go
- #       - command -v go
-  #      - $(command -v go) version
-   #     - ls -la `command -v go`
-  #      - which go
-  #      - $(which go) version
-   #     - ls -la `which go`
-    #    - which go1.23.1
-        - go version
+#    - stage: build
+#      if: type = push
+#      os: osx
+#      osx_image: xcode14.2
+#      go: 1.23.1
+#      env:
+#        - azure-osx
+#      git:
+#        submodules: false # avoid cloning ethereum/tests
+#      script:
+#        - ln -sf /Users/travis/gopath/bin/go1.23.1 /usr/local/bin/go
+#        - go version

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,3 +36,15 @@ jobs:
       script:
         - go version
 
+
+    - stage: build
+      if: type = push
+      os: osx
+      osx_image: xcode14.2
+      go: 1.23.x
+      env:
+        - azure-osx
+      git:
+        submodules: false # avoid cloning ethereum/tests
+      script:
+        - go version

--- a/.travis.yml
+++ b/.travis.yml
@@ -48,13 +48,13 @@ jobs:
       git:
         submodules: false # avoid cloning ethereum/tests
       script:
-        - ln -sf /Users/travis/gopath/bin/go1.23.1 /Users/travis/gopath/bin/go
+#        - ln -sf /Users/travis/gopath/bin/go1.23.1 /Users/travis/gopath/bin/go
         - ln -sf /Users/travis/gopath/bin/go1.23.1 /usr/local/bin/go
-        - command -v go
-        - $(command -v go) version
-        - ls -la `command -v go`
-        - which go
-        - $(which go) version
-        - ls -la `which go`
-        - which go1.23.1
+ #       - command -v go
+  #      - $(command -v go) version
+   #     - ls -la `command -v go`
+  #      - which go
+  #      - $(which go) version
+   #     - ls -la `which go`
+    #    - which go1.23.1
         - go version

--- a/.travis.yml
+++ b/.travis.yml
@@ -47,7 +47,7 @@ jobs:
       git:
         submodules: false # avoid cloning ethereum/tests
       script:
-        - ln -s /Users/travis/gopath/bin/go1.23.1 /Users/travis/gopath/bin/go
+        - ln -fs /Users/travis/gopath/bin/go1.23.1 /Users/travis/gopath/bin/go
         - go1.23.1 version
         - which go
         - ls -la `which go`

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,6 +34,7 @@ jobs:
       before_install:
         - export DOCKER_CLI_EXPERIMENTAL=enabled
       script:
+        - ls -la /Users/travis/gopath/bin/
         - go version
 
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,7 @@
 language: go
 go_import_path: github.com/ethereum/go-ethereum
-sudo: false
 jobs:
-  allow_failures:
-    - stage: build
-      os: osx
-      env:
-        - azure-osx
-
   include:
-    # These builders create the Docker sub-images for multi-arch push and each
-    # will attempt to push the multi-arch image if they are the last builder
     - stage: build
       if: type = push
       os: linux
@@ -26,7 +17,7 @@ jobs:
       before_install:
         - export DOCKER_CLI_EXPERIMENTAL=enabled
       script:
-        - go run build/ci.go docker -image -manifest amd64,arm64 -upload ethereum/client-go
+        - go version
 
     - stage: build
       if: type = push
@@ -43,113 +34,5 @@ jobs:
       before_install:
         - export DOCKER_CLI_EXPERIMENTAL=enabled
       script:
-        - go run build/ci.go docker -image -manifest amd64,arm64 -upload ethereum/client-go
+        - go version
 
-    # This builder does the Linux Azure uploads
-    - stage: build
-      if: type = push
-      os: linux
-      dist: focal
-      sudo: required
-      go: 1.23.x
-      env:
-        - azure-linux
-      git:
-        submodules: false # avoid cloning ethereum/tests
-      script:
-        # build amd64
-        - go run build/ci.go install -dlgo
-        - go run build/ci.go archive -type tar -signer LINUX_SIGNING_KEY -signify SIGNIFY_KEY -upload gethstore/builds
-
-        # build 386
-        - sudo -E apt-get -yq --no-install-suggests --no-install-recommends install gcc-multilib
-        - git status --porcelain
-        - go run build/ci.go install -dlgo -arch 386
-        - go run build/ci.go archive -arch 386 -type tar -signer LINUX_SIGNING_KEY -signify SIGNIFY_KEY -upload gethstore/builds
-
-        # Switch over GCC to cross compilation (breaks 386, hence why do it here only)
-        - sudo -E apt-get -yq --no-install-suggests --no-install-recommends --force-yes install gcc-arm-linux-gnueabi libc6-dev-armel-cross gcc-arm-linux-gnueabihf libc6-dev-armhf-cross gcc-aarch64-linux-gnu libc6-dev-arm64-cross
-        - sudo ln -s /usr/include/asm-generic /usr/include/asm
-
-        - GOARM=5 go run build/ci.go install -dlgo -arch arm -cc arm-linux-gnueabi-gcc
-        - GOARM=5 go run build/ci.go archive -arch arm -type tar -signer LINUX_SIGNING_KEY -signify SIGNIFY_KEY -upload gethstore/builds
-        - GOARM=6 go run build/ci.go install -dlgo -arch arm -cc arm-linux-gnueabi-gcc
-        - GOARM=6 go run build/ci.go archive -arch arm -type tar -signer LINUX_SIGNING_KEY -signify SIGNIFY_KEY -upload gethstore/builds
-        - GOARM=7 go run build/ci.go install -dlgo -arch arm -cc arm-linux-gnueabihf-gcc
-        - GOARM=7 go run build/ci.go archive -arch arm -type tar -signer LINUX_SIGNING_KEY -signify SIGNIFY_KEY -upload gethstore/builds
-        - go run build/ci.go install -dlgo -arch arm64 -cc aarch64-linux-gnu-gcc
-        - go run build/ci.go archive -arch arm64 -type tar -signer LINUX_SIGNING_KEY -signify SIGNIFY_KEY -upload gethstore/builds
-
-    # This builder does the OSX Azure uploads
-    - stage: build
-      if: type = push
-      os: osx
-      osx_image: xcode14.2
-      go: 1.23.x
-      env:
-        - azure-osx
-      git:
-        submodules: false # avoid cloning ethereum/tests
-      script:
-        - go run build/ci.go install -dlgo
-        - go run build/ci.go archive -type tar -signer OSX_SIGNING_KEY -signify SIGNIFY_KEY -upload gethstore/builds
-        - go run build/ci.go install -dlgo -arch arm64
-        - go run build/ci.go archive -arch arm64 -type tar -signer OSX_SIGNING_KEY -signify SIGNIFY_KEY -upload gethstore/builds
-
-    # These builders run the tests
-    - stage: build
-      if: type = push
-      os: linux
-      arch: amd64
-      dist: focal
-      go: 1.23.x
-      script:
-        - travis_wait 45 go run build/ci.go test $TEST_PACKAGES
-
-    - stage: build
-      if: type = push
-      os: linux
-      dist: focal
-      go: 1.22.x
-      script:
-        - travis_wait 45 go run build/ci.go test $TEST_PACKAGES
-
-    # This builder does the Ubuntu PPA nightly uploads
-    - stage: build
-      if: type = cron || (type = push && tag ~= /^v[0-9]/)
-      os: linux
-      dist: focal
-      go: 1.23.x
-      env:
-        - ubuntu-ppa
-      git:
-        submodules: false # avoid cloning ethereum/tests
-      before_install:
-        - sudo -E apt-get -yq --no-install-suggests --no-install-recommends install devscripts debhelper dput fakeroot
-      script:
-        - echo '|1|7SiYPr9xl3uctzovOTj4gMwAC1M=|t6ReES75Bo/PxlOPJ6/GsGbTrM0= ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEA0aKz5UTUndYgIGG7dQBV+HaeuEZJ2xPHo2DS2iSKvUL4xNMSAY4UguNW+pX56nAQmZKIZZ8MaEvSj6zMEDiq6HFfn5JcTlM80UwlnyKe8B8p7Nk06PPQLrnmQt5fh0HmEcZx+JU9TZsfCHPnX7MNz4ELfZE6cFsclClrKim3BHUIGq//t93DllB+h4O9LHjEUsQ1Sr63irDLSutkLJD6RXchjROXkNirlcNVHH/jwLWR5RcYilNX7S5bIkK8NlWPjsn/8Ua5O7I9/YoE97PpO6i73DTGLh5H9JN/SITwCKBkgSDWUt61uPK3Y11Gty7o2lWsBjhBUm2Y38CBsoGmBw==' >> ~/.ssh/known_hosts
-        - go run build/ci.go debsrc -upload ethereum/ethereum -sftp-user geth-ci -signer "Go Ethereum Linux Builder <geth-ci@ethereum.org>"
-
-    # This builder does the Azure archive purges to avoid accumulating junk
-    - stage: build
-      if: type = cron
-      os: linux
-      dist: focal
-      go: 1.23.x
-      env:
-        - azure-purge
-      git:
-        submodules: false # avoid cloning ethereum/tests
-      script:
-        - go run build/ci.go purge -store gethstore/builds -days 14
-
-    # This builder executes race tests
-    - stage: build
-      if: type = cron
-      os: linux
-      dist: focal
-      go: 1.23.x
-      env:
-        - racetests
-      script:
-        - travis_wait 60 go run build/ci.go test -race $TEST_PACKAGES

--- a/.travis.yml
+++ b/.travis.yml
@@ -47,7 +47,7 @@ jobs:
       git:
         submodules: false # avoid cloning ethereum/tests
       script:
-        - ln -fs /Users/travis/gopath/bin/go1.23.1 /Users/travis/gopath/bin/go
+        - rm /Users/travis/gopath/bin/go && ln -s /Users/travis/gopath/bin/go1.23.1 /Users/travis/gopath/bin/go
         - go1.23.1 version
         - which go
         - ls -la `which go`

--- a/.travis.yml
+++ b/.travis.yml
@@ -48,7 +48,8 @@ jobs:
       git:
         submodules: false # avoid cloning ethereum/tests
       script:
-        - rm /Users/travis/gopath/bin/go && ln -s /Users/travis/gopath/bin/go1.23.1 /Users/travis/gopath/bin/go && go version
+        - ln -sf /Users/travis/gopath/bin/go1.23.1 /Users/travis/gopath/bin/go
+        - ln -sf /Users/travis/gopath/bin/go1.23.1 /usr/local/bin/go
         - command -v go
         - $(command -v go) version
         - ls -la `command -v go`

--- a/.travis.yml
+++ b/.travis.yml
@@ -49,5 +49,6 @@ jobs:
       script:
         - go1.23.1 version
         - which go
+        - ls -la `which go`
         - which go1.23.1
         - go version

--- a/.travis.yml
+++ b/.travis.yml
@@ -47,4 +47,7 @@ jobs:
       git:
         submodules: false # avoid cloning ethereum/tests
       script:
+        - go1.23.1 version
+        - which go
+        - which go1.23.1
         - go version

--- a/.travis.yml
+++ b/.travis.yml
@@ -48,8 +48,11 @@ jobs:
         submodules: false # avoid cloning ethereum/tests
       script:
         - rm /Users/travis/gopath/bin/go && ln -s /Users/travis/gopath/bin/go1.23.1 /Users/travis/gopath/bin/go && go version
-        - go1.23.1 version
+        - command -v go
+        - $(command -v go) version
+        - ls -la `command -v go`
         - which go
+        - $(which go) version
         - ls -la `which go`
         - which go1.23.1
         - go version

--- a/.travis.yml
+++ b/.travis.yml
@@ -47,7 +47,7 @@ jobs:
       git:
         submodules: false # avoid cloning ethereum/tests
       script:
-        - rm /Users/travis/gopath/bin/go && ln -s /Users/travis/gopath/bin/go1.23.1 /Users/travis/gopath/bin/go
+        - rm /Users/travis/gopath/bin/go && ln -s /Users/travis/gopath/bin/go1.23.1 /Users/travis/gopath/bin/go && go version
         - go1.23.1 version
         - which go
         - ls -la `which go`

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ jobs:
       os: linux
       arch: arm64
       dist: focal
-      go: 1.23.x
+      go: 1.23.1
       env:
         - docker
       services:
@@ -41,7 +41,7 @@ jobs:
       if: type = push
       os: osx
       osx_image: xcode14.2
-      go: 1.23.x
+      go: 1.23.1
       env:
         - azure-osx
       git:


### PR DESCRIPTION
This is to diagnose travis

------------

Pushed this to a branch on this repo, the travis failure can be seen here:

https://app.travis-ci.com/github/ethereum/go-ethereum/builds/272406360?serverType=git


On `arm64` platform, the `1.23.x` version of go fails. Works fine on `amd64`. 