### PR TITLE
fix: typos in documentation files

### DIFF
--- a/cmd/clef/rules.md
+++ b/cmd/clef/rules.md
@@ -2,7 +2,7 @@
 
 The `signer` binary contains a ruleset engine, implemented with [OttoVM](https://github.com/robertkrimen/otto)
 
-It enables usecases like the following:
+It enables use cases like the following:
 
 * I want to auto-approve transactions with contract `CasinoDapp`, with up to `0.05 ether` in value to maximum `1 ether` per 24h period
 * I want to auto-approve transaction to contract `EthAlarmClock` with `data`=`0xdeadbeef`, if `value=0`, `gas < 44k` and `gasPrice < 40Gwei`

--- a/cmd/evm/README.md
+++ b/cmd/evm/README.md
@@ -16,7 +16,7 @@ which can
 1. Take a prestate, including
    - Accounts,
    - Block context information,
-   - Previous blockshashes (*optional)
+   - Previous block hashes (*optional)
 2. Apply a set of transactions,
 3. Apply a mining-reward (*optional),
 4. And generate a post-state, including

--- a/cmd/evm/eest.go
+++ b/cmd/evm/eest.go
@@ -22,7 +22,7 @@ import "regexp"
 // within its filename by the execution spec test (EEST).
 type testMetadata struct {
 	fork       string
-	module     string // which python module gnerated the test, e.g. eip7702
+	module     string // which python module generated the test, e.g. eip7702
 	file       string // exact file the test came from, e.g. test_gas.py
 	function   string // func that created the test, e.g. test_valid_mcopy_operations
 	parameters string // the name of the parameters which were used to fill the test, e.g. zero_inputs

--- a/eth/downloader/skeleton.go
+++ b/eth/downloader/skeleton.go
@@ -275,7 +275,7 @@ func (s *skeleton) startup() {
 			for {
 				// If the sync cycle terminated or was terminated, propagate up when
 				// higher layers request termination. There's no fancy explicit error
-				// signalling as the sync loop should never terminate (TM).
+				// signaling as the sync loop should never terminate (TM).
 				newhead, err := s.sync(head)
 				switch {
 				case err == errSyncLinked:

--- a/internal/guide/guide_test.go
+++ b/internal/guide/guide_test.go
@@ -15,7 +15,7 @@
 // along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
 
 // This file contains the code snippets from the developer's guide embedded into
-// Go tests. This ensures that any code published in out guides will not break
+// Go tests. This ensures that any code published in our guides will not break
 // accidentally via some code update. If some API changes nonetheless that needs
 // modifying this file, please port any modification over into the developer's
 // guide wiki pages too!


### PR DESCRIPTION
Corrected `usecases` to `use cases`
Corrected `blockshashes` to `block hashes`
Corrected `gnerated` to `generated`
Corrected `signalling` to `signaling`
Corrected `out` to `our`