### PR TITLE
core/rawdb: check if os.Lstat(datadir) returns error in freezer.

### DIFF
--- a/core/rawdb/freezer.go
+++ b/core/rawdb/freezer.go
@@ -87,6 +87,10 @@ func NewFreezer(datadir string, namespace string, readonly bool, maxTableSize ui
 	)
 	// Ensure the datadir is not a symbolic link if it exists.
 	if info, err := os.Lstat(datadir); !os.IsNotExist(err) {
+		if err != nil {
+			log.Warn("error Lstat the database:", err)
+			return nil, errors.New("lstat failed")
+		}
 		if info == nil {
 			log.Warn("Could not Lstat the database", "path", datadir)
 			return nil, errors.New("lstat failed")


### PR DESCRIPTION
Following up with the PR: [core/rawdb: fix panic in freezer](https://github.com/ethereum/go-ethereum/commit/c5a8d3485191d15363b9817da1afcac3fce5ddeb)

if the info == nil, it is likely the `error != nil` too. So will it also be better to check the `err != nil`? In that way, we could get the error from the log.
