### PR TITLE
core/tracing: extends tracing.Hooks with OnSystemCallStartV2

### DIFF
--- a/core/state_processor.go
+++ b/core/state_processor.go
@@ -221,7 +221,9 @@ func ApplyTransaction(config *params.ChainConfig, evm *vm.EVM, gp *GasPool, stat
 // contract. This method is exported to be used in tests.
 func ProcessBeaconBlockRoot(beaconRoot common.Hash, vmenv *vm.EVM, statedb vm.StateDB) {
 	if tracer := vmenv.Config.Tracer; tracer != nil {
-		if tracer.OnSystemCallStart != nil {
+		if tracer.OnSystemCallStartV2 != nil {
+			tracer.OnSystemCallStartV2(vmenv.GetVMContext())
+		} else if tracer.OnSystemCallStart != nil {
 			tracer.OnSystemCallStart()
 		}
 		if tracer.OnSystemCallEnd != nil {
@@ -247,7 +249,9 @@ func ProcessBeaconBlockRoot(beaconRoot common.Hash, vmenv *vm.EVM, statedb vm.St
 // as per EIP-2935.
 func ProcessParentBlockHash(prevHash common.Hash, vmenv *vm.EVM, statedb vm.StateDB) {
 	if tracer := vmenv.Config.Tracer; tracer != nil {
-		if tracer.OnSystemCallStart != nil {
+		if tracer.OnSystemCallStartV2 != nil {
+			tracer.OnSystemCallStartV2(vmenv.GetVMContext())
+		} else if tracer.OnSystemCallStart != nil {
 			tracer.OnSystemCallStart()
 		}
 		if tracer.OnSystemCallEnd != nil {
@@ -283,14 +287,15 @@ func ProcessConsolidationQueue(vmenv *vm.EVM, statedb vm.StateDB) []byte {
 
 func processRequestsSystemCall(vmenv *vm.EVM, statedb vm.StateDB, requestType byte, addr common.Address) []byte {
 	if tracer := vmenv.Config.Tracer; tracer != nil {
-		if tracer.OnSystemCallStart != nil {
+		if tracer.OnSystemCallStartV2 != nil {
+			tracer.OnSystemCallStartV2(vmenv.GetVMContext())
+		} else if tracer.OnSystemCallStart != nil {
 			tracer.OnSystemCallStart()
 		}
 		if tracer.OnSystemCallEnd != nil {
 			defer tracer.OnSystemCallEnd()
 		}
 	}
-
 	msg := &Message{
 		From:      params.SystemAddress,
 		GasLimit:  30_000_000,

--- a/core/tracing/hooks.go
+++ b/core/tracing/hooks.go
@@ -145,6 +145,10 @@ type (
 	// will not be invoked.
 	OnSystemCallStartHook = func()
 
+	// OnSystemCallStartHookV2 is called when a system call is about to be executed. Refer
+	// to `OnSystemCallStartHook` for more information.
+	OnSystemCallStartHookV2 = func(vm *VMContext)
+
 	// OnSystemCallEndHook is called when a system call has finished executing. Today,
 	// this hook is invoked when the EIP-4788 system call is about to be executed to set the
 	// beacon block root.
@@ -180,14 +184,15 @@ type Hooks struct {
 	OnFault     FaultHook
 	OnGasChange GasChangeHook
 	// Chain events
-	OnBlockchainInit  BlockchainInitHook
-	OnClose           CloseHook
-	OnBlockStart      BlockStartHook
-	OnBlockEnd        BlockEndHook
-	OnSkippedBlock    SkippedBlockHook
-	OnGenesisBlock    GenesisBlockHook
-	OnSystemCallStart OnSystemCallStartHook
-	OnSystemCallEnd   OnSystemCallEndHook
+	OnBlockchainInit    BlockchainInitHook
+	OnClose             CloseHook
+	OnBlockStart        BlockStartHook
+	OnBlockEnd          BlockEndHook
+	OnSkippedBlock      SkippedBlockHook
+	OnGenesisBlock      GenesisBlockHook
+	OnSystemCallStart   OnSystemCallStartHook
+	OnSystemCallStartV2 OnSystemCallStartHookV2
+	OnSystemCallEnd     OnSystemCallEndHook
 	// State events
 	OnBalanceChange BalanceChangeHook
 	OnNonceChange   NonceChangeHook


### PR DESCRIPTION
This PR extends the Hooks interface with a new method, `OnSystemCallStartV2`, which takes `VMContext` as its parameter.

Motivation

By including `VMContext` as a parameter, the `OnSystemCallStartV2` hook achieves parity with the `OnTxStart` hook in terms of provided insights. This alignment simplifies the inner tracer logic, enabling consistent handling of state changes and internal calls within the same framework.