### PR TITLE
core/state: sort deleted accounts for witness determinism

### DIFF
--- a/core/state/state_object.go
+++ b/core/state/state_object.go
@@ -20,6 +20,7 @@ import (
 	"bytes"
 	"fmt"
 	"maps"
+	"slices"
 	"time"
 
 	"github.com/ethereum/go-ethereum/common"
@@ -348,6 +349,9 @@ func (s *stateObject) updateTrie() (Trie, error) {
 		// Cache the items for preloading
 		used = append(used, common.CopyBytes(key[:])) // Copy needed for closure
 	}
+	// Perform deletes in sorted order to make the touched trie nodes deterministic
+	slices.SortFunc(deletions, func(a, b common.Hash) int { return bytes.Compare(a[:], b[:]) })
+
 	for _, key := range deletions {
 		if err := tr.DeleteStorage(s.address, key[:]); err != nil {
 			s.db.setError(err)

--- a/core/state/statedb.go
+++ b/core/state/statedb.go
@@ -18,6 +18,7 @@
 package state
 
 import (
+	"bytes"
 	"errors"
 	"fmt"
 	"maps"
@@ -895,6 +896,9 @@ func (s *StateDB) IntermediateRoot(deleteEmptyObjects bool) common.Hash {
 		}
 		usedAddrs = append(usedAddrs, common.CopyBytes(addr[:])) // Copy needed for closure
 	}
+	// Perform deletes in sorted order to make the touched trie nodes deterministic
+	slices.SortFunc(deletedAddrs, func(a, b common.Address) int { return bytes.Compare(a[:], b[:]) })
+
 	for _, deletedAddr := range deletedAddrs {
 		s.deleteStateObject(deletedAddr)
 		s.AccountDeleted += 1


### PR DESCRIPTION
We've made inserts happen before deletes to keep the witness deterministic, but there seems to be also a similar issue happening depending on the deletion order with the expanded child trie nodes. This PR makes the deletion order sorted so witnesses across clients will behave the same.