### PR TITLE
core/tracing: add GetCodeHash to StateDB

### DIFF
--- a/core/tracing/hooks.go
+++ b/core/tracing/hooks.go
@@ -42,6 +42,7 @@ type StateDB interface {
 	GetBalance(common.Address) *uint256.Int
 	GetNonce(common.Address) uint64
 	GetCode(common.Address) []byte
+	GetCodeHash(common.Address) common.Hash
 	GetState(common.Address, common.Hash) common.Hash
 	GetTransientState(common.Address, common.Hash) common.Hash
 	Exist(common.Address) bool


### PR DESCRIPTION
This PR extends tracing.StateDB by adding a GetCodeHash function.

Motivation

- Currently, tracing.StateDB supports 2 out of 3 basic account data getters (GetBalance and GetNonce). Adding GetCodeHash completes the set, making it 3/3.

- This addition significantly improves the performance of tracers that need to compute code hashes. Previously, the only available option was to use `crypto.Keccak256Hash(t.stateDB.GetCode(addr))`, which is less efficient.