### PR TITLE
Typo fix README.md

### DIFF
--- a/cmd/evm/README.md
+++ b/cmd/evm/README.md
@@ -27,7 +27,7 @@ which can
 ### Specification
 
 The idea is to specify the behaviour of this binary very _strict_, so that other
-node implementors can build replicas based on their own state-machines, and the
+node implementers can build replicas based on their own state-machines, and the
 state generators can swap between a \`geth\`-based implementation and a \`parityvm\`-based
 implementation.
 


### PR DESCRIPTION
# Pull Request: Typo Fix in `README.md`

## Description

This pull request corrects a minor typo in the `cmd/evm/README.md` file. The word **"implementors"** has been replaced with **"implementers"** to align with standard terminology and improve clarity.

## Changes Made

- Replaced **"implementors"** with **"implementers"** in `cmd/evm/README.md`.

