### PR TITLE
eth/catalyst: fix validation of type 0 request

### DIFF
--- a/eth/catalyst/api.go
+++ b/eth/catalyst/api.go
@@ -1272,19 +1272,16 @@ func convertRequests(hex []hexutil.Bytes) [][]byte {
 
 // validateRequests checks that requests are ordered by their type and are not empty.
 func validateRequests(requests [][]byte) error {
-	// Magic value to ensure the first request is always valid.
-	last := byte(0xff)
-	for _, req := range requests {
+	for i, req := range requests {
 		// No empty requests.
 		if len(req) < 2 {
 			return fmt.Errorf("empty request: %v", req)
 		}
 		// Check that requests are ordered by their type.
 		// Each type must appear only once.
-		if last != 0xff && req[0] <= last {
+		if i > 0 && req[0] <= requests[i-1][0] {
 			return fmt.Errorf("invalid request order: %v", req)
 		}
-		last = req[0]
 	}
 	return nil
 }

--- a/eth/catalyst/api.go
+++ b/eth/catalyst/api.go
@@ -1272,7 +1272,8 @@ func convertRequests(hex []hexutil.Bytes) [][]byte {
 
 // validateRequests checks that requests are ordered by their type and are not empty.
 func validateRequests(requests [][]byte) error {
-	var last byte
+	// Magic value to ensure the first request is always valid.
+	last := byte(0xff)
 	for _, req := range requests {
 		// No empty requests.
 		if len(req) < 2 {
@@ -1280,7 +1281,7 @@ func validateRequests(requests [][]byte) error {
 		}
 		// Check that requests are ordered by their type.
 		// Each type must appear only once.
-		if req[0] <= last {
+		if last != 0xff && req[0] <= last {
 			return fmt.Errorf("invalid request order: %v", req)
 		}
 		last = req[0]


### PR DESCRIPTION
I caught this error on Hive. It was introduced by https://github.com/ethereum/go-ethereum/pull/31071 because after adding the equality check the request type 0 will be rejected.