### PR TITLE
core: copy genesis before modifying

### DIFF
--- a/core/genesis.go
+++ b/core/genesis.go
@@ -281,9 +281,14 @@ func SetupGenesisBlock(db ethdb.Database, triedb *triedb.Database, genesis *Gene
 }
 
 func SetupGenesisBlockWithOverride(db ethdb.Database, triedb *triedb.Database, origGenesis *Genesis, overrides *ChainOverrides) (*params.ChainConfig, common.Hash, *params.ConfigCompatError, error) {
+	// Copy the genesis, so we can operate on a copy.
+	var genesis *Genesis
+	if origGenesis != nil {
+		genesis = new(Genesis)
+		*genesis = *origGenesis
+	}
 	// Sanitize the supplied genesis, ensuring it has the associated chain
 	// config attached.
-	genesis := origGenesis.copy()
 	if genesis != nil && genesis.Config == nil {
 		return nil, common.Hash{}, nil, errGenesisNoConfig
 	}
@@ -549,19 +554,6 @@ func (g *Genesis) MustCommit(db ethdb.Database, triedb *triedb.Database) *types.
 		panic(err)
 	}
 	return block
-}
-
-// copy copies the genesis.
-func (g *Genesis) copy() *Genesis {
-	if g != nil {
-		cpy := *g
-		if g.Config != nil {
-			conf := *g.Config
-			cpy.Config = &conf
-		}
-		return &cpy
-	}
-	return nil
 }
 
 // EnableVerkleAtGenesis indicates whether the verkle fork should be activated

--- a/core/genesis.go
+++ b/core/genesis.go
@@ -280,9 +280,10 @@ func SetupGenesisBlock(db ethdb.Database, triedb *triedb.Database, genesis *Gene
 	return SetupGenesisBlockWithOverride(db, triedb, genesis, nil)
 }
 
-func SetupGenesisBlockWithOverride(db ethdb.Database, triedb *triedb.Database, genesis *Genesis, overrides *ChainOverrides) (*params.ChainConfig, common.Hash, *params.ConfigCompatError, error) {
+func SetupGenesisBlockWithOverride(db ethdb.Database, triedb *triedb.Database, origGenesis *Genesis, overrides *ChainOverrides) (*params.ChainConfig, common.Hash, *params.ConfigCompatError, error) {
 	// Sanitize the supplied genesis, ensuring it has the associated chain
 	// config attached.
+	genesis := origGenesis.Copy()
 	if genesis != nil && genesis.Config == nil {
 		return nil, common.Hash{}, nil, errGenesisNoConfig
 	}
@@ -548,6 +549,19 @@ func (g *Genesis) MustCommit(db ethdb.Database, triedb *triedb.Database) *types.
 		panic(err)
 	}
 	return block
+}
+
+// Copy copies the genesis.
+func (g *Genesis) Copy() *Genesis {
+	if g != nil {
+		cpy := *g
+		if g.Config != nil {
+			conf := *g.Config
+			cpy.Config = &conf
+		}
+		return &cpy
+	}
+	return nil
 }
 
 // EnableVerkleAtGenesis indicates whether the verkle fork should be activated

--- a/core/genesis.go
+++ b/core/genesis.go
@@ -551,7 +551,7 @@ func (g *Genesis) MustCommit(db ethdb.Database, triedb *triedb.Database) *types.
 	return block
 }
 
-// Copy copies the genesis.
+// copy copies the genesis.
 func (g *Genesis) copy() *Genesis {
 	if g != nil {
 		cpy := *g

--- a/core/genesis.go
+++ b/core/genesis.go
@@ -75,6 +75,19 @@ type Genesis struct {
 	BlobGasUsed   *uint64     `json:"blobGasUsed"`   // EIP-4844
 }
 
+// copy copies the genesis.
+func (g *Genesis) copy() *Genesis {
+	if g != nil {
+		cpy := *g
+		if g.Config != nil {
+			conf := *g.Config
+			cpy.Config = &conf
+		}
+		return &cpy
+	}
+	return nil
+}
+
 func ReadGenesis(db ethdb.Database) (*Genesis, error) {
 	var genesis Genesis
 	stored := rawdb.ReadCanonicalHash(db, 0)
@@ -248,21 +261,17 @@ type ChainOverrides struct {
 }
 
 // apply applies the chain overrides on the supplied chain config.
-func (o *ChainOverrides) apply(cfg *params.ChainConfig) (*params.ChainConfig, error) {
+func (o *ChainOverrides) apply(cfg *params.ChainConfig) error {
 	if o == nil || cfg == nil {
-		return cfg, nil
+		return nil
 	}
-	cpy := *cfg
 	if o.OverrideCancun != nil {
-		cpy.CancunTime = o.OverrideCancun
+		cfg.CancunTime = o.OverrideCancun
 	}
 	if o.OverrideVerkle != nil {
-		cpy.VerkleTime = o.OverrideVerkle
+		cfg.VerkleTime = o.OverrideVerkle
 	}
-	if err := cpy.CheckConfigForkOrder(); err != nil {
-		return nil, err
-	}
-	return &cpy, nil
+	return cfg.CheckConfigForkOrder()
 }
 
 // SetupGenesisBlock writes or updates the genesis block in db.
@@ -280,13 +289,9 @@ func SetupGenesisBlock(db ethdb.Database, triedb *triedb.Database, genesis *Gene
 	return SetupGenesisBlockWithOverride(db, triedb, genesis, nil)
 }
 
-func SetupGenesisBlockWithOverride(db ethdb.Database, triedb *triedb.Database, origGenesis *Genesis, overrides *ChainOverrides) (*params.ChainConfig, common.Hash, *params.ConfigCompatError, error) {
+func SetupGenesisBlockWithOverride(db ethdb.Database, triedb *triedb.Database, genesis *Genesis, overrides *ChainOverrides) (*params.ChainConfig, common.Hash, *params.ConfigCompatError, error) {
 	// Copy the genesis, so we can operate on a copy.
-	var genesis *Genesis
-	if origGenesis != nil {
-		genesis = new(Genesis)
-		*genesis = *origGenesis
-	}
+	genesis = genesis.copy()
 	// Sanitize the supplied genesis, ensuring it has the associated chain
 	// config attached.
 	if genesis != nil && genesis.Config == nil {
@@ -301,17 +306,15 @@ func SetupGenesisBlockWithOverride(db ethdb.Database, triedb *triedb.Database, o
 		} else {
 			log.Info("Writing custom genesis block")
 		}
-		chainCfg, err := overrides.apply(genesis.Config)
-		if err != nil {
+		if err := overrides.apply(genesis.Config); err != nil {
 			return nil, common.Hash{}, nil, err
 		}
-		genesis.Config = chainCfg
 
 		block, err := genesis.Commit(db, triedb)
 		if err != nil {
 			return nil, common.Hash{}, nil, err
 		}
-		return chainCfg, block.Hash(), nil, nil
+		return genesis.Config, block.Hash(), nil, nil
 	}
 	// Commit the genesis if the genesis block exists in the ancient database
 	// but the key-value database is empty without initializing the genesis
@@ -328,11 +331,9 @@ func SetupGenesisBlockWithOverride(db ethdb.Database, triedb *triedb.Database, o
 		} else {
 			log.Info("Writing custom genesis block")
 		}
-		chainCfg, err := overrides.apply(genesis.Config)
-		if err != nil {
+		if err := overrides.apply(genesis.Config); err != nil {
 			return nil, common.Hash{}, nil, err
 		}
-		genesis.Config = chainCfg
 
 		if hash := genesis.ToBlock().Hash(); hash != ghash {
 			return nil, common.Hash{}, nil, &GenesisMismatchError{ghash, hash}
@@ -341,17 +342,15 @@ func SetupGenesisBlockWithOverride(db ethdb.Database, triedb *triedb.Database, o
 		if err != nil {
 			return nil, common.Hash{}, nil, err
 		}
-		return chainCfg, block.Hash(), nil, nil
+		return genesis.Config, block.Hash(), nil, nil
 	}
 	// The genesis block has already been committed previously. Verify that the
 	// provided genesis with chain overrides matches the existing one, and update
 	// the stored chain config if necessary.
 	if genesis != nil {
-		chainCfg, err := overrides.apply(genesis.Config)
-		if err != nil {
+		if err := overrides.apply(genesis.Config); err != nil {
 			return nil, common.Hash{}, nil, err
 		}
-		genesis.Config = chainCfg
 
 		if hash := genesis.ToBlock().Hash(); hash != ghash {
 			return nil, common.Hash{}, nil, &GenesisMismatchError{ghash, hash}

--- a/core/genesis.go
+++ b/core/genesis.go
@@ -283,7 +283,7 @@ func SetupGenesisBlock(db ethdb.Database, triedb *triedb.Database, genesis *Gene
 func SetupGenesisBlockWithOverride(db ethdb.Database, triedb *triedb.Database, origGenesis *Genesis, overrides *ChainOverrides) (*params.ChainConfig, common.Hash, *params.ConfigCompatError, error) {
 	// Sanitize the supplied genesis, ensuring it has the associated chain
 	// config attached.
-	genesis := origGenesis.Copy()
+	genesis := origGenesis.copy()
 	if genesis != nil && genesis.Config == nil {
 		return nil, common.Hash{}, nil, errGenesisNoConfig
 	}
@@ -552,7 +552,7 @@ func (g *Genesis) MustCommit(db ethdb.Database, triedb *triedb.Database) *types.
 }
 
 // Copy copies the genesis.
-func (g *Genesis) Copy() *Genesis {
+func (g *Genesis) copy() *Genesis {
 	if g != nil {
 		cpy := *g
 		if g.Config != nil {

--- a/eth/downloader/testchain_test.go
+++ b/eth/downloader/testchain_test.go
@@ -210,7 +210,7 @@ func newTestBlockchain(blocks []*types.Block) *core.BlockChain {
 		testBlockchains[head] = new(testBlockchain)
 	}
 	tbc := testBlockchains[head]
-	defer testBlockchainsLock.Unlock()
+	testBlockchainsLock.Unlock()
 
 	// Ensure that the database is generated
 	tbc.gen.Do(func() {

--- a/eth/downloader/testchain_test.go
+++ b/eth/downloader/testchain_test.go
@@ -210,7 +210,7 @@ func newTestBlockchain(blocks []*types.Block) *core.BlockChain {
 		testBlockchains[head] = new(testBlockchain)
 	}
 	tbc := testBlockchains[head]
-	testBlockchainsLock.Unlock()
+	defer testBlockchainsLock.Unlock()
 
 	// Ensure that the database is generated
 	tbc.gen.Do(func() {


### PR DESCRIPTION
This PR fixes the following data race:

The issue was that SetupGenesisWithOverride would overwrite the passed chain config

```
WARNING: DATA RACE
Write at 0x0000011fcea0 by goroutine 107204:
  github.com/ethereum/go-ethereum/core.SetupGenesisBlockWithOverride()
      /home/matematik/go/src/github.com/ethereum/go-ethereum/core/genesis.go:302 +0x244
  github.com/ethereum/go-ethereum/core.NewBlockChain()
      /home/matematik/go/src/github.com/ethereum/go-ethereum/core/blockchain.go:285 +0x668
  github.com/ethereum/go-ethereum/eth/downloader.newTestBlockchain.func1()
      /home/matematik/go/src/github.com/ethereum/go-ethereum/eth/downloader/testchain_test.go:220 +0x1cb
  sync.(*Once).doSlow()
      /home/matematik/sdk/go1.22.1/src/sync/once.go:74 +0xf0
  sync.(*Once).Do()
      /home/matematik/sdk/go1.22.1/src/sync/once.go:65 +0x44
  github.com/ethereum/go-ethereum/eth/downloader.newTestBlockchain()
      /home/matematik/go/src/github.com/ethereum/go-ethereum/eth/downloader/testchain_test.go:216 +0x2a8
  github.com/ethereum/go-ethereum/eth/downloader.init.2.func4()
      /home/matematik/go/src/github.com/ethereum/go-ethereum/eth/downloader/testchain_test.go:109 +0x44
  github.com/ethereum/go-ethereum/eth/downloader.init.2.gowrap1()
      /home/matematik/go/src/github.com/ethereum/go-ethereum/eth/downloader/testchain_test.go:111 +0x61

Previous read at 0x0000011fcea0 by goroutine 107207:
  github.com/ethereum/go-ethereum/core.EnableVerkleAtGenesis()
      /home/matematik/go/src/github.com/ethereum/go-ethereum/core/genesis.go:565 +0x8b
  github.com/ethereum/go-ethereum/core.NewBlockChain()
      /home/matematik/go/src/github.com/ethereum/go-ethereum/core/blockchain.go:275 +0xb0
  github.com/ethereum/go-ethereum/eth/downloader.newTestBlockchain.func1()
      /home/matematik/go/src/github.com/ethereum/go-ethereum/eth/downloader/testchain_test.go:220 +0x1cb
  sync.(*Once).doSlow()
      /home/matematik/sdk/go1.22.1/src/sync/once.go:74 +0xf0
  sync.(*Once).Do()
      /home/matematik/sdk/go1.22.1/src/sync/once.go:65 +0x44
  github.com/ethereum/go-ethereum/eth/downloader.newTestBlockchain()
      /home/matematik/go/src/github.com/ethereum/go-ethereum/eth/downloader/testchain_test.go:216 +0x2a8
  github.com/ethereum/go-ethereum/eth/downloader.init.2.func4()
      /home/matematik/go/src/github.com/ethereum/go-ethereum/eth/downloader/testchain_test.go:109 +0x44
  github.com/ethereum/go-ethereum/eth/downloader.init.2.gowrap1()
      /home/matematik/go/src/github.com/ethereum/go-ethereum/eth/downloader/testchain_test.go:111 +0x61

Goroutine 107204 (running) created at:
  github.com/ethereum/go-ethereum/eth/downloader.init.2()
      /home/matematik/go/src/github.com/ethereum/go-ethereum/eth/downloader/testchain_test.go:108 +0xcd3

Goroutine 107207 (running) created at:
  github.com/ethereum/go-ethereum/eth/downloader.init.2()
      /home/matematik/go/src/github.com/ethereum/go-ethereum/eth/downloader/testchain_test.go:108 +0xcd3
==================
==================
WARNING: DATA RACE
Write at 0x0000011fcea0 by goroutine 107210:
  github.com/ethereum/go-ethereum/core.SetupGenesisBlockWithOverride()
      /home/matematik/go/src/github.com/ethereum/go-ethereum/core/genesis.go:302 +0x244
  github.com/ethereum/go-ethereum/core.NewBlockChain()
      /home/matematik/go/src/github.com/ethereum/go-ethereum/core/blockchain.go:285 +0x668
  github.com/ethereum/go-ethereum/eth/downloader.newTestBlockchain.func1()
      /home/matematik/go/src/github.com/ethereum/go-ethereum/eth/downloader/testchain_test.go:220 +0x1cb
  sync.(*Once).doSlow()
      /home/matematik/sdk/go1.22.1/src/sync/once.go:74 +0xf0
  sync.(*Once).Do()
      /home/matematik/sdk/go1.22.1/src/sync/once.go:65 +0x44
  github.com/ethereum/go-ethereum/eth/downloader.newTestBlockchain()
      /home/matematik/go/src/github.com/ethereum/go-ethereum/eth/downloader/testchain_test.go:216 +0x2a8
  github.com/ethereum/go-ethereum/eth/downloader.init.2.func4()
      /home/matematik/go/src/github.com/ethereum/go-ethereum/eth/downloader/testchain_test.go:109 +0x44
  github.com/ethereum/go-ethereum/eth/downloader.init.2.gowrap1()
      /home/matematik/go/src/github.com/ethereum/go-ethereum/eth/downloader/testchain_test.go:111 +0x61

Previous read at 0x0000011fcea0 by goroutine 107204:
  github.com/ethereum/go-ethereum/core.(*Genesis).Commit()
      /home/matematik/go/src/github.com/ethereum/go-ethereum/core/genesis.go:509 +0xe4
  github.com/ethereum/go-ethereum/core.SetupGenesisBlockWithOverride()
      /home/matematik/go/src/github.com/ethereum/go-ethereum/core/genesis.go:304 +0x2a4
  github.com/ethereum/go-ethereum/core.NewBlockChain()
      /home/matematik/go/sr
 ```