### PR TITLE
consensus/clique, miner: remove clique -> accounts dependency

### DIFF
--- a/miner/payload_building_test.go
+++ b/miner/payload_building_test.go
@@ -22,7 +22,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/ethereum/go-ethereum/accounts"
 	"github.com/ethereum/go-ethereum/beacon/engine"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/consensus"
@@ -114,9 +113,7 @@ func newTestWorkerBackend(t *testing.T, chainConfig *params.ChainConfig, engine 
 	case *clique.Clique:
 		gspec.ExtraData = make([]byte, 32+common.AddressLength+crypto.SignatureLength)
 		copy(gspec.ExtraData[32:32+common.AddressLength], testBankAddress.Bytes())
-		e.Authorize(testBankAddress, func(account accounts.Account, s string, data []byte) ([]byte, error) {
-			return crypto.Sign(crypto.Keccak256(data), testBankKey)
-		})
+		e.Authorize(testBankAddress)
 	case *ethash.Ethash:
 	default:
 		t.Fatalf("unexpected consensus engine type: %T", engine)


### PR DESCRIPTION
Clique currently depends on the `accounts` package. This was a bit of a big cannon even in the past, just to pass a signer "account" to the Clique block producer. Either way, nowadays Geth does not support clique mining any more, so by removing that bit of functionality from our code, we can also break this dependency.

Clique should ideally be further torn out, but this at least gets us one step closer to cleanups.