### PR TITLE
cmd/utils: change blssync.JWTSecretFlag to DirectoryFlag

### DIFF
--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -326,7 +326,7 @@ var (
 		Usage:    "Target EL engine API URL",
 		Category: flags.BeaconCategory,
 	}
-	BlsyncJWTSecretFlag = &cli.StringFlag{
+	BlsyncJWTSecretFlag = &flags.DirectoryFlag{
 		Name:     "blsync.jwtsecret",
 		Usage:    "Path to a JWT secret to use for target engine API endpoint",
 		Category: flags.BeaconCategory,


### PR DESCRIPTION
closes https://github.com/ethereum/go-ethereum/issues/30304

We already use `DirectoryFlag` for `authrpc.jwtsecret` which expands the tilde, so this should work out of the box