### PR TITLE
tests/fuzzers/bls12381: fix error message in fuzzCrossG2Add

### DIFF
--- a/tests/fuzzers/bls12381/bls12381_fuzz.go
+++ b/tests/fuzzers/bls12381/bls12381_fuzz.go
@@ -140,7 +140,7 @@ func fuzzCrossG1Add(data []byte) int {
 
 	bl3 := blst.P1AffinesAdd([]*blst.P1Affine{bl1, bl2})
 	if !(bytes.Equal(cp.Marshal(), bl3.Serialize())) {
-		panic("G2 point addition mismatch blst / geth ")
+		panic("G1 point addition mismatch blst / geth ")
 	}
 
 	return 1
@@ -168,7 +168,7 @@ func fuzzCrossG2Add(data []byte) int {
 
 	bl3 := blst.P2AffinesAdd([]*blst.P2Affine{bl1, bl2})
 	if !(bytes.Equal(gp.Marshal(), bl3.Serialize())) {
-		panic("G1 point addition mismatch blst / geth ")
+		panic("G2 point addition mismatch blst / geth ")
 	}
 
 	return 1

--- a/tests/fuzzers/bls12381/bls12381_fuzz.go
+++ b/tests/fuzzers/bls12381/bls12381_fuzz.go
@@ -140,7 +140,7 @@ func fuzzCrossG1Add(data []byte) int {
 
 	bl3 := blst.P1AffinesAdd([]*blst.P1Affine{bl1, bl2})
 	if !(bytes.Equal(cp.Marshal(), bl3.Serialize())) {
-		panic("G1 point addition mismatch blst / geth ")
+		panic("G2 point addition mismatch blst / geth ")
 	}
 
 	return 1


### PR DESCRIPTION
**Description:**  
I noticed a typo in the error message within the `fuzzCrossG2Add` function. The panic message incorrectly references "G1 point addition mismatch" when it should be "G2 point addition mismatch," as the function deals with G2 points.

This doesn't affect functionality but could cause confusion during debugging. I've updated the message to reflect the correct curve.  

Here's the fix:  
```go
panic("G2 point addition mismatch blst / geth ")
```  

Thanks!