### PR TITLE
trie: reduce allocations in stacktrie

### DIFF
--- a/trie/bytepool.go
+++ b/trie/bytepool.go
@@ -16,7 +16,7 @@
 
 package trie
 
-// bytesPool is a pool for byteslices. It is safe for concurrent use.
+// bytesPool is a pool for byte slices. It is safe for concurrent use.
 type bytesPool struct {
 	c chan []byte
 	w int
@@ -40,6 +40,15 @@ func (bp *bytesPool) Get() []byte {
 	default:
 		return make([]byte, 0, bp.w)
 	}
+}
+
+// GetWithSize returns a slice with specified byte slice size.
+func (bp *bytesPool) GetWithSize(s int) []byte {
+	b := bp.Get()
+	if cap(b) < s {
+		return make([]byte, s)
+	}
+	return b[:s]
 }
 
 // Put returns a slice to the pool. Safe for concurrent use. This method

--- a/trie/bytepool.go
+++ b/trie/bytepool.go
@@ -1,20 +1,39 @@
+// Copyright 2024 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+
 package trie
 
-type bytepool struct {
+// bytesPool is a pool for byteslices. It is safe for concurrent use.
+type bytesPool struct {
 	c chan []byte
 	w int
-	h int
 }
 
-func newByteslicepool(sliceCap, nitems int) *bytepool {
-	b := &bytepool{
+// newBytesPool creates a new bytesPool. The sliceCap sets the capacity of
+// newly allocated slices, and the nitems determines how many items the pool
+// will hold, at maximum.
+func newBytesPool(sliceCap, nitems int) *bytesPool {
+	return &bytesPool{
 		c: make(chan []byte, nitems),
 		w: sliceCap,
 	}
-	return b
 }
 
-func (bp *bytepool) Get() []byte {
+// Get returns a slice. Safe for concurrent use.
+func (bp *bytesPool) Get() []byte {
 	select {
 	case b := <-bp.c:
 		return b
@@ -23,13 +42,10 @@ func (bp *bytepool) Get() []byte {
 	}
 }
 
-func (bp *bytepool) Put(b []byte) {
-	// Ignore too small slices
-	if cap(b) < bp.w {
-		return
-	}
-	// Don't retain too large slices either
-	if cap(b) > 3*bp.w {
+// Put returns a slice to the pool. Safe for concurrent use. This method
+// will ignore slices that are too small or too large (>3x the cap)
+func (bp *bytesPool) Put(b []byte) {
+	if c := cap(b); c < bp.w || c > 3*bp.w {
 		return
 	}
 	select {

--- a/trie/bytepool.go
+++ b/trie/bytepool.go
@@ -1,0 +1,39 @@
+package trie
+
+type bytepool struct {
+	c chan []byte
+	w int
+	h int
+}
+
+func newByteslicepool(sliceCap, nitems int) *bytepool {
+	b := &bytepool{
+		c: make(chan []byte, nitems),
+		w: sliceCap,
+	}
+	return b
+}
+
+func (bp *bytepool) Get() []byte {
+	select {
+	case b := <-bp.c:
+		return b
+	default:
+		return make([]byte, 0, bp.w)
+	}
+}
+
+func (bp *bytepool) Put(b []byte) {
+	// Ignore too small slices
+	if cap(b) < bp.w {
+		return
+	}
+	// Don't retain too large slices either
+	if cap(b) > 3*bp.w {
+		return
+	}
+	select {
+	case bp.c <- b:
+	default:
+	}
+}

--- a/trie/encoding.go
+++ b/trie/encoding.go
@@ -104,6 +104,17 @@ func keybytesToHex(str []byte) []byte {
 	return nibbles
 }
 
+// writeHexKey writes the hexkey into the given slice.
+// OBS! This method omits the termination flag.
+// OBS! The dst slice must be at least 2x as large as the key
+func writeHexKey(dst []byte, key []byte) {
+	_ = dst[2*len(key)-1]
+	for i, b := range key {
+		dst[i*2] = b / 16
+		dst[i*2+1] = b % 16
+	}
+}
+
 // hexToKeybytes turns hex nibbles into key bytes.
 // This can only be used for keys of even length.
 func hexToKeybytes(hex []byte) []byte {

--- a/trie/encoding.go
+++ b/trie/encoding.go
@@ -107,12 +107,13 @@ func keybytesToHex(str []byte) []byte {
 // writeHexKey writes the hexkey into the given slice.
 // OBS! This method omits the termination flag.
 // OBS! The dst slice must be at least 2x as large as the key
-func writeHexKey(dst []byte, key []byte) {
+func writeHexKey(dst []byte, key []byte) []byte {
 	_ = dst[2*len(key)-1]
 	for i, b := range key {
 		dst[i*2] = b / 16
 		dst[i*2+1] = b % 16
 	}
+	return dst[:2*len(key)]
 }
 
 // hexToKeybytes turns hex nibbles into key bytes.

--- a/trie/hasher.go
+++ b/trie/hasher.go
@@ -188,6 +188,14 @@ func (h *hasher) hashData(data []byte) hashNode {
 	return n
 }
 
+// hashDataTo hashes the provided data to the dest buffer (must be at least
+// 32 byte large)
+func (h *hasher) hashDataTo(data []byte, dest []byte) {
+	h.sha.Reset()
+	h.sha.Write(data)
+	h.sha.Read(dest)
+}
+
 // proofHash is used to construct trie proofs, and returns the 'collapsed'
 // node (for later RLP encoding) as well as the hashed node -- unless the
 // node is smaller than 32 bytes, in which case it will be returned as is.

--- a/trie/hasher.go
+++ b/trie/hasher.go
@@ -188,12 +188,12 @@ func (h *hasher) hashData(data []byte) hashNode {
 	return n
 }
 
-// hashDataTo hashes the provided data to the dest buffer (must be at least
-// 32 byte large)
-func (h *hasher) hashDataTo(data []byte, dest []byte) {
+// hashDataTo hashes the provided data to the given destination buffer. The caller
+// must ensure that the dst buffer is of appropriate size.
+func (h *hasher) hashDataTo(dst, data []byte) {
 	h.sha.Reset()
 	h.sha.Write(data)
-	h.sha.Read(dest)
+	h.sha.Read(dst)
 }
 
 // proofHash is used to construct trie proofs, and returns the 'collapsed'

--- a/trie/node.go
+++ b/trie/node.go
@@ -46,17 +46,23 @@ type (
 	hashNode  []byte
 	valueNode []byte
 
-	//fullnodeEncoder is a type used exclusively for encoding. Briefly instantiating
-	// a fullnodeEncoder and initializing with existing slices is less memory
-	// intense than using the fullNode type.
+	// fullnodeEncoder is a type used exclusively for encoding fullNode.
+	// Briefly instantiating a fullnodeEncoder and initializing with
+	// existing slices is less memory intense than using the fullNode type.
 	fullnodeEncoder struct {
 		Children [17][]byte
 	}
 
-	//shortNodeEncoder is a type used exclusively for encoding. Briefly instantiating
-	// a shortNodeEncoder and initializing with existing slices is less memory
-	// intense than using the shortNode type.
-	shortNodeEncoder struct {
+	// extNodeEncoder is a type used exclusively for encoding extension node.
+	// Briefly instantiating a extNodeEncoder and initializing with existing
+	// slices is less memory intense than using the shortNode type.
+	extNodeEncoder struct {
+		Key []byte
+		Val []byte
+	}
+
+	// leafNodeEncoder is a type used exclusively for encoding leaf node.
+	leafNodeEncoder struct {
 		Key []byte
 		Val []byte
 	}

--- a/trie/node.go
+++ b/trie/node.go
@@ -135,19 +135,6 @@ func (n valueNode) fstring(ind string) string {
 	return fmt.Sprintf("%x ", []byte(n))
 }
 
-// rawNode is a simple binary blob used to differentiate between collapsed trie
-// nodes and already encoded RLP binary blobs (while at the same time store them
-// in the same cache fields).
-type rawNode []byte
-
-func (n rawNode) cache() (hashNode, bool)   { panic("this should never end up in a live trie") }
-func (n rawNode) fstring(ind string) string { panic("this should never end up in a live trie") }
-
-func (n rawNode) EncodeRLP(w io.Writer) error {
-	_, err := w.Write(n)
-	return err
-}
-
 // mustDecodeNode is a wrapper of decodeNode and panic if any error is encountered.
 func mustDecodeNode(hash, buf []byte) node {
 	n, err := decodeNode(hash, buf)

--- a/trie/node.go
+++ b/trie/node.go
@@ -51,16 +51,14 @@ type (
 	// intense than using the fullNode type.
 	fullnodeEncoder struct {
 		Children [17][]byte
-		flags    nodeFlag
 	}
 
 	//shortNodeEncoder is a type used exclusively for encoding. Briefly instantiating
 	// a shortNodeEncoder and initializing with existing slices is less memory
 	// intense than using the shortNode type.
 	shortNodeEncoder struct {
-		Key   []byte
-		Val   []byte
-		flags nodeFlag
+		Key []byte
+		Val []byte
 	}
 )
 
@@ -84,20 +82,16 @@ type nodeFlag struct {
 	dirty bool     // whether the node has changes that must be written to the database
 }
 
-func (n *fullNode) cache() (hashNode, bool)         { return n.flags.hash, n.flags.dirty }
-func (n *fullnodeEncoder) cache() (hashNode, bool)  { return n.flags.hash, n.flags.dirty }
-func (n *shortNode) cache() (hashNode, bool)        { return n.flags.hash, n.flags.dirty }
-func (n *shortNodeEncoder) cache() (hashNode, bool) { return n.flags.hash, n.flags.dirty }
-func (n hashNode) cache() (hashNode, bool)          { return nil, true }
-func (n valueNode) cache() (hashNode, bool)         { return nil, true }
+func (n *fullNode) cache() (hashNode, bool)  { return n.flags.hash, n.flags.dirty }
+func (n *shortNode) cache() (hashNode, bool) { return n.flags.hash, n.flags.dirty }
+func (n hashNode) cache() (hashNode, bool)   { return nil, true }
+func (n valueNode) cache() (hashNode, bool)  { return nil, true }
 
 // Pretty printing.
-func (n *fullNode) String() string         { return n.fstring("") }
-func (n *fullnodeEncoder) String() string  { return n.fstring("") }
-func (n *shortNode) String() string        { return n.fstring("") }
-func (n *shortNodeEncoder) String() string { return n.fstring("") }
-func (n hashNode) String() string          { return n.fstring("") }
-func (n valueNode) String() string         { return n.fstring("") }
+func (n *fullNode) String() string  { return n.fstring("") }
+func (n *shortNode) String() string { return n.fstring("") }
+func (n hashNode) String() string   { return n.fstring("") }
+func (n valueNode) String() string  { return n.fstring("") }
 
 func (n *fullNode) fstring(ind string) string {
 	resp := fmt.Sprintf("[\n%s  ", ind)
@@ -111,22 +105,8 @@ func (n *fullNode) fstring(ind string) string {
 	return resp + fmt.Sprintf("\n%s] ", ind)
 }
 
-func (n *fullnodeEncoder) fstring(ind string) string {
-	resp := fmt.Sprintf("[\n%s  ", ind)
-	for i, node := range &n.Children {
-		if node == nil {
-			resp += fmt.Sprintf("%s: <nil> ", indices[i])
-		} else {
-			resp += fmt.Sprintf("%s: %x", indices[i], node)
-		}
-	}
-	return resp + fmt.Sprintf("\n%s] ", ind)
-}
 func (n *shortNode) fstring(ind string) string {
 	return fmt.Sprintf("{%x: %v} ", n.Key, n.Val.fstring(ind+"  "))
-}
-func (n *shortNodeEncoder) fstring(ind string) string {
-	return fmt.Sprintf("{%x: %x} ", n.Key, n.Val)
 }
 func (n hashNode) fstring(ind string) string {
 	return fmt.Sprintf("<%x> ", []byte(n))

--- a/trie/node_enc.go
+++ b/trie/node_enc.go
@@ -65,7 +65,7 @@ func (n *shortNode) encode(w rlp.EncoderBuffer) {
 	w.ListEnd(offset)
 }
 
-func (n *shortNodeEncoder) encode(w rlp.EncoderBuffer) {
+func (n *extNodeEncoder) encode(w rlp.EncoderBuffer) {
 	offset := w.List()
 	w.WriteBytes(n.Key)
 
@@ -76,6 +76,19 @@ func (n *shortNodeEncoder) encode(w rlp.EncoderBuffer) {
 	} else {
 		w.WriteBytes(n.Val) // hashNode
 	}
+	w.ListEnd(offset)
+}
+
+func (n *leafNodeEncoder) encode(w rlp.EncoderBuffer) {
+	offset := w.List()
+
+	// Encode the key to Compact format. The assumption is held
+	// that it's safe to modify the key in place.
+	n.Key = append(n.Key, 16) // termination flag
+	n.Key = hexToCompactInPlace(n.Key)
+
+	w.WriteBytes(n.Key) // Compact format key
+	w.WriteBytes(n.Val) // Value node, must be non-nil
 	w.ListEnd(offset)
 }
 

--- a/trie/node_enc.go
+++ b/trie/node_enc.go
@@ -81,12 +81,6 @@ func (n *extNodeEncoder) encode(w rlp.EncoderBuffer) {
 
 func (n *leafNodeEncoder) encode(w rlp.EncoderBuffer) {
 	offset := w.List()
-
-	// Encode the key to Compact format. The assumption is held
-	// that it's safe to modify the key in place.
-	n.Key = append(n.Key, 16) // termination flag
-	n.Key = hexToCompactInPlace(n.Key)
-
 	w.WriteBytes(n.Key) // Compact format key
 	w.WriteBytes(n.Val) // Value node, must be non-nil
 	w.ListEnd(offset)

--- a/trie/node_enc.go
+++ b/trie/node_enc.go
@@ -86,7 +86,3 @@ func (n hashNode) encode(w rlp.EncoderBuffer) {
 func (n valueNode) encode(w rlp.EncoderBuffer) {
 	w.WriteBytes(n)
 }
-
-func (n rawNode) encode(w rlp.EncoderBuffer) {
-	w.Write(n)
-}

--- a/trie/node_enc.go
+++ b/trie/node_enc.go
@@ -40,6 +40,20 @@ func (n *fullNode) encode(w rlp.EncoderBuffer) {
 	w.ListEnd(offset)
 }
 
+func (n *fullnodeEncoder) encode(w rlp.EncoderBuffer) {
+	offset := w.List()
+	for _, c := range n.Children {
+		if c == nil {
+			w.Write(rlp.EmptyString)
+		} else if len(c) < 32 {
+			w.Write(c) // rawNode
+		} else {
+			w.WriteBytes(c) // hashNode
+		}
+	}
+	w.ListEnd(offset)
+}
+
 func (n *shortNode) encode(w rlp.EncoderBuffer) {
 	offset := w.List()
 	w.WriteBytes(n.Key)
@@ -47,6 +61,20 @@ func (n *shortNode) encode(w rlp.EncoderBuffer) {
 		n.Val.encode(w)
 	} else {
 		w.Write(rlp.EmptyString)
+	}
+	w.ListEnd(offset)
+}
+
+func (n *shortNodeEncoder) encode(w rlp.EncoderBuffer) {
+	offset := w.List()
+	w.WriteBytes(n.Key)
+
+	if n.Val == nil {
+		w.Write(rlp.EmptyString)
+	} else if len(n.Val) < 32 {
+		w.Write(n.Val) // rawNode
+	} else {
+		w.WriteBytes(n.Val) // hashNode
 	}
 	w.ListEnd(offset)
 }

--- a/trie/stacktrie.go
+++ b/trie/stacktrie.go
@@ -48,16 +48,19 @@ type StackTrie struct {
 	last       []byte
 	onTrieNode OnTrieNode
 
-	keyScratch []byte
+	keyScratch  []byte
+	pathScratch []byte
 }
 
 // NewStackTrie allocates and initializes an empty trie. The committed nodes
 // will be discarded immediately if no callback is configured.
 func NewStackTrie(onTrieNode OnTrieNode) *StackTrie {
 	return &StackTrie{
-		root:       stPool.Get().(*stNode),
-		h:          newHasher(false),
-		onTrieNode: onTrieNode,
+		root:        stPool.Get().(*stNode),
+		h:           newHasher(false),
+		onTrieNode:  onTrieNode,
+		keyScratch:  make([]byte, 0, 32),
+		pathScratch: make([]byte, 0, 32),
 	}
 }
 
@@ -86,7 +89,7 @@ func (t *StackTrie) Update(key, value []byte) error {
 	} else {
 		t.last = append(t.last[:0], k...) // reuse key slice
 	}
-	t.insert(t.root, k, value, nil)
+	t.insert(t.root, k, value, t.pathScratch[:0])
 	return nil
 }
 

--- a/trie/stacktrie.go
+++ b/trie/stacktrie.go
@@ -68,7 +68,7 @@ func (t *StackTrie) grow(key []byte) {
 	if cap(t.kBuf) < 2*len(key) {
 		t.kBuf = make([]byte, 2*len(key))
 	}
-	if cap(t.pBuf) < len(key) {
+	if cap(t.pBuf) < 2*len(key) {
 		t.pBuf = make([]byte, 2*len(key))
 	}
 }
@@ -353,6 +353,7 @@ func (t *StackTrie) hash(st *stNode, path []byte) {
 		}
 		nodes.encode(t.h.encbuf)
 		blob = t.h.encodedBytes()
+
 		for i, child := range st.children {
 			if child == nil {
 				continue
@@ -377,8 +378,9 @@ func (t *StackTrie) hash(st *stNode, path []byte) {
 		st.children[0] = nil
 
 	case leafNode:
+		st.key = append(st.key, byte(16))
 		n := leafNodeEncoder{
-			Key: st.key,
+			Key: hexToCompactInPlace(st.key),
 			Val: st.val,
 		}
 		n.encode(t.h.encbuf)

--- a/trie/stacktrie.go
+++ b/trie/stacktrie.go
@@ -27,7 +27,7 @@ import (
 
 var (
 	stPool = sync.Pool{New: func() any { return new(stNode) }}
-	bPool  = sync.Pool{New: func() any { return make([]byte, 0, 32) }}
+	bPool  = newByteslicepool(32, 100)
 	_      = types.TrieHasher((*StackTrie)(nil))
 )
 
@@ -398,7 +398,7 @@ func (t *StackTrie) hash(st *stNode, path []byte) {
 	// Skip committing the non-root node if the size is smaller than 32 bytes
 	// as tiny nodes are always embedded in their parent except root node.
 	if len(blob) < 32 && len(path) > 0 {
-		val := bPool.Get().([]byte)
+		val := bPool.Get()
 		val = val[:len(blob)]
 		copy(val, blob)
 		st.val = val
@@ -406,7 +406,7 @@ func (t *StackTrie) hash(st *stNode, path []byte) {
 	}
 	// Write the hash to the 'val'. We allocate a new val here to not mutate
 	// input values.
-	val := bPool.Get().([]byte)
+	val := bPool.Get()
 	val = val[:32]
 	t.h.hashDataTo(blob, val)
 	st.val = val


### PR DESCRIPTION
This PR uses various tweaks and tricks to make the stacktrie near alloc-free. 

```
[user@work go-ethereum]$ benchstat stacktrie.1 stacktrie.7
goos: linux
goarch: amd64
pkg: github.com/ethereum/go-ethereum/trie
cpu: 12th Gen Intel(R) Core(TM) i7-1270P
             │ stacktrie.1  │             stacktrie.7              │
             │    sec/op    │    sec/op     vs base                │
Insert100K-8   106.97m ± 8%   88.21m ± 34%  -17.54% (p=0.000 n=10)

             │   stacktrie.1    │             stacktrie.7              │
             │       B/op       │     B/op      vs base                │
Insert100K-8   13199.608Ki ± 0%   3.424Ki ± 3%  -99.97% (p=0.000 n=10)

             │  stacktrie.1   │             stacktrie.7             │
             │   allocs/op    │ allocs/op   vs base                 │
Insert100K-8   553428.50 ± 0%   22.00 ± 5%  -100.00% (p=0.000 n=10)
```
Also improves derivesha:
```
goos: linux
goarch: amd64
pkg: github.com/ethereum/go-ethereum/core/types
cpu: 12th Gen Intel(R) Core(TM) i7-1270P
                          │ derivesha.1 │             derivesha.2              │
                          │   sec/op    │    sec/op     vs base                │
DeriveSha200/stack_trie-8   477.8µ ± 2%   430.0µ ± 12%  -10.00% (p=0.000 n=10)

                          │ derivesha.1  │             derivesha.2              │
                          │     B/op     │     B/op      vs base                │
DeriveSha200/stack_trie-8   45.17Ki ± 0%   25.65Ki ± 0%  -43.21% (p=0.000 n=10)

                          │ derivesha.1 │            derivesha.2             │
                          │  allocs/op  │ allocs/op   vs base                │
DeriveSha200/stack_trie-8   1259.0 ± 0%   232.0 ± 0%  -81.57% (p=0.000 n=10)

```

