### PR TITLE
website: Fix incorrect objects page redirect

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -192,12 +192,7 @@
 
 [[redirects]]
   from = "/docs/rpc/objects"
-  to = "/docs"
-  force = true
-
-[[redirects]]
-  from = "/docs/interacting-with-geth/rpc/objects"
-  to = "/docs"
+  to = "/docs/interacting-with-geth/rpc/objects"
   force = true
 
 [[redirects]]

--- a/redirects.js
+++ b/redirects.js
@@ -183,12 +183,7 @@ const redirects = [
   },
   {
     source: '/docs/rpc/objects',
-    destination: '/docs',
-    permanent: true
-  },
-  {
-    source: '/docs/interacting-with-geth/rpc/objects',
-    destination: '/docs',
+    destination: '/docs/interacting-with-geth/rpc/objects',
     permanent: true
   },
   {


### PR DESCRIPTION
Deletes a previous forced redirect of the objects page and updates the intended redirect to the correct one

Fixes #30214 