### PR TITLE
p2p: fix DiscReason encoding/decoding

### DIFF
--- a/p2p/peer.go
+++ b/p2p/peer.go
@@ -345,9 +345,7 @@ func (p *Peer) handle(msg Msg) error {
 	case msg.Code == discMsg:
 		// This is the last message. We don't need to discard or
 		// check errors because, the connection will be closed after it.
-		var m struct{ R DiscReason }
-		rlp.Decode(msg.Payload, &m)
-		return m.R
+		return decodeDisconnectMessage(msg.Payload)
 	case msg.Code < baseProtocolLength:
 		// ignore other base protocol messages
 		return msg.Discard()
@@ -370,6 +368,27 @@ func (p *Peer) handle(msg Msg) error {
 		}
 	}
 	return nil
+}
+
+// decodeDisconnectMessage decodes the payload of discMsg.
+func decodeDisconnectMessage(r io.Reader) (reason DiscReason) {
+	s := rlp.NewStream(r, 100)
+	k, _, err := s.Kind()
+	if err != nil {
+		return DiscInvalid
+	}
+	if k == rlp.List {
+		s.List()
+		err = s.Decode(&reason)
+	} else {
+		// Legacy path: some implementations, including geth, used to send the disconnect
+		// reason as a byte array by accident.
+		err = s.Decode(&reason)
+	}
+	if err != nil {
+		reason = DiscInvalid
+	}
+	return reason
 }
 
 func countMatchingProtocols(protocols []Protocol, caps []Cap) int {

--- a/p2p/peer.go
+++ b/p2p/peer.go
@@ -343,11 +343,11 @@ func (p *Peer) handle(msg Msg) error {
 		case <-p.closed:
 		}
 	case msg.Code == discMsg:
-		var reason [1]DiscReason
 		// This is the last message. We don't need to discard or
 		// check errors because, the connection will be closed after it.
-		rlp.Decode(msg.Payload, &reason)
-		return reason[0]
+		var m struct{ R DiscReason }
+		rlp.Decode(msg.Payload, &m)
+		return m.R
 	case msg.Code < baseProtocolLength:
 		// ignore other base protocol messages
 		return msg.Discard()

--- a/p2p/peer.go
+++ b/p2p/peer.go
@@ -343,11 +343,11 @@ func (p *Peer) handle(msg Msg) error {
 		case <-p.closed:
 		}
 	case msg.Code == discMsg:
+		var reason [1]DiscReason
 		// This is the last message. We don't need to discard or
 		// check errors because, the connection will be closed after it.
-		var m struct{ R DiscReason }
-		rlp.Decode(msg.Payload, &m)
-		return m.R
+		rlp.Decode(msg.Payload, &reason)
+		return reason[0]
 	case msg.Code < baseProtocolLength:
 		// ignore other base protocol messages
 		return msg.Discard()

--- a/p2p/peer_error.go
+++ b/p2p/peer_error.go
@@ -92,7 +92,7 @@ var discReasonToString = [...]string{
 }
 
 func (d DiscReason) String() string {
-	if len(discReasonToString) <= int(d) {
+	if len(discReasonToString) <= int(d) || discReasonToString[d] == "" {
 		return fmt.Sprintf("unknown disconnect reason %d", d)
 	}
 	return discReasonToString[d]

--- a/p2p/peer_error.go
+++ b/p2p/peer_error.go
@@ -70,6 +70,8 @@ const (
 	DiscSelf
 	DiscReadTimeout
 	DiscSubprotocolError = DiscReason(0x10)
+
+	DiscInvalid = 0xff
 )
 
 var discReasonToString = [...]string{
@@ -86,6 +88,7 @@ var discReasonToString = [...]string{
 	DiscSelf:                "connected to self",
 	DiscReadTimeout:         "read timeout",
 	DiscSubprotocolError:    "subprotocol error",
+	DiscInvalid:             "invalid disconnect reason",
 }
 
 func (d DiscReason) String() string {

--- a/p2p/peer_test.go
+++ b/p2p/peer_test.go
@@ -17,9 +17,12 @@
 package p2p
 
 import (
+	"bytes"
 	"encoding/binary"
 	"errors"
 	"fmt"
+	"github.com/autonity/autonity/rlp"
+	"github.com/stretchr/testify/require"
 	"math/rand"
 	"net"
 	"reflect"
@@ -359,4 +362,16 @@ func TestMatchProtocols(t *testing.T) {
 			}
 		}
 	}
+}
+
+func TestDiscReasonDecoding(t *testing.T) {
+	// as it is encoded func (t *rlpxTransport) close(err error) in transport.go
+	var payload bytes.Buffer
+	err := rlp.Encode(&payload, []DiscReason{DiscQuitting})
+	require.NoError(t, err)
+
+	p := &Peer{}
+	err = p.handle(Msg{Code: discMsg, Payload: bytes.NewReader(payload.Bytes())})
+	t.Log(err)
+	require.True(t, errors.Is(err, DiscQuitting))
 }

--- a/p2p/peer_test.go
+++ b/p2p/peer_test.go
@@ -17,12 +17,9 @@
 package p2p
 
 import (
-	"bytes"
 	"encoding/binary"
 	"errors"
 	"fmt"
-	"github.com/ethereum/go-ethereum/rlp"
-	"github.com/stretchr/testify/require"
 	"math/rand"
 	"net"
 	"reflect"
@@ -362,16 +359,4 @@ func TestMatchProtocols(t *testing.T) {
 			}
 		}
 	}
-}
-
-func TestDiscReasonDecoding(t *testing.T) {
-	// as it is encoded func (t *rlpxTransport) close(err error) in transport.go
-	var payload bytes.Buffer
-	err := rlp.Encode(&payload, []DiscReason{DiscQuitting})
-	require.NoError(t, err)
-
-	p := &Peer{}
-	err = p.handle(Msg{Code: discMsg, Payload: bytes.NewReader(payload.Bytes())})
-	t.Log(err)
-	require.True(t, errors.Is(err, DiscQuitting))
 }

--- a/p2p/peer_test.go
+++ b/p2p/peer_test.go
@@ -21,7 +21,7 @@ import (
 	"encoding/binary"
 	"errors"
 	"fmt"
-	"github.com/autonity/autonity/rlp"
+	"github.com/ethereum/go-ethereum/rlp"
 	"github.com/stretchr/testify/require"
 	"math/rand"
 	"net"

--- a/p2p/transport.go
+++ b/p2p/transport.go
@@ -120,8 +120,7 @@ func (t *rlpxTransport) close(err error) {
 			if err := t.conn.SetWriteDeadline(deadline); err == nil {
 				// Connection supports write deadline.
 				t.wbuf.Reset()
-				size, reader, _ := rlp.EncodeToReader(reason)
-				io.CopyN(&t.wbuf, reader, int64(size))
+				rlp.Encode(&t.wbuf, []interface{}{reason})
 				t.conn.Write(discMsg, t.wbuf.Bytes())
 			}
 		}

--- a/p2p/transport.go
+++ b/p2p/transport.go
@@ -123,8 +123,8 @@ func (t *rlpxTransport) close(err error) {
 				t.conn.Write(discMsg, t.wbuf.Bytes())
 			}
 		}
+		t.conn.Close()
 	}
-	t.conn.Close()
 }
 
 func (t *rlpxTransport) doEncHandshake(prv *ecdsa.PrivateKey) (*ecdsa.PublicKey, error) {

--- a/p2p/transport.go
+++ b/p2p/transport.go
@@ -113,19 +113,17 @@ func (t *rlpxTransport) close(err error) {
 	// Tell the remote end why we're disconnecting if possible.
 	// We only bother doing this if the underlying connection supports
 	// setting a timeout tough.
-	if t.conn != nil {
-		if reason, ok := err.(DiscReason); ok && reason != DiscNetworkError {
-			// We do not use the WriteMsg func since we want a custom deadline
-			deadline := time.Now().Add(discWriteTimeout)
-			if err := t.conn.SetWriteDeadline(deadline); err == nil {
-				// Connection supports write deadline.
-				t.wbuf.Reset()
-				rlp.Encode(&t.wbuf, []any{reason})
-				t.conn.Write(discMsg, t.wbuf.Bytes())
-			}
+	if reason, ok := err.(DiscReason); ok && reason != DiscNetworkError {
+		// We do not use the WriteMsg func since we want a custom deadline
+		deadline := time.Now().Add(discWriteTimeout)
+		if err := t.conn.SetWriteDeadline(deadline); err == nil {
+			// Connection supports write deadline.
+			t.wbuf.Reset()
+			rlp.Encode(&t.wbuf, []any{reason})
+			t.conn.Write(discMsg, t.wbuf.Bytes())
 		}
-		t.conn.Close()
 	}
+	t.conn.Close()
 }
 
 func (t *rlpxTransport) doEncHandshake(prv *ecdsa.PrivateKey) (*ecdsa.PublicKey, error) {

--- a/p2p/transport_test.go
+++ b/p2p/transport_test.go
@@ -97,7 +97,7 @@ func TestProtocolHandshake(t *testing.T) {
 			return
 		}
 
-		if err := ExpectMsg(rlpx, discMsg, []DiscReason{DiscQuitting}); err != nil {
+		if err := ExpectMsg(rlpx, discMsg, []any{DiscQuitting}); err != nil {
 			t.Errorf("error receiving disconnect: %v", err)
 		}
 	}()
@@ -112,7 +112,13 @@ func TestProtocolHandshakeErrors(t *testing.T) {
 	}{
 		{
 			code: discMsg,
-			msg:  []DiscReason{DiscQuitting},
+			msg:  []any{DiscQuitting},
+			err:  DiscQuitting,
+		},
+		{
+			// legacy disconnect encoding as byte array
+			code: discMsg,
+			msg:  []byte{byte(DiscQuitting)},
 			err:  DiscQuitting,
 		},
 		{


### PR DESCRIPTION
This PR reverts back the change to the `DiscReason` rlp decoding done in https://github.com/ethereum/go-ethereum/pull/24507

It also adds a test to check for correctness. The current code in `master` will fail the test since the rlp decoding of DiscReason will fail. However the error returned from `rlp.Decode` is not checked, so the client proceeds using the default value for DiscReason, which is `DiscRequested`.

This PR also prevents a possible nil pointer dereference when closing an rlpx connection.