### PR TITLE
cmd/geth: actually enable metrics when passed via toml

### DIFF
--- a/cmd/geth/chaincmd.go
+++ b/cmd/geth/chaincmd.go
@@ -282,13 +282,12 @@ func importChain(ctx *cli.Context) error {
 	if ctx.Args().Len() < 1 {
 		utils.Fatalf("This command requires an argument.")
 	}
-	// Start metrics export if enabled
-	utils.SetupMetrics(ctx)
-	// Start system runtime metrics collection
-	go metrics.CollectProcessMetrics(3 * time.Second)
-
-	stack, _ := makeConfigNode(ctx)
+	stack, cfg := makeConfigNode(ctx)
 	defer stack.Close()
+
+	// Start metrics export if enabled
+	utils.SetupMetrics(&cfg.Metrics)
+	go metrics.CollectProcessMetrics(3 * time.Second)
 
 	chain, db := utils.MakeChain(ctx, stack, false)
 	defer db.Close()

--- a/cmd/geth/config.go
+++ b/cmd/geth/config.go
@@ -25,6 +25,7 @@ import (
 	"runtime"
 	"slices"
 	"strings"
+	"time"
 	"unicode"
 
 	"github.com/ethereum/go-ethereum/accounts"
@@ -191,6 +192,10 @@ func makeFullNode(ctx *cli.Context) *node.Node {
 		v := ctx.Uint64(utils.OverrideVerkle.Name)
 		cfg.Eth.OverrideVerkle = &v
 	}
+
+	// Start metrics export if enabled
+	utils.SetupMetrics(&cfg.Metrics)
+	go metrics.CollectProcessMetrics(3 * time.Second)
 
 	backend, eth := utils.RegisterEthService(stack, &cfg.Eth)
 

--- a/cmd/geth/config.go
+++ b/cmd/geth/config.go
@@ -151,7 +151,7 @@ func loadBaseConfig(ctx *cli.Context) gethConfig {
 	// Load config file.
 	if file := ctx.String(configFileFlag.Name); file != "" {
 		if err := loadConfig(file, &cfg); err != nil {
-			utils.Fatalf("%v", err)
+			utils.Fatalf("failed to load config: %v", err)
 		}
 	}
 

--- a/cmd/geth/main.go
+++ b/cmd/geth/main.go
@@ -34,7 +34,6 @@ import (
 	"github.com/ethereum/go-ethereum/internal/debug"
 	"github.com/ethereum/go-ethereum/internal/flags"
 	"github.com/ethereum/go-ethereum/log"
-	"github.com/ethereum/go-ethereum/metrics"
 	"github.com/ethereum/go-ethereum/node"
 	"go.uber.org/automaxprocs/maxprocs"
 
@@ -325,12 +324,6 @@ func prepare(ctx *cli.Context) {
 			ctx.Set(utils.CacheFlag.Name, strconv.Itoa(4096))
 		}
 	}
-
-	// Start metrics export if enabled
-	utils.SetupMetrics(ctx)
-
-	// Start system runtime metrics collection
-	go metrics.CollectProcessMetrics(3 * time.Second)
 }
 
 // geth is the main entry point into the system if no special subcommand is run.

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -1969,24 +1969,19 @@ func RegisterFullSyncTester(stack *node.Node, eth *eth.Ethereum, target common.H
 	log.Info("Registered full-sync tester", "hash", target)
 }
 
-func SetupMetrics(ctx *cli.Context) {
-	if metrics.Enabled {
+func SetupMetrics(cfg *metrics.Config) {
+	if cfg.Enabled {
 		log.Info("Enabling metrics collection")
-
 		var (
-			enableExport   = ctx.Bool(MetricsEnableInfluxDBFlag.Name)
-			enableExportV2 = ctx.Bool(MetricsEnableInfluxDBV2Flag.Name)
+			enableExport   = cfg.EnableInfluxDB
+			enableExportV2 = cfg.EnableInfluxDBV2
 		)
-
+		if enableExport && enableExportV2 {
+			Fatalf("Flags %v can't be used at the same time", strings.Join([]string{MetricsEnableInfluxDBFlag.Name, MetricsEnableInfluxDBV2Flag.Name}, ", "))
+		}
 		if enableExport || enableExportV2 {
-			CheckExclusive(ctx, MetricsEnableInfluxDBFlag, MetricsEnableInfluxDBV2Flag)
-
-			v1FlagIsSet := ctx.IsSet(MetricsInfluxDBUsernameFlag.Name) ||
-				ctx.IsSet(MetricsInfluxDBPasswordFlag.Name)
-
-			v2FlagIsSet := ctx.IsSet(MetricsInfluxDBTokenFlag.Name) ||
-				ctx.IsSet(MetricsInfluxDBOrganizationFlag.Name) ||
-				ctx.IsSet(MetricsInfluxDBBucketFlag.Name)
+			v1FlagIsSet := cfg.InfluxDBUsername != "" || cfg.InfluxDBPassword != ""
+			v2FlagIsSet := cfg.InfluxDBToken != "" || cfg.InfluxDBOrganization != "" || cfg.InfluxDBBucket != ""
 
 			if enableExport && v2FlagIsSet {
 				Fatalf("Flags --influxdb.metrics.organization, --influxdb.metrics.token, --influxdb.metrics.bucket are only available for influxdb-v2")
@@ -1996,35 +1991,35 @@ func SetupMetrics(ctx *cli.Context) {
 		}
 
 		var (
-			endpoint = ctx.String(MetricsInfluxDBEndpointFlag.Name)
-			database = ctx.String(MetricsInfluxDBDatabaseFlag.Name)
-			username = ctx.String(MetricsInfluxDBUsernameFlag.Name)
-			password = ctx.String(MetricsInfluxDBPasswordFlag.Name)
+			endpoint = cfg.InfluxDBEndpoint
+			database = cfg.InfluxDBDatabase
+			username = cfg.InfluxDBUsername
+			password = cfg.InfluxDBPassword
 
-			token        = ctx.String(MetricsInfluxDBTokenFlag.Name)
-			bucket       = ctx.String(MetricsInfluxDBBucketFlag.Name)
-			organization = ctx.String(MetricsInfluxDBOrganizationFlag.Name)
+			token        = cfg.InfluxDBToken
+			bucket       = cfg.InfluxDBBucket
+			organization = cfg.InfluxDBOrganization
 		)
 
 		if enableExport {
-			tagsMap := SplitTagsFlag(ctx.String(MetricsInfluxDBTagsFlag.Name))
+			tagsMap := SplitTagsFlag(cfg.InfluxDBTags)
 
 			log.Info("Enabling metrics export to InfluxDB")
 
 			go influxdb.InfluxDBWithTags(metrics.DefaultRegistry, 10*time.Second, endpoint, database, username, password, "geth.", tagsMap)
 		} else if enableExportV2 {
-			tagsMap := SplitTagsFlag(ctx.String(MetricsInfluxDBTagsFlag.Name))
+			tagsMap := SplitTagsFlag(cfg.InfluxDBTags)
 
 			log.Info("Enabling metrics export to InfluxDB (v2)")
 
 			go influxdb.InfluxDBV2WithTags(metrics.DefaultRegistry, 10*time.Second, endpoint, token, bucket, organization, "geth.", tagsMap)
 		}
 
-		if ctx.IsSet(MetricsHTTPFlag.Name) {
-			address := net.JoinHostPort(ctx.String(MetricsHTTPFlag.Name), fmt.Sprintf("%d", ctx.Int(MetricsPortFlag.Name)))
+		if cfg.HTTP != "" {
+			address := net.JoinHostPort(cfg.HTTP, fmt.Sprintf("%d", cfg.Port))
 			log.Info("Enabling stand-alone metrics HTTP endpoint", "address", address)
 			exp.Setup(address)
-		} else if ctx.IsSet(MetricsPortFlag.Name) {
+		} else if cfg.HTTP == "" && cfg.Port != 0 {
 			log.Warn(fmt.Sprintf("--%s specified without --%s, metrics server will not start.", MetricsPortFlag.Name, MetricsHTTPFlag.Name))
 		}
 	}

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -56,11 +56,16 @@ func init() {
 	// Now visit the flags we defined which are present in the args and see if we
 	// should enable metrics.
 	fs.Visit(func(f *flag.Flag) {
+		g, ok := f.Value.(flag.Getter)
+		if !ok {
+			// Don't expect this to fail, but skip over just in case it does.
+			return
+		}
 		switch f.Name {
 		case "metrics":
-			Enabled = true
+			Enabled = g.Get().(bool)
 		case "config":
-			data, err := os.ReadFile(f.Value.String())
+			data, err := os.ReadFile(g.Get().(string))
 			if err != nil {
 				return
 			}


### PR DESCRIPTION
closes #28303, replaces #28101

--

When we added metrics to the config toml back in #22083, they didn't actually seem to get enabled when you start the client with the toml. That is fixed here by only starting the metrics after we have parsed the config for it.

You can verify it's working by running this snippet:

```console
$ go run ./cmd/geth --metrics --metrics.addr 0.0.0.0 dumpconfig > conf && go run ./cmd/geth --config conf -dev 2>&1 | grep metrics
INFO [11-21|21:02:06.148] Enabling metrics collection
INFO [11-21|21:02:06.148] Enabling stand-alone metrics HTTP endpoint address=0.0.0.0:6060
INFO [11-21|21:02:06.148] Starting metrics server                  addr=http://0.0.0.0:6060/debug/metrics
```