### PR TITLE
build: use slices.Clone for copying slice

### DIFF
--- a/build/ci.go
+++ b/build/ci.go
@@ -53,6 +53,7 @@ import (
 	"path"
 	"path/filepath"
 	"runtime"
+	"slices"
 	"strings"
 	"time"
 
@@ -226,8 +227,7 @@ func doInstall(cmdline []string) {
 
 	// Do the build!
 	for _, pkg := range packages {
-		args := make([]string, len(gobuild.Args))
-		copy(args, gobuild.Args)
+		args := slices.Clone(gobuild.Args)
 		args = append(args, "-o", executablePath(path.Base(pkg)))
 		args = append(args, pkg)
 		build.MustRun(&exec.Cmd{Path: gobuild.Path, Args: args, Env: gobuild.Env})


### PR DESCRIPTION
Since functions from `slices` package are already used extensively, this makes it more consistent with other places in the project.