### PR TITLE
chore: use fixed version of go in travis build step

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ jobs:
       os: linux
       arch: amd64
       dist: focal
-      go: 1.23.x
+      go: 1.23.2
       env:
         - docker
       services:
@@ -33,7 +33,7 @@ jobs:
       os: linux
       dist: focal
       sudo: required
-      go: 1.23.x
+      go: 1.23.2
       env:
         - azure-linux
       git:
@@ -85,7 +85,7 @@ jobs:
       os: linux
       arch: amd64
       dist: focal
-      go: 1.23.x
+      go: 1.23.2
       script:
         - travis_wait 45 go run build/ci.go test $TEST_PACKAGES
 
@@ -102,7 +102,7 @@ jobs:
       if: type = cron || (type = push && tag ~= /^v[0-9]/)
       os: linux
       dist: focal
-      go: 1.23.x
+      go: 1.23.2
       env:
         - ubuntu-ppa
       git:
@@ -118,7 +118,7 @@ jobs:
       if: type = cron
       os: linux
       dist: focal
-      go: 1.23.x
+      go: 1.23.2
       env:
         - azure-purge
       git:
@@ -131,7 +131,7 @@ jobs:
       if: type = cron
       os: linux
       dist: focal
-      go: 1.23.x
+      go: 1.23.2
       env:
         - racetests
       script:


### PR DESCRIPTION
The travis ci build step is failing currently as the go version variable is defined as: `1.23.x` which fails are external packages do not have versions with this:

```
go: golang.org/dl/go1.23.x@latest: module golang.org/dl@latest found (v0.0.0-20241001165935-bedb0f791d00), but does not contain package golang.org/dl/go1.23.x
go1.23.x: command not found
```

can be reproduced locally via directly running:
```
hussanchoudhry@Hussans-MacBook-Pro-2 go-ethereum % go get golang.org/dl/go1.23.x@latest
go: downloading golang.org/dl v0.0.0-20241001165935-bedb0f791d00
go: module golang.org/dl@latest found (v0.0.0-20241001165935-bedb0f791d00), but does not contain package golang.org/dl/go1.23.x
```

and verified by passing a fixed version:
```
hussanchoudhry@Hussans-MacBook-Pro-2 go-ethereum % go get golang.org/dl/go1.23.2@latest
go: added golang.org/dl v0.0.0-20241001165935-bedb0f791d00
```

[reference build example](https://app.travis-ci.com/github/ethereum/go-ethereum/jobs/627569187)