### PR TITLE
Correct Phrase for Clarity and Precision

### DIFF
--- a/cmd/clef/docs/setup.md
+++ b/cmd/clef/docs/setup.md
@@ -8,7 +8,7 @@ in order to ensure that the keys remain safe in the event that your computer sho
 
 ### Background 
 
-The Qubes operating system is based around virtual machines (qubes), where a set of virtual machines are configured, typically for 
+The Qubes operating system is based on virtual machines (qubes), where a set of virtual machines are configured, typically for 
 different purposes such as:
 
 - personal


### PR DESCRIPTION
Description: This PR changes the phrase "based around" to "based on" for improved clarity and precision.

Why it’s useful:

"Based on" is the more standard and widely accepted phrase in technical writing, and it provides clearer meaning compared to "based around," which can be ambiguous.
This change helps improve the readability and professionalism of the documentation.