### PR TITLE
p2p/discover: fix flaky test which wrote to test.log after completion

### DIFF
--- a/p2p/discover/v4_lookup_test.go
+++ b/p2p/discover/v4_lookup_test.go
@@ -68,7 +68,11 @@ func TestUDPv4_Lookup(t *testing.T) {
 func TestUDPv4_LookupIterator(t *testing.T) {
 	t.Parallel()
 	test := newUDPTest(t)
-	defer test.close()
+	var wg sync.WaitGroup
+	defer func() {
+		test.close()
+		wg.Wait()
+	}()
 
 	// Seed table with initial nodes.
 	bootnodes := make([]*enode.Node, len(lookupTestnet.dists[256]))
@@ -76,7 +80,6 @@ func TestUDPv4_LookupIterator(t *testing.T) {
 		bootnodes[i] = lookupTestnet.node(256, i)
 	}
 	fillTable(test.table, bootnodes, true)
-	var wg sync.WaitGroup
 	wg.Add(1)
 	go func() {
 		serveTestnet(test, lookupTestnet)
@@ -101,8 +104,6 @@ func TestUDPv4_LookupIterator(t *testing.T) {
 	if err := checkNodesEqual(results, want); err != nil {
 		t.Fatal(err)
 	}
-	test.close()
-	wg.Wait()
 }
 
 // TestUDPv4_LookupIteratorClose checks that lookupIterator ends when its Close
@@ -110,7 +111,11 @@ func TestUDPv4_LookupIterator(t *testing.T) {
 func TestUDPv4_LookupIteratorClose(t *testing.T) {
 	t.Parallel()
 	test := newUDPTest(t)
-	defer test.close()
+	var wg sync.WaitGroup
+	defer func() {
+		test.close()
+		wg.Wait()
+	}()
 
 	// Seed table with initial nodes.
 	bootnodes := make([]*enode.Node, len(lookupTestnet.dists[256]))
@@ -119,7 +124,6 @@ func TestUDPv4_LookupIteratorClose(t *testing.T) {
 	}
 	fillTable(test.table, bootnodes, true)
 
-	var wg sync.WaitGroup
 	wg.Add(1)
 	go func() {
 		serveTestnet(test, lookupTestnet)
@@ -146,8 +150,6 @@ func TestUDPv4_LookupIteratorClose(t *testing.T) {
 	if n := it.Node(); n != nil {
 		t.Errorf("iterator returned non-nil node after close and %d more calls", ncalls)
 	}
-	test.close()
-	wg.Wait()
 }
 
 func serveTestnet(test *udpTest, testnet *preminedTestnet) {

--- a/p2p/enode/nodedb.go
+++ b/p2p/enode/nodedb.go
@@ -496,6 +496,10 @@ func nextNode(it iterator.Iterator) *Node {
 
 // Close flushes and closes the database files.
 func (db *DB) Close() {
-	close(db.quit)
+	select {
+	case <-db.quit: // already closed
+	default:
+		close(db.quit)
+	}
 	db.lvl.Close()
 }


### PR DESCRIPTION
This PR fixes two tests, which had a tendency to sometimes write to the `*testing.T` `log` facility. This is considered a major breach of etiquette by `golang`.  This PR fixes it by using waitgroups to ensure that the handler/logwriter terminates before the test exits. 

closes #30505