### PR TITLE
beacon/light: optimize lock usage in `HeadTracker`

### DIFF
--- a/beacon/light/head_tracker.go
+++ b/beacon/light/head_tracker.go
@@ -69,12 +69,13 @@ func (h *HeadTracker) ValidatedFinality() (types.FinalityUpdate, bool) {
 // slot or same slot and more signers) then ValidatedOptimistic is updated.
 // The boolean return flag signals if ValidatedOptimistic has been changed.
 func (h *HeadTracker) ValidateOptimistic(update types.OptimisticUpdate) (bool, error) {
-	h.lock.Lock()
-	defer h.lock.Unlock()
-
 	if err := update.Validate(); err != nil {
 		return false, err
 	}
+
+	h.lock.Lock()
+	defer h.lock.Unlock()
+
 	replace, err := h.validate(update.SignedHeader(), h.optimisticUpdate.SignedHeader())
 	if replace {
 		h.optimisticUpdate, h.hasOptimisticUpdate = update, true
@@ -88,12 +89,13 @@ func (h *HeadTracker) ValidateOptimistic(update types.OptimisticUpdate) (bool, e
 // slot or same slot and more signers) then ValidatedFinality is updated.
 // The boolean return flag signals if ValidatedFinality has been changed.
 func (h *HeadTracker) ValidateFinality(update types.FinalityUpdate) (bool, error) {
-	h.lock.Lock()
-	defer h.lock.Unlock()
-
 	if err := update.Validate(); err != nil {
 		return false, err
 	}
+
+	h.lock.Lock()
+	defer h.lock.Unlock()
+
 	replace, err := h.validate(update.SignedHeader(), h.finalityUpdate.SignedHeader())
 	if replace {
 		h.finalityUpdate, h.hasFinalityUpdate = update, true


### PR DESCRIPTION
`update.Validate()` can be called before grabbing the lock.