### PR TITLE
core/state: Ensure Exist method returns true for self-destructed accounts

### DIFF
--- a/core/state/statedb.go
+++ b/core/state/statedb.go
@@ -294,7 +294,7 @@ func (s *StateDB) SubRefund(gas uint64) {
 // Exist reports whether the given account address exists in the state.
 // Notably this also returns true for self-destructed accounts.
 func (s *StateDB) Exist(addr common.Address) bool {
-	return s.getStateObject(addr) != nil
+	return s.getStateObject(addr) != nil || s.stateObjectsDestruct[addr] != nil
 }
 
 // Empty returns whether the state object is either non-existent


### PR DESCRIPTION
This PR fixes the `Exist` method in `StateDB` to correctly return `true` for self-destructed accounts, aligning the implementation with the method's documentation.

### Problem
The original documentation for the `Exist` method states:

> **"Notably this also returns true for self-destructed accounts."**

But the `getStateObject` method returns `nil` for accounts that have been self-destructed or deleted during execution.

### Changes:
- Updated the `Exist` method to check the `stateObjectsDestruct` map.