### PR TITLE
Return Revert Data

### DIFF
--- a/internal/ethapi/errors.go
+++ b/internal/ethapi/errors.go
@@ -51,12 +51,24 @@ func newRevertError(revert []byte) *revertError {
 	if errUnpack == nil {
 		err = fmt.Errorf("%w: %v", vm.ErrExecutionReverted, reason)
 	} else {
-		err = fmt.Errorf("%w: %v", vm.ErrExecutionReverted, hexutil.Encode(revert))
+		err = fmt.Errorf("%w: %v", vm.ErrExecutionReverted, formatRevertError(revert))
 	}
 	return &revertError{
 		error:  err,
 		reason: hexutil.Encode(revert),
 	}
+}
+
+// formatRevertError formats the revert data into a custom error message
+func formatRevertError(revert []byte) string {
+	if len(revert) >= 4 {
+		selector := revert[:4]
+		params := revert[4:]
+		return fmt.Sprintf("custom error %s: %s",
+			hexutil.Encode(selector),
+			hexutil.Encode(params))
+	}
+	return hexutil.Encode(revert)
 }
 
 // TxIndexingError is an API error that indicates the transaction indexing is not

--- a/internal/ethapi/errors.go
+++ b/internal/ethapi/errors.go
@@ -46,11 +46,12 @@ func (e *revertError) ErrorData() interface{} {
 
 // newRevertError creates a revertError instance with the provided revert data.
 func newRevertError(revert []byte) *revertError {
-	err := vm.ErrExecutionReverted
-
+	var err error
 	reason, errUnpack := abi.UnpackRevert(revert)
 	if errUnpack == nil {
 		err = fmt.Errorf("%w: %v", vm.ErrExecutionReverted, reason)
+	} else {
+		err = fmt.Errorf("%w: %v", vm.ErrExecutionReverted, hexutil.Encode(revert))
 	}
 	return &revertError{
 		error:  err,

--- a/rpc/client.go
+++ b/rpc/client.go
@@ -365,7 +365,8 @@ func (c *Client) CallContext(ctx context.Context, result interface{}, method str
 	resp := batchresp[0]
 	switch {
 	case resp.Error != nil:
-		return resp.Error
+		errMsg := fmt.Sprintf("%s: %s", resp.Error.Message, resp.Error.Data)
+		return errors.New(errMsg)
 	case len(resp.Result) == 0:
 		return ErrNoResult
 	default:

--- a/rpc/client.go
+++ b/rpc/client.go
@@ -365,8 +365,7 @@ func (c *Client) CallContext(ctx context.Context, result interface{}, method str
 	resp := batchresp[0]
 	switch {
 	case resp.Error != nil:
-		errMsg := fmt.Sprintf("%s: %s", resp.Error.Message, resp.Error.Data)
-		return errors.New(errMsg)
+		return resp.Error
 	case len(resp.Result) == 0:
 		return ErrNoResult
 	default:

--- a/rpc/json.go
+++ b/rpc/json.go
@@ -146,6 +146,9 @@ func (err *jsonError) Error() string {
 	if err.Message == "" {
 		return fmt.Sprintf("json-rpc error %d", err.Code)
 	}
+	if err.Message == "execution reverted" && err.Data != "" {
+		return fmt.Sprintf("%s: %s", err.Message, err.Data)
+	}
 	return err.Message
 }
 


### PR DESCRIPTION
fix: https://github.com/ethereum/go-ethereum/issues/26823

The return value would be like this:

```console
execution reverted: 0x96c6fd1e000000000000000000000000f805dfc724dcd7288b04d8ea7a5b0a9cda8f25cc
```

which is `error ERC20InvalidSender(address sender);` in solidity

### Summary (Generated by copilot):

This pull request includes a small but significant change to the error handling in the `rpc/json.go` file. The change enhances the error message formatting for specific conditions.

Error handling improvement:

* [`rpc/json.go`](diffhunk://#diff-a3e5f9004d7d6d4e0dbfcd7868edb40c6999eb60fabbd2e0b7aafed9124e55feR149-R151): Modified the `Error` method of the `jsonError` struct to include additional details in the error message when the message is "execution reverted" and there is data available.