### PR TITLE
eth/filters:  ensure filter api timeout loop terminates with filter event system termination

### DIFF
--- a/eth/filters/api.go
+++ b/eth/filters/api.go
@@ -90,7 +90,11 @@ func (api *FilterAPI) timeoutLoop(timeout time.Duration) {
 	ticker := time.NewTicker(timeout)
 	defer ticker.Stop()
 	for {
-		<-ticker.C
+		select {
+		case <-ticker.C:
+		case <-api.events.chainSub.Err():
+			return
+		}
 		api.filtersMu.Lock()
 		for id, f := range api.filters {
 			select {


### PR DESCRIPTION
Discovered from failing test introduced https://github.com/ethereum/go-ethereum/pull/31033 .  We should ensure `timeoutLoop` terminates if the filter event system is terminated.