### PR TITLE
core/state/snapshot: handle legacy journal

### DIFF
--- a/core/state/snapshot/journal.go
+++ b/core/state/snapshot/journal.go
@@ -33,9 +33,10 @@ import (
 	"github.com/ethereum/go-ethereum/triedb"
 )
 
-// 0: initial version
-// 1: destruct flag in diff layer is removed
-const journalVersion uint64 = 1
+const (
+	journalInitVersion    uint64 = 0 // initial version
+	journalCurrentVersion uint64 = 1 // current version, with destruct flag (in diff layers) removed
+)
 
 // journalGenerator is a disk layer entry containing the generator progress marker.
 type journalGenerator struct {
@@ -48,6 +49,11 @@ type journalGenerator struct {
 	Accounts uint64
 	Slots    uint64
 	Storage  uint64
+}
+
+// journalDestruct is an account deletion entry in a diffLayer's disk journal.
+type journalDestruct struct {
+	Hash common.Hash
 }
 
 // journalAccount is an account entry in a diffLayer's disk journal.
@@ -285,8 +291,8 @@ func iterateJournal(db ethdb.KeyValueReader, callback journalCallback) error {
 		log.Warn("Failed to resolve the journal version", "error", err)
 		return errors.New("failed to resolve journal version")
 	}
-	if version != journalVersion {
-		log.Warn("Discarded the snapshot journal with wrong version", "required", journalVersion, "got", version)
+	if version != journalInitVersion && version != journalCurrentVersion {
+		log.Warn("Discarded journal with wrong version", "required", journalCurrentVersion, "got", version)
 		return errors.New("wrong journal version")
 	}
 	// Secondly, resolve the disk layer root, ensure it's continuous
@@ -315,6 +321,36 @@ func iterateJournal(db ethdb.KeyValueReader, callback journalCallback) error {
 				return nil
 			}
 			return fmt.Errorf("load diff root: %v", err)
+		}
+		// If a legacy journal is detected, decode the destruct set from the stream.
+		// The destruct set has been deprecated. If the journal contains non-empty
+		// destruct set, then it is deemed incompatible.
+		//
+		// Since self-destruction has been deprecated following the cancun fork,
+		// the destruct set is expected to be nil for layers above the fork block.
+		// However, an exception occurs during contract deployment: pre-funded accounts
+		// may self-destruct, causing accounts with non-zero balances to be removed
+		// from the state. For example,
+		// https://etherscan.io/tx/0xa087333d83f0cd63b96bdafb686462e1622ce25f40bd499e03efb1051f31fe49).
+		//
+		// For nodes with a fully synced state, the legacy journal is likely compatible
+		// with the updated definition, eliminating the need for regeneration. Unfortunately,
+		// nodes performing a full sync of historical chain segments or encountering
+		// pre-funded account deletions may face incompatibilities, leading to automatic
+		// snapshot regeneration.
+		//
+		// This approach minimizes snapshot regeneration for Geth nodes upgrading from a
+		// legacy version that are already synced. The workaround can be safely removed
+		// after the next hard fork.
+		if version == journalInitVersion {
+			var destructs []journalDestruct
+			if err := r.Decode(&destructs); err != nil {
+				return fmt.Errorf("load diff destructs: %v", err)
+			}
+			if len(destructs) > 0 {
+				log.Warn("Incompatible legacy journal detected", "version", journalInitVersion)
+				return fmt.Errorf("incompatible legacy journal detected")
+			}
 		}
 		if err := r.Decode(&accounts); err != nil {
 			return fmt.Errorf("load diff accounts: %v", err)

--- a/core/state/snapshot/journal.go
+++ b/core/state/snapshot/journal.go
@@ -34,8 +34,9 @@ import (
 )
 
 const (
-	journalInitVersion    uint64 = 0 // initial version
-	journalCurrentVersion uint64 = 1 // current version, with destruct flag (in diff layers) removed
+	journalV0             uint64 = 0 // initial version
+	journalV1             uint64 = 1 // current version, with destruct flag (in diff layers) removed
+	journalCurrentVersion        = journalV1
 )
 
 // journalGenerator is a disk layer entry containing the generator progress marker.
@@ -291,7 +292,7 @@ func iterateJournal(db ethdb.KeyValueReader, callback journalCallback) error {
 		log.Warn("Failed to resolve the journal version", "error", err)
 		return errors.New("failed to resolve journal version")
 	}
-	if version != journalInitVersion && version != journalCurrentVersion {
+	if version != journalV0 && version != journalCurrentVersion {
 		log.Warn("Discarded journal with wrong version", "required", journalCurrentVersion, "got", version)
 		return errors.New("wrong journal version")
 	}
@@ -342,13 +343,13 @@ func iterateJournal(db ethdb.KeyValueReader, callback journalCallback) error {
 		// This approach minimizes snapshot regeneration for Geth nodes upgrading from a
 		// legacy version that are already synced. The workaround can be safely removed
 		// after the next hard fork.
-		if version == journalInitVersion {
+		if version == journalV0 {
 			var destructs []journalDestruct
 			if err := r.Decode(&destructs); err != nil {
 				return fmt.Errorf("load diff destructs: %v", err)
 			}
 			if len(destructs) > 0 {
-				log.Warn("Incompatible legacy journal detected", "version", journalInitVersion)
+				log.Warn("Incompatible legacy journal detected", "version", journalV0)
 				return fmt.Errorf("incompatible legacy journal detected")
 			}
 		}

--- a/core/state/snapshot/snapshot.go
+++ b/core/state/snapshot/snapshot.go
@@ -664,7 +664,7 @@ func (t *Tree) Journal(root common.Hash) (common.Hash, error) {
 
 	// Firstly write out the metadata of journal
 	journal := new(bytes.Buffer)
-	if err := rlp.Encode(journal, journalVersion); err != nil {
+	if err := rlp.Encode(journal, journalCurrentVersion); err != nil {
 		return common.Hash{}, err
 	}
 	diskroot := t.diskRoot()


### PR DESCRIPTION
This workaround is meant to minimize the possibility for snapshot generation 
once the geth node upgrades to new version (specifically #30752 )

In #30752, the journal format in state snapshot is modified by removing the
destruct set. Therefore, the existing old format (version = 0) will be discarded
and all in-memory layers will be lost. Unfortunately, the lost in-memory layers 
can't be recovered by some other approaches, and the entire state snapshot 
will be regenerated (it will last about 2.5 hours).

This pull request introduces a workaround to adopt the legacy journal if the 
destruct set contained is empty. Since self-destruction has been deprecated 
following the cancun fork, the destruct set is expected to be nil for layers above
the fork block. However, an exception occurs during contract deployment: 
pre-funded accounts may self-destruct, causing accounts with non-zero balances
to be removed from the state. For example,
https://etherscan.io/tx/0xa087333d83f0cd63b96bdafb686462e1622ce25f40bd499e03efb1051f31fe49).


For nodes with a fully synced state, the legacy journal is likely compatible with 
the updated definition, eliminating the need for regeneration. Unfortunately,
nodes performing a full sync of historical chain segments or encountering pre-funded 
account deletions may face incompatibilities, leading to automatic snapshot regeneration.

---

The frequency for pre-funded account deletion is:

```
INFO [11-24|22:43:15.261] Account destruct                         address=0x259706Cf2C5068e6Ec06110Ab10E38D0a69102Cd block=21,258,272
INFO [11-24|23:01:02.627] Account destruct                         address=0xC5fa99FD294A00Ef8db82D2D25E9730a25F07Ae6 block=21,258,360
INFO [11-24|23:01:49.715] Account destruct                         address=0xEc27aF7a25cb0cf75BA3363d59760d0C73752Ae4 block=21,258,364
INFO [11-24|23:02:26.724] Account destruct                         address=0x779C00853815324BaEFd1a765eE2a153d9a7F797 block=21,258,368
INFO [11-24|23:32:15.881] Account destruct                         address=0x882fc7bF996B11928b90d9B4269b7361D3736050 block=21,258,517
INFO [11-24|23:40:01.477] Account destruct                         address=0x8b3E911798A257E773666074a34631112bd8cf77 block=21,258,555
INFO [11-24|23:55:25.618] Account destruct                         address=0x87A3A2067bde74B7E4bC887FF507be659B5646AA block=21,258,633
INFO [11-25|00:33:37.862] Account destruct                         address=0xd9b725CE0Ae09849ad84f9902ADD4Dc952524a77 block=21,258,824
INFO [11-25|00:44:36.791] Account destruct                         address=0xe1001FD1dE7f42464b17D6CD423019512f81a12a block=21,258,878
INFO [11-25|01:11:02.953] Account destruct                         address=0xeBF49c1eE53c115fA9f8675857C3edB4a3feF3c6 block=21,259,010
INFO [11-25|01:29:27.172] Account destruct                         address=0x6f8e6aA41120CfFa24D2047d55f1DC9120271223 block=21,259,101
INFO [11-25|01:49:25.481] Account destruct                         address=0x6369702e4C3a9737964cE653EA35Aa30Cf2b69c5 block=21,259,196
INFO [11-25|02:03:25.771] Account destruct                         address=0xF1bD226125A8862D9be10b37f9b4B76CAA0a801D block=21,259,253
INFO [11-25|02:27:49.646] Account destruct                         address=0x01B65520dBB1391ADF3d278A52c9a0E727EA08D4 block=21,259,388
INFO [11-25|02:28:02.046] Account destruct                         address=0x2E132096075b53ce5D0280463aAd5AB65c8E40b4 block=21,259,390
INFO [11-25|02:58:37.508] Account destruct                         address=0xB8a874615354f4e2F303636D085C88e9d70D1106 block=21,259,543
INFO [11-25|03:01:37.529] Account destruct                         address=0xd1F1c7693832534Eb8a0D0977642C149Db01df47 block=21,259,558
INFO [11-25|04:17:25.379] Account destruct                         address=0x5C9De3bC86EDD7Da9D069EC1970C98F3ea1Bc5D3 block=21,259,934
INFO [11-25|04:26:01.999] Account destruct                         address=0xC5fa99FD294A00Ef8db82D2D25E9730a25F07Ae6 block=21,259,978
INFO [11-25|05:25:38.002] Account destruct                         address=0xC5fa99FD294A00Ef8db82D2D25E9730a25F07Ae6 block=21,260,275
INFO [11-25|05:47:49.818] Account destruct                         address=0xb4d69c596ec4E8Fd22996F00fBdbF1f9eb7012cD block=21,260,385
INFO [11-25|05:48:01.282] Account destruct                         address=0xC5fa99FD294A00Ef8db82D2D25E9730a25F07Ae6 block=21,260,386
INFO [11-25|06:07:13.669] Account destruct                         address=0x802fC10377cE5e3A5588cBaD5bbCDbA610B13414 block=21,260,481
INFO [11-25|06:39:49.592] Account destruct                         address=0xb3CdFF2f92724b09C1e95EF27b05eC5A1E2E83B8 block=21,260,642
INFO [11-25|06:53:26.612] Account destruct                         address=0x3fF4439c8b67591D6710B02CF6eC8dD57A67D263 block=21,260,711
INFO [11-25|07:01:37.629] Account destruct                         address=0x41ECa4417562f06E4aA0f2aac69E8587B83B1716 block=21,260,752
INFO [11-25|07:27:25.713] Account destruct                         address=0x6e62E2C9ddAefa9E1f6Ac35fEb626B4b6Bf34097 block=21,260,881
INFO [11-25|07:44:15.221] Account destruct                         address=0x9f04547273b8CB15C01c3282124B76dA2341aD0e block=21,260,963
INFO [11-25|07:48:38.254] Account destruct                         address=0x63C69b0694C69C301BE64ceE9F998081Eea26907 block=21,260,985
INFO [11-25|08:03:01.461] Account destruct                         address=0xE3a818c09d628621A859a4Ade331763951af1f46 block=21,261,057
INFO [11-25|08:22:51.099] Account destruct                         address=0x3fF4439c8b67591D6710B02CF6eC8dD57A67D263 block=21,261,156
INFO [11-25|08:38:38.669] Account destruct                         address=0x403a8e87C2875499C0e800d3C35CFE86963384D6 block=21,261,236
INFO [11-25|08:49:02.912] Account destruct                         address=0xcea527BCCcc92e9f3AF9FC44D7d19B34736D8321 block=21,261,287
INFO [11-25|08:54:50.832] Account destruct                         address=0xdebF7F022918e26CE092E271E74ed4b3806ec74a block=21,261,316
INFO [11-25|08:58:49.699] Account destruct                         address=0x49002D93D02ef5ae7C6996B2aBBED7D90AbAD682 block=21,261,336
INFO [11-25|09:12:14.647] Account destruct                         address=0xf207DfEA822eEAeD6b7228D276DE0572BEe6425a block=21,261,403
INFO [11-25|09:12:52.361] Account destruct                         address=0x6D7eFC595402488794237Fbe4F8F946368806a52 block=21,261,406
INFO [11-25|09:36:02.789] Account destruct                         address=0xAFE193Fcf99377C3A8C44f3B58339BfC47448501 block=21,261,522
INFO [11-25|09:40:26.003] Account destruct                         address=0xFCd7e4d1faffc1dc78E259c4AdD49511D9d0D17E block=21,261,544
INFO [11-25|09:42:26.892] Account destruct                         address=0x906e7a74bB09b86AD875Ff65f3bfc6db1CC3f644 block=21,261,554
```