### PR TITLE
fix: omit null witness field from payload envelope

### DIFF
--- a/beacon/engine/gen_epe.go
+++ b/beacon/engine/gen_epe.go
@@ -20,7 +20,7 @@ func (e ExecutionPayloadEnvelope) MarshalJSON() ([]byte, error) {
 		BlobsBundle      *BlobsBundleV1  `json:"blobsBundle"`
 		Requests         []hexutil.Bytes `json:"executionRequests"`
 		Override         bool            `json:"shouldOverrideBuilder"`
-		Witness          *hexutil.Bytes  `json:"witness"`
+		Witness          *hexutil.Bytes  `json:"witness,omitempty"`
 	}
 	var enc ExecutionPayloadEnvelope
 	enc.ExecutionPayload = e.ExecutionPayload
@@ -45,7 +45,7 @@ func (e *ExecutionPayloadEnvelope) UnmarshalJSON(input []byte) error {
 		BlobsBundle      *BlobsBundleV1  `json:"blobsBundle"`
 		Requests         []hexutil.Bytes `json:"executionRequests"`
 		Override         *bool           `json:"shouldOverrideBuilder"`
-		Witness          *hexutil.Bytes  `json:"witness"`
+		Witness          *hexutil.Bytes  `json:"witness,omitempty"`
 	}
 	var dec ExecutionPayloadEnvelope
 	if err := json.Unmarshal(input, &dec); err != nil {

--- a/beacon/engine/types.go
+++ b/beacon/engine/types.go
@@ -109,7 +109,7 @@ type ExecutionPayloadEnvelope struct {
 	BlobsBundle      *BlobsBundleV1  `json:"blobsBundle"`
 	Requests         [][]byte        `json:"executionRequests"`
 	Override         bool            `json:"shouldOverrideBuilder"`
-	Witness          *hexutil.Bytes  `json:"witness"`
+	Witness          *hexutil.Bytes  `json:"witness,omitempty"`
 }
 
 type BlobsBundleV1 struct {


### PR DESCRIPTION
## Description

Omit null `witness` field from payload envelope.

## Motivation

Currently, JSON encoded payload types always include `"witness": null`, which, I believe, is not intentional.