### PR TITLE
Add tracing methods **(TraceTransaction, TraceCall, TraceBlock, TraceChain)**

### DIFF
--- a/ethclient/ethclient.go
+++ b/ethclient/ethclient.go
@@ -29,6 +29,7 @@ import (
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/rpc"
+	"github.com/ethereum/go-ethereum/eth/tracers"
 )
 
 // Client defines typed wrappers for the Ethereum RPC API.

--- a/ethclient/ethclient.go
+++ b/ethclient/ethclient.go
@@ -66,6 +66,13 @@ func (c *Client) TraceCall(ctx context.Context, callArgs interface{}) (*tracers.
 	return &result, err
 }
 
+// TraceTransaction: fetches a specific transaction
+func (c *Client) TraceTransaction(ctx context.Context, txHash string) (*tracers.TraceResult, error) {
+    var result tracers.TraceResult
+    err := c.rpcClient.CallContext(ctx, &result, "debug_traceTransaction", txHash, nil)
+    return &result, err
+}
+
 
 // Close closes the underlying RPC connection.
 func (ec *Client) Close() {

--- a/ethclient/ethclient.go
+++ b/ethclient/ethclient.go
@@ -50,10 +50,22 @@ func DialContext(ctx context.Context, rawurl string) (*Client, error) {
 	return NewClient(c), nil
 }
 
+type Client struct {
+	rpcClient *rpc.Client
+}
+
 // NewClient creates a client that uses the given RPC client.
 func NewClient(c *rpc.Client) *Client {
 	return &Client{c}
 }
+
+// TraceCall: for call operation
+func (c *Client) TraceCall(ctx context.Context, callArgs interface{}) (*tracers.TraceResult, error) {
+	var result tracers.TraceResult
+	err := c.rpcClient.CallContext(ctx, &result, "debug_traceCall", callArgs)
+	return &result, err
+}
+
 
 // Close closes the underlying RPC connection.
 func (ec *Client) Close() {

--- a/ethclient/ethclient.go
+++ b/ethclient/ethclient.go
@@ -73,6 +73,20 @@ func (c *Client) TraceTransaction(ctx context.Context, txHash string) (*tracers.
     return &result, err
 }
 
+// TraceBlock: fetches the trace for a specific block
+func (c *Client) TraceBlock(ctx context.Context, blockHash string) (*tracers.TraceResult, error) {
+    var result tracers.TraceResult
+    err := c.rpcClient.CallContext(ctx, &result, "debug_traceBlock", blockHash)
+    return &result, err
+}
+
+// TraceChain: fetches the trace for a chain
+func (c *Client) TraceChain(ctx context.Context, blockHash string, count int) ([]*tracers.TraceResult, error) {
+    var result []*tracers.TraceResult
+    err := c.rpcClient.CallContext(ctx, &result, "debug_traceChain", blockHash, count)
+    return result, err
+}
+
 
 // Close closes the underlying RPC connection.
 func (ec *Client) Close() {

--- a/ethclient/ethclient_test.go
+++ b/ethclient/ethclient_test.go
@@ -39,6 +39,7 @@ import (
 	"github.com/ethereum/go-ethereum/node"
 	"github.com/ethereum/go-ethereum/params"
 	"github.com/ethereum/go-ethereum/rpc"
+	 "github.com/ethereum/go-ethereum/eth/tracers"
 )
 
 // Verify that Client implements the ethereum interfaces.
@@ -684,4 +685,62 @@ func ExampleRevertErrorData() {
 	// Output:
 	// revert: 08c379a00000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000000a75736572206572726f72
 	// message: user error
+}
+
+func TestTracing(t *testing.T) {
+	rpcClient := getRPCClient(t)
+	client := NewClient(rpcClient)
+
+	t.Run("TraceTransaction", func(t *testing.T) {
+		txHash := testTx1.Hash()
+
+		result, err := client.TraceTransaction(context.Background(), txHash.Hex())
+		if err != nil {
+			t.Fatalf("Failed to trace transaction: %v", err)
+		}
+
+		assert.NotNil(t, result, "Trace result should not be nil")
+		t.Logf("Trace Transaction Result: %+v", result)
+	})
+
+	t.Run("TraceCall", func(t *testing.T) {
+		callArgs := map[string]interface{}{
+			"from": testAddr,
+			"to":   revertContractAddr,
+			"data": revertCode,
+		}
+
+		result, err := client.TraceCall(context.Background(), callArgs)
+		if err != nil {
+			t.Fatalf("Failed to trace call: %v", err)
+		}
+
+		assert.NotNil(t, result, "Trace result should not be nil")
+		t.Logf("Trace Call Result: %+v", result)
+	})
+
+	t.Run("TraceBlock", func(t *testing.T) {
+		blockHash := common.HexToHash(testKey)
+
+		result, err := client.TraceBlock(context.Background(), blockHash.Hex())
+		if err != nil {
+			t.Fatalf("Failed to trace block: %v", err)
+		}
+
+		assert.NotNil(t, result, "Trace result should not be nil")
+		t.Logf("Trace Block Result: %+v", result)
+	})
+
+	t.Run("TraceChain", func(t *testing.T) {
+		blockHash := common.HexToHash(testKey)
+		count := 10
+
+		result, err := client.TraceChain(context.Background(), blockHash.Hex(), count)
+		if err != nil {
+			t.Fatalf("Failed to trace chain: %v", err)
+		}
+
+		assert.NotNil(t, result, "Trace result should not be nil")
+		t.Logf("Trace Chain Result: %+v", result)
+	})
 }


### PR DESCRIPTION
Resolves: #28182

Added `TraceTransaction`, `TraceCall`, `TraceBlock`, and `TraceChain` methods to `ethclient`, with a single test case using an RPC URL for flexibility across networks.