### PR TITLE
Support passing vm.Config to core.ExecuteStateless

### DIFF
--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -1926,7 +1926,7 @@ func (bc *BlockChain) processBlock(block *types.Block, statedb *state.StateDB, s
 		task := types.NewBlockWithHeader(context).WithBody(*block.Body())
 
 		// Run the stateless self-cross-validation
-		crossStateRoot, crossReceiptRoot, err := ExecuteStateless(bc.chainConfig, task, witness)
+		crossStateRoot, crossReceiptRoot, err := ExecuteStateless(bc.chainConfig, task, witness, vm.Config{})
 		if err != nil {
 			return nil, fmt.Errorf("stateless self-validation failed: %v", err)
 		}

--- a/core/stateless.go
+++ b/core/stateless.go
@@ -40,7 +40,7 @@ import (
 //   - It cannot be placed outside of core, because it needs to construct a dud headerchain
 //
 // TODO(karalabe): Would be nice to resolve both issues above somehow and move it.
-func ExecuteStateless(config *params.ChainConfig, block *types.Block, witness *stateless.Witness) (common.Hash, common.Hash, error) {
+func ExecuteStateless(config *params.ChainConfig, block *types.Block, witness *stateless.Witness, cfg vm.Config) (common.Hash, common.Hash, error) {
 	// Sanity check if the supplied block accidentally contains a set root or
 	// receipt hash. If so, be very loud, but still continue.
 	if block.Root() != (common.Hash{}) {
@@ -66,7 +66,7 @@ func ExecuteStateless(config *params.ChainConfig, block *types.Block, witness *s
 	validator := NewBlockValidator(config, nil) // No chain, we only validate the state, not the block
 
 	// Run the stateless blocks processing and self-validate certain fields
-	res, err := processor.Process(block, db, vm.Config{})
+	res, err := processor.Process(block, db, cfg)
 	if err != nil {
 		return common.Hash{}, common.Hash{}, err
 	}

--- a/eth/catalyst/api.go
+++ b/eth/catalyst/api.go
@@ -995,7 +995,7 @@ func (api *ConsensusAPI) executeStatelessPayload(params engine.ExecutableData, v
 	api.lastNewPayloadLock.Unlock()
 
 	log.Trace("Executing block statelessly", "number", block.Number(), "hash", params.BlockHash)
-	stateRoot, receiptRoot, err := core.ExecuteStateless(api.eth.BlockChain().Config(), block, witness)
+	stateRoot, receiptRoot, err := core.ExecuteStateless(api.eth.BlockChain().Config(), block, witness, *api.eth.BlockChain().GetVMConfig())
 	if err != nil {
 		log.Warn("ExecuteStatelessPayload: execution failed", "err", err)
 		errorMsg := err.Error()


### PR DESCRIPTION
Right now there's no way to pass a tracer to `core.ExecuteStateless` for debugging.

This PR adds a `vm.Config` argument. It also passes in the blockchain's vm config on the `executeStatelessPayload` API method.