### PR TITLE
core/state: add code to state reader

### DIFF
--- a/core/state/database.go
+++ b/core/state/database.go
@@ -193,7 +193,7 @@ func (db *CachingDB) Reader(stateRoot common.Hash) (Reader, error) {
 	}
 	// Set up the trie reader, which is expected to always be available
 	// as the gatekeeper unless the state is corrupted.
-	tr, err := newTrieReader(stateRoot, db.triedb, db.pointCache)
+	tr, err := newTrieReader(stateRoot, db.triedb, db, db.pointCache)
 	if err != nil {
 		return nil, err
 	}

--- a/core/state/reader.go
+++ b/core/state/reader.go
@@ -336,7 +336,8 @@ func (r *multiReader) Storage(addr common.Address, slot common.Hash) (common.Has
 func (r *multiReader) ContractCode(addr common.Address, codeHash common.Hash) ([]byte, error) {
 	var errs []error
 	for _, reader := range r.readers {
-		// Only trie reader can provide contract code.
+		// Skip state reader as it doesn't provide contract code and
+		// always returns an error.
 		if _, ok := reader.(*trieReader); ok {
 			code, err := reader.ContractCode(addr, codeHash)
 			if err == nil {
@@ -352,7 +353,8 @@ func (r *multiReader) ContractCode(addr common.Address, codeHash common.Hash) ([
 func (r *multiReader) ContractCodeSize(addr common.Address, codeHash common.Hash) (int, error) {
 	var errs []error
 	for _, reader := range r.readers {
-		// Only trie reader can provide contract code.
+		// Skip state reader as it doesn't provide contract code and
+		// always returns an error.
 		if _, ok := reader.(*trieReader); ok {
 			size, err := reader.ContractCodeSize(addr, codeHash)
 			if err == nil {

--- a/core/state/reader.go
+++ b/core/state/reader.go
@@ -136,12 +136,12 @@ func (r *stateReader) Storage(addr common.Address, key common.Hash) (common.Hash
 
 // ContractCode implements Reader, retrieving the code associated with a particular account.
 func (r *stateReader) ContractCode(addr common.Address, codeHash common.Hash) ([]byte, error) {
-	return nil, nil
+	return nil, errors.New("not supported")
 }
 
 // ContractCodeSize implements Reader, returning the size of the code associated with a particular account.
 func (r *stateReader) ContractCodeSize(addr common.Address, codeHash common.Hash) (int, error) {
-	return 0, nil
+	return 0, errors.New("not supported")
 }
 
 // Copy implements Reader, returning a deep-copied snap reader.
@@ -336,9 +336,13 @@ func (r *multiReader) Storage(addr common.Address, slot common.Hash) (common.Has
 func (r *multiReader) ContractCode(addr common.Address, codeHash common.Hash) ([]byte, error) {
 	var errs []error
 	for _, reader := range r.readers {
-		code, err := reader.ContractCode(addr, codeHash)
-		if err == nil {
-			return code, nil
+		// Only trie reader can provide contract code.
+		if _, ok := reader.(*trieReader); ok {
+			code, err := reader.ContractCode(addr, codeHash)
+			if err == nil {
+				return code, nil
+			}
+			errs = append(errs, err)
 		}
 	}
 	return nil, errors.Join(errs...)
@@ -348,9 +352,13 @@ func (r *multiReader) ContractCode(addr common.Address, codeHash common.Hash) ([
 func (r *multiReader) ContractCodeSize(addr common.Address, codeHash common.Hash) (int, error) {
 	var errs []error
 	for _, reader := range r.readers {
-		size, err := reader.ContractCodeSize(addr, codeHash)
-		if err == nil {
-			return size, nil
+		// Only trie reader can provide contract code.
+		if _, ok := reader.(*trieReader); ok {
+			size, err := reader.ContractCodeSize(addr, codeHash)
+			if err == nil {
+				return size, nil
+			}
+			errs = append(errs, err)
 		}
 	}
 	return 0, errors.Join(errs...)

--- a/core/state/reader.go
+++ b/core/state/reader.go
@@ -50,15 +50,13 @@ type Reader interface {
 
 	// ContractCode returns the code associated with a particular account.
 	//
-	// - Returns an empty code if it does not exist
-	// - It can return an error to indicate code doesn't exist
+	// - It returns an error to indicate code doesn't exist
 	// - The returned code is safe to modify after the call
 	ContractCode(addr common.Address, codeHash common.Hash) ([]byte, error)
 
 	// ContractCodeSize returns the size of the code associated with a particular account.
 	//
-	// - Returns 0 if the code does not exist
-	// - It can return an error to indicate code doesn't exist
+	// - It returns an error to indicate code doesn't exist
 	ContractCodeSize(addr common.Address, codeHash common.Hash) (int, error)
 
 	// Copy returns a deep-copied state reader.
@@ -269,12 +267,13 @@ func (r *trieReader) Copy() Reader {
 		tries[addr] = mustCopyTrie(tr)
 	}
 	return &trieReader{
-		root:     r.root,
-		db:       r.db,
-		buff:     crypto.NewKeccakState(),
-		mainTrie: mustCopyTrie(r.mainTrie),
-		subRoots: maps.Clone(r.subRoots),
-		subTries: tries,
+		root:       r.root,
+		db:         r.db,
+		contractDB: r.contractDB,
+		buff:       crypto.NewKeccakState(),
+		mainTrie:   mustCopyTrie(r.mainTrie),
+		subRoots:   maps.Clone(r.subRoots),
+		subTries:   tries,
 	}
 }
 

--- a/core/state/state_object.go
+++ b/core/state/state_object.go
@@ -510,7 +510,7 @@ func (s *stateObject) Code() []byte {
 	if bytes.Equal(s.CodeHash(), types.EmptyCodeHash.Bytes()) {
 		return nil
 	}
-	code, err := s.db.db.ContractCode(s.address, common.BytesToHash(s.CodeHash()))
+	code, err := s.db.reader.ContractCode(s.address, common.BytesToHash(s.CodeHash()))
 	if err != nil {
 		s.db.setError(fmt.Errorf("can't load code hash %x: %v", s.CodeHash(), err))
 	}
@@ -528,7 +528,7 @@ func (s *stateObject) CodeSize() int {
 	if bytes.Equal(s.CodeHash(), types.EmptyCodeHash.Bytes()) {
 		return 0
 	}
-	size, err := s.db.db.ContractCodeSize(s.address, common.BytesToHash(s.CodeHash()))
+	size, err := s.db.reader.ContractCodeSize(s.address, common.BytesToHash(s.CodeHash()))
 	if err != nil {
 		s.db.setError(fmt.Errorf("can't load code size %x: %v", s.CodeHash(), err))
 	}


### PR DESCRIPTION
Contract code is technically also a part of the state. This PR adds code to the state reader interface. We also add code size because code size is separately cached in the cachingDB (although I think the overhead of computing the code size on the consumer end should not be too bad).

The motivation is #30441 where we are overriding the state reader interface to hook into state read events (account load, storage load and code load). You can see how that is done here: https://github.com/s1na/go-ethereum/commit/a22b30b9968f65b333fabd9905359f181f19be6f#diff-abb7c3ba4a7ea95d325d17a5c93b0ebde2c5b43e67f2bc3eb0f76a0c5fc7a8cfR335-R337

