### PR TITLE
core/state: don't panic on unknown trie type

### DIFF
--- a/core/state/database.go
+++ b/core/state/database.go
@@ -17,8 +17,6 @@
 package state
 
 import (
-	"fmt"
-
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/lru"
 	"github.com/ethereum/go-ethereum/core/rawdb"
@@ -274,6 +272,9 @@ func mustCopyTrie(t Trie) Trie {
 	case *trie.VerkleTrie:
 		return t.Copy()
 	default:
-		panic(fmt.Errorf("unknown trie type %T", t))
+		// Rare case: Return the identity if the trie type is not directly
+		// implemented within go-ethereum. Any copy logic would need to be handled
+		// by the caller outside go-ethereum.
+		return t
 	}
 }


### PR DESCRIPTION
My geth EVM wrapper library [`w3vm`](https://pkg.go.dev/github.com/lmittmann/w3/w3vm) broke for `v1.14.9+`. The issue is the function [`mustCopyTrie`](https://github.com/ethereum/go-ethereum/blame/75f847390f5a44614f26c255db67e76cb0f4c308/core/state/database.go#L277) and the panic for any other trie type but `StateTrie` and `VerkleTrie`. My library handles state storage and state fetching independently and needs to implement a custom `state.Reader`, `state.Database`, and `state.Trie`. This "fix" is a bit ugly but super simple for an issue that should be super rare.