### PR TITLE
triedb/pathdb: fix state revert on v2 history

### DIFF
--- a/triedb/pathdb/database_test.go
+++ b/triedb/pathdb/database_test.go
@@ -527,7 +527,7 @@ func TestDisable(t *testing.T) {
 		maxDiffLayers = 128
 	}()
 
-	tester := newTester(t, 0, false, 12)
+	tester := newTester(t, 0, false, 32)
 	defer tester.release()
 
 	stored := crypto.Keccak256Hash(rawdb.ReadAccountTrieNode(tester.db.diskdb, nil))

--- a/triedb/pathdb/database_test.go
+++ b/triedb/pathdb/database_test.go
@@ -73,10 +73,10 @@ const (
 
 type genctx struct {
 	stateRoot     common.Hash
-	accounts      map[common.Hash][]byte
-	storages      map[common.Hash]map[common.Hash][]byte
-	accountOrigin map[common.Address][]byte
-	storageOrigin map[common.Address]map[common.Hash][]byte
+	accounts      map[common.Hash][]byte                    // Keyed by the hash of account address
+	storages      map[common.Hash]map[common.Hash][]byte    // Keyed by the hash of account address and the hash of storage key
+	accountOrigin map[common.Address][]byte                 // Keyed by the account address
+	storageOrigin map[common.Address]map[common.Hash][]byte // Keyed by the account address and the hash of storage key
 	nodes         *trienode.MergedNodeSet
 }
 
@@ -113,22 +113,23 @@ type tester struct {
 	preimages map[common.Hash][]byte
 
 	// current state set
-	accounts map[common.Hash][]byte
-	storages map[common.Hash]map[common.Hash][]byte
+	accounts map[common.Hash][]byte                 // Keyed by the hash of account address
+	storages map[common.Hash]map[common.Hash][]byte // Keyed by the hash of account address and the hash of storage key
 
 	// state snapshots
-	snapAccounts map[common.Hash]map[common.Hash][]byte
-	snapStorages map[common.Hash]map[common.Hash]map[common.Hash][]byte
+	snapAccounts map[common.Hash]map[common.Hash][]byte                 // Keyed by the hash of account address
+	snapStorages map[common.Hash]map[common.Hash]map[common.Hash][]byte // Keyed by the hash of account address and the hash of storage key
 }
 
-func newTester(t *testing.T, historyLimit uint64, isVerkle bool) *tester {
+func newTester(t *testing.T, historyLimit uint64, isVerkle bool, layers int) *tester {
 	var (
 		disk, _ = rawdb.NewDatabaseWithFreezer(rawdb.NewMemoryDatabase(), t.TempDir(), "", false)
 		db      = New(disk, &Config{
 			StateHistory:    historyLimit,
-			CleanCacheSize:  16 * 1024,
-			WriteBufferSize: 16 * 1024,
+			CleanCacheSize:  256 * 1024,
+			WriteBufferSize: 256 * 1024,
 		}, isVerkle)
+
 		obj = &tester{
 			db:           db,
 			preimages:    make(map[common.Hash][]byte),
@@ -138,7 +139,7 @@ func newTester(t *testing.T, historyLimit uint64, isVerkle bool) *tester {
 			snapStorages: make(map[common.Hash]map[common.Hash]map[common.Hash][]byte),
 		}
 	)
-	for i := 0; i < 12; i++ {
+	for i := 0; i < layers; i++ {
 		var parent = types.EmptyRootHash
 		if len(obj.roots) != 0 {
 			parent = obj.roots[len(obj.roots)-1]
@@ -264,11 +265,11 @@ func (t *tester) generate(parent common.Hash, rawStorageKey bool) (common.Hash, 
 			addr := testrand.Address()
 			addrHash := crypto.Keccak256Hash(addr.Bytes())
 
-			// short circuit if the account was already existent
+			// Short circuit if the account was already existent
 			if _, ok := t.accounts[addrHash]; ok {
 				continue
 			}
-			// short circuit if the account has been modified within the same transition
+			// Short circuit if the account has been modified within the same transition
 			if _, ok := dirties[addrHash]; ok {
 				continue
 			}
@@ -448,7 +449,7 @@ func TestDatabaseRollback(t *testing.T) {
 	}()
 
 	// Verify state histories
-	tester := newTester(t, 0, false)
+	tester := newTester(t, 0, false, 32)
 	defer tester.release()
 
 	if err := tester.verifyHistory(); err != nil {
@@ -482,7 +483,7 @@ func TestDatabaseRecoverable(t *testing.T) {
 	}()
 
 	var (
-		tester = newTester(t, 0, false)
+		tester = newTester(t, 0, false, 12)
 		index  = tester.bottomIndex()
 	)
 	defer tester.release()
@@ -526,7 +527,7 @@ func TestDisable(t *testing.T) {
 		maxDiffLayers = 128
 	}()
 
-	tester := newTester(t, 0, false)
+	tester := newTester(t, 0, false, 12)
 	defer tester.release()
 
 	stored := crypto.Keccak256Hash(rawdb.ReadAccountTrieNode(tester.db.diskdb, nil))
@@ -568,7 +569,7 @@ func TestCommit(t *testing.T) {
 		maxDiffLayers = 128
 	}()
 
-	tester := newTester(t, 0, false)
+	tester := newTester(t, 0, false, 12)
 	defer tester.release()
 
 	if err := tester.db.Commit(tester.lastHash(), false); err != nil {
@@ -598,7 +599,7 @@ func TestJournal(t *testing.T) {
 		maxDiffLayers = 128
 	}()
 
-	tester := newTester(t, 0, false)
+	tester := newTester(t, 0, false, 12)
 	defer tester.release()
 
 	if err := tester.db.Journal(tester.lastHash()); err != nil {
@@ -628,7 +629,7 @@ func TestCorruptedJournal(t *testing.T) {
 		maxDiffLayers = 128
 	}()
 
-	tester := newTester(t, 0, false)
+	tester := newTester(t, 0, false, 12)
 	defer tester.release()
 
 	if err := tester.db.Journal(tester.lastHash()); err != nil {
@@ -676,7 +677,7 @@ func TestTailTruncateHistory(t *testing.T) {
 		maxDiffLayers = 128
 	}()
 
-	tester := newTester(t, 10, false)
+	tester := newTester(t, 10, false, 12)
 	defer tester.release()
 
 	tester.db.Close()

--- a/triedb/pathdb/disklayer.go
+++ b/triedb/pathdb/disklayer.go
@@ -302,6 +302,10 @@ func (dl *diskLayer) revert(h *history) (*diskLayer, error) {
 	if err != nil {
 		return nil, err
 	}
+	// Derive the state modification set from the history, keyed by the hash
+	// of the account address and the storage key.
+	accounts, storages := h.stateSet()
+
 	// Mark the diskLayer as stale before applying any mutations on top.
 	dl.lock.Lock()
 	defer dl.lock.Unlock()
@@ -314,7 +318,6 @@ func (dl *diskLayer) revert(h *history) (*diskLayer, error) {
 	// needs to be reverted is not yet flushed and cached in node
 	// buffer, otherwise, manipulate persistent state directly.
 	if !dl.buffer.empty() {
-		accounts, storages := h.stateSet()
 		err := dl.buffer.revertTo(dl.db.diskdb, nodes, accounts, storages)
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
State history v2 has been shipped and will take effect after the Cancun fork. 
However, the state revert function does not differentiate between v1 and v2, 
instead blindly using the storage map key for state reversion. 

This mismatch between the keys of the live state set and the state history 
can trigger a panic: `non-existent storage slot for reverting`.

This flaw has been fixed in this PR.