### PR TITLE
rpc: fix go-routine leaks in client handler

### DIFF
--- a/rpc/client.go
+++ b/rpc/client.go
@@ -125,7 +125,7 @@ func (c *Client) newClientConn(conn ServerCodec) *clientConn {
 }
 
 func (cc *clientConn) close(err error, inflightReq *requestOp) {
-	cc.handler.close(err, inflightReq)
+	cc.handler.close(err, inflightReq, true)
 	cc.codec.close()
 }
 

--- a/rpc/handler.go
+++ b/rpc/handler.go
@@ -313,10 +313,16 @@ func (h *handler) handleNonBatchCall(cp *callProc, msg *jsonrpcMessage) {
 
 // close cancels all requests except for inflightReq and waits for
 // call goroutines to shut down.
-func (h *handler) close(err error, inflightReq *requestOp) {
+// force = true must be user only for client-side handlers.
+func (h *handler) close(err error, inflightReq *requestOp, force bool) {
 	h.cancelAllRequests(err, inflightReq)
-	h.cancelRoot()
-	h.callWG.Wait()
+	if force {
+		h.cancelRoot()
+		h.callWG.Wait()
+	} else {
+		h.callWG.Wait()
+		h.cancelRoot()
+	}
 	h.cancelServerSubscriptions(err)
 }
 

--- a/rpc/handler.go
+++ b/rpc/handler.go
@@ -315,8 +315,8 @@ func (h *handler) handleNonBatchCall(cp *callProc, msg *jsonrpcMessage) {
 // call goroutines to shut down.
 func (h *handler) close(err error, inflightReq *requestOp) {
 	h.cancelAllRequests(err, inflightReq)
-	h.callWG.Wait()
 	h.cancelRoot()
+	h.callWG.Wait()
 	h.cancelServerSubscriptions(err)
 }
 

--- a/rpc/server.go
+++ b/rpc/server.go
@@ -149,7 +149,7 @@ func (s *Server) serveSingleRequest(ctx context.Context, codec ServerCodec) {
 
 	h := newHandler(ctx, codec, s.idgen, &s.services, s.batchItemLimit, s.batchResponseLimit)
 	h.allowSubscribe = false
-	defer h.close(io.EOF, nil)
+	defer h.close(io.EOF, nil, false)
 
 	reqs, batch, err := codec.readBatch()
 	if err != nil {


### PR DESCRIPTION
Fix [the issue](https://github.com/ethereum/go-ethereum/issues/26040)

With this fix same test in a `goleak mode` (see the issue description) also fails. But it happens cause of metric go-routine which is fine. There are no stuck client go-routines anymore:

```
go test -v -run=TestClientCancelWebsocket .
=== RUN   TestClientCancelWebsocket
=== PAUSE TestClientCancelWebsocket
=== CONT  TestClientCancelWebsocket
    client_test.go:334: found unexpected goroutines:
        [Goroutine 1 in state chan receive, with testing.tRunner.func1 on top of the stack:
        testing.tRunner.func1()
        	/usr/local/go/src/testing/testing.go:1650 +0x43c
        testing.tRunner(0x140001b3040, 0x140002bfc58)
        	/usr/local/go/src/testing/testing.go:1695 +0x128
        testing.runTests(0x140001a85d0, {0x102a44fe0, 0x33, 0x33}, {0x140002bfd18?, 0x102246030?, 0x102a4bc20?})
        	/usr/local/go/src/testing/testing.go:2159 +0x3b0
        testing.(*M).Run(0x140001a5400)
        	/usr/local/go/src/testing/testing.go:2027 +0x5a4
        main.main()
        	_testmain.go:151 +0x16c

         Goroutine 35 in state chan receive, with github.com/ethereum/go-ethereum/metrics.(*meterTicker).loop on top of the stack:
        github.com/ethereum/go-ethereum/metrics.(*meterTicker).loop(0x102a4b7e0)
        	/Users/i-tsyplenkov/repos/go/src/github.com/ilia-tsyplenkov/go-ethereum/metrics/meter.go:159 +0x50
        created by github.com/ethereum/go-ethereum/metrics.(*meterTicker).add in goroutine 1
        	/Users/i-tsyplenkov/repos/go/src/github.com/ilia-tsyplenkov/go-ethereum/metrics/meter.go:145 +0xc8
        ]
--- FAIL: TestClientCancelWebsocket (7.16s)
FAIL
FAIL	github.com/ethereum/go-ethereum/rpc	7.569s
FAIL
```