### PR TITLE
p2p/nat: properly propagate internal address error in AddMapping

### DIFF
--- a/p2p/nat/natupnp.go
+++ b/p2p/nat/natupnp.go
@@ -82,7 +82,7 @@ func (n *upnp) ExternalIP() (addr net.IP, err error) {
 func (n *upnp) AddMapping(protocol string, extport, intport int, desc string, lifetime time.Duration) (uint16, error) {
 	ip, err := n.internalAddress()
 	if err != nil {
-		return 0, nil // TODO: Shouldn't we return the error?
+		return 0, err
 	}
 	protocol = strings.ToUpper(protocol)
 	lifetimeS := uint32(lifetime / time.Second)


### PR DESCRIPTION
The AddMapping method was silently ignoring errors when getting the internal
address, which could lead to unexpected behavior. Now it properly propagates
the error to the caller, making error handling more robust and transparent.

Fixes TODO comment in natupnp.go.