### PR TITLE
cmd/geth: avoid hard coding the IPC name

### DIFF
--- a/cmd/geth/config.go
+++ b/cmd/geth/config.go
@@ -132,7 +132,7 @@ func defaultNodeConfig() node.Config {
 	cfg.Version = version.WithCommit(git.Commit, git.Date)
 	cfg.HTTPModules = append(cfg.HTTPModules, "eth")
 	cfg.WSModules = append(cfg.WSModules, "eth")
-	cfg.IPCPath = "geth.ipc"
+	cfg.IPCPath = clientIdentifier + ".ipc"
 	return cfg
 }
 


### PR DESCRIPTION
This is a super insignificant change, it just annoyed me. The datadir path is generated from the `clientIdentifier`, so it felt appropriate to also generate the IPC path from the same variable instead of hard coding it.