### PR TITLE
chore: fix 404 status URL

### DIFF
--- a/internal/era/accumulator.go
+++ b/internal/era/accumulator.go
@@ -49,7 +49,7 @@ func ComputeAccumulator(hashes []common.Hash, tds []*big.Int) (common.Hash, erro
 
 // headerRecord is an individual record for a historical header.
 //
-// See https://github.com/ethereum/portal-network-specs/blob/master/history-network.md#the-header-accumulator
+// See https://github.com/ethereum/portal-network-specs/blob/master/history/history-network.md#the-header-accumulator
 // for more information.
 type headerRecord struct {
 	Hash            common.Hash


### PR DESCRIPTION
The previous link has expired and has been replaced with the latest address.