### PR TITLE
Stacktrie allocs 2

### DIFF
--- a/core/types/bytepool.go
+++ b/core/types/bytepool.go
@@ -14,26 +14,26 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
 
-package trie
+package types
 
-// bytesPool is a pool for byteslices. It is safe for concurrent use.
-type bytesPool struct {
+// BytesPool is a pool for byteslices. It is safe for concurrent use.
+type BytesPool struct {
 	c chan []byte
 	w int
 }
 
-// newBytesPool creates a new bytesPool. The sliceCap sets the capacity of
+// NewBytesPool creates a new BytesPool. The sliceCap sets the capacity of
 // newly allocated slices, and the nitems determines how many items the pool
 // will hold, at maximum.
-func newBytesPool(sliceCap, nitems int) *bytesPool {
-	return &bytesPool{
+func NewBytesPool(sliceCap, nitems int) *BytesPool {
+	return &BytesPool{
 		c: make(chan []byte, nitems),
 		w: sliceCap,
 	}
 }
 
 // Get returns a slice. Safe for concurrent use.
-func (bp *bytesPool) Get() []byte {
+func (bp *BytesPool) Get() []byte {
 	select {
 	case b := <-bp.c:
 		return b
@@ -44,7 +44,7 @@ func (bp *bytesPool) Get() []byte {
 
 // Put returns a slice to the pool. Safe for concurrent use. This method
 // will ignore slices that are too small or too large (>3x the cap)
-func (bp *bytesPool) Put(b []byte) {
+func (bp *BytesPool) Put(b []byte) {
 	if c := cap(b); c < bp.w || c > 3*bp.w {
 		return
 	}

--- a/core/types/hashing_test.go
+++ b/core/types/hashing_test.go
@@ -81,13 +81,18 @@ func BenchmarkDeriveSha200(b *testing.B) {
 	if err != nil {
 		b.Fatal(err)
 	}
-	var exp common.Hash
-	var got common.Hash
+	var exp = types.DeriveSha(txs, trie.NewEmpty(triedb.NewDatabase(rawdb.NewMemoryDatabase(), nil)))
+
+	var have common.Hash
+
 	b.Run("std_trie", func(b *testing.B) {
 		b.ResetTimer()
 		b.ReportAllocs()
 		for i := 0; i < b.N; i++ {
-			exp = types.DeriveSha(txs, trie.NewEmpty(triedb.NewDatabase(rawdb.NewMemoryDatabase(), nil)))
+			have = types.DeriveSha(txs, trie.NewEmpty(triedb.NewDatabase(rawdb.NewMemoryDatabase(), nil)))
+		}
+		if have != exp {
+			b.Errorf("got %x exp %x", have, exp)
 		}
 	})
 
@@ -95,12 +100,22 @@ func BenchmarkDeriveSha200(b *testing.B) {
 		b.ResetTimer()
 		b.ReportAllocs()
 		for i := 0; i < b.N; i++ {
-			got = types.DeriveSha(txs, trie.NewStackTrie(nil))
+			have = types.DeriveShaNG(txs, trie.NewStackTrie(nil))
+		}
+		if have != exp {
+			b.Errorf("got %x exp %x", have, exp)
 		}
 	})
-	if got != exp {
-		b.Errorf("got %x exp %x", got, exp)
-	}
+	//b.Run("stack_trie_reuse", func(b *testing.B) {
+	//	b.ResetTimer()
+	//	b.ReportAllocs()
+	//	for i := 0; i < b.N; i++ {
+	//		have = types.DeriveShaNG(txs, trie.NewStackTrie(nil))
+	//	}
+	//	if have != exp {
+	//		b.Errorf("got %x exp %x", have, exp)
+	//	}
+	//})
 }
 
 func TestFuzzDeriveSha(t *testing.T) {

--- a/trie/bytepool.go
+++ b/trie/bytepool.go
@@ -1,20 +1,39 @@
+// Copyright 2024 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+
 package trie
 
-type bytepool struct {
+// bytesPool is a pool for byteslices. It is safe for concurrent use.
+type bytesPool struct {
 	c chan []byte
 	w int
-	h int
 }
 
-func newByteslicepool(sliceCap, nitems int) *bytepool {
-	b := &bytepool{
+// newBytesPool creates a new bytesPool. The sliceCap sets the capacity of
+// newly allocated slices, and the nitems determines how many items the pool
+// will hold, at maximum.
+func newBytesPool(sliceCap, nitems int) *bytesPool {
+	return &bytesPool{
 		c: make(chan []byte, nitems),
 		w: sliceCap,
 	}
-	return b
 }
 
-func (bp *bytepool) Get() []byte {
+// Get returns a slice. Safe for concurrent use.
+func (bp *bytesPool) Get() []byte {
 	select {
 	case b := <-bp.c:
 		return b
@@ -23,13 +42,10 @@ func (bp *bytepool) Get() []byte {
 	}
 }
 
-func (bp *bytepool) Put(b []byte) {
-	// Ignore too small slices
-	if cap(b) < bp.w {
-		return
-	}
-	// Don't retain too large slices either
-	if cap(b) > 3*bp.w {
+// Put returns a slice to the pool. Safe for concurrent use. This method
+// will ignore slices that are too small or too large (>3x the cap)
+func (bp *bytesPool) Put(b []byte) {
+	if c := cap(b); c < bp.w || c > 3*bp.w {
 		return
 	}
 	select {

--- a/trie/bytepool.go
+++ b/trie/bytepool.go
@@ -1,0 +1,39 @@
+package trie
+
+type bytepool struct {
+	c chan []byte
+	w int
+	h int
+}
+
+func newByteslicepool(sliceCap, nitems int) *bytepool {
+	b := &bytepool{
+		c: make(chan []byte, nitems),
+		w: sliceCap,
+	}
+	return b
+}
+
+func (bp *bytepool) Get() []byte {
+	select {
+	case b := <-bp.c:
+		return b
+	default:
+		return make([]byte, 0, bp.w)
+	}
+}
+
+func (bp *bytepool) Put(b []byte) {
+	// Ignore too small slices
+	if cap(b) < bp.w {
+		return
+	}
+	// Don't retain too large slices either
+	if cap(b) > 3*bp.w {
+		return
+	}
+	select {
+	case bp.c <- b:
+	default:
+	}
+}

--- a/trie/encoding.go
+++ b/trie/encoding.go
@@ -104,6 +104,17 @@ func keybytesToHex(str []byte) []byte {
 	return nibbles
 }
 
+// writeHexKey writes the hexkey into the given slice.
+// OBS! This method omits the termination flag.
+// OBS! The dst slice must be at least 2x as large as the key
+func writeHexKey(dst []byte, key []byte) {
+	_ = dst[2*len(key)-1]
+	for i, b := range key {
+		dst[i*2] = b / 16
+		dst[i*2+1] = b % 16
+	}
+}
+
 // hexToKeybytes turns hex nibbles into key bytes.
 // This can only be used for keys of even length.
 func hexToKeybytes(hex []byte) []byte {

--- a/trie/hasher.go
+++ b/trie/hasher.go
@@ -188,6 +188,14 @@ func (h *hasher) hashData(data []byte) hashNode {
 	return n
 }
 
+// hashDataTo hashes the provided data to the dest buffer (must be at least
+// 32 byte large)
+func (h *hasher) hashDataTo(data []byte, dest []byte) {
+	h.sha.Reset()
+	h.sha.Write(data)
+	h.sha.Read(dest)
+}
+
 // proofHash is used to construct trie proofs, and returns the 'collapsed'
 // node (for later RLP encoding) as well as the hashed node -- unless the
 // node is smaller than 32 bytes, in which case it will be returned as is.

--- a/trie/hasher.go
+++ b/trie/hasher.go
@@ -188,12 +188,12 @@ func (h *hasher) hashData(data []byte) hashNode {
 	return n
 }
 
-// hashDataTo hashes the provided data to the dest buffer (must be at least
-// 32 byte large)
-func (h *hasher) hashDataTo(data []byte, dest []byte) {
+// hashDataTo hashes the provided data to the given destination buffer. The caller
+// must ensure that the dst buffer is of appropriate size.
+func (h *hasher) hashDataTo(dst, data []byte) {
 	h.sha.Reset()
 	h.sha.Write(data)
-	h.sha.Read(dest)
+	h.sha.Read(dst)
 }
 
 // proofHash is used to construct trie proofs, and returns the 'collapsed'

--- a/trie/node_enc.go
+++ b/trie/node_enc.go
@@ -40,6 +40,20 @@ func (n *fullNode) encode(w rlp.EncoderBuffer) {
 	w.ListEnd(offset)
 }
 
+func (n *fullnodeEncoder) encode(w rlp.EncoderBuffer) {
+	offset := w.List()
+	for _, c := range n.Children {
+		if c == nil {
+			w.Write(rlp.EmptyString)
+		} else if len(c) < 32 {
+			w.Write(c) // rawNode
+		} else {
+			w.WriteBytes(c) // hashNode
+		}
+	}
+	w.ListEnd(offset)
+}
+
 func (n *shortNode) encode(w rlp.EncoderBuffer) {
 	offset := w.List()
 	w.WriteBytes(n.Key)
@@ -47,6 +61,20 @@ func (n *shortNode) encode(w rlp.EncoderBuffer) {
 		n.Val.encode(w)
 	} else {
 		w.Write(rlp.EmptyString)
+	}
+	w.ListEnd(offset)
+}
+
+func (n *shortNodeEncoder) encode(w rlp.EncoderBuffer) {
+	offset := w.List()
+	w.WriteBytes(n.Key)
+
+	if n.Val == nil {
+		w.Write(rlp.EmptyString)
+	} else if len(n.Val) < 32 {
+		w.Write(n.Val) // rawNode
+	} else {
+		w.WriteBytes(n.Val) // hashNode
 	}
 	w.ListEnd(offset)
 }

--- a/trie/stacktrie.go
+++ b/trie/stacktrie.go
@@ -48,16 +48,19 @@ type StackTrie struct {
 	last       []byte
 	onTrieNode OnTrieNode
 
-	keyScratch []byte
+	keyScratch  []byte
+	pathScratch []byte
 }
 
 // NewStackTrie allocates and initializes an empty trie. The committed nodes
 // will be discarded immediately if no callback is configured.
 func NewStackTrie(onTrieNode OnTrieNode) *StackTrie {
 	return &StackTrie{
-		root:       stPool.Get().(*stNode),
-		h:          newHasher(false),
-		onTrieNode: onTrieNode,
+		root:        stPool.Get().(*stNode),
+		h:           newHasher(false),
+		onTrieNode:  onTrieNode,
+		keyScratch:  make([]byte, 0, 32),
+		pathScratch: make([]byte, 0, 32),
 	}
 }
 
@@ -86,7 +89,7 @@ func (t *StackTrie) Update(key, value []byte) error {
 	} else {
 		t.last = append(t.last[:0], k...) // reuse key slice
 	}
-	t.insert(t.root, k, value, nil)
+	t.insert(t.root, k, value, t.pathScratch[:0])
 	return nil
 }
 

--- a/trie/stacktrie.go
+++ b/trie/stacktrie.go
@@ -27,7 +27,7 @@ import (
 
 var (
 	stPool = sync.Pool{New: func() any { return new(stNode) }}
-	bPool  = sync.Pool{New: func() any { return make([]byte, 0, 32) }}
+	bPool  = newByteslicepool(32, 100)
 	_      = types.TrieHasher((*StackTrie)(nil))
 )
 
@@ -398,7 +398,7 @@ func (t *StackTrie) hash(st *stNode, path []byte) {
 	// Skip committing the non-root node if the size is smaller than 32 bytes
 	// as tiny nodes are always embedded in their parent except root node.
 	if len(blob) < 32 && len(path) > 0 {
-		val := bPool.Get().([]byte)
+		val := bPool.Get()
 		val = val[:len(blob)]
 		copy(val, blob)
 		st.val = val
@@ -406,7 +406,7 @@ func (t *StackTrie) hash(st *stNode, path []byte) {
 	}
 	// Write the hash to the 'val'. We allocate a new val here to not mutate
 	// input values.
-	val := bPool.Get().([]byte)
+	val := bPool.Get()
 	val = val[:32]
 	t.h.hashDataTo(blob, val)
 	st.val = val

--- a/trie/stacktrie.go
+++ b/trie/stacktrie.go
@@ -27,7 +27,7 @@ import (
 
 var (
 	stPool = sync.Pool{New: func() any { return new(stNode) }}
-	bPool  = newByteslicepool(32, 100)
+	bPool  = newBytesPool(32, 100)
 	_      = types.TrieHasher((*StackTrie)(nil))
 )
 
@@ -48,20 +48,19 @@ type StackTrie struct {
 	h          *hasher
 	last       []byte
 	onTrieNode OnTrieNode
-
-	keyScratch  []byte
-	pathScratch []byte
+	kBuf       []byte // buf space used for hex-key during insertions
+	pBuf       []byte // buf space used for path during insertions
 }
 
 // NewStackTrie allocates and initializes an empty trie. The committed nodes
 // will be discarded immediately if no callback is configured.
 func NewStackTrie(onTrieNode OnTrieNode) *StackTrie {
 	return &StackTrie{
-		root:        stPool.Get().(*stNode),
-		h:           newHasher(false),
-		onTrieNode:  onTrieNode,
-		keyScratch:  make([]byte, 0, 32),
-		pathScratch: make([]byte, 0, 32),
+		root:       stPool.Get().(*stNode),
+		h:          newHasher(false),
+		onTrieNode: onTrieNode,
+		kBuf:       make([]byte, 0, 32),
+		pBuf:       make([]byte, 0, 32),
 	}
 }
 
@@ -71,16 +70,14 @@ func (t *StackTrie) Update(key, value []byte) error {
 		return errors.New("trying to insert empty (deletion)")
 	}
 	var k []byte
-	{
-		// We can reuse the key scratch area, but only if the insert-method
-		// never holds on to it.
-		if cap(t.keyScratch) < 2*len(key) { // realloc to ensure sufficient cap
-			t.keyScratch = make([]byte, 2*len(key), 2*len(key))
+	{                                 // Need to expand the 'key' into hex-form. We use the dedicated buf for that.
+		if cap(t.kBuf) < 2*len(key) { // realloc to ensure sufficient cap
+			t.kBuf = make([]byte, 2*len(key), 2*len(key))
 		}
 		// resize to ensure correct size
-		t.keyScratch = t.keyScratch[:2*len(key)]
-		writeHexKey(t.keyScratch, key)
-		k = t.keyScratch
+		t.kBuf = t.kBuf[:2*len(key)]
+		writeHexKey(t.kBuf, key)
+		k = t.kBuf
 	}
 	if bytes.Compare(t.last, k) >= 0 {
 		return errors.New("non-ascending key order")
@@ -90,7 +87,7 @@ func (t *StackTrie) Update(key, value []byte) error {
 	} else {
 		t.last = append(t.last[:0], k...) // reuse key slice
 	}
-	t.insert(t.root, k, value, t.pathScratch[:0])
+	t.insert(t.root, k, value, t.pBuf[:0])
 	return nil
 }
 
@@ -173,9 +170,11 @@ func (n *stNode) getDiffIndex(key []byte) int {
 	return len(n.key)
 }
 
-// Helper function to that inserts a (key, value) pair into
-// the trie.
-// The key is not retained by this method, but always copied if needed.
+// Helper function to that inserts a (key, value) pair into the trie.
+//   - The key is not retained by this method, but always copied if needed.
+//   - The value is retained by this method, as long as the leaf that it represents
+//     remains unhashed. However: it is never modified.
+//   - The path is not retained by this method.
 func (t *StackTrie) insert(st *stNode, key, value []byte, path []byte) {
 	switch st.typ {
 	case branchNode: /* Branch */
@@ -408,7 +407,7 @@ func (t *StackTrie) hash(st *stNode, path []byte) {
 	// input values.
 	val := bPool.Get()
 	val = val[:32]
-	t.h.hashDataTo(blob, val)
+	t.h.hashDataTo(val, blob)
 	st.val = val
 
 	// Invoke the callback it's provided. Notably, the path and blob slices are


### PR DESCRIPTION
The PR https://github.com/ethereum/go-ethereum/pull/30743 improves derivesha:
```
goos: linux
goarch: amd64
pkg: github.com/ethereum/go-ethereum/core/types
cpu: 12th Gen Intel(R) Core(TM) i7-1270P
                          │ derivesha.1 │             derivesha.2              │
                          │   sec/op    │    sec/op     vs base                │
DeriveSha200/stack_trie-8   477.8µ ± 2%   430.0µ ± 12%  -10.00% (p=0.000 n=10)

                          │ derivesha.1  │             derivesha.2              │
                          │     B/op     │     B/op      vs base                │
DeriveSha200/stack_trie-8   45.17Ki ± 0%   25.65Ki ± 0%  -43.21% (p=0.000 n=10)

                          │ derivesha.1 │            derivesha.2             │
                          │  allocs/op  │ allocs/op   vs base                │
DeriveSha200/stack_trie-8   1259.0 ± 0%   232.0 ± 0%  -81.57% (p=0.000 n=10)

```
This PR takes it one step further. It allows the derivesha method to hand a bytepool to the hasher. The stacktrie can thus use this to feed value-buffers back to the caller, and thus we can avoid a lot of `common.CopyBytes`. 

It's not very elegant, but it does reduce the allocs even further:

```
goos: linux
goarch: amd64
pkg: github.com/ethereum/go-ethereum/core/types
cpu: 12th Gen Intel(R) Core(TM) i7-1270P
                          │ derivesha.2  │             derivesha.3             │
                          │    sec/op    │    sec/op     vs base               │
DeriveSha200/stack_trie-8   430.0µ ± 12%   467.1µ ± 19%  +8.64% (p=0.023 n=10)

                          │  derivesha.2  │             derivesha.3              │
                          │     B/op      │     B/op      vs base                │
DeriveSha200/stack_trie-8   25.654Ki ± 0%   5.494Ki ± 0%  -78.59% (p=0.000 n=10)

                          │ derivesha.2 │            derivesha.3             │
                          │  allocs/op  │ allocs/op   vs base                │
DeriveSha200/stack_trie-8   232.00 ± 0%   37.00 ± 0%  -84.05% (p=0.000 n=10)
``` 

Definitely not merge:able as is, putting it up for discussion