### PR TITLE
docs: rm the deprecated --metrics.expensive flag 

### DIFF
--- a/docs/fundamentals/config-files.md
+++ b/docs/fundamentals/config-files.md
@@ -14,8 +14,8 @@ The benefit of writing a shell script for starting a Geth node is that it is mor
 To create a shell script, save the Geth startup commands in a shell file, prepended with `#!/bin/bash`. The contents of the file might look like this:
 
 ```sh
-#! /bin/bash
-./geth --sepolia --datadir sepoliadata --authrpc.addr localhost --authrpc.port 8551, 8545 --authrpc.vhosts localhost --authrpc.jwtsecret sepoliadata/jwtsecret --http --http.api eth,net --metrics.expensive --metric.addr 127.0.0.1 --metrics.port 6060
+#!/bin/bash
+./geth --sepolia --datadir sepoliadata --authrpc.addr localhost --authrpc.port 8551, 8545 --authrpc.vhosts localhost --authrpc.jwtsecret sepoliadata/jwtsecret --http --http.api eth,net --metrics --metric.addr 127.0.0.1 --metrics.port 6060
 ```
 
 Save the file as (e.g.) `start-geth.sh`. Then make the file executable using

--- a/docs/monitoring/metrics.md
+++ b/docs/monitoring/metrics.md
@@ -3,7 +3,7 @@ title: Metrics
 description: Introduction to reporting metrics from Geth
 ---
 
-Geth includes a variety of optional metrics that can be reported to the user. However, metrics are disabled by default to save on the computational overhead for the average user. Users that choose to see more detailed metrics can enable them using the `--metrics` flag when starting Geth. Some metrics are classed as especially expensive and are only enabled when the `--metrics.expensive` flag is supplied. For example, per-packet network traffic data is considered expensive.
+Geth includes a variety of optional metrics that can be reported to the user. However, metrics are disabled by default to save on the computational overhead for the average user. Users that choose to see more detailed metrics can enable them using the `--metrics` flag when starting Geth.
 
 The goal of the Geth metrics system is that - similar to logs - arbitrary metric collections can be added to any part of the code without requiring fancy constructs to analyze them (counter variables, public interfaces, crossing over the APIs, console hooks, etc). Instead, metrics should be "updated" whenever and wherever needed and be automatically collected, surfaced through the APIs, queryable and visualizable for analysis.
 
@@ -40,10 +40,10 @@ A gauge is a single int64 value. Its value can increment and decrement - as with
 
 ## Querying metrics {#querying-metrics}
 
-Geth collects metrics if the `--metrics` flag is provided at startup. Those metrics are available via an HTTP server if the `--metrics.addr` flag is also provided. By default the metrics are served at `127.0.0.1:6060/debug/metrics` but a custom IP address can be provided. A custom port can also be provided to the `--metrics.port` flag. More computationally expensive metrics are toggled on or off by providing or omitting the `--metrics.expensive` flag. For example, to serve all metrics at the default address and port:
+Geth collects metrics if the `--metrics` flag is provided at startup. Those metrics are available via an HTTP server if the `--metrics.addr` flag is also provided. By default the metrics are served at `127.0.0.1:6060/debug/metrics` but a custom IP address can be provided. A custom port can also be provided to the `--metrics.port` flag. For example, to serve all metrics at the default address and port:
 
 ```sh
-geth <other commands> --metrics --metrics.addr 127.0.0.1 --metrics.expensive
+geth <other commands> --metrics --metrics.addr 127.0.0.1 --metrics.port 6060
 ```
 
 Navigating the browser to the given metrics address displays all the available metrics in the form


### PR DESCRIPTION
As the `--metrics.expensive` flag was marked as depreated, 

`Expensive metrics are collected by default, please remove this flag` 

we should remove this flag also in the website document.