### PR TITLE
miner: remove Miner duplicated pendingMutex

### DIFF
--- a/miner/miner.go
+++ b/miner/miner.go
@@ -72,7 +72,6 @@ type Miner struct {
 	txpool      *txpool.TxPool
 	chain       *core.BlockChain
 	pending     *pending
-	pendingMu   sync.Mutex // Lock protects the pending block
 }
 
 // New creates a new miner with provided config.
@@ -134,8 +133,6 @@ func (miner *Miner) BuildPayload(args *BuildPayloadArgs, witness bool) (*Payload
 // The result might be nil if pending generation is failed.
 func (miner *Miner) getPending() *newPayloadResult {
 	header := miner.chain.CurrentHeader()
-	miner.pendingMu.Lock()
-	defer miner.pendingMu.Unlock()
 	if cached := miner.pending.resolve(header.Hash()); cached != nil {
 		return cached
 	}


### PR DESCRIPTION
# Issue description
The `pendingMu` mutex in the `Miner` struct appears to be redundant as its intended purpose overlaps with the existing `lock` in the `pending` struct.

# Rationale

1.  **`pendingMu` in `Miner`** 

`Miner` contains a `pendingMu   sync.Mutex` to protect `pending` 

https://github.com/ethereum/go-ethereum/blob/a9ab53d751b018ee493b909d520eb5f3daba6734/miner/miner.go#L67-L76

And the `pendingMu` used [here](https://github.com/ethereum/go-ethereum/blob/master/miner/miner.go#L135-L165). the `pendingMu` will protect both `pending.resolve` and `pending.update`

```go
func (miner *Miner) getPending() *newPayloadResult {
	header := miner.chain.CurrentHeader()
	miner.pendingMu.Lock()
	defer miner.pendingMu.Unlock()
   
        if cached := miner.pending.resolve(header.Hash()); cached != nil {
		return cached
	}
	
	// ....
	
	miner.pending.update(header.Hash(), ret)
	return ret
}
```

2. **`lock` in `pending`**

But, the pending struct already has a `sync.Mutex` named `lock`, which protects its internal state, including the `resolve` and `update` methods:

https://github.com/ethereum/go-ethereum/blob/a9ab53d751b018ee493b909d520eb5f3daba6734/miner/pending.go#L32-L37

https://github.com/ethereum/go-ethereum/blob/a9ab53d751b018ee493b909d520eb5f3daba6734/miner/pending.go#L43-L45

https://github.com/ethereum/go-ethereum/blob/a9ab53d751b018ee493b909d520eb5f3daba6734/miner/pending.go#L60-L62

3. **Redundancy**
Since the `lock` in `pending` already ensures thread-safe access to resolve and update, the additional `pendingMu` in the `Miner` struct is unnecessary.
