### PR TITLE
consensus/misc/eip4844: use head's target blobs, not parent

### DIFF
--- a/cmd/evm/internal/t8ntool/execution.go
+++ b/cmd/evm/internal/t8ntool/execution.go
@@ -194,11 +194,11 @@ func (pre *Prestate) Apply(vmConfig vm.Config, chainConfig *params.ChainConfig, 
 				ExcessBlobGas: pre.Env.ParentExcessBlobGas,
 				BlobGasUsed:   pre.Env.ParentBlobGasUsed,
 			}
-			excessBlobGas = eip4844.CalcExcessBlobGas(chainConfig, parent)
 			header := &types.Header{
 				Time:          pre.Env.Timestamp,
 				ExcessBlobGas: &excessBlobGas,
 			}
+			excessBlobGas = eip4844.CalcExcessBlobGas(chainConfig, parent, header)
 			vmContext.BlobBaseFee = eip4844.CalcBlobFee(chainConfig, header)
 		}
 	}

--- a/consensus/misc/eip4844/eip4844.go
+++ b/consensus/misc/eip4844/eip4844.go
@@ -50,7 +50,7 @@ func VerifyEIP4844Header(config *params.ChainConfig, parent, header *types.Heade
 		return fmt.Errorf("blob gas used %d not a multiple of blob gas per blob %d", header.BlobGasUsed, params.BlobTxBlobGasPerBlob)
 	}
 	// Verify the excessBlobGas is correct based on the parent header
-	expectedExcessBlobGas := CalcExcessBlobGas(config, parent)
+	expectedExcessBlobGas := CalcExcessBlobGas(config, parent, header)
 	if *header.ExcessBlobGas != expectedExcessBlobGas {
 		return fmt.Errorf("invalid excessBlobGas: have %d, want %d", *header.ExcessBlobGas, expectedExcessBlobGas)
 	}
@@ -59,9 +59,9 @@ func VerifyEIP4844Header(config *params.ChainConfig, parent, header *types.Heade
 
 // CalcExcessBlobGas calculates the excess blob gas after applying the set of
 // blobs on top of the excess blob gas.
-func CalcExcessBlobGas(config *params.ChainConfig, parent *types.Header) uint64 {
+func CalcExcessBlobGas(config *params.ChainConfig, parent, header *types.Header) uint64 {
 	var (
-		targetGas           = uint64(targetBlobsPerBlock(config, parent.Time)) * params.BlobTxBlobGasPerBlob
+		targetGas           = uint64(targetBlobsPerBlock(config, header.Time)) * params.BlobTxBlobGasPerBlob
 		parentExcessBlobGas uint64
 		parentBlobGasUsed   uint64
 	)

--- a/consensus/misc/eip4844/eip4844_test.go
+++ b/consensus/misc/eip4844/eip4844_test.go
@@ -57,12 +57,15 @@ func TestCalcExcessBlobGas(t *testing.T) {
 	}
 	for i, tt := range tests {
 		blobGasUsed := uint64(tt.blobs) * params.BlobTxBlobGasPerBlob
-		header := &types.Header{
+		head := &types.Header{
+			Time: *config.CancunTime,
+		}
+		parent := &types.Header{
 			Time:          *config.CancunTime,
 			ExcessBlobGas: &tt.excess,
 			BlobGasUsed:   &blobGasUsed,
 		}
-		result := CalcExcessBlobGas(config, header, header)
+		result := CalcExcessBlobGas(config, parent, head)
 		if result != tt.want {
 			t.Errorf("test %d: excess blob gas mismatch: have %v, want %v", i, result, tt.want)
 		}

--- a/consensus/misc/eip4844/eip4844_test.go
+++ b/consensus/misc/eip4844/eip4844_test.go
@@ -57,15 +57,12 @@ func TestCalcExcessBlobGas(t *testing.T) {
 	}
 	for i, tt := range tests {
 		blobGasUsed := uint64(tt.blobs) * params.BlobTxBlobGasPerBlob
-		head := &types.Header{
-			Time: *config.CancunTime,
-		}
-		parent := &types.Header{
-			Time:          *config.CancunTime + 12,
+		header := &types.Header{
+			Time:          *config.CancunTime,
 			ExcessBlobGas: &tt.excess,
 			BlobGasUsed:   &blobGasUsed,
 		}
-		result := CalcExcessBlobGas(config, parent, head)
+		result := CalcExcessBlobGas(config, header, header)
 		if result != tt.want {
 			t.Errorf("test %d: excess blob gas mismatch: have %v, want %v", i, result, tt.want)
 		}

--- a/consensus/misc/eip4844/eip4844_test.go
+++ b/consensus/misc/eip4844/eip4844_test.go
@@ -57,12 +57,15 @@ func TestCalcExcessBlobGas(t *testing.T) {
 	}
 	for i, tt := range tests {
 		blobGasUsed := uint64(tt.blobs) * params.BlobTxBlobGasPerBlob
+		head := &types.Header{
+			Time: *config.CancunTime,
+		}
 		parent := &types.Header{
-			Time:          *config.CancunTime,
+			Time:          *config.CancunTime + 12,
 			ExcessBlobGas: &tt.excess,
 			BlobGasUsed:   &blobGasUsed,
 		}
-		result := CalcExcessBlobGas(config, parent)
+		result := CalcExcessBlobGas(config, parent, head)
 		if result != tt.want {
 			t.Errorf("test %d: excess blob gas mismatch: have %v, want %v", i, result, tt.want)
 		}

--- a/core/chain_makers.go
+++ b/core/chain_makers.go
@@ -600,7 +600,7 @@ func (cm *chainMaker) makeHeader(parent *types.Block, state *state.StateDB, engi
 		}
 	}
 	if cm.config.IsCancun(header.Number, header.Time) {
-		excessBlobGas := eip4844.CalcExcessBlobGas(cm.config, parent.Header())
+		excessBlobGas := eip4844.CalcExcessBlobGas(cm.config, parent.Header(), header)
 		header.ExcessBlobGas = &excessBlobGas
 		header.BlobGasUsed = new(uint64)
 		header.ParentBeaconRoot = new(common.Hash)

--- a/core/state_processor_test.go
+++ b/core/state_processor_test.go
@@ -407,7 +407,7 @@ func GenerateBadBlock(parent *types.Block, engine consensus.Engine, txs types.Tr
 	}
 	header.Root = common.BytesToHash(hasher.Sum(nil))
 	if config.IsCancun(header.Number, header.Time) {
-		excess := eip4844.CalcExcessBlobGas(config, parent.Header())
+		excess := eip4844.CalcExcessBlobGas(config, parent.Header(), header)
 		used := uint64(nBlobs * params.BlobTxBlobGasPerBlob)
 		header.ExcessBlobGas = &excess
 		header.BlobGasUsed = &used

--- a/eth/gasprice/feehistory.go
+++ b/eth/gasprice/feehistory.go
@@ -97,7 +97,7 @@ func (oracle *Oracle) processBlock(bf *blockFees, percentiles []float64) {
 	// Fill in blob base fee and next blob base fee.
 	if excessBlobGas := bf.header.ExcessBlobGas; excessBlobGas != nil {
 		bf.results.blobBaseFee = eip4844.CalcBlobFee(config, bf.header)
-		excess := eip4844.CalcExcessBlobGas(config, bf.header)
+		excess := eip4844.CalcExcessBlobGas(config, bf.header, bf.header)
 		next := &types.Header{Number: bf.header.Number, Time: bf.header.Time, ExcessBlobGas: &excess}
 		bf.results.nextBlobBaseFee = eip4844.CalcBlobFee(config, next)
 	} else {

--- a/eth/tracers/internal/tracetest/util.go
+++ b/eth/tracers/internal/tracetest/util.go
@@ -54,7 +54,7 @@ func (c *callContext) toBlockContext(genesis *core.Genesis) vm.BlockContext {
 	}
 
 	if genesis.ExcessBlobGas != nil && genesis.BlobGasUsed != nil {
-		excess := eip4844.CalcExcessBlobGas(genesis.Config, genesis.ToBlock().Header())
+		excess := eip4844.CalcExcessBlobGas(genesis.Config, genesis.ToBlock().Header(), genesis.ToBlock().Header())
 		header := &types.Header{ExcessBlobGas: &excess, Number: genesis.Config.LondonBlock, Time: *genesis.Config.CancunTime}
 		context.BlobBaseFee = eip4844.CalcBlobFee(genesis.Config, header)
 	}

--- a/eth/tracers/internal/tracetest/util.go
+++ b/eth/tracers/internal/tracetest/util.go
@@ -54,8 +54,9 @@ func (c *callContext) toBlockContext(genesis *core.Genesis) vm.BlockContext {
 	}
 
 	if genesis.ExcessBlobGas != nil && genesis.BlobGasUsed != nil {
-		excess := eip4844.CalcExcessBlobGas(genesis.Config, genesis.ToBlock().Header(), genesis.ToBlock().Header())
-		header := &types.Header{ExcessBlobGas: &excess, Number: genesis.Config.LondonBlock, Time: *genesis.Config.CancunTime}
+		header := &types.Header{Number: genesis.Config.LondonBlock, Time: *genesis.Config.CancunTime}
+		excess := eip4844.CalcExcessBlobGas(genesis.Config, header, genesis.ToBlock().Header())
+		header.ExcessBlobGas = &excess
 		context.BlobBaseFee = eip4844.CalcBlobFee(genesis.Config, header)
 	}
 	return context

--- a/internal/ethapi/simulate.go
+++ b/internal/ethapi/simulate.go
@@ -159,7 +159,7 @@ func (sim *simulator) processBlock(ctx context.Context, block *simBlock, header,
 	if sim.chainConfig.IsCancun(header.Number, header.Time) {
 		var excess uint64
 		if sim.chainConfig.IsCancun(parent.Number, parent.Time) {
-			excess = eip4844.CalcExcessBlobGas(sim.chainConfig, parent)
+			excess = eip4844.CalcExcessBlobGas(sim.chainConfig, parent, header)
 		}
 		header.ExcessBlobGas = &excess
 	}

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -210,7 +210,7 @@ func (miner *Miner) prepareWork(genParams *generateParams, witness bool) (*envir
 	if miner.chainConfig.IsCancun(header.Number, header.Time) {
 		var excessBlobGas uint64
 		if miner.chainConfig.IsCancun(parent.Number, parent.Time) {
-			excessBlobGas = eip4844.CalcExcessBlobGas(miner.chainConfig, parent)
+			excessBlobGas = eip4844.CalcExcessBlobGas(miner.chainConfig, parent, header)
 		}
 		header.BlobGasUsed = new(uint64)
 		header.ExcessBlobGas = &excessBlobGas


### PR DESCRIPTION
~~*This PR is built on #31002.*~~

--

A clarification was made to EIP-7691 stating that at the fork boundary it is required to use the target blob count associated with the head block, rather than the parent as implemented here.

See for more: https://github.com/ethereum/EIPs/pull/9249