### PR TITLE
all: typos in comments

### DIFF
--- a/build/ci.go
+++ b/build/ci.go
@@ -256,7 +256,7 @@ func buildFlags(env build.Environment, staticLinking bool, buildTags []string) (
 		// See https://sourceware.org/binutils/docs-2.23.1/ld/Options.html#Options
 		// regarding the options --build-id=none and --strip-all. It is needed for
 		// reproducible builds; removing references to temporary files in C-land, and
-		// making build-id reproducably absent.
+		// making build-id reproducibly absent.
 		extld := []string{"-Wl,-z,stack-size=0x800000,--build-id=none,--strip-all"}
 		if staticLinking {
 			extld = append(extld, "-static")

--- a/core/verkle_witness_test.go
+++ b/core/verkle_witness_test.go
@@ -1033,7 +1033,7 @@ func TestProcessVerkleSelfDestructInSameTxWithSelfBeneficiaryAndPrefundedAccount
 	)
 	// Prefund the account, at an address that the contract will be deployed at,
 	// before it selfdestrucs. We can therefore check that the account itseld is
-	// NOT destroyed, which is what the currrent version of the spec requires.
+	// NOT destroyed, which is what the current version of the spec requires.
 	// TODO(gballet) revisit after the spec has been modified.
 	gspec.Alloc[contract] = types.Account{
 		Balance: big.NewInt(100),

--- a/core/vm/eof.go
+++ b/core/vm/eof.go
@@ -96,7 +96,7 @@ func (meta *functionMetadata) checkInputs(stackMin int) error {
 }
 
 // checkStackMax checks the if current maximum stack combined with the
-// functin max stack will result in a stack overflow, and if so returns an error.
+// function max stack will result in a stack overflow, and if so returns an error.
 func (meta *functionMetadata) checkStackMax(stackMax int) error {
 	newMaxStack := stackMax + int(meta.maxStackHeight) - int(meta.inputs)
 	if newMaxStack > int(params.StackLimit) {

--- a/trie/utils/verkle.go
+++ b/trie/utils/verkle.go
@@ -217,7 +217,7 @@ func StorageIndex(storageKey []byte) (*uint256.Int, byte) {
 	// The first MAIN_STORAGE_OFFSET group will see its
 	// first 64 slots unreachable. This is either a typo in the
 	// spec or intended to conserve the 256-u256
-	// aligment. If we decide to ever access these 64
+	// alignment. If we decide to ever access these 64
 	// slots, uncomment this.
 	// // Get the new offset since we now know that we are above 64.
 	// pos.Sub(&pos, codeStorageDelta)


### PR DESCRIPTION
Since err != nil has been judged before, nil is returned directly here, which is more obvious, readable and less error-prone.
