### PR TITLE
all: use slices.Concat

### DIFF
--- a/accounts/manager.go
+++ b/accounts/manager.go
@@ -18,6 +18,7 @@ package accounts
 
 import (
 	"reflect"
+	"slices"
 	"sort"
 	"sync"
 
@@ -255,7 +256,7 @@ func merge(slice []Wallet, wallets ...Wallet) []Wallet {
 			slice = append(slice, wallet)
 			continue
 		}
-		slice = append(slice[:n], append([]Wallet{wallet}, slice[n:]...)...)
+		slice = slices.Concat(slice[:n], []Wallet{wallet}, slice[n:])
 	}
 	return slice
 }

--- a/core/bloombits/matcher.go
+++ b/core/bloombits/matcher.go
@@ -21,6 +21,7 @@ import (
 	"context"
 	"errors"
 	"math"
+	"slices"
 	"sort"
 	"sync"
 	"sync/atomic"
@@ -417,7 +418,7 @@ func (m *Matcher) distributor(dist chan *request, session *MatcherSession) {
 			// New retrieval request arrived to be distributed to some fetcher process
 			queue := requests[req.bit]
 			index := sort.Search(len(queue), func(i int) bool { return queue[i] >= req.section })
-			requests[req.bit] = append(queue[:index], append([]uint64{req.section}, queue[index:]...)...)
+			requests[req.bit] = slices.Concat(queue[:index], []uint64{req.section}, queue[index:])
 
 			// If it's a new bit and we have waiting fetchers, allocate to them
 			if len(queue) == 0 {
@@ -485,7 +486,7 @@ func (m *Matcher) distributor(dist chan *request, session *MatcherSession) {
 				queue := requests[result.Bit]
 				for _, section := range missing {
 					index := sort.Search(len(queue), func(i int) bool { return queue[i] >= section })
-					queue = append(queue[:index], append([]uint64{section}, queue[index:]...)...)
+					queue = slices.Concat(queue[:index], []uint64{section}, queue[index:])
 				}
 				requests[result.Bit] = queue
 

--- a/core/forkid/forkid.go
+++ b/core/forkid/forkid.go
@@ -135,7 +135,7 @@ func newFilter(config *params.ChainConfig, genesis *types.Block, headfn func() (
 	// Calculate the all the valid fork hash and fork next combos
 	var (
 		forksByBlock, forksByTime = gatherForks(config, genesis.Time())
-		forks                     = append(append([]uint64{}, forksByBlock...), forksByTime...)
+		forks                     = slices.Concat(forksByBlock, forksByTime)
 		sums                      = make([][4]byte, len(forks)+1) // 0th is the genesis
 	)
 	hash := crc32.ChecksumIEEE(genesis.Hash().Bytes())

--- a/core/rawdb/schema.go
+++ b/core/rawdb/schema.go
@@ -20,6 +20,7 @@ package rawdb
 import (
 	"bytes"
 	"encoding/binary"
+	"slices"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/crypto"
@@ -171,7 +172,7 @@ func headerKeyPrefix(number uint64) []byte {
 
 // headerKey = headerPrefix + num (uint64 big endian) + hash
 func headerKey(number uint64, hash common.Hash) []byte {
-	return append(append(headerPrefix, encodeBlockNumber(number)...), hash.Bytes()...)
+	return slices.Concat(headerPrefix, encodeBlockNumber(number), hash.Bytes())
 }
 
 // headerTDKey = headerPrefix + num (uint64 big endian) + hash + headerTDSuffix
@@ -181,7 +182,7 @@ func headerTDKey(number uint64, hash common.Hash) []byte {
 
 // headerHashKey = headerPrefix + num (uint64 big endian) + headerHashSuffix
 func headerHashKey(number uint64) []byte {
-	return append(append(headerPrefix, encodeBlockNumber(number)...), headerHashSuffix...)
+	return slices.Concat(headerPrefix, encodeBlockNumber(number), headerHashSuffix)
 }
 
 // headerNumberKey = headerNumberPrefix + hash
@@ -191,12 +192,12 @@ func headerNumberKey(hash common.Hash) []byte {
 
 // blockBodyKey = blockBodyPrefix + num (uint64 big endian) + hash
 func blockBodyKey(number uint64, hash common.Hash) []byte {
-	return append(append(blockBodyPrefix, encodeBlockNumber(number)...), hash.Bytes()...)
+	return slices.Concat(blockBodyPrefix, encodeBlockNumber(number), hash.Bytes())
 }
 
 // blockReceiptsKey = blockReceiptsPrefix + num (uint64 big endian) + hash
 func blockReceiptsKey(number uint64, hash common.Hash) []byte {
-	return append(append(blockReceiptsPrefix, encodeBlockNumber(number)...), hash.Bytes()...)
+	return slices.Concat(blockReceiptsPrefix, encodeBlockNumber(number), hash.Bytes())
 }
 
 // txLookupKey = txLookupPrefix + hash
@@ -225,7 +226,7 @@ func storageSnapshotsKey(accountHash common.Hash) []byte {
 
 // bloomBitsKey = bloomBitsPrefix + bit (uint16 big endian) + section (uint64 big endian) + hash
 func bloomBitsKey(bit uint, section uint64, hash common.Hash) []byte {
-	key := append(append(bloomBitsPrefix, make([]byte, 10)...), hash.Bytes()...)
+	key := slices.Concat(bloomBitsPrefix, make([]byte, 10), hash.Bytes())
 
 	binary.BigEndian.PutUint16(key[1:], uint16(bit))
 	binary.BigEndian.PutUint64(key[3:], section)

--- a/core/vm/eof.go
+++ b/core/vm/eof.go
@@ -137,7 +137,7 @@ func (c *Container) MarshalBinary() []byte {
 
 	// Write section contents.
 	for _, ty := range c.types {
-		b = append(b, ty.inputs, ty.outputs, byte(ty.maxStackHeight >> 8), byte(ty.maxStackHeight & 0x00ff))
+		b = append(b, ty.inputs, ty.outputs, byte(ty.maxStackHeight>>8), byte(ty.maxStackHeight&0x00ff))
 	}
 	b = slices.Concat(b, slices.Concat(c.codeSections...), slices.Concat(encodedContainer...))
 	b = append(b, c.data...)

--- a/core/vm/eof.go
+++ b/core/vm/eof.go
@@ -22,6 +22,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"slices"
 	"strings"
 
 	"github.com/ethereum/go-ethereum/params"
@@ -136,14 +137,9 @@ func (c *Container) MarshalBinary() []byte {
 
 	// Write section contents.
 	for _, ty := range c.types {
-		b = append(b, []byte{ty.inputs, ty.outputs, byte(ty.maxStackHeight >> 8), byte(ty.maxStackHeight & 0x00ff)}...)
+		b = append(b, ty.inputs, ty.outputs, byte(ty.maxStackHeight >> 8), byte(ty.maxStackHeight & 0x00ff))
 	}
-	for _, code := range c.codeSections {
-		b = append(b, code...)
-	}
-	for _, section := range encodedContainer {
-		b = append(b, section...)
-	}
+	b = slices.Concat(b, slices.Concat(c.codeSections...), slices.Concat(encodedContainer...))
 	b = append(b, c.data...)
 
 	return b

--- a/eth/downloader/downloader.go
+++ b/eth/downloader/downloader.go
@@ -21,6 +21,7 @@ import (
 	"errors"
 	"fmt"
 	"math/big"
+	"slices"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -872,7 +873,7 @@ func (d *Downloader) processSnapSyncContent() error {
 				}
 			}
 		} else { // results already piled up, consume before handling pivot move
-			results = append(append([]*fetchResult{oldPivot}, oldTail...), results...)
+			results = slices.Concat([]*fetchResult{oldPivot}, oldTail, results)
 		}
 		// Split around the pivot block and process the two sides via snap/full sync
 		if !d.committed.Load() {

--- a/internal/flags/helpers.go
+++ b/internal/flags/helpers.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"os"
 	"regexp"
+	"slices"
 	"sort"
 	"strings"
 
@@ -50,11 +51,7 @@ func NewApp(usage string) *cli.App {
 
 // Merge merges the given flag slices.
 func Merge(groups ...[]cli.Flag) []cli.Flag {
-	var ret []cli.Flag
-	for _, group := range groups {
-		ret = append(ret, group...)
-	}
-	return ret
+	return slices.Concat(groups...)
 }
 
 var migrationApplied = map[*cli.Command]struct{}{}

--- a/trie/sync.go
+++ b/trie/sync.go
@@ -19,6 +19,7 @@ package trie
 import (
 	"errors"
 	"fmt"
+	"slices"
 	"sync"
 
 	"github.com/ethereum/go-ethereum/common"
@@ -553,7 +554,7 @@ func (s *Sync) children(req *nodeRequest, object node) ([]*nodeRequest, error) {
 		}
 		children = []childNode{{
 			node: node.Val,
-			path: append(append([]byte(nil), req.path...), key...),
+			path: slices.Concat(req.path, key),
 		}}
 		// Mark all internal nodes between shortNode and its **in disk**
 		// child as invalid. This is essential in the case of path mode
@@ -595,7 +596,7 @@ func (s *Sync) children(req *nodeRequest, object node) ([]*nodeRequest, error) {
 			if node.Children[i] != nil {
 				children = append(children, childNode{
 					node: node.Children[i],
-					path: append(append([]byte(nil), req.path...), byte(i)),
+					path: slices.Concat(req.path, []byte{i}),
 				})
 			}
 		}

--- a/trie/sync.go
+++ b/trie/sync.go
@@ -596,7 +596,7 @@ func (s *Sync) children(req *nodeRequest, object node) ([]*nodeRequest, error) {
 			if node.Children[i] != nil {
 				children = append(children, childNode{
 					node: node.Children[i],
-					path: slices.Concat(req.path, []byte{i}),
+					path: append(append([]byte(nil), req.path...), byte(i)),
 				})
 			}
 		}


### PR DESCRIPTION
Added in go1.22.0, `slices.Concat` returns a new slice concatenating the passed in slices.
When there are two or more embedded `append` in code, it would be more efficient to use `slices.Concat`.

Reference:
https://pkg.go.dev/slices#Concat
https://cs.opensource.google/go/go/+/refs/tags/go1.23.2:src/slices/slices.go;l=473

Rationale for this Pull Request:
1. Make code cleaner
2. Benchmark suggests less allocs and faster.

## Benchmark:
```
goos: linux
goarch: amd64 
BenchmarkConcat-16    	21168130	        48.83 ns/op	      64 B/op	       1 allocs/op
BenchmarkAppend-16    	18253052	        60.65 ns/op	     144 B/op	       2 allocs/op
PASS
ok  	test	2.274s
```
code:
```
package test

import (
	"slices"
	"testing"
)

func BenchmarkConcat(bb *testing.B) {
	n := 20
	a := make([]byte, n)
	b := make([]byte, n)
	c := make([]byte, n)

 	for i := 0; i < bb.N; i++ {
		_ = slices.Concat(a, b, c)
	}
}


func BenchmarkAppend(bb *testing.B) {
	n := 20
	a := make([]byte, n)
	b := make([]byte, n)
	c := make([]byte, n)

	for i := 0; i < bb.N; i++ {
		_ = append(append(a, b...), c...)
	}
}
```
```
go test -run - -bench=. -benchmem
```
