### PR TITLE
cmd, core, eth: add support for Reth style ExEx plugins

### DIFF
--- a/cmd/geth/chaincmd.go
+++ b/cmd/geth/chaincmd.go
@@ -102,7 +102,7 @@ if one is set.  Otherwise it prints the genesis from the datadir.`,
 			utils.VMTraceJsonConfigFlag,
 			utils.TransactionHistoryFlag,
 			utils.StateHistoryFlag,
-		}, utils.DatabaseFlags),
+		}, utils.DatabaseFlags, utils.ExExPluginFlags()),
 		Description: `
 The import command imports blocks from an RLP-encoded form. The form can be one file
 with several RLP-encoded blocks, or several files can be used.

--- a/cmd/geth/main.go
+++ b/cmd/geth/main.go
@@ -156,7 +156,7 @@ var (
 		utils.BeaconGenesisRootFlag,
 		utils.BeaconGenesisTimeFlag,
 		utils.BeaconCheckpointFlag,
-	}, utils.NetworkFlags, utils.DatabaseFlags)
+	}, utils.NetworkFlags, utils.DatabaseFlags, utils.ExExPluginFlags())
 
 	rpcFlags = []cli.Flag{
 		utils.HTTPEnabledFlag,

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -1932,8 +1932,8 @@ func SetEthConfig(ctx *cli.Context, stack *node.Node, cfg *ethconfig.Config) {
 	for _, flag := range ExExPluginFlags() {
 		if flag, ok := flag.(*cli.BoolFlag); ok {
 			if ctx.IsSet(flag.Name) {
-				plugin := strings.TrimLeft(flag.Name, "exex.") // TODO(karalabe): Custom flag
-				config := ctx.String(flag.Name + ".config")    // TODO(karalabe): Custom flag
+				plugin, _ := strings.CutPrefix(flag.Name, "exex.") // TODO(karalabe): Custom flag
+				config := ctx.String(flag.Name + ".config")        // TODO(karalabe): Custom flag
 
 				if err := exex.Instantiate(plugin, config); err != nil {
 					Fatalf("Failed to instantiate ExEx plugin %s: %v", plugin, err)
@@ -2234,8 +2234,8 @@ func MakeChain(ctx *cli.Context, stack *node.Node, readonly bool) (*core.BlockCh
 	for _, flag := range ExExPluginFlags() {
 		if flag, ok := flag.(*cli.BoolFlag); ok {
 			if ctx.IsSet(flag.Name) {
-				plugin := strings.TrimLeft(flag.Name, "exex.") // TODO(karalabe): Custom flag
-				config := ctx.String(flag.Name + ".config")    // TODO(karalabe): Custom flag
+				plugin, _ := strings.CutPrefix(flag.Name, "exex.") // TODO(karalabe): Custom flag
+				config := ctx.String(flag.Name + ".config")        // TODO(karalabe): Custom flag
 
 				if err := exex.Instantiate(plugin, config); err != nil {
 					Fatalf("Failed to instantiate ExEx plugin %s: %v", plugin, err)

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -981,7 +981,12 @@ func ExExPluginFlags() []cli.Flag {
 	for _, name := range exex.Plugins() {
 		flagset = append(flagset, &cli.BoolFlag{
 			Name:     fmt.Sprintf("exex.%s", name),
-			Usage:    fmt.Sprintf("Enables the %s execution extension plugin", name),
+			Usage:    fmt.Sprintf("Enables the '%s' execution extension plugin", name),
+			Category: flags.ExExCategory,
+		})
+		flagset = append(flagset, &cli.StringFlag{
+			Name:     fmt.Sprintf("exex.%s.config", name),
+			Usage:    fmt.Sprintf("Opaque config to pass to the '%s' execution extension plugin", name),
 			Category: flags.ExExCategory,
 		})
 	}
@@ -1925,12 +1930,16 @@ func SetEthConfig(ctx *cli.Context, stack *node.Node, cfg *ethconfig.Config) {
 	}
 	// Execution extension plugins
 	for _, flag := range ExExPluginFlags() {
-		if ctx.IsSet(flag.(*cli.BoolFlag).Name) {
-			plugin := strings.TrimLeft(flag.(*cli.BoolFlag).Name, "exex.") // TODO(karalabe): Custom flag
-			if err := exex.Instantiate(plugin); err != nil {
-				Fatalf("Failed to instantiate ExEx plugin %s: %v", plugin, err)
+		if flag, ok := flag.(*cli.BoolFlag); ok {
+			if ctx.IsSet(flag.Name) {
+				plugin := strings.TrimLeft(flag.Name, "exex.") // TODO(karalabe): Custom flag
+				config := ctx.String(flag.Name + ".config")    // TODO(karalabe): Custom flag
+
+				if err := exex.Instantiate(plugin, config); err != nil {
+					Fatalf("Failed to instantiate ExEx plugin %s: %v", plugin, err)
+				}
+				log.Info("Instantiated ExEx plugin", "name", plugin)
 			}
-			log.Info("Instantiated ExEx plugin", "name", plugin)
 		}
 	}
 }
@@ -2223,12 +2232,16 @@ func MakeChain(ctx *cli.Context, stack *node.Node, readonly bool) (*core.BlockCh
 		}
 	}
 	for _, flag := range ExExPluginFlags() {
-		if ctx.IsSet(flag.(*cli.BoolFlag).Name) {
-			plugin := strings.TrimLeft(flag.(*cli.BoolFlag).Name, "exex.") // TODO(karalabe): Custom flag
-			if err := exex.Instantiate(plugin); err != nil {
-				Fatalf("Failed to instantiate ExEx plugin %s: %v", plugin, err)
+		if flag, ok := flag.(*cli.BoolFlag); ok {
+			if ctx.IsSet(flag.Name) {
+				plugin := strings.TrimLeft(flag.Name, "exex.") // TODO(karalabe): Custom flag
+				config := ctx.String(flag.Name + ".config")    // TODO(karalabe): Custom flag
+
+				if err := exex.Instantiate(plugin, config); err != nil {
+					Fatalf("Failed to instantiate ExEx plugin %s: %v", plugin, err)
+				}
+				log.Info("Instantiated ExEx plugin", "name", plugin)
 			}
-			log.Info("Instantiated ExEx plugin", "name", plugin)
 		}
 	}
 	// Disable transaction indexing/unindexing by default.

--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -613,6 +613,7 @@ func (bc *BlockChain) SetFinalized(header *types.Header) {
 	if header != nil {
 		rawdb.WriteFinalizedBlockHash(bc.db, header.Hash())
 		headFinalizedBlockGauge.Update(int64(header.Number.Uint64()))
+		exex.TriggerFinalHook(header)
 	} else {
 		rawdb.WriteFinalizedBlockHash(bc.db, common.Hash{})
 		headFinalizedBlockGauge.Update(0)

--- a/core/blockchain_reader.go
+++ b/core/blockchain_reader.go
@@ -209,6 +209,27 @@ func (bc *BlockChain) GetBlocksFromHash(hash common.Hash, n int) (blocks []*type
 	return
 }
 
+// GetReceiptsByNumber retrieves the receipts for all transactions in a given block.
+func (bc *BlockChain) GetReceiptsByNumber(number uint64) types.Receipts {
+	hash := rawdb.ReadCanonicalHash(bc.db, number)
+	if hash == (common.Hash{}) {
+		return nil
+	}
+	if receipts, ok := bc.receiptsCache.Get(hash); ok {
+		return receipts
+	}
+	header := bc.GetHeader(hash, number)
+	if header == nil {
+		return nil
+	}
+	receipts := rawdb.ReadReceipts(bc.db, hash, number, header.Time, bc.chainConfig)
+	if receipts == nil {
+		return nil
+	}
+	bc.receiptsCache.Add(hash, receipts)
+	return receipts
+}
+
 // GetReceiptsByHash retrieves the receipts for all transactions in a given block.
 func (bc *BlockChain) GetReceiptsByHash(hash common.Hash) types.Receipts {
 	if receipts, ok := bc.receiptsCache.Get(hash); ok {

--- a/core/exex/exex.go
+++ b/core/exex/exex.go
@@ -1,0 +1,42 @@
+// Copyright 2024 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+
+// Package exex contains the stable API of the Geth Execution Extensions.
+package exex
+
+import (
+	"github.com/ethereum/go-ethereum/log"
+)
+
+// RegisterV1 registers an execution extension plugin with a unique name.
+func RegisterV1(name string, constructor NewPluginV1) {
+	globalRegistry.RegisterV1(name, constructor)
+}
+
+// NewPluginV1 is the constructor signature for making a new plugin.
+type NewPluginV1 func(logger log.Logger) (*PluginV1, error)
+
+// PluginV1 is an Execution Extension module that can be injected into Geth's
+// processing pipeline to subscribe to different node, chain and EVM lifecycle
+// events.
+//
+// Note, V1 of the Execution Extension plugin module has not yet been stabilized.
+// There might be breaking changes until it is tagged as released!
+type PluginV1 struct {
+	OnInit  InitHook  // Called when the chain gets initialized within Geth
+	OnClose CloseHook // Called when the chain gets torn down within Geth
+	OnHead  HeadHook  // Called when the chain head block is updated in Geth
+}

--- a/core/exex/exex.go
+++ b/core/exex/exex.go
@@ -27,7 +27,15 @@ func RegisterV1(name string, constructor NewPluginV1) {
 }
 
 // NewPluginV1 is the constructor signature for making a new plugin.
-type NewPluginV1 func(logger log.Logger) (*PluginV1, error)
+type NewPluginV1 func(config *ConfigV1) (*PluginV1, error)
+
+// ConfigV1 contains some configurations for initializing exex plugins. Some of
+// the fields originate from Geth, other fields from user configs.
+type ConfigV1 struct {
+	Logger log.Logger // Geth's logger with the plugin name injected
+
+	User string // Opaque flag provided by the user on the CLI
+}
 
 // PluginV1 is an Execution Extension module that can be injected into Geth's
 // processing pipeline to subscribe to different node, chain and EVM lifecycle

--- a/core/exex/exex.go
+++ b/core/exex/exex.go
@@ -48,4 +48,5 @@ type PluginV1 struct {
 	OnClose CloseHook // Called when the chain gets torn down within Geth
 	OnHead  HeadHook  // Called when the chain head block is updated in Geth
 	OnReorg ReorgHook // Called wnen the chain reorgs to a sidechain within Geth
+	OnFinal FinalHook // Called when the chain finalizes a block within Geth
 }

--- a/core/exex/exex.go
+++ b/core/exex/exex.go
@@ -47,4 +47,5 @@ type PluginV1 struct {
 	OnInit  InitHook  // Called when the chain gets initialized within Geth
 	OnClose CloseHook // Called when the chain gets torn down within Geth
 	OnHead  HeadHook  // Called when the chain head block is updated in Geth
+	OnReorg ReorgHook // Called wnen the chain reorgs to a sidechain within Geth
 }

--- a/core/exex/exex/adapter_chain.go
+++ b/core/exex/exex/adapter_chain.go
@@ -32,6 +32,7 @@ type gethChain interface {
 	GetHeaderByNumber(number uint64) *types.Header
 	GetBlockByNumber(number uint64) *types.Block
 	StateAt(root common.Hash) (*state.StateDB, error)
+	GetReceiptsByNumber(number uint64) types.Receipts
 }
 
 // chainAdapter is an adapter to convert Geth's internal blockchain (unstable
@@ -75,4 +76,18 @@ func (a *chainAdapter) State(root common.Hash) exex.State {
 		return nil
 	}
 	return wrapState(state)
+}
+
+// Receipts retrieves a set of receits belonging to all transactions within
+// a block from the canonical chain. Receipts on side-chains are not exposed
+// by the Chain interface.
+func (a *chainAdapter) Receipts(number uint64) []*types.Receipt {
+	// Receipts have public fields, copy to prevent modification
+	receipts := a.chain.GetReceiptsByNumber(number)
+
+	copies := make([]*types.Receipt, 0, len(receipts))
+	for _, receipt := range receipts {
+		copies = append(copies, types.CopyReceipt(receipt))
+	}
+	return copies
 }

--- a/core/exex/exex/adapter_chain.go
+++ b/core/exex/exex/adapter_chain.go
@@ -89,7 +89,7 @@ func (a *chainAdapter) State(root common.Hash) exex.State {
 	return wrapState(root, state, a.chain.Snapshots())
 }
 
-// Receipts retrieves a set of receits belonging to all transactions within
+// Receipts retrieves a set of receipts belonging to all transactions within
 // a block from the canonical chain. Receipts on side-chains are not exposed
 // by the Chain interface.
 func (a *chainAdapter) Receipts(number uint64) []*types.Receipt {

--- a/core/exex/exex/adapter_chain.go
+++ b/core/exex/exex/adapter_chain.go
@@ -1,0 +1,78 @@
+// Copyright 2024 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+
+package exex
+
+import (
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/exex"
+	"github.com/ethereum/go-ethereum/core/state"
+	"github.com/ethereum/go-ethereum/core/types"
+)
+
+// gethChain provides dep-free read access to Geth's internal chain object.
+//
+// The methods here are not documented as this interface is not a public thing,
+// rather it's a dynamic cast to break cross-package dependencies.
+type gethChain interface {
+	CurrentBlock() *types.Header
+	GetHeaderByNumber(number uint64) *types.Header
+	GetBlockByNumber(number uint64) *types.Block
+	StateAt(root common.Hash) (*state.StateDB, error)
+}
+
+// chainAdapter is an adapter to convert Geth's internal blockchain (unstable
+// and legacy API) into the exex chain interface (stable API).
+type chainAdapter struct {
+	chain gethChain
+}
+
+// wrapChain wraps a Geth internal chain object into an exex stable API.
+func wrapChain(chain gethChain) exex.Chain {
+	return &chainAdapter{chain: chain}
+}
+
+// Head retrieves the current head block's header from the canonical chain.
+func (a *chainAdapter) Head() *types.Header {
+	// Headers have public fields, copy to prevent modification
+	return types.CopyHeader(a.chain.CurrentBlock())
+}
+
+// Header retrieves a block header with the given number from the canonical
+// chain. Headers on side-chains are not exposed by the Chain interface.
+func (a *chainAdapter) Header(number uint64) *types.Header {
+	// Headers have public fields, copy to prevent modification
+	if header := a.chain.GetHeaderByNumber(number); header != nil {
+		return types.CopyHeader(header)
+	}
+	return nil
+}
+
+// Block retrieves a block header with the given number from the canonical
+// chain. Blocks on side-chains are not exposed by the Chain interface.
+func (a *chainAdapter) Block(number uint64) *types.Block {
+	// Blocks don't have public fields, return live objects directly
+	return a.chain.GetBlockByNumber(number)
+}
+
+// State retrieves a state accessor at a given root hash.
+func (a *chainAdapter) State(root common.Hash) exex.State {
+	state, err := a.chain.StateAt(root)
+	if err != nil {
+		return nil
+	}
+	return wrapState(state)
+}

--- a/core/exex/exex/adapter_chain.go
+++ b/core/exex/exex/adapter_chain.go
@@ -30,6 +30,7 @@ import (
 // rather it's a dynamic cast to break cross-package dependencies.
 type gethChain interface {
 	CurrentBlock() *types.Header
+	CurrentFinalBlock() *types.Header
 	GetHeaderByNumber(number uint64) *types.Header
 	GetBlockByNumber(number uint64) *types.Block
 	StateAt(root common.Hash) (*state.StateDB, error)
@@ -52,6 +53,14 @@ func wrapChain(chain gethChain) exex.Chain {
 func (a *chainAdapter) Head() *types.Header {
 	// Headers have public fields, copy to prevent modification
 	return types.CopyHeader(a.chain.CurrentBlock())
+}
+
+// Final retrieves the last finalized block from the chain. If no finality
+// is known yet (not synced, not past merge, etc.) or Geth crashed and is
+// recovering, the returns header will be nil.
+func (a *chainAdapter) Final() *types.Header {
+	// Headers have public fields, copy to prevent modification
+	return types.CopyHeader(a.chain.CurrentFinalBlock())
 }
 
 // Header retrieves a block header with the given number from the canonical

--- a/core/exex/exex/adapter_chain.go
+++ b/core/exex/exex/adapter_chain.go
@@ -20,6 +20,7 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/exex"
 	"github.com/ethereum/go-ethereum/core/state"
+	"github.com/ethereum/go-ethereum/core/state/snapshot"
 	"github.com/ethereum/go-ethereum/core/types"
 )
 
@@ -32,6 +33,7 @@ type gethChain interface {
 	GetHeaderByNumber(number uint64) *types.Header
 	GetBlockByNumber(number uint64) *types.Block
 	StateAt(root common.Hash) (*state.StateDB, error)
+	Snapshots() *snapshot.Tree
 	GetReceiptsByNumber(number uint64) types.Receipts
 }
 
@@ -75,7 +77,7 @@ func (a *chainAdapter) State(root common.Hash) exex.State {
 	if err != nil {
 		return nil
 	}
-	return wrapState(state)
+	return wrapState(root, state, a.chain.Snapshots())
 }
 
 // Receipts retrieves a set of receits belonging to all transactions within

--- a/core/exex/exex/adapter_state.go
+++ b/core/exex/exex/adapter_state.go
@@ -1,0 +1,43 @@
+package exex
+
+import (
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/exex"
+	"github.com/ethereum/go-ethereum/core/state"
+	"github.com/holiman/uint256"
+)
+
+// stateAdapter is an adapter to convert Geth's internal state db (unstable
+// and legacy API) into the exex state interface (stable API).
+type stateAdapter struct {
+	state *state.StateDB
+}
+
+// wrapState wraps a Geth internal state object into an exex stable API.
+func wrapState(state *state.StateDB) exex.State {
+	return &stateAdapter{state: state}
+}
+
+// Balance retrieves the balance of the given account, or 0 if the account is
+// not found in the state.
+func (a *stateAdapter) Balance(addr common.Address) *uint256.Int {
+	return a.state.GetBalance(addr)
+}
+
+// Nonce retrieves the nonce of the given account, or 0 if the account is not
+// found in the state.
+func (a *stateAdapter) Nonce(addr common.Address) uint64 {
+	return a.state.GetNonce(addr)
+}
+
+// Code retrieves the bytecode associated with the given account, or a nil slice
+// if the account is not found.
+func (a *stateAdapter) Code(addr common.Address) []byte {
+	return common.CopyBytes(a.state.GetCode(addr))
+}
+
+// Storage retrieves the value associated with a specific storage slot key within
+// a specific account.
+func (a *stateAdapter) Storage(addr common.Address, slot common.Hash) common.Hash {
+	return a.state.GetState(addr, slot)
+}

--- a/core/exex/exex/adapter_state.go
+++ b/core/exex/exex/adapter_state.go
@@ -1,20 +1,36 @@
+// Copyright 2024 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+
 package exex
 
 import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/exex"
-	"github.com/ethereum/go-ethereum/core/state"
+	"github.com/ethereum/go-ethereum/core/vm"
 	"github.com/holiman/uint256"
 )
 
 // stateAdapter is an adapter to convert Geth's internal state db (unstable
 // and legacy API) into the exex state interface (stable API).
 type stateAdapter struct {
-	state *state.StateDB
+	state vm.StateDB
 }
 
 // wrapState wraps a Geth internal state object into an exex stable API.
-func wrapState(state *state.StateDB) exex.State {
+func wrapState(state vm.StateDB) exex.State {
 	return &stateAdapter{state: state}
 }
 

--- a/core/exex/exex/registry.go
+++ b/core/exex/exex/registry.go
@@ -38,6 +38,7 @@ type registry interface {
 	TriggerInitHook(chain exex.Chain)
 	TriggerCloseHook()
 	TriggerHeadHook(head *types.Header)
+	TriggerReorgHook(headers []*types.Header, revert bool)
 }
 
 // Plugins returns a list of all registered plugins to generate CLI flags.
@@ -63,4 +64,9 @@ func TriggerCloseHook() {
 // TriggerHeadHook triggers the OnHead hook in exex plugins.
 func TriggerHeadHook(head *types.Header) {
 	globalRegistry.TriggerHeadHook(head)
+}
+
+// TriggerReorgHook triggers the OnReorg hook in exex plugins.
+func TriggerReorgHook(headers []*types.Header, revert bool) {
+	globalRegistry.TriggerReorgHook(headers, revert)
 }

--- a/core/exex/exex/registry.go
+++ b/core/exex/exex/registry.go
@@ -1,0 +1,66 @@
+// Copyright 2024 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+
+package exex
+
+import (
+	"github.com/ethereum/go-ethereum/core/exex"
+	"github.com/ethereum/go-ethereum/core/types"
+)
+
+// globalRegistry is the Geth internal version of the exex registry with the
+// trigger methods exposed to be callable from within Geth.
+var globalRegistry registry
+
+func init() {
+	globalRegistry = exex.Registry().(registry)
+}
+
+// registry exposes all the hidden methods on the plugin registry to allow event
+// triggers to be invoked.
+type registry interface {
+	Plugins() []string
+	Instantiate(name string) error
+
+	TriggerInitHook(chain exex.Chain)
+	TriggerCloseHook()
+	TriggerHeadHook(head *types.Header)
+}
+
+// Plugins returns a list of all registered plugins to generate CLI flags.
+func Plugins() []string {
+	return globalRegistry.Plugins()
+}
+
+// Instantiate constructs an execution extension plugin from a unique name.
+func Instantiate(name string) error {
+	return globalRegistry.Instantiate(name)
+}
+
+// TriggerInitHook triggers the OnInit hook in exex plugins.
+func TriggerInitHook(chain gethChain) {
+	globalRegistry.TriggerInitHook(wrapChain(chain))
+}
+
+// TriggerCloseHook triggers the OnClose hook in exex plugins.
+func TriggerCloseHook() {
+	globalRegistry.TriggerCloseHook()
+}
+
+// TriggerHeadHook triggers the OnHead hook in exex plugins.
+func TriggerHeadHook(head *types.Header) {
+	globalRegistry.TriggerHeadHook(head)
+}

--- a/core/exex/exex/registry.go
+++ b/core/exex/exex/registry.go
@@ -33,7 +33,7 @@ func init() {
 // triggers to be invoked.
 type registry interface {
 	Plugins() []string
-	Instantiate(name string) error
+	Instantiate(name string, userconf string) error
 
 	TriggerInitHook(chain exex.Chain)
 	TriggerCloseHook()
@@ -46,8 +46,8 @@ func Plugins() []string {
 }
 
 // Instantiate constructs an execution extension plugin from a unique name.
-func Instantiate(name string) error {
-	return globalRegistry.Instantiate(name)
+func Instantiate(name string, userconf string) error {
+	return globalRegistry.Instantiate(name, userconf)
 }
 
 // TriggerInitHook triggers the OnInit hook in exex plugins.

--- a/core/exex/exex/registry.go
+++ b/core/exex/exex/registry.go
@@ -39,6 +39,7 @@ type registry interface {
 	TriggerCloseHook()
 	TriggerHeadHook(head *types.Header)
 	TriggerReorgHook(headers []*types.Header, revert bool)
+	TriggerFinalHook(header *types.Header)
 }
 
 // Plugins returns a list of all registered plugins to generate CLI flags.
@@ -69,4 +70,9 @@ func TriggerHeadHook(head *types.Header) {
 // TriggerReorgHook triggers the OnReorg hook in exex plugins.
 func TriggerReorgHook(headers []*types.Header, revert bool) {
 	globalRegistry.TriggerReorgHook(headers, revert)
+}
+
+// TriggerFinalHook triggers the OnFinal hook in exex plugins.
+func TriggerFinalHook(header *types.Header) {
+	globalRegistry.TriggerFinalHook(header)
 }

--- a/core/exex/hooks.go
+++ b/core/exex/hooks.go
@@ -51,3 +51,6 @@ type HeadHook = func(head *types.Header)
 // to pass in both the reverted and applied headers at the same time, but that
 // would require chain accessorts to support sidechains, which complicate APIs.
 type ReorgHook = func(headers []*types.Header, revert bool)
+
+// FinalHook is called when the chain finalizes a past block.
+type FinalHook = func(header *types.Header)

--- a/core/exex/hooks.go
+++ b/core/exex/hooks.go
@@ -1,0 +1,38 @@
+// Copyright 2024 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+
+package exex
+
+import "github.com/ethereum/go-ethereum/core/types"
+
+// InitHook is called when the chain gets initialized within Geth.
+type InitHook = func(chain Chain)
+
+// CloseHook is called when the chain gets torn down within Geth.
+type CloseHook = func()
+
+// HeadHook is called when the chain head block is updated.
+//
+//   - During full sync, this will be called for each block
+//   - During snap sync, this will be called from pivot onwards
+//   - In sync, this will be called on fork-choice updates
+type HeadHook = func(head *types.Header)
+
+// TODO(karalabe): This is interesting. We need to keep events in sync with the
+// user's chain access capabilities. We either need to provide side-chain access,
+// which gets nasty fast; or we need to reorg in lockstep; or we need two events
+// one to start a reorg (going back) and one having finished (going forward).
+// type ReorgHook = func(old, new *types.Header) error

--- a/core/exex/interface_chain.go
+++ b/core/exex/interface_chain.go
@@ -1,0 +1,42 @@
+// Copyright 2024 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+
+package exex
+
+import (
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+)
+
+// Chain provides read access to Geth's internal chain object.
+type Chain interface {
+	// TODO(karalabe): Wrap chain config into an exex interface
+	// Config() *params.ChainConfig
+
+	// Head retrieves the current head block's header from the canonical chain.
+	Head() *types.Header
+
+	// Header retrieves a block header with the given number from the canonical
+	// chain. Headers on side-chains are not exposed by the Chain interface.
+	Header(number uint64) *types.Header
+
+	// Block retrieves an entire block with the given number from the canonical
+	// chain. Blocks on side-chains are not exposed by the Chain interface.
+	Block(number uint64) *types.Block
+
+	// State retrieves a state accessor at a given root hash.
+	State(root common.Hash) State
+}

--- a/core/exex/interface_chain.go
+++ b/core/exex/interface_chain.go
@@ -29,6 +29,11 @@ type Chain interface {
 	// Head retrieves the current head block's header from the canonical chain.
 	Head() *types.Header
 
+	// Final retrieves the last finalized block from the chain. If no finality
+	// is known yet (not synced, not past merge, etc.) or Geth crashed and is
+	// recovering, the returns header will be nil.
+	Final() *types.Header
+
 	// Header retrieves a block header with the given number from the canonical
 	// chain. Headers on side-chains are not exposed by the Chain interface.
 	Header(number uint64) *types.Header

--- a/core/exex/interface_chain.go
+++ b/core/exex/interface_chain.go
@@ -39,4 +39,9 @@ type Chain interface {
 
 	// State retrieves a state accessor at a given root hash.
 	State(root common.Hash) State
+
+	// Receipts retrieves a set of receipts belonging to all transactions within
+	// a block from the canonical chain. Receipts on side-chains are not exposed
+	// by the Chain interface.
+	Receipts(number uint64) []*types.Receipt
 }

--- a/core/exex/interface_chain.go
+++ b/core/exex/interface_chain.go
@@ -37,7 +37,8 @@ type Chain interface {
 	// chain. Blocks on side-chains are not exposed by the Chain interface.
 	Block(number uint64) *types.Block
 
-	// State retrieves a state accessor at a given root hash.
+	// State retrieves a state accessor at a given root hash, or nil if the state
+	// associated with the given block has already been pruned.
 	State(root common.Hash) State
 
 	// Receipts retrieves a set of receipts belonging to all transactions within

--- a/core/exex/interface_state.go
+++ b/core/exex/interface_state.go
@@ -1,0 +1,25 @@
+package exex
+
+import (
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/holiman/uint256"
+)
+
+// State provides read access to Geth's internal state object.
+type State interface {
+	// Balance retrieves the balance of the given account, or 0 if the account
+	// is not found in the state.
+	Balance(addr common.Address) *uint256.Int
+
+	// Nonce retrieves the nonce of the given account, or 0 if the account is
+	// not found in the state.
+	Nonce(addr common.Address) uint64
+
+	// Code retrieves the bytecode associated with the given account, or a nil
+	// slice if the account is not found.
+	Code(addr common.Address) []byte
+
+	// Storage retrieves the value associated with a specific storage slot key
+	// within a specific account.
+	Storage(addr common.Address, slot common.Hash) common.Hash
+}

--- a/core/exex/interface_state.go
+++ b/core/exex/interface_state.go
@@ -1,7 +1,24 @@
+// Copyright 2024 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+
 package exex
 
 import (
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/state/snapshot"
 	"github.com/holiman/uint256"
 )
 
@@ -22,4 +39,22 @@ type State interface {
 	// Storage retrieves the value associated with a specific storage slot key
 	// within a specific account.
 	Storage(addr common.Address, slot common.Hash) common.Hash
+
+	// AccountIterator retrieves an iterator to walk across all the known accounts
+	// in the Ethereum state trie from a starting position, or returns nil if the
+	// requested state is unavailable in snapshot (accelerated access) form.
+	//
+	// Iteration is in Merkle-Patricia order (address hash alphabetically).
+	AccountIterator(seek common.Hash) snapshot.AccountIterator
+
+	// StorageIterator retrieves an iterator to walk across all the known storage
+	// slots the Ethereum state trie of a given account, from a starting position,
+	// or returns nil if the requested state is unavailable in snapshot (accelerated
+	// access) form.
+	//
+	// Iteration is in Merkle-Patricia order (storage slot hash alphabetically).
+	//
+	// The account is the hash of the address. This is due to the AccountIterator
+	// also walking the state in hash order, not address order.
+	StorageIterator(account common.Hash, seek common.Hash) snapshot.StorageIterator
 }

--- a/core/exex/registry.go
+++ b/core/exex/registry.go
@@ -1,0 +1,48 @@
+// Copyright 2024 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+
+package exex
+
+// globalRegistry is the public plugin registry to inject execution extensions into.
+var globalRegistry = newRegistry()
+
+// Registry retrieves the global plugin registry.
+//
+// Note, the downcast to interface{} is deliberate to hide all the methods on the
+// registry and avoid plugins from accidentally poking at unintended internals.
+func Registry() interface{} {
+	return globalRegistry
+}
+
+// registry is the collection of Execution Extension plugins which can be used
+// to extend Geth's functionality with external code.
+type registry struct {
+	pluginsMakersV1 map[string]NewPluginV1
+	pluginsV1       map[string]*PluginV1
+}
+
+// newRegistry creates a new exex plugin registry.
+func newRegistry() *registry {
+	return &registry{
+		pluginsMakersV1: make(map[string]NewPluginV1),
+		pluginsV1:       make(map[string]*PluginV1),
+	}
+}
+
+// RegisterV1 registers an execution extension plugin with a unique name.
+func (reg *registry) RegisterV1(name string, constructor NewPluginV1) {
+	reg.pluginsMakersV1[name] = constructor
+}

--- a/core/exex/registry_internal.go
+++ b/core/exex/registry_internal.go
@@ -35,10 +35,13 @@ func (reg *registry) Plugins() []string {
 }
 
 // Instantiate constructs an execution extension plugin from a unique name.
-func (reg *registry) Instantiate(name string) error {
+func (reg *registry) Instantiate(name string, userconf string) error {
 	// Try instantiating a V1 plugin
 	if constructor, ok := globalRegistry.pluginsMakersV1[name]; ok {
-		plugin, err := constructor(log.New("exex", name))
+		plugin, err := constructor(&ConfigV1{
+			Logger: log.New("exex", name),
+			User:   userconf,
+		})
 		if err != nil {
 			return err
 		}

--- a/core/exex/registry_internal.go
+++ b/core/exex/registry_internal.go
@@ -87,3 +87,12 @@ func (reg *registry) TriggerReorgHook(headers []*types.Header, revert bool) {
 		}
 	}
 }
+
+// TriggerFinalHook triggers the OnFinal hook in exex plugins.
+func (reg *registry) TriggerFinalHook(header *types.Header) {
+	for _, plugin := range globalRegistry.pluginsV1 {
+		if plugin.OnFinal != nil {
+			plugin.OnFinal(header)
+		}
+	}
+}

--- a/core/exex/registry_internal.go
+++ b/core/exex/registry_internal.go
@@ -78,3 +78,12 @@ func (reg *registry) TriggerHeadHook(head *types.Header) {
 		}
 	}
 }
+
+// TriggerReorgHook triggers the OnReorg hook in exex plugins.
+func (reg *registry) TriggerReorgHook(headers []*types.Header, revert bool) {
+	for _, plugin := range globalRegistry.pluginsV1 {
+		if plugin.OnReorg != nil {
+			plugin.OnReorg(headers, revert)
+		}
+	}
+}

--- a/core/exex/registry_internal.go
+++ b/core/exex/registry_internal.go
@@ -1,0 +1,77 @@
+// Copyright 2024 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+
+package exex
+
+import (
+	"errors"
+	"sort"
+
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/log"
+)
+
+// Plugins returns a list of all registered plugins to generate CLI flags.
+func (reg *registry) Plugins() []string {
+	plugins := make([]string, 0, len(reg.pluginsMakersV1))
+	for name := range reg.pluginsMakersV1 {
+		plugins = append(plugins, name)
+	}
+	sort.Strings(plugins)
+	return plugins
+}
+
+// Instantiate constructs an execution extension plugin from a unique name.
+func (reg *registry) Instantiate(name string) error {
+	// Try instantiating a V1 plugin
+	if constructor, ok := globalRegistry.pluginsMakersV1[name]; ok {
+		plugin, err := constructor(log.New("exex", name))
+		if err != nil {
+			return err
+		}
+		globalRegistry.pluginsV1[name] = plugin
+		return nil
+	}
+	// No plugins matched across any versions, return a failure
+	return errors.New("not found")
+}
+
+// TriggerInitHook triggers the OnInit hook in exex plugins.
+func (reg *registry) TriggerInitHook(chain Chain) {
+	for _, plugin := range globalRegistry.pluginsV1 {
+		if plugin.OnInit != nil {
+			plugin.OnInit(chain)
+		}
+	}
+}
+
+// TriggerCloseHook triggers the OnClose hook in exex plugins.
+func (reg *registry) TriggerCloseHook() {
+	for _, plugin := range globalRegistry.pluginsV1 {
+		if plugin.OnClose != nil {
+			plugin.OnClose()
+		}
+	}
+}
+
+// TriggerHeadHook triggers the OnHead hook in exex plugins.
+func (reg *registry) TriggerHeadHook(head *types.Header) {
+	for _, plugin := range globalRegistry.pluginsV1 {
+		if plugin.OnHead != nil {
+			plugin.OnHead(head)
+		}
+	}
+}

--- a/core/types/log.go
+++ b/core/types/log.go
@@ -53,6 +53,20 @@ type Log struct {
 	Removed bool `json:"removed" rlp:"-"`
 }
 
+// CopyLog creates a deep copy of a log.
+func CopyLog(l *Log) *Log {
+	cpy := *l
+	if len(l.Topics) > 0 {
+		cpy.Topics = make([]common.Hash, len(l.Topics))
+		copy(cpy.Topics, l.Topics)
+	}
+	if len(l.Data) > 0 {
+		cpy.Data = make([]byte, len(l.Data))
+		copy(cpy.Data, l.Data)
+	}
+	return &cpy
+}
+
 type logMarshaling struct {
 	Data        hexutil.Bytes
 	BlockNumber hexutil.Uint64

--- a/core/types/receipt.go
+++ b/core/types/receipt.go
@@ -117,6 +117,31 @@ func NewReceipt(root []byte, failed bool, cumulativeGasUsed uint64) *Receipt {
 	return r
 }
 
+// CopyReceipt creates a deep copy of a receipt.
+func CopyReceipt(r *Receipt) *Receipt {
+	cpy := *r
+	if len(r.PostState) > 0 {
+		cpy.PostState = make([]byte, len(r.PostState))
+		copy(cpy.PostState, r.PostState)
+	}
+	if len(r.Logs) > 0 {
+		cpy.Logs = make([]*Log, len(r.Logs))
+		for i, log := range r.Logs {
+			cpy.Logs[i] = CopyLog(log)
+		}
+	}
+	if r.EffectiveGasPrice != nil {
+		cpy.EffectiveGasPrice = new(big.Int).Set(r.EffectiveGasPrice)
+	}
+	if r.BlobGasPrice != nil {
+		cpy.BlobGasPrice = new(big.Int).Set(r.BlobGasPrice)
+	}
+	if r.BlockNumber != nil {
+		cpy.BlockNumber = new(big.Int).Set(r.BlockNumber)
+	}
+	return &cpy
+}
+
 // EncodeRLP implements rlp.Encoder, and flattens the consensus fields of a receipt
 // into an RLP stream. If no post state is present, byzantium fork is assumed.
 func (r *Receipt) EncodeRLP(w io.Writer) error {

--- a/internal/flags/categories.go
+++ b/internal/flags/categories.go
@@ -32,6 +32,7 @@ const (
 	MinerCategory      = "MINER"
 	GasPriceCategory   = "GAS PRICE ORACLE"
 	VMCategory         = "VIRTUAL MACHINE"
+	ExExCategory       = "EXECUTION EXTENSIONS"
 	LoggingCategory    = "LOGGING AND DEBUGGING"
 	MetricsCategory    = "METRICS AND STATS"
 	MiscCategory       = "MISC"

--- a/plugins/minimal.go
+++ b/plugins/minimal.go
@@ -19,7 +19,6 @@ package plugins
 import (
 	"github.com/ethereum/go-ethereum/core/exex"
 	"github.com/ethereum/go-ethereum/core/types"
-	"github.com/ethereum/go-ethereum/log"
 )
 
 // Register the minimal ExEx plugin into Geth.
@@ -29,10 +28,10 @@ func init() {
 
 // newMinimalPlugin creates a minimal Execution Extension plugin to react to some
 // chain events.
-func newMinimalPlugin(logger log.Logger) (*exex.PluginV1, error) {
+func newMinimalPlugin(config *exex.ConfigV1) (*exex.PluginV1, error) {
 	return &exex.PluginV1{
 		OnHead: func(head *types.Header) {
-			logger.Info("Chain head updated", "number", head.Number, "hash", head.Hash())
+			config.Logger.Info("Chain head updated", "number", head.Number, "hash", head.Hash())
 		},
 	}, nil
 }

--- a/plugins/minimal.go
+++ b/plugins/minimal.go
@@ -1,0 +1,38 @@
+// Copyright 2024 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+
+package plugins
+
+import (
+	"github.com/ethereum/go-ethereum/core/exex"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/log"
+)
+
+// Register the minimal ExEx plugin into Geth.
+func init() {
+	exex.RegisterV1("minimal", newMinimalPlugin)
+}
+
+// newMinimalPlugin creates a minimal Execution Extension plugin to react to some
+// chain events.
+func newMinimalPlugin(logger log.Logger) (*exex.PluginV1, error) {
+	return &exex.PluginV1{
+		OnHead: func(head *types.Header) {
+			logger.Info("Chain head updated", "number", head.Number, "hash", head.Hash())
+		},
+	}, nil
+}

--- a/plugins/minimal.go
+++ b/plugins/minimal.go
@@ -33,5 +33,12 @@ func newMinimalPlugin(config *exex.ConfigV1) (*exex.PluginV1, error) {
 		OnHead: func(head *types.Header) {
 			config.Logger.Info("Chain head updated", "number", head.Number, "hash", head.Hash())
 		},
+		OnReorg: func(headers []*types.Header, revert bool) {
+			if revert {
+				config.Logger.Warn("Reorging blocks out", "count", len(headers))
+			} else {
+				config.Logger.Warn("Reorging blocks in", "count", len(headers))
+			}
+		},
 	}, nil
 }


### PR DESCRIPTION
We've been working on [live tracers](https://geth.ethereum.org/docs/developers/evm-tracing/live-tracing) for a while now, allowing hooking into the EVM lifecycle. Whilst that work is super useful in itself, sometimes it is useful to hook into higher level chain events too (head events, reorgs, etc). This is what [Reth pioneered with ExEx](https://www.paradigm.xyz/2024/05/reth-exex), and it's also essentially what this PR introduces.

***The PR is a work in progress, so the API might change. Even if it gets merged, the API will remain fluid for now.***

## Quickstart

From a user perspective, execution extensions are essentially plugins that implement a slew of (optional) callbacks so that they might react to chain and EVM events with 0-delay, immediately as they are happening within the node itself. Since Go does not have the capability to dynamically load/unload code, all such code needs to be compiled into Geth for now (and probably forseeable future).

To implement a plugin, you need 2 things:

- Create a Go method that returns an `exex.Plugin` struct.
- Register your plugin into Geth's ExEx plugin registry.

For an absolute minimal code, take a look at our `minimal` ExEx plugin, included in Geth in the `plugins` package.

```go
package plugins

import (
	"github.com/ethereum/go-ethereum/core/exex"
	"github.com/ethereum/go-ethereum/core/types"
	"github.com/ethereum/go-ethereum/log"
)

// Register the minimal ExEx plugin into Geth.
func init() {
	exex.RegisterV1("minimal", newMinimalPlugin)
}

// newMinimalPlugin creates a minimal Execution Extension plugin to react to some
// chain events.
func newMinimalPlugin(config *exex.ConfigV1) (*exex.PluginV1, error) {
	return &exex.PluginV1{
		OnHead: func(head *types.Header) {
			config.Logger.Info("Chain head updated", "number", head.Number, "hash", head.Hash())
		},
	}, nil
}
```

This code is super tiny, yet achieves a lot:

- The plugin constructor (`newMinimalPlugin`) we've defined creates an `*exex.PluginV1`, which is essentially a set of optional callbacks. Out of all these callbacks, this plugin only implements the `OnHead` method, so will only receive events for that.
- The constructor needs to implement `exex.NewPluginV1`, which takes a config. The config contains a logger from Geth to allow hooking into Geth's logging subsystem with the plugin name already pre-set. It also contains a user configuration string that the plugin can interpret as it wants.
- The `init` call registers this plugin under the globally unique name of `minimal`. This will ***automatically*** create a new CLI flag for Geth `--exex.minimal` that will allow running Geth with or without the plugin enabled; and also `--exex.minimal.config` that the user can pass arbitrary opaque configurations to the plugin. You can run `geth --help` to check what plugins have been registered by us - or by you.

```
   EXECUTION EXTENSIONS

   
    --exex.minimal                      (default: false)                   ($GETH_EXEX_MINIMAL)
          Enables the 'minimal' execution extension plugin
   
    --exex.minimal.config value                                            ($GETH_EXEX_MINIMAL_CONFIG)
          Opaque config to pass to the 'minimal' execution extension plugin
```

You can place your custom plugins anywhere really within Geth, but they need to be imported, so for small plugins consider dropping them into the same `plugins` folder which is already seeded into Geth. Alternatively create a subdirectory under `plugins`, but then add a blank import statement to `plugins` so your code gets compiled into Geth.

## Hooks

This section is fluid. I've tried to document as I go along, but don't expect API stability until I merge this thing. Even after that it might be a bit wobbly for a few releases until people start using it.

- Chain hooks:
  - `OnInit(chain exex.Chain)`: Called when the chain gets initialized within Geth.
  - `OnClose()`: Called when the chain gets torn down within Geth.
  - `OnHead(head *types.Header)`: Called when the chain head block is updated.
  - `OnReorg(headers []*types.Header, revert bool)`: Called when the chain is reorging.
  - `OnFinal(header *types.Header)`: Called when the chain finalizes a past block.

The plugins have access to the following chain constructs (via `*exex.Chain`):

- `Head() *types.Header`: Retrieves the current head block's header.
- `Final() *types.Header`: Retrieves the current finalized block's header.
- `Header(number uint64) *types.Header`: Retrieves a canonical block header with the given number.
- `Block(number uint64) *types.Block`: Retrieves an entire canonical block with the given number.
- `State(root common.Hash) State`: Retrieves a state accessor at a given root hash.
- `Receipts(number uint64) []*types.Receipt`: Retrieves a set of canonical receipts with the given number.

The plugins have access to the following state constructs (via `exex.State`):

- `Balance(addr common.Address) *uint256.Int`: Retrieves the balance of the given account.
- `Nonce(addr common.Address) uint64`: Retrieves the nonce of the given account.
- `Code(addr common.Address) []byte`: Retrieves the bytecode associated with the given account.
- `Storage(addr common.Address, slot common.Hash) common.Hash`: Retrieves the value associated with a specific storage slot.
- `AccountIterator(seek common.Hash) snapshot.AccountIterator`: Retrieves an iterator to walk across all the known accounts.
- `StorageIterator(account common.Hash, seek common.Hash) snapshot.StorageIterator`: Retrieves an iterator to walk across all the known storage slots

## Internals

### Package structure

Implementation wise, there are 2 `exex` packages that this PR introduces. This might seem a bit wonky, but it's done for an API separation of concerns reason:

- `core/exex` is the public API that will have versioning and stability guarantees.
- `core/exex/exex` is the internal API that Geth itself will call for operating the plugins.

You'll see that the actual functionality is fully implemented within `core/exex` (because doing otherwise would lead to dependency cycles), but it is hidden from public consumption and the `core/exex/exex` package just re-exposes those via an interface what `core/exex` took effort to hide. This might be a bit of a funky design, but it ensures that `core/exex` will contains a strongly versioned stable user API without risking that some plugin calls something it's not supposed.

### Singleton namespace

Our live tracer is cheating a bit, because it was injected into the vmConfig struct and passed around Geth everywhere. We could do a similar integration for exex plugins too, but with a more-encompassing event surface, we'd potentially end up with passing it across everything.

We might want to do that in the future, but until we figure out what's needed and what not, the current code uses a singleton global instance and every event trigger directly calls into it via the internal `exex` package (e.g. `exex.TriggerHeadHook`. This in theory permits us to trigger hooks from anywhere within Geth. In practice, dependency loops will be the killer, so let's see :D 