### PR TITLE
core: use sync.Once for SenderCacher initialization

### DIFF
--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -1616,7 +1616,7 @@ func (bc *BlockChain) insertChain(chain types.Blocks, setHead bool, makeWitness 
 		return nil, 0, nil
 	}
 	// Start a parallel signature recovery (signer will fluke on fork transition, minimal perf loss)
-	GetSenderCacher().RecoverFromBlocks(types.MakeSigner(bc.chainConfig, chain[0].Number(), chain[0].Time()), chain)
+	SenderCacher().RecoverFromBlocks(types.MakeSigner(bc.chainConfig, chain[0].Number(), chain[0].Time()), chain)
 
 	var (
 		stats     = insertStats{startTime: mclock.Now()}

--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -1616,7 +1616,7 @@ func (bc *BlockChain) insertChain(chain types.Blocks, setHead bool, makeWitness 
 		return nil, 0, nil
 	}
 	// Start a parallel signature recovery (signer will fluke on fork transition, minimal perf loss)
-	SenderCacher.RecoverFromBlocks(types.MakeSigner(bc.chainConfig, chain[0].Number(), chain[0].Time()), chain)
+	GetSenderCacher().RecoverFromBlocks(types.MakeSigner(bc.chainConfig, chain[0].Number(), chain[0].Time()), chain)
 
 	var (
 		stats     = insertStats{startTime: mclock.Now()}

--- a/core/sender_cacher.go
+++ b/core/sender_cacher.go
@@ -31,10 +31,10 @@ var (
 	senderCacherInstance = newTxSenderCacher(runtime.NumCPU())
 )
 
-// GetSenderCacher returns the singleton instance of SenderCacher.
+// SenderCacher returns the singleton instance of SenderCacher.
 // If the instance has not been initialized yet, it will be created using newTxSenderCacher.
 // This function is thread-safe and ensures that initialization happens only once.
-func GetSenderCacher() *txSenderCacher {
+func SenderCacher() *txSenderCacher {
 	senderCacherOnce.Do(func() {
 		senderCacherInstance = newTxSenderCacher(runtime.NumCPU())
 	})

--- a/core/sender_cacher.go
+++ b/core/sender_cacher.go
@@ -28,7 +28,7 @@ var (
 	// It leverages sync.Once to provide thread-safe lazy initialization.
 	senderCacherOnce sync.Once
 	// senderCacherInstance is a concurrent transaction sender recoverer and cacher.
-	senderCacherInstance = newTxSenderCacher(runtime.NumCPU())
+	senderCacherInstance *txSenderCacher
 )
 
 // SenderCacher returns the singleton instance of SenderCacher.

--- a/core/sender_cacher.go
+++ b/core/sender_cacher.go
@@ -23,22 +23,15 @@ import (
 	"github.com/ethereum/go-ethereum/core/types"
 )
 
-var (
-	// senderCacherOnce is used to ensure that the SenderCacher is initialized only once.
-	// It leverages sync.Once to provide thread-safe lazy initialization.
-	senderCacherOnce sync.Once
-	// senderCacherInstance is a concurrent transaction sender recoverer and cacher.
-	senderCacherInstance *txSenderCacher
-)
+// senderCacherOnce is used to ensure that the SenderCacher is initialized only once.
+var senderCacherOnce = sync.OnceValue(func() *txSenderCacher {
+	return newTxSenderCacher(runtime.NumCPU())
+})
 
-// SenderCacher returns the singleton instance of SenderCacher.
-// If the instance has not been initialized yet, it will be created using newTxSenderCacher.
+// SenderCacher returns the singleton instance of SenderCacher, initializing it if called for the first time.
 // This function is thread-safe and ensures that initialization happens only once.
 func SenderCacher() *txSenderCacher {
-	senderCacherOnce.Do(func() {
-		senderCacherInstance = newTxSenderCacher(runtime.NumCPU())
-	})
-	return senderCacherInstance
+	return senderCacherOnce()
 }
 
 // txSenderCacherRequest is a request for recovering transaction senders with a

--- a/core/txpool/legacypool/legacypool.go
+++ b/core/txpool/legacypool/legacypool.go
@@ -1440,7 +1440,7 @@ func (pool *LegacyPool) reset(oldHead, newHead *types.Header) {
 
 	// Inject any transactions discarded due to reorgs
 	log.Debug("Reinjecting stale transactions", "count", len(reinject))
-	core.GetSenderCacher().Recover(pool.signer, reinject)
+	core.SenderCacher().Recover(pool.signer, reinject)
 	pool.addTxsLocked(reinject, false)
 }
 

--- a/core/txpool/legacypool/legacypool.go
+++ b/core/txpool/legacypool/legacypool.go
@@ -1440,7 +1440,7 @@ func (pool *LegacyPool) reset(oldHead, newHead *types.Header) {
 
 	// Inject any transactions discarded due to reorgs
 	log.Debug("Reinjecting stale transactions", "count", len(reinject))
-	core.SenderCacher.Recover(pool.signer, reinject)
+	core.GetSenderCacher().Recover(pool.signer, reinject)
 	pool.addTxsLocked(reinject, false)
 }
 


### PR DESCRIPTION
This pull request focuses on refactoring the `SenderCacher` initialization and usage to ensure thread-safe lazy initialization. The changes include modifying the way `SenderCacher` is accessed and updating relevant function calls.

Key changes include:

### Benefits of Avoiding Global Initialization for SenderCacher

* By not creating the `SenderCacher` instance globally on startup, created on-demand
* More thread Safety

### Refactoring `SenderCacher` initialization:

* [`core/sender_cacher.go`](diffhunk://#diff-dd52cbf4eef8ac1b1a73b870d766707497a7ee4e69b90c4ee3e1b0e25e54b041R21-R42): Introduced a singleton pattern for `SenderCacher` using `sync.Once` to ensure thread-safe lazy initialization. Added the `GetSenderCacher` function to return the singleton instance.

### Updating function calls to use the new `GetSenderCacher` method:

* [`core/blockchain.go`](diffhunk://#diff-53d5f4b8a536ec2a8c8c92bf70b8268f1d77ad77e9f316e6f68a2bcae5303215L1619-R1619): Updated the `insertChain` function to use `GetSenderCacher` instead of directly accessing `SenderCacher`.
* [`core/txpool/legacypool/legacypool.go`](diffhunk://#diff-3b03ebf997a1699ce8e84a53a4b3981e403e74e2f90128eb188ad4226703970cL1443-R1443): Modified the `reset` function in `LegacyPool` to use `GetSenderCacher` for recovering senders.