### PR TITLE
go.mod: remove toolchain line

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,8 +2,6 @@ module github.com/ethereum/go-ethereum
 
 go 1.22
 
-toolchain go1.22.0
-
 require (
 	github.com/Azure/azure-sdk-for-go/sdk/storage/azblob v1.2.0
 	github.com/Microsoft/go-winio v0.6.2


### PR DESCRIPTION
We have our own system for downloading the toolchain, and really don't want Go's to get in the way of that. We may switch to Go's builtin toolchain support, but not now.