### PR TITLE
eth/tracers/logger: return revert reason

### DIFF
--- a/eth/tracers/logger/logger.go
+++ b/eth/tracers/logger/logger.go
@@ -19,6 +19,7 @@ package logger
 import (
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"maps"
@@ -350,7 +351,7 @@ func (l *StructLogger) GetResult() (json.RawMessage, error) {
 	returnData := common.CopyBytes(l.output)
 	// Return data when successful and revert reason when reverted, otherwise empty.
 	returnVal := fmt.Sprintf("%x", returnData)
-	if failed && l.err != vm.ErrExecutionReverted {
+	if failed && !errors.Is(l.err, vm.ErrExecutionReverted) {
 		returnVal = ""
 	}
 	return json.Marshal(&ExecutionResult{

--- a/eth/tracers/logger/logger_test.go
+++ b/eth/tracers/logger/logger_test.go
@@ -108,3 +108,18 @@ func TestStructLogMarshalingOmitEmpty(t *testing.T) {
 		})
 	}
 }
+
+func TestErrorCompare(t *testing.T) {
+	err := vm.ErrExecutionReverted
+	if err != vm.ErrExecutionReverted {
+		t.Fatal("error compare")
+	}
+	// wrap err and test again
+	err = vm.VMErrorFromErr(err)
+	if err == vm.ErrExecutionReverted { // equality comparison fails
+		t.Fatal("error compare should fail")
+	}
+	if !errors.Is(err, vm.ErrExecutionReverted) { // check all wrapped errors
+		t.Fatal("error compare: err is not a vm.ErrExecutionReverted")
+	}
+}

--- a/eth/tracers/logger/logger_test.go
+++ b/eth/tracers/logger/logger_test.go
@@ -108,18 +108,3 @@ func TestStructLogMarshalingOmitEmpty(t *testing.T) {
 		})
 	}
 }
-
-func TestErrorCompare(t *testing.T) {
-	err := vm.ErrExecutionReverted
-	if err != vm.ErrExecutionReverted {
-		t.Fatal("error compare")
-	}
-	// wrap err and test again
-	err = vm.VMErrorFromErr(err)
-	if err == vm.ErrExecutionReverted { // equality comparison fails
-		t.Fatal("error compare should fail")
-	}
-	if !errors.Is(err, vm.ErrExecutionReverted) { // check all wrapped errors
-		t.Fatal("error compare: err is not a vm.ErrExecutionReverted")
-	}
-}


### PR DESCRIPTION
The logger tracer is dropping data from a revert.
Because of error wrapping the == comparison is not sufficient. errors.Is is needed.