### PR TITLE
core/vm: simplify tracer hook invocation in interpreter loop

### DIFF
--- a/core/vm/interpreter.go
+++ b/core/vm/interpreter.go
@@ -291,7 +291,6 @@ func (in *EVMInterpreter) Run(contract *Contract, input []byte, readOnly bool) (
 				contract.Gas -= dynamicCost
 			}
 
-
 		}
 		// Do tracing before potential memory expansion
 		if debug {

--- a/core/vm/interpreter.go
+++ b/core/vm/interpreter.go
@@ -258,9 +258,9 @@ func (in *EVMInterpreter) Run(contract *Contract, input []byte, readOnly bool) (
 			contract.Gas -= cost
 		}
 
+		// All ops with a dynamic memory usage also has a dynamic gas cost.
+		var memorySize uint64
 		if operation.dynamicGas != nil {
-			// All ops with a dynamic memory usage also has a dynamic gas cost.
-			var memorySize uint64
 			// calculate the new memory size and expand the memory to fit
 			// the operation
 			// Memory check needs to be done prior to evaluating the dynamic gas portion,
@@ -291,20 +291,10 @@ func (in *EVMInterpreter) Run(contract *Contract, input []byte, readOnly bool) (
 				contract.Gas -= dynamicCost
 			}
 
-			// Do tracing before memory expansion
-			if debug {
-				if in.evm.Config.Tracer.OnGasChange != nil {
-					in.evm.Config.Tracer.OnGasChange(gasCopy, gasCopy-cost, tracing.GasChangeCallOpCode)
-				}
-				if in.evm.Config.Tracer.OnOpcode != nil {
-					in.evm.Config.Tracer.OnOpcode(pc, byte(op), gasCopy, cost, callContext, in.returnData, in.evm.depth, VMErrorFromErr(err))
-					logged = true
-				}
-			}
-			if memorySize > 0 {
-				mem.Resize(memorySize)
-			}
-		} else if debug {
+
+		}
+		// Do tracing before memory expansion
+		if debug {
 			if in.evm.Config.Tracer.OnGasChange != nil {
 				in.evm.Config.Tracer.OnGasChange(gasCopy, gasCopy-cost, tracing.GasChangeCallOpCode)
 			}
@@ -312,6 +302,9 @@ func (in *EVMInterpreter) Run(contract *Contract, input []byte, readOnly bool) (
 				in.evm.Config.Tracer.OnOpcode(pc, byte(op), gasCopy, cost, callContext, in.returnData, in.evm.depth, VMErrorFromErr(err))
 				logged = true
 			}
+		}
+		if memorySize > 0 {
+			mem.Resize(memorySize)
 		}
 
 		// execute the operation

--- a/core/vm/interpreter.go
+++ b/core/vm/interpreter.go
@@ -293,7 +293,7 @@ func (in *EVMInterpreter) Run(contract *Contract, input []byte, readOnly bool) (
 
 
 		}
-		// Do tracing before memory expansion
+		// Do tracing before potential memory expansion
 		if debug {
 			if in.evm.Config.Tracer.OnGasChange != nil {
 				in.evm.Config.Tracer.OnGasChange(gasCopy, gasCopy-cost, tracing.GasChangeCallOpCode)

--- a/core/vm/interpreter.go
+++ b/core/vm/interpreter.go
@@ -290,7 +290,6 @@ func (in *EVMInterpreter) Run(contract *Contract, input []byte, readOnly bool) (
 			} else {
 				contract.Gas -= dynamicCost
 			}
-
 		}
 
 		// Do tracing before potential memory expansion

--- a/core/vm/interpreter.go
+++ b/core/vm/interpreter.go
@@ -292,6 +292,7 @@ func (in *EVMInterpreter) Run(contract *Contract, input []byte, readOnly bool) (
 			}
 
 		}
+
 		// Do tracing before potential memory expansion
 		if debug {
 			if in.evm.Config.Tracer.OnGasChange != nil {


### PR DESCRIPTION
Removes duplicate code in the interpreter loop.

The tradeoff is an additional conditional check in the hot loop of the interpreter, but this should not have a measurable performance impact.  I can run the benchmarks to verify this at a later time.