### PR TITLE
Title: Fix typos and improve clarity in tutorial and rules documentation

### DIFF
--- a/cmd/clef/rules.md
+++ b/cmd/clef/rules.md
@@ -83,7 +83,7 @@ Some security precautions can be made, such as:
 
 * Never load `ruleset.js` unless the file is `readonly` (`r-??-??-?`). If the user wishes to modify the ruleset, he must make it writeable and then set back to readonly.
   * This is to prevent attacks where files are dropped on the users disk.
-* Since we're going to have to have some form of secure storage (not defined in this section), we could also store the `sha3` of the `ruleset.js` file in there.
+* Since we're going to have some form of secure storage (not defined in this section), we could also store the `sha3` of the `ruleset.js` file in there.
   * If the user wishes to modify the ruleset, he'd then have to perform e.g. `signer --attest /path/to/ruleset --credential <creds>`
 
 ##### Security of implementation

--- a/cmd/clef/tutorial.md
+++ b/cmd/clef/tutorial.md
@@ -227,7 +227,7 @@ In this example:
     - Auto-rejected if the message does not contain `bazonk`,
 - Any other requests will be passed along for manual confirmation.
 
-*Note, to make this example work, please use you own accounts. You can create a new account either via Clef or the traditional account CLI tools. If the latter was chosen, make sure both Clef and Geth use the same keystore by specifying `--keystore path/to/your/keystore` when running Clef.*
+*Note, to make this example work, please use your own accounts. You can create a new account either via Clef or the traditional account CLI tools. If the latter was chosen, make sure both Clef and Geth use the same keystore by specifying `--keystore path/to/your/keystore` when running Clef.*
 
 Attest the new rule file so that Clef will accept loading it:
 

--- a/cmd/clef/tutorial.md
+++ b/cmd/clef/tutorial.md
@@ -41,7 +41,7 @@ You should treat 'masterseed.json' with utmost secrecy and make a backup of it!
 
 ## Remote interactions
 
-Clef is capable of managing both key-file based accounts as well as hardware wallets. To evaluate clef, we're going to point it to our Rinkeby testnet keystore and specify the Rinkeby chain ID for signing (Clef doesn't have a backing chain, so it doesn't know what network it runs on).
+Clef is capable of managing both key-file based accounts and hardware wallets. To evaluate clef, we're going to point it to our Rinkeby testnet keystore and specify the Rinkeby chain ID for signing (Clef doesn't have a backing chain, so it doesn't know what network it runs on).
 
 ```text
 $ clef --keystore ~/.ethereum/rinkeby/keystore --chainid 4


### PR DESCRIPTION
This pull request addresses several minor typos and improves clarity in the documentation files `rules.md` and `tutorial.md`. Key changes include:
- Corrected the repetition of "have to have" in `rules.md`.
- Fixed the phrase "use you own accounts" to "use your own accounts" in `tutorial.md`.
- Improved the phrasing of "key-file based accounts as well as hardware wallets" to "key-file based accounts and hardware wallets" for consistency in `tutorial.md`.

These changes enhance readability and ensure proper grammar usage.
