### PR TITLE
core/rawdb: make sure specified state scheme is valid

### DIFF
--- a/core/rawdb/accessors_trie.go
+++ b/core/rawdb/accessors_trie.go
@@ -302,6 +302,10 @@ func ParseStateScheme(provided string, disk ethdb.Database) (string, error) {
 		log.Info("State scheme set to already existing", "scheme", stored)
 		return stored, nil // reuse scheme of persistent scheme
 	}
+	// If state scheme is specified, ensure it's valid.
+	if provided != HashScheme && provided != PathScheme {
+		return "", fmt.Errorf("invalid state scheme %s", provided)
+	}
 	// If state scheme is specified, ensure it's compatible with
 	// persistent state.
 	if stored == "" || provided == stored {


### PR DESCRIPTION
When first start `geth` with the flags:

export FLAGS="--state.scheme=path --syncmode=full"
geth
...
  --authrpc.addr=0.0.0.0 \
  --authrpc.jwtsecret=/geth/jwt.hex \
  --allow-insecure-unlock \
  --state.scheme=path \
  "$FLAGS"

This is the illegal log message, and then `geth` can normally start:
`State scheme set by user                 scheme="path --syncmode=full"`

Finally, `geth` started with `snap` sync mode and `hash` state scheme, it's not what I want.