### PR TITLE
cmd, internal: extract wallet event listener logic

### DIFF
--- a/cmd/geth/main.go
+++ b/cmd/geth/main.go
@@ -34,6 +34,7 @@ import (
 	"github.com/ethereum/go-ethereum/ethclient"
 	"github.com/ethereum/go-ethereum/internal/debug"
 	"github.com/ethereum/go-ethereum/internal/flags"
+	"github.com/ethereum/go-ethereum/internal/walletevent"
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/metrics"
 	"github.com/ethereum/go-ethereum/node"
@@ -368,7 +369,8 @@ func startNode(ctx *cli.Context, stack *node.Node, isConsole bool) {
 	// Create a client to interact with local geth node.
 	rpcClient := stack.Attach()
 	ethClient := ethclient.NewClient(rpcClient)
-	walletEventListener := walletevent.NewListener(&log)
+	logger := log.New(ctx)
+	walletEventListener := walletevent.NewListener(logger, ethClient)
 
 	go walletEventListener.Listen(stack.AccountManager().Wallets(), events)
 

--- a/cmd/geth/main.go
+++ b/cmd/geth/main.go
@@ -368,39 +368,9 @@ func startNode(ctx *cli.Context, stack *node.Node, isConsole bool) {
 	// Create a client to interact with local geth node.
 	rpcClient := stack.Attach()
 	ethClient := ethclient.NewClient(rpcClient)
+	walletEventListener := walletevent.NewListener(&log)
 
-	go func() {
-		// Open any wallets already attached
-		for _, wallet := range stack.AccountManager().Wallets() {
-			if err := wallet.Open(""); err != nil {
-				log.Warn("Failed to open wallet", "url", wallet.URL(), "err", err)
-			}
-		}
-		// Listen for wallet event till termination
-		for event := range events {
-			switch event.Kind {
-			case accounts.WalletArrived:
-				if err := event.Wallet.Open(""); err != nil {
-					log.Warn("New wallet appeared, failed to open", "url", event.Wallet.URL(), "err", err)
-				}
-			case accounts.WalletOpened:
-				status, _ := event.Wallet.Status()
-				log.Info("New wallet appeared", "url", event.Wallet.URL(), "status", status)
-
-				var derivationPaths []accounts.DerivationPath
-				if event.Wallet.URL().Scheme == "ledger" {
-					derivationPaths = append(derivationPaths, accounts.LegacyLedgerBaseDerivationPath)
-				}
-				derivationPaths = append(derivationPaths, accounts.DefaultBaseDerivationPath)
-
-				event.Wallet.SelfDerive(derivationPaths, ethClient)
-
-			case accounts.WalletDropped:
-				log.Info("Old wallet dropped", "url", event.Wallet.URL())
-				event.Wallet.Close()
-			}
-		}
-	}()
+	go walletEventListener.Listen(stack.AccountManager().Wallets(), events)
 
 	// Spawn a standalone goroutine for status synchronization monitoring,
 	// close the node when synchronization is complete if user required.

--- a/internal/walletevent/listener.go
+++ b/internal/walletevent/listener.go
@@ -1,0 +1,73 @@
+// Copyright 2024 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+
+package walletevent
+
+import (
+	"github.com/ethereum/go-ethereum/accounts"
+)
+
+type (
+	Listener struct {
+		logger logger
+	}
+
+	logger interface {
+		Warn(msg string, ctx ...interface{})
+		Info(msg string, ctx ...interface{})
+	}
+)
+
+// NewListener creates a new wallet event listener.
+func NewListener(logger logger) *Listener {
+	return Listener{
+		logger: logger,
+	}
+}
+
+// Listen creates a new event listener for accounts.WalletEvent
+func (l *Listener) Listen(wallets []accounts.Wallet, events chan accounts.WalletEvent) {
+	// Open any wallets already attached
+	for _, wallet := range wallets {
+		if err := wallet.Open(""); err != nil {
+			l.logger.Warn("Failed to open wallet", "url", wallet.URL(), "err", err)
+		}
+	}
+	// Listen for wallet event till termination
+	for event := range events {
+		switch event.Kind {
+		case accounts.WalletArrived:
+			if err := event.Wallet.Open(""); err != nil {
+				l.logger.Warn("New wallet appeared, failed to open", "url", event.Wallet.URL(), "err", err)
+			}
+		case accounts.WalletOpened:
+			status, _ := event.Wallet.Status()
+			l.logger.Info("New wallet appeared", "url", event.Wallet.URL(), "status", status)
+
+			var derivationPaths []accounts.DerivationPath
+			if event.Wallet.URL().Scheme == "ledger" {
+				derivationPaths = append(derivationPaths, accounts.LegacyLedgerBaseDerivationPath)
+			}
+			derivationPaths = append(derivationPaths, accounts.DefaultBaseDerivationPath)
+
+			event.Wallet.SelfDerive(derivationPaths, ethClient)
+
+		case accounts.WalletDropped:
+			l.logger.Info("Old wallet dropped", "url", event.Wallet.URL())
+			event.Wallet.Close()
+		}
+	}
+}

--- a/internal/walletevent/listener.go
+++ b/internal/walletevent/listener.go
@@ -17,12 +17,14 @@
 package walletevent
 
 import (
+	"github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/accounts"
 )
 
 type (
 	Listener struct {
-		logger logger
+		logger    logger
+		ethClient ethereum.ChainStateReader
 	}
 
 	logger interface {
@@ -32,9 +34,10 @@ type (
 )
 
 // NewListener creates a new wallet event listener.
-func NewListener(logger logger) *Listener {
-	return Listener{
-		logger: logger,
+func NewListener(logger logger, ethClient ethereum.ChainStateReader) *Listener {
+	return &Listener{
+		logger:    logger,
+		ethClient: ethClient,
 	}
 }
 
@@ -63,7 +66,7 @@ func (l *Listener) Listen(wallets []accounts.Wallet, events chan accounts.Wallet
 			}
 			derivationPaths = append(derivationPaths, accounts.DefaultBaseDerivationPath)
 
-			event.Wallet.SelfDerive(derivationPaths, ethClient)
+			event.Wallet.SelfDerive(derivationPaths, l.ethClient)
 
 		case accounts.WalletDropped:
 			l.logger.Info("Old wallet dropped", "url", event.Wallet.URL())


### PR DESCRIPTION
This PR extracts the wallet event listener logic from the `cmd/geth/main.go` file and into its own go pkg

This simplifies the `main.go` spin-up, and potentially can re-use this wallet event listening logic in the future