### PR TITLE
internal/flags: fix "flag redefined" bug for alias on custom flags

### DIFF
--- a/internal/flags/flags.go
+++ b/internal/flags/flags.go
@@ -90,7 +90,7 @@ func (f *DirectoryFlag) Apply(set *flag.FlagSet) error {
 		}
 	}
 	eachName(f, func(name string) {
-		set.Var(&f.Value, f.Name, f.Usage)
+		set.Var(&f.Value, name, f.Usage)
 	})
 	return nil
 }
@@ -172,7 +172,7 @@ func (f *BigFlag) Apply(set *flag.FlagSet) error {
 	}
 	eachName(f, func(name string) {
 		f.Value = new(big.Int)
-		set.Var((*bigValue)(f.Value), f.Name, f.Usage)
+		set.Var((*bigValue)(f.Value), name, f.Usage)
 	})
 	return nil
 }


### PR DESCRIPTION
If we define an alias for any of DirectoryString and BigFlag, `geth` or `make test` will panic with message `flag redefined`. For example:

```go
	AncientFlag = &flags.DirectoryFlag{
		Name:     "datadir.ancient",
		Aliases:  []string{"datadir-ancient"},
		Usage:    "Root directory for ancient data (default = inside chaindata)",
		Category: flags.EthCategory,
	}
```

The geth will panic with the following message

```text
geth flag redefined: datadir.ancient
panic: geth flag redefined: datadir.ancient
```

Some of test cases will fail with the following message when we run `make test`:

```text
    test_cmd.go:261: (stderr:1) geth-test flag redefined: datadir.ancient
    test_cmd.go:261: (stderr:1) panic: geth-test flag redefined: datadir.ancient
```
