### PR TITLE
fix nil pointer when block does not exist

### DIFF
--- a/eth/api_backend.go
+++ b/eth/api_backend.go
@@ -19,6 +19,7 @@ package eth
 import (
 	"context"
 	"errors"
+	"fmt"
 	"math/big"
 	"time"
 
@@ -163,7 +164,12 @@ func (b *EthAPIBackend) GetBody(ctx context.Context, hash common.Hash, number rp
 
 func (b *EthAPIBackend) BlockByNumberOrHash(ctx context.Context, blockNrOrHash rpc.BlockNumberOrHash) (*types.Block, error) {
 	if blockNr, ok := blockNrOrHash.Number(); ok {
-		return b.BlockByNumber(ctx, blockNr)
+		block, err := b.BlockByNumber(ctx, blockNr)
+		if block == nil && err == nil {
+			err = fmt.Errorf("block %v not found", blockNrOrHash)
+			return nil, err
+		}
+		return block, err
 	}
 	if hash, ok := blockNrOrHash.Hash(); ok {
 		header := b.eth.blockchain.GetHeaderByHash(hash)

--- a/internal/ethapi/api_test.go
+++ b/internal/ethapi/api_test.go
@@ -526,7 +526,12 @@ func (b testBackend) BlockByHash(ctx context.Context, hash common.Hash) (*types.
 }
 func (b testBackend) BlockByNumberOrHash(ctx context.Context, blockNrOrHash rpc.BlockNumberOrHash) (*types.Block, error) {
 	if blockNr, ok := blockNrOrHash.Number(); ok {
-		return b.BlockByNumber(ctx, blockNr)
+		block, err := b.BlockByNumber(ctx, blockNr)
+		if block == nil && err == nil {
+			err = fmt.Errorf("block %v not found", blockNrOrHash)
+			return nil, err
+		}
+		return block, err
 	}
 	if blockHash, ok := blockNrOrHash.Hash(); ok {
 		return b.BlockByHash(ctx, blockHash)


### PR DESCRIPTION
This PR fixes the following thing:

When `block` does not exist, `hash = block.Hash()` will cause a panic.

```go
internal/ethapi/api.go

// GetRawHeader retrieves the RLP encoding for a single header.
func (api *DebugAPI) GetRawHeader(ctx context.Context, blockNrOrHash rpc.BlockNumberOrHash) (hexutil.Bytes, error) {
	var hash common.Hash
	if h, ok := blockNrOrHash.Hash(); ok {
		hash = h
	} else {
		block, err := api.b.BlockByNumberOrHash(ctx, blockNrOrHash)
		if err != nil {
			return nil, err
		} 
                hash = block.Hash()
	}
	...
}

```