### PR TITLE
core: prevent block level tracers from crashing the node

### DIFF
--- a/core/blockchain_tracing.go
+++ b/core/blockchain_tracing.go
@@ -1,0 +1,97 @@
+// Copyright 2024 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+
+// Package core implements the Ethereum consensus protocol.
+package core
+
+import (
+	"github.com/ethereum/go-ethereum/core/tracing"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/log"
+	"github.com/ethereum/go-ethereum/params"
+)
+
+// guardedOnGenesisBlock wraps the tracer OnGenesisBlock method with 'recover'. If
+// a panic occurs, the hook will be disabled.
+func (bc *BlockChain) guardedOnGenesisBlock(genesis *types.Block, alloc types.GenesisAlloc) {
+	defer func() {
+		if err := recover(); err != nil {
+			log.Warn("Tracer OnGenesisBlock exited with panic, disabling tracer", "err", err)
+			bc.logger.OnGenesisBlock = nil
+		}
+	}()
+	bc.logger.OnGenesisBlock(genesis, alloc)
+}
+
+// guardedOnBlockchainInit wraps the tracer OnBlockchainInit method with 'recover'. If
+// a panic occurs, the hook will be disabled.
+func (bc *BlockChain) guardedOnBlockchainInit(chainConfig *params.ChainConfig) {
+	defer func() {
+		if err := recover(); err != nil {
+			log.Warn("Tracer OnBlockchainInit exited with panic, disabling tracer", "err", err)
+			bc.logger.OnBlockchainInit = nil
+		}
+	}()
+	bc.logger.OnBlockchainInit(chainConfig)
+}
+
+// guardedOnBlockStart wraps the tracer OnBlockStart method with 'recover'. If
+// a panic occurs, the hook will be disabled.
+func (bc *BlockChain) guardedOnBlockStart(blockEvent tracing.BlockEvent) {
+	defer func() {
+		if err := recover(); err != nil {
+			log.Warn("Tracer OnBlockStart exited with panic, disabling tracer", "err", err)
+			bc.logger.OnBlockStart = nil
+		}
+	}()
+	bc.logger.OnBlockStart(blockEvent)
+}
+
+// guardedOnBlockEnd wraps the tracer OnBlockEnd method with 'recover'. If
+// a panic occurs, the hook will be disabled.
+func (bc *BlockChain) guardedOnBlockEnd(err error) {
+	defer func() {
+		if err := recover(); err != nil {
+			log.Warn("Tracer OnBlockEnd exited with panic, disabling tracer", "err", err)
+			bc.logger.OnBlockEnd = nil
+		}
+	}()
+	bc.logger.OnBlockEnd(err)
+}
+
+// guardedOnClose wraps the tracer OnClose method with 'recover'. If
+// a panic occurs, the hook will be disabled.
+func (bc *BlockChain) guardedOnClose() {
+	defer func() {
+		if err := recover(); err != nil {
+			log.Warn("Tracer OnClose exited with panic, disabling tracer", "err", err)
+			bc.logger.OnClose = nil
+		}
+	}()
+	bc.logger.OnClose()
+}
+
+// guardedOnSkippedBlock wraps the tracer OnSkippedBlock method with 'recover'. If
+// a panic occurs, the hook will be disabled.
+func (bc *BlockChain) guardedOnSkippedBlock(event tracing.BlockEvent) {
+	defer func() {
+		if err := recover(); err != nil {
+			log.Warn("Tracer OnSkippedBlock exited with panic, disabling tracer", "err", err)
+			bc.logger.OnSkippedBlock = nil
+		}
+	}()
+	bc.logger.OnSkippedBlock(event)
+}

--- a/eth/tracers/live/crash.go
+++ b/eth/tracers/live/crash.go
@@ -1,0 +1,129 @@
+// Copyright 2024 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+
+package live
+
+import (
+	"encoding/json"
+	"math/big"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/tracing"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/eth/tracers"
+	"github.com/ethereum/go-ethereum/params"
+)
+
+func init() {
+	tracers.LiveDirectory.Register("crash", newCrashTracer)
+}
+
+// crash is a no-op live tracer. It's there to
+// catch changes in the tracing interface, as well as
+// for testing live tracing performance. Can be removed
+// as soon as we have a real live tracer.
+type crash struct{}
+
+func newCrashTracer(_ json.RawMessage) (*tracing.Hooks, error) {
+	t := &crash{}
+	return &tracing.Hooks{
+		OnTxStart:        t.OnTxStart,
+		OnTxEnd:          t.OnTxEnd,
+		OnEnter:          t.OnEnter,
+		OnExit:           t.OnExit,
+		OnOpcode:         t.OnOpcode,
+		OnFault:          t.OnFault,
+		OnGasChange:      t.OnGasChange,
+		OnBlockchainInit: t.OnBlockchainInit,
+		OnBlockStart:     t.OnBlockStart,
+		OnBlockEnd:       t.OnBlockEnd,
+		OnSkippedBlock:   t.OnSkippedBlock,
+		OnGenesisBlock:   t.OnGenesisBlock,
+		OnBalanceChange:  t.OnBalanceChange,
+		OnNonceChange:    t.OnNonceChange,
+		OnCodeChange:     t.OnCodeChange,
+		OnStorageChange:  t.OnStorageChange,
+		OnLog:            t.OnLog,
+	}, nil
+}
+
+func (t *crash) OnOpcode(pc uint64, op byte, gas, cost uint64, scope tracing.OpContext, rData []byte, depth int, err error) {
+	panic("OnOpcode")
+}
+
+func (t *crash) OnFault(pc uint64, op byte, gas, cost uint64, _ tracing.OpContext, depth int, err error) {
+	panic("OnFault")
+}
+
+func (t *crash) OnEnter(depth int, typ byte, from common.Address, to common.Address, input []byte, gas uint64, value *big.Int) {
+	panic("OnEnter")
+}
+
+func (t *crash) OnExit(depth int, output []byte, gasUsed uint64, err error, reverted bool) {
+	panic("OnExit")
+}
+
+func (t *crash) OnTxStart(vm *tracing.VMContext, tx *types.Transaction, from common.Address) {
+	panic("OnTxStart")
+}
+
+func (t *crash) OnTxEnd(receipt *types.Receipt, err error) {
+	panic("OnTxEnd")
+}
+
+func (t *crash) OnBlockStart(ev tracing.BlockEvent) {
+	panic("OnBlockStart")
+}
+
+func (t *crash) OnBlockEnd(err error) {
+	panic("OnBlockEnd")
+}
+
+func (t *crash) OnSkippedBlock(ev tracing.BlockEvent) {
+	panic("OnSkippedBlock")
+}
+
+func (t *crash) OnBlockchainInit(chainConfig *params.ChainConfig) {
+	panic("OnBlockchainInit")
+}
+
+func (t *crash) OnGenesisBlock(b *types.Block, alloc types.GenesisAlloc) {
+	panic("OnGenesisBlock")
+}
+
+func (t *crash) OnBalanceChange(a common.Address, prev, new *big.Int, reason tracing.BalanceChangeReason) {
+	panic("OnBalanceChange")
+}
+
+func (t *crash) OnNonceChange(a common.Address, prev, new uint64) {
+	panic("OnNonceChange")
+}
+
+func (t *crash) OnCodeChange(a common.Address, prevCodeHash common.Hash, prev []byte, codeHash common.Hash, code []byte) {
+	panic("OnCodeChange")
+}
+
+func (t *crash) OnStorageChange(a common.Address, k, prev, new common.Hash) {
+	panic("OnStorageChange")
+}
+
+func (t *crash) OnLog(l *types.Log) {
+	panic("OnLog")
+}
+
+func (t *crash) OnGasChange(old, new uint64, reason tracing.GasChangeReason) {
+	panic("OnGasChange")
+}


### PR DESCRIPTION
This PR is a work in progress to add some protection around calling the tracers. 

Example of running this with the included panic:y tracer
```
$ go run ./cmd/geth --dev --vmtrace crash  console
...
> eth.sendTransaction({from:eth.accounts[0], to:eth.accounts[0], value:1})
INFO [11-28|15:29:54.151] Setting new local account                address=0x23dbe6cB33eFc438a329A82332f4D534d05Ccc1e
INFO [11-28|15:29:54.151] Submitted transaction                    hash=0x7873a51aad23813f54f1d1a13bdaf488261730da8f7f0d375e9da44e2e01ac10 from=0x23dbe6cB33eFc438a329A82332f4D534d05Ccc1e nonce=0 recipient=0x23dbe6cB33eFc438a329A82332f4D534d05Ccc1e value=1
"0x7873a51aad23813f54f1d1a13bdaf488261730da8f7f0d375e9da44e2e01ac10"
> INFO [11-28|15:29:54.152] Starting work on payload                 id=0x03ae2b05cba5436c
INFO [11-28|15:29:54.153] Updated payload                          id=0x03ae2b05cba5436c number=1 hash=936f7f..7d2bd9 txs=1 withdrawals=0 gas=21000 fees=2.1e-14 root=981368..692038 elapsed="826.575µs"
WARN [11-28|15:29:54.154] Tracer OnBlockStart exited with panic, disabling tracer err=OnBlockStart
WARN [11-28|15:29:54.154] Tracer OnBlockEnd exited with panic, disabling tracer err=OnBlockEnd
INFO [11-28|15:29:54.154] Stopping work on payload                 id=0x03ae2b05cba5436c reason=delivery
panic: OnEnter

goroutine 47 [running]:
github.com/ethereum/go-ethereum/eth/tracers/live.(*crash).OnEnter(...)
        /home/user/go/src/github.com/ethereum/go-ethereum/eth/tracers/live/crash.go:72
```

Ideally perhaps we should not just disable the hook, but actually stop chain processing. That is a bit more tricky, though. Opening for discussion, 