### PR TITLE
ethdb: refactor Database interface

### DIFF
--- a/core/rawdb/accessors_indexes_test.go
+++ b/core/rawdb/accessors_indexes_test.go
@@ -35,17 +35,17 @@ var newTestHasher = blocktest.NewHasher
 func TestLookupStorage(t *testing.T) {
 	tests := []struct {
 		name                        string
-		writeTxLookupEntriesByBlock func(ethdb.Writer, *types.Block)
+		writeTxLookupEntriesByBlock func(ethdb.KeyValueWriter, *types.Block)
 	}{
 		{
 			"DatabaseV6",
-			func(db ethdb.Writer, block *types.Block) {
+			func(db ethdb.KeyValueWriter, block *types.Block) {
 				WriteTxLookupEntriesByBlock(db, block)
 			},
 		},
 		{
 			"DatabaseV4-V5",
-			func(db ethdb.Writer, block *types.Block) {
+			func(db ethdb.KeyValueWriter, block *types.Block) {
 				for _, tx := range block.Transactions() {
 					db.Put(txLookupKey(tx.Hash()), block.Hash().Bytes())
 				}
@@ -53,7 +53,7 @@ func TestLookupStorage(t *testing.T) {
 		},
 		{
 			"DatabaseV3",
-			func(db ethdb.Writer, block *types.Block) {
+			func(db ethdb.KeyValueWriter, block *types.Block) {
 				for index, tx := range block.Transactions() {
 					entry := LegacyTxLookupEntry{
 						BlockHash:  block.Hash(),

--- a/core/rawdb/freezer.go
+++ b/core/rawdb/freezer.go
@@ -58,8 +58,9 @@ const freezerTableSize = 2 * 1000 * 1000 * 1000
 // - The append-only nature ensures that disk writes are minimized.
 // - The in-order data ensures that disk reads are always optimized.
 type Freezer struct {
-	frozen atomic.Uint64 // Number of items already frozen
-	tail   atomic.Uint64 // Number of the first stored item in the freezer
+	datadir string
+	frozen  atomic.Uint64 // Number of items already frozen
+	tail    atomic.Uint64 // Number of the first stored item in the freezer
 
 	// This lock synchronizes writers and the truncate operation, as well as
 	// the "atomic" (batched) read operations.
@@ -109,6 +110,7 @@ func NewFreezer(datadir string, namespace string, readonly bool, maxTableSize ui
 	}
 	// Open all the supported data tables
 	freezer := &Freezer{
+		datadir:      datadir,
 		readonly:     readonly,
 		tables:       make(map[string]*freezerTable),
 		instanceLock: lock,
@@ -170,6 +172,11 @@ func (f *Freezer) Close() error {
 		return fmt.Errorf("%v", errs)
 	}
 	return nil
+}
+
+// AncientDatadir returns the path of the ancient store.
+func (f *Freezer) AncientDatadir() (string, error) {
+	return f.datadir, nil
 }
 
 // HasAncient returns an indicator whether the specified ancient data exists

--- a/core/rawdb/freezer_memory.go
+++ b/core/rawdb/freezer_memory.go
@@ -419,3 +419,9 @@ func (f *MemoryFreezer) Reset() error {
 	f.items, f.tail = 0, 0
 	return nil
 }
+
+// AncientDatadir returns the path of the ancient store.
+// Since the memory freezer is ephemeral, an empty string is returned.
+func (f *MemoryFreezer) AncientDatadir() (string, error) {
+	return "", nil
+}

--- a/core/rawdb/freezer_resettable.go
+++ b/core/rawdb/freezer_resettable.go
@@ -202,6 +202,14 @@ func (f *resettableFreezer) Sync() error {
 	return f.freezer.Sync()
 }
 
+// AncientDatadir returns the path of the ancient store.
+func (f *resettableFreezer) AncientDatadir() (string, error) {
+	f.lock.RLock()
+	defer f.lock.RUnlock()
+
+	return f.freezer.AncientDatadir()
+}
+
 // cleanup removes the directory located in the specified path
 // has the name with deletion marker suffix.
 func cleanup(path string) error {

--- a/ethdb/database.go
+++ b/ethdb/database.go
@@ -162,26 +162,12 @@ type Reader interface {
 	AncientReader
 }
 
-// Writer contains the methods required to write data to both key-value as well as
-// immutable ancient data.
-type Writer interface {
-	KeyValueWriter
-	KeyValueRangeDeleter
-	AncientWriter
-}
-
-// Stater contains the methods required to retrieve states from both key-value as well as
-// immutable ancient data.
-type Stater interface {
-	KeyValueStater
-	AncientStater
-}
-
 // AncientStore contains all the methods required to allow handling different
 // ancient data stores backing immutable data store.
 type AncientStore interface {
 	AncientReader
 	AncientWriter
+	AncientStater
 	io.Closer
 }
 
@@ -196,11 +182,6 @@ type ResettableAncientStore interface {
 // Database contains all the methods required by the high level database to not
 // only access the key-value data store but also the ancient chain store.
 type Database interface {
-	Reader
-	Writer
-	Batcher
-	Iteratee
-	Stater
-	Compacter
-	io.Closer
+	KeyValueStore
+	AncientStore
 }


### PR DESCRIPTION
This clears up the ethdb.Database interface, making it more understandable that it is basically just the AncientStore and KeyValueStore combined. Also removes a few interfaces that are not needed anymore, and makes a few types implement the `AncientStater` interface