### PR TITLE
core/types: updates for EIP-7702 API functions

### DIFF
--- a/core/blockchain_test.go
+++ b/core/blockchain_test.go
@@ -4273,12 +4273,12 @@ func TestEIP7702(t *testing.T) {
 	// 1. tx -> addr1 which is delegated to 0xaaaa
 	// 2. addr1:0xaaaa calls into addr2:0xbbbb
 	// 3. addr2:0xbbbb  writes to storage
-	auth1, _ := types.SignAuthorization(key1, types.SetCodeAuthorization{
+	auth1, _ := types.SignSetCode(key1, types.SetCodeAuthorization{
 		ChainID: gspec.Config.ChainID.Uint64(),
 		Address: aa,
 		Nonce:   1,
 	})
-	auth2, _ := types.SignAuthorization(key2, types.SetCodeAuthorization{
+	auth2, _ := types.SignSetCode(key2, types.SetCodeAuthorization{
 		ChainID: 0,
 		Address: bb,
 		Nonce:   0,

--- a/core/blockchain_test.go
+++ b/core/blockchain_test.go
@@ -4273,12 +4273,12 @@ func TestEIP7702(t *testing.T) {
 	// 1. tx -> addr1 which is delegated to 0xaaaa
 	// 2. addr1:0xaaaa calls into addr2:0xbbbb
 	// 3. addr2:0xbbbb  writes to storage
-	auth1, _ := types.SignAuth(types.Authorization{
+	auth1, _ := types.SignAuth(types.SetCodeAuthorization{
 		ChainID: gspec.Config.ChainID.Uint64(),
 		Address: aa,
 		Nonce:   1,
 	}, key1)
-	auth2, _ := types.SignAuth(types.Authorization{
+	auth2, _ := types.SignAuth(types.SetCodeAuthorization{
 		ChainID: 0,
 		Address: bb,
 		Nonce:   0,
@@ -4293,7 +4293,7 @@ func TestEIP7702(t *testing.T) {
 			Gas:       500000,
 			GasFeeCap: uint256.MustFromBig(newGwei(5)),
 			GasTipCap: uint256.NewInt(2),
-			AuthList:  []types.Authorization{auth1, auth2},
+			AuthList:  []types.SetCodeAuthorization{auth1, auth2},
 		}
 		tx := types.MustSignNewTx(key1, signer, txdata)
 		b.AddTx(tx)

--- a/core/blockchain_test.go
+++ b/core/blockchain_test.go
@@ -4273,16 +4273,16 @@ func TestEIP7702(t *testing.T) {
 	// 1. tx -> addr1 which is delegated to 0xaaaa
 	// 2. addr1:0xaaaa calls into addr2:0xbbbb
 	// 3. addr2:0xbbbb  writes to storage
-	auth1, _ := types.SignAuth(types.SetCodeAuthorization{
+	auth1, _ := types.SignAuthorization(key1, types.SetCodeAuthorization{
 		ChainID: gspec.Config.ChainID.Uint64(),
 		Address: aa,
 		Nonce:   1,
-	}, key1)
-	auth2, _ := types.SignAuth(types.SetCodeAuthorization{
+	})
+	auth2, _ := types.SignAuthorization(key2, types.SetCodeAuthorization{
 		ChainID: 0,
 		Address: bb,
 		Nonce:   0,
-	}, key2)
+	})
 
 	_, blocks, _ := GenerateChainWithGenesis(gspec, engine, 1, func(i int, b *BlockGen) {
 		b.SetCoinbase(aa)

--- a/core/state_processor_test.go
+++ b/core/state_processor_test.go
@@ -111,7 +111,7 @@ func TestStateProcessorErrors(t *testing.T) {
 		}
 		return tx
 	}
-	var mkSetCodeTx = func(nonce uint64, to common.Address, gasLimit uint64, gasTipCap, gasFeeCap *big.Int, authlist []types.Authorization) *types.Transaction {
+	var mkSetCodeTx = func(nonce uint64, to common.Address, gasLimit uint64, gasTipCap, gasFeeCap *big.Int, authlist []types.SetCodeAuthorization) *types.Transaction {
 		tx, err := types.SignTx(types.NewTx(&types.SetCodeTx{
 			Nonce:     nonce,
 			GasTipCap: uint256.MustFromBig(gasTipCap),

--- a/core/state_transition.go
+++ b/core/state_transition.go
@@ -67,7 +67,7 @@ func (result *ExecutionResult) Revert() []byte {
 }
 
 // IntrinsicGas computes the 'intrinsic gas' for a message with the given data.
-func IntrinsicGas(data []byte, accessList types.AccessList, authList []types.Authorization, isContractCreation, isHomestead, isEIP2028, isEIP3860 bool) (uint64, error) {
+func IntrinsicGas(data []byte, accessList types.AccessList, authList []types.SetCodeAuthorization, isContractCreation, isHomestead, isEIP2028, isEIP3860 bool) (uint64, error) {
 	// Set the starting gas for the raw transaction
 	var gas uint64
 	if isContractCreation && isHomestead {
@@ -143,7 +143,7 @@ type Message struct {
 	AccessList    types.AccessList
 	BlobGasFeeCap *big.Int
 	BlobHashes    []common.Hash
-	AuthList      []types.Authorization
+	AuthList      []types.SetCodeAuthorization
 
 	// When SkipNonceChecks is true, the message nonce is not checked against the
 	// account nonce in state.
@@ -528,7 +528,7 @@ func (st *stateTransition) execute() (*ExecutionResult, error) {
 }
 
 // validateAuthorization validates an EIP-7702 authorization against the state.
-func (st *stateTransition) validateAuthorization(auth *types.Authorization) (authority common.Address, err error) {
+func (st *stateTransition) validateAuthorization(auth *types.SetCodeAuthorization) (authority common.Address, err error) {
 	// Verify chain ID is 0 or equal to current chain ID.
 	if auth.ChainID != 0 && st.evm.ChainConfig().ChainID.Uint64() != auth.ChainID {
 		return authority, ErrAuthorizationWrongChainID
@@ -559,7 +559,7 @@ func (st *stateTransition) validateAuthorization(auth *types.Authorization) (aut
 }
 
 // applyAuthorization applies an EIP-7702 code delegation to the state.
-func (st *stateTransition) applyAuthorization(msg *Message, auth *types.Authorization) error {
+func (st *stateTransition) applyAuthorization(msg *Message, auth *types.SetCodeAuthorization) error {
 	authority, err := st.validateAuthorization(auth)
 	if err != nil {
 		return err

--- a/core/types/gen_authorization.go
+++ b/core/types/gen_authorization.go
@@ -14,8 +14,8 @@ import (
 var _ = (*authorizationMarshaling)(nil)
 
 // MarshalJSON marshals as JSON.
-func (a Authorization) MarshalJSON() ([]byte, error) {
-	type Authorization struct {
+func (s SetCodeAuthorization) MarshalJSON() ([]byte, error) {
+	type SetCodeAuthorization struct {
 		ChainID hexutil.Uint64 `json:"chainId" gencodec:"required"`
 		Address common.Address `json:"address" gencodec:"required"`
 		Nonce   hexutil.Uint64 `json:"nonce" gencodec:"required"`
@@ -23,19 +23,19 @@ func (a Authorization) MarshalJSON() ([]byte, error) {
 		R       hexutil.U256   `json:"r" gencodec:"required"`
 		S       hexutil.U256   `json:"s" gencodec:"required"`
 	}
-	var enc Authorization
-	enc.ChainID = hexutil.Uint64(a.ChainID)
-	enc.Address = a.Address
-	enc.Nonce = hexutil.Uint64(a.Nonce)
-	enc.V = hexutil.Uint64(a.V)
-	enc.R = hexutil.U256(a.R)
-	enc.S = hexutil.U256(a.S)
+	var enc SetCodeAuthorization
+	enc.ChainID = hexutil.Uint64(s.ChainID)
+	enc.Address = s.Address
+	enc.Nonce = hexutil.Uint64(s.Nonce)
+	enc.V = hexutil.Uint64(s.V)
+	enc.R = hexutil.U256(s.R)
+	enc.S = hexutil.U256(s.S)
 	return json.Marshal(&enc)
 }
 
 // UnmarshalJSON unmarshals from JSON.
-func (a *Authorization) UnmarshalJSON(input []byte) error {
-	type Authorization struct {
+func (s *SetCodeAuthorization) UnmarshalJSON(input []byte) error {
+	type SetCodeAuthorization struct {
 		ChainID *hexutil.Uint64 `json:"chainId" gencodec:"required"`
 		Address *common.Address `json:"address" gencodec:"required"`
 		Nonce   *hexutil.Uint64 `json:"nonce" gencodec:"required"`
@@ -43,33 +43,33 @@ func (a *Authorization) UnmarshalJSON(input []byte) error {
 		R       *hexutil.U256   `json:"r" gencodec:"required"`
 		S       *hexutil.U256   `json:"s" gencodec:"required"`
 	}
-	var dec Authorization
+	var dec SetCodeAuthorization
 	if err := json.Unmarshal(input, &dec); err != nil {
 		return err
 	}
 	if dec.ChainID == nil {
-		return errors.New("missing required field 'chainId' for Authorization")
+		return errors.New("missing required field 'chainId' for SetCodeAuthorization")
 	}
-	a.ChainID = uint64(*dec.ChainID)
+	s.ChainID = uint64(*dec.ChainID)
 	if dec.Address == nil {
-		return errors.New("missing required field 'address' for Authorization")
+		return errors.New("missing required field 'address' for SetCodeAuthorization")
 	}
-	a.Address = *dec.Address
+	s.Address = *dec.Address
 	if dec.Nonce == nil {
-		return errors.New("missing required field 'nonce' for Authorization")
+		return errors.New("missing required field 'nonce' for SetCodeAuthorization")
 	}
-	a.Nonce = uint64(*dec.Nonce)
+	s.Nonce = uint64(*dec.Nonce)
 	if dec.V == nil {
-		return errors.New("missing required field 'v' for Authorization")
+		return errors.New("missing required field 'v' for SetCodeAuthorization")
 	}
-	a.V = uint8(*dec.V)
+	s.V = uint8(*dec.V)
 	if dec.R == nil {
-		return errors.New("missing required field 'r' for Authorization")
+		return errors.New("missing required field 'r' for SetCodeAuthorization")
 	}
-	a.R = uint256.Int(*dec.R)
+	s.R = uint256.Int(*dec.R)
 	if dec.S == nil {
-		return errors.New("missing required field 's' for Authorization")
+		return errors.New("missing required field 's' for SetCodeAuthorization")
 	}
-	a.S = uint256.Int(*dec.S)
+	s.S = uint256.Int(*dec.S)
 	return nil
 }

--- a/core/types/transaction.go
+++ b/core/types/transaction.go
@@ -475,7 +475,7 @@ func (tx *Transaction) WithBlobTxSidecar(sideCar *BlobTxSidecar) *Transaction {
 }
 
 // AuthList returns the authorizations list of the transaction.
-func (tx *Transaction) AuthList() []Authorization {
+func (tx *Transaction) AuthList() []SetCodeAuthorization {
 	setcodetx, ok := tx.inner.(*SetCodeTx)
 	if !ok {
 		return nil

--- a/core/types/transaction_marshalling.go
+++ b/core/types/transaction_marshalling.go
@@ -31,23 +31,23 @@ import (
 type txJSON struct {
 	Type hexutil.Uint64 `json:"type"`
 
-	ChainID              *hexutil.Big    `json:"chainId,omitempty"`
-	Nonce                *hexutil.Uint64 `json:"nonce"`
-	To                   *common.Address `json:"to"`
-	Gas                  *hexutil.Uint64 `json:"gas"`
-	GasPrice             *hexutil.Big    `json:"gasPrice"`
-	MaxPriorityFeePerGas *hexutil.Big    `json:"maxPriorityFeePerGas"`
-	MaxFeePerGas         *hexutil.Big    `json:"maxFeePerGas"`
-	MaxFeePerBlobGas     *hexutil.Big    `json:"maxFeePerBlobGas,omitempty"`
-	Value                *hexutil.Big    `json:"value"`
-	Input                *hexutil.Bytes  `json:"input"`
-	AccessList           *AccessList     `json:"accessList,omitempty"`
-	BlobVersionedHashes  []common.Hash   `json:"blobVersionedHashes,omitempty"`
-	AuthorizationList    []Authorization `json:"authorizationList,omitempty"`
-	V                    *hexutil.Big    `json:"v"`
-	R                    *hexutil.Big    `json:"r"`
-	S                    *hexutil.Big    `json:"s"`
-	YParity              *hexutil.Uint64 `json:"yParity,omitempty"`
+	ChainID              *hexutil.Big           `json:"chainId,omitempty"`
+	Nonce                *hexutil.Uint64        `json:"nonce"`
+	To                   *common.Address        `json:"to"`
+	Gas                  *hexutil.Uint64        `json:"gas"`
+	GasPrice             *hexutil.Big           `json:"gasPrice"`
+	MaxPriorityFeePerGas *hexutil.Big           `json:"maxPriorityFeePerGas"`
+	MaxFeePerGas         *hexutil.Big           `json:"maxFeePerGas"`
+	MaxFeePerBlobGas     *hexutil.Big           `json:"maxFeePerBlobGas,omitempty"`
+	Value                *hexutil.Big           `json:"value"`
+	Input                *hexutil.Bytes         `json:"input"`
+	AccessList           *AccessList            `json:"accessList,omitempty"`
+	BlobVersionedHashes  []common.Hash          `json:"blobVersionedHashes,omitempty"`
+	AuthorizationList    []SetCodeAuthorization `json:"authorizationList,omitempty"`
+	V                    *hexutil.Big           `json:"v"`
+	R                    *hexutil.Big           `json:"r"`
+	S                    *hexutil.Big           `json:"s"`
+	YParity              *hexutil.Uint64        `json:"yParity,omitempty"`
 
 	// Blob transaction sidecar encoding:
 	Blobs       []kzg4844.Blob       `json:"blobs,omitempty"`

--- a/core/types/tx_setcode.go
+++ b/core/types/tx_setcode.go
@@ -87,28 +87,22 @@ type authorizationMarshaling struct {
 	S       hexutil.U256
 }
 
-// SignAuth signs the provided authorization.
-func SignAuth(auth SetCodeAuthorization, prv *ecdsa.PrivateKey) (SetCodeAuthorization, error) {
+// SignAuthorization sets the signature of a code authorization.
+func SignAuthorization(prv *ecdsa.PrivateKey, auth SetCodeAuthorization) (SetCodeAuthorization, error) {
 	sighash := auth.sigHash()
 	sig, err := crypto.Sign(sighash[:], prv)
 	if err != nil {
 		return SetCodeAuthorization{}, err
 	}
-	return auth.withSignature(sig), nil
-}
-
-// withSignature updates the signature of an Authorization to be equal the
-// decoded signature provided in sig.
-func (a *SetCodeAuthorization) withSignature(sig []byte) SetCodeAuthorization {
 	r, s, _ := decodeSignature(sig)
 	return SetCodeAuthorization{
-		ChainID: a.ChainID,
-		Address: a.Address,
-		Nonce:   a.Nonce,
+		ChainID: auth.ChainID,
+		Address: auth.Address,
+		Nonce:   auth.Nonce,
 		V:       sig[64],
 		R:       *uint256.MustFromBig(r),
 		S:       *uint256.MustFromBig(s),
-	}
+	}, nil
 }
 
 func (a *SetCodeAuthorization) sigHash() common.Hash {

--- a/core/types/tx_setcode.go
+++ b/core/types/tx_setcode.go
@@ -87,8 +87,8 @@ type authorizationMarshaling struct {
 	S       hexutil.U256
 }
 
-// SignAuthorization sets the signature of a code authorization.
-func SignAuthorization(prv *ecdsa.PrivateKey, auth SetCodeAuthorization) (SetCodeAuthorization, error) {
+// SignSetCode creates a signed the SetCode authorization.
+func SignSetCode(prv *ecdsa.PrivateKey, auth SetCodeAuthorization) (SetCodeAuthorization, error) {
 	sighash := auth.sigHash()
 	sig, err := crypto.Sign(sighash[:], prv)
 	if err != nil {

--- a/core/types/tx_setcode.go
+++ b/core/types/tx_setcode.go
@@ -58,7 +58,7 @@ type SetCodeTx struct {
 	Value      *uint256.Int
 	Data       []byte
 	AccessList AccessList
-	AuthList   []Authorization
+	AuthList   []SetCodeAuthorization
 
 	// Signature values
 	V *uint256.Int `json:"v" gencodec:"required"`
@@ -66,10 +66,10 @@ type SetCodeTx struct {
 	S *uint256.Int `json:"s" gencodec:"required"`
 }
 
-//go:generate go run github.com/fjl/gencodec -type Authorization -field-override authorizationMarshaling -out gen_authorization.go
+//go:generate go run github.com/fjl/gencodec -type SetCodeAuthorization -field-override authorizationMarshaling -out gen_authorization.go
 
-// Authorization is an authorization from an account to deploy code at its address.
-type Authorization struct {
+// SetCodeAuthorization is an authorization from an account to deploy code at its address.
+type SetCodeAuthorization struct {
 	ChainID uint64         `json:"chainId" gencodec:"required"`
 	Address common.Address `json:"address" gencodec:"required"`
 	Nonce   uint64         `json:"nonce" gencodec:"required"`
@@ -88,20 +88,20 @@ type authorizationMarshaling struct {
 }
 
 // SignAuth signs the provided authorization.
-func SignAuth(auth Authorization, prv *ecdsa.PrivateKey) (Authorization, error) {
+func SignAuth(auth SetCodeAuthorization, prv *ecdsa.PrivateKey) (SetCodeAuthorization, error) {
 	sighash := auth.sigHash()
 	sig, err := crypto.Sign(sighash[:], prv)
 	if err != nil {
-		return Authorization{}, err
+		return SetCodeAuthorization{}, err
 	}
 	return auth.withSignature(sig), nil
 }
 
 // withSignature updates the signature of an Authorization to be equal the
 // decoded signature provided in sig.
-func (a *Authorization) withSignature(sig []byte) Authorization {
+func (a *SetCodeAuthorization) withSignature(sig []byte) SetCodeAuthorization {
 	r, s, _ := decodeSignature(sig)
-	return Authorization{
+	return SetCodeAuthorization{
 		ChainID: a.ChainID,
 		Address: a.Address,
 		Nonce:   a.Nonce,
@@ -111,7 +111,7 @@ func (a *Authorization) withSignature(sig []byte) Authorization {
 	}
 }
 
-func (a *Authorization) sigHash() common.Hash {
+func (a *SetCodeAuthorization) sigHash() common.Hash {
 	return prefixedRlpHash(0x05, []any{
 		a.ChainID,
 		a.Address,
@@ -120,7 +120,7 @@ func (a *Authorization) sigHash() common.Hash {
 }
 
 // Authority recovers the the authorizing account of an authorization.
-func (a *Authorization) Authority() (common.Address, error) {
+func (a *SetCodeAuthorization) Authority() (common.Address, error) {
 	sighash := a.sigHash()
 	if !crypto.ValidateSignatureValues(a.V, a.R.ToBig(), a.S.ToBig(), true) {
 		return common.Address{}, ErrInvalidSig
@@ -152,7 +152,7 @@ func (tx *SetCodeTx) copy() TxData {
 		Gas:   tx.Gas,
 		// These are copied below.
 		AccessList: make(AccessList, len(tx.AccessList)),
-		AuthList:   make([]Authorization, len(tx.AuthList)),
+		AuthList:   make([]SetCodeAuthorization, len(tx.AuthList)),
 		Value:      new(uint256.Int),
 		ChainID:    tx.ChainID,
 		GasTipCap:  new(uint256.Int),

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -937,29 +937,29 @@ func RPCMarshalBlock(block *types.Block, inclTx bool, fullTx bool, config *param
 
 // RPCTransaction represents a transaction that will serialize to the RPC representation of a transaction
 type RPCTransaction struct {
-	BlockHash           *common.Hash          `json:"blockHash"`
-	BlockNumber         *hexutil.Big          `json:"blockNumber"`
-	From                common.Address        `json:"from"`
-	Gas                 hexutil.Uint64        `json:"gas"`
-	GasPrice            *hexutil.Big          `json:"gasPrice"`
-	GasFeeCap           *hexutil.Big          `json:"maxFeePerGas,omitempty"`
-	GasTipCap           *hexutil.Big          `json:"maxPriorityFeePerGas,omitempty"`
-	MaxFeePerBlobGas    *hexutil.Big          `json:"maxFeePerBlobGas,omitempty"`
-	Hash                common.Hash           `json:"hash"`
-	Input               hexutil.Bytes         `json:"input"`
-	Nonce               hexutil.Uint64        `json:"nonce"`
-	To                  *common.Address       `json:"to"`
-	TransactionIndex    *hexutil.Uint64       `json:"transactionIndex"`
-	Value               *hexutil.Big          `json:"value"`
-	Type                hexutil.Uint64        `json:"type"`
-	Accesses            *types.AccessList     `json:"accessList,omitempty"`
-	ChainID             *hexutil.Big          `json:"chainId,omitempty"`
-	BlobVersionedHashes []common.Hash         `json:"blobVersionedHashes,omitempty"`
-	AuthorizationList   []types.Authorization `json:"authorizationList,omitempty"`
-	V                   *hexutil.Big          `json:"v"`
-	R                   *hexutil.Big          `json:"r"`
-	S                   *hexutil.Big          `json:"s"`
-	YParity             *hexutil.Uint64       `json:"yParity,omitempty"`
+	BlockHash           *common.Hash                 `json:"blockHash"`
+	BlockNumber         *hexutil.Big                 `json:"blockNumber"`
+	From                common.Address               `json:"from"`
+	Gas                 hexutil.Uint64               `json:"gas"`
+	GasPrice            *hexutil.Big                 `json:"gasPrice"`
+	GasFeeCap           *hexutil.Big                 `json:"maxFeePerGas,omitempty"`
+	GasTipCap           *hexutil.Big                 `json:"maxPriorityFeePerGas,omitempty"`
+	MaxFeePerBlobGas    *hexutil.Big                 `json:"maxFeePerBlobGas,omitempty"`
+	Hash                common.Hash                  `json:"hash"`
+	Input               hexutil.Bytes                `json:"input"`
+	Nonce               hexutil.Uint64               `json:"nonce"`
+	To                  *common.Address              `json:"to"`
+	TransactionIndex    *hexutil.Uint64              `json:"transactionIndex"`
+	Value               *hexutil.Big                 `json:"value"`
+	Type                hexutil.Uint64               `json:"type"`
+	Accesses            *types.AccessList            `json:"accessList,omitempty"`
+	ChainID             *hexutil.Big                 `json:"chainId,omitempty"`
+	BlobVersionedHashes []common.Hash                `json:"blobVersionedHashes,omitempty"`
+	AuthorizationList   []types.SetCodeAuthorization `json:"authorizationList,omitempty"`
+	V                   *hexutil.Big                 `json:"v"`
+	R                   *hexutil.Big                 `json:"r"`
+	S                   *hexutil.Big                 `json:"s"`
+	YParity             *hexutil.Uint64              `json:"yParity,omitempty"`
 }
 
 // newRPCTransaction returns a transaction that will serialize to the RPC

--- a/internal/ethapi/transaction_args.go
+++ b/internal/ethapi/transaction_args.go
@@ -73,7 +73,7 @@ type TransactionArgs struct {
 	Proofs      []kzg4844.Proof      `json:"proofs"`
 
 	// For SetCodeTxType
-	AuthorizationList []types.Authorization `json:"authorizationList"`
+	AuthorizationList []types.SetCodeAuthorization `json:"authorizationList"`
 
 	// This configures whether blobs are allowed to be passed.
 	blobSidecarAllowed bool
@@ -497,7 +497,7 @@ func (args *TransactionArgs) ToTransaction(defaultType int) *types.Transaction {
 		if args.AccessList != nil {
 			al = *args.AccessList
 		}
-		authList := []types.Authorization{}
+		authList := []types.SetCodeAuthorization{}
 		if args.AuthorizationList != nil {
 			authList = args.AuthorizationList
 		}

--- a/tests/state_test_util.go
+++ b/tests/state_test_util.go
@@ -441,11 +441,11 @@ func (tx *stTransaction) toMessage(ps stPostState, baseFee *big.Int) (*core.Mess
 	if gasPrice == nil {
 		return nil, errors.New("no gas price provided")
 	}
-	var authList []types.Authorization
+	var authList []types.SetCodeAuthorization
 	if tx.AuthorizationList != nil {
-		authList = make([]types.Authorization, len(tx.AuthorizationList))
+		authList = make([]types.SetCodeAuthorization, len(tx.AuthorizationList))
 		for i, auth := range tx.AuthorizationList {
-			authList[i] = types.Authorization{
+			authList[i] = types.SetCodeAuthorization{
 				ChainID: auth.ChainID,
 				Address: auth.Address,
 				Nonce:   auth.Nonce,


### PR DESCRIPTION
Here I am proposing two small changes to the exported API for EIP-7702:

(1) `Authorization` has a very generic name, but it is in fact only used for one niche use case: authorizing code in a `SetCodeTx`. So I propose calling it `SetCodeAuthorization` instead. The signing function is renamed to `SignSetCode` instead of `SignAuth`.
   
(2) The signing function for authorizations should take key as the first parameter, and the authorization second. The key will almost always be in a variable, while the authorization can be given as a literal. Compare these two invocations:

```go
a, err := types.SignSetCode(types.SetCodeAuthorization{
    ChainID: getChainID(),
    Nonce: getNonce(),
}, key)
```

with

```go
a, err := types.SignSetCode(key, types.SetCodeAuthorization{
    ChainID: getChainID(),
    Nonce: getNonce(),
})
```

I feel like the second one is easier to read.