### PR TITLE
core: fix TestStateProcessorErrors test

### DIFF
--- a/core/state_processor_test.go
+++ b/core/state_processor_test.go
@@ -97,7 +97,6 @@ func TestStateProcessorErrors(t *testing.T) {
 	}
 	var mkBlobTx = func(nonce uint64, to common.Address, gasLimit uint64, gasTipCap, gasFeeCap, blobGasFeeCap *big.Int, hashes []common.Hash) *types.Transaction {
 		tx, err := types.SignTx(types.NewTx(&types.BlobTx{
-			ChainID:    new(uint256.Int),
 			Nonce:      nonce,
 			GasTipCap:  uint256.MustFromBig(gasTipCap),
 			GasFeeCap:  uint256.MustFromBig(gasFeeCap),
@@ -114,7 +113,6 @@ func TestStateProcessorErrors(t *testing.T) {
 	}
 	var mkSetCodeTx = func(nonce uint64, to common.Address, gasLimit uint64, gasTipCap, gasFeeCap *big.Int, authlist []types.SetCodeAuthorization) *types.Transaction {
 		tx, err := types.SignTx(types.NewTx(&types.SetCodeTx{
-			ChainID:   new(uint256.Int),
 			Nonce:     nonce,
 			GasTipCap: uint256.MustFromBig(gasTipCap),
 			GasFeeCap: uint256.MustFromBig(gasFeeCap),

--- a/core/state_processor_test.go
+++ b/core/state_processor_test.go
@@ -97,6 +97,7 @@ func TestStateProcessorErrors(t *testing.T) {
 	}
 	var mkBlobTx = func(nonce uint64, to common.Address, gasLimit uint64, gasTipCap, gasFeeCap, blobGasFeeCap *big.Int, hashes []common.Hash) *types.Transaction {
 		tx, err := types.SignTx(types.NewTx(&types.BlobTx{
+			ChainID:    new(uint256.Int),
 			Nonce:      nonce,
 			GasTipCap:  uint256.MustFromBig(gasTipCap),
 			GasFeeCap:  uint256.MustFromBig(gasFeeCap),
@@ -113,6 +114,7 @@ func TestStateProcessorErrors(t *testing.T) {
 	}
 	var mkSetCodeTx = func(nonce uint64, to common.Address, gasLimit uint64, gasTipCap, gasFeeCap *big.Int, authlist []types.SetCodeAuthorization) *types.Transaction {
 		tx, err := types.SignTx(types.NewTx(&types.SetCodeTx{
+			ChainID:   new(uint256.Int),
 			Nonce:     nonce,
 			GasTipCap: uint256.MustFromBig(gasTipCap),
 			GasFeeCap: uint256.MustFromBig(gasFeeCap),

--- a/core/types/transaction_signing.go
+++ b/core/types/transaction_signing.go
@@ -219,7 +219,7 @@ func (s pragueSigner) SignatureValues(tx *Transaction, sig []byte) (R, S, V *big
 	}
 	// Check that chain ID of tx matches the signer. We also accept ID zero here,
 	// because it indicates that the chain ID was not specified in the tx.
-	if txdata.ChainID.Sign() != 0 && txdata.ChainID.CmpBig(s.chainId) != 0 {
+	if tx.ChainId().Sign() != 0 && tx.ChainId().Cmp(s.chainId) != 0 {
 		return nil, nil, nil, fmt.Errorf("%w: have %d want %d", ErrInvalidChainId, txdata.ChainID, s.chainId)
 	}
 	R, S, _ = decodeSignature(sig)
@@ -287,7 +287,7 @@ func (s cancunSigner) SignatureValues(tx *Transaction, sig []byte) (R, S, V *big
 	}
 	// Check that chain ID of tx matches the signer. We also accept ID zero here,
 	// because it indicates that the chain ID was not specified in the tx.
-	if txdata.ChainID.Sign() != 0 && txdata.ChainID.CmpBig(s.chainId) != 0 {
+	if tx.ChainId().Sign() != 0 && tx.ChainId().Cmp(s.chainId) != 0 {
 		return nil, nil, nil, fmt.Errorf("%w: have %d want %d", ErrInvalidChainId, txdata.ChainID, s.chainId)
 	}
 	R, S, _ = decodeSignature(sig)

--- a/core/types/transaction_signing.go
+++ b/core/types/transaction_signing.go
@@ -219,7 +219,10 @@ func (s pragueSigner) SignatureValues(tx *Transaction, sig []byte) (R, S, V *big
 	}
 	// Check that chain ID of tx matches the signer. We also accept ID zero here,
 	// because it indicates that the chain ID was not specified in the tx.
-	if tx.ChainId().Sign() != 0 && tx.ChainId().Cmp(s.chainId) != 0 {
+	if txdata.ChainID == nil {
+		return nil, nil, nil, fmt.Errorf("%w: chainID not set", ErrInvalidChainId)
+	}
+	if txdata.ChainID.Sign() != 0 && txdata.ChainID.CmpBig(s.chainId) != 0 {
 		return nil, nil, nil, fmt.Errorf("%w: have %d want %d", ErrInvalidChainId, txdata.ChainID, s.chainId)
 	}
 	R, S, _ = decodeSignature(sig)
@@ -287,7 +290,10 @@ func (s cancunSigner) SignatureValues(tx *Transaction, sig []byte) (R, S, V *big
 	}
 	// Check that chain ID of tx matches the signer. We also accept ID zero here,
 	// because it indicates that the chain ID was not specified in the tx.
-	if tx.ChainId().Sign() != 0 && tx.ChainId().Cmp(s.chainId) != 0 {
+	if txdata.ChainID == nil {
+		return nil, nil, nil, fmt.Errorf("%w: chainID not set", ErrInvalidChainId)
+	}
+	if txdata.ChainID.Sign() != 0 && txdata.ChainID.CmpBig(s.chainId) != 0 {
 		return nil, nil, nil, fmt.Errorf("%w: have %d want %d", ErrInvalidChainId, txdata.ChainID, s.chainId)
 	}
 	R, S, _ = decodeSignature(sig)

--- a/core/types/tx_blob.go
+++ b/core/types/tx_blob.go
@@ -150,8 +150,13 @@ func (tx *BlobTx) copy() TxData {
 }
 
 // accessors for innerTx.
-func (tx *BlobTx) txType() byte           { return BlobTxType }
-func (tx *BlobTx) chainID() *big.Int      { return tx.ChainID.ToBig() }
+func (tx *BlobTx) txType() byte { return BlobTxType }
+func (tx *BlobTx) chainID() *big.Int {
+	if tx.ChainID == nil {
+		return new(big.Int)
+	}
+	return tx.ChainID.ToBig()
+}
 func (tx *BlobTx) accessList() AccessList { return tx.AccessList }
 func (tx *BlobTx) data() []byte           { return tx.Data }
 func (tx *BlobTx) gas() uint64            { return tx.Gas }

--- a/core/types/tx_setcode.go
+++ b/core/types/tx_setcode.go
@@ -179,8 +179,13 @@ func (tx *SetCodeTx) copy() TxData {
 }
 
 // accessors for innerTx.
-func (tx *SetCodeTx) txType() byte           { return SetCodeTxType }
-func (tx *SetCodeTx) chainID() *big.Int      { return tx.ChainID.ToBig() }
+func (tx *SetCodeTx) txType() byte { return SetCodeTxType }
+func (tx *SetCodeTx) chainID() *big.Int {
+	if tx.ChainID == nil {
+		return new(big.Int)
+	}
+	return tx.ChainID.ToBig()
+}
 func (tx *SetCodeTx) accessList() AccessList { return tx.AccessList }
 func (tx *SetCodeTx) data() []byte           { return tx.Data }
 func (tx *SetCodeTx) gas() uint64            { return tx.Gas }


### PR DESCRIPTION
https://github.com/ethereum/go-ethereum/pull/31032 was merged under the assumption that chainID will never be nil in our code (since that is checked during unmarshalling). However during some hand-constructed tests, we kept the chainID unset, which resulted in a panic'ing test