### PR TITLE
Typo Update 2021-08-22-split-postmortem.md

### DIFF
--- a/docs/postmortems/2021-08-22-split-postmortem.md
+++ b/docs/postmortems/2021-08-22-split-postmortem.md
@@ -6,7 +6,7 @@ This is a post-mortem concerning the minority split that occurred on Ethereum ma
 
 
 - 2021-08-17: Guido Vranken submitted a bounty report. Investigation started, root cause identified, patch variations discussed. 
-- 2021-08-18: Made public announcement over twitter about upcoming security release upcoming Tuesday. Downstream projects were also notified about the upcoming patch-release.
+- 2021-08-18: Made public announcement over Twitter about the upcoming security release on Tuesday. Downstream projects were also notified about the upcoming patch-release.
 - 2021-08-24: Released [v1.10.8](https://github.com/ethereum/go-ethereum/releases/tag/v1.10.8) containing the fix on Tuesday morning (CET). Erigon released [v2021.08.04](https://github.com/ledgerwatch/erigon/releases/tag/v2021.08.04).
 - 2021-08-27: At 12:50:07 UTC, issue exploited. Analysis started roughly 30m later, 
 


### PR DESCRIPTION
### Description:
This pull request addresses a minor grammatical error in the documentation. Specifically, the phrase:

- **"Made public announcement over twitter about upcoming security release upcoming Tuesday."**

contains a redundant use of the word "upcoming." The sentence has been corrected to:

- **"Made public announcement over Twitter about the upcoming security release on Tuesday."**

### Importance:
While this is a minor issue, clarity and accuracy in documentation are crucial for maintaining professionalism and avoiding confusion. This change improves the readability and ensures that the documentation reflects the intended meaning without unnecessary repetition.