### PR TITLE
core/vm: fix system call detection in extcodecopy

### DIFF
--- a/core/vm/eips.go
+++ b/core/vm/eips.go
@@ -338,13 +338,9 @@ func opExtCodeCopyEIP4762(pc *uint64, interpreter *EVMInterpreter, scope *ScopeC
 	}
 	addr := common.Address(a.Bytes20())
 	code := interpreter.evm.StateDB.GetCode(addr)
-	contract := &Contract{
-		Code: code,
-		self: AccountRef(addr),
-	}
 	paddedCodeCopy, copyOffset, nonPaddedCopyLength := getDataAndAdjustedBounds(code, uint64CodeOffset, length.Uint64())
-	if !contract.IsSystemCall {
-		statelessGas := interpreter.evm.AccessEvents.CodeChunksRangeGas(addr, copyOffset, nonPaddedCopyLength, uint64(len(contract.Code)), false)
+	if !isSystemCall(AccountRef(addr)) {
+		statelessGas := interpreter.evm.AccessEvents.CodeChunksRangeGas(addr, copyOffset, nonPaddedCopyLength, uint64(len(code)), false)
 		if !scope.Contract.UseGas(statelessGas, interpreter.evm.Config.Tracer, tracing.GasChangeUnspecified) {
 			scope.Contract.Gas = 0
 			return nil, ErrOutOfGas

--- a/core/vm/eips.go
+++ b/core/vm/eips.go
@@ -339,7 +339,7 @@ func opExtCodeCopyEIP4762(pc *uint64, interpreter *EVMInterpreter, scope *ScopeC
 	addr := common.Address(a.Bytes20())
 	code := interpreter.evm.StateDB.GetCode(addr)
 	paddedCodeCopy, copyOffset, nonPaddedCopyLength := getDataAndAdjustedBounds(code, uint64CodeOffset, length.Uint64())
-	if !isSystemCall(AccountRef(addr)) {
+	if !isSystemContract(addr) {
 		statelessGas := interpreter.evm.AccessEvents.CodeChunksRangeGas(addr, copyOffset, nonPaddedCopyLength, uint64(len(code)), false)
 		if !scope.Contract.UseGas(statelessGas, interpreter.evm.Config.Tracer, tracing.GasChangeUnspecified) {
 			scope.Contract.Gas = 0

--- a/core/vm/evm.go
+++ b/core/vm/evm.go
@@ -169,6 +169,15 @@ func isSystemCall(caller ContractRef) bool {
 	return caller.Address() == params.SystemAddress
 }
 
+func isSystemContract(callee common.Address) bool {
+	switch callee {
+	case params.BeaconRootsAddress, params.HistoryStorageAddress, params.WithdrawalQueueAddress, params.ConsolidationQueueAddress:
+		return true
+	default:
+		return false
+	}
+}
+
 // Call executes the contract associated with the addr with the given input as
 // parameters. It also handles any necessary value transfer required and takse
 // the necessary steps to create accounts and reverses the state in case of an


### PR DESCRIPTION
The check for a system call in `EXTCODECOPY` was always true, since it was based on an ad-hoc contract with `IsSystemCall` defaulting to `false`.

Replace this with a proper call to `isSystemCall(target addr)` to figure out if the leaves of the target contract must be filtered out since it's a system contract.