### PR TITLE
eth/tracers/internal/tracertest: add missing Random to call context

### DIFF
--- a/eth/tracers/internal/tracetest/util.go
+++ b/eth/tracers/internal/tracetest/util.go
@@ -46,8 +46,12 @@ func (c *callContext) toBlockContext(genesis *core.Genesis) vm.BlockContext {
 	}
 	if genesis.Config.IsLondon(context.BlockNumber) {
 		context.BaseFee = (*big.Int)(c.BaseFee)
+	}
+
+	if genesis.Config.TerminalTotalDifficulty != nil && genesis.Config.TerminalTotalDifficulty.Sign() == 0 {
 		context.Random = &genesis.Mixhash
 	}
+
 	if genesis.ExcessBlobGas != nil && genesis.BlobGasUsed != nil {
 		excessBlobGas := eip4844.CalcExcessBlobGas(*genesis.ExcessBlobGas, *genesis.BlobGasUsed)
 		context.BlobBaseFee = eip4844.CalcBlobFee(excessBlobGas)

--- a/eth/tracers/internal/tracetest/util.go
+++ b/eth/tracers/internal/tracetest/util.go
@@ -46,6 +46,7 @@ func (c *callContext) toBlockContext(genesis *core.Genesis) vm.BlockContext {
 	}
 	if genesis.Config.IsLondon(context.BlockNumber) {
 		context.BaseFee = (*big.Int)(c.BaseFee)
+		context.Random = &genesis.Mixhash
 	}
 	if genesis.ExcessBlobGas != nil && genesis.BlobGasUsed != nil {
 		excessBlobGas := eip4844.CalcExcessBlobGas(*genesis.ExcessBlobGas, *genesis.BlobGasUsed)


### PR DESCRIPTION
I have a test locally, but the callTracer test always complains `invalid opcode: PUSH0`

if we want to test chain after the Merge, then the Random(aka prevRandao) should be not be nil

https://github.com/ethereum/go-ethereum/blob/a5fe7353cff959d6fcfcdd9593de19056edb9bdb/core/vm/evm.go#L128

https://github.com/ethereum/go-ethereum/blob/a5fe7353cff959d6fcfcdd9593de19056edb9bdb/params/config.go#L923-L925
