### PR TITLE
core/state: lock-free `subfetcher`

### DIFF
--- a/core/state/trie_prefetcher.go
+++ b/core/state/trie_prefetcher.go
@@ -290,6 +290,8 @@ func (sf *subfetcher) schedule(addrs []common.Address, slots []common.Hash, read
 	select {
 	case sf.tasks <- tasks:
 		return nil
+	case <-sf.stop:
+		return errTerminated // imminently so no need to wait for sf.term
 	case <-sf.term:
 		return errTerminated
 	}

--- a/core/state/trie_prefetcher_test.go
+++ b/core/state/trie_prefetcher_test.go
@@ -18,6 +18,7 @@ package state
 
 import (
 	"math/big"
+	"sync"
 	"testing"
 
 	"github.com/ethereum/go-ethereum/common"
@@ -64,6 +65,55 @@ func TestUseAfterTerminate(t *testing.T) {
 	if tr := prefetcher.trie(common.Hash{}, db.originalRoot); tr == nil {
 		t.Errorf("Prefetcher returned nil trie after terminate")
 	}
+}
+
+func TestSchdeulerTerminationRaceCondition(t *testing.T) {
+	// The lock-based implementation of [subfetcher] had a race condition
+	// whereby schedule() could obtain the lock after the <-sf.stop branch of
+	// loop() had already checked for an empty queue. Although probabilistic,
+	// this test reliably triggered at a rate of ~4 in 10,000 on an Apple M3 Max
+	// chip.
+
+	t.Parallel()
+	db := filledStateDB()
+	skey := common.HexToHash("aaa")
+
+	// Maximise concurrency by synchronising all scheduling and termination.
+	start := make(chan struct{})
+	var wg sync.WaitGroup
+
+	for i := 0; i < 50_000; i++ {
+		wg.Add(3)
+		fetcher := newSubfetcher(db.db, db.originalRoot, common.Hash{}, db.originalRoot, common.Address{})
+
+		var gotScheduleErr error
+		doneScheduling := make(chan struct{})
+		go func() {
+			defer wg.Done()
+			<-start
+			gotScheduleErr = fetcher.schedule(nil, []common.Hash{skey}, false)
+			close(doneScheduling)
+		}()
+
+		go func() {
+			defer wg.Done()
+			<-start
+			fetcher.terminate(false)
+		}()
+
+		go func() {
+			defer wg.Done()
+			<-doneScheduling
+			fetcher.wait()
+
+			if gotScheduleErr == nil && len(fetcher.tasks) > 0 {
+				t.Errorf("%T.schedule() returned nil error but %d task(s) remain in queue after %T.wait() returned", fetcher, len(fetcher.tasks), fetcher)
+			}
+		}()
+	}
+
+	close(start)
+	wg.Wait()
 }
 
 func TestVerklePrefetcher(t *testing.T) {


### PR DESCRIPTION
Trie prefetching with a `state.subfetcher` previously relied on a pattern of {lock, set tasks, unlock, send void on `wake` channel}, which I've collapsed into a single channel send. This allows the lock to be removed entirely.

The old implementation had a subtle race condition between `schedule()` and `terminate()` (demonstrated in a test), which is fixed by this new pattern. There was a guarantee of task handoff but not of receipt by `loop()` because of the `wake` channel's buffering and deliberate dropping of excess sends.

The new `tasks` channel is never closed, just like the old `wake` one wasn't. If that needs to be addressed I think it's best done in another PR.

I know that #30629 made significant allocation improvements and I don't want to inadvertently make things worse, but I can't find the benchmarks that were used there. Happy to run them if someone can please point me in the right direction.

> [!NOTE]
> The code changed significantly after the first review.

See [Go Blog: Share Memory By Communicating](https://go.dev/blog/codelab-share#:~:text=Do%20not%20communicate%20by%20sharing%20memory%3B%20instead%2C%20share%20memory%20by%20communicating.) for background.