### PR TITLE
core/txpool/blobpool: return all reinject-addresses

### DIFF
--- a/core/txpool/blobpool/blobpool.go
+++ b/core/txpool/blobpool/blobpool.go
@@ -949,9 +949,7 @@ func (p *BlobPool) reorg(oldHead, newHead *types.Header) (map[common.Address][]*
 				lost = append(lost, tx)
 			}
 		}
-		if len(lost) > 0 {
-			reinject[addr] = lost
-		}
+		reinject[addr] = lost
 
 		// Update the set that was already reincluded to track the blocks in limbo
 		for _, tx := range types.TxDifference(included[addr], discarded[addr]) {


### PR DESCRIPTION
This PR reverts part of #30437. 

I failed to take note of this at the time, but now I am unsure if the "avoid reinject adding empty value" part was correct. 

Previously, `reinject` would contains an empty list for the address `addr`, and the blobpool Reset function would then call `p.recheck` on that `addr`

```golang
	if reinject, inclusions := p.reorg(oldHead, newHead); reinject != nil {
		var adds []*types.Transaction
		for addr, txs := range reinject {
			// Blindly push all the lost transactions back into the pool
			for _, tx := range txs {
				if err := p.reinject(addr, tx.Hash()); err == nil {
					adds = append(adds, tx.WithoutBlobTxSidecar())
				}
			}
			// Recheck the account's pooled transactions to drop included and
			// invalidated ones
			p.recheck(addr, inclusions)
		}
		if len(adds) > 0 {
			p.insertFeed.Send(core.NewTxsEvent{Txs: adds})
		}
	}
```
I think the new code is wrong: it may very well happen that we reorg out a transaction, but it is _not_ eligible for re-injection, because the filtering fails: 
```golang
			if p.Filter(tx) {
				lost = append(lost, tx)
			}
```

```golang
// Filter returns whether the given transaction can be consumed by the blob pool.
func (p *BlobPool) Filter(tx *types.Transaction) bool {
	return tx.Type() == types.BlobTxType
}

```
That is: we reorg-out a regular transaction, it is not eligible for re-injection (in the blob pool), and thus the blob pool becomes off: it's should have invoked `recheck` on the account. 

-------------

This PR restores the earlier behaviour. I'm still not 100% sure which is correct, opening for discussion. 
