### PR TITLE
core/state: commit snapshot only if the base layer exists

### DIFF
--- a/core/state/statedb.go
+++ b/core/state/statedb.go
@@ -1265,7 +1265,7 @@ func (s *StateDB) commitAndFlush(block uint64, deleteEmptyObjects bool) (*stateU
 	}
 	if !ret.empty() {
 		// If snapshotting is enabled, update the snapshot tree with this new version
-		if snap := s.db.Snapshot(); snap != nil {
+		if snap := s.db.Snapshot(); snap != nil && snap.Snapshot(ret.originRoot) != nil {
 			start := time.Now()
 			if err := snap.Update(ret.root, ret.originRoot, ret.destructs, ret.accounts, ret.storages); err != nil {
 				log.Warn("Failed to update snapshot tree", "from", ret.originRoot, "to", ret.root, "err", err)


### PR DESCRIPTION
This pull request skips the state snapshot update if the base layer is not existent, 
eliminating the numerous warning logs after an unclean shutdown.

Specifically, Geth will rewind its chain head to a historical block after unclean shutdown
and state snapshot will be remained as unchanged waiting for recovery. During this 
period of time, the snapshot is unusable and all state updates should be ignored/skipped
for state snapshot update. This pull request fixes this "flaw".

The warning logs:

```
^[[33mWARN ^[[0m[09-23|10:18:48.379] Failed to update snapshot tree           ^[[33mfrom^[[0m=6f23c3..2d5e28 ^[[33mto^[[0m=e07088..376d9e ^[[33merr^[[0m="parent [0x6f23c30f2a9a4ec370baace9d3c05f974009e1dae8d1a3af5f8644a2ad2d5e28] snapshot missing"
^[[33mWARN ^[[0m[09-23|10:18:48.379] Failed to cap snapshot tree              ^[[33mroot^[[0m=e07088..376d9e ^[[33mlayers^[[0m=128 ^[[33merr^[[0m="snapshot [0xe070887f8cf08a895bbac73310cbf4ece8525e92c0203c717ef2d59142376d9e] missing"
^[[33mWARN ^[[0m[09-23|10:18:48.534] Failed to update snapshot tree           ^[[33mfrom^[[0m=e07088..376d9e ^[[33mto^[[0m=70fb7b..970c0f ^[[33merr^[[0m="parent [0xe070887f8cf08a895bbac73310cbf4ece8525e92c0203c717ef2d59142376d9e] snapshot missing"
^[[33mWARN ^[[0m[09-23|10:18:48.534] Failed to cap snapshot tree              ^[[33mroot^[[0m=70fb7b..970c0f ^[[33mlayers^[[0m=128 ^[[33merr^[[0m="snapshot [0x70fb7bae4720b63735759f1236bd2ed8305a89d308a5752edf8a618be3970c0f] missing"
^[[33mWARN ^[[0m[09-23|10:18:48.726] Failed to update snapshot tree           ^[[33mfrom^[[0m=70fb7b..970c0f ^[[33mto^[[0m=2875a5..99a820 ^[[33merr^[[0m="parent [0x70fb7bae4720b63735759f1236bd2ed8305a89d308a5752edf8a618be3970c0f] snapshot missing"
^[[33mWARN ^[[0m[09-23|10:18:48.726] Failed to cap snapshot tree              ^[[33mroot^[[0m=2875a5..99a820 ^[[33mlayers^[[0m=128 ^[[33merr^[[0m="snapshot [0x2875a54a86ea10be1ced8d89573e7ebfbe7b263dcc137930af2a70b84799a820] missing"
^[[33mWARN ^[[0m[09-23|10:18:48.868] Failed to update snapshot tree           ^[[33mfrom^[[0m=2875a5..99a820 ^[[33mto^[[0m=324399..1ec161 ^[[33merr^[[0m="parent [0x2875a54a86ea10be1ced8d89573e7ebfbe7b263dcc137930af2a70b84799a820] snapshot missing"
^[[33mWARN ^[[0m[09-23|10:18:48.868] Failed to cap snapshot tree              ^[[33mroot^[[0m=324399..1ec161 ^[[33mlayers^[[0m=128 ^[[33merr^[[0m="snapshot [0x324399a755597f7bbc4b456b8c5ca18c22bbcedd6fa51e2938fb7d345f1ec161] missing"
^[[33mWARN ^[[0m[09-23|10:18:49.048] Failed to update snapshot tree           ^[[33mfrom^[[0m=324399..1ec161 ^[[33mto^[[0m=676fad..a7c5cb ^[[33merr^[[0m="parent [0x324399a755597f7bbc4b456b8c5ca18c22bbcedd6fa51e2938fb7d345f1ec161] snapshot missing"
^[[33mWARN ^[[0m[09-23|10:18:49.048] Failed to cap snapshot tree              ^[[33mroot^[[0m=676fad..a7c5cb ^[[33mlayers^[[0m=128 ^[[33merr^[[0m="snapshot [0x676fad834d78ee9781f38faff89c5a546fd254f80102d1486f824ac711a7c5cb] missing"
^[[33mWARN ^[[0m[09-23|10:18:49.228] Failed to update snapshot tree           ^[[33mfrom^[[0m=676fad..a7c5cb ^[[33mto^[[0m=c3454a..0097f0 ^[[33merr^[[0m="parent [0x676fad834d78ee9781f38faff89c5a546fd254f80102d1486f824ac711a7c5cb] snapshot missing"
^[[33mWARN ^[[0m[09-23|10:18:49.228] Failed to cap snapshot tree              ^[[33mroot^[[0m=c3454a..0097f0 ^[[33mlayers^[[0m=128 ^[[33merr^[[0m="snapshot [0xc3454a98a9aa676915f934d1d6d02e16497bb3dae52ae2f4d2cc9b38870097f0] missing"
```



