### PR TITLE
core/vm: nil check memorySize instead of dynamicGas

### DIFF
--- a/core/vm/interpreter.go
+++ b/core/vm/interpreter.go
@@ -258,7 +258,7 @@ func (in *EVMInterpreter) Run(contract *Contract, input []byte, readOnly bool) (
 			contract.Gas -= cost
 		}
 
-		if operation.dynamicGas != nil {
+		if operation.memorySize != nil {
 			// All ops with a dynamic memory usage also has a dynamic gas cost.
 			var memorySize uint64
 			// calculate the new memory size and expand the memory to fit


### PR DESCRIPTION
We have the assumption that if an opcode has memorySize function then it has dynamicGas function. And we check that condition of every opcode in validate function. But in the interpreter, we actually assume that if an opcode has dynamicGas then it has memorySize function. However, it is still correct as every opcode currently have either these 2 functions or none. So this commit is trivial, to make the interpreter consistent with asssumption in validate function to avoid confusion.