### PR TITLE
core/state/snapshot: simplify snapshot rebuild

### DIFF
--- a/core/state/snapshot/snapshot.go
+++ b/core/state/snapshot/snapshot.go
@@ -218,9 +218,8 @@ func New(config Config, diskdb ethdb.KeyValueStore, triedb *triedb.Database, roo
 		return snap, nil
 	}
 	// Existing snapshot loaded, seed all the layers
-	for head != nil {
+	for ; head != nil; head = head.Parent() {
 		snap.layers[head.Root()] = head
-		head = head.Parent()
 	}
 	return snap, nil
 }


### PR DESCRIPTION
This PR is purely for improved readability; I was doing work involving the file and think this may help others who are trying to understand what's going on.

1. `snapshot.Tree.Rebuild()` now returns a function that blocks until regeneration is complete, allowing `Tree.waitBuild()` to be removed entirely as all it did was search for the `done` channel behind this new function.
2. Its usage inside `New()` is also simplified by (a) only waiting if `!AsyncBuild`; and (b) avoiding the double negative of `if !NoBuild`.