### PR TITLE
feat:expose discv5 function for portal discv5 json rpc

### DIFF
--- a/cmd/devp2p/discv4cmd.go
+++ b/cmd/devp2p/discv4cmd.go
@@ -163,7 +163,7 @@ func discv4Ping(ctx *cli.Context) error {
 	defer disc.Close()
 
 	start := time.Now()
-	if err := disc.Ping(n); err != nil {
+	if err := disc.PingWithoutResp(n); err != nil {
 		return fmt.Errorf("node didn't respond: %v", err)
 	}
 	fmt.Printf("node responded to ping (RTT %v).\n", time.Since(start))

--- a/cmd/devp2p/discv5cmd.go
+++ b/cmd/devp2p/discv5cmd.go
@@ -84,7 +84,7 @@ func discv5Ping(ctx *cli.Context) error {
 	disc, _ := startV5(ctx)
 	defer disc.Close()
 
-	fmt.Println(disc.Ping(n))
+	fmt.Println(disc.PingWithoutResp(n))
 	return nil
 }
 

--- a/p2p/discover/table.go
+++ b/p2p/discover/table.go
@@ -694,3 +694,49 @@ func pushNode(list []*tableNode, n *tableNode, max int) ([]*tableNode, *tableNod
 	list[0] = n
 	return list, removed
 }
+
+// waitInit waits until the table is initialized.
+func (tab *Table) waitInit() {
+	<-tab.initDone
+}
+
+// nodeList returns all nodes contained in the table.
+func (tab *Table) nodeList() []*enode.Node {
+	if !tab.isInitDone() {
+		return nil
+	}
+
+	tab.mutex.Lock()
+	defer tab.mutex.Unlock()
+
+	var nodes []*enode.Node
+	for _, b := range &tab.buckets {
+		for _, n := range b.entries {
+			nodes = append(nodes, n.Node)
+		}
+	}
+	return nodes
+}
+
+// nodeIds returns the node IDs hex representation in the table.
+func (tab *Table) nodeIds() [][]string {
+	tab.mutex.Lock()
+	defer tab.mutex.Unlock()
+	nodes := make([][]string, 0)
+	for _, b := range &tab.buckets {
+		bucketNodes := make([]string, 0)
+		for _, n := range b.entries {
+			bucketNodes = append(bucketNodes, fmt.Sprintf("0x%s", n.ID().String()))
+		}
+		nodes = append(nodes, bucketNodes)
+	}
+	return nodes
+}
+
+// deleteNode removes a node from the table.
+func (tab *Table) deleteNode(n *enode.Node) {
+	tab.mutex.Lock()
+	defer tab.mutex.Unlock()
+	b := tab.bucket(n.ID())
+	tab.deleteInBucket(b, n.ID())
+}

--- a/p2p/discover/v4_udp.go
+++ b/p2p/discover/v4_udp.go
@@ -210,8 +210,8 @@ func (t *UDPv4) ourEndpoint() v4wire.Endpoint {
 	return v4wire.NewEndpoint(addr, uint16(node.TCP()))
 }
 
-// Ping sends a ping message to the given node.
-func (t *UDPv4) Ping(n *enode.Node) error {
+// PingWithoutResp sends a ping message to the given node.
+func (t *UDPv4) PingWithoutResp(n *enode.Node) error {
 	_, err := t.ping(n)
 	return err
 }

--- a/p2p/discover/v5_udp_test.go
+++ b/p2p/discover/v5_udp_test.go
@@ -288,7 +288,7 @@ func TestUDPv5_findnodeCall(t *testing.T) {
 	)
 	go func() {
 		var err error
-		response, err = test.udp.findnode(remote, distances)
+		response, err = test.udp.Findnode(remote, distances)
 		done <- err
 	}()
 
@@ -398,7 +398,7 @@ func TestUDPv5_callTimeoutReset(t *testing.T) {
 		done     = make(chan error, 1)
 	)
 	go func() {
-		_, err := test.udp.findnode(remote, []uint{distance})
+		_, err := test.udp.Findnode(remote, []uint{distance})
 		done <- err
 	}()
 


### PR DESCRIPTION
This PR fix #31093 .

### Function Renaming for Clarity:
* For support portal `discv5_ping` json rpc endpoint, added a `PingWithResp` function and renamed `Ping` to `PingWithoutResp` for refactoring.
* For support portal `discv5_routingTableInfo` json rpc endpoint, added `RoutingTableInfo` function and `nodeIds` function. 
* For support portal `discv5_deleteEnr` json rpc endpoint, added `DeleteNode` function and `deleteNode` function. 
* For support portal `discv5_lookupEnr` json rpc endpoint, added `ResolveNodeId` function.
* For support portal `discv5_addEnr` json rpc endpoint, added `AddKnownNode` function.
* For support portal `discv5_GetEnr` json rpc endpoint, renamed `getNode` to `GetNode`.
* For support portal `discv5_findNode` json rpc endpoint, renamed `findnode` to `Findnode`.
* Added `WaitInit` function and `waitInit` for support portal hive test.
* Refactor `AllNodes` function.
