### PR TITLE
cmd/{geth,utils}: read genesis block from db in chain import

### DIFF
--- a/cmd/geth/chaincmd.go
+++ b/cmd/geth/chaincmd.go
@@ -290,7 +290,13 @@ func importChain(ctx *cli.Context) error {
 	stack, _ := makeConfigNode(ctx)
 	defer stack.Close()
 
-	chain, db := utils.MakeChain(ctx, stack, false)
+	db := utils.MakeChainDatabase(ctx, stack, false)
+
+	// if the error is not nil, no genesis is present in the db and so the default
+	// behavior of creating the genesis block applies.
+	genesis, _ := core.ReadGenesis(db)
+
+	chain, db := utils.MakeChainWithGenesisBlockAndChainDB(genesis, db, ctx, stack, false)
 	defer db.Close()
 
 	// Start periodically gathering memory profiles

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -2138,6 +2138,10 @@ func MakeChain(ctx *cli.Context, stack *node.Node, readonly bool) (*core.BlockCh
 		gspec   = MakeGenesis(ctx)
 		chainDb = MakeChainDatabase(ctx, stack, readonly)
 	)
+	return MakeChainWithGenesisBlockAndChainDB(gspec, chainDb, ctx, stack, readonly)
+}
+
+func MakeChainWithGenesisBlockAndChainDB(gspec *core.Genesis, chainDb ethdb.Database, ctx *cli.Context, stack *node.Node, readonly bool) (*core.BlockChain, ethdb.Database) {
 	config, err := core.LoadChainConfig(chainDb, gspec)
 	if err != nil {
 		Fatalf("%v", err)


### PR DESCRIPTION
I discovered that importing blocks from a non "official" chain is broken.

This is because the import function will call `MakeGenesis`, which doesn't try to load any block from the db, and falls back on the hardcoded ones. If none of these hardcoded genesis blocks work, it YOLOs it by returning a `nil` genesis. This doesn't go well: at some point, the genesis is filled with default values, whose hash never matches that of the genesis block that was stored with `geth init`.

Somehow, the genesis block should be passed to `MakeChain`. So this PR introduces `MakeChainWithGenesisBlockAndChain` so that this info can be recovered from the DB.

I'm not a big fan of it, and I think we should remove `MakeChain` altogether. But I'm putting this out there to gather input on the approach, which is perfectible imo.

Ultimately, this is coming down to `SetupGenesisWithOverrides` doing too much, that should be refactored. Happy to have the discussion here.