### PR TITLE
eth/tracers/logger: support tracing system calls

### DIFF
--- a/eth/tracers/logger/logger.go
+++ b/eth/tracers/logger/logger.go
@@ -240,10 +240,11 @@ func NewStructLogger(cfg *Config) *StructLogger {
 
 func (l *StructLogger) Hooks() *tracing.Hooks {
 	return &tracing.Hooks{
-		OnTxStart: l.OnTxStart,
-		OnTxEnd:   l.OnTxEnd,
-		OnExit:    l.OnExit,
-		OnOpcode:  l.OnOpcode,
+		OnTxStart:           l.OnTxStart,
+		OnTxEnd:             l.OnTxEnd,
+		OnSystemCallStartV2: l.OnSystemCallStart,
+		OnExit:              l.OnExit,
+		OnOpcode:            l.OnOpcode,
 	}
 }
 
@@ -358,6 +359,9 @@ func (l *StructLogger) Stop(err error) {
 }
 
 func (l *StructLogger) OnTxStart(env *tracing.VMContext, tx *types.Transaction, from common.Address) {
+	l.env = env
+}
+func (l *StructLogger) OnSystemCallStart(env *tracing.VMContext) {
 	l.env = env
 }
 

--- a/eth/tracers/logger/logger.go
+++ b/eth/tracers/logger/logger.go
@@ -217,6 +217,7 @@ type StructLogger struct {
 
 	interrupt atomic.Bool // Atomic flag to signal execution interruption
 	reason    error       // Textual reason for the interruption
+	skip      bool        // skip processing hooks.
 }
 
 // NewStreamingStructLogger returns a new streaming logger.
@@ -243,6 +244,7 @@ func (l *StructLogger) Hooks() *tracing.Hooks {
 		OnTxStart:           l.OnTxStart,
 		OnTxEnd:             l.OnTxEnd,
 		OnSystemCallStartV2: l.OnSystemCallStart,
+		OnSystemCallEnd:     l.OnSystemCallEnd,
 		OnExit:              l.OnExit,
 		OnOpcode:            l.OnOpcode,
 	}
@@ -254,6 +256,10 @@ func (l *StructLogger) Hooks() *tracing.Hooks {
 func (l *StructLogger) OnOpcode(pc uint64, opcode byte, gas, cost uint64, scope tracing.OpContext, rData []byte, depth int, err error) {
 	// If tracing was interrupted, exit
 	if l.interrupt.Load() {
+		return
+	}
+	// Processing a system call.
+	if l.skip {
 		return
 	}
 	// check if already accumulated the size of the response.
@@ -321,6 +327,9 @@ func (l *StructLogger) OnExit(depth int, output []byte, gasUsed uint64, err erro
 	if depth != 0 {
 		return
 	}
+	if l.skip {
+		return
+	}
 	l.output = output
 	l.err = err
 	// TODO @holiman, should we output the per-scope output?
@@ -362,7 +371,11 @@ func (l *StructLogger) OnTxStart(env *tracing.VMContext, tx *types.Transaction, 
 	l.env = env
 }
 func (l *StructLogger) OnSystemCallStart(env *tracing.VMContext) {
-	l.env = env
+	l.skip = true
+}
+
+func (l *StructLogger) OnSystemCallEnd() {
+	l.skip = false
 }
 
 func (l *StructLogger) OnTxEnd(receipt *types.Receipt, err error) {
@@ -393,9 +406,10 @@ func WriteTrace(writer io.Writer, logs []StructLog) {
 }
 
 type mdLogger struct {
-	out io.Writer
-	cfg *Config
-	env *tracing.VMContext
+	out  io.Writer
+	cfg  *Config
+	env  *tracing.VMContext
+	skip bool
 }
 
 // NewMarkdownLogger creates a logger which outputs information in a format adapted
@@ -412,6 +426,7 @@ func (t *mdLogger) Hooks() *tracing.Hooks {
 	return &tracing.Hooks{
 		OnTxStart:           t.OnTxStart,
 		OnSystemCallStartV2: t.OnSystemCallStart,
+		OnSystemCallEnd:     t.OnSystemCallEnd,
 		OnEnter:             t.OnEnter,
 		OnExit:              t.OnExit,
 		OnOpcode:            t.OnOpcode,
@@ -422,11 +437,19 @@ func (t *mdLogger) Hooks() *tracing.Hooks {
 func (t *mdLogger) OnTxStart(env *tracing.VMContext, tx *types.Transaction, from common.Address) {
 	t.env = env
 }
+
 func (t *mdLogger) OnSystemCallStart(env *tracing.VMContext) {
-	t.env = env
+	t.skip = true
+}
+
+func (t *mdLogger) OnSystemCallEnd() {
+	t.skip = false
 }
 
 func (t *mdLogger) OnEnter(depth int, typ byte, from common.Address, to common.Address, input []byte, gas uint64, value *big.Int) {
+	if t.skip {
+		return
+	}
 	if depth != 0 {
 		return
 	}
@@ -454,6 +477,9 @@ func (t *mdLogger) OnEnter(depth int, typ byte, from common.Address, to common.A
 }
 
 func (t *mdLogger) OnExit(depth int, output []byte, gasUsed uint64, err error, reverted bool) {
+	if t.skip {
+		return
+	}
 	if depth == 0 {
 		fmt.Fprintf(t.out, "\nPost-execution info:\n"+
 			"  - output: `%#x`\n"+
@@ -465,6 +491,9 @@ func (t *mdLogger) OnExit(depth int, output []byte, gasUsed uint64, err error, r
 
 // OnOpcode also tracks SLOAD/SSTORE ops to track storage change.
 func (t *mdLogger) OnOpcode(pc uint64, op byte, gas, cost uint64, scope tracing.OpContext, rData []byte, depth int, err error) {
+	if t.skip {
+		return
+	}
 	stack := scope.StackData()
 	fmt.Fprintf(t.out, "| %4d  | %10v  |  %3d |%10v |", pc, vm.OpCode(op).String(),
 		cost, t.env.StateDB.GetRefund())
@@ -485,6 +514,9 @@ func (t *mdLogger) OnOpcode(pc uint64, op byte, gas, cost uint64, scope tracing.
 }
 
 func (t *mdLogger) OnFault(pc uint64, op byte, gas, cost uint64, scope tracing.OpContext, depth int, err error) {
+	if t.skip {
+		return
+	}
 	fmt.Fprintf(t.out, "\nError: at pc=%d, op=%v: %v\n", pc, op, err)
 }
 

--- a/eth/tracers/logger/logger.go
+++ b/eth/tracers/logger/logger.go
@@ -410,15 +410,19 @@ func NewMarkdownLogger(cfg *Config, writer io.Writer) *mdLogger {
 
 func (t *mdLogger) Hooks() *tracing.Hooks {
 	return &tracing.Hooks{
-		OnTxStart: t.OnTxStart,
-		OnEnter:   t.OnEnter,
-		OnExit:    t.OnExit,
-		OnOpcode:  t.OnOpcode,
-		OnFault:   t.OnFault,
+		OnTxStart:           t.OnTxStart,
+		OnSystemCallStartV2: t.OnTxStart,
+		OnEnter:             t.OnEnter,
+		OnExit:              t.OnExit,
+		OnOpcode:            t.OnOpcode,
+		OnFault:             t.OnFault,
 	}
 }
 
 func (t *mdLogger) OnTxStart(env *tracing.VMContext, tx *types.Transaction, from common.Address) {
+	t.env = env
+}
+func (t *mdLogger) OnSystemCallStart(env *tracing.VMContext) {
 	t.env = env
 }
 

--- a/eth/tracers/logger/logger.go
+++ b/eth/tracers/logger/logger.go
@@ -411,7 +411,7 @@ func NewMarkdownLogger(cfg *Config, writer io.Writer) *mdLogger {
 func (t *mdLogger) Hooks() *tracing.Hooks {
 	return &tracing.Hooks{
 		OnTxStart:           t.OnTxStart,
-		OnSystemCallStartV2: t.OnTxStart,
+		OnSystemCallStartV2: t.OnSystemCallStart,
 		OnEnter:             t.OnEnter,
 		OnExit:              t.OnExit,
 		OnOpcode:            t.OnOpcode,


### PR DESCRIPTION
The struct logger relies on the `OnTxStart` hook to store the execution context. In order to support tracing system calls, the logger also needs to listen to the `OnSystemCallStartV2` hook.