### PR TITLE
core/types: add length check in CalcRequestsHash

### DIFF
--- a/core/types/block.go
+++ b/core/types/block.go
@@ -463,9 +463,11 @@ func CalcRequestsHash(requests [][]byte) common.Hash {
 	h1, h2 := sha256.New(), sha256.New()
 	var buf common.Hash
 	for _, item := range requests {
-		h1.Reset()
-		h1.Write(item)
-		h2.Write(h1.Sum(buf[:0]))
+		if len(item) > 1 { // skip items with only requestType and no data.
+			h1.Reset()
+			h1.Write(item)
+			h2.Write(h1.Sum(buf[:0]))
+		}
 	}
 	h2.Sum(buf[:0])
 	return buf


### PR DESCRIPTION
The existing implementation is correct when building and verifying blocks, since we will only collect non-empty requests into the block requests list.

But it isn't correct for cases where a requests list containing empty items is sent by the consensus layer on the engine API. We want to ensure that empty requests do not cause a difference in validation there, so the commitment computation should explicitly skip them.