### PR TITLE
cmd/evm: don't reuse state between iterations, show errors

### DIFF
--- a/cmd/evm/runner.go
+++ b/cmd/evm/runner.go
@@ -84,6 +84,7 @@ type execStats struct {
 
 func timedExec(bench bool, execFunc func() ([]byte, uint64, error)) ([]byte, execStats, error) {
 	if bench {
+		testing.Init()
 		// Do one warm-up run
 		output, gasUsed, err := execFunc()
 		result := testing.Benchmark(func(b *testing.B) {

--- a/cmd/evm/runner.go
+++ b/cmd/evm/runner.go
@@ -326,8 +326,8 @@ allocated bytes: %d
 	}
 	if tracer == nil {
 		fmt.Printf("%#x\n", output)
-		if execErr != nil {
-			fmt.Printf(" error: %v\n", execErr)
+		if err != nil {
+			fmt.Printf(" error: %v\n", err)
 		}
 	}
 

--- a/cmd/evm/runner.go
+++ b/cmd/evm/runner.go
@@ -93,7 +93,7 @@ func timedExec(bench bool, execFunc func() ([]byte, uint64, error)) ([]byte, exe
 					panic(fmt.Sprintf("output differs, have\n%x\nwant %x\n", haveOutput, output))
 				}
 				if haveGasUsed != gasUsed {
-					panic(fmt.Sprintf("gas differs, have %v want%v", haveGasUsed, gasUsed))
+					panic(fmt.Sprintf("gas differs, have %v want %v", haveGasUsed, gasUsed))
 				}
 				if haveErr != err {
 					panic(fmt.Sprintf("err differs, have %v want %v", haveErr, err))

--- a/cmd/evm/runner.go
+++ b/cmd/evm/runner.go
@@ -301,10 +301,9 @@ func runCmd(ctx *cli.Context) error {
 	}
 
 	bench := ctx.Bool(BenchFlag.Name)
-	output, stats, execErr, benchErr := timedExec(bench, execFunc)
-	if benchErr != nil {
-		fmt.Printf("benchmarking execution failed: %v\n", benchErr)
-		return benchErr
+	output, stats, execErr, err := timedExec(bench, execFunc)
+	if err != nil {
+		return fmt.Errorf("benchmarking failed: %v\n", err)
 	}
 
 	if ctx.Bool(DumpFlag.Name) {

--- a/cmd/evm/runner.go
+++ b/cmd/evm/runner.go
@@ -314,7 +314,7 @@ func runCmd(ctx *cli.Context) error {
 			logger.WriteTrace(os.Stderr, debugLogger.StructLogs())
 		}
 		fmt.Fprintln(os.Stderr, "#### LOGS ####")
-		logger.WriteLogs(os.Stderr, prestate.Logs())
+		logger.WriteLogs(os.Stderr, runtimeConfig.State.Logs())
 	}
 
 	if bench || ctx.Bool(StatDumpFlag.Name) {

--- a/cmd/evm/runner.go
+++ b/cmd/evm/runner.go
@@ -88,7 +88,6 @@ func timedExec(bench bool, execFunc func() ([]byte, uint64, error)) (output []by
 		var gasUsed uint64
 		output, gasUsed, execErr = execFunc()
 		var benchErr error
-		testing.Init()
 		result := testing.Benchmark(func(b *testing.B) {
 			for i := 0; i < b.N; i++ {
 				haveOutput, haveGasUsed, haveErr := execFunc()

--- a/cmd/evm/runner.go
+++ b/cmd/evm/runner.go
@@ -292,7 +292,7 @@ func runCmd(ctx *cli.Context) error {
 	}
 
 	bench := ctx.Bool(BenchFlag.Name)
-	output, stats, execErr := timedExec(bench, execFunc)
+	output, stats, err := timedExec(bench, execFunc)
 
 	if ctx.Bool(DumpFlag.Name) {
 		root, err := runtimeConfig.State.Commit(genesisConfig.Number, true)

--- a/cmd/evm/runner.go
+++ b/cmd/evm/runner.go
@@ -95,8 +95,8 @@ func timedExec(bench bool, execFunc func() ([]byte, uint64, error)) ([]byte, exe
 				if haveGasUsed != gasUsed {
 					panic(fmt.Sprintf("gas differs, have %v want%v", haveGasUsed, gasUsed))
 				}
-				if haveErr != execErr {
-					panic(fmt.Sprintf("err differs, have %v want %v", haveErr, execErr))
+				if haveErr != err {
+					panic(fmt.Sprintf("err differs, have %v want %v", haveErr, err))
 				}
 			}
 		})

--- a/cmd/evm/runner.go
+++ b/cmd/evm/runner.go
@@ -90,7 +90,7 @@ func timedExec(bench bool, execFunc func() ([]byte, uint64, error)) ([]byte, exe
 			for i := 0; i < b.N; i++ {
 				haveOutput, haveGasUsed, haveErr := execFunc()
 				if !bytes.Equal(haveOutput, output) {
-					panic(fmt.Sprintf("output differs, have\n%x\nwant %x\n", haveOutput, output))
+					panic(fmt.Sprintf("output differs\nhave %x\nwant %x\n", haveOutput, output))
 				}
 				if haveGasUsed != gasUsed {
 					panic(fmt.Sprintf("gas differs, have %v want %v", haveGasUsed, gasUsed))

--- a/cmd/evm/staterunner.go
+++ b/cmd/evm/staterunner.go
@@ -179,7 +179,7 @@ func runStateTest(ctx *cli.Context, fname string, cfg vm.Config, dump bool, benc
 		if bench {
 			// TODO: verify that each bench exec didn't produce a different result than the first run
 			// ..
-			_, stats, _, _ := timedExec(true, func() ([]byte, uint64, error) {
+			_, stats, _ := timedExec(true, func() ([]byte, uint64, error) {
 				_, _, gasUsed, _ := test.test.RunNoVerify(test.st, cfg, false, rawdb.HashScheme)
 				return nil, gasUsed, nil
 			})

--- a/cmd/evm/staterunner.go
+++ b/cmd/evm/staterunner.go
@@ -177,7 +177,9 @@ func runStateTest(ctx *cli.Context, fname string, cfg vm.Config, dump bool, benc
 			}
 		})
 		if bench {
-			_, stats, _ := timedExec(true, func() ([]byte, uint64, error) {
+			// TODO: verify that each bench exec didn't produce a different result than the first run
+			// ..
+			_, stats, _, _ := timedExec(true, func() ([]byte, uint64, error) {
 				_, _, gasUsed, _ := test.test.RunNoVerify(test.st, cfg, false, rawdb.HashScheme)
 				return nil, gasUsed, nil
 			})

--- a/cmd/evm/staterunner.go
+++ b/cmd/evm/staterunner.go
@@ -177,8 +177,6 @@ func runStateTest(ctx *cli.Context, fname string, cfg vm.Config, dump bool, benc
 			}
 		})
 		if bench {
-			// TODO: verify that each bench exec didn't produce a different result than the first run
-			// ..
 			_, stats, _ := timedExec(true, func() ([]byte, uint64, error) {
 				_, _, gasUsed, _ := test.test.RunNoVerify(test.st, cfg, false, rawdb.HashScheme)
 				return nil, gasUsed, nil


### PR DESCRIPTION
Reusing state between benchmark iterations resulted in inconsistent results across runs, which surfaced in https://github.com/ethereum/go-ethereum/issues/30778 .

If these errors are triggered again, they should be printed to output.  To ensure that the code invoking `testing.Benchmark()` can catch and output these errors, and then exit:  I replace calls to `t.B.Fatalf` with setting an error which is consumed by the calling code.

The same consistency checks should probably be applied to the state test benchmarker.  I am figuring that out now.

closes https://github.com/ethereum/go-ethereum/issues/30778 .