### PR TITLE
p2p/discover: add config option for disabling FINDNODE liveness check

### DIFF
--- a/p2p/discover/common.go
+++ b/p2p/discover/common.go
@@ -53,9 +53,10 @@ type Config struct {
 	Unhandled   chan<- ReadPacket // unhandled packets are sent on this channel
 
 	// Node table configuration:
-	Bootnodes       []*enode.Node // list of bootstrap nodes
-	PingInterval    time.Duration // speed of node liveness check
-	RefreshInterval time.Duration // used in bucket refresh
+	Bootnodes               []*enode.Node // list of bootstrap nodes
+	PingInterval            time.Duration // speed of node liveness check
+	RefreshInterval         time.Duration // used in bucket refresh
+	NoFindnodeLivenessCheck bool          // turns off validation of table nodes in FINDNODE handler
 
 	// The options below are useful in very specific cases, like in unit tests.
 	V5ProtocolID *[6]byte

--- a/p2p/discover/table.go
+++ b/p2p/discover/table.go
@@ -268,9 +268,9 @@ func (tab *Table) findnodeByID(target enode.ID, nresults int, preferLive bool) *
 	return nodes
 }
 
-// appendLiveNodes adds nodes at the given distance to the result slice.
+// appendBucketNodes adds nodes at the given distance to the result slice.
 // This is used by the FINDNODE/v5 handler.
-func (tab *Table) appendLiveNodes(dist uint, result []*enode.Node) []*enode.Node {
+func (tab *Table) appendBucketNodes(dist uint, result []*enode.Node, checkLive bool) []*enode.Node {
 	if dist > 256 {
 		return result
 	}
@@ -280,7 +280,7 @@ func (tab *Table) appendLiveNodes(dist uint, result []*enode.Node) []*enode.Node
 
 	tab.mutex.Lock()
 	for _, n := range tab.bucketAtDistance(int(dist)).entries {
-		if n.isValidatedLive {
+		if !checkLive || n.isValidatedLive {
 			result = append(result, n.Node)
 		}
 	}

--- a/p2p/discover/v4_udp.go
+++ b/p2p/discover/v4_udp.go
@@ -746,7 +746,8 @@ func (t *UDPv4) handleFindnode(h *packetHandlerV4, from netip.AddrPort, fromID e
 
 	// Determine closest nodes.
 	target := enode.ID(crypto.Keccak256Hash(req.Target[:]))
-	closest := t.tab.findnodeByID(target, bucketSize, true).entries
+	preferLive := !t.tab.cfg.NoFindnodeLivenessCheck
+	closest := t.tab.findnodeByID(target, bucketSize, preferLive).entries
 
 	// Send neighbors in chunks with at most maxNeighbors per packet
 	// to stay below the packet size limit.

--- a/p2p/discover/v5_udp.go
+++ b/p2p/discover/v5_udp.go
@@ -862,7 +862,8 @@ func (t *UDPv5) collectTableNodes(rip netip.Addr, distances []uint, limit int) [
 		}
 		processed[dist] = struct{}{}
 
-		for _, n := range t.tab.appendLiveNodes(dist, bn[:0]) {
+		checkLive := !t.tab.cfg.NoFindnodeLivenessCheck
+		for _, n := range t.tab.appendBucketNodes(dist, bn[:0], checkLive) {
 			// Apply some pre-checks to avoid sending invalid nodes.
 			// Note liveness is checked by appendLiveNodes.
 			if netutil.CheckRelayAddr(rip, n.IPAddr()) != nil {


### PR DESCRIPTION
This is for fixing Prysm integration tests.