### PR TITLE
core/types, internal/ethapi: fixes for prague RPC encoding

### DIFF
--- a/core/types/block.go
+++ b/core/types/block.go
@@ -105,7 +105,7 @@ type Header struct {
 	ParentBeaconRoot *common.Hash `json:"parentBeaconBlockRoot" rlp:"optional"`
 
 	// RequestsHash was added by EIP-7685 and is ignored in legacy headers.
-	RequestsHash *common.Hash `json:"requestsRoot" rlp:"optional"`
+	RequestsHash *common.Hash `json:"requestsHash" rlp:"optional"`
 }
 
 // field type overrides for gencodec

--- a/core/types/gen_authorization.go
+++ b/core/types/gen_authorization.go
@@ -20,16 +20,16 @@ func (a Authorization) MarshalJSON() ([]byte, error) {
 		Address common.Address `json:"address" gencodec:"required"`
 		Nonce   hexutil.Uint64 `json:"nonce" gencodec:"required"`
 		V       hexutil.Uint64 `json:"v" gencodec:"required"`
-		R       uint256.Int    `json:"r" gencodec:"required"`
-		S       uint256.Int    `json:"s" gencodec:"required"`
+		R       hexutil.U256   `json:"r" gencodec:"required"`
+		S       hexutil.U256   `json:"s" gencodec:"required"`
 	}
 	var enc Authorization
 	enc.ChainID = hexutil.Uint64(a.ChainID)
 	enc.Address = a.Address
 	enc.Nonce = hexutil.Uint64(a.Nonce)
 	enc.V = hexutil.Uint64(a.V)
-	enc.R = a.R
-	enc.S = a.S
+	enc.R = hexutil.U256(a.R)
+	enc.S = hexutil.U256(a.S)
 	return json.Marshal(&enc)
 }
 
@@ -40,8 +40,8 @@ func (a *Authorization) UnmarshalJSON(input []byte) error {
 		Address *common.Address `json:"address" gencodec:"required"`
 		Nonce   *hexutil.Uint64 `json:"nonce" gencodec:"required"`
 		V       *hexutil.Uint64 `json:"v" gencodec:"required"`
-		R       *uint256.Int    `json:"r" gencodec:"required"`
-		S       *uint256.Int    `json:"s" gencodec:"required"`
+		R       *hexutil.U256   `json:"r" gencodec:"required"`
+		S       *hexutil.U256   `json:"s" gencodec:"required"`
 	}
 	var dec Authorization
 	if err := json.Unmarshal(input, &dec); err != nil {
@@ -66,10 +66,10 @@ func (a *Authorization) UnmarshalJSON(input []byte) error {
 	if dec.R == nil {
 		return errors.New("missing required field 'r' for Authorization")
 	}
-	a.R = *dec.R
+	a.R = uint256.Int(*dec.R)
 	if dec.S == nil {
 		return errors.New("missing required field 's' for Authorization")
 	}
-	a.S = *dec.S
+	a.S = uint256.Int(*dec.S)
 	return nil
 }

--- a/core/types/gen_header_json.go
+++ b/core/types/gen_header_json.go
@@ -36,7 +36,7 @@ func (h Header) MarshalJSON() ([]byte, error) {
 		BlobGasUsed      *hexutil.Uint64 `json:"blobGasUsed" rlp:"optional"`
 		ExcessBlobGas    *hexutil.Uint64 `json:"excessBlobGas" rlp:"optional"`
 		ParentBeaconRoot *common.Hash    `json:"parentBeaconBlockRoot" rlp:"optional"`
-		RequestsHash     *common.Hash    `json:"requestsRoot" rlp:"optional"`
+		RequestsHash     *common.Hash    `json:"requestsHash" rlp:"optional"`
 		Hash             common.Hash     `json:"hash"`
 	}
 	var enc Header
@@ -88,7 +88,7 @@ func (h *Header) UnmarshalJSON(input []byte) error {
 		BlobGasUsed      *hexutil.Uint64 `json:"blobGasUsed" rlp:"optional"`
 		ExcessBlobGas    *hexutil.Uint64 `json:"excessBlobGas" rlp:"optional"`
 		ParentBeaconRoot *common.Hash    `json:"parentBeaconBlockRoot" rlp:"optional"`
-		RequestsHash     *common.Hash    `json:"requestsRoot" rlp:"optional"`
+		RequestsHash     *common.Hash    `json:"requestsHash" rlp:"optional"`
 	}
 	var dec Header
 	if err := json.Unmarshal(input, &dec); err != nil {

--- a/core/types/tx_setcode.go
+++ b/core/types/tx_setcode.go
@@ -83,6 +83,8 @@ type authorizationMarshaling struct {
 	ChainID hexutil.Uint64
 	Nonce   hexutil.Uint64
 	V       hexutil.Uint64
+	R       hexutil.U256
+	S       hexutil.U256
 }
 
 // SignAuth signs the provided authorization.

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -895,7 +895,7 @@ func RPCMarshalHeader(head *types.Header) map[string]interface{} {
 		result["parentBeaconBlockRoot"] = head.ParentBeaconRoot
 	}
 	if head.RequestsHash != nil {
-		result["requestsRoot"] = head.RequestsHash
+		result["requestsHash"] = head.RequestsHash
 	}
 	return result
 }

--- a/internal/ethapi/transaction_args.go
+++ b/internal/ethapi/transaction_args.go
@@ -466,6 +466,7 @@ func (args *TransactionArgs) ToMessage(baseFee *big.Int, skipNonceCheck, skipEoA
 		AccessList:       accessList,
 		BlobGasFeeCap:    (*big.Int)(args.BlobFeeCap),
 		BlobHashes:       args.BlobHashes,
+		AuthList:         args.AuthorizationList,
 		SkipNonceChecks:  skipNonceCheck,
 		SkipFromEOACheck: skipEoACheck,
 	}


### PR DESCRIPTION
Fixing some issues I found while regenerating RPC tests for Prague:

- Authorization signature values were not encoded as hex
- `requestsRoot` in block should be `requestsHash`
- `authorizationList` should work for `eth_call`