### PR TITLE
abi: unpack error into interface

### DIFF
--- a/accounts/abi/abi.go
+++ b/accounts/abi/abi.go
@@ -95,8 +95,11 @@ func (abi ABI) getArguments(name string, data []byte) (Arguments, error) {
 	if event, ok := abi.Events[name]; ok {
 		args = event.Inputs
 	}
+	if err, ok := abi.Errors[name]; ok {
+		args = err.Inputs
+	}
 	if args == nil {
-		return nil, fmt.Errorf("abi: could not locate named method or event: %s", name)
+		return nil, fmt.Errorf("abi: could not locate named method, event or error: %s", name)
 	}
 	return args, nil
 }

--- a/accounts/abi/abi.go
+++ b/accounts/abi/abi.go
@@ -84,7 +84,7 @@ func (abi ABI) Pack(name string, args ...interface{}) ([]byte, error) {
 
 func (abi ABI) getArguments(name string, data []byte) (Arguments, error) {
 	// since there can't be naming collisions with contracts and events,
-	// we need to decide whether we're calling a method or an event
+	// we need to decide whether we're calling a method, event or an error
 	var args Arguments
 	if method, ok := abi.Methods[name]; ok {
 		if len(data)%32 != 0 {

--- a/accounts/abi/abi_test.go
+++ b/accounts/abi/abi_test.go
@@ -21,7 +21,6 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
-	"github.com/ethereum/go-ethereum/internal/testrand"
 	"math/big"
 	"reflect"
 	"strings"
@@ -30,6 +29,7 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/math"
 	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/ethereum/go-ethereum/internal/testrand"
 )
 
 const jsondata = `
@@ -318,7 +318,7 @@ func TestCustomErrors(t *testing.T) {
 	check("MyError", "MyError(uint256)")
 }
 
-func TestCustomErrorUnpack(t *testing.T) {
+func TestCustomErrorUnpackIntoInterface(t *testing.T) {
 	t.Parallel()
 	errorName := "MyError"
 	json := fmt.Sprintf(`[{"inputs":[{"internalType":"address","name":"sender","type":"address"},{"internalType":"uint256","name":"balance","type":"uint256"}],"name":"%s","type":"error"}]`, errorName)

--- a/accounts/abi/abi_test.go
+++ b/accounts/abi/abi_test.go
@@ -21,6 +21,7 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
+	"github.com/ethereum/go-ethereum/internal/testrand"
 	"math/big"
 	"reflect"
 	"strings"
@@ -315,6 +316,38 @@ func TestCustomErrors(t *testing.T) {
 		}
 	}
 	check("MyError", "MyError(uint256)")
+}
+
+func TestCustomErrorUnpack(t *testing.T) {
+	t.Parallel()
+	errorName := "MyError"
+	json := fmt.Sprintf(`[{"inputs":[{"internalType":"address","name":"sender","type":"address"},{"internalType":"uint256","name":"balance","type":"uint256"}],"name":"%s","type":"error"}]`, errorName)
+	abi, err := JSON(strings.NewReader(json))
+	if err != nil {
+		t.Fatal(err)
+	}
+	type MyError struct {
+		Sender  common.Address
+		Balance *big.Int
+	}
+
+	sender := testrand.Address()
+	balance := new(big.Int).SetBytes(testrand.Bytes(8))
+	encoded, err := abi.Errors[errorName].Inputs.Pack(sender, balance)
+	if err != nil {
+		t.Fatal(err)
+	}
+	result := MyError{}
+	err = abi.UnpackIntoInterface(&result, errorName, encoded)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Sender != sender {
+		t.Errorf("expected %x got %x", sender, result.Sender)
+	}
+	if result.Balance.Cmp(balance) != 0 {
+		t.Errorf("expected %v got %v", balance, result.Balance)
+	}
 }
 
 func TestMultiPack(t *testing.T) {


### PR DESCRIPTION
This PR adds the error fragments to `func (abi ABI) getArguments` which allows decoding of typed errors