### PR TITLE
beacon/engine: check for empty requests

### DIFF
--- a/beacon/engine/types.go
+++ b/beacon/engine/types.go
@@ -265,10 +265,17 @@ func ExecutableDataToBlockNoHash(data ExecutableData, versionedHashes []common.H
 
 	var requestsHash *common.Hash
 	if requests != nil {
+		var last byte
 		for _, req := range requests {
+			// No empty requests.
 			if len(req) < 2 {
 				return nil, fmt.Errorf("empty request: %v", req)
 			}
+			// Check that requests are ordered by their type.
+			if req[0] < last {
+				return nil, fmt.Errorf("invalid request order: %v", req)
+			}
+
 		}
 		h := types.CalcRequestsHash(requests)
 		requestsHash = &h

--- a/beacon/engine/types.go
+++ b/beacon/engine/types.go
@@ -265,6 +265,11 @@ func ExecutableDataToBlockNoHash(data ExecutableData, versionedHashes []common.H
 
 	var requestsHash *common.Hash
 	if requests != nil {
+		for _, req := range requests {
+			if len(req) < 2 {
+				return nil, fmt.Errorf("empty request: %v", req)
+			}
+		}
 		h := types.CalcRequestsHash(requests)
 		requestsHash = &h
 	}

--- a/beacon/engine/types.go
+++ b/beacon/engine/types.go
@@ -275,7 +275,7 @@ func ExecutableDataToBlockNoHash(data ExecutableData, versionedHashes []common.H
 			if req[0] < last {
 				return nil, fmt.Errorf("invalid request order: %v", req)
 			}
-last = req[0]
+			last = req[0]
 		}
 		h := types.CalcRequestsHash(requests)
 		requestsHash = &h

--- a/beacon/engine/types.go
+++ b/beacon/engine/types.go
@@ -265,18 +265,6 @@ func ExecutableDataToBlockNoHash(data ExecutableData, versionedHashes []common.H
 
 	var requestsHash *common.Hash
 	if requests != nil {
-		var last byte
-		for _, req := range requests {
-			// No empty requests.
-			if len(req) < 2 {
-				return nil, fmt.Errorf("empty request: %v", req)
-			}
-			// Check that requests are ordered by their type.
-			if req[0] < last {
-				return nil, fmt.Errorf("invalid request order: %v", req)
-			}
-			last = req[0]
-		}
 		h := types.CalcRequestsHash(requests)
 		requestsHash = &h
 	}

--- a/beacon/engine/types.go
+++ b/beacon/engine/types.go
@@ -275,7 +275,7 @@ func ExecutableDataToBlockNoHash(data ExecutableData, versionedHashes []common.H
 			if req[0] < last {
 				return nil, fmt.Errorf("invalid request order: %v", req)
 			}
-
+last = req[0]
 		}
 		h := types.CalcRequestsHash(requests)
 		requestsHash = &h


### PR DESCRIPTION
According to https://github.com/ethereum/execution-apis/blob/main/src/engine/prague.md#engine_newpayloadv4:

> Elements of the list MUST be ordered by request_type in ascending order. Elements with empty request_data MUST be excluded from the list.