### PR TITLE
ethdb/memorydb: faster DeleteRange

### DIFF
--- a/ethdb/memorydb/memorydb.go
+++ b/ethdb/memorydb/memorydb.go
@@ -126,6 +126,9 @@ func (db *Database) Delete(key []byte) error {
 func (db *Database) DeleteRange(start, end []byte) error {
 	db.lock.Lock()
 	defer db.lock.Unlock()
+	if db.db == nil {
+		return errMemorydbClosed
+	}
 
 	for key := range db.db {
 		if key >= string(start) && key < string(end) {

--- a/ethdb/memorydb/memorydb.go
+++ b/ethdb/memorydb/memorydb.go
@@ -18,7 +18,6 @@
 package memorydb
 
 import (
-	"bytes"
 	"errors"
 	"sort"
 	"strings"
@@ -125,12 +124,12 @@ func (db *Database) Delete(key []byte) error {
 // DeleteRange deletes all of the keys (and values) in the range [start,end)
 // (inclusive on start, exclusive on end).
 func (db *Database) DeleteRange(start, end []byte) error {
-	it := db.NewIterator(nil, start)
-	defer it.Release()
+	db.lock.Lock()
+	defer db.lock.Unlock()
 
-	for it.Next() && bytes.Compare(end, it.Key()) > 0 {
-		if err := db.Delete(it.Key()); err != nil {
-			return err
+	for key := range db.db {
+		if key >= string(start) && key < string(end) {
+			delete(db.db, key)
 		}
 	}
 	return nil


### PR DESCRIPTION
This PR replaces the iterator based DeleteRange implementation of memorydb with a simpler and much faster loop that directly deletes keys in the order of iteration instead of unnecessarily collecting keys in memory and sorting them.