### PR TITLE
internal/ethapi:  Set basefee for `AccessList` based on given block, not chain tip

### DIFF
--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -1642,7 +1642,6 @@ func AccessList(ctx context.Context, b Backend, blockNrOrHash rpc.BlockNumberOrH
 	} else {
 		to = crypto.CreateAddress(args.from(), uint64(*args.Nonce))
 	}
-	fmt.Printf("nonce %d\nto %x\n", *args.Nonce, to)
 	isPostMerge := header.Difficulty.Sign() == 0
 	// Retrieve the precompiles since they don't need to be added to the access list
 	precompiles := vm.ActivePrecompiles(b.ChainConfig().Rules(header.Number, isPostMerge, header.Time))

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -1627,15 +1627,8 @@ func AccessList(ctx context.Context, b Backend, blockNrOrHash rpc.BlockNumberOrH
 		return nil, 0, nil, err
 	}
 
-	// Ensure any missing fields are filled, extract the recipient and input data
-	if err := args.setDefaults(ctx, b, true); err != nil {
-		return nil, 0, nil, err
-	}
-
-	// Set dynamic fee fields to 0 to avoid validation checks during execution.
-	// These are irrelevant to calculation of access lists and gas cost.
-	args.MaxFeePerGas = new(hexutil.Big)
-	args.MaxPriorityFeePerGas = new(hexutil.Big)
+	blockCtx := core.NewEVMBlockContext(header, NewChainContext(ctx, b), nil)
+	args.CallDefaults(b.RPCGasCap(), blockCtx.BaseFee, b.ChainConfig().ChainID)
 
 	var to common.Address
 	if args.To != nil {

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -1627,6 +1627,7 @@ func AccessList(ctx context.Context, b Backend, blockNrOrHash rpc.BlockNumberOrH
 		return nil, 0, nil, err
 	}
 
+	// fill in missing fields based on the state at the specified block
 	if args.Nonce == nil {
 		nonce := hexutil.Uint64(db.GetNonce(args.from()))
 		args.Nonce = &nonce
@@ -1635,7 +1636,6 @@ func AccessList(ctx context.Context, b Backend, blockNrOrHash rpc.BlockNumberOrH
 	if err := args.CallDefaults(b.RPCGasCap(), blockCtx.BaseFee, b.ChainConfig().ChainID); err != nil {
 		return types.AccessList{}, 0, nil, err
 	}
-
 	var to common.Address
 	if args.To != nil {
 		to = *args.To

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -1627,15 +1627,19 @@ func AccessList(ctx context.Context, b Backend, blockNrOrHash rpc.BlockNumberOrH
 		return nil, 0, nil, err
 	}
 
-	// fill in missing fields based on the state at the specified block
+	// Ensure any missing fields are filled, extract the recipient and input data
+	if err = args.setFeeDefaults(ctx, b, header); err != nil {
+		return nil, 0, nil, err
+	}
 	if args.Nonce == nil {
 		nonce := hexutil.Uint64(db.GetNonce(args.from()))
 		args.Nonce = &nonce
 	}
 	blockCtx := core.NewEVMBlockContext(header, NewChainContext(ctx, b), nil)
-	if err := args.CallDefaults(b.RPCGasCap(), blockCtx.BaseFee, b.ChainConfig().ChainID); err != nil {
-		return types.AccessList{}, 0, nil, err
+	if err = args.CallDefaults(b.RPCGasCap(), blockCtx.BaseFee, b.ChainConfig().ChainID); err != nil {
+		return nil, 0, nil, err
 	}
+
 	var to common.Address
 	if args.To != nil {
 		to = *args.To

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -1631,6 +1631,12 @@ func AccessList(ctx context.Context, b Backend, blockNrOrHash rpc.BlockNumberOrH
 	if err := args.setDefaults(ctx, b, true); err != nil {
 		return nil, 0, nil, err
 	}
+
+	// Set dynamic fee fields to 0 to avoid validation checks during execution.
+	// These are irrelevant to calculation of access lists and gas cost.
+	args.MaxFeePerGas = new(hexutil.Big)
+	args.MaxPriorityFeePerGas = new(hexutil.Big)
+
 	var to common.Address
 	if args.To != nil {
 		to = *args.To

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -1627,8 +1627,14 @@ func AccessList(ctx context.Context, b Backend, blockNrOrHash rpc.BlockNumberOrH
 		return nil, 0, nil, err
 	}
 
+	if args.Nonce == nil {
+		nonce := hexutil.Uint64(db.GetNonce(args.from()))
+		args.Nonce = &nonce
+	}
 	blockCtx := core.NewEVMBlockContext(header, NewChainContext(ctx, b), nil)
-	args.CallDefaults(b.RPCGasCap(), blockCtx.BaseFee, b.ChainConfig().ChainID)
+	if err := args.CallDefaults(b.RPCGasCap(), blockCtx.BaseFee, b.ChainConfig().ChainID); err != nil {
+		return types.AccessList{}, 0, nil, err
+	}
 
 	var to common.Address
 	if args.To != nil {
@@ -1636,6 +1642,7 @@ func AccessList(ctx context.Context, b Backend, blockNrOrHash rpc.BlockNumberOrH
 	} else {
 		to = crypto.CreateAddress(args.from(), uint64(*args.Nonce))
 	}
+	fmt.Printf("nonce %d\nto %x\n", *args.Nonce, to)
 	isPostMerge := header.Difficulty.Sign() == 0
 	// Retrieve the precompiles since they don't need to be added to the access list
 	precompiles := vm.ActivePrecompiles(b.ChainConfig().Rules(header.Number, isPostMerge, header.Time))

--- a/internal/ethapi/transaction_args.go
+++ b/internal/ethapi/transaction_args.go
@@ -100,7 +100,7 @@ func (args *TransactionArgs) setDefaults(ctx context.Context, b Backend, skipGas
 	if err := args.setBlobTxSidecar(ctx); err != nil {
 		return err
 	}
-	if err := args.setFeeDefaults(ctx, b); err != nil {
+	if err := args.setFeeDefaults(ctx, b, b.CurrentHeader()); err != nil {
 		return err
 	}
 
@@ -183,8 +183,7 @@ func (args *TransactionArgs) setDefaults(ctx context.Context, b Backend, skipGas
 }
 
 // setFeeDefaults fills in default fee values for unspecified tx fields.
-func (args *TransactionArgs) setFeeDefaults(ctx context.Context, b Backend) error {
-	head := b.CurrentHeader()
+func (args *TransactionArgs) setFeeDefaults(ctx context.Context, b Backend, head *types.Header) error {
 	// Sanity check the EIP-4844 fee parameters.
 	if args.BlobFeeCap != nil && args.BlobFeeCap.ToInt().Sign() == 0 {
 		return errors.New("maxFeePerBlobGas, if specified, must be non-zero")

--- a/internal/ethapi/transaction_args_test.go
+++ b/internal/ethapi/transaction_args_test.go
@@ -238,7 +238,7 @@ func TestSetFeeDefaults(t *testing.T) {
 			t.Fatalf("failed to set fork: %v", err)
 		}
 		got := test.in
-		err := got.setFeeDefaults(ctx, b)
+		err := got.setFeeDefaults(ctx, b, b.CurrentHeader())
 		if err != nil {
 			if test.err == nil {
 				t.Fatalf("test %d (%s): unexpected error: %s", i, test.name, err)


### PR DESCRIPTION
totally WIP, and I'm not sure this is correct.  I need to further validate this tomorrow.

Should close https://github.com/ethereum/go-ethereum/issues/30145 .  The problem is that for `AccessList`, we are filling transaction fields with `TransactionArgs.setDefaults` which afaict is meant to validate provided fields and give proper values to missing fields based on the state at the current chain tip.

`eth_call`-like methods seem to populate fields using `TransactionArgs.CallDefaults`, which also seems appropriate for `eth_accessList` as it is `eth_call`-like under the hood:  it can be executed against historical blocks.

The referenced issue reflects this:  if we calculate defaults for the transaction's dynamic fee fields based on the chain tip, but re-execute against a historical block, then we can encounter a situation where the calculated default for the gas tip is below the base fee of the historical block.