### PR TITLE
ethclient: enhance the description of using block number tags

### DIFF
--- a/ethclient/ethclient.go
+++ b/ethclient/ethclient.go
@@ -90,6 +90,12 @@ func (ec *Client) BlockByHash(ctx context.Context, hash common.Hash) (*types.Blo
 //
 // Note that loading full blocks requires two requests. Use HeaderByNumber
 // if you don't need all transactions or uncle headers.
+// if you want to use tag like earliest, latest, finalized, safe, or finalized, you can use the
+// UnmarshalJSON fuction to get the corresponding number
+// eg:
+// var bn rpc.BlockNumber
+// err := json.Unmarshal([]byte(`"finalized"`), &bn)
+// you will get -3  and you can use for the number param
 func (ec *Client) BlockByNumber(ctx context.Context, number *big.Int) (*types.Block, error) {
 	return ec.getBlock(ctx, "eth_getBlockByNumber", toBlockNumArg(number), true)
 }

--- a/ethclient/ethclient.go
+++ b/ethclient/ethclient.go
@@ -94,6 +94,13 @@ func (ec *Client) BlockByNumber(ctx context.Context, number *big.Int) (*types.Bl
 	return ec.getBlock(ctx, "eth_getBlockByNumber", toBlockNumArg(number), true)
 }
 
+// BlockByNumber returns a block from the current canonical chain. If tag is nil, the
+// latest known block is returned.
+// you can use the special tag earliest, latest, finalized, safe, or finalized.
+func (ec *Client) BlockBySpecialTag(ctx context.Context, tag string) (*types.Block, error) {
+	return ec.getBlock(ctx, "eth_getBlockByNumber", tag, true)
+}
+
 // BlockNumber returns the most recent block number
 func (ec *Client) BlockNumber(ctx context.Context) (uint64, error) {
 	var result hexutil.Uint64

--- a/ethclient/ethclient.go
+++ b/ethclient/ethclient.go
@@ -85,26 +85,25 @@ func (ec *Client) BlockByHash(ctx context.Context, hash common.Hash) (*types.Blo
 	return ec.getBlock(ctx, "eth_getBlockByHash", hash, true)
 }
 
-// BlockByNumber returns a block from the current canonical chain. If number is nil, the
-// latest known block is returned.
+// BlockByNumber returns a block from the current canonical chain.
+// If `number` is nil, the latest known block is returned.
 //
-// Note that loading full blocks requires two requests. Use HeaderByNumber
-// if you don't need all transactions or uncle headers.
-// if you want to use tag like earliest, latest, finalized, safe, or finalized, you can use the
-// UnmarshalJSON fuction to get the corresponding number
-// eg:
-// var bn rpc.BlockNumber
-// err := json.Unmarshal([]byte(`"finalized"`), &bn)
-// you will get -3  and you can use for the number param
+// Use `HeaderByNumber` if you don't need full transaction data or uncle headers.
+//
+// Supported special block number tags:
+// - `earliest`  : The genesis (earliest) block
+// - `latest`    : The most recently included block
+// - `safe`      : The latest safe head block
+// - `finalized` : The latest finalized block
+// - `pending`   : The pending block
+//
+// Example usage:
+//
+// ```go
+// BlockByNumber(context.Background(), big.NewInt(int64(rpc.LatestBlockNumber)))
+// ```
 func (ec *Client) BlockByNumber(ctx context.Context, number *big.Int) (*types.Block, error) {
 	return ec.getBlock(ctx, "eth_getBlockByNumber", toBlockNumArg(number), true)
-}
-
-// BlockByNumber returns a block from the current canonical chain. If tag is nil, the
-// latest known block is returned.
-// you can use the special tag earliest, latest, finalized, safe, or finalized.
-func (ec *Client) BlockBySpecialTag(ctx context.Context, tag string) (*types.Block, error) {
-	return ec.getBlock(ctx, "eth_getBlockByNumber", tag, true)
 }
 
 // BlockNumber returns the most recent block number
@@ -223,8 +222,21 @@ func (ec *Client) HeaderByHash(ctx context.Context, hash common.Hash) (*types.He
 	return head, err
 }
 
-// HeaderByNumber returns a block header from the current canonical chain. If number is
-// nil, the latest known header is returned.
+// HeaderByNumber returns a block header from the current canonical chain.
+// If `number` is nil, the latest known block header is returned.
+//
+// Supported special block number tags:
+// - `earliest`  : The genesis (earliest) block
+// - `latest`    : The most recently included block
+// - `safe`      : The latest safe head block
+// - `finalized` : The latest finalized block
+// - `pending`   : The pending block
+//
+// Example usage:
+//
+// ```go
+// HeaderByNumber(context.Background(), big.NewInt(int64(rpc.LatestBlockNumber)))
+// ```
 func (ec *Client) HeaderByNumber(ctx context.Context, number *big.Int) (*types.Header, error) {
 	var head *types.Header
 	err := ec.c.CallContext(ctx, &head, "eth_getBlockByNumber", toBlockNumArg(number), false)


### PR DESCRIPTION
When querying blocks using special tags, there is no direct method call. It requires delving into the code to find the corresponding number for the special tag and then retrieve the block, which is inconvenient. Therefore, a method was encapsulated to directly query blocks using special tags.