### PR TITLE
crypto: document errInvalidPubkey error variable

### DIFF
--- a/crypto/crypto.go
+++ b/crypto/crypto.go
@@ -49,7 +49,12 @@ var (
 	secp256k1halfN = new(big.Int).Div(secp256k1N, big.NewInt(2))
 )
 
-var errInvalidPubkey = errors.New("invalid secp256k1 public key")
+var (
+    // errInvalidPubkey is returned when an invalid secp256k1 public key is provided.
+    // This can occur during public key unmarshaling if the provided bytes do not
+    // represent a valid point on the secp256k1 curve.
+    errInvalidPubkey = errors.New("invalid secp256k1 public key")
+)
 
 // EllipticCurve contains curve operations.
 type EllipticCurve interface {


### PR DESCRIPTION
This PR improves the documentation of the errInvalidPubkey error variable by:

1. Adding detailed godoc comments explaining when and why this error occurs
2. Clarifying that it's specifically related to invalid secp256k1 curve points during public key unmarshaling
3. Organizing the error declaration in a var block following Go's standard practices

The change enhances code readability and helps developers better understand when this error might be encountered, while maintaining the exact same functionality.