### PR TITLE
build: get rid of ci.go -> common direct dependency

### DIFF
--- a/internal/build/file.go
+++ b/internal/build/file.go
@@ -1,4 +1,4 @@
-// Copyright 2014 The go-ethereum Authors
+// Copyright 2024 The go-ethereum Authors
 // This file is part of the go-ethereum library.
 //
 // The go-ethereum library is free software: you can redistribute it and/or modify
@@ -14,26 +14,15 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
 
-package common
+package build
 
-import (
-	"os"
-	"path/filepath"
-)
+import "os"
 
-// FileExist checks if a file exists at filePath.
-func FileExist(filePath string) bool {
-	_, err := os.Stat(filePath)
+// FileExist checks if a file exists at path.
+func FileExist(path string) bool {
+	_, err := os.Stat(path)
 	if err != nil && os.IsNotExist(err) {
 		return false
 	}
 	return true
-}
-
-// AbsolutePath returns datadir + filename, or filename if it is absolute.
-func AbsolutePath(datadir string, filename string) string {
-	if filepath.IsAbs(filename) {
-		return filename
-	}
-	return filepath.Join(datadir, filename)
 }


### PR DESCRIPTION
Our CI build script should not depend on Ethereum data types. There's still an indirect dependency through params.version, but I'll do that in a followup since there's are multiple possible approaches.