### PR TITLE
core/txpool: Improve error responses

### DIFF
--- a/core/txpool/txpool.go
+++ b/core/txpool/txpool.go
@@ -341,7 +341,7 @@ func (p *TxPool) Add(txs []*types.Transaction, local bool, sync bool) []error {
 	for i, split := range splits {
 		// If the transaction was rejected by all subpools, mark it unsupported
 		if split == -1 {
-			errs[i] = fmt.Errorf("%w (type %d)", core.ErrTxTypeNotSupported, txs[i].Type())
+			errs[i] = fmt.Errorf("%w: received type %d", core.ErrTxTypeNotSupported, txs[i].Type())
 			continue
 		}
 		// Find which subpool handled it and pull in the corresponding error

--- a/core/txpool/txpool.go
+++ b/core/txpool/txpool.go
@@ -341,7 +341,7 @@ func (p *TxPool) Add(txs []*types.Transaction, local bool, sync bool) []error {
 	for i, split := range splits {
 		// If the transaction was rejected by all subpools, mark it unsupported
 		if split == -1 {
-			errs[i] = core.ErrTxTypeNotSupported
+			errs[i] = fmt.Errorf("%w (type %d)", core.ErrTxTypeNotSupported, txs[i].Type())
 			continue
 		}
 		// Find which subpool handled it and pull in the corresponding error

--- a/core/txpool/validation.go
+++ b/core/txpool/validation.go
@@ -99,7 +99,7 @@ func ValidateTransaction(tx *types.Transaction, head *types.Header, signer types
 	}
 	// Make sure the transaction is signed properly
 	if _, err := types.Sender(signer, tx); err != nil {
-		return ErrInvalidSender
+		return fmt.Errorf("%w: %w", ErrInvalidSender, err)
 	}
 	// Ensure the transaction has more gas than the bare minimum needed to cover
 	// the transaction metadata

--- a/core/txpool/validation.go
+++ b/core/txpool/validation.go
@@ -99,7 +99,7 @@ func ValidateTransaction(tx *types.Transaction, head *types.Header, signer types
 	}
 	// Make sure the transaction is signed properly
 	if _, err := types.Sender(signer, tx); err != nil {
-		return fmt.Errorf("%w: %w", ErrInvalidSender, err)
+		return fmt.Errorf("%w: %v", ErrInvalidSender, err)
 	}
 	// Ensure the transaction has more gas than the bare minimum needed to cover
 	// the transaction metadata


### PR DESCRIPTION
I noticed that these two responses can make their way back to the transaction
submitter when submitting unsupported tx types.

Adding the extra context makes it easier for the submitter to understand what
went wrong. Particularly in the case of the invalid sender response, which is
returned when an unsupported transaction type is encountered.