### PR TITLE
p2p/discover: make discv5 response timeout configurable

### DIFF
--- a/p2p/discover/common.go
+++ b/p2p/discover/common.go
@@ -49,8 +49,9 @@ type Config struct {
 	// All remaining settings are optional.
 
 	// Packet handling configuration:
-	NetRestrict *netutil.Netlist  // list of allowed IP networks
-	Unhandled   chan<- ReadPacket // unhandled packets are sent on this channel
+	NetRestrict   *netutil.Netlist  // list of allowed IP networks
+	Unhandled     chan<- ReadPacket // unhandled packets are sent on this channel
+	V5RespTimeout time.Duration     // timeout for v5 queries
 
 	// Node table configuration:
 	Bootnodes               []*enode.Node // list of bootstrap nodes
@@ -72,6 +73,9 @@ func (cfg Config) withDefaults() Config {
 	}
 	if cfg.RefreshInterval == 0 {
 		cfg.RefreshInterval = 30 * time.Minute
+	}
+	if cfg.V5RespTimeout == 0 {
+		cfg.V5RespTimeout = 700 * time.Millisecond
 	}
 
 	// Debug/test settings:

--- a/p2p/discover/v5_udp.go
+++ b/p2p/discover/v5_udp.go
@@ -60,16 +60,16 @@ type codecV5 interface {
 // UDPv5 is the implementation of protocol version 5.
 type UDPv5 struct {
 	// static fields
-	conn          UDPConn
-	tab           *Table
-	netrestrict   *netutil.Netlist
-	priv          *ecdsa.PrivateKey
-	localNode     *enode.LocalNode
-	db            *enode.DB
-	log           log.Logger
-	clock         mclock.Clock
-	validSchemes  enr.IdentityScheme
-	v5respTimeout time.Duration
+	conn         UDPConn
+	tab          *Table
+	netrestrict  *netutil.Netlist
+	priv         *ecdsa.PrivateKey
+	localNode    *enode.LocalNode
+	db           *enode.DB
+	log          log.Logger
+	clock        mclock.Clock
+	validSchemes enr.IdentityScheme
+	respTimeout  time.Duration
 
 	// misc buffers used during message handling
 	logcontext []interface{}
@@ -149,15 +149,15 @@ func newUDPv5(conn UDPConn, ln *enode.LocalNode, cfg Config) (*UDPv5, error) {
 	cfg = cfg.withDefaults()
 	t := &UDPv5{
 		// static fields
-		conn:          newMeteredConn(conn),
-		localNode:     ln,
-		db:            ln.Database(),
-		netrestrict:   cfg.NetRestrict,
-		priv:          cfg.PrivateKey,
-		log:           cfg.Log,
-		validSchemes:  cfg.ValidSchemes,
-		clock:         cfg.Clock,
-		v5respTimeout: cfg.V5RespTimeout,
+		conn:         newMeteredConn(conn),
+		localNode:    ln,
+		db:           ln.Database(),
+		netrestrict:  cfg.NetRestrict,
+		priv:         cfg.PrivateKey,
+		log:          cfg.Log,
+		validSchemes: cfg.ValidSchemes,
+		clock:        cfg.Clock,
+		respTimeout:  cfg.V5RespTimeout,
 		// channels into dispatch
 		packetInCh:    make(chan ReadPacket, 1),
 		readNextCh:    make(chan struct{}, 1),
@@ -576,7 +576,7 @@ func (t *UDPv5) startResponseTimeout(c *callV5) {
 		timer mclock.Timer
 		done  = make(chan struct{})
 	)
-	timer = t.clock.AfterFunc(t.v5respTimeout, func() {
+	timer = t.clock.AfterFunc(t.respTimeout, func() {
 		<-done
 		select {
 		case t.respTimeoutCh <- &callTimeout{c, timer}:


### PR DESCRIPTION
This PR fix #31118 . It make discv5 response timeout configuable.