### PR TITLE
cmd/abigen: make one of `--abi` or `--combined-json` be required

### DIFF
--- a/cmd/abigen/main.go
+++ b/cmd/abigen/main.go
@@ -98,8 +98,12 @@ func abigen(c *cli.Context) error {
 	if c.String(pkgFlag.Name) == "" {
 		utils.Fatalf("No destination package specified (--pkg)")
 	}
-	if c.String(abiFlag.Name) == "" {
-		utils.Fatalf("No contract ABI source specified (--abi)")
+	if c.String(abiFlag.Name) == "" && c.String(jsonFlag.Name) == "" {
+		utils.Fatalf("Either contract ABI source (--abi) or combined-json (--combined-json) are required")
+	}
+	
+	if c.String(abiFlag.Name) != "" && c.String(jsonFlag.Name) != "" {
+		utils.Fatalf("contract ABI source (--abi) and combined-json (--combined-json) are mutually-exclusive")
 	}
 	var lang bind.Lang
 	switch c.String(langFlag.Name) {

--- a/cmd/abigen/main.go
+++ b/cmd/abigen/main.go
@@ -98,6 +98,9 @@ func abigen(c *cli.Context) error {
 	if c.String(pkgFlag.Name) == "" {
 		utils.Fatalf("No destination package specified (--pkg)")
 	}
+	if c.String(abiFlag.Name) == "" {
+		utils.Fatalf("No contract ABI source specified (--abi)")
+	}
 	var lang bind.Lang
 	switch c.String(langFlag.Name) {
 	case "go":

--- a/cmd/abigen/main.go
+++ b/cmd/abigen/main.go
@@ -101,10 +101,6 @@ func abigen(c *cli.Context) error {
 	if c.String(abiFlag.Name) == "" && c.String(jsonFlag.Name) == "" {
 		utils.Fatalf("Either contract ABI source (--abi) or combined-json (--combined-json) are required")
 	}
-	
-	if c.String(abiFlag.Name) != "" && c.String(jsonFlag.Name) != "" {
-		utils.Fatalf("contract ABI source (--abi) and combined-json (--combined-json) are mutually-exclusive")
-	}
 	var lang bind.Lang
 	switch c.String(langFlag.Name) {
 	case "go":


### PR DESCRIPTION
This PR addresses issue #30768 , which highlights that running cmd/abigen/abigen --pkg my_package example.json (erroneously omitting the --abi flag) generates an empty binding, when it should fail explicitly.

Changes

--abi flag is now mandatory when running abigen command and fail explicitly if it is missing

If theses changes are good, I’d be happy to continue familiarizing myself with the project and contributing to it!