### PR TITLE
core/vm/program: create evm programming utility

### DIFF
--- a/core/vm/program/program.go
+++ b/core/vm/program/program.go
@@ -1,0 +1,364 @@
+// Copyright 2024 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the goevmlab library. If not, see <http://www.gnu.org/licenses/>.
+
+package program
+
+import (
+	"fmt"
+	"math/big"
+
+	"github.com/ethereum/go-ethereum/core/vm"
+	"github.com/holiman/uint256"
+)
+
+// Program is a simple bytecode container. It can be used to construct
+// simple EVM programs. Errors during construction of a Program typically
+// cause panics: so avoid using these programs in production settings or on
+// untrusted input.
+// This package is mainly meant to aid in testing. This is not a production
+// -level "compiler".
+type Program struct {
+	code []byte
+}
+
+func New() *Program {
+	return &Program{
+		code: make([]byte, 0),
+	}
+}
+
+// add adds the op to the code.
+func (p *Program) add(op byte) *Program {
+	p.code = append(p.code, op)
+	return p
+}
+
+// pushBig creates a PUSHX instruction and pushes the given val.
+// - If the val is nil, it pushes zero
+// - If the val is bigger than 32 bytes, it panics
+func (p *Program) pushBig(val *big.Int) {
+	if val == nil {
+		val = big.NewInt(0)
+	}
+	valBytes := val.Bytes()
+	if len(valBytes) == 0 {
+		valBytes = append(valBytes, 0)
+	}
+	bLen := len(valBytes)
+	if bLen > 32 {
+		panic(fmt.Sprintf("Push value too large, %d bytes", bLen))
+	}
+	p.add(byte(vm.PUSH1) - 1 + byte(bLen))
+	p.Append(valBytes)
+
+}
+
+// Append appends the given data to the code.
+func (p *Program) Append(data []byte) *Program {
+	p.code = append(p.code, data...)
+	return p
+}
+
+// Op appends the given opcode
+func (p *Program) Op(op vm.OpCode) *Program {
+	return p.add(byte(op))
+}
+
+// Ops appends the given opcodes
+func (p *Program) Ops(ops ...vm.OpCode) *Program {
+	for _, op := range ops {
+		p.add(byte(op))
+	}
+	return p
+}
+
+// Push creates a PUSHX instruction with the data provided
+func (p *Program) Push(val any) *Program {
+	switch v := val.(type) {
+	case int:
+		p.pushBig(new(big.Int).SetUint64(uint64(v)))
+	case uint64:
+		p.pushBig(new(big.Int).SetUint64(v))
+	case uint32:
+		p.pushBig(new(big.Int).SetUint64(uint64(v)))
+	case *big.Int:
+		p.pushBig(v)
+	case *uint256.Int:
+		p.pushBig(v.ToBig())
+	case uint256.Int:
+		p.pushBig(v.ToBig())
+	case []byte:
+		p.pushBig(new(big.Int).SetBytes(v))
+	case byte:
+		p.pushBig(new(big.Int).SetUint64(uint64(v)))
+	case interface{ Bytes() []byte }:
+		// Here, we jump through some hovm in order to avoid depending on
+		// go-ethereum types.Address and common.Hash, and instead use the
+		// interface. This works on both values and pointers!
+		p.pushBig(new(big.Int).SetBytes(v.Bytes()))
+	case nil:
+		p.pushBig(nil)
+	default:
+		panic(fmt.Sprintf("unsupported type %v", v))
+	}
+	return p
+}
+
+// Push0 implements PUSH0 (0x5f)
+func (p *Program) Push0() *Program {
+	return p.Op(vm.PUSH0)
+}
+
+// Bytecode returns the Program bytecode
+func (p *Program) Bytecode() []byte {
+	return p.code
+}
+
+// Hex returns the Program bytecode as a hex string
+func (p *Program) Hex() string {
+	return fmt.Sprintf("%02x", p.Bytecode())
+}
+
+// ExtcodeCopy performsa an extcodecopy invocation
+func (p *Program) ExtcodeCopy(address, memOffset, codeOffset, length any) {
+	p.Push(length)
+	p.Push(codeOffset)
+	p.Push(memOffset)
+	p.Push(address)
+	p.Op(vm.EXTCODECOPY)
+}
+
+// Call is a convenience function to make a call. If 'gas' is nil, the opcode GAS will
+// be used to provide all gas.
+func (p *Program) Call(gas *big.Int, address, value, inOffset, inSize, outOffset, outSize any) {
+	p.Push(outSize)
+	p.Push(outOffset)
+	p.Push(inSize)
+	p.Push(inOffset)
+	p.Push(value)
+	p.Push(address)
+	if gas == nil {
+		p.Op(vm.GAS)
+	} else {
+		p.pushBig(gas)
+	}
+	p.Op(vm.CALL)
+}
+
+// DelegateCall is a convenience function to make a delegatecall. If 'gas' is nil, the opcode GAS will
+// be used to provide all gas.
+func (p *Program) DelegateCall(gas *big.Int, address, inOffset, inSize, outOffset, outSize any) {
+	p.Push(outSize)
+	p.Push(outOffset)
+	p.Push(inSize)
+	p.Push(inOffset)
+	p.Push(address)
+	if gas == nil {
+		p.Op(vm.GAS)
+	} else {
+		p.pushBig(gas)
+	}
+	p.Op(vm.DELEGATECALL)
+}
+
+// StaticCall is a convenience function to make a staticcall. If 'gas' is nil, the opcode GAS will
+// be used to provide all gas.
+func (p *Program) StaticCall(gas *big.Int, address, inOffset, inSize, outOffset, outSize any) {
+	p.Push(outSize)
+	p.Push(outOffset)
+	p.Push(inSize)
+	p.Push(inOffset)
+	p.Push(address)
+	if gas == nil {
+		p.Op(vm.GAS)
+	} else {
+		p.pushBig(gas)
+	}
+	p.Op(vm.STATICCALL)
+}
+
+// StaticCall is a convenience function to make a callcode. If 'gas' is nil, the opcode GAS will
+// be used to provide all gas.
+func (p *Program) CallCode(gas *big.Int, address, value, inOffset, inSize, outOffset, outSize any) {
+	p.Push(outSize)
+	p.Push(outOffset)
+	p.Push(inSize)
+	p.Push(inOffset)
+	p.Push(value)
+	p.Push(address)
+	if gas == nil {
+		p.Op(vm.GAS)
+	} else {
+		p.pushBig(gas)
+	}
+	p.Op(vm.CALLCODE)
+}
+
+// Label returns the PC (of the next instruction)
+func (p *Program) Label() uint64 {
+	return uint64(len(p.code))
+}
+
+// Jumpdest adds a JUMPDEST op, and returns the PC of that instruction
+func (p *Program) Jumpdest() uint64 {
+	here := p.Label()
+	p.Op(vm.JUMPDEST)
+	return here
+}
+
+// Jump pushes the destination and adds a JUMP
+func (p *Program) Jump(loc any) {
+	p.Push(loc)
+	p.Op(vm.JUMP)
+}
+
+// Jump pushes the destination and adds a JUMP
+func (p *Program) JumpIf(loc any, condition any) {
+	p.Push(condition)
+	p.Push(loc)
+	p.Op(vm.JUMPI)
+}
+
+func (p *Program) Size() int {
+	return len(p.code)
+}
+
+// InputToMemory stores the input (calldata) to memory as address (20 bytes).
+func (p *Program) InputAddressToStack(inputOffset uint32) *Program {
+	p.Push(inputOffset)
+	p.Op(vm.CALLDATALOAD) // Loads [n -> n + 32] of input data to stack top
+	mask, ok := big.NewInt(0).SetString("FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF", 16)
+	if !ok {
+		panic("whoa")
+	}
+	p.Push(mask) // turn into address
+	return p.Op(vm.AND)
+}
+
+// MStore stores the provided data (into the memory area starting at memStart)
+func (p *Program) Mstore(data []byte, memStart uint32) *Program {
+	var idx = 0
+	// We need to store it in chunks of 32 bytes
+	for ; idx+32 <= len(data); idx += 32 {
+		chunk := data[idx : idx+32]
+		// push the value
+		p.Push(chunk)
+		// push the memory index
+		p.Push(uint32(idx) + memStart)
+		p.Op(vm.MSTORE)
+	}
+	// Remainders become stored using MSTORE8
+	for ; idx < len(data); idx++ {
+		b := data[idx]
+		// push the byte
+		p.Push(b)
+		p.Push(uint32(idx) + memStart)
+		p.Op(vm.MSTORE8)
+	}
+	return p
+}
+
+// MemToStorage copies the given memory area into SSTORE slots,
+// It expects data to be aligned to 32 byte, and does not zero out
+// remainders if some data is not
+// I.e, if given a 1-byte area, it will still copy the full 32 bytes to storage
+func (p *Program) MemToStorage(memStart, memSize, startSlot int) *Program {
+	// We need to store it in chunks of 32 bytes
+	for idx := memStart; idx < (memStart + memSize); idx += 32 {
+		dataStart := idx
+		// Mload the chunk
+		p.Push(dataStart)
+		p.Op(vm.MLOAD)
+		// Value is now on stack,
+		p.Push(startSlot)
+		p.Op(vm.SSTORE)
+		startSlot++
+	}
+	return p
+}
+
+// Sstore stores the given byte array to the given slot.
+// OBS! Does not verify that the value indeed fits into 32 bytes
+// If it does not, it will panic later on via pushBig
+func (p *Program) Sstore(slot any, value any) *Program {
+	p.Push(value)
+	p.Push(slot)
+	return p.Op(vm.SSTORE)
+}
+
+// Tstore stores the given byte array to the given t-slot.
+// OBS! Does not verify that the value indeed fits into 32 bytes
+// If it does not, it will panic later on via pushBig
+func (p *Program) Tstore(slot any, value any) *Program {
+	p.Push(value)
+	p.Push(slot)
+	return p.Op(vm.TSTORE)
+}
+
+func (p *Program) Return(offset, len uint32) *Program {
+	p.Push(len)
+	p.Push(offset)
+	return p.Op(vm.RETURN)
+}
+
+// ReturnData loads the given data into memory, and does a return with it
+func (p *Program) ReturnData(data []byte) *Program {
+	p.Mstore(data, 0)
+	return p.Return(0, uint32(len(data)))
+}
+
+// Create2 uses create2 to construct a contract with the given bytecode.
+// This operation leaves either '0' or address on the stack.
+func (p *Program) Create2(code []byte, salt any) *Program {
+	var (
+		value  = 0
+		offset = 0
+		size   = len(code)
+	)
+	// Load the code into mem
+	p.Mstore(code, 0)
+	// Create it
+	return p.Push(salt).
+		Push(size).
+		Push(offset).
+		Push(value).
+		Op(vm.CREATE2)
+	// On the stack now, is either
+	// zero: in case of failure
+	// address: in case of success
+}
+
+// Create2AndCall calls create2 with the given initcode and salt, and then calls
+// into the created contract (or calls into zero, if the creation failed).
+func (p *Program) Create2AndCall(code []byte, salt any) *Program {
+	p.Create2(code, salt)
+	// If there happen to be a zero on the stack, it doesn't matter, we're
+	// not sending any value anyway
+	p.Push(0).Push(0) // mem out
+	p.Push(0).Push(0) // mem in
+	p.Push(0)         // value
+	p.Op(vm.DUP6)     // address
+	p.Op(vm.GAS)
+	p.Op(vm.CALL)
+	p.Op(vm.POP)        // pop the retval
+	return p.Op(vm.POP) // pop the address
+}
+
+// Selfdestruct pushes beneficiary and invokes selfdestruct.
+func (p *Program) Selfdestruct(beneficiary any) *Program {
+	p.Push(beneficiary)
+	return p.Op(vm.SELFDESTRUCT)
+}

--- a/core/vm/program/program.go
+++ b/core/vm/program/program.go
@@ -14,6 +14,11 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with the goevmlab library. If not, see <http://www.gnu.org/licenses/>.
 
+// package program is a utility to create EVM bytecode for testing, but _not_ for production. As such:
+//
+// - There are not package guarantees. We might iterate heavily on this package, and do backwards-incompatible changes without warning
+// - There are no quality-guarantees. These utilities may produce evm-code that is non-functional. YMMV.
+// - There are no stability-guarantees. The utility will `panic` if the inputs do not align / make sense.
 package program
 
 import (

--- a/core/vm/program/program.go
+++ b/core/vm/program/program.go
@@ -138,17 +138,17 @@ func (p *Program) Hex() string {
 }
 
 // ExtcodeCopy performsa an extcodecopy invocation
-func (p *Program) ExtcodeCopy(address, memOffset, codeOffset, length any) {
+func (p *Program) ExtcodeCopy(address, memOffset, codeOffset, length any) *Program {
 	p.Push(length)
 	p.Push(codeOffset)
 	p.Push(memOffset)
 	p.Push(address)
-	p.Op(vm.EXTCODECOPY)
+	return p.Op(vm.EXTCODECOPY)
 }
 
 // Call is a convenience function to make a call. If 'gas' is nil, the opcode GAS will
 // be used to provide all gas.
-func (p *Program) Call(gas *big.Int, address, value, inOffset, inSize, outOffset, outSize any) {
+func (p *Program) Call(gas *big.Int, address, value, inOffset, inSize, outOffset, outSize any) *Program {
 	p.Push(outSize)
 	p.Push(outOffset)
 	p.Push(inSize)
@@ -160,12 +160,12 @@ func (p *Program) Call(gas *big.Int, address, value, inOffset, inSize, outOffset
 	} else {
 		p.pushBig(gas)
 	}
-	p.Op(vm.CALL)
+	return p.Op(vm.CALL)
 }
 
 // DelegateCall is a convenience function to make a delegatecall. If 'gas' is nil, the opcode GAS will
 // be used to provide all gas.
-func (p *Program) DelegateCall(gas *big.Int, address, inOffset, inSize, outOffset, outSize any) {
+func (p *Program) DelegateCall(gas *big.Int, address, inOffset, inSize, outOffset, outSize any) *Program {
 	p.Push(outSize)
 	p.Push(outOffset)
 	p.Push(inSize)
@@ -176,12 +176,12 @@ func (p *Program) DelegateCall(gas *big.Int, address, inOffset, inSize, outOffse
 	} else {
 		p.pushBig(gas)
 	}
-	p.Op(vm.DELEGATECALL)
+	return p.Op(vm.DELEGATECALL)
 }
 
 // StaticCall is a convenience function to make a staticcall. If 'gas' is nil, the opcode GAS will
 // be used to provide all gas.
-func (p *Program) StaticCall(gas *big.Int, address, inOffset, inSize, outOffset, outSize any) {
+func (p *Program) StaticCall(gas *big.Int, address, inOffset, inSize, outOffset, outSize any) *Program {
 	p.Push(outSize)
 	p.Push(outOffset)
 	p.Push(inSize)
@@ -192,12 +192,12 @@ func (p *Program) StaticCall(gas *big.Int, address, inOffset, inSize, outOffset,
 	} else {
 		p.pushBig(gas)
 	}
-	p.Op(vm.STATICCALL)
+	return p.Op(vm.STATICCALL)
 }
 
 // StaticCall is a convenience function to make a callcode. If 'gas' is nil, the opcode GAS will
 // be used to provide all gas.
-func (p *Program) CallCode(gas *big.Int, address, value, inOffset, inSize, outOffset, outSize any) {
+func (p *Program) CallCode(gas *big.Int, address, value, inOffset, inSize, outOffset, outSize any) *Program {
 	p.Push(outSize)
 	p.Push(outOffset)
 	p.Push(inSize)
@@ -209,7 +209,7 @@ func (p *Program) CallCode(gas *big.Int, address, value, inOffset, inSize, outOf
 	} else {
 		p.pushBig(gas)
 	}
-	p.Op(vm.CALLCODE)
+	return p.Op(vm.CALLCODE)
 }
 
 // Label returns the PC (of the next instruction)

--- a/core/vm/program/program.go
+++ b/core/vm/program/program.go
@@ -149,11 +149,11 @@ func (p *Program) ExtcodeCopy(address, memOffset, codeOffset, length any) *Progr
 // Call is a convenience function to make a call. If 'gas' is nil, the opcode GAS will
 // be used to provide all gas.
 func (p *Program) Call(gas *big.Int, address, value, inOffset, inSize, outOffset, outSize any) *Program {
-	p.Push(outSize)
-	p.Push(outOffset)
-	p.Push(inSize)
-	p.Push(inOffset)
-	p.Push(value)
+	if outOffset == outSize && inSize == outSize && inOffset == outSize && value == outSize {
+		p.Push(outSize).Ops(vm.DUP1, vm.DUP1, vm.DUP1, vm.DUP1)
+	} else {
+		p.Push(outSize).Push(outOffset).Push(inSize).Push(inOffset).Push(value)
+	}
 	p.Push(address)
 	if gas == nil {
 		p.Op(vm.GAS)
@@ -166,10 +166,11 @@ func (p *Program) Call(gas *big.Int, address, value, inOffset, inSize, outOffset
 // DelegateCall is a convenience function to make a delegatecall. If 'gas' is nil, the opcode GAS will
 // be used to provide all gas.
 func (p *Program) DelegateCall(gas *big.Int, address, inOffset, inSize, outOffset, outSize any) *Program {
-	p.Push(outSize)
-	p.Push(outOffset)
-	p.Push(inSize)
-	p.Push(inOffset)
+	if outOffset == outSize && inSize == outSize && inOffset == outSize {
+		p.Push(outSize).Ops(vm.DUP1, vm.DUP1, vm.DUP1)
+	} else {
+		p.Push(outSize).Push(outOffset).Push(inSize).Push(inOffset)
+	}
 	p.Push(address)
 	if gas == nil {
 		p.Op(vm.GAS)
@@ -182,10 +183,11 @@ func (p *Program) DelegateCall(gas *big.Int, address, inOffset, inSize, outOffse
 // StaticCall is a convenience function to make a staticcall. If 'gas' is nil, the opcode GAS will
 // be used to provide all gas.
 func (p *Program) StaticCall(gas *big.Int, address, inOffset, inSize, outOffset, outSize any) *Program {
-	p.Push(outSize)
-	p.Push(outOffset)
-	p.Push(inSize)
-	p.Push(inOffset)
+	if outOffset == outSize && inSize == outSize && inOffset == outSize {
+		p.Push(outSize).Ops(vm.DUP1, vm.DUP1, vm.DUP1)
+	} else {
+		p.Push(outSize).Push(outOffset).Push(inSize).Push(inOffset)
+	}
 	p.Push(address)
 	if gas == nil {
 		p.Op(vm.GAS)
@@ -198,10 +200,11 @@ func (p *Program) StaticCall(gas *big.Int, address, inOffset, inSize, outOffset,
 // StaticCall is a convenience function to make a callcode. If 'gas' is nil, the opcode GAS will
 // be used to provide all gas.
 func (p *Program) CallCode(gas *big.Int, address, value, inOffset, inSize, outOffset, outSize any) *Program {
-	p.Push(outSize)
-	p.Push(outOffset)
-	p.Push(inSize)
-	p.Push(inOffset)
+	if outOffset == outSize && inSize == outSize && inOffset == outSize {
+		p.Push(outSize).Ops(vm.DUP1, vm.DUP1, vm.DUP1)
+	} else {
+		p.Push(outSize).Push(outOffset).Push(inSize).Push(inOffset)
+	}
 	p.Push(value)
 	p.Push(address)
 	if gas == nil {
@@ -218,16 +221,17 @@ func (p *Program) Label() uint64 {
 }
 
 // Jumpdest adds a JUMPDEST op, and returns the PC of that instruction
-func (p *Program) Jumpdest() uint64 {
+func (p *Program) Jumpdest() (*Program, uint64) {
 	here := p.Label()
 	p.Op(vm.JUMPDEST)
-	return here
+	return p, here
 }
 
 // Jump pushes the destination and adds a JUMP
-func (p *Program) Jump(loc any) {
+func (p *Program) Jump(loc any) *Program {
 	p.Push(loc)
 	p.Op(vm.JUMP)
+	return p
 }
 
 // Jump pushes the destination and adds a JUMP

--- a/core/vm/program/program.go
+++ b/core/vm/program/program.go
@@ -39,6 +39,7 @@ type Program struct {
 	code []byte
 }
 
+// New creates a new Program
 func New() *Program {
 	return &Program{
 		code: make([]byte, 0),
@@ -54,21 +55,17 @@ func (p *Program) add(op byte) *Program {
 // pushBig creates a PUSHX instruction and pushes the given val.
 // - If the val is nil, it pushes zero
 // - If the val is bigger than 32 bytes, it panics
-func (p *Program) pushBig(val *big.Int) {
+func (p *Program) doPush(val *uint256.Int) {
 	if val == nil {
-		val = big.NewInt(0)
+		val = new(uint256.Int)
 	}
 	valBytes := val.Bytes()
 	if len(valBytes) == 0 {
 		valBytes = append(valBytes, 0)
 	}
 	bLen := len(valBytes)
-	if bLen > 32 {
-		panic(fmt.Sprintf("Push value too large, %d bytes", bLen))
-	}
 	p.add(byte(vm.PUSH1) - 1 + byte(bLen))
 	p.Append(valBytes)
-
 }
 
 // Append appends the given data to the code.
@@ -77,67 +74,77 @@ func (p *Program) Append(data []byte) *Program {
 	return p
 }
 
-// Op appends the given opcode
-func (p *Program) Op(op vm.OpCode) *Program {
-	return p.add(byte(op))
+// Bytes returns the Program bytecode. OBS: This is not a copy.
+func (p *Program) Bytes() []byte {
+	return p.code
 }
 
-// Ops appends the given opcodes
-func (p *Program) Ops(ops ...vm.OpCode) *Program {
+// SetBytes sets the Program bytecode. The combination of Bytes and SetBytes means
+// that external callers can implement missing functionality:
+//
+//	...
+//	prog.Push(1)
+//	code := prog.Bytes()
+//	manipulate(code)
+//	prog.SetBytes(code)
+func (p *Program) SetBytes(code []byte) {
+	p.code = code
+}
+
+// Hex returns the Program bytecode as a hex string.
+func (p *Program) Hex() string {
+	return fmt.Sprintf("%02x", p.Bytes())
+}
+
+// Op appends the given opcode(s).
+func (p *Program) Op(ops ...vm.OpCode) *Program {
 	for _, op := range ops {
 		p.add(byte(op))
 	}
 	return p
 }
 
-// Push creates a PUSHX instruction with the data provided
+// Push creates a PUSHX instruction with the data provided. If zero is being pushed,
+// PUSH0 will be avoided in favour of [PUSH1 0], to ensure backwards compatibility.
 func (p *Program) Push(val any) *Program {
 	switch v := val.(type) {
 	case int:
-		p.pushBig(new(big.Int).SetUint64(uint64(v)))
+		p.doPush(new(uint256.Int).SetUint64(uint64(v)))
 	case uint64:
-		p.pushBig(new(big.Int).SetUint64(v))
+		p.doPush(new(uint256.Int).SetUint64(v))
 	case uint32:
-		p.pushBig(new(big.Int).SetUint64(uint64(v)))
+		p.doPush(new(uint256.Int).SetUint64(uint64(v)))
+	case uint16:
+		p.doPush(new(uint256.Int).SetUint64(uint64(v)))
 	case *big.Int:
-		p.pushBig(v)
+		p.doPush(uint256.MustFromBig(v))
 	case *uint256.Int:
-		p.pushBig(v.ToBig())
+		p.doPush(v)
 	case uint256.Int:
-		p.pushBig(v.ToBig())
+		p.doPush(&v)
 	case []byte:
-		p.pushBig(new(big.Int).SetBytes(v))
+		p.doPush(new(uint256.Int).SetBytes(v))
 	case byte:
-		p.pushBig(new(big.Int).SetUint64(uint64(v)))
+		p.doPush(new(uint256.Int).SetUint64(uint64(v)))
 	case interface{ Bytes() []byte }:
-		// Here, we jump through some hovm in order to avoid depending on
+		// Here, we jump through some hoops in order to avoid depending on
 		// go-ethereum types.Address and common.Hash, and instead use the
 		// interface. This works on both values and pointers!
-		p.pushBig(new(big.Int).SetBytes(v.Bytes()))
+		p.doPush(new(uint256.Int).SetBytes(v.Bytes()))
 	case nil:
-		p.pushBig(nil)
+		p.doPush(nil)
 	default:
-		panic(fmt.Sprintf("unsupported type %v", v))
+		panic(fmt.Sprintf("unsupported type %T", v))
 	}
 	return p
 }
 
-// Push0 implements PUSH0 (0x5f)
+// Push0 implements PUSH0 (0x5f).
 func (p *Program) Push0() *Program {
 	return p.Op(vm.PUSH0)
 }
 
-// Bytes returns the Program bytecode
-func (p *Program) Bytes() []byte {
-	return p.code
-}
-
-// Hex returns the Program bytecode as a hex string
-func (p *Program) Hex() string {
-	return fmt.Sprintf("%02x", p.Bytes())
-}
-
-// ExtcodeCopy performsa an extcodecopy invocation
+// ExtcodeCopy performs an extcodecopy invocation.
 func (p *Program) ExtcodeCopy(address, memOffset, codeOffset, length any) *Program {
 	p.Push(length)
 	p.Push(codeOffset)
@@ -148,9 +155,9 @@ func (p *Program) ExtcodeCopy(address, memOffset, codeOffset, length any) *Progr
 
 // Call is a convenience function to make a call. If 'gas' is nil, the opcode GAS will
 // be used to provide all gas.
-func (p *Program) Call(gas *big.Int, address, value, inOffset, inSize, outOffset, outSize any) *Program {
+func (p *Program) Call(gas *uint256.Int, address, value, inOffset, inSize, outOffset, outSize any) *Program {
 	if outOffset == outSize && inSize == outSize && inOffset == outSize && value == outSize {
-		p.Push(outSize).Ops(vm.DUP1, vm.DUP1, vm.DUP1, vm.DUP1)
+		p.Push(outSize).Op(vm.DUP1, vm.DUP1, vm.DUP1, vm.DUP1)
 	} else {
 		p.Push(outSize).Push(outOffset).Push(inSize).Push(inOffset).Push(value)
 	}
@@ -158,16 +165,16 @@ func (p *Program) Call(gas *big.Int, address, value, inOffset, inSize, outOffset
 	if gas == nil {
 		p.Op(vm.GAS)
 	} else {
-		p.pushBig(gas)
+		p.doPush(gas)
 	}
 	return p.Op(vm.CALL)
 }
 
 // DelegateCall is a convenience function to make a delegatecall. If 'gas' is nil, the opcode GAS will
 // be used to provide all gas.
-func (p *Program) DelegateCall(gas *big.Int, address, inOffset, inSize, outOffset, outSize any) *Program {
+func (p *Program) DelegateCall(gas *uint256.Int, address, inOffset, inSize, outOffset, outSize any) *Program {
 	if outOffset == outSize && inSize == outSize && inOffset == outSize {
-		p.Push(outSize).Ops(vm.DUP1, vm.DUP1, vm.DUP1)
+		p.Push(outSize).Op(vm.DUP1, vm.DUP1, vm.DUP1)
 	} else {
 		p.Push(outSize).Push(outOffset).Push(inSize).Push(inOffset)
 	}
@@ -175,16 +182,16 @@ func (p *Program) DelegateCall(gas *big.Int, address, inOffset, inSize, outOffse
 	if gas == nil {
 		p.Op(vm.GAS)
 	} else {
-		p.pushBig(gas)
+		p.doPush(gas)
 	}
 	return p.Op(vm.DELEGATECALL)
 }
 
 // StaticCall is a convenience function to make a staticcall. If 'gas' is nil, the opcode GAS will
 // be used to provide all gas.
-func (p *Program) StaticCall(gas *big.Int, address, inOffset, inSize, outOffset, outSize any) *Program {
+func (p *Program) StaticCall(gas *uint256.Int, address, inOffset, inSize, outOffset, outSize any) *Program {
 	if outOffset == outSize && inSize == outSize && inOffset == outSize {
-		p.Push(outSize).Ops(vm.DUP1, vm.DUP1, vm.DUP1)
+		p.Push(outSize).Op(vm.DUP1, vm.DUP1, vm.DUP1)
 	} else {
 		p.Push(outSize).Push(outOffset).Push(inSize).Push(inOffset)
 	}
@@ -192,16 +199,16 @@ func (p *Program) StaticCall(gas *big.Int, address, inOffset, inSize, outOffset,
 	if gas == nil {
 		p.Op(vm.GAS)
 	} else {
-		p.pushBig(gas)
+		p.doPush(gas)
 	}
 	return p.Op(vm.STATICCALL)
 }
 
 // StaticCall is a convenience function to make a callcode. If 'gas' is nil, the opcode GAS will
 // be used to provide all gas.
-func (p *Program) CallCode(gas *big.Int, address, value, inOffset, inSize, outOffset, outSize any) *Program {
+func (p *Program) CallCode(gas *uint256.Int, address, value, inOffset, inSize, outOffset, outSize any) *Program {
 	if outOffset == outSize && inSize == outSize && inOffset == outSize {
-		p.Push(outSize).Ops(vm.DUP1, vm.DUP1, vm.DUP1)
+		p.Push(outSize).Op(vm.DUP1, vm.DUP1, vm.DUP1)
 	} else {
 		p.Push(outSize).Push(outOffset).Push(inSize).Push(inOffset)
 	}
@@ -210,54 +217,53 @@ func (p *Program) CallCode(gas *big.Int, address, value, inOffset, inSize, outOf
 	if gas == nil {
 		p.Op(vm.GAS)
 	} else {
-		p.pushBig(gas)
+		p.doPush(gas)
 	}
 	return p.Op(vm.CALLCODE)
 }
 
-// Label returns the PC (of the next instruction)
+// Label returns the PC (of the next instruction).
 func (p *Program) Label() uint64 {
 	return uint64(len(p.code))
 }
 
-// Jumpdest adds a JUMPDEST op, and returns the PC of that instruction
+// Jumpdest adds a JUMPDEST op, and returns the PC of that instruction.
 func (p *Program) Jumpdest() (*Program, uint64) {
 	here := p.Label()
 	p.Op(vm.JUMPDEST)
 	return p, here
 }
 
-// Jump pushes the destination and adds a JUMP
+// Jump pushes the destination and adds a JUMP.
 func (p *Program) Jump(loc any) *Program {
 	p.Push(loc)
 	p.Op(vm.JUMP)
 	return p
 }
 
-// Jump pushes the destination and adds a JUMP
-func (p *Program) JumpIf(loc any, condition any) {
+// JumpIf implements JUMPI.
+func (p *Program) JumpIf(loc any, condition any) *Program {
 	p.Push(condition)
 	p.Push(loc)
 	p.Op(vm.JUMPI)
+	return p
 }
 
+// Size returns the current size of the bytecode.
 func (p *Program) Size() int {
 	return len(p.code)
 }
 
-// InputToMemory stores the input (calldata) to memory as address (20 bytes).
+// InputAddressToStack stores the input (calldata) to memory as address (20 bytes).
 func (p *Program) InputAddressToStack(inputOffset uint32) *Program {
 	p.Push(inputOffset)
 	p.Op(vm.CALLDATALOAD) // Loads [n -> n + 32] of input data to stack top
-	mask, ok := big.NewInt(0).SetString("FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF", 16)
-	if !ok {
-		panic("whoa")
-	}
+	mask, _ := big.NewInt(0).SetString("FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF", 16)
 	p.Push(mask) // turn into address
 	return p.Op(vm.AND)
 }
 
-// MStore stores the provided data (into the memory area starting at memStart)
+// MStore stores the provided data (into the memory area starting at memStart).
 func (p *Program) Mstore(data []byte, memStart uint32) *Program {
 	var idx = 0
 	// We need to store it in chunks of 32 bytes
@@ -292,11 +298,11 @@ func (p *Program) Mstore(data []byte, memStart uint32) *Program {
 func (p *Program) MstoreSmall(data []byte, memStart uint32) *Program {
 	if len(data) > 32 {
 		// For larger sizes, use Mstore instead.
-		panic(fmt.Sprintf("only <=32 byte data size supported"))
+		panic("only <=32 byte data size supported")
 	}
 	if len(data) == 0 {
 		// Storing 0-length data smells of an error somewhere.
-		panic(fmt.Sprintf("data is zero length"))
+		panic("data is zero length")
 	}
 	// push the value
 	p.Push(data)
@@ -309,7 +315,7 @@ func (p *Program) MstoreSmall(data []byte, memStart uint32) *Program {
 // MemToStorage copies the given memory area into SSTORE slots,
 // It expects data to be aligned to 32 byte, and does not zero out
 // remainders if some data is not
-// I.e, if given a 1-byte area, it will still copy the full 32 bytes to storage
+// I.e, if given a 1-byte area, it will still copy the full 32 bytes to storage.
 func (p *Program) MemToStorage(memStart, memSize, startSlot int) *Program {
 	// We need to store it in chunks of 32 bytes
 	for idx := memStart; idx < (memStart + memSize); idx += 32 {
@@ -350,8 +356,8 @@ func (p *Program) ReturnViaCodeCopy(data []byte) *Program {
 }
 
 // Sstore stores the given byte array to the given slot.
-// OBS! Does not verify that the value indeed fits into 32 bytes
-// If it does not, it will panic later on via pushBig
+// OBS! Does not verify that the value indeed fits into 32 bytes.
+// If it does not, it will panic later on via doPush.
 func (p *Program) Sstore(slot any, value any) *Program {
 	p.Push(value)
 	p.Push(slot)
@@ -359,14 +365,15 @@ func (p *Program) Sstore(slot any, value any) *Program {
 }
 
 // Tstore stores the given byte array to the given t-slot.
-// OBS! Does not verify that the value indeed fits into 32 bytes
-// If it does not, it will panic later on via pushBig
+// OBS! Does not verify that the value indeed fits into 32 bytes.
+// If it does not, it will panic later on via doPush.
 func (p *Program) Tstore(slot any, value any) *Program {
 	p.Push(value)
 	p.Push(slot)
 	return p.Op(vm.TSTORE)
 }
 
+// Return implements RETURN
 func (p *Program) Return(offset, len int) *Program {
 	p.Push(len)
 	p.Push(offset)
@@ -396,13 +403,13 @@ func (p *Program) Create2(code []byte, salt any) *Program {
 		Push(value).
 		Op(vm.CREATE2)
 	// On the stack now, is either
-	// zero: in case of failure
-	// address: in case of success
+	// - zero: in case of failure, OR
+	// - address: in case of success
 }
 
-// Create2AndCall calls create2 with the given initcode and salt, and then calls
+// Create2ThenCall calls create2 with the given initcode and salt, and then calls
 // into the created contract (or calls into zero, if the creation failed).
-func (p *Program) Create2AndCall(code []byte, salt any) *Program {
+func (p *Program) Create2ThenCall(code []byte, salt any) *Program {
 	p.Create2(code, salt)
 	// If there happen to be a zero on the stack, it doesn't matter, we're
 	// not sending any value anyway

--- a/core/vm/program/program_test.go
+++ b/core/vm/program/program_test.go
@@ -129,6 +129,22 @@ func TestReturnData(t *testing.T) {
 			t.Errorf("have %v want %v", have, want)
 		}
 	}
+	{ // ReturnViaCodeCopy
+		data := common.FromHex("0x6001")
+		have := New().Append([]byte{0x5b, 0x5b, 0x5b}).ReturnViaCodeCopy(data).Hex()
+		want := "5b5b5b600261001060003960026000f36001"
+		if have != want {
+			t.Errorf("have %v want %v", have, want)
+		}
+	}
+	{ // ReturnViaCodeCopy larger code
+		data := common.FromHex("7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff60005260206000f3")
+		have := New().Append([]byte{0x5b, 0x5b, 0x5b}).ReturnViaCodeCopy(data).Hex()
+		want := "5b5b5b602961001060003960296000f37fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff60005260206000f3"
+		if have != want {
+			t.Errorf("have %v want %v", have, want)
+		}
+	}
 }
 
 func TestCreateAndCall(t *testing.T) {
@@ -194,10 +210,10 @@ func TestGenerator(t *testing.T) {
 			},
 			haveFn: func() []byte {
 				initcode := New().Return(0, 0).Bytes()
-				return New().MstorePadded(initcode, 0).
-					Push(len(initcode)).      // length
+				return New().MstoreSmall(initcode, 0).
+					Push(len(initcode)). // length
 					Push(32 - len(initcode)). // offset
-					Push(0).                  // value
+					Push(0). // value
 					Op(vm.CREATE).
 					Op(vm.POP).Bytes()
 			},
@@ -217,11 +233,11 @@ func TestGenerator(t *testing.T) {
 			},
 			haveFn: func() []byte {
 				initcode := New().Return(0, 0).Bytes()
-				return New().MstorePadded(initcode, 0).
-					Push(1).                  // salt
-					Push(len(initcode)).      // length
+				return New().MstoreSmall(initcode, 0).
+					Push(1). // salt
+					Push(len(initcode)). // length
 					Push(32 - len(initcode)). // offset
-					Push(0).                  // value
+					Push(0). // value
 					Op(vm.CREATE2).
 					Op(vm.POP).Bytes()
 			},

--- a/core/vm/program/program_test.go
+++ b/core/vm/program/program_test.go
@@ -1,0 +1,46 @@
+// Copyright 2024 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the goevmlab library. If not, see <http://www.gnu.org/licenses/>.
+
+package program
+
+import (
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/vm"
+
+	"bytes"
+	"testing"
+)
+
+func TestCreate2Call(t *testing.T) {
+	// Some runtime code
+	runtime := New().Ops(vm.ADDRESS, vm.SELFDESTRUCT).Bytecode()
+	want := common.FromHex("0x30ff")
+	if !bytes.Equal(want, runtime) {
+		t.Fatalf("runtime code error\nwant: %x\nhave: %x\n", want, runtime)
+	}
+	// A constructor returning the runtime code
+	initcode := New().ReturnData(runtime).Bytecode()
+	want = common.FromHex("603060005360ff60015360026000f3")
+	if !bytes.Equal(want, initcode) {
+		t.Fatalf("initcode error\nwant: %x\nhave: %x\n", want, initcode)
+	}
+	// A factory invoking the constructor
+	outer := New().Create2AndCall(initcode, nil).Bytecode()
+	want = common.FromHex("60606000536030600153606060025360006003536053600453606060055360ff6006536060600753600160085360536009536060600a536002600b536060600c536000600d5360f3600e536000600f60006000f560006000600060006000855af15050")
+	if !bytes.Equal(want, outer) {
+		t.Fatalf("factory error\nwant: %x\nhave: %x\n", want, outer)
+	}
+}

--- a/core/vm/program/readme.md
+++ b/core/vm/program/readme.md
@@ -1,0 +1,30 @@
+### What is this
+
+In many cases, we have a need to create somewhat nontrivial bytecode, for testing various
+quirks related to state transition or evm execution.
+
+For example, we want to have a `CREATE2`- op create a contract, which is then invoked, and when invoked does a selfdestruct-to-self.
+
+It is overkill to go full solidity, but it is also a bit tricky do assemble this by concatenating bytes.
+
+This utility takes an approach from [goevmlab](https://github.com/holiman/goevmlab/) where it has been used for several years,
+a go-lang utility to assemble evm bytecode.
+
+Using this utility, the case above can be expressed as:
+```golang
+	// Some runtime code
+	runtime := program.New().Ops(vm.ADDRESS, vm.SELFDESTRUCT).Bytecode()
+	// A constructor returning the runtime code
+	initcode := program.New().ReturnData(runtime).Bytecode()
+	// A factory invoking the constructor
+	outer := program.New().Create2AndCall(initcode, nil).Bytecode()
+```
+
+### Warning
+
+This package is a utility for testing, _not_ for production. As such:
+
+- There are not package guarantees. We might iterate heavily on this package, and do backwards-incompatible changes without warning
+- There are no quality-guarantees. These utilities may produce evm-code that is non-functional. YMMV.
+- There are no stability-guarantees. The utility will `panic` if the inputs do not align / make sense.
+

--- a/core/vm/runtime/runtime_test.go
+++ b/core/vm/runtime/runtime_test.go
@@ -442,30 +442,22 @@ func BenchmarkSimpleLoop(b *testing.B) {
 	// Call identity, and pop return value
 	staticCallIdentity := p.
 		StaticCall(nil, 0x4, 0, 0, 0, 0).
-		Op(vm.POP). // pop return value
-		Jump(lbl).  // jump to label
-		Bytecode()
+		Op(vm.POP).Jump(lbl).Bytecode() // pop return value and jump to label
 
 	p, lbl = program.New().Jumpdest()
 	callIdentity := p.
 		Call(nil, 0x4, 0, 0, 0, 0, 0).
-		Op(vm.POP). // pop return value
-		Jump(lbl).  // jump to label
-		Bytecode()
+		Op(vm.POP).Jump(lbl).Bytecode() // pop return value and jump to label
 
 	p, lbl = program.New().Jumpdest()
 	callInexistant := p.
 		Call(nil, 0xff, 0, 0, 0, 0, 0).
-		Op(vm.POP). // pop return value
-		Jump(lbl).  // jump to label
-		Bytecode()
+		Op(vm.POP).Jump(lbl).Bytecode() // pop return value and jump to label
 
 	p, lbl = program.New().Jumpdest()
 	callEOA := p.
 		Call(nil, 0xE0, 0, 0, 0, 0, 0). // call addr of EOA
-		Op(vm.POP).                     // pop return value
-		Jump(lbl).                      // jump to label
-		Bytecode()
+		Op(vm.POP).Jump(lbl).Bytecode() // pop return value and jump to label
 
 	p, lbl = program.New().Jumpdest()
 	// Push as if we were making call, then pop it off again, and loop
@@ -485,9 +477,7 @@ func BenchmarkSimpleLoop(b *testing.B) {
 	p, lbl = program.New().Jumpdest()
 	callRevertingContractWithInput := p.
 		Call(nil, 0xee, 0, 0, 0x20, 0x0, 0x0).
-		Op(vm.POP).
-		Jump(lbl).
-		Bytecode()
+		Op(vm.POP).Jump(lbl).Bytecode() // pop return value and jump to label
 
 	//tracer := logger.NewJSONLogger(nil, os.Stdout)
 	//Execute(loopingCode, nil, &Config{

--- a/core/vm/runtime/runtime_test.go
+++ b/core/vm/runtime/runtime_test.go
@@ -477,7 +477,7 @@ func BenchmarkSimpleLoop(b *testing.B) {
 
 	p, lbl = program.New().Jumpdest()
 	loopingCode2 := p.
-		Push(0x01020304).Push(0x0102030405).
+		Push(0x01020304).Push(uint64(0x0102030405)).
 		Ops(vm.POP, vm.POP).
 		Op(vm.PUSH6).Append(make([]byte, 6)).Op(vm.JUMP). // Jumpdest zero expressed in 6 bytes
 		Bytecode()


### PR DESCRIPTION
In many cases, we have a need to create somewhat nontrivial bytecode. A recent example is the verkle statetests, where we want a `CREATE2`- op to create a contract, which can then be invoked, and when invoked does a selfdestruct-to-self. 

It is overkill to go full solidity, but it is also a bit tricky do assemble this by concatenating bytes. This PR takes an approach that I've been using in goevmlab for several years. 

Using this utility, the case can be expressed as: 
```golang
	// Some runtime code
	runtime := program.New().Ops(vm.ADDRESS, vm.SELFDESTRUCT).Bytecode()
	// A constructor returning the runtime code
	initcode := program.New().ReturnData(runtime).Bytecode()
	// A factory invoking the constructor
	outer := program.New().Create2AndCall(initcode, nil).Bytecode()
```

We have a lot of places in the codebase where we concatenate bytes, cast from `vm.OpCode` . If we use this approach, we can make those places a bit more maintainable/robust. 

WDYT?


Note: I could have just added a dependency to goevmlab `Program`. However, goevmlab depends on go-ethereum, and I'd rather just avoid the potential cycle problems. 