### PR TITLE
travis: work around travis/osx/go1.23 setup bug

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -91,6 +91,7 @@ jobs:
       git:
         submodules: false # avoid cloning ethereum/tests
       script:
+        - ln -sf /Users/travis/gopath/bin/go1.23.1 /usr/local/bin/go # Work around travis go-setup bug
         - go run build/ci.go install -dlgo
         - go run build/ci.go archive -type tar -signer OSX_SIGNING_KEY -signify SIGNIFY_KEY -upload gethstore/builds
         - go run build/ci.go install -dlgo -arch arm64


### PR DESCRIPTION
This is a work-around for a strange issue with travis, specifically, `os=osx, go: 1.23.1`. When this is used, the actual go that ends up being used is `go1.19.4 darwin/amd64 `. 

Using `which go`, it told me that the `go` in the path was a softlink at `/Users/travis/gopath/bin/go1.23.1  `. However, this was not true: using `command -v go`, it told me that the actual `go` that was used is a softlink at  `/usr/local/bin/go`. 

This change rewrites the `/usr/local/bin/go` softlink to point to the binary at `/Users/travis/gopath/bin/go1.23.1`, so we get the right go-version. 