### PR TITLE
cmd/evm: make evm statetest accept non-json files

### DIFF
--- a/cmd/evm/blockrunner.go
+++ b/cmd/evm/blockrunner.go
@@ -50,7 +50,7 @@ func blockTestCmd(ctx *cli.Context) error {
 		return errors.New("path argument required")
 	}
 	var (
-		collected = collectJSONFiles(path)
+		collected = collectFiles(path)
 		results   []testResult
 	)
 	for _, fname := range collected {

--- a/cmd/evm/main.go
+++ b/cmd/evm/main.go
@@ -262,10 +262,15 @@ func tracerFromFlags(ctx *cli.Context) *tracing.Hooks {
 	}
 }
 
-// collectJSONFiles walks the given path and accumulates all files with json
-// extension.
-func collectJSONFiles(path string) []string {
+// collectFiles walks the given path. If the path is a directory, it will
+// return a list of all accumulates all files with json extension.
+// Otherwise (if path points to a file), it will return the path.
+func collectFiles(path string) []string {
 	var out []string
+	if info, err := os.Stat(path); err == nil && !info.IsDir() {
+		// User explicitly pointed out a file, ignore extension.
+		return []string{path}
+	}
 	err := filepath.Walk(path, func(path string, info fs.FileInfo, err error) error {
 		if err != nil {
 			return err

--- a/cmd/evm/staterunner.go
+++ b/cmd/evm/staterunner.go
@@ -63,7 +63,7 @@ func stateTestCmd(ctx *cli.Context) error {
 	// If path is provided, run the tests at that path.
 	if len(path) != 0 {
 		var (
-			collected = collectJSONFiles(path)
+			collected = collectFiles(path)
 			results   []testResult
 		)
 		for _, fname := range collected {


### PR DESCRIPTION
This fixes a regression introduced recently. Without this fix, it's not possible to use statetests without `.json` suffix. 

This is problematic for goevmlab `minimizer`, which appends the suffix `.min` during processing.  

Without fix
```
[user@work go-ethereum]$ go run ./cmd/evm/ statetest --trace --trace.format=json ./00155493-mixed-6.json.min.min
null
```
With fix
```
[user@work go-ethereum]$ go run ./cmd/evm/ statetest --trace --trace.format=json ./00155493-mixed-6.json.min.min
{"pc":0,"op":127,"gas":"0x19e701","gasCost":"0x3","memSize":0,"stack":[],"depth":1,"refund":0,"opName":"PUSH32"}
{"pc":33,"op":95,"gas":"0x19e6fe","gasCost":"0x2","memSize":0,"stack":["0xc159603ab9942405d1c9c45c46403949f0540852afe082105fc3a18449358973"],"depth":1,"refund":0,"opName":"PUSH0"}
```