### PR TITLE
ethdb/pebble: switch to increasing level sizes

### DIFF
--- a/ethdb/pebble/pebble.go
+++ b/ethdb/pebble/pebble.go
@@ -213,12 +213,12 @@ func New(file string, cache int, handles int, namespace string, readonly bool, e
 		// options for the last level are used for all subsequent levels.
 		Levels: []pebble.LevelOptions{
 			{TargetFileSize: 2 * 1024 * 1024, FilterPolicy: bloom.FilterPolicy(10)},
-			{TargetFileSize: 2 * 1024 * 1024, FilterPolicy: bloom.FilterPolicy(10)},
-			{TargetFileSize: 2 * 1024 * 1024, FilterPolicy: bloom.FilterPolicy(10)},
-			{TargetFileSize: 2 * 1024 * 1024, FilterPolicy: bloom.FilterPolicy(10)},
-			{TargetFileSize: 2 * 1024 * 1024, FilterPolicy: bloom.FilterPolicy(10)},
-			{TargetFileSize: 2 * 1024 * 1024, FilterPolicy: bloom.FilterPolicy(10)},
-			{TargetFileSize: 2 * 1024 * 1024, FilterPolicy: bloom.FilterPolicy(10)},
+			{TargetFileSize: 4 * 1024 * 1024, FilterPolicy: bloom.FilterPolicy(10)},
+			{TargetFileSize: 8 * 1024 * 1024, FilterPolicy: bloom.FilterPolicy(10)},
+			{TargetFileSize: 16 * 1024 * 1024, FilterPolicy: bloom.FilterPolicy(10)},
+			{TargetFileSize: 32 * 1024 * 1024, FilterPolicy: bloom.FilterPolicy(10)},
+			{TargetFileSize: 64 * 1024 * 1024, FilterPolicy: bloom.FilterPolicy(10)},
+			{TargetFileSize: 128 * 1024 * 1024, FilterPolicy: bloom.FilterPolicy(10)},
 		},
 		ReadOnly: readonly,
 		EventListener: &pebble.EventListener{


### PR DESCRIPTION
Since forever we've been using 2MB database files, ever since the LevelDB era. We've sometimes attempted to change these to something different, but compaction-induced db writes always blew up disk IO tens fold.

A lot of time passed however, and nowadays we're using a completely different data scheme (path vs hash), which has much more localized writes. Out of curiosity I've ran a benchmark changing back the levels to exponentially increasing ones.

Naturally, the obvious effect is the number of files:

- `master` branch with 2MB files across all levels has about 160K data files in the datastore.
- `pr` branch has about 9.2K data files in the datastore.

These have been expected, but the more interesting question is how this affects performance (charts: green == master, yellow == PR)?

Full syncing the chain is ever so slightly faster with the PR. Approximately 12h across 13 days. Not bad, but also nothing special. Could be just differences in the machines, but even if realistic, 12h is always welcome.

<img width="1574" alt="Screenshot 2024-10-15 at 16 44 55" src="https://github.com/user-attachments/assets/63727191-905d-4ae5-a3b1-c4472a3e49e9">

CPU usage wise, the leveled database (after some initial data pileup) uses half a CPU core less computation, most probably due to less compaction shuffling. This is a surprise, but a welcome one. Probably not something amazingly relevant, but it's never bad to lower resources.

<img width="1574" alt="Screenshot 2024-10-15 at 16 46 42" src="https://github.com/user-attachments/assets/9cb012ab-9181-4dfe-ac83-2b0b8bbb9ec9">

IO wait is as expected. With larger files, when compaction hits, there's more data to mobilize, so there should be more time waiting for data in general. That said, during a whole full sync we haven't ever hit disk limits, so it seems to be an acceptable compromise.

<img width="1574" alt="Screenshot 2024-10-15 at 16 48 53" src="https://github.com/user-attachments/assets/515b007a-b6f2-4c74-bc97-68552f287229">

The stat I was most worried about though, disk writes. Historically this is what blew up beyond acceptable levels. Pleasantly noticing, the PRs disk write hit is about 5% after an entire full sync. That is amazing. 

<img width="1574" alt="Screenshot 2024-10-15 at 16 50 48" src="https://github.com/user-attachments/assets/dd8cbaa8-eb2f-4cb4-ba60-206c87bb9804">

---

All in all, seems this change has relatively negligible performance implications, but in exchange reduces the number of database files from 160K to 10K. My 2c is that reducing the file count would be very valuable as on OSes where the file system might not handle many files very gracefully, this could be the difference between very fast and unusably slow.