### PR TITLE
wip: context-aware mutex to timout in catalyst-api 

### DIFF
--- a/eth/tracers/live/sleep.go
+++ b/eth/tracers/live/sleep.go
@@ -1,0 +1,117 @@
+// Copyright 2024 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+
+package live
+
+import (
+	"encoding/json"
+	"math/big"
+
+	"fmt"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/tracing"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/eth/tracers"
+	"github.com/ethereum/go-ethereum/params"
+	"time"
+)
+
+func init() {
+	tracers.LiveDirectory.Register("sleep", newSleeperTracer)
+}
+
+// sleeper is a no-op live tracer. It's there to
+// catch changes in the tracing interface, as well as
+// for testing live tracing performance. Can be removed
+// as soon as we have a real live tracer.
+type sleeper struct{}
+
+func newSleeperTracer(_ json.RawMessage) (*tracing.Hooks, error) {
+	t := &sleeper{}
+	return &tracing.Hooks{
+		OnTxStart:        t.OnTxStart,
+		OnTxEnd:          t.OnTxEnd,
+		OnEnter:          t.OnEnter,
+		OnExit:           t.OnExit,
+		OnOpcode:         t.OnOpcode,
+		OnFault:          t.OnFault,
+		OnGasChange:      t.OnGasChange,
+		OnBlockchainInit: t.OnBlockchainInit,
+		OnBlockStart:     t.OnBlockStart,
+		OnBlockEnd:       t.OnBlockEnd,
+		OnSkippedBlock:   t.OnSkippedBlock,
+		OnGenesisBlock:   t.OnGenesisBlock,
+		OnBalanceChange:  t.OnBalanceChange,
+		OnNonceChange:    t.OnNonceChange,
+		OnCodeChange:     t.OnCodeChange,
+		OnStorageChange:  t.OnStorageChange,
+		OnLog:            t.OnLog,
+	}, nil
+}
+
+func (t *sleeper) OnOpcode(pc uint64, op byte, gas, cost uint64, scope tracing.OpContext, rData []byte, depth int, err error) {
+}
+
+func (t *sleeper) OnFault(pc uint64, op byte, gas, cost uint64, _ tracing.OpContext, depth int, err error) {
+}
+
+func (t *sleeper) OnEnter(depth int, typ byte, from common.Address, to common.Address, input []byte, gas uint64, value *big.Int) {
+}
+
+func (t *sleeper) OnExit(depth int, output []byte, gasUsed uint64, err error, reverted bool) {
+}
+
+func (t *sleeper) OnTxStart(vm *tracing.VMContext, tx *types.Transaction, from common.Address) {
+}
+
+func (t *sleeper) OnTxEnd(receipt *types.Receipt, err error) {
+}
+
+func (t *sleeper) OnBlockStart(ev tracing.BlockEvent) {
+	fmt.Printf("sleeper going to sleep for 30 minutes\n")
+	time.Sleep(30 * time.Minute)
+	fmt.Printf("sleeper waking up\n")
+}
+
+func (t *sleeper) OnBlockEnd(err error) {
+}
+
+func (t *sleeper) OnSkippedBlock(ev tracing.BlockEvent) {}
+
+func (t *sleeper) OnBlockchainInit(chainConfig *params.ChainConfig) {
+}
+
+func (t *sleeper) OnGenesisBlock(b *types.Block, alloc types.GenesisAlloc) {
+}
+
+func (t *sleeper) OnBalanceChange(a common.Address, prev, new *big.Int, reason tracing.BalanceChangeReason) {
+}
+
+func (t *sleeper) OnNonceChange(a common.Address, prev, new uint64) {
+}
+
+func (t *sleeper) OnCodeChange(a common.Address, prevCodeHash common.Hash, prev []byte, codeHash common.Hash, code []byte) {
+}
+
+func (t *sleeper) OnStorageChange(a common.Address, k, prev, new common.Hash) {
+}
+
+func (t *sleeper) OnLog(l *types.Log) {
+
+}
+
+func (t *sleeper) OnGasChange(old, new uint64, reason tracing.GasChangeReason) {
+}

--- a/internal/syncx/mutex_test.go
+++ b/internal/syncx/mutex_test.go
@@ -1,0 +1,34 @@
+package syncx
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestCancel(t *testing.T) {
+	t.Skip("not a good test, also time-consuming")
+	mu := NewClosableMutex()
+	var wg sync.WaitGroup
+	wg.Add(3)
+	waiter := func(id int, waitTime time.Duration) {
+		defer wg.Done()
+		ctx, _ := context.WithTimeout(context.Background(), waitTime)
+		if mu.TryLockWithContext(ctx) {
+			fmt.Printf("%d. Sleeping\n", id)
+			time.Sleep(10 * time.Second)
+			fmt.Printf("%d. Waking\n", id)
+			mu.Unlock()
+		} else {
+			fmt.Printf("%d. Cancelling\n", id)
+		}
+	}
+
+	go waiter(1, 5*time.Second)
+	time.Sleep(100 * time.Millisecond)
+	go waiter(2, 5*time.Second)
+	go waiter(3, 15*time.Second)
+	wg.Wait()
+}


### PR DESCRIPTION
This PR contains an experiment, where a chain tracer sleeps for `30m` every block. I made this to see how a node reacts when being held up, e.g. by slow blocks in general of if a node operator wants to do heavy processing during tracing.

On one of two nodes, there was a massive pileup of goroutines.
![Screenshot 2024-11-28 at 20-15-33 Dual Geth - Grafana](https://github.com/user-attachments/assets/63a2ee53-323e-4a3d-b6ed-45438d3e3c26)

For the one that is croaking, this is what the CL does: 
```
Nov 28 21:05:43 bench05.ethdevops.io blsync INFO [11-28|20:05:43.855] Successful ForkchoiceUpdated head=02992a..bc69a7 status=SYNCING
Nov 28 21:06:06 bench05.ethdevops.io blsync ERROR[11-28|20:06:06.528] Failed NewPayload number=21,288,468 hash=945c04..ec3022 error="Post \"http://geth:8551\": context deadline exceeded"
Nov 28 21:06:06 bench05.ethdevops.io blsync INFO [11-28|20:06:06.529] Successful ForkchoiceUpdated head=945c04..ec3022 status=SYNCING
Nov 28 21:06:17 bench05.ethdevops.io blsync ERROR[11-28|20:06:17.868] Failed NewPayload number=21,288,469 hash=f4798f..0dea98 error="Post \"http://geth:8551\": context deadline exceeded"
```
They time out after a minute, and it adds another one. So every minute, it makes a request, which time it FOR IT, but we do not time out internally. For the one that is _not_ building a goroutine mountain, it instead reports this:
```
Nov 28 21:08:49 bench06.ethdevops.io blsync ERROR[11-28|20:08:49.332] Failed ForkchoiceUpdated head=946f38..a850a9 error="beacon syncer reorging"
Nov 28 21:08:49 bench06.ethdevops.io blsync INFO [11-28|20:08:49.449] Successful NewPayload number=21,288,483 hash=aa0646..d6c267 status=SYNCING
```
It doesn't even try to issue NewPayloads.

---------

Anyway, the two goroutines are stuck in two locations: 
```
[user@work ansible]$ cat stacks05 | grep "catalyst/api.go:835" | wc -l
1556
[user@work ansible]$ cat stacks05 | grep "rpc/handler.go:318" | wc -l 
1557
```
One is the `NewPayloadV3` method, and the other is the http handler for that. So both stem from the same cause: obtaining a lock before inserting a block. 

This PR adds a context-aware `TryLock`-verison to our already existing `ClosableMutex`. By using this mutex instead of a regular one, we can choose to give up, instead of waiting indefinitely. Waiting longer than "whatever we believe the remote-side timeout is" is totally pointless. 

Obviously in draft -- I'm still investigating if there are more things we need to fix. However, the mutex-addition is, I think, fine. Will put this on the machines soon:ish, to see how she flies.  