### PR TITLE
eth/catalyst/api: compensate for the inability to capture panic caused by register

### DIFF
--- a/eth/catalyst/api.go
+++ b/eth/catalyst/api.go
@@ -46,6 +46,11 @@ import (
 // Register adds the engine API to the full node.
 func Register(stack *node.Node, backend *eth.Ethereum) error {
 	log.Warn("Engine API enabled", "protocol", "eth")
+	defer func() {
+		if r := recover(); r != nil {
+			err = fmt.Errorf("panic %v when register consensus api", r)
+		}
+	}()
 	stack.RegisterAPIs([]rpc.API{
 		{
 			Namespace:     "engine",


### PR DESCRIPTION
If a panic occurs during the process of registering an external consensus API, it should be delivered to catalyst The return value of Register is processed. In the overall system design, this place is used as a service registration before Geth starts. If err is returned, it will be log Terminate the program in the form of Panic.


![1733194245933](https://github.com/user-attachments/assets/f4074ed4-08ec-4b01-9170-c6a738cf3d80)


I personally believe that this is a necessary measure to make the register function more fully expressive. Of course, this change will not cause any changes to the program at the moment, but it can prevent the register's panic from having a significant impact
