### PR TITLE
core/state: invoke OnCodeChange-hook on selfdestruct

### DIFF
--- a/core/state/statedb_hooked.go
+++ b/core/state/statedb_hooked.go
@@ -208,11 +208,11 @@ func (s *hookedStateDB) SelfDestruct(address common.Address) uint256.Int {
 
 	prev := s.inner.SelfDestruct(address)
 
-	if !prev.IsZero() && s.hooks.OnBalanceChange != nil {
+	if s.hooks.OnBalanceChange != nil && !prev.IsZero() {
 		s.hooks.OnBalanceChange(address, prev.ToBig(), new(big.Int), tracing.BalanceDecreaseSelfdestruct)
 	}
 
-	if len(prevCode) > 0 && s.hooks.OnCodeChange != nil {
+	if s.hooks.OnCodeChange != nil && len(prevCode) > 0 {
 		s.hooks.OnCodeChange(address, prevCodeHash, prevCode, types.EmptyCodeHash, nil)
 	}
 
@@ -230,11 +230,11 @@ func (s *hookedStateDB) SelfDestruct6780(address common.Address) (uint256.Int, b
 
 	prev, changed := s.inner.SelfDestruct6780(address)
 
-	if !prev.IsZero() && changed && s.hooks.OnBalanceChange != nil {
+	if s.hooks.OnBalanceChange != nil && changed && !prev.IsZero() {
 		s.hooks.OnBalanceChange(address, prev.ToBig(), new(big.Int), tracing.BalanceDecreaseSelfdestruct)
 	}
 
-	if len(prevCode) > 0 && changed && s.hooks.OnCodeChange != nil {
+	if s.hooks.OnCodeChange != nil && changed && len(prevCode) > 0 {
 		s.hooks.OnCodeChange(address, prevCodeHash, prevCode, types.EmptyCodeHash, nil)
 	}
 

--- a/core/state/statedb_hooked.go
+++ b/core/state/statedb_hooked.go
@@ -198,22 +198,42 @@ func (s *hookedStateDB) SetState(address common.Address, key common.Hash, value 
 }
 
 func (s *hookedStateDB) SelfDestruct(address common.Address) uint256.Int {
+	prevCode := s.inner.GetCode(address)
+	prevCodeHash := s.inner.GetCodeHash(address)
 	prev := s.inner.SelfDestruct(address)
+
 	if !prev.IsZero() {
 		if s.hooks.OnBalanceChange != nil {
 			s.hooks.OnBalanceChange(address, prev.ToBig(), new(big.Int), tracing.BalanceDecreaseSelfdestruct)
 		}
 	}
+
+	if len(prevCode) > 0 {
+		if s.hooks.OnCodeChange != nil {
+			s.hooks.OnCodeChange(address, prevCodeHash, prevCode, types.EmptyCodeHash, nil)
+		}
+	}
+
 	return prev
 }
 
 func (s *hookedStateDB) SelfDestruct6780(address common.Address) (uint256.Int, bool) {
+	prevCodeHash := s.inner.GetCodeHash(address)
+	prevCode := s.inner.GetCode(address)
 	prev, changed := s.inner.SelfDestruct6780(address)
+
 	if !prev.IsZero() && changed {
 		if s.hooks.OnBalanceChange != nil {
 			s.hooks.OnBalanceChange(address, prev.ToBig(), new(big.Int), tracing.BalanceDecreaseSelfdestruct)
 		}
 	}
+
+	if len(prevCode) > 0 && changed {
+		if s.hooks.OnCodeChange != nil {
+			s.hooks.OnCodeChange(address, prevCodeHash, prevCode, types.EmptyCodeHash, nil)
+		}
+	}
+
 	return prev, changed
 }
 


### PR DESCRIPTION
Implemented code change tracking for `selfdestruct` operations by adding `OnCodeChange` hooks in the `SelfDestruct` and `SelfDestruct6780` methods of the `hookedStateDB` structure. 

Motivation:
Now, we can track `OnCodeChange` when the contract is deployed. It would be nice also to be able to track changes (code, codeHash) when the contract is destroyed.

Let me know if this makes sense or if I need to improve/fix anything