### PR TITLE
fix: It is recommended to use the fmt.Errorf method with parameters instead of the errors.New method without parameters.

### DIFF
--- a/cmd/devp2p/dns_route53.go
+++ b/cmd/devp2p/dns_route53.go
@@ -208,7 +208,7 @@ func (c *route53Client) findZoneID(name string) (string, error) {
 		req.DNSName = resp.NextDNSName
 		req.HostedZoneId = resp.NextHostedZoneId
 	}
-	return "", errors.New("can't find zone ID for " + name)
+	return "", fmt.Errorf("can't find zone ID for %s", name)
 }
 
 // computeChanges creates DNS changes for the given set of DNS discovery records.

--- a/cmd/geth/config.go
+++ b/cmd/geth/config.go
@@ -18,7 +18,6 @@ package main
 
 import (
 	"bufio"
-	"errors"
 	"fmt"
 	"os"
 	"reflect"
@@ -121,7 +120,7 @@ func loadConfig(file string, cfg *gethConfig) error {
 	err = tomlSettings.NewDecoder(bufio.NewReader(f)).Decode(cfg)
 	// Add file name to errors that have a line number.
 	if _, ok := err.(*toml.LineError); ok {
-		err = errors.New(file + ", " + err.Error())
+		err = fmt.Errorf("%s, %v", file, err)
 	}
 	return err
 }


### PR DESCRIPTION
fix: It is recommended to use the fmt.Errorf method with parameters instead of the errors.New method without parameters.