### PR TITLE
core: default zero difficulty in genesis

### DIFF
--- a/core/genesis.go
+++ b/core/genesis.go
@@ -35,6 +35,7 @@ import (
 	"github.com/ethereum/go-ethereum/ethdb"
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/params"
+	"github.com/ethereum/go-ethereum/params/forks"
 	"github.com/ethereum/go-ethereum/rlp"
 	"github.com/ethereum/go-ethereum/trie"
 	"github.com/ethereum/go-ethereum/triedb"
@@ -460,7 +461,13 @@ func (g *Genesis) toBlockWithRoot(root common.Hash) *types.Block {
 		head.GasLimit = params.GenesisGasLimit
 	}
 	if g.Difficulty == nil && g.Mixhash == (common.Hash{}) {
-		head.Difficulty = params.GenesisDifficulty
+		if g.Config.LatestFork(g.Timestamp) >= forks.Shanghai {
+			// If chain is merged at genesis, set difficulty to zero.
+			head.Difficulty = big.NewInt(0)
+		} else {
+			// In case chain is not merged at genesis, set default genesis difficulty.
+			head.Difficulty = params.GenesisDifficulty
+		}
 	}
 	if g.Config != nil && g.Config.IsLondon(common.Big0) {
 		if g.BaseFee != nil {

--- a/internal/ethapi/testdata/eth_getBlockReceipts-block-with-blob-tx.json
+++ b/internal/ethapi/testdata/eth_getBlockReceipts-block-with-blob-tx.json
@@ -2,7 +2,7 @@
   {
     "blobGasPrice": "0x1",
     "blobGasUsed": "0x20000",
-    "blockHash": "0x5f58514bcb3b216908f0aff6ced44666c3aa250df06093150ac850a7a7850f3c",
+    "blockHash": "0x12f35dd085ba1bb9ce75b18c5dcf82e837c2a424131bdb0a638d31ccf7b63852",
     "blockNumber": "0x6",
     "contractAddress": null,
     "cumulativeGasUsed": "0x5208",

--- a/internal/ethapi/testdata/eth_getBlockReceipts-block-with-contract-create-tx.json
+++ b/internal/ethapi/testdata/eth_getBlockReceipts-block-with-contract-create-tx.json
@@ -1,6 +1,6 @@
 [
   {
-    "blockHash": "0xb3e447c77374fd285964cba692e96b1673a88a959726826b5b6e2dca15472b0a",
+    "blockHash": "0x96de79feef96d5ec9f81123b63a74766200633dbb95fd61023415ed87b479703",
     "blockNumber": "0x2",
     "contractAddress": "0xae9bea628c4ce503dcfd7e305cab4e29e7476592",
     "cumulativeGasUsed": "0xcf50",

--- a/internal/ethapi/testdata/eth_getBlockReceipts-block-with-dynamic-fee-tx.json
+++ b/internal/ethapi/testdata/eth_getBlockReceipts-block-with-dynamic-fee-tx.json
@@ -1,6 +1,6 @@
 [
   {
-    "blockHash": "0x47cd44027bb55856a175e36be0396bad221e52172529d9c1bf12bf5424a041ae",
+    "blockHash": "0xaeff4444b1447c13d1b64b155c52c9e4b4b88601f2fe6ca5aa91a99695046ac4",
     "blockNumber": "0x4",
     "contractAddress": null,
     "cumulativeGasUsed": "0x5564",

--- a/internal/ethapi/testdata/eth_getBlockReceipts-block-with-legacy-contract-call-tx.json
+++ b/internal/ethapi/testdata/eth_getBlockReceipts-block-with-legacy-contract-call-tx.json
@@ -1,6 +1,6 @@
 [
   {
-    "blockHash": "0xcc6225bf39327429a3d869af71182d619a354155187d0b5a8ecd6a9309cffcaa",
+    "blockHash": "0x824b90c5bf9a0886e6c7fe62bb6f5a76dd295e25187e0954e821baa4a3466889",
     "blockNumber": "0x3",
     "contractAddress": null,
     "cumulativeGasUsed": "0x5e28",
@@ -19,7 +19,7 @@
         "blockNumber": "0x3",
         "transactionHash": "0xeaf3921cbf03ba45bad4e6ab807b196ce3b2a0b5bacc355b6272fa96b11b4287",
         "transactionIndex": "0x0",
-        "blockHash": "0xcc6225bf39327429a3d869af71182d619a354155187d0b5a8ecd6a9309cffcaa",
+        "blockHash": "0x824b90c5bf9a0886e6c7fe62bb6f5a76dd295e25187e0954e821baa4a3466889",
         "logIndex": "0x0",
         "removed": false
       }

--- a/internal/ethapi/testdata/eth_getBlockReceipts-block-with-legacy-transfer-tx.json
+++ b/internal/ethapi/testdata/eth_getBlockReceipts-block-with-legacy-transfer-tx.json
@@ -1,6 +1,6 @@
 [
   {
-    "blockHash": "0xe9bd1d8c303b1af5c704b9d78e62c54a34af47e0db04ac1389a5ef74a619b9da",
+    "blockHash": "0xd086509bb9758be8588fba13ea6f80bee66781e301e0d091643c8f0a86dfd582",
     "blockNumber": "0x1",
     "contractAddress": null,
     "cumulativeGasUsed": "0x5208",

--- a/internal/ethapi/testdata/eth_getBlockReceipts-tag-latest.json
+++ b/internal/ethapi/testdata/eth_getBlockReceipts-tag-latest.json
@@ -2,7 +2,7 @@
   {
     "blobGasPrice": "0x1",
     "blobGasUsed": "0x20000",
-    "blockHash": "0x5f58514bcb3b216908f0aff6ced44666c3aa250df06093150ac850a7a7850f3c",
+    "blockHash": "0x12f35dd085ba1bb9ce75b18c5dcf82e837c2a424131bdb0a638d31ccf7b63852",
     "blockNumber": "0x6",
     "contractAddress": null,
     "cumulativeGasUsed": "0x5208",

--- a/internal/ethapi/testdata/eth_getTransactionReceipt-blob-tx.json
+++ b/internal/ethapi/testdata/eth_getTransactionReceipt-blob-tx.json
@@ -1,7 +1,7 @@
 {
   "blobGasPrice": "0x1",
   "blobGasUsed": "0x20000",
-  "blockHash": "0x5f58514bcb3b216908f0aff6ced44666c3aa250df06093150ac850a7a7850f3c",
+  "blockHash": "0x12f35dd085ba1bb9ce75b18c5dcf82e837c2a424131bdb0a638d31ccf7b63852",
   "blockNumber": "0x6",
   "contractAddress": null,
   "cumulativeGasUsed": "0x5208",

--- a/internal/ethapi/testdata/eth_getTransactionReceipt-create-contract-tx.json
+++ b/internal/ethapi/testdata/eth_getTransactionReceipt-create-contract-tx.json
@@ -1,5 +1,5 @@
 {
-  "blockHash": "0xb3e447c77374fd285964cba692e96b1673a88a959726826b5b6e2dca15472b0a",
+  "blockHash": "0x96de79feef96d5ec9f81123b63a74766200633dbb95fd61023415ed87b479703",
   "blockNumber": "0x2",
   "contractAddress": "0xae9bea628c4ce503dcfd7e305cab4e29e7476592",
   "cumulativeGasUsed": "0xcf50",

--- a/internal/ethapi/testdata/eth_getTransactionReceipt-create-contract-with-access-list.json
+++ b/internal/ethapi/testdata/eth_getTransactionReceipt-create-contract-with-access-list.json
@@ -1,5 +1,5 @@
 {
-  "blockHash": "0x5bff93f8f94ba7ee52bef1a80062b9fed22c6d1eebb2b0e87a4a003365a7bd66",
+  "blockHash": "0x3a33ee3927eebdf45100251bde853743cefa1527abbc4933f54cb184df7377a9",
   "blockNumber": "0x5",
   "contractAddress": "0xfdaa97661a584d977b4d3abb5370766ff5b86a18",
   "cumulativeGasUsed": "0xe01c",

--- a/internal/ethapi/testdata/eth_getTransactionReceipt-dynamic-tx-with-logs.json
+++ b/internal/ethapi/testdata/eth_getTransactionReceipt-dynamic-tx-with-logs.json
@@ -1,5 +1,5 @@
 {
-  "blockHash": "0x47cd44027bb55856a175e36be0396bad221e52172529d9c1bf12bf5424a041ae",
+  "blockHash": "0xaeff4444b1447c13d1b64b155c52c9e4b4b88601f2fe6ca5aa91a99695046ac4",
   "blockNumber": "0x4",
   "contractAddress": null,
   "cumulativeGasUsed": "0x5564",

--- a/internal/ethapi/testdata/eth_getTransactionReceipt-normal-transfer-tx.json
+++ b/internal/ethapi/testdata/eth_getTransactionReceipt-normal-transfer-tx.json
@@ -1,5 +1,5 @@
 {
-  "blockHash": "0xe9bd1d8c303b1af5c704b9d78e62c54a34af47e0db04ac1389a5ef74a619b9da",
+  "blockHash": "0xd086509bb9758be8588fba13ea6f80bee66781e301e0d091643c8f0a86dfd582",
   "blockNumber": "0x1",
   "contractAddress": null,
   "cumulativeGasUsed": "0x5208",

--- a/internal/ethapi/testdata/eth_getTransactionReceipt-with-logs.json
+++ b/internal/ethapi/testdata/eth_getTransactionReceipt-with-logs.json
@@ -1,5 +1,5 @@
 {
-  "blockHash": "0xcc6225bf39327429a3d869af71182d619a354155187d0b5a8ecd6a9309cffcaa",
+  "blockHash": "0x824b90c5bf9a0886e6c7fe62bb6f5a76dd295e25187e0954e821baa4a3466889",
   "blockNumber": "0x3",
   "contractAddress": null,
   "cumulativeGasUsed": "0x5e28",
@@ -18,7 +18,7 @@
       "blockNumber": "0x3",
       "transactionHash": "0xeaf3921cbf03ba45bad4e6ab807b196ce3b2a0b5bacc355b6272fa96b11b4287",
       "transactionIndex": "0x0",
-      "blockHash": "0xcc6225bf39327429a3d869af71182d619a354155187d0b5a8ecd6a9309cffcaa",
+      "blockHash": "0x824b90c5bf9a0886e6c7fe62bb6f5a76dd295e25187e0954e821baa4a3466889",
       "logIndex": "0x0",
       "removed": false
     }


### PR DESCRIPTION
Right now we default to `params.GenesisDifficulty` when the difficulty is not configured for genesis. This causes the genesis to be a non-conforming "merged" block since the difficulty is non-zero. This PR will determine if a chain is merged (i.e. a timestamped fork is already active) and set the difficulty to zero in such instances. It retains the original behavior when the chain is not merged at genesis.