### PR TITLE
tests: fix test panic

### DIFF
--- a/tests/state_test_util.go
+++ b/tests/state_test_util.go
@@ -308,6 +308,7 @@ func (t *StateTest) RunNoVerify(subtest StateSubtest, vmconfig vm.Config, snapsh
 		if tracer := evm.Config.Tracer; tracer != nil && tracer.OnTxEnd != nil {
 			evm.Config.Tracer.OnTxEnd(nil, err)
 		}
+		return st, common.Hash{}, 0, err
 	}
 	// Add 0-value mining reward. This only makes a difference in the cases
 	// where
@@ -322,7 +323,7 @@ func (t *StateTest) RunNoVerify(subtest StateSubtest, vmconfig vm.Config, snapsh
 		receipt := &types.Receipt{GasUsed: vmRet.UsedGas}
 		tracer.OnTxEnd(receipt, nil)
 	}
-	return st, root, vmRet.UsedGas, err
+	return st, root, vmRet.UsedGas, nil
 }
 
 func (t *StateTest) gasLimit(subtest StateSubtest) uint64 {


### PR DESCRIPTION
Fix test panic 

```
--- FAIL: TestState (5.11s)
    init_test.go:200: missing test files
    --- FAIL: TestState/stSpecialTest/eoaEmptyParis.json (0.01s)
        --- FAIL: TestState/stSpecialTest/eoaEmptyParis.json/Shanghai/2/hash/trie (0.00s)
panic: runtime error: invalid memory address or nil pointer dereference [recovered]
        panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x2 addr=0x0 pc=0x100cc3210]

goroutine 24268777 [running]:
testing.tRunner.func1.2({0x100ec02e0, 0x1011a0c70})
        /usr/local/go/src/testing/testing.go:1631 +0x1c4
testing.tRunner.func1()
        /usr/local/go/src/testing/testing.go:1634 +0x33c
panic({0x100ec02e0?, 0x1011a0c70?})
        /usr/local/go/src/runtime/panic.go:770 +0x124
github.com/ethereum/go-ethereum/tests.(*StateTest).RunNoVerify(0x1400469ac60, {{0x140098860f0?, 0x50?}, 0x14d696148?}, {0x0, 0x0, 0x0, {0x0, 0x0, 0x0}, ...}, ...)
        /Users/mac/gopath/src/github.com/ethereum/go-ethereum/tests/state_test_util.go:325 +0xbf0
github.com/ethereum/go-ethereum/tests.(*StateTest).Run(0x1400469ac60, {{0x140098860f0?, 0x8?}, 0x2?}, {0x0, 0x0, 0x0, {0x0, 0x0, 0x0}, ...}, ...)
        /Users/mac/gopath/src/github.com/ethereum/go-ethereum/tests/state_test_util.go:199 +0xb8
github.com/ethereum/go-ethereum/tests.execStateTest.func1.1({0x0, 0x0, 0x0, {0x0, 0x0, 0x0}, 0x0})
        /Users/mac/gopath/src/github.com/ethereum/go-ethereum/tests/state_test.go:121 +0xac
github.com/ethereum/go-ethereum/tests.withTrace(0x140008541a0, 0x989680, 0x14002f0df00)
        /Users/mac/gopath/src/github.com/ethereum/go-ethereum/tests/state_test.go:184 +0x64
github.com/ethereum/go-ethereum/tests.execStateTest.func1(0x140008541a0)
        /Users/mac/gopath/src/github.com/ethereum/go-ethereum/tests/state_test.go:119 +0x12c
testing.tRunner(0x140008541a0, 0x14002b82800)
        /usr/local/go/src/testing/testing.go:1689 +0xec
created by testing.(*T).Run in goroutine 23926816
        /usr/local/go/src/testing/testing.go:1742 +0x318
FAIL    github.com/ethereum/go-ethereum/tests   179.337s
ok      github.com/ethereum/go-ethereum/tests/fuzzers/bls12381  1.069s
ok      github.com/ethereum/go-ethereum/tests/fuzzers/bn256     1.862s
ok      github.com/ethereum/go-ethereum/tests/fuzzers/difficulty        2.402s
ok      github.com/ethereum/go-ethereum/tests/fuzzers/rangeproof        1.582s
ok      github.com/ethereum/go-ethereum/tests/fuzzers/secp256k1 1.343s
ok      github.com/ethereum/go-ethereum/tests/fuzzers/txfetcher 2.172s

```