### PR TITLE
trie: remove redundant comparision in VerifyRangeProof

### DIFF
--- a/trie/proof.go
+++ b/trie/proof.go
@@ -526,9 +526,6 @@ func VerifyRangeProof(rootHash common.Hash, firstKey []byte, keys [][]byte, valu
 		if err != nil {
 			return false, err
 		}
-		if !bytes.Equal(firstKey, keys[0]) {
-			return false, errors.New("correct proof but invalid key")
-		}
 		if !bytes.Equal(val, values[0]) {
 			return false, errors.New("correct proof but invalid data")
 		}


### PR DESCRIPTION
The code was introduced in #21250, where lastKey was passed in by the caller.

In #28331, the logic was modified to take the last element from keys as lastKey.

When keys contains only one element, lastKey is equal to keys[0]. 
After comparing firstKey and lastKey, there is no need to compare firstKey with keys[0] again.
