### PR TITLE
txpool: add SetCode transactions to legacy pool

### DIFF
--- a/core/txpool/legacypool/legacypool.go
+++ b/core/txpool/legacypool/legacypool.go
@@ -276,10 +276,10 @@ func New(config Config, chain BlockChain) *LegacyPool {
 }
 
 // Filter returns whether the given transaction can be consumed by the legacy
-// pool, specifically, whether it is a Legacy, AccessList or Dynamic transaction.
+// pool, specifically, whether it is a Legacy, AccessList, Dynamic or SetCode transaction.
 func (pool *LegacyPool) Filter(tx *types.Transaction) bool {
 	switch tx.Type() {
-	case types.LegacyTxType, types.AccessListTxType, types.DynamicFeeTxType:
+	case types.LegacyTxType, types.AccessListTxType, types.DynamicFeeTxType, types.SetCodeTxType:
 		return true
 	default:
 		return false


### PR DESCRIPTION
This PR adds SetCode transactions to the legacy pool.

rationale: although EIP-7702 introduces a new scenario where the EOA nonce can be incremented, it looks like the transaction pool can still handle addresses with updated nonces by monitoring newly added blocks on the node. This ensures that the nonce of transactions in the transaction pool will not be lower than the account's nonce. So, no changes are needed to the transaction pool's logic.