### PR TITLE
Fix minor typo in error message formatting Update signify.go

### DIFF
--- a/crypto/signify/signify.go
+++ b/crypto/signify/signify.go
@@ -32,7 +32,7 @@ import (
 
 var (
 	errInvalidKeyHeader = errors.New("incorrect key header")
-	errInvalidKeyLength = errors.New("invalid, key length != 104")
+	errInvalidKeyLength = errors.New("invalid key length != 104")
 )
 
 func parsePrivateKey(key string) (k ed25519.PrivateKey, header []byte, keyNum []byte, err error) {


### PR DESCRIPTION
While reviewing the error messages, I noticed an extra comma after the word "invalid." This typo could potentially confuse developers when reading logs or debugging issues.

I've removed the redundant comma to ensure the message is clean and consistent. 