### PR TITLE
core/tracing: add GetTransientState method to StateDB interface for accessing transient state data

### DIFF
--- a/core/tracing/hooks.go
+++ b/core/tracing/hooks.go
@@ -43,6 +43,7 @@ type StateDB interface {
 	GetNonce(common.Address) uint64
 	GetCode(common.Address) []byte
 	GetState(common.Address, common.Hash) common.Hash
+	GetTransientState(common.Address, common.Hash) common.Hash
 	Exist(common.Address) bool
 	GetRefund() uint64
 }


### PR DESCRIPTION
The previous tracing implementation gave access to `TransientState`, in the current one is missing, so I extended the interface. I checked and no hooks collect it. 

This gives the ability to analyze the transient state for custom tracers (e.g. mine). 