### PR TITLE
core/txpool/legacypool: ensure pending nonces are reset by SubPool.Clear

### DIFF
--- a/core/txpool/legacypool/legacypool.go
+++ b/core/txpool/legacypool/legacypool.go
@@ -1994,6 +1994,7 @@ func (pool *LegacyPool) Clear() {
 	pool.priced = newPricedList(pool.all)
 	pool.pending = make(map[common.Address]*list)
 	pool.queue = make(map[common.Address]*list)
+	pool.pendingNonces = newNoncer(pool.currentState)
 
 	if !pool.config.NoLocals && pool.config.Journal != "" {
 		pool.journal = newTxJournal(pool.config.Journal)

--- a/ethclient/simulated/backend_test.go
+++ b/ethclient/simulated/backend_test.go
@@ -37,8 +37,10 @@ import (
 var _ bind.ContractBackend = (Client)(nil)
 
 var (
-	testKey, _ = crypto.HexToECDSA("b71c71a67e1177ad4e901695e1b4b9ee17ae16c6668d313eac2f96dbcda3f291")
-	testAddr   = crypto.PubkeyToAddress(testKey.PublicKey)
+	testKey, _  = crypto.HexToECDSA("b71c71a67e1177ad4e901695e1b4b9ee17ae16c6668d313eac2f96dbcda3f291")
+	testAddr    = crypto.PubkeyToAddress(testKey.PublicKey)
+	testKey2, _ = crypto.HexToECDSA("7ee346e3f7efc685250053bfbafbfc880d58dc6145247053d4fb3cb0f66dfcb2")
+	testAddr2   = crypto.PubkeyToAddress(testKey2.PublicKey)
 )
 
 func simTestBackend(testAddr common.Address) *Backend {

--- a/ethclient/simulated/backend_test.go
+++ b/ethclient/simulated/backend_test.go
@@ -20,12 +20,13 @@ import (
 	"context"
 	"crypto/ecdsa"
 	"crypto/sha256"
-	"github.com/ethereum/go-ethereum/crypto/kzg4844"
-	"github.com/holiman/uint256"
 	"math/big"
 	"math/rand"
 	"testing"
 	"time"
+
+	"github.com/ethereum/go-ethereum/crypto/kzg4844"
+	"github.com/holiman/uint256"
 
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"

--- a/ethclient/simulated/rollback_test.go
+++ b/ethclient/simulated/rollback_test.go
@@ -1,0 +1,107 @@
+package simulated
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/ethereum/go-ethereum/core/types"
+)
+
+// TestTransactionRollbackBehavior verifies the behavior of transactions
+// in the simulated backend after rollback operations.
+//
+// The test demonstrates that after a rollback:
+//  1. The first test shows normal transaction processing without rollback
+//  2. The second test shows that transactions immediately after rollback fail
+//  3. The third test shows a workaround: committing an empty block after rollback
+//     makes subsequent transactions succeed
+func TestTransactionRollbackBehavior(t *testing.T) {
+	sim := simTestBackend(testAddr)
+	defer sim.Close()
+	client := sim.Client()
+
+	t.Run("Case 1: Basic Transaction (Control Case)", func(t *testing.T) {
+		// Demonstrates normal transaction processing works as expected
+		tx := testSendSignedTx(t, sim)
+		sim.Commit()
+		assertSuccessfulReceipt(t, client, tx)
+	})
+
+	t.Run("Case 2: Transaction After Rollback (Shows Issue)", func(t *testing.T) {
+		// First transaction gets rolled back
+		_ = testSendSignedTx(t, sim)
+		sim.Rollback()
+
+		// Attempting to process a new transaction immediately after rollback
+		// Currently, this case fails to get a valid receipt
+		tx := testSendSignedTx(t, sim)
+		sim.Commit()
+		assertSuccessfulReceipt(t, client, tx)
+	})
+
+	t.Run("Case 3: Transaction After Rollback with Empty Block (Workaround)", func(t *testing.T) {
+		// First transaction gets rolled back
+		_ = testSendSignedTx(t, sim)
+		sim.Rollback()
+
+		// Workaround: Commit an empty block after rollback
+		sim.Commit()
+
+		// Now the new transaction succeeds
+		tx := testSendSignedTx(t, sim)
+		sim.Commit()
+		assertSuccessfulReceipt(t, client, tx)
+	})
+}
+
+// testSendSignedTx sends a signed transaction to the simulated backend.
+// It does not commit the block.
+func testSendSignedTx(t *testing.T, sim *Backend) *types.Transaction {
+	t.Helper()
+	client := sim.Client()
+	ctx := context.Background()
+
+	signedTx, err := newTx(sim, testKey)
+	if err != nil {
+		t.Fatalf("failed to create transaction: %v", err)
+	}
+
+	if err = client.SendTransaction(ctx, signedTx); err != nil {
+		t.Fatalf("failed to send transaction: %v", err)
+	}
+
+	return signedTx
+}
+
+// assertSuccessfulReceipt verifies that a transaction was successfully processed
+// by checking its receipt status.
+func assertSuccessfulReceipt(t *testing.T, client Client, tx *types.Transaction) {
+	t.Helper()
+	ctx := context.Background()
+
+	var (
+		receipt *types.Receipt
+		err     error
+	)
+
+	// Poll for receipt with timeout
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		receipt, err = client.TransactionReceipt(ctx, tx.Hash())
+		if err == nil && receipt != nil {
+			break
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+
+	if err != nil {
+		t.Fatalf("failed to get transaction receipt: %v", err)
+	}
+	if receipt == nil {
+		t.Fatal("transaction receipt is nil")
+	}
+	if receipt.Status != types.ReceiptStatusSuccessful {
+		t.Fatalf("transaction failed with status: %v", receipt.Status)
+	}
+}

--- a/ethclient/simulated/rollback_test.go
+++ b/ethclient/simulated/rollback_test.go
@@ -70,8 +70,7 @@ func testSendSignedTx(t *testing.T, key *ecdsa.PrivateKey, sim *Backend, isBlobT
 	return signedTx
 }
 
-// assertSuccessfulReceipt verifies that a transaction was successfully included as of the pending state
-// by checking its receipt status.
+// pendingStateHasTx returns true if a given transaction was successfully included as of the latest pending state.
 func pendingStateHasTx(client Client, tx *types.Transaction) bool {
 	ctx := context.Background()
 


### PR DESCRIPTION
closes https://github.com/ethereum/go-ethereum/issues/30842