### PR TITLE
build: provide a flag to disable publishing in dockerx build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ jobs:
       before_install:
         - export DOCKER_CLI_EXPERIMENTAL=enabled
       script:
-        - go run build/ci.go dockerx -platform "linux/amd64,linux/arm64,linux/riscv64" -upload ethereum/client-go
+        - go run build/ci.go dockerx -platform "linux/amd64,linux/arm64,linux/riscv64" -hub ethereum/client-go -upload
 
     # This builder does the Linux Azure uploads
     - stage: build

--- a/build/ci.go
+++ b/build/ci.go
@@ -720,7 +720,10 @@ func doDockerBuildx(cmdline []string) {
 		tags = []string{"stable", fmt.Sprintf("release-%v", version.Family), "v" + version.Semantic}
 	}
 	// Need to create a mult-arch builder
-	build.MustRunCommand("docker", "buildx", "create", "--use", "--name", "multi-arch-builder", "--platform", *platform)
+	check := exec.Command("docker", "buildx", "inspect", "multi-arch-builder")
+	if check.Run() != nil {
+		build.MustRunCommand("docker", "buildx", "create", "--use", "--name", "multi-arch-builder", "--platform", *platform)
+	}
 
 	for _, spec := range []struct {
 		file string

--- a/build/ci.go
+++ b/build/ci.go
@@ -737,7 +737,6 @@ func doDockerBuildx(cmdline []string) {
 				"--build-arg", "BUILDNUM="+env.Buildnum,
 				"--tag", gethImage,
 				"--platform", *platform,
-				"--push",
 				"--file", spec.file,
 			)
 			if *upload {


### PR DESCRIPTION
This changes the `-upload` flag to just toggle the upload. The remote image name is now configured using the `-hub` flag.