### PR TITLE
fix nil pointer when block does not exist

### DIFF
--- a/eth/api_backend.go
+++ b/eth/api_backend.go
@@ -19,6 +19,7 @@ package eth
 import (
 	"context"
 	"errors"
+	"fmt"
 	"math/big"
 	"time"
 
@@ -143,7 +144,11 @@ func (b *EthAPIBackend) BlockByNumber(ctx context.Context, number rpc.BlockNumbe
 		}
 		return b.eth.blockchain.GetBlock(header.Hash(), header.Number.Uint64()), nil
 	}
-	return b.eth.blockchain.GetBlockByNumber(uint64(number)), nil
+	block := b.eth.blockchain.GetBlockByNumber(uint64(number))
+	if block == nil {
+		return nil, fmt.Errorf("block #%d not found", number)
+	}
+	return block, nil
 }
 
 func (b *EthAPIBackend) BlockByHash(ctx context.Context, hash common.Hash) (*types.Block, error) {

--- a/eth/tracers/api.go
+++ b/eth/tracers/api.go
@@ -114,9 +114,6 @@ func (api *API) blockByNumber(ctx context.Context, number rpc.BlockNumber) (*typ
 	if err != nil {
 		return nil, err
 	}
-	if block == nil {
-		return nil, fmt.Errorf("block #%d not found", number)
-	}
 	return block, nil
 }
 

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -1746,9 +1746,9 @@ func (api *DebugAPI) GetRawTransaction(ctx context.Context, hash common.Hash) (h
 
 // PrintBlock retrieves a block and returns its pretty printed form.
 func (api *DebugAPI) PrintBlock(ctx context.Context, number uint64) (string, error) {
-	block, _ := api.b.BlockByNumber(ctx, rpc.BlockNumber(number))
-	if block == nil {
-		return "", fmt.Errorf("block #%d not found", number)
+	block, err := api.b.BlockByNumber(ctx, rpc.BlockNumber(number))
+	if err != nil {
+		return "", err
 	}
 	return spew.Sdump(block), nil
 }


### PR DESCRIPTION
This PR fixes "nil pointer error occurs when block is nil".

The following `GetBlockByNumber` function is used in several places, but only in `func (b *EthAPIBackend) BlockByNumber(ctx context.Context, number rpc.BlockNumber) (*types.Block, error)` at `eth/api_backend.go` did not implement error handling when block is nil.

https://github.com/ethereum/go-ethereum/blob/master/eth/api_backend.go#L146

So I think we also should fix the `b.BlockByNumber`, by returning the error if the required block is not existent.

```go
func (bc *core.BlockChain) GetBlockByNumber(number uint64) *types.Block
```

quote: https://github.com/ethereum/go-ethereum/pull/31104#issuecomment-2629993925