### PR TITLE
beacon/engine: strip type byte in requests

### DIFF
--- a/beacon/blsync/engineclient.go
+++ b/beacon/blsync/engineclient.go
@@ -92,7 +92,7 @@ func (ec *engineClient) updateLoop(headCh <-chan types.ChainHeadEvent) {
 }
 
 func (ec *engineClient) callNewPayload(fork string, event types.ChainHeadEvent) (string, error) {
-	execData := engine.BlockToExecutableData(event.Block, nil, nil).ExecutionPayload
+	execData := engine.BlockToExecutableData(event.Block, nil, nil, nil).ExecutionPayload
 
 	var (
 		method string

--- a/eth/catalyst/api_test.go
+++ b/eth/catalyst/api_test.go
@@ -590,10 +590,10 @@ We expect
 (3) If the parent is unavailable, the LVH should not be set.
 
 	CommonAncestor◄─▲── P1 ◄── P2  ◄─ P3  ◄─ ... ◄─ Pn
-	                │
-	                └── P1' ◄─ P2' ◄─ P3' ◄─ ... ◄─ Pn'
-	                │
-	                └── P1''
+					│
+					└── P1' ◄─ P2' ◄─ P3' ◄─ ... ◄─ Pn'
+					│
+					└── P1''
 */
 func TestNewPayloadOnInvalidChain(t *testing.T) {
 	genesis, preMergeBlocks := generateMergeChain(10, false)
@@ -1600,7 +1600,7 @@ func TestBlockToPayloadWithBlobs(t *testing.T) {
 	}
 
 	block := types.NewBlock(&header, &types.Body{Transactions: txs}, nil, trie.NewStackTrie(nil))
-	envelope := engine.BlockToExecutableData(block, nil, sidecars)
+	envelope := engine.BlockToExecutableData(block, nil, sidecars, nil)
 	var want int
 	for _, tx := range txs {
 		want += len(tx.BlobHashes())

--- a/eth/catalyst/api_test.go
+++ b/eth/catalyst/api_test.go
@@ -590,10 +590,10 @@ We expect
 (3) If the parent is unavailable, the LVH should not be set.
 
 	CommonAncestor◄─▲── P1 ◄── P2  ◄─ P3  ◄─ ... ◄─ Pn
-					│
-					└── P1' ◄─ P2' ◄─ P3' ◄─ ... ◄─ Pn'
-					│
-					└── P1''
+	                │
+	                └── P1' ◄─ P2' ◄─ P3' ◄─ ... ◄─ Pn'
+	                │
+	                └── P1''
 */
 func TestNewPayloadOnInvalidChain(t *testing.T) {
 	genesis, preMergeBlocks := generateMergeChain(10, false)

--- a/miner/payload_building.go
+++ b/miner/payload_building.go
@@ -69,26 +69,28 @@ func (args *BuildPayloadArgs) Id() engine.PayloadID {
 // the revenue. Therefore, the empty-block here is always available and full-block
 // will be set/updated afterwards.
 type Payload struct {
-	id           engine.PayloadID
-	empty        *types.Block
-	emptyWitness *stateless.Witness
-	full         *types.Block
-	fullWitness  *stateless.Witness
-	sidecars     []*types.BlobTxSidecar
-	requests     [][]byte
-	fullFees     *big.Int
-	stop         chan struct{}
-	lock         sync.Mutex
-	cond         *sync.Cond
+	id            engine.PayloadID
+	empty         *types.Block
+	emptyWitness  *stateless.Witness
+	full          *types.Block
+	fullWitness   *stateless.Witness
+	sidecars      []*types.BlobTxSidecar
+	emptyRequests [][]byte
+	requests      [][]byte
+	fullFees      *big.Int
+	stop          chan struct{}
+	lock          sync.Mutex
+	cond          *sync.Cond
 }
 
 // newPayload initializes the payload object.
-func newPayload(empty *types.Block, witness *stateless.Witness, id engine.PayloadID) *Payload {
+func newPayload(empty *types.Block, emptyRequests [][]byte, witness *stateless.Witness, id engine.PayloadID) *Payload {
 	payload := &Payload{
-		id:           id,
-		empty:        empty,
-		emptyWitness: witness,
-		stop:         make(chan struct{}),
+		id:            id,
+		empty:         empty,
+		emptyRequests: emptyRequests,
+		emptyWitness:  witness,
+		stop:          make(chan struct{}),
 	}
 	log.Info("Starting work on payload", "id", payload.id)
 	payload.cond = sync.NewCond(&payload.lock)
@@ -143,16 +145,14 @@ func (payload *Payload) Resolve() *engine.ExecutionPayloadEnvelope {
 		close(payload.stop)
 	}
 	if payload.full != nil {
-		envelope := engine.BlockToExecutableData(payload.full, payload.fullFees, payload.sidecars)
-		envelope.Requests = payload.requests
+		envelope := engine.BlockToExecutableData(payload.full, payload.fullFees, payload.sidecars, payload.emptyRequests)
 		if payload.fullWitness != nil {
 			envelope.Witness = new(hexutil.Bytes)
 			*envelope.Witness, _ = rlp.EncodeToBytes(payload.fullWitness) // cannot fail
 		}
 		return envelope
 	}
-	envelope := engine.BlockToExecutableData(payload.empty, big.NewInt(0), nil)
-	envelope.Requests = payload.requests
+	envelope := engine.BlockToExecutableData(payload.empty, big.NewInt(0), nil, payload.emptyRequests)
 	if payload.emptyWitness != nil {
 		envelope.Witness = new(hexutil.Bytes)
 		*envelope.Witness, _ = rlp.EncodeToBytes(payload.emptyWitness) // cannot fail
@@ -166,8 +166,7 @@ func (payload *Payload) ResolveEmpty() *engine.ExecutionPayloadEnvelope {
 	payload.lock.Lock()
 	defer payload.lock.Unlock()
 
-	envelope := engine.BlockToExecutableData(payload.empty, big.NewInt(0), nil)
-	envelope.Requests = payload.requests
+	envelope := engine.BlockToExecutableData(payload.empty, big.NewInt(0), nil, payload.emptyRequests)
 	if payload.emptyWitness != nil {
 		envelope.Witness = new(hexutil.Bytes)
 		*envelope.Witness, _ = rlp.EncodeToBytes(payload.emptyWitness) // cannot fail
@@ -198,8 +197,7 @@ func (payload *Payload) ResolveFull() *engine.ExecutionPayloadEnvelope {
 	default:
 		close(payload.stop)
 	}
-	envelope := engine.BlockToExecutableData(payload.full, payload.fullFees, payload.sidecars)
-	envelope.Requests = payload.requests
+	envelope := engine.BlockToExecutableData(payload.full, payload.fullFees, payload.sidecars, payload.requests)
 	if payload.fullWitness != nil {
 		envelope.Witness = new(hexutil.Bytes)
 		*envelope.Witness, _ = rlp.EncodeToBytes(payload.fullWitness) // cannot fail
@@ -227,7 +225,7 @@ func (miner *Miner) buildPayload(args *BuildPayloadArgs, witness bool) (*Payload
 		return nil, empty.err
 	}
 	// Construct a payload object for return.
-	payload := newPayload(empty.block, empty.witness, args.Id())
+	payload := newPayload(empty.block, empty.requests, empty.witness, args.Id())
 
 	// Spin up a routine for updating the payload in background. This strategy
 	// can maximum the revenue for including transactions with highest fee.


### PR DESCRIPTION
This change brings geth into compliance with the current engine API specification for the Prague fork. I have moved the assignment of ExecutionPayloadEnvelope.Requests into BlockToExecutableData to ensure there is a single place where the type is removed.

While doing so, I noticed that handling of requests in the miner was not quite correct for the empty payload. It would return `nil` requests for the empty payload even for blocks after the Prague fork. To fix this, I have added the emptyRequests field in miner.Payload.