### PR TITLE
core/state: set-based journalling

### DIFF
--- a/cmd/evm/internal/t8ntool/execution.go
+++ b/cmd/evm/internal/t8ntool/execution.go
@@ -278,6 +278,7 @@ func (pre *Prestate) Apply(vmConfig vm.Config, chainConfig *params.ChainConfig,
 			}
 			continue
 		}
+		statedb.DiscardSnapshot(snapshot)
 		includedTxs = append(includedTxs, tx)
 		if hashError != nil {
 			return nil, nil, nil, NewError(ErrorMissingBlockhash, hashError)

--- a/cmd/evm/runner.go
+++ b/cmd/evm/runner.go
@@ -158,7 +158,8 @@ func runCmd(ctx *cli.Context) error {
 	sdb := state.NewDatabase(triedb, nil)
 	statedb, _ = state.New(genesis.Root(), sdb)
 	chainConfig = genesisConfig.Config
-
+	id := statedb.Snapshot()
+	defer statedb.DiscardSnapshot(id)
 	if ctx.String(SenderFlag.Name) != "" {
 		sender = common.HexToAddress(ctx.String(SenderFlag.Name))
 	}

--- a/core/genesis.go
+++ b/core/genesis.go
@@ -152,6 +152,7 @@ func flushAlloc(ga *types.GenesisAlloc, triedb *triedb.Database) (common.Hash, e
 	if err != nil {
 		return common.Hash{}, err
 	}
+
 	for addr, account := range *ga {
 		if account.Balance != nil {
 			// This is not actually logged via tracer because OnGenesisBlock

--- a/core/state/journal_api.go
+++ b/core/state/journal_api.go
@@ -2,12 +2,22 @@ package state
 
 import (
 	"github.com/ethereum/go-ethereum/common"
-	"github.com/holiman/uint256"
+	"github.com/ethereum/go-ethereum/core/types"
 )
 
 type journal interface {
-
 	// snapshot returns an identifier for the current revision of the state.
+	// The lifeycle of journalling is as follows:
+	// - snapshot() starts a 'scope'.
+	// - Tee method snapshot() may be called any number of times.
+	// - For each call to snapshot, there should be a corresponding call to end
+	//  the scope via either of:
+	//   - revertToSnapshot, which undoes the changes in the scope, or
+	//   - discardSnapshot, which discards the ability to revert the changes in the scope.
+	//     - This operation might merge the changes into the parent scope.
+	//       If it does not merge the changes into the parent scope, it must create
+	//       a new snapshot internally, in order to ensure that order of changes
+	//       remains intact.
 	snapshot() int
 
 	// revertToSnapshot reverts all state changes made since the given revision.
@@ -15,6 +25,11 @@ type journal interface {
 
 	// reset clears the journal so it can be reused.
 	reset()
+
+	// DiscardSnapshot removes the snapshot with the given id; after calling this
+	// method, it is no longer possible to revert to that particular snapshot, the
+	// changes are considered part of the parent scope.
+	DiscardSnapshot(revid int)
 
 	// dirtyAccounts returns a list of all accounts modified in this journal
 	dirtyAccounts() []common.Address
@@ -34,12 +49,12 @@ type journal interface {
 	// createContract journals the creation of a new contract at addr.
 	// OBS: This method must not be applied twice, it assumes that the pre-state
 	// (i.e the rollback-state) is non-created.
-	createContract(addr common.Address)
+	createContract(addr common.Address, account *types.StateAccount)
 
 	// destruct journals the destruction of an account in the trie.
-	// OBS: This method must not be applied twice -- it always assumes that the
-	// pre-state (i.e the rollback-state) is non-destructed.
-	destruct(addr common.Address)
+	// pre-state (i.e the rollback-state) is non-destructed (and, for the purpose
+	// of EIP-XXX (TODO lookup), created in this tx).
+	destruct(addr common.Address, account *types.StateAccount)
 
 	// storageChange journals a change in the storage data related to addr.
 	// It records the key and previous value of the slot.
@@ -52,19 +67,19 @@ type journal interface {
 	// refundChange journals that the refund has been changed, recording the previous value.
 	refundChange(previous uint64)
 
-	// balanceChange journals tha the balance of addr has been changed, recording the previous value
-	balanceChange(addr common.Address, previous *uint256.Int)
+	// balanceChange journals that the balance of addr has been changed, recording the previous value
+	balanceChange(addr common.Address, account *types.StateAccount, destructed, newContract bool)
 
-	// JournalSetCode journals that the code of addr has been set.
+	// setCode journals that the code of addr has been set.
 	// OBS: This method must not be applied twice -- it always assumes that the
 	// pre-state (i.e the rollback-state) is "no code".
-	setCode(addr common.Address)
+	setCode(addr common.Address, account *types.StateAccount)
 
 	// nonceChange journals that the nonce of addr was changed, recording the previous value.
-	nonceChange(addr common.Address, prev uint64)
+	nonceChange(addr common.Address, account *types.StateAccount, destructed, newContract bool)
 
 	// touchChange journals that the account at addr was touched during execution.
-	touchChange(addr common.Address)
+	touchChange(addr common.Address, account *types.StateAccount, destructed, newContract bool)
 
 	// copy returns a deep-copied journal.
 	copy() journal

--- a/core/state/journal_api.go
+++ b/core/state/journal_api.go
@@ -1,0 +1,71 @@
+package state
+
+import (
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/holiman/uint256"
+)
+
+type journal interface {
+
+	// snapshot returns an identifier for the current revision of the state.
+	snapshot() int
+
+	// revertToSnapshot reverts all state changes made since the given revision.
+	revertToSnapshot(revid int, s *StateDB)
+
+	// reset clears the journal so it can be reused.
+	reset()
+
+	// dirtyAccounts returns a list of all accounts modified in this journal
+	dirtyAccounts() []common.Address
+
+	// accessListAddAccount journals the adding of addr to the access list
+	accessListAddAccount(addr common.Address)
+
+	// accessListAddSlot journals the adding of addr/slot to the access list
+	accessListAddSlot(addr common.Address, slot common.Hash)
+
+	// logChange journals the adding of a log related to the txHash
+	logChange(txHash common.Hash)
+
+	// createObject journals the event of a new account created in the trie.
+	createObject(addr common.Address)
+
+	// createContract journals the creation of a new contract at addr.
+	// OBS: This method must not be applied twice, it assumes that the pre-state
+	// (i.e the rollback-state) is non-created.
+	createContract(addr common.Address)
+
+	// destruct journals the destruction of an account in the trie.
+	// OBS: This method must not be applied twice -- it always assumes that the
+	// pre-state (i.e the rollback-state) is non-destructed.
+	destruct(addr common.Address)
+
+	// storageChange journals a change in the storage data related to addr.
+	// It records the key and previous value of the slot.
+	storageChange(addr common.Address, key, prev, origin common.Hash)
+
+	// transientStateChange journals a change in the t-storage data related to addr.
+	// It records the key and previous value of the slot.
+	transientStateChange(addr common.Address, key, prev common.Hash)
+
+	// refundChange journals that the refund has been changed, recording the previous value.
+	refundChange(previous uint64)
+
+	// balanceChange journals tha the balance of addr has been changed, recording the previous value
+	balanceChange(addr common.Address, previous *uint256.Int)
+
+	// JournalSetCode journals that the code of addr has been set.
+	// OBS: This method must not be applied twice -- it always assumes that the
+	// pre-state (i.e the rollback-state) is "no code".
+	setCode(addr common.Address)
+
+	// nonceChange journals that the nonce of addr was changed, recording the previous value.
+	nonceChange(addr common.Address, prev uint64)
+
+	// touchChange journals that the account at addr was touched during execution.
+	touchChange(addr common.Address)
+
+	// copy returns a deep-copied journal.
+	copy() journal
+}

--- a/core/state/journal_test.go
+++ b/core/state/journal_test.go
@@ -1,0 +1,132 @@
+// Copyright 2024 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+
+// Package state provides a caching layer atop the Ethereum state trie.
+package state
+
+import (
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/holiman/uint256"
+)
+
+func TestLinearJournalDirty(t *testing.T) {
+	testJournalDirty(t, newLinearJournal())
+}
+
+func TestSparseJournalDirty(t *testing.T) {
+	testJournalDirty(t, newSparseJournal())
+}
+
+// This test verifies some basics around journalling: the ability to
+// deliver a dirty-set.
+func testJournalDirty(t *testing.T, j journal) {
+	acc := &types.StateAccount{
+		Nonce:    1,
+		Balance:  new(uint256.Int),
+		Root:     common.Hash{},
+		CodeHash: nil,
+	}
+	{
+		j.nonceChange(common.Address{0x1}, acc, false, false)
+		if have, want := len(j.dirtyAccounts()), 1; have != want {
+			t.Errorf("wrong size of dirty accounts, have %v want %v", have, want)
+		}
+	}
+	{
+		j.storageChange(common.Address{0x2}, common.Hash{0x1}, common.Hash{0x1}, common.Hash{})
+		if have, want := len(j.dirtyAccounts()), 2; have != want {
+			t.Errorf("wrong size of dirty accounts, have %v want %v", have, want)
+		}
+	}
+	{ // The previous scopes should also be accounted for
+		j.snapshot()
+		if have, want := len(j.dirtyAccounts()), 2; have != want {
+			t.Errorf("wrong size of dirty accounts, have %v want %v", have, want)
+		}
+	}
+}
+
+func TestLinearJournalAccessList(t *testing.T) {
+	testJournalAccessList(t, newLinearJournal())
+}
+
+func TestSparseJournalAccessList(t *testing.T) {
+	testJournalAccessList(t, newSparseJournal())
+}
+
+func testJournalAccessList(t *testing.T, j journal) {
+	var statedb = &StateDB{}
+	statedb.accessList = newAccessList()
+	statedb.journal = j
+
+	{
+		// If the journal performs the rollback in the wrong order, this
+		// will cause a panic.
+		id := j.snapshot()
+		statedb.AddSlotToAccessList(common.Address{0x1}, common.Hash{0x4})
+		statedb.AddSlotToAccessList(common.Address{0x3}, common.Hash{0x4})
+		statedb.RevertToSnapshot(id)
+	}
+	{
+		id := j.snapshot()
+		statedb.AddAddressToAccessList(common.Address{0x2})
+		statedb.AddAddressToAccessList(common.Address{0x3})
+		statedb.AddAddressToAccessList(common.Address{0x4})
+		statedb.RevertToSnapshot(id)
+		if statedb.accessList.ContainsAddress(common.Address{0x2}) {
+			t.Fatal("should be missing")
+		}
+	}
+}
+
+func TestLinearJournalRefunds(t *testing.T) {
+	testJournalRefunds(t, newLinearJournal())
+}
+
+func TestSparseJournalRefunds(t *testing.T) {
+	testJournalRefunds(t, newSparseJournal())
+}
+
+func testJournalRefunds(t *testing.T, j journal) {
+	var statedb = &StateDB{}
+	statedb.accessList = newAccessList()
+	statedb.journal = j
+	zero := j.snapshot()
+	j.refundChange(0)
+	j.refundChange(1)
+	{
+		id := j.snapshot()
+		j.refundChange(2)
+		j.refundChange(3)
+		j.revertToSnapshot(id, statedb)
+		if have, want := statedb.refund, uint64(2); have != want {
+			t.Fatalf("have %d want %d", have, want)
+		}
+	}
+	{
+		id := j.snapshot()
+		j.refundChange(2)
+		j.refundChange(3)
+		j.DiscardSnapshot(id)
+	}
+	j.revertToSnapshot(zero, statedb)
+	if have, want := statedb.refund, uint64(0); have != want {
+		t.Fatalf("have %d want %d", have, want)
+	}
+}

--- a/core/state/setjournal.go
+++ b/core/state/setjournal.go
@@ -1,0 +1,486 @@
+// Copyright 2024 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+
+package state
+
+import (
+	"bytes"
+	"fmt"
+	"maps"
+	"slices"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/log"
+	"github.com/holiman/uint256"
+)
+
+var (
+	_ journal = (*sparseJournal)(nil)
+)
+
+// journalAccount represents the 'journable state' of a types.Account.
+// Which means, all the normal fields except storage root, but also with a
+// destruction-flag.
+type journalAccount struct {
+	nonce       uint64
+	balance     uint256.Int
+	codeHash    []byte // nil == emptyCodeHAsh
+	destructed  bool
+	newContract bool
+}
+
+type addrSlot struct {
+	addr common.Address
+	slot common.Hash
+}
+
+type doubleHash struct {
+	origin common.Hash
+	prev   common.Hash
+}
+
+// scopedJournal represents all changes within a single callscope. These changes
+// are either all reverted, or all committed -- they cannot be partially applied.
+type scopedJournal struct {
+	accountChanges map[common.Address]*journalAccount
+	refund         int64
+	logs           []common.Hash
+
+	accessListAddresses []common.Address
+	accessListAddrSlots []addrSlot
+
+	storageChanges  map[common.Address]map[common.Hash]doubleHash
+	tStorageChanges map[common.Address]map[common.Hash]common.Hash
+}
+
+func newScopedJournal() *scopedJournal {
+	return &scopedJournal{
+		refund: -1,
+	}
+}
+
+func (j *scopedJournal) deepCopy() *scopedJournal {
+	var cpy = &scopedJournal{
+		// The accountChanges copy will copy the pointers to
+		// journalAccount objects: thus not actually deep copy those
+		// objects. That is fine: we never mutate journalAccount.
+		accountChanges:      maps.Clone(j.accountChanges),
+		refund:              j.refund,
+		logs:                slices.Clone(j.logs),
+		accessListAddresses: slices.Clone(j.accessListAddresses),
+		accessListAddrSlots: slices.Clone(j.accessListAddrSlots),
+	}
+	if j.storageChanges != nil {
+		cpy.storageChanges = make(map[common.Address]map[common.Hash]doubleHash)
+		for addr, changes := range j.storageChanges {
+			cpy.storageChanges[addr] = maps.Clone(changes)
+		}
+	}
+	if j.tStorageChanges != nil {
+		cpy.tStorageChanges = make(map[common.Address]map[common.Hash]common.Hash)
+		for addr, changes := range j.tStorageChanges {
+			cpy.tStorageChanges[addr] = maps.Clone(changes)
+		}
+	}
+	return cpy
+}
+
+func (j *scopedJournal) journalRefundChange(prev uint64) {
+	if j.refund == -1 {
+		// We convert from uint64 to int64 here, so that we can use -1
+		// to represent "no previous value set".
+		// Treating refund as int64 is fine, there's no possibility for
+		// refund to ever exceed maxInt64.
+		j.refund = int64(prev)
+	}
+}
+
+// journalAccountChange is the common shared implementation for all account-changes.
+// These changes all fall back to this method:
+// - balance change
+// - nonce change
+// - destruct-change
+// - code change
+// - touch change
+// - creation change (in this case, the account is nil)
+func (j *scopedJournal) journalAccountChange(address common.Address, account *types.StateAccount, destructed, newContract bool) {
+	if j.accountChanges == nil {
+		j.accountChanges = make(map[common.Address]*journalAccount)
+	}
+	// If the account has already been journalled, we're done here
+	if _, ok := j.accountChanges[address]; ok {
+		return
+	}
+	if account == nil {
+		j.accountChanges[address] = nil // created now, previously non-existent
+		return
+	}
+	ja := &journalAccount{
+		nonce:       account.Nonce,
+		balance:     *account.Balance,
+		destructed:  destructed,
+		newContract: newContract,
+	}
+	if !bytes.Equal(account.CodeHash, types.EmptyCodeHash[:]) {
+		ja.codeHash = account.CodeHash
+	}
+	j.accountChanges[address] = ja
+}
+
+func (j *scopedJournal) journalLog(txHash common.Hash) {
+	j.logs = append(j.logs, txHash)
+}
+
+func (j *scopedJournal) journalAccessListAddAccount(addr common.Address) {
+	j.accessListAddresses = append(j.accessListAddresses, addr)
+}
+
+func (j *scopedJournal) journalAccessListAddSlot(addr common.Address, slot common.Hash) {
+	j.accessListAddrSlots = append(j.accessListAddrSlots, addrSlot{addr, slot})
+}
+
+func (j *scopedJournal) journalSetState(addr common.Address, key, prev, origin common.Hash) {
+	if j.storageChanges == nil {
+		j.storageChanges = make(map[common.Address]map[common.Hash]doubleHash)
+	}
+	changes, ok := j.storageChanges[addr]
+	if !ok {
+		changes = make(map[common.Hash]doubleHash)
+		j.storageChanges[addr] = changes
+	}
+	// Do not overwrite a previous value!
+	if _, ok := changes[key]; !ok {
+		changes[key] = doubleHash{origin: origin, prev: prev}
+	}
+}
+
+func (j *scopedJournal) journalSetTransientState(addr common.Address, key, prev common.Hash) {
+	if j.tStorageChanges == nil {
+		j.tStorageChanges = make(map[common.Address]map[common.Hash]common.Hash)
+	}
+	changes, ok := j.tStorageChanges[addr]
+	if !ok {
+		changes = make(map[common.Hash]common.Hash)
+		j.tStorageChanges[addr] = changes
+	}
+	// Do not overwrite a previous value!
+	if _, ok := changes[key]; !ok {
+		changes[key] = prev
+	}
+}
+
+func (j *scopedJournal) revert(s *StateDB) {
+	// Revert refund
+	if j.refund != -1 {
+		s.refund = uint64(j.refund)
+	}
+	// Revert storage changes
+	for addr, changes := range j.storageChanges {
+		obj := s.getStateObject(addr)
+		for key, val := range changes {
+			obj.setState(key, val.prev, val.origin)
+		}
+	}
+	// Revert t-store changes
+	for addr, changes := range j.tStorageChanges {
+		for key, val := range changes {
+			s.setTransientState(addr, key, val)
+		}
+	}
+
+	// Revert changes to accounts
+	for addr, data := range j.accountChanges {
+		if data == nil { // Reverting a create
+			delete(s.stateObjects, addr)
+			continue
+		}
+		obj := s.getStateObject(addr)
+		obj.setNonce(data.nonce)
+		// Setting 'code' to nil means it will be loaded from disk
+		// next time it is needed. We avoid nilling it unless required
+		journalHash := data.codeHash
+		if data.codeHash == nil {
+			if !bytes.Equal(obj.CodeHash(), types.EmptyCodeHash[:]) {
+				obj.setCode(types.EmptyCodeHash, nil)
+			}
+		} else {
+			if !bytes.Equal(obj.CodeHash(), journalHash) {
+				obj.setCode(common.BytesToHash(data.codeHash), nil)
+			}
+		}
+		obj.setBalance(&data.balance)
+		obj.selfDestructed = data.destructed
+		obj.newContract = data.newContract
+	}
+	// Revert logs
+	for _, txhash := range j.logs {
+		logs := s.logs[txhash]
+		if len(logs) == 1 {
+			delete(s.logs, txhash)
+		} else {
+			s.logs[txhash] = logs[:len(logs)-1]
+		}
+		s.logSize--
+	}
+	// Revert access list additions
+	for i := len(j.accessListAddrSlots) - 1; i >= 0; i-- {
+		item := j.accessListAddrSlots[i]
+		s.accessList.DeleteSlot(item.addr, item.slot)
+	}
+	for i := len(j.accessListAddresses) - 1; i >= 0; i-- {
+		s.accessList.DeleteAddress(j.accessListAddresses[i])
+	}
+}
+
+func (j *scopedJournal) merge(parent *scopedJournal) {
+	if parent.refund == -1 {
+		parent.refund = j.refund
+	}
+	// Revert changes to accounts
+	if parent.accountChanges == nil {
+		parent.accountChanges = j.accountChanges
+	} else {
+		for addr, data := range j.accountChanges {
+			if _, present := parent.accountChanges[addr]; present {
+				// Nothing to do here, it's already stored in parent scope
+				continue
+			}
+			parent.accountChanges[addr] = data
+		}
+	}
+	// Revert logs
+	parent.logs = append(parent.logs, j.logs...)
+
+	// Revert access list additions
+	parent.accessListAddrSlots = append(parent.accessListAddrSlots, j.accessListAddrSlots...)
+	parent.accessListAddresses = append(parent.accessListAddresses, j.accessListAddresses...)
+
+	if parent.storageChanges == nil {
+		parent.storageChanges = j.storageChanges
+	} else {
+		// Merge storage changes
+		for addr, changes := range j.storageChanges {
+			prevChanges, ok := parent.storageChanges[addr]
+			if !ok {
+				parent.storageChanges[addr] = changes
+				continue
+			}
+			for k, v := range changes {
+				if _, ok := prevChanges[k]; !ok {
+					prevChanges[k] = v
+				}
+			}
+		}
+	}
+	if parent.tStorageChanges == nil {
+		parent.tStorageChanges = j.tStorageChanges
+	} else {
+		// Revert t-store changes
+		for addr, changes := range j.tStorageChanges {
+			prevChanges, ok := parent.tStorageChanges[addr]
+			if !ok {
+				parent.tStorageChanges[addr] = changes
+				continue
+			}
+			for k, v := range changes {
+				if _, ok := prevChanges[k]; !ok {
+					prevChanges[k] = v
+				}
+			}
+		}
+	}
+}
+
+func (j *scopedJournal) addDirtyAccounts(set map[common.Address]any) {
+	// Changes due to account changes
+	for addr := range j.accountChanges {
+		set[addr] = []interface{}{}
+	}
+	// Changes due to storage changes
+	for addr := range j.storageChanges {
+		set[addr] = []interface{}{}
+	}
+}
+
+// sparseJournal contains the list of state modifications applied since the last state
+// commit. These are tracked to be able to be reverted in the case of an execution
+// exception or request for reversal.
+type sparseJournal struct {
+	entries   []*scopedJournal // Current changes tracked by the journal
+	ripeMagic bool
+}
+
+// newJournal creates a new initialized journal.
+func newSparseJournal() *sparseJournal {
+	s := new(sparseJournal)
+	s.snapshot() // create snaphot zero
+	return s
+}
+
+// reset clears the journal, after this operation the journal can be used
+// anew. It is semantically similar to calling 'newJournal', but the underlying
+// slices can be reused
+func (j *sparseJournal) reset() {
+	j.entries = j.entries[:0]
+	j.snapshot()
+}
+
+func (j *sparseJournal) copy() journal {
+	cp := &sparseJournal{
+		entries: make([]*scopedJournal, 0, len(j.entries)),
+	}
+	for _, entry := range j.entries {
+		cp.entries = append(cp.entries, entry.deepCopy())
+	}
+	return cp
+}
+
+// snapshot returns an identifier for the current revision of the state.
+// OBS: A call to Snapshot is _required_ in order to initialize the journalling,
+// invoking the journal-methods without having invoked Snapshot will lead to
+// panic.
+func (j *sparseJournal) snapshot() int {
+	id := len(j.entries)
+	j.entries = append(j.entries, newScopedJournal())
+	return id
+}
+
+// revertToSnapshot reverts all state changes made since the given revision.
+func (j *sparseJournal) revertToSnapshot(id int, s *StateDB) {
+	if id >= len(j.entries) {
+		panic(fmt.Errorf("revision id %v cannot be reverted", id))
+	}
+	// Revert the entries sequentially
+	for i := len(j.entries) - 1; i >= id; i-- {
+		entry := j.entries[i]
+		entry.revert(s)
+	}
+	j.entries = j.entries[:id]
+}
+
+func (j *sparseJournal) DiscardSnapshot(id int) {
+	if id == 0 {
+		return
+	}
+	// here we must merge the 'id' with it's parent.
+	want := len(j.entries) - 1
+	have := id
+	if want != have {
+		if want == 0 && id == 1 {
+			// If a transcation is applied successfully, the statedb.Finalize will
+			// end by clearing and resetting the journal. Invoking a DiscardSnapshot
+			// afterwards will lead us here.
+			// Let's not panic, but it's ok to complain a bit
+			log.Error("Extraneous invocation to discard snapshot")
+			return
+		} else {
+			panic(fmt.Sprintf("journalling error, want discard(%d), have discard(%d)", want, have))
+		}
+	}
+	entry := j.entries[id]
+	parent := j.entries[id-1]
+	entry.merge(parent)
+	j.entries = j.entries[:id]
+}
+
+func (j *sparseJournal) journalAccountChange(addr common.Address, account *types.StateAccount, destructed, newContract bool) {
+	j.entries[len(j.entries)-1].journalAccountChange(addr, account, destructed, newContract)
+}
+
+func (j *sparseJournal) nonceChange(addr common.Address, account *types.StateAccount, destructed, newContract bool) {
+	j.journalAccountChange(addr, account, destructed, newContract)
+}
+
+func (j *sparseJournal) balanceChange(addr common.Address, account *types.StateAccount, destructed, newContract bool) {
+	j.journalAccountChange(addr, account, destructed, newContract)
+}
+
+func (j *sparseJournal) setCode(addr common.Address, account *types.StateAccount) {
+	j.journalAccountChange(addr, account, false, true)
+}
+
+func (j *sparseJournal) createObject(addr common.Address) {
+	// Creating an account which is destructed, hence already exists, is not
+	// allowed, hence we know destructed == 'false'.
+	// Also, if we are creating the account now, it cannot yet be a
+	// newContract (that might come later)
+	j.journalAccountChange(addr, nil, false, false)
+}
+
+func (j *sparseJournal) createContract(addr common.Address, account *types.StateAccount) {
+	// Creating an account which is destructed, hence already exists, is not
+	// allowed, hence we know it to be 'false'.
+	// Also: if we create the contract now, it cannot be previously created
+	j.journalAccountChange(addr, account, false, false)
+}
+
+func (j *sparseJournal) destruct(addr common.Address, account *types.StateAccount) {
+	// destructing an already destructed account must not be journalled. Hence we
+	// know it to be 'false'.
+	// Also: if we're allowed to destruct it, it must be `newContract:true`, OR
+	// the concept of newContract is unused and moot.
+	j.journalAccountChange(addr, account, false, true)
+}
+
+// var ripemd = common.HexToAddress("0000000000000000000000000000000000000003")
+func (j *sparseJournal) touchChange(addr common.Address, account *types.StateAccount, destructed, newContract bool) {
+	j.journalAccountChange(addr, account, destructed, newContract)
+	if addr == ripemd {
+		// Explicitly put it in the dirty-cache one extra time. Ripe magic.
+		j.ripeMagic = true
+	}
+}
+
+func (j *sparseJournal) logChange(txHash common.Hash) {
+	j.entries[len(j.entries)-1].journalLog(txHash)
+}
+
+func (j *sparseJournal) refundChange(prev uint64) {
+	j.entries[len(j.entries)-1].journalRefundChange(prev)
+}
+
+func (j *sparseJournal) accessListAddAccount(addr common.Address) {
+	j.entries[len(j.entries)-1].journalAccessListAddAccount(addr)
+}
+
+func (j *sparseJournal) accessListAddSlot(addr common.Address, slot common.Hash) {
+	j.entries[len(j.entries)-1].journalAccessListAddSlot(addr, slot)
+}
+
+func (j *sparseJournal) storageChange(addr common.Address, key, prev, origin common.Hash) {
+	j.entries[len(j.entries)-1].journalSetState(addr, key, prev, origin)
+}
+
+func (j *sparseJournal) transientStateChange(addr common.Address, key, prev common.Hash) {
+	j.entries[len(j.entries)-1].journalSetTransientState(addr, key, prev)
+}
+
+func (j *sparseJournal) dirtyAccounts() []common.Address {
+	// The dirty-set should encompass all layers
+	var dirty = make(map[common.Address]any)
+	for _, scope := range j.entries {
+		scope.addDirtyAccounts(dirty)
+	}
+	if j.ripeMagic {
+		dirty[ripemd] = []interface{}{}
+	}
+	var dirtyList = make([]common.Address, 0, len(dirty))
+	for addr := range dirty {
+		dirtyList = append(dirtyList, addr)
+	}
+	return dirtyList
+}

--- a/core/state/state_object.go
+++ b/core/state/state_object.go
@@ -113,7 +113,7 @@ func (s *stateObject) markSelfdestructed() {
 }
 
 func (s *stateObject) touch() {
-	s.db.journal.touchChange(s.address)
+	s.db.journal.touchChange(s.address, &s.data, s.selfDestructed, s.newContract)
 }
 
 // getTrie returns the associated storage trie. The trie will be opened if it's
@@ -462,7 +462,7 @@ func (s *stateObject) AddBalance(amount *uint256.Int) uint256.Int {
 // SetBalance sets the balance for the object, and returns the previous balance.
 func (s *stateObject) SetBalance(amount *uint256.Int) uint256.Int {
 	prev := *s.data.Balance
-	s.db.journal.balanceChange(s.address, s.data.Balance)
+	s.db.journal.balanceChange(s.address, &s.data, s.selfDestructed, s.newContract)
 	s.setBalance(amount)
 	return prev
 }
@@ -536,7 +536,7 @@ func (s *stateObject) CodeSize() int {
 }
 
 func (s *stateObject) SetCode(codeHash common.Hash, code []byte) {
-	s.db.journal.setCode(s.address)
+	s.db.journal.setCode(s.address, &s.data)
 	s.setCode(codeHash, code)
 }
 
@@ -547,7 +547,7 @@ func (s *stateObject) setCode(codeHash common.Hash, code []byte) {
 }
 
 func (s *stateObject) SetNonce(nonce uint64) {
-	s.db.journal.nonceChange(s.address, s.data.Nonce)
+	s.db.journal.nonceChange(s.address, &s.data, s.selfDestructed, s.newContract)
 	s.setNonce(nonce)
 }
 

--- a/core/state/statedb.go
+++ b/core/state/statedb.go
@@ -133,7 +133,7 @@ type StateDB struct {
 
 	// Journal of state modifications. This is the backbone of
 	// Snapshot and RevertToSnapshot.
-	journal *journal
+	journal journal
 
 	// State witness if cross validation is needed
 	witness *stateless.Witness
@@ -177,7 +177,7 @@ func New(root common.Hash, db Database) (*StateDB, error) {
 		mutations:            make(map[common.Address]*mutation),
 		logs:                 make(map[common.Hash][]*types.Log),
 		preimages:            make(map[common.Hash][]byte),
-		journal:              newJournal(),
+		journal:              newLinearJournal(),
 		accessList:           newAccessList(),
 		transientStorage:     newTransientStorage(),
 	}
@@ -719,8 +719,9 @@ func (s *StateDB) GetRefund() uint64 {
 // the journal as well as the refunds. Finalise, however, will not push any updates
 // into the tries just yet. Only IntermediateRoot or Commit will do that.
 func (s *StateDB) Finalise(deleteEmptyObjects bool) {
-	addressesToPrefetch := make([]common.Address, 0, len(s.journal.dirties))
-	for addr := range s.journal.dirties {
+	dirties := s.journal.dirtyAccounts()
+	addressesToPrefetch := make([]common.Address, 0, len(dirties))
+	for _, addr := range dirties {
 		obj, exist := s.stateObjects[addr]
 		if !exist {
 			// ripeMD is 'touched' at block 1714175, in tx 0x1237f737031e40bcde4a8b7e717b2d15e3ecadfe49bb1bbc71ee9deb09c6fcf2

--- a/core/state/statedb_hooked.go
+++ b/core/state/statedb_hooked.go
@@ -141,6 +141,10 @@ func (s *hookedStateDB) Prepare(rules params.Rules, sender, coinbase common.Addr
 	s.inner.Prepare(rules, sender, coinbase, dest, precompiles, txAccesses)
 }
 
+func (s *hookedStateDB) DiscardSnapshot(id int) {
+	s.inner.DiscardSnapshot(id)
+}
+
 func (s *hookedStateDB) RevertToSnapshot(i int) {
 	s.inner.RevertToSnapshot(i)
 }
@@ -230,7 +234,7 @@ func (s *hookedStateDB) Finalise(deleteEmptyObjects bool) {
 	if s.hooks.OnBalanceChange == nil {
 		return
 	}
-	for addr := range s.inner.journal.dirties {
+	for _, addr := range s.inner.journal.dirtyAccounts() {
 		obj := s.inner.stateObjects[addr]
 		if obj != nil && obj.selfDestructed {
 			// If ether was sent to account post-selfdestruct it is burnt.

--- a/core/state/statedb_test.go
+++ b/core/state/statedb_test.go
@@ -228,7 +228,7 @@ func TestCopy(t *testing.T) {
 }
 
 // TestCopyWithDirtyJournal tests if Copy can correct create a equal copied
-// stateDB with dirty journal present.
+// stateDB with dirty linearJournal present.
 func TestCopyWithDirtyJournal(t *testing.T) {
 	db := NewDatabaseForTesting()
 	orig, _ := New(types.EmptyRootHash, db)
@@ -410,8 +410,8 @@ func newTestAction(addr common.Address, r *rand.Rand) testAction {
 					// We also set some code here, to prevent the
 					// CreateContract action from being performed twice in a row,
 					// which would cause a difference in state when unrolling
-					// the journal. (CreateContact assumes created was false prior to
-					// invocation, and the journal rollback sets it to false).
+					// the linearJournal. (CreateContact assumes created was false prior to
+					// invocation, and the linearJournal rollback sets it to false).
 					s.SetCode(addr, []byte{1})
 				}
 			},
@@ -677,22 +677,23 @@ func (test *snapshotTest) checkEqual(state, checkstate *StateDB) error {
 		return fmt.Errorf("got GetLogs(common.Hash{}) == %v, want GetLogs(common.Hash{}) == %v",
 			state.GetLogs(common.Hash{}, 0, common.Hash{}), checkstate.GetLogs(common.Hash{}, 0, common.Hash{}))
 	}
-	if !maps.Equal(state.journal.dirties, checkstate.journal.dirties) {
-		getKeys := func(dirty map[common.Address]int) string {
-			var keys []common.Address
-			out := new(strings.Builder)
-			for key := range dirty {
-				keys = append(keys, key)
+	{ // Check the dirty-accounts
+		have := state.journal.dirtyAccounts()
+		want := checkstate.journal.dirtyAccounts()
+		slices.SortFunc(have, common.Address.Cmp)
+		slices.SortFunc(want, common.Address.Cmp)
+		if !slices.Equal(have, want) {
+			getKeys := func(keys []common.Address) string {
+				out := new(strings.Builder)
+				for i, key := range keys {
+					fmt.Fprintf(out, "  %d. %v\n", i, key)
+				}
+				return out.String()
 			}
-			slices.SortFunc(keys, common.Address.Cmp)
-			for i, key := range keys {
-				fmt.Fprintf(out, "  %d. %v\n", i, key)
-			}
-			return out.String()
+			haveK := getKeys(state.journal.dirtyAccounts())
+			wantK := getKeys(checkstate.journal.dirtyAccounts())
+			return fmt.Errorf("dirty-journal set mismatch.\nhave:\n%v\nwant:\n%v\n", haveK, wantK)
 		}
-		have := getKeys(state.journal.dirties)
-		want := getKeys(checkstate.journal.dirties)
-		return fmt.Errorf("dirty-journal set mismatch.\nhave:\n%v\nwant:\n%v\n", have, want)
 	}
 	return nil
 }
@@ -706,11 +707,11 @@ func TestTouchDelete(t *testing.T) {
 	snapshot := s.state.Snapshot()
 	s.state.AddBalance(common.Address{}, new(uint256.Int), tracing.BalanceChangeUnspecified)
 
-	if len(s.state.journal.dirties) != 1 {
+	if len(s.state.journal.dirtyAccounts()) != 1 {
 		t.Fatal("expected one dirty state object")
 	}
 	s.state.RevertToSnapshot(snapshot)
-	if len(s.state.journal.dirties) != 0 {
+	if len(s.state.journal.dirtyAccounts()) != 0 {
 		t.Fatal("expected no dirty state object")
 	}
 }
@@ -1099,32 +1100,51 @@ func TestStateDBAccessList(t *testing.T) {
 		}
 	}
 
+	var ids []int
+	push := func(id int) {
+		ids = append(ids, id)
+	}
+	pop := func() int {
+		id := ids[len(ids)-1]
+		ids = ids[:len(ids)-1]
+		return id
+	}
+
+	push(state.journal.snapshot())                    // journal id 0
 	state.AddAddressToAccessList(addr("aa"))          // 1
-	state.AddSlotToAccessList(addr("bb"), slot("01")) // 2,3
+	push(state.journal.snapshot())                    // journal id 1
+	state.AddAddressToAccessList(addr("bb"))          // 2
+	push(state.journal.snapshot())                    // journal id 2
+	state.AddSlotToAccessList(addr("bb"), slot("01")) // 3
+	push(state.journal.snapshot())                    // journal id 3
 	state.AddSlotToAccessList(addr("bb"), slot("02")) // 4
+	push(state.journal.snapshot())                    // journal id 4
 	verifyAddrs("aa", "bb")
 	verifySlots("bb", "01", "02")
 
 	// Make a copy
 	stateCopy1 := state.Copy()
-	if exp, got := 4, state.journal.length(); exp != got {
-		t.Fatalf("journal length mismatch: have %d, want %d", got, exp)
+	if exp, got := 4, state.journal.(*linearJournal).length(); exp != got {
+		t.Fatalf("linearJournal length mismatch: have %d, want %d", got, exp)
 	}
 
-	// same again, should cause no journal entries
+	// same again, should cause no linearJournal entries
 	state.AddSlotToAccessList(addr("bb"), slot("01"))
 	state.AddSlotToAccessList(addr("bb"), slot("02"))
 	state.AddAddressToAccessList(addr("aa"))
-	if exp, got := 4, state.journal.length(); exp != got {
-		t.Fatalf("journal length mismatch: have %d, want %d", got, exp)
+	if exp, got := 4, state.journal.(*linearJournal).length(); exp != got {
+		t.Fatalf("linearJournal length mismatch: have %d, want %d", got, exp)
 	}
 	// some new ones
 	state.AddSlotToAccessList(addr("bb"), slot("03")) // 5
+	push(state.journal.snapshot())                    // journal id 5
 	state.AddSlotToAccessList(addr("aa"), slot("01")) // 6
-	state.AddSlotToAccessList(addr("cc"), slot("01")) // 7,8
-	state.AddAddressToAccessList(addr("cc"))
-	if exp, got := 8, state.journal.length(); exp != got {
-		t.Fatalf("journal length mismatch: have %d, want %d", got, exp)
+	push(state.journal.snapshot())                    // journal id 6
+	state.AddAddressToAccessList(addr("cc"))          // 7
+	push(state.journal.snapshot())                    // journal id 7
+	state.AddSlotToAccessList(addr("cc"), slot("01")) // 8
+	if exp, got := 8, state.journal.(*linearJournal).length(); exp != got {
+		t.Fatalf("linearJournal length mismatch: have %d, want %d", got, exp)
 	}
 
 	verifyAddrs("aa", "bb", "cc")
@@ -1133,7 +1153,7 @@ func TestStateDBAccessList(t *testing.T) {
 	verifySlots("cc", "01")
 
 	// now start rolling back changes
-	state.journal.revert(state, 7)
+	state.journal.revertToSnapshot(pop(), state) // revert to 6
 	if _, ok := state.SlotInAccessList(addr("cc"), slot("01")); ok {
 		t.Fatalf("slot present, expected missing")
 	}
@@ -1141,7 +1161,7 @@ func TestStateDBAccessList(t *testing.T) {
 	verifySlots("aa", "01")
 	verifySlots("bb", "01", "02", "03")
 
-	state.journal.revert(state, 6)
+	state.journal.revertToSnapshot(pop(), state) // revert to 5
 	if state.AddressInAccessList(addr("cc")) {
 		t.Fatalf("addr present, expected missing")
 	}
@@ -1149,40 +1169,40 @@ func TestStateDBAccessList(t *testing.T) {
 	verifySlots("aa", "01")
 	verifySlots("bb", "01", "02", "03")
 
-	state.journal.revert(state, 5)
+	state.journal.revertToSnapshot(pop(), state) // revert to 4
 	if _, ok := state.SlotInAccessList(addr("aa"), slot("01")); ok {
 		t.Fatalf("slot present, expected missing")
 	}
 	verifyAddrs("aa", "bb")
 	verifySlots("bb", "01", "02", "03")
 
-	state.journal.revert(state, 4)
+	state.journal.revertToSnapshot(pop(), state) // revert to 3
 	if _, ok := state.SlotInAccessList(addr("bb"), slot("03")); ok {
 		t.Fatalf("slot present, expected missing")
 	}
 	verifyAddrs("aa", "bb")
 	verifySlots("bb", "01", "02")
 
-	state.journal.revert(state, 3)
+	state.journal.revertToSnapshot(pop(), state) // revert to 2
 	if _, ok := state.SlotInAccessList(addr("bb"), slot("02")); ok {
 		t.Fatalf("slot present, expected missing")
 	}
 	verifyAddrs("aa", "bb")
 	verifySlots("bb", "01")
 
-	state.journal.revert(state, 2)
+	state.journal.revertToSnapshot(pop(), state) // revert to 1
 	if _, ok := state.SlotInAccessList(addr("bb"), slot("01")); ok {
 		t.Fatalf("slot present, expected missing")
 	}
 	verifyAddrs("aa", "bb")
 
-	state.journal.revert(state, 1)
+	state.journal.revertToSnapshot(pop(), state) // revert to 0
 	if state.AddressInAccessList(addr("bb")) {
 		t.Fatalf("addr present, expected missing")
 	}
 	verifyAddrs("aa")
 
-	state.journal.revert(state, 0)
+	state.journal.revertToSnapshot(0, state)
 	if state.AddressInAccessList(addr("aa")) {
 		t.Fatalf("addr present, expected missing")
 	}
@@ -1253,10 +1273,10 @@ func TestStateDBTransientStorage(t *testing.T) {
 	key := common.Hash{0x01}
 	value := common.Hash{0x02}
 	addr := common.Address{}
-
+	revision := state.journal.snapshot()
 	state.SetTransientState(addr, key, value)
-	if exp, got := 1, state.journal.length(); exp != got {
-		t.Fatalf("journal length mismatch: have %d, want %d", got, exp)
+	if exp, got := 1, state.journal.(*linearJournal).length(); exp != got {
+		t.Fatalf("linearJournal length mismatch: have %d, want %d", got, exp)
 	}
 	// the retrieved value should equal what was set
 	if got := state.GetTransientState(addr, key); got != value {
@@ -1265,7 +1285,7 @@ func TestStateDBTransientStorage(t *testing.T) {
 
 	// revert the transient state being set and then check that the
 	// value is now the empty hash
-	state.journal.revert(state, 0)
+	state.journal.revertToSnapshot(revision, state)
 	if got, exp := state.GetTransientState(addr, key), (common.Hash{}); exp != got {
 		t.Fatalf("transient storage mismatch: have %x, want %x", got, exp)
 	}

--- a/core/vm/evm.go
+++ b/core/vm/evm.go
@@ -201,6 +201,7 @@ func (evm *EVM) Call(caller ContractRef, addr common.Address, input []byte, gas 
 
 		if !isPrecompile && evm.chainRules.IsEIP158 && value.IsZero() {
 			// Calling a non-existing account, don't do anything.
+			evm.StateDB.DiscardSnapshot(snapshot)
 			return nil, gas, nil
 		}
 		evm.StateDB.CreateAccount(addr)
@@ -240,9 +241,8 @@ func (evm *EVM) Call(caller ContractRef, addr common.Address, input []byte, gas 
 
 			gas = 0
 		}
-		// TODO: consider clearing up unused snapshots:
-		//} else {
-		//	evm.StateDB.DiscardSnapshot(snapshot)
+	} else {
+		evm.StateDB.DiscardSnapshot(snapshot)
 	}
 	return ret, gas, err
 }
@@ -299,6 +299,8 @@ func (evm *EVM) CallCode(caller ContractRef, addr common.Address, input []byte, 
 
 			gas = 0
 		}
+	} else {
+		evm.StateDB.DiscardSnapshot(snapshot)
 	}
 	return ret, gas, err
 }
@@ -348,6 +350,8 @@ func (evm *EVM) DelegateCall(caller ContractRef, addr common.Address, input []by
 			}
 			gas = 0
 		}
+	} else {
+		evm.StateDB.DiscardSnapshot(snapshot)
 	}
 	return ret, gas, err
 }
@@ -410,6 +414,8 @@ func (evm *EVM) StaticCall(caller ContractRef, addr common.Address, input []byte
 
 			gas = 0
 		}
+	} else {
+		evm.StateDB.DiscardSnapshot(snapshot)
 	}
 	return ret, gas, err
 }
@@ -521,6 +527,8 @@ func (evm *EVM) create(caller ContractRef, codeAndHash *codeAndHash, gas uint64,
 		if err != ErrExecutionReverted {
 			contract.UseGas(contract.Gas, evm.Config.Tracer, tracing.GasChangeCallFailedExecution)
 		}
+	} else {
+		evm.StateDB.DiscardSnapshot(snapshot)
 	}
 	return ret, address, contract.Gas, err
 }

--- a/core/vm/interface.go
+++ b/core/vm/interface.go
@@ -88,7 +88,14 @@ type StateDB interface {
 
 	Prepare(rules params.Rules, sender, coinbase common.Address, dest *common.Address, precompiles []common.Address, txAccesses types.AccessList)
 
+	// RevertToSnapshot reverts all state changes made since the given revision.
 	RevertToSnapshot(int)
+
+	// DiscardSnapshot removes the snapshot with the given id; after calling this
+	// method, it is no longer possible to revert to that particular snapshot, the
+	// changes are considered part of the parent scope.
+	DiscardSnapshot(int)
+	// Snapshot returns an identifier for the current scope of the state.
 	Snapshot() int
 
 	AddLog(*types.Log)

--- a/tests/state_test_util.go
+++ b/tests/state_test_util.go
@@ -308,6 +308,8 @@ func (t *StateTest) RunNoVerify(subtest StateSubtest, vmconfig vm.Config, snapsh
 		if tracer := evm.Config.Tracer; tracer != nil && tracer.OnTxEnd != nil {
 			evm.Config.Tracer.OnTxEnd(nil, err)
 		}
+	} else {
+		st.StateDB.DiscardSnapshot(snapshot)
 	}
 	// Add 0-value mining reward. This only makes a difference in the cases
 	// where


### PR DESCRIPTION
This is a second attempt at https://github.com/ethereum/go-ethereum/pull/30500 . 

This PR introduces set-based journalling, where the journalling-events are basically stored in per-scoped maps.

Whenever we enter a new call scope, we create a new scoped journal. Changes within the same scoped journal overwrite eachother. For example: if a scope updates a balance to from 6 to 5 then 4, then 3, there will only be one preimage in the journal. As opposed to the old journal (linear_journal), which would have multiple entries: [ prev: 6, prev: 5, prev:4].

The linear / appending journal is wasteful on memory, and also slow on rollbacks, since each change is rolled back individually.


------------------


@karalabe reminded me of the burntpix benchmark, on which this PR excels, so I thought it was worth another chance. 

`master`:
```
[user@work go-ethereum]$ ./evm_master run --prestate ./burntpix.json --receiver 0x49206861766520746F6F206D7563682074696D65  --input 0xa4de9ab4000000000000000000000000000000000000000000000000000000000F1FD58E000000000000000000000000000000000000000000000000000000000007A120 --bench | tail -c +131 | sed 's/[0]*$//' | xxd -r -p > output.svg
```
```
EVM gas used:    5642735088
execution time:  49.349209526s
allocations:     915684
allocated bytes: 175333368
```
This PR: 
```
[user@work go-ethereum]$ ./evm_setjournal run --prestate ./burntpix.json --receiver 0x49206861766520746F6F206D7563682074696D65  --input 0xa4de9ab4000000000000000000000000000000000000000000000000000000000F1FD58E000000000000000000000000000000000000000000000000000000000007A120 --bench | tail -c +131 | sed 's/[0]*$//' | xxd -r -p > output.svg
```
```
EVM gas used:    5642735088
execution time:  48.740463584s
allocations:     30198
allocated bytes: 30308272
```
Allocations, `915K` -> `30K`,
Allocated bytes: `175M` -> `30M`

