### PR TITLE
core/vm: add comment to `StateDB.GetBalance`

### DIFF
--- a/core/vm/interface.go
+++ b/core/vm/interface.go
@@ -35,6 +35,7 @@ type StateDB interface {
 
 	SubBalance(common.Address, *uint256.Int, tracing.BalanceChangeReason) uint256.Int
 	AddBalance(common.Address, *uint256.Int, tracing.BalanceChangeReason) uint256.Int
+	// note: should never modify the returned value, as it's reused for performance purpose
 	GetBalance(common.Address) *uint256.Int
 
 	GetNonce(common.Address) uint64


### PR DESCRIPTION
`GetBalance` returns a reference to the underlying value(e.g., [here](https://github.com/ethereum/go-ethereum/blob/bce420b99fd8b5a7a35a9f38b5246f8e2219acbf/core/state/statedb.go#L313)), it'll be a serious mistake to modify it in-place.

Maybe a better option is to return `uint256.Int` instead of `*uint256.Int`.
