### PR TITLE
core, state: introduce code reader interface

### DIFF
--- a/core/blockchain_reader.go
+++ b/core/blockchain_reader.go
@@ -344,10 +344,7 @@ func (bc *BlockChain) stateRecoverable(root common.Hash) bool {
 
 // ContractCodeWithPrefix retrieves a blob of data associated with a contract
 // hash either from ephemeral in-memory cache, or from persistent storage.
-//
-// If the code doesn't exist in the in-memory cache, check the storage with
-// new code scheme.
-func (bc *BlockChain) ContractCodeWithPrefix(hash common.Hash) ([]byte, error) {
+func (bc *BlockChain) ContractCodeWithPrefix(hash common.Hash) []byte {
 	// TODO(rjl493456442) The associated account address is also required
 	// in Verkle scheme. Fix it once snap-sync is supported for Verkle.
 	return bc.statedb.ContractCodeWithPrefix(common.Address{}, hash)

--- a/core/state/iterator.go
+++ b/core/state/iterator.go
@@ -136,7 +136,7 @@ func (it *nodeIterator) step() error {
 	}
 	if !bytes.Equal(account.CodeHash, types.EmptyCodeHash.Bytes()) {
 		it.codeHash = common.BytesToHash(account.CodeHash)
-		it.code, err = it.state.db.ContractCode(address, common.BytesToHash(account.CodeHash))
+		it.code, err = it.state.reader.ContractCode(address, common.BytesToHash(account.CodeHash))
 		if err != nil {
 			return fmt.Errorf("code %x: %v", account.CodeHash, err)
 		}

--- a/core/state/iterator.go
+++ b/core/state/iterator.go
@@ -136,7 +136,7 @@ func (it *nodeIterator) step() error {
 	}
 	if !bytes.Equal(account.CodeHash, types.EmptyCodeHash.Bytes()) {
 		it.codeHash = common.BytesToHash(account.CodeHash)
-		it.code, err = it.state.reader.ContractCode(address, common.BytesToHash(account.CodeHash))
+		it.code, err = it.state.reader.Code(address, common.BytesToHash(account.CodeHash))
 		if err != nil {
 			return fmt.Errorf("code %x: %v", account.CodeHash, err)
 		}

--- a/core/state/iterator.go
+++ b/core/state/iterator.go
@@ -140,6 +140,9 @@ func (it *nodeIterator) step() error {
 		if err != nil {
 			return fmt.Errorf("code %x: %v", account.CodeHash, err)
 		}
+		if len(it.code) == 0 {
+			return fmt.Errorf("code is not found: %x", account.CodeHash)
+		}
 	}
 	it.accountHash = it.stateIt.Parent()
 	return nil

--- a/core/state/state_object.go
+++ b/core/state/state_object.go
@@ -514,6 +514,9 @@ func (s *stateObject) Code() []byte {
 	if err != nil {
 		s.db.setError(fmt.Errorf("can't load code hash %x: %v", s.CodeHash(), err))
 	}
+	if len(code) == 0 {
+		s.db.setError(fmt.Errorf("code is not found %x", s.CodeHash()))
+	}
 	s.code = code
 	return code
 }
@@ -531,6 +534,9 @@ func (s *stateObject) CodeSize() int {
 	size, err := s.db.reader.ContractCodeSize(s.address, common.BytesToHash(s.CodeHash()))
 	if err != nil {
 		s.db.setError(fmt.Errorf("can't load code size %x: %v", s.CodeHash(), err))
+	}
+	if size == 0 {
+		s.db.setError(fmt.Errorf("code is not found %x", s.CodeHash()))
 	}
 	return size
 }

--- a/core/state/state_object.go
+++ b/core/state/state_object.go
@@ -510,7 +510,7 @@ func (s *stateObject) Code() []byte {
 	if bytes.Equal(s.CodeHash(), types.EmptyCodeHash.Bytes()) {
 		return nil
 	}
-	code, err := s.db.db.ContractCode(s.address, common.BytesToHash(s.CodeHash()))
+	code, err := s.db.reader.ContractCode(s.address, common.BytesToHash(s.CodeHash()))
 	if err != nil {
 		s.db.setError(fmt.Errorf("can't load code hash %x: %v", s.CodeHash(), err))
 	}
@@ -528,7 +528,7 @@ func (s *stateObject) CodeSize() int {
 	if bytes.Equal(s.CodeHash(), types.EmptyCodeHash.Bytes()) {
 		return 0
 	}
-	size, err := s.db.db.ContractCodeSize(s.address, common.BytesToHash(s.CodeHash()))
+	size, err := s.db.reader.ContractCodeSize(s.address, common.BytesToHash(s.CodeHash()))
 	if err != nil {
 		s.db.setError(fmt.Errorf("can't load code size %x: %v", s.CodeHash(), err))
 	}

--- a/core/state/state_object.go
+++ b/core/state/state_object.go
@@ -510,7 +510,7 @@ func (s *stateObject) Code() []byte {
 	if bytes.Equal(s.CodeHash(), types.EmptyCodeHash.Bytes()) {
 		return nil
 	}
-	code, err := s.db.reader.ContractCode(s.address, common.BytesToHash(s.CodeHash()))
+	code, err := s.db.reader.Code(s.address, common.BytesToHash(s.CodeHash()))
 	if err != nil {
 		s.db.setError(fmt.Errorf("can't load code hash %x: %v", s.CodeHash(), err))
 	}
@@ -531,7 +531,7 @@ func (s *stateObject) CodeSize() int {
 	if bytes.Equal(s.CodeHash(), types.EmptyCodeHash.Bytes()) {
 		return 0
 	}
-	size, err := s.db.reader.ContractCodeSize(s.address, common.BytesToHash(s.CodeHash()))
+	size, err := s.db.reader.CodeSize(s.address, common.BytesToHash(s.CodeHash()))
 	if err != nil {
 		s.db.setError(fmt.Errorf("can't load code size %x: %v", s.CodeHash(), err))
 	}

--- a/core/state/statedb.go
+++ b/core/state/statedb.go
@@ -650,10 +650,11 @@ func (s *StateDB) CreateContract(addr common.Address) {
 // Snapshots of the copied state cannot be applied to the copy.
 func (s *StateDB) Copy() *StateDB {
 	// Copy all the basic fields, initialize the memory ones
+	reader, _ := s.db.Reader(s.originalRoot) // impossible to fail
 	state := &StateDB{
 		db:                   s.db,
 		trie:                 mustCopyTrie(s.trie),
-		reader:               s.reader.Copy(),
+		reader:               reader,
 		originalRoot:         s.originalRoot,
 		stateObjects:         make(map[common.Address]*stateObject, len(s.stateObjects)),
 		stateObjectsDestruct: make(map[common.Address]*stateObject, len(s.stateObjectsDestruct)),

--- a/core/state/sync_test.go
+++ b/core/state/sync_test.go
@@ -221,7 +221,7 @@ func testIterativeStateSync(t *testing.T, count int, commit bool, bypath bool, s
 			codeResults = make([]trie.CodeSyncResult, len(codeElements))
 		)
 		for i, element := range codeElements {
-			data, err := cReader.ContractCode(common.Address{}, element.code)
+			data, err := cReader.Code(common.Address{}, element.code)
 			if err != nil || len(data) == 0 {
 				t.Fatalf("failed to retrieve contract bytecode for hash %x", element.code)
 			}
@@ -345,7 +345,7 @@ func testIterativeDelayedStateSync(t *testing.T, scheme string) {
 		if len(codeElements) > 0 {
 			codeResults := make([]trie.CodeSyncResult, len(codeElements)/2+1)
 			for i, element := range codeElements[:len(codeResults)] {
-				data, err := cReader.ContractCode(common.Address{}, element.code)
+				data, err := cReader.Code(common.Address{}, element.code)
 				if err != nil || len(data) == 0 {
 					t.Fatalf("failed to retrieve contract bytecode for %x", element.code)
 				}
@@ -451,7 +451,7 @@ func testIterativeRandomStateSync(t *testing.T, count int, scheme string) {
 		if len(codeQueue) > 0 {
 			results := make([]trie.CodeSyncResult, 0, len(codeQueue))
 			for hash := range codeQueue {
-				data, err := cReader.ContractCode(common.Address{}, hash)
+				data, err := cReader.Code(common.Address{}, hash)
 				if err != nil || len(data) == 0 {
 					t.Fatalf("failed to retrieve node data for %x", hash)
 				}
@@ -550,7 +550,7 @@ func testIterativeRandomDelayedStateSync(t *testing.T, scheme string) {
 			for hash := range codeQueue {
 				delete(codeQueue, hash)
 
-				data, err := cReader.ContractCode(common.Address{}, hash)
+				data, err := cReader.Code(common.Address{}, hash)
 				if err != nil || len(data) == 0 {
 					t.Fatalf("failed to retrieve node data for %x", hash)
 				}
@@ -670,7 +670,7 @@ func testIncompleteStateSync(t *testing.T, scheme string) {
 		if len(codeQueue) > 0 {
 			results := make([]trie.CodeSyncResult, 0, len(codeQueue))
 			for hash := range codeQueue {
-				data, err := cReader.ContractCode(common.Address{}, hash)
+				data, err := cReader.Code(common.Address{}, hash)
 				if err != nil || len(data) == 0 {
 					t.Fatalf("failed to retrieve node data for %x", hash)
 				}

--- a/core/state/sync_test.go
+++ b/core/state/sync_test.go
@@ -210,13 +210,17 @@ func testIterativeStateSync(t *testing.T, count int, commit bool, bypath bool, s
 	if err != nil {
 		t.Fatalf("state is not existent, %#x", srcRoot)
 	}
+	cReader, err := srcDb.Reader(srcRoot)
+	if err != nil {
+		t.Fatalf("state is not existent, %#x", srcRoot)
+	}
 	for len(nodeElements)+len(codeElements) > 0 {
 		var (
 			nodeResults = make([]trie.NodeSyncResult, len(nodeElements))
 			codeResults = make([]trie.CodeSyncResult, len(codeElements))
 		)
 		for i, element := range codeElements {
-			data, err := srcDb.ContractCode(common.Address{}, element.code)
+			data, err := cReader.ContractCode(common.Address{}, element.code)
 			if err != nil {
 				t.Fatalf("failed to retrieve contract bytecode for hash %x", element.code)
 			}
@@ -329,6 +333,10 @@ func testIterativeDelayedStateSync(t *testing.T, scheme string) {
 	if err != nil {
 		t.Fatalf("state is not existent, %#x", srcRoot)
 	}
+	cReader, err := srcDb.Reader(srcRoot)
+	if err != nil {
+		t.Fatalf("state is not existent, %#x", srcRoot)
+	}
 	for len(nodeElements)+len(codeElements) > 0 {
 		// Sync only half of the scheduled nodes
 		var nodeProcessed int
@@ -336,7 +344,7 @@ func testIterativeDelayedStateSync(t *testing.T, scheme string) {
 		if len(codeElements) > 0 {
 			codeResults := make([]trie.CodeSyncResult, len(codeElements)/2+1)
 			for i, element := range codeElements[:len(codeResults)] {
-				data, err := srcDb.ContractCode(common.Address{}, element.code)
+				data, err := cReader.ContractCode(common.Address{}, element.code)
 				if err != nil {
 					t.Fatalf("failed to retrieve contract bytecode for %x", element.code)
 				}
@@ -433,12 +441,16 @@ func testIterativeRandomStateSync(t *testing.T, count int, scheme string) {
 	if err != nil {
 		t.Fatalf("state is not existent, %#x", srcRoot)
 	}
+	cReader, err := srcDb.Reader(srcRoot)
+	if err != nil {
+		t.Fatalf("state is not existent, %#x", srcRoot)
+	}
 	for len(nodeQueue)+len(codeQueue) > 0 {
 		// Fetch all the queued nodes in a random order
 		if len(codeQueue) > 0 {
 			results := make([]trie.CodeSyncResult, 0, len(codeQueue))
 			for hash := range codeQueue {
-				data, err := srcDb.ContractCode(common.Address{}, hash)
+				data, err := cReader.ContractCode(common.Address{}, hash)
 				if err != nil {
 					t.Fatalf("failed to retrieve node data for %x", hash)
 				}
@@ -526,6 +538,10 @@ func testIterativeRandomDelayedStateSync(t *testing.T, scheme string) {
 	if err != nil {
 		t.Fatalf("state is not existent, %#x", srcRoot)
 	}
+	cReader, err := srcDb.Reader(srcRoot)
+	if err != nil {
+		t.Fatalf("state is not existent, %#x", srcRoot)
+	}
 	for len(nodeQueue)+len(codeQueue) > 0 {
 		// Sync only half of the scheduled nodes, even those in random order
 		if len(codeQueue) > 0 {
@@ -533,7 +549,7 @@ func testIterativeRandomDelayedStateSync(t *testing.T, scheme string) {
 			for hash := range codeQueue {
 				delete(codeQueue, hash)
 
-				data, err := srcDb.ContractCode(common.Address{}, hash)
+				data, err := cReader.ContractCode(common.Address{}, hash)
 				if err != nil {
 					t.Fatalf("failed to retrieve node data for %x", hash)
 				}
@@ -631,6 +647,10 @@ func testIncompleteStateSync(t *testing.T, scheme string) {
 	if err != nil {
 		t.Fatalf("state is not available %x", srcRoot)
 	}
+	cReader, err := srcDb.Reader(srcRoot)
+	if err != nil {
+		t.Fatalf("state is not existent, %#x", srcRoot)
+	}
 	nodeQueue := make(map[string]stateElement)
 	codeQueue := make(map[common.Hash]struct{})
 	paths, nodes, codes := sched.Missing(1)
@@ -649,7 +669,7 @@ func testIncompleteStateSync(t *testing.T, scheme string) {
 		if len(codeQueue) > 0 {
 			results := make([]trie.CodeSyncResult, 0, len(codeQueue))
 			for hash := range codeQueue {
-				data, err := srcDb.ContractCode(common.Address{}, hash)
+				data, err := cReader.ContractCode(common.Address{}, hash)
 				if err != nil {
 					t.Fatalf("failed to retrieve node data for %x", hash)
 				}

--- a/core/state/sync_test.go
+++ b/core/state/sync_test.go
@@ -18,7 +18,6 @@ package state
 
 import (
 	"bytes"
-	"fmt"
 	"testing"
 
 	"github.com/ethereum/go-ethereum/common"

--- a/core/state/sync_test.go
+++ b/core/state/sync_test.go
@@ -735,9 +735,9 @@ func testIncompleteStateSync(t *testing.T, scheme string) {
 	for _, node := range addedCodes {
 		val := rawdb.ReadCode(dstDb, node)
 		if len(val) == 0 {
-			fmt.Println("node code")
+			t.Logf("no code: %v", node)
 		} else {
-			fmt.Println("has code")
+			t.Logf("has code: %v", node)
 		}
 		rawdb.DeleteCode(dstDb, node)
 		if err := checkStateConsistency(dstDb, ndb.Scheme(), srcRoot); err == nil {

--- a/eth/protocols/snap/handler.go
+++ b/eth/protocols/snap/handler.go
@@ -454,7 +454,7 @@ func ServiceGetByteCodesQuery(chain *core.BlockChain, req *GetByteCodesPacket) [
 			// Peers should not request the empty code, but if they do, at
 			// least sent them back a correct response without db lookups
 			codes = append(codes, []byte{})
-		} else if blob, err := chain.ContractCodeWithPrefix(hash); err == nil {
+		} else if blob := chain.ContractCodeWithPrefix(hash); len(blob) > 0 {
 			codes = append(codes, blob)
 			bytes += uint64(len(blob))
 		}


### PR DESCRIPTION
It's an alternative of #30808 

This PR introduces a `ContractCodeReader` interface with functions defined:

```go
// ContractCodeReader defines the interface for accessing contract code.
type ContractCodeReader interface {
	// Code retrieves a particular contract's code.
	//
	// - Returns nil code along with nil error if the requested contract code
	//   doesn't exist
	// - Returns an error only if an unexpected issue occurs
	Code(addr common.Address, codeHash common.Hash) ([]byte, error)

	// CodeSize retrieves a particular contracts code's size.
	//
	// - Returns zero code size along with nil error if the requested contract code
	//   doesn't exist
	// - Returns an error only if an unexpected issue occurs
	CodeSize(addr common.Address, codeHash common.Hash) (int, error)
}
```

This interface can be implemented in various ways. Although the codebase currently includes only one implementation, additional implementations could be created for different purposes and scenarios, such as a code reader designed for the Verkle tree approach or one that reads code from the witness.

*Notably, this interface modifies the function’s semantics. If the contract code is not found, no error will be returned. An error should only be returned in the event of an unexpected issue, primarily for future implementations.*

---

Besides, the original `Reader` interface is extended with `ContractCodeReader`, it gives us more flexibility to manipulate the reader with additional logics on top, e.g. Hooks.

```go
// Reader defines the interface for accessing accounts, storage slots and contract
// code associated with a specific state.
type Reader interface {
	ContractCodeReader
	StateReader
}
```

