### PR TITLE
# Grammar and Consistency Fixes

### DIFF
--- a/cmd/clef/README.md
+++ b/cmd/clef/README.md
@@ -570,8 +570,8 @@ Results in the following invocation on the UI:
   "params": [
     {
       "transaction": {
-        "from": "0x0x694267f14675d7e1b9494fd8d72fefe1755710fa",
-        "to": "0x0x07a565b7ed7d7a678680a4c162885bedbb695fe0",
+        "from": "0x694267f14675d7e1b9494fd8d72fefe1755710fa",
+        "to": "0x07a565b7ed7d7a678680a4c162885bedbb695fe0",
         "gas": "0x333",
         "gasPrice": "0x1",
         "value": "0x0",
@@ -912,7 +912,7 @@ along with the UI.
 
 ### UI Implementations
 
-There are a couple of implementation for a UI. We'll try to keep this list up to date.
+There are a couple of implementations for a UI. We'll try to keep this list up to date.
 
 | Name | Repo | UI type| No external resources| Blocky support| Verifies permissions | Hash information | No secondary storage | Statically linked| Can modify parameters|
 | ---- | ---- | -------| ---- | ---- | ---- |---- | ---- | ---- | ---- |

--- a/eth/tracers/internal/tracetest/README.md
+++ b/eth/tracers/internal/tracetest/README.md
@@ -1,6 +1,6 @@
 # Filling test cases
 
-To fill test cases for the built-in tracers, the `makeTest.js` script can be used. Given a transaction on a dev/test network, `makeTest.js` will fetch its prestate and then traces with the given configuration.
+To fill test cases for the built-in tracers, the `makeTest.js` script can be used. Given a transaction on a dev/test network, `makeTest.js` will fetch its prestate and then trace with the given configuration.
 In the Geth console do:
 
 ```terminal


### PR DESCRIPTION

## Changes Made

### cmd/clef/README.md
- Old: "There are a couple of implementation for a UI"
- New: "There are a couple of implementations for a UI"
Reason: Fixed plural form for better grammatical accuracy

### cmd/evm/testdata/10/readme.md
- Old: "0x0x694267f14675d7e1b9494fd8d72fefe1755710fa"
- New: "0x694267f14675d7e1b9494fd8d72fefe1755710fa"
Reason: Removed duplicate "0x" prefix for correct address format

### eth/tracers/internal/tracetest/README.md
- Old: "will fetch its prestate and then traces with"
- New: "will fetch its prestate and then trace with"
Reason: Corrected verb form for proper grammatical structure

These changes improve:
1. Grammatical accuracy
2. Technical correctness
3. Documentation readability
4. Consistency across files
