### PR TITLE
internal/debug: rename --trace to --go-execution-trace

### DIFF
--- a/internal/debug/flags.go
+++ b/internal/debug/flags.go
@@ -136,8 +136,8 @@ var (
 		Category: flags.LoggingCategory,
 	}
 	traceFlag = &cli.StringFlag{
-		Name:     "trace",
-		Usage:    "Write execution trace to the given file",
+		Name:     "go-execution-trace",
+		Usage:    "Write Go execution trace to the given file",
 		Category: flags.LoggingCategory,
 	}
 )


### PR DESCRIPTION
This flag is very rarely needed, so it's OK for it to have a verbose name. The name --trace also conflicts with the concept of EVM tracing, which is much more heavily used.