### PR TITLE
core/txpool:  terminate subpool reset goroutine if pool was closed

### DIFF
--- a/core/txpool/txpool.go
+++ b/core/txpool/txpool.go
@@ -224,7 +224,12 @@ func (p *TxPool) loop(head *types.Header, chain BlockChain) {
 					for _, subpool := range p.subpools {
 						subpool.Reset(oldHead, newHead)
 					}
-					resetDone <- newHead
+					select {
+					case resetDone <- newHead:
+						break
+					case <-p.term:
+						return
+					}
 				}(oldHead, newHead)
 
 				// If the reset operation was explicitly requested, consider it

--- a/core/txpool/txpool.go
+++ b/core/txpool/txpool.go
@@ -226,9 +226,7 @@ func (p *TxPool) loop(head *types.Header, chain BlockChain) {
 					}
 					select {
 					case resetDone <- newHead:
-						break
 					case <-p.term:
-						return
 					}
 				}(oldHead, newHead)
 


### PR DESCRIPTION
if the pool terminates before `resetDone` can be read, then the go-routine will hang.