### PR TITLE
eth/tracers: do system contract processing prior to parallel-tracing 

### DIFF
--- a/eth/tracers/api.go
+++ b/eth/tracers/api.go
@@ -603,6 +603,17 @@ func (api *API) traceBlock(ctx context.Context, block *types.Block, config *Trac
 		return nil, err
 	}
 	defer release()
+
+	blockCtx := core.NewEVMBlockContext(block.Header(), api.chainContext(ctx), nil)
+	if beaconRoot := block.BeaconRoot(); beaconRoot != nil {
+		vmenv := vm.NewEVM(blockCtx, vm.TxContext{}, statedb, api.backend.ChainConfig(), vm.Config{})
+		core.ProcessBeaconBlockRoot(*beaconRoot, vmenv, statedb)
+	}
+	if api.backend.ChainConfig().IsPrague(block.Number(), block.Time()) {
+		vmenv := vm.NewEVM(blockCtx, vm.TxContext{}, statedb, api.backend.ChainConfig(), vm.Config{})
+		core.ProcessParentBlockHash(block.ParentHash(), vmenv, statedb)
+	}
+
 	// JS tracers have high overhead. In this case run a parallel
 	// process that generates states in one thread and traces txes
 	// in separate worker threads.
@@ -615,18 +626,9 @@ func (api *API) traceBlock(ctx context.Context, block *types.Block, config *Trac
 	var (
 		txs       = block.Transactions()
 		blockHash = block.Hash()
-		blockCtx  = core.NewEVMBlockContext(block.Header(), api.chainContext(ctx), nil)
 		signer    = types.MakeSigner(api.backend.ChainConfig(), block.Number(), block.Time())
 		results   = make([]*txTraceResult, len(txs))
 	)
-	if beaconRoot := block.BeaconRoot(); beaconRoot != nil {
-		vmenv := vm.NewEVM(blockCtx, vm.TxContext{}, statedb, api.backend.ChainConfig(), vm.Config{})
-		core.ProcessBeaconBlockRoot(*beaconRoot, vmenv, statedb)
-	}
-	if api.backend.ChainConfig().IsPrague(block.Number(), block.Time()) {
-		vmenv := vm.NewEVM(blockCtx, vm.TxContext{}, statedb, api.backend.ChainConfig(), vm.Config{})
-		core.ProcessParentBlockHash(block.ParentHash(), vmenv, statedb)
-	}
 	for i, tx := range txs {
 		// Generate the next state snapshot fast without tracing
 		msg, _ := core.TransactionToMessage(tx, signer, block.BaseFee())
@@ -654,20 +656,9 @@ func (api *API) traceBlockParallel(ctx context.Context, block *types.Block, stat
 		txs       = block.Transactions()
 		blockHash = block.Hash()
 		signer    = types.MakeSigner(api.backend.ChainConfig(), block.Number(), block.Time())
-		blockCtx  = core.NewEVMBlockContext(block.Header(), api.chainContext(ctx), nil)
 		results   = make([]*txTraceResult, len(txs))
 		pend      sync.WaitGroup
 	)
-
-	if beaconRoot := block.BeaconRoot(); beaconRoot != nil {
-		vmenv := vm.NewEVM(blockCtx, vm.TxContext{}, statedb, api.backend.ChainConfig(), vm.Config{})
-		core.ProcessBeaconBlockRoot(*beaconRoot, vmenv, statedb)
-	}
-	if api.backend.ChainConfig().IsPrague(block.Number(), block.Time()) {
-		vmenv := vm.NewEVM(blockCtx, vm.TxContext{}, statedb, api.backend.ChainConfig(), vm.Config{})
-		core.ProcessParentBlockHash(block.ParentHash(), vmenv, statedb)
-	}
-
 	threads := runtime.NumCPU()
 	if threads > len(txs) {
 		threads = len(txs)


### PR DESCRIPTION
### Description

`debug_traceBlockByNumber` may return incorrect result on some blocks, with JS tracers.
This PR tries to fix it.

`traceBlockParallel` does not apply `ProcessBeaconBlockRoot` and `ProcessParentBlockHash`  before executing block's transactions, which may cause some transactions trace to report unexpected reverted errors.

### Case
request

```
{
    "method": "debug_traceBlockByNumber",
    "params": [
        "0x128c38d",
        {
            "tracer": "callTracerLegacy"
        }
    ],
    "id": 1,
    "jsonrpc": "2.0"
}
```

In response, tx [`0x8236b9e4749102df80e43130d7df505cb7e9b3036c2fa8759867b5fbbf837370`](https://etherscan.io/tx/0x8236b9e4749102df80e43130d7df505cb7e9b3036c2fa8759867b5fbbf837370) would show `"error": "execution reverted"`, that's wrong.
```
{
            "txHash": "0x8236b9e4749102df80e43130d7df505cb7e9b3036c2fa8759867b5fbbf837370",
            "result": {
                "type": "CALL",
                "from": "0xb4f1e5db68512f06d378b5e02e7ebbe7d2c705ef",
                "to": "0x5c44f2d7545fdd7a2a91513286aac71194d0f5d7",
                "value": "0x0",
                "gas": "0x7045",
                "gasUsed": "0x66c6",
                "input": "0x00",
                "output": "0x08c379a0000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000016600000000000000000000000000000000000000000000000000000000000000",
                "error": "execution reverted",
                "calls": [
                    {
                        "type": "CALL",
                        "from": "0x5c44f2d7545fdd7a2a91513286aac71194d0f5d7",
                        "to": "0x000f3df6d732807ef1319fb7b8bb8522d0beac02",
                        "value": "0x0",
                        "gas": "0x127a",
                        "gasUsed": "0x89c",
                        "input": "0x0000000000000000000000000000000000000000000000000000000065f5cc67",
                        "error": "execution reverted"
                    }
                ]
            }
        }
```

Expected result
```
{
            "txHash": "0x8236b9e4749102df80e43130d7df505cb7e9b3036c2fa8759867b5fbbf837370",
            "result": {
                "from": "0xb4f1e5db68512f06d378b5e02e7ebbe7d2c705ef",
                "gas": "0x7045",
                "gasUsed": "0x6eea",
                "to": "0x5c44f2d7545fdd7a2a91513286aac71194d0f5d7",
                "input": "0x00",
                "calls": [
                    {
                        "from": "0x5c44f2d7545fdd7a2a91513286aac71194d0f5d7",
                        "gas": "0x127a",
                        "gasUsed": "0x10e0",
                        "to": "0x000f3df6d732807ef1319fb7b8bb8522d0beac02",
                        "input": "0x0000000000000000000000000000000000000000000000000000000065f5cc67",
                        "output": "0x210595812d9b27c3ca7e0e1b5ac186733110293e2d207a44e3416a7af3f48226",
                        "value": "0x0",
                        "type": "CALL"
                    }
                ],
                "value": "0x0",
                "type": "CALL"
            }
        }
```