### PR TITLE
triedb/pathdb: fix tester generator

### DIFF
--- a/triedb/pathdb/database_test.go
+++ b/triedb/pathdb/database_test.go
@@ -222,7 +222,12 @@ func (t *tester) generate(parent common.Hash) (common.Hash, *trienode.MergedNode
 		dirties = make(map[common.Hash]struct{})
 	)
 	for i := 0; i < 20; i++ {
-		switch rand.Intn(opLen) {
+		// Start with account creation always
+		op := createAccountOp
+		if i > 0 {
+			op = rand.Intn(opLen)
+		}
+		switch op {
 		case createAccountOp:
 			// account creation
 			addr := testrand.Address()


### PR DESCRIPTION
There is a "rare" bug in test generator: If the run is very unlucky it can use `modifyAccountOp` / `deleteAccountOp` without creating any account, leading to have a trie root same as the parent.
This pull request includes a change to the `generate` function in the `database_test.go` file to ensure that account creation 
always occurs first during the test iterations. 

Changes in test logic:

* [`triedb/pathdb/database_test.go`](diffhunk://#diff-aa0965b61dc78a72ef175bc83cacadd7e5f29613ea543f86242a459b7259ccb9L225-R230): Modified the `generate` function to start with account creation in the first iteration, ensuring consistent initial conditions for the test.