### PR TITLE
Correction of typos and inaccuracies

### DIFF
--- a/docs/postmortems/2021-08-22-split-postmortem.md
+++ b/docs/postmortems/2021-08-22-split-postmortem.md
@@ -6,7 +6,7 @@ This is a post-mortem concerning the minority split that occurred on Ethereum ma
 
 
 - 2021-08-17: Guido Vranken submitted a bounty report. Investigation started, root cause identified, patch variations discussed. 
-- 2021-08-18: Made public announcement over twitter about upcoming security release upcoming Tuesday. Downstream projects were also notified about the upcoming patch-release.
+- 2021-08-18: Made public announcement over twitter about upcoming security release on Tuesday. Downstream projects were also notified about the upcoming patch-release.
 - 2021-08-24: Released [v1.10.8](https://github.com/ethereum/go-ethereum/releases/tag/v1.10.8) containing the fix on Tuesday morning (CET). Erigon released [v2021.08.04](https://github.com/ledgerwatch/erigon/releases/tag/v2021.08.04).
 - 2021-08-27: At 12:50:07 UTC, issue exploited. Analysis started roughly 30m later, 
 
@@ -18,7 +18,7 @@ This is a post-mortem concerning the minority split that occurred on Ethereum ma
 
 On 2021-08-17, Guido Vranken submitted a report to bounty@ethereum.org. This coincided with a geth-meetup in Berlin, so the geth team could fairly quickly analyse the issue. 
 
-He submitted a proof of concept which called the `dataCopy` precompile, where the input slice and output slice were overlapping but shifted. Doing a `copy` where the `src` and `dest` overlaps is not a problem in itself, however, the `returnData`slice was _also_ using the same memory as a backing-array.
+He submitted a proof of concept which called the `dataCopy` precompile, where the input slice and output slice were overlapping but shifted. Doing a `copy` where the `src` and `dest` overlaps is not a problem in itself, however, the `returnData` slice was _also_ using the same memory as a backing-array.
 
 #### Technical details
 

--- a/tests/fuzzers/README.md
+++ b/tests/fuzzers/README.md
@@ -31,11 +31,10 @@ go-fuzz -bin ./rlp/rlp-fuzz.zip
 
 ### Notes
 
-Once a 'crasher' is found, the fuzzer tries to avoid reporting the same vector twice, so stores the fault in the `suppressions` folder. Thus, if you 
-e.g. make changes to fix a bug, you should _remove_ all data from the `suppressions`-folder, to verify that the issue is indeed resolved. 
+Once a 'crasher' is found, the fuzzer tries to avoid reporting the same vector twice, so it stores the fault in the `suppressions` folder. Thus, if you, for example, make changes to fix a bug, you should _remove_ all data from the `suppressions`-folder, to verify that the issue is indeed resolved. 
 
-Also, if you have only one and the same exit-point for multiple different types of test, the suppression can make the fuzzer hide different types of errors. So make
-sure that each type of failure is unique (for an example, see the rlp fuzzer, where a counter `i` is used to differentiate between failures: 
+Also, if you have only one and the same exit point for multiple different types of test, the suppression can make the fuzzer hide different types of errors. So make
+sure that each type of failure is unique (for example, see the RLP fuzzer, where a counter `i` is used to differentiate between failures: 
 
 ```golang
 		if !bytes.Equal(input, output) {


### PR DESCRIPTION
### Issues and Fixes

1. **"upcoming security release upcoming Tuesday"**  → **"upcoming security release on Tuesday"**
    Repetition of the word "upcoming".  

2. **"the returnDataslice"** → **"the returnData slice"**
    Missing space between "returnData" and "slice".  

3. **"so stores the fault"** → **"so it stores the fault"**  
   Added the missing word "it" for grammatical accuracy.

4. **"if you e.g. make changes"** → **"if you, for example, make changes"**  
   Replaced the abbreviation "e.g." with "for example" for clarity and a more formal tone.

5. **"exit-point"** → **"exit point"**  
   Removed the hyphen, as "exit point" should be written as two separate words.

6. **"for an example"** → **"for example"**  
   Removed "an," as "for example" is a fixed expression and does not require an article.

7. **"rlp fuzzer"** → **"RLP fuzzer"**  
   Changed "rlp" to uppercase "RLP" to reflect proper capitalization, as it is likely an acronym.

These corrections make the text clearer and grammatically accurate.
