### PR TITLE
cmd/evm, eth/tracers: refactor structlogger + make it streamable

### DIFF
--- a/cmd/evm/main.go
+++ b/cmd/evm/main.go
@@ -240,13 +240,13 @@ func tracerFromFlags(ctx *cli.Context) *tracing.Hooks {
 	}
 	switch {
 	case ctx.Bool(TraceFlag.Name) && ctx.String(TraceFormatFlag.Name) == "struct":
-		return logger.NewStructLogger(config).Hooks()
+		return logger.NewStreamingStructLogger(config, os.Stderr).Hooks()
 	case ctx.Bool(TraceFlag.Name) && ctx.String(TraceFormatFlag.Name) == "json":
 		return logger.NewJSONLogger(config, os.Stderr)
 	case ctx.Bool(MachineFlag.Name):
 		return logger.NewJSONLogger(config, os.Stderr)
 	case ctx.Bool(DebugFlag.Name):
-		return logger.NewStructLogger(config).Hooks()
+		return logger.NewStreamingStructLogger(config, os.Stderr).Hooks()
 	default:
 		return nil
 	}

--- a/cmd/evm/runner.go
+++ b/cmd/evm/runner.go
@@ -207,7 +207,6 @@ func runCmd(ctx *cli.Context) error {
 
 	var (
 		tracer      *tracing.Hooks
-		debugLogger *logger.StructLogger
 		prestate    *state.StateDB
 		chainConfig *params.ChainConfig
 		sender      = common.BytesToAddress([]byte("sender"))
@@ -219,10 +218,7 @@ func runCmd(ctx *cli.Context) error {
 	if ctx.Bool(MachineFlag.Name) {
 		tracer = logger.NewJSONLogger(logconfig, os.Stdout)
 	} else if ctx.Bool(DebugFlag.Name) {
-		debugLogger = logger.NewStreamingStructLogger(logconfig, os.Stderr)
-		tracer = debugLogger.Hooks()
-	} else {
-		debugLogger = logger.NewStreamingStructLogger(logconfig, os.Stderr)
+		tracer = logger.NewStreamingStructLogger(logconfig, os.Stderr).Hooks()
 	}
 
 	initialGas := ctx.Uint64(GasFlag.Name)

--- a/eth/tracers/api_test.go
+++ b/eth/tracers/api_test.go
@@ -535,7 +535,7 @@ func TestTraceTransaction(t *testing.T) {
 		Gas:         params.TxGas,
 		Failed:      false,
 		ReturnValue: "",
-		StructLogs:  []logger.StructLogRes{},
+		StructLogs:  []json.RawMessage{},
 	}) {
 		t.Error("Transaction tracing result is different")
 	}

--- a/eth/tracers/logger/logger.go
+++ b/eth/tracers/logger/logger.go
@@ -222,6 +222,7 @@ func NewStreamingStructLogger(cfg *Config, writer io.Writer) *StructLogger {
 func NewStructLogger(cfg *Config) *StructLogger {
 	logger := &StructLogger{
 		storage: make(map[common.Address]Storage),
+		logs:    make([]json.RawMessage, 0),
 	}
 	if cfg != nil {
 		logger.cfg = *cfg
@@ -236,14 +237,6 @@ func (l *StructLogger) Hooks() *tracing.Hooks {
 		OnExit:    l.OnExit,
 		OnOpcode:  l.OnOpcode,
 	}
-}
-
-// Reset clears the data held by the logger.
-func (l *StructLogger) Reset() {
-	l.storage = make(map[common.Address]Storage)
-	l.output = make([]byte, 0)
-	l.logs = l.logs[:0]
-	l.err = nil
 }
 
 // OnOpcode logs a new structured log message and pushes it out to the environment

--- a/eth/tracers/logger/logger.go
+++ b/eth/tracers/logger/logger.go
@@ -94,31 +94,31 @@ func (s *StructLog) ErrorString() string {
 	return ""
 }
 
-func (log *StructLog) WriteTo(writer io.Writer) {
-	fmt.Fprintf(writer, "%-16spc=%08d gas=%v cost=%v", log.Op, log.Pc, log.Gas, log.GasCost)
-	if log.Err != nil {
-		fmt.Fprintf(writer, " ERROR: %v", log.Err)
+func (s *StructLog) WriteTo(writer io.Writer) {
+	fmt.Fprintf(writer, "%-16spc=%08d gas=%v cost=%v", s.Op, s.Pc, s.Gas, s.GasCost)
+	if s.Err != nil {
+		fmt.Fprintf(writer, " ERROR: %v", s.Err)
 	}
 	fmt.Fprintln(writer)
-	if len(log.Stack) > 0 {
+	if len(s.Stack) > 0 {
 		fmt.Fprintln(writer, "Stack:")
-		for i := len(log.Stack) - 1; i >= 0; i-- {
-			fmt.Fprintf(writer, "%08d  %s\n", len(log.Stack)-i-1, log.Stack[i].Hex())
+		for i := len(s.Stack) - 1; i >= 0; i-- {
+			fmt.Fprintf(writer, "%08d  %s\n", len(s.Stack)-i-1, s.Stack[i].Hex())
 		}
 	}
-	if len(log.Memory) > 0 {
+	if len(s.Memory) > 0 {
 		fmt.Fprintln(writer, "Memory:")
-		fmt.Fprint(writer, hex.Dump(log.Memory))
+		fmt.Fprint(writer, hex.Dump(s.Memory))
 	}
-	if len(log.Storage) > 0 {
+	if len(s.Storage) > 0 {
 		fmt.Fprintln(writer, "Storage:")
-		for h, item := range log.Storage {
+		for h, item := range s.Storage {
 			fmt.Fprintf(writer, "%x: %x\n", h, item)
 		}
 	}
-	if len(log.ReturnData) > 0 {
+	if len(s.ReturnData) > 0 {
 		fmt.Fprintln(writer, "ReturnData:")
-		fmt.Fprint(writer, hex.Dump(log.ReturnData))
+		fmt.Fprint(writer, hex.Dump(s.ReturnData))
 	}
 	fmt.Fprintln(writer)
 }
@@ -148,36 +148,36 @@ type StructLogRes struct {
 //   - memory: legacy uses a list of 64-char strings, each representing 32-byte chunks
 //     of evm memory. Non-legacy just uses a string of hexdata, no chunking.
 //   - storage: legacy has a storage-field.
-func (log *StructLog) toLegacyJSON() json.RawMessage {
+func (s *StructLog) toLegacyJSON() json.RawMessage {
 	msg := StructLogRes{
-		Pc:            log.Pc,
-		Op:            log.Op.String(),
-		Gas:           log.Gas,
-		GasCost:       log.GasCost,
-		Depth:         log.Depth,
-		Error:         log.ErrorString(),
-		RefundCounter: log.RefundCounter,
+		Pc:            s.Pc,
+		Op:            s.Op.String(),
+		Gas:           s.Gas,
+		GasCost:       s.GasCost,
+		Depth:         s.Depth,
+		Error:         s.ErrorString(),
+		RefundCounter: s.RefundCounter,
 	}
-	if log.Stack != nil {
-		stack := make([]string, len(log.Stack))
-		for i, stackValue := range log.Stack {
+	if s.Stack != nil {
+		stack := make([]string, len(s.Stack))
+		for i, stackValue := range s.Stack {
 			stack[i] = stackValue.Hex()
 		}
 		msg.Stack = &stack
 	}
-	if len(log.ReturnData) > 0 {
-		msg.ReturnData = hexutil.Bytes(log.ReturnData).String()
+	if len(s.ReturnData) > 0 {
+		msg.ReturnData = hexutil.Bytes(s.ReturnData).String()
 	}
-	if log.Memory != nil {
-		memory := make([]string, 0, (len(log.Memory)+31)/32)
-		for i := 0; i+32 <= len(log.Memory); i += 32 {
-			memory = append(memory, fmt.Sprintf("%x", log.Memory[i:i+32]))
+	if s.Memory != nil {
+		memory := make([]string, 0, (len(s.Memory)+31)/32)
+		for i := 0; i+32 <= len(s.Memory); i += 32 {
+			memory = append(memory, fmt.Sprintf("%x", s.Memory[i:i+32]))
 		}
 		msg.Memory = &memory
 	}
-	if log.Storage != nil {
+	if s.Storage != nil {
 		storage := make(map[string]string)
-		for i, storageValue := range log.Storage {
+		for i, storageValue := range s.Storage {
 			storage[fmt.Sprintf("%x", i)] = fmt.Sprintf("%x", storageValue)
 		}
 		msg.Storage = &storage


### PR DESCRIPTION
This PR refactors the structlog a bit, making it so that it can be used in a streaming mode. 

-------------

OBS: this PR makes a change in the input `config` config, the third input-parem field to `debug.traceCall`. Previously, seteting it to e.g. ` {"enableMemory": true, "limit": 1024}` would mean that the response was limited to `1024` items. Since an 'item' may include both memory and storage, the actual size of the response was undertermined. 
After this change, the response will be limited to `1024` __`bytes`__ (or thereabouts). 



-----------


The commandline usage of structlog now uses the streaming mode, leaving the non-streaming mode of operation for the eth_Call. 

There are two benefits of streaming mode 
1. Not have to maintain a long list of operations, 
2. Not have to duplicate / n-plicate data, e.g. memory / stack / returndata so that each entry has their own private slice. 

Before:
```
[user@work go-ethereum]$ ./evm-master --debug --code 604019 run

#### TRACE ####
PUSH1           pc=00000000 gas=10000000000 cost=3

NOT             pc=00000002 gas=9999999997 cost=3
Stack:
00000000  0x40

STOP            pc=00000003 gas=9999999994 cost=0
Stack:
00000000  0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffbf

#### LOGS ####
```
After
```
[user@work go-ethereum]$ ./evm-structlog --debug --code 604019 run
PUSH1           pc=00000000 gas=10000000000 cost=3

NOT             pc=00000002 gas=9999999997 cost=3
Stack:
00000000  0x40

STOP            pc=00000003 gas=9999999994 cost=0
Stack:
00000000  0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffbf

```