### PR TITLE
p2p/server_nat: set stun IP to localnode

### DIFF
--- a/p2p/nat/nat_test.go
+++ b/p2p/nat/nat_test.go
@@ -69,10 +69,10 @@ func TestAutoDiscRace(t *testing.T) {
 func TestParseStun(t *testing.T) {
 	testcases := []struct {
 		natStr string
-		want   *stun
+		want   STUN
 	}{
-		{"stun", &stun{serverList: strings.Split(stunDefaultServers, "\n")}},
-		{"stun:1.2.3.4:1234", &stun{serverList: []string{"1.2.3.4:1234"}}},
+		{"stun", STUN{stun: stun{serverList: strings.Split(stunDefaultServers, "\n")}}},
+		{"stun:1.2.3.4:1234", STUN{stun: stun{serverList: []string{"1.2.3.4:1234"}}}},
 	}
 
 	for _, tc := range testcases {
@@ -80,7 +80,7 @@ func TestParseStun(t *testing.T) {
 		if err != nil {
 			t.Errorf("should no err, but get %v", err)
 		}
-		stun := nat.(*stun)
+		stun := nat.(STUN)
 		assert.Equal(t, stun.serverList, tc.want.serverList)
 	}
 }

--- a/p2p/nat/stun.go
+++ b/p2p/nat/stun.go
@@ -36,6 +36,9 @@ const requestLimit = 3
 
 var errSTUNFailed = errors.New("STUN requests failed")
 
+type STUN struct {
+	stun
+}
 type stun struct {
 	serverList []string
 }
@@ -77,7 +80,7 @@ func (stun) DeleteMapping(string, int, int) error {
 	return nil
 }
 
-func (s *stun) ExternalIP() (net.IP, error) {
+func (s stun) ExternalIP() (net.IP, error) {
 	for _, server := range s.randomServers(requestLimit) {
 		ip, err := s.externalIP(server)
 		if err != nil {

--- a/p2p/nat/stun.go
+++ b/p2p/nat/stun.go
@@ -54,7 +54,7 @@ func newSTUN(serverAddr string) (Interface, error) {
 		}
 		s.serverList = []string{serverAddr}
 	}
-	return s, nil
+	return STUN{stun: *s}, nil
 }
 
 func (s stun) String() string {

--- a/p2p/server_nat.go
+++ b/p2p/server_nat.go
@@ -57,8 +57,7 @@ func (srv *Server) setupPortMapping() {
 		// No NAT interface configured.
 		srv.loopWG.Add(1)
 		go srv.consumePortMappingRequests()
-
-	case nat.ExtIP:
+	case nat.ExtIP, nat.STUN:
 		// ExtIP doesn't block, set the IP right away.
 		ip, _ := srv.NAT.ExternalIP()
 		srv.localnode.SetStaticIP(ip)


### PR DESCRIPTION
fix #31107 

as `stun` is private, a public `STUN` is a simple wrapper。

The `STUN` and `ExtIP` has the same handler, just get the IP and set to the localnode.
