### PR TITLE
internal/ethapi: update default simulation timestamp increment to 12

### DIFF
--- a/internal/ethapi/simulate.go
+++ b/internal/ethapi/simulate.go
@@ -45,7 +45,7 @@ const (
 	maxSimulateBlocks = 256
 
 	// timestampIncrement is the default increment between block timestamps.
-	timestampIncrement = 1
+	timestampIncrement = 12
 )
 
 // simBlock is a batch of calls to be simulated sequentially.

--- a/internal/ethapi/simulate_test.go
+++ b/internal/ethapi/simulate_test.go
@@ -41,19 +41,19 @@ func TestSimulateSanitizeBlockOrder(t *testing.T) {
 			baseNumber:    10,
 			baseTimestamp: 50,
 			blocks:        []simBlock{{}, {}, {}},
-			expected:      []result{{number: 11, timestamp: 51}, {number: 12, timestamp: 52}, {number: 13, timestamp: 53}},
+			expected:      []result{{number: 11, timestamp: 62}, {number: 12, timestamp: 74}, {number: 13, timestamp: 86}},
 		},
 		{
 			baseNumber:    10,
 			baseTimestamp: 50,
-			blocks:        []simBlock{{BlockOverrides: &override.BlockOverrides{Number: newInt(13), Time: newUint64(70)}}, {}},
-			expected:      []result{{number: 11, timestamp: 51}, {number: 12, timestamp: 52}, {number: 13, timestamp: 70}, {number: 14, timestamp: 71}},
+			blocks:        []simBlock{{BlockOverrides: &override.BlockOverrides{Number: newInt(13), Time: newUint64(80)}}, {}},
+			expected:      []result{{number: 11, timestamp: 62}, {number: 12, timestamp: 74}, {number: 13, timestamp: 80}, {number: 14, timestamp: 92}},
 		},
 		{
 			baseNumber:    10,
 			baseTimestamp: 50,
 			blocks:        []simBlock{{BlockOverrides: &override.BlockOverrides{Number: newInt(11)}}, {BlockOverrides: &override.BlockOverrides{Number: newInt(14)}}, {}},
-			expected:      []result{{number: 11, timestamp: 51}, {number: 12, timestamp: 52}, {number: 13, timestamp: 53}, {number: 14, timestamp: 54}, {number: 15, timestamp: 55}},
+			expected:      []result{{number: 11, timestamp: 62}, {number: 12, timestamp: 74}, {number: 13, timestamp: 86}, {number: 14, timestamp: 98}, {number: 15, timestamp: 110}},
 		},
 		{
 			baseNumber:    10,
@@ -64,8 +64,8 @@ func TestSimulateSanitizeBlockOrder(t *testing.T) {
 		{
 			baseNumber:    10,
 			baseTimestamp: 50,
-			blocks:        []simBlock{{BlockOverrides: &override.BlockOverrides{Number: newInt(13), Time: newUint64(52)}}},
-			err:           "block timestamps must be in order: 52 <= 52",
+			blocks:        []simBlock{{BlockOverrides: &override.BlockOverrides{Number: newInt(13), Time: newUint64(74)}}},
+			err:           "block timestamps must be in order: 74 <= 74",
 		},
 		{
 			baseNumber:    10,
@@ -76,8 +76,8 @@ func TestSimulateSanitizeBlockOrder(t *testing.T) {
 		{
 			baseNumber:    10,
 			baseTimestamp: 50,
-			blocks:        []simBlock{{BlockOverrides: &override.BlockOverrides{Number: newInt(11), Time: newUint64(60)}}, {BlockOverrides: &override.BlockOverrides{Number: newInt(13), Time: newUint64(61)}}},
-			err:           "block timestamps must be in order: 61 <= 61",
+			blocks:        []simBlock{{BlockOverrides: &override.BlockOverrides{Number: newInt(11), Time: newUint64(60)}}, {BlockOverrides: &override.BlockOverrides{Number: newInt(13), Time: newUint64(72)}}},
+			err:           "block timestamps must be in order: 72 <= 72",
 		},
 	} {
 		sim := &simulator{base: &types.Header{Number: big.NewInt(int64(tc.baseNumber)), Time: tc.baseTimestamp}}


### PR DESCRIPTION
As per https://github.com/ethereum/execution-apis/pull/484/commits/3324ce9301134913a7e156e1721aac34c8301e97 update the default timestamp increment to 12s.