### PR TITLE
build: upgrade golangci-lint to v1.63.4

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -3,9 +3,6 @@
 run:
   timeout: 20m
   tests: true
-  # default is true. Enables skipping of directories:
-  #   vendor$, third_party$, testdata$, examples$, Godeps$, builtin$
-  skip-dirs-use-default: true
 
 linters:
   disable-all: true
@@ -54,6 +51,9 @@ linters-settings:
         exclude: [""]
 
 issues:
+  # default is true. Enables skipping of directories:
+  #   vendor$, third_party$, testdata$, examples$, Godeps$, builtin$
+  exclude-dirs-use-default: true
   exclude-files:
     - core/genesis_alloc.go
   exclude-rules:

--- a/build/checksums.txt
+++ b/build/checksums.txt
@@ -56,37 +56,37 @@ fc77c0531406d092c5356167e45c05a22d16bea84e3fa555e0f03af085c11763  go1.23.4.windo
 8347c1aa4e1e67954d12830f88dbe44bd7ac0ec134bb472783dbfb5a3a8865d0  go1.23.4.windows-arm64.msi
 db69cae5006753c785345c3215ad941f8b6224e2f81fec471c42d6857bee0e6f  go1.23.4.windows-arm64.zip
 
-# version:golangci 1.61.0
+# version:golangci 1.63.4
 # https://github.com/golangci/golangci-lint/releases/
-# https://github.com/golangci/golangci-lint/releases/download/v1.61.0/
-5c280ef3284f80c54fd90d73dc39ca276953949da1db03eb9dd0fbf868cc6e55  golangci-lint-1.61.0-darwin-amd64.tar.gz
-544334890701e4e04a6e574bc010bea8945205c08c44cced73745a6378012d36  golangci-lint-1.61.0-darwin-arm64.tar.gz
-e885a6f561092055930ebd298914d80e8fd2e10d2b1e9942836c2c6a115301fa  golangci-lint-1.61.0-freebsd-386.tar.gz
-b13f6a3f11f65e7ff66b734d7554df3bbae0f485768848424e7554ed289e19c2  golangci-lint-1.61.0-freebsd-amd64.tar.gz
-cd8e7bbe5b8f33ed1597aa1cc588da96a3b9f22e1b9ae60d93511eae1a0ee8c5  golangci-lint-1.61.0-freebsd-armv6.tar.gz
-7ade524dbd88bd250968f45e190af90e151fa5ee63dd6aa7f7bb90e8155db61d  golangci-lint-1.61.0-freebsd-armv7.tar.gz
-0fe3cd8a1ed8d9f54f48670a5af3df056d6040d94017057f0f4d65c930660ad9  golangci-lint-1.61.0-illumos-amd64.tar.gz
-b463fc5053a612abd26393ebaff1d85d7d56058946f4f0f7bf25ed44ea899415  golangci-lint-1.61.0-linux-386.tar.gz
-77cb0af99379d9a21d5dc8c38364d060e864a01bd2f3e30b5e8cc550c3a54111  golangci-lint-1.61.0-linux-amd64.tar.gz
-af60ac05566d9351615cb31b4cc070185c25bf8cbd9b09c1873aa5ec6f3cc17e  golangci-lint-1.61.0-linux-arm64.tar.gz
-1f307f2fcc5d7d674062a967a0d83a7091e300529aa237ec6ad2b3dd14c897f5  golangci-lint-1.61.0-linux-armv6.tar.gz
-3ad8cbaae75a547450844811300f99c4cd290277398e43d22b9eb1792d15af4c  golangci-lint-1.61.0-linux-armv7.tar.gz
-9be2ca67d961d7699079739cf6f7c8291c5183d57e34d1677de21ca19d0bd3ed  golangci-lint-1.61.0-linux-loong64.tar.gz
-90d005e1648115ebf0861b408eab9c936079a24763e883058b0a227cd3135d31  golangci-lint-1.61.0-linux-mips64.tar.gz
-6d2ed4f49407115460b8c10ccfc40fd177e0887a48864a2879dd16e84ba2a48c  golangci-lint-1.61.0-linux-mips64le.tar.gz
-633089589af5a58b7430afb6eee107d4e9c99e8d91711ddc219eb13a07e8d3b8  golangci-lint-1.61.0-linux-ppc64le.tar.gz
-4c1a097d9e0d1b4a8144dae6a1f5583a38d662f3bdc1498c4e954b6ed856be98  golangci-lint-1.61.0-linux-riscv64.tar.gz
-30581d3c987d287b7064617f1a2694143e10dffc40bc25be6636006ee82d7e1c  golangci-lint-1.61.0-linux-s390x.tar.gz
-42530bf8100bd43c07f5efe6d92148ba6c5a7a712d510c6f24be85af6571d5eb  golangci-lint-1.61.0-netbsd-386.tar.gz
-b8bb07c920f6601edf718d5e82ec0784fd590b0992b42b6ec18da99f26013ed4  golangci-lint-1.61.0-netbsd-amd64.tar.gz
-353a51527c60bd0776b0891b03f247c791986f625fca689d121972c624e54198  golangci-lint-1.61.0-netbsd-arm64.tar.gz
-957a6272c3137910514225704c5dac0723b9c65eb7d9587366a997736e2d7580  golangci-lint-1.61.0-netbsd-armv6.tar.gz
-a89eb28ff7f18f5cd52b914739360fa95cf2f643de4adeca46e26bec3a07e8d8  golangci-lint-1.61.0-netbsd-armv7.tar.gz
-d8d74c43600b271393000717a4ed157d7a15bb85bab7db2efad9b63a694d4634  golangci-lint-1.61.0-windows-386.zip
-e7bc2a81929a50f830244d6d2e657cce4f19a59aff49fa9000176ff34fda64ce  golangci-lint-1.61.0-windows-amd64.zip
-ed97c221596dd771e3dd9344872c140340bee2e819cd7a90afa1de752f1f2e0f  golangci-lint-1.61.0-windows-arm64.zip
-4b365233948b13d02d45928a5c390045e00945e919747b9887b5f260247541ae  golangci-lint-1.61.0-windows-armv6.zip
-595538fb64d152173959d28f6235227f9cd969a828e5af0c4e960d02af4ffd0e  golangci-lint-1.61.0-windows-armv7.zip
+# https://github.com/golangci/golangci-lint/releases/download/v1.63.4/
+878d017cc360e4fb19510d39852c8189852e3c48e7ce0337577df73507c97d68  golangci-lint-1.63.4-darwin-amd64.tar.gz
+a2b630c2ac8466393f0ccbbede4462387b6c190697a70bc2298c6d2123f21bbf  golangci-lint-1.63.4-darwin-arm64.tar.gz
+8938b74aa92888e561a1c5a4c175110b92f84e7d24733703e6d9ebc39e9cd5f8  golangci-lint-1.63.4-freebsd-386.tar.gz
+054903339d620df2e760b978920100986e3b03bcb058f669d520a71dac9c34ed  golangci-lint-1.63.4-freebsd-amd64.tar.gz
+a19d499f961a02608348e8b626537a88edfaab6e1b6534f1eff742b5d6d750e4  golangci-lint-1.63.4-freebsd-armv6.tar.gz
+00d616f0fb275b780ce4d26604bdd7fdbfe6bc9c63acd5a0b31498e1f7511108  golangci-lint-1.63.4-freebsd-armv7.tar.gz
+d453688e0eabded3c1a97ff5a2777bb0df5a18851efdaaaf6b472e3e5713c33e  golangci-lint-1.63.4-illumos-amd64.tar.gz
+6b1bec847fc9f347d53712d05606a49d55d0e3b5c1bacadfed2393f3503de0e9  golangci-lint-1.63.4-linux-386.tar.gz
+01abb14a4df47b5ca585eff3c34b105023cba92ec34ff17212dbb83855581690  golangci-lint-1.63.4-linux-amd64.tar.gz
+51f0c79d19a92353e0465fb30a4901a0644a975d34e6f399ad2eebc0160bbb24  golangci-lint-1.63.4-linux-arm64.tar.gz
+8d0a43f41e8424fbae10f7aa2dc29999f98112817c6dba63d7dc76832940a673  golangci-lint-1.63.4-linux-armv6.tar.gz
+1045a047b31e9302c9160c7b0f199f4ac1bd02a1b221a2d9521bd3507f0cf671  golangci-lint-1.63.4-linux-armv7.tar.gz
+933fe10ab50ce3bb0806e15a4ae69fe20f0549abf91dea0161236000ca706e67  golangci-lint-1.63.4-linux-loong64.tar.gz
+45798630cbad5642862766051199fa862ef3c33d569cab12f01cac4f68e2ddd5  golangci-lint-1.63.4-linux-mips64.tar.gz
+86ae25335ddb24975d2c915c1af0c7fad70dce99d0b4614fa4bee392de714aa2  golangci-lint-1.63.4-linux-mips64le.tar.gz
+33dabd11aaba4b602938da98bcf49aabab55019557e0115cdc3dbcc3009768fa  golangci-lint-1.63.4-linux-ppc64le.tar.gz
+4e7a81230a663bcdf30bba5689ce96040abc76994dbc2003dce32c8dca8c06f3  golangci-lint-1.63.4-linux-riscv64.tar.gz
+21370b49c7c47f4d9b8f982c952f940b01e65710174c3b4dad7b6452d58f92ec  golangci-lint-1.63.4-linux-s390x.tar.gz
+255866a6464c7e11bb7edd8e6e6ad54f11e1f01b82ba9ca229698ac788cd9724  golangci-lint-1.63.4-netbsd-386.tar.gz
+2798c040ac658bda97224f204795199c81ac97bb207b21c02b664aaed380d5d2  golangci-lint-1.63.4-netbsd-amd64.tar.gz
+b910eecffd0064103837e7e1abe870deb8ade22331e6dffe319f430d49399c8e  golangci-lint-1.63.4-netbsd-arm64.tar.gz
+df2693ef37147b457c3e2089614537dd2ae2e18e53641e756a5b404f4c72d3fa  golangci-lint-1.63.4-netbsd-armv6.tar.gz
+a28a533366974bd7834c4516cd6075bff3419a508d1ed7aa63ae8182768b352e  golangci-lint-1.63.4-netbsd-armv7.tar.gz
+368932775fb5c620b324dabf018155f3365f5e33c5af5b26e9321db373f96eea  golangci-lint-1.63.4-windows-386.zip
+184d13c2b8f5441576bec2a0d8ba7b2d45445595cf796b879a73bcc98c39f8c1  golangci-lint-1.63.4-windows-amd64.zip
+4fabf175d5b05ef0858ded49527948eebac50e9093814979fd84555a75fb80a6  golangci-lint-1.63.4-windows-arm64.zip
+e92be3f3ff30d4a849fb4b9a4c8d56837dee45269cb405a3ecad52fa034c781b  golangci-lint-1.63.4-windows-armv6.zip
+c71d348653b8f7fbb109bb10c1a481722bc6b0b2b6e731b897f99ac869f7653e  golangci-lint-1.63.4-windows-armv7.zip
 
 # This is the builder on PPA that will build Go itself (inception-y), don't modify!
 #

--- a/core/txpool/blobpool/blobpool.go
+++ b/core/txpool/blobpool/blobpool.go
@@ -1751,7 +1751,7 @@ func (p *BlobPool) Clear() {
 	// The transaction addition may attempt to reserve the sender addr which
 	// can't happen until Clear releases the reservation lock.  Clear cannot
 	// acquire the subpool lock until the transaction addition is completed.
-	for acct, _ := range p.index {
+	for acct := range p.index {
 		p.reserve(acct, false)
 	}
 	p.lookup = newLookup()

--- a/core/txpool/legacypool/legacypool.go
+++ b/core/txpool/legacypool/legacypool.go
@@ -1986,7 +1986,7 @@ func (pool *LegacyPool) Clear() {
 		senderAddr, _ := types.Sender(pool.signer, tx)
 		pool.reserve(senderAddr, false)
 	}
-	for localSender, _ := range pool.locals.accounts {
+	for localSender := range pool.locals.accounts {
 		pool.reserve(localSender, false)
 	}
 


### PR DESCRIPTION
This PR upgrades `golangci-lint` to v1.63.4 and fixes a warn message which is reported by v1.63.4:

```text
WARN [config_reader] The configuration option `run.skip-dirs-use-default` is deprecated, please use `issues.exclude-dirs-use-default`.
```

Also fixes 2 warnings which are reported by v1.63.4:

```text
core/txpool/blobpool/blobpool.go:1754:12: S1005: unnecessary assignment to the blank identifier (gosimple)
        for acct, _ := range p.index {
                  ^
core/txpool/legacypool/legacypool.go:1989:19: S1005: unnecessary assignment to the blank identifier (gosimple)
        for localSender, _ := range pool.locals.accounts {
                         ^
```