### PR TITLE
build: wip use buildx to build multi-platform docker images

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,8 +9,7 @@ jobs:
         - azure-osx
 
   include:
-    # These builders create the Docker sub-images for multi-arch push and each
-    # will attempt to push the multi-arch image if they are the last builder
+    # This builder create and push the Docker images for all architectures
     - stage: build
       if: type = push
       os: linux
@@ -26,24 +25,7 @@ jobs:
       before_install:
         - export DOCKER_CLI_EXPERIMENTAL=enabled
       script:
-        - go run build/ci.go docker -image -manifest amd64,arm64 -upload ethereum/client-go
-
-    - stage: build
-      if: type = push
-      os: linux
-      arch: arm64
-      dist: focal
-      go: 1.23.x
-      env:
-        - docker
-      services:
-        - docker
-      git:
-        submodules: false # avoid cloning ethereum/tests
-      before_install:
-        - export DOCKER_CLI_EXPERIMENTAL=enabled
-      script:
-        - go run build/ci.go docker -image -manifest amd64,arm64 -upload ethereum/client-go
+        - go run build/ci.go dockerx -manifest amd64,arm64 -upload ethereum/client-gox
 
     # This builder does the Linux Azure uploads
     - stage: build


### PR DESCRIPTION
This is a work in progress of a `buildx`-based docker image creator. Our current builder is very complicated: 
- Use multiple builders, on different platforms (arm vs amd). 
- They build and push their own native platform
- One of them (random which, decided by a race) generates a `manifest` image, which basically says "stable == stable-amd64 and/or stable/amd64". 

With docker [buildx](https://docs.docker.com/reference/cli/docker/buildx/), we can build all archs in one go. 

If I run this on `master` (to disable the `maybeSkipArchive`), and set `DryRun` to true  in `util.go` and execute, these are the actions it _would_ have attempted:  

```
[user@work go-ethereum]$ go run build/ci.go dockerx  -manifest amd64,arm64 -upload ethereum/client-go 
>>> docker buildx --build-arg COMMIT=283be238172c8ae3a05f97e2f3c159f5c2319e07 --build-arg VERSION=1.14.11-unstable --build-arg BUILDNUM= --tag ethereum/client-go:latest-amd64 --platform amd64 --load --push --file Dockerfile .
>>> docker buildx --build-arg COMMIT=283be238172c8ae3a05f97e2f3c159f5c2319e07 --build-arg VERSION=1.14.11-unstable --build-arg BUILDNUM= --tag ethereum/client-go:latest-arm64 --platform arm64 --load --push --file Dockerfile .
>>> docker buildx imagetools create --tag ethereum/client-go:latest ethereum/client-go:latest-amd64 ethereum/client-go:latest-arm64
>>> docker buildx --build-arg COMMIT=283be238172c8ae3a05f97e2f3c159f5c2319e07 --build-arg VERSION=1.14.11-unstable --build-arg BUILDNUM= --tag ethereum/client-go:alltools-latest-amd64 --platform amd64 --load --push --file Dockerfile.alltools .
>>> docker buildx --build-arg COMMIT=283be238172c8ae3a05f97e2f3c159f5c2319e07 --build-arg VERSION=1.14.11-unstable --build-arg BUILDNUM= --tag ethereum/client-go:alltools-latest-arm64 --platform arm64 --load --push --file Dockerfile.alltools .
>>> docker buildx imagetools create --tag ethereum/client-go:alltools-latest ethereum/client-go:alltools-latest-amd64 ethereum/client-go:alltools-latest-arm64
```
Now, this is a bit gnarly to experiment with on travis, and I also don't want to bork the existing images.  So maybe I'll just push to a new tag, e.g., instead of `ethereum/client-go`, we could use `ethereum/client-gox` until it works?  