### PR TITLE
syncx: fix mutex dead lock

### DIFF
--- a/internal/syncx/mutex.go
+++ b/internal/syncx/mutex.go
@@ -15,6 +15,7 @@
 // along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
 
 // Package syncx contains exotic synchronization primitives.
+
 package syncx
 
 // ClosableMutex is a mutex that can also be closed.

--- a/internal/syncx/mutex.go
+++ b/internal/syncx/mutex.go
@@ -17,7 +17,8 @@
 // Package syncx contains exotic synchronization primitives.
 package syncx
 
-// ClosableMutex is a mutex that can be closed. Once closed, it cannot be locked again.
+// ClosableMutex is a mutex that can be closed.
+// Once closed, it cannot be locked again.
 type ClosableMutex struct {
 	ch chan struct{}
 }
@@ -29,7 +30,8 @@ func NewClosableMutex() *ClosableMutex {
 	return &ClosableMutex{ch: ch}
 }
 
-// TryLock attempts to acquire the lock. Returns true if successful, false if the lock is closed or unavailable.
+// TryLock attempts to lock cm.
+// If the mutex is closed, TryLock returns false.
 func (cm *ClosableMutex) TryLock() bool {
 	select {
 	case <-cm.ch:
@@ -39,7 +41,8 @@ func (cm *ClosableMutex) TryLock() bool {
 	}
 }
 
-// MustLock acquires the lock. Panics if the lock is already closed.
+// MustLock locks cm.
+// If the mutex is closed, MustLock panics.
 func (cm *ClosableMutex) MustLock() {
 	select {
 	case <-cm.ch:
@@ -49,7 +52,7 @@ func (cm *ClosableMutex) MustLock() {
 	}
 }
 
-// Unlock releases the lock. Panics if the lock is already closed or if called without holding the lock.
+// Unlock unlocks cm.
 func (cm *ClosableMutex) Unlock() {
 	select {
 	case cm.ch <- struct{}{}:
@@ -58,7 +61,7 @@ func (cm *ClosableMutex) Unlock() {
 	}
 }
 
-// Close closes the mutex, preventing further lock operations. Panics if called on an already-closed mutex.
+// Close locks the mutex, then closes it.
 func (cm *ClosableMutex) Close() {
 	select {
 	case <-cm.ch:

--- a/internal/syncx/mutex.go
+++ b/internal/syncx/mutex.go
@@ -17,8 +17,8 @@
 // Package syncx contains exotic synchronization primitives.
 package syncx
 
-// ClosableMutex is a mutex that can be closed.
-// Once closed, it cannot be locked again.
+// ClosableMutex is a mutex that can also be closed.
+// Once closed, it can never be taken again.
 type ClosableMutex struct {
 	ch chan struct{}
 }

--- a/internal/syncx/mutex.go
+++ b/internal/syncx/mutex.go
@@ -65,7 +65,10 @@ func (cm *ClosableMutex) Unlock() {
 // Close locks the mutex, then closes it.
 func (cm *ClosableMutex) Close() {
 	select {
-	case <-cm.ch:
+	case _, ok := <-cm.ch:
+		if !ok {
+			panic("Close of already-closed ClosableMutex")
+		}
 	default:
 	}
 	close(cm.ch)

--- a/internal/syncx/mutex.go
+++ b/internal/syncx/mutex.go
@@ -27,7 +27,7 @@ type ClosableMutex struct {
 func NewClosableMutex() *ClosableMutex {
 	ch := make(chan struct{}, 1)
 	ch <- struct{}{}
-	return &ClosableMutex{ch: ch}
+	return &ClosableMutex{ch}
 }
 
 // TryLock attempts to lock cm.

--- a/internal/syncx/mutex_test.go
+++ b/internal/syncx/mutex_test.go
@@ -32,7 +32,9 @@ func TestClosableMutex_MustLock(t *testing.T) {
 	cm := NewClosableMutex()
 	cm.MustLock()
 	defer func() {
-		if r := recover(); r == nil {
+		if r := recover(); r != nil {
+			t.Log("panic detected:", r) // Log the panic message
+		} else {
 			t.Fatal("expected MustLock to panic when already locked")
 		}
 	}()

--- a/internal/syncx/mutex_test.go
+++ b/internal/syncx/mutex_test.go
@@ -5,6 +5,9 @@ import (
 	"time"
 )
 
+// TestClosableMutex_TryLock tests the TryLock functionality of ClosableMutex.
+// It verifies that TryLock succeeds when the mutex is unlocked, fails when already locked,
+// succeeds after unlocking, and fails after the mutex is closed.
 func TestClosableMutex_TryLock(t *testing.T) {
 	cm := NewClosableMutex()
 	if !cm.TryLock() {
@@ -23,6 +26,8 @@ func TestClosableMutex_TryLock(t *testing.T) {
 	}
 }
 
+// TestClosableMutex_MustLock tests the MustLock functionality of ClosableMutex.
+// It verifies that MustLock succeeds when the mutex is unlocked and panics when already locked.
 func TestClosableMutex_MustLock(t *testing.T) {
 	cm := NewClosableMutex()
 	cm.MustLock()
@@ -34,6 +39,8 @@ func TestClosableMutex_MustLock(t *testing.T) {
 	cm.MustLock()
 }
 
+// TestClosableMutex_Unlock tests the Unlock functionality of ClosableMutex.
+// It verifies that Unlock succeeds when the mutex is locked and panics when already unlocked.
 func TestClosableMutex_Unlock(t *testing.T) {
 	cm := NewClosableMutex()
 	cm.MustLock()
@@ -46,6 +53,8 @@ func TestClosableMutex_Unlock(t *testing.T) {
 	cm.Unlock()
 }
 
+// TestClosableMutex_Close tests the Close functionality of ClosableMutex.
+// It verifies that Close succeeds when the mutex is locked and panics when already closed.
 func TestClosableMutex_Close(t *testing.T) {
 	cm := NewClosableMutex()
 	cm.MustLock()
@@ -58,20 +67,23 @@ func TestClosableMutex_Close(t *testing.T) {
 	cm.Close()
 }
 
+// TestClosableMutex_Concurrent tests the concurrent behavior of ClosableMutex.
+// It verifies that TryLock fails when the mutex is locked by another goroutine
+// and succeeds after the other goroutine unlocks it.
 func TestClosableMutex_Concurrent(t *testing.T) {
 	cm := NewClosableMutex()
 	done := make(chan struct{})
 	go func() {
 		cm.MustLock()
-		time.Sleep(100 * time.Millisecond)
+		time.Sleep(100 * time.Millisecond) // Simulate work while holding the lock
 		cm.Unlock()
 		close(done)
 	}()
-	time.Sleep(50 * time.Millisecond)
+	time.Sleep(50 * time.Millisecond) // Wait for the goroutine to acquire the lock
 	if cm.TryLock() {
 		t.Fatal("expected TryLock to fail when locked by another goroutine")
 	}
-	<-done
+	<-done // Wait for the goroutine to release the lock
 	if !cm.TryLock() {
 		t.Fatal("expected TryLock to succeed after other goroutine unlocks")
 	}

--- a/internal/syncx/mutex_test.go
+++ b/internal/syncx/mutex_test.go
@@ -1,0 +1,79 @@
+package syncx
+
+import (
+	"testing"
+	"time"
+)
+
+func TestClosableMutex_TryLock(t *testing.T) {
+	cm := NewClosableMutex()
+	if !cm.TryLock() {
+		t.Fatal("expected TryLock to succeed")
+	}
+	if cm.TryLock() {
+		t.Fatal("expected TryLock to fail when already locked")
+	}
+	cm.Unlock()
+	if !cm.TryLock() {
+		t.Fatal("expected TryLock to succeed after unlock")
+	}
+	cm.Close()
+	if cm.TryLock() {
+		t.Fatal("expected TryLock to fail after close")
+	}
+}
+
+func TestClosableMutex_MustLock(t *testing.T) {
+	cm := NewClosableMutex()
+	cm.MustLock()
+	defer func() {
+		if r := recover(); r == nil {
+			t.Fatal("expected MustLock to panic when already locked")
+		}
+	}()
+	cm.MustLock()
+}
+
+func TestClosableMutex_Unlock(t *testing.T) {
+	cm := NewClosableMutex()
+	cm.MustLock()
+	cm.Unlock()
+	defer func() {
+		if r := recover(); r == nil {
+			t.Fatal("expected Unlock to panic when already unlocked")
+		}
+	}()
+	cm.Unlock()
+}
+
+func TestClosableMutex_Close(t *testing.T) {
+	cm := NewClosableMutex()
+	cm.MustLock()
+	cm.Close()
+	defer func() {
+		if r := recover(); r == nil {
+			t.Fatal("expected Close to panic when already closed")
+		}
+	}()
+	cm.Close()
+}
+
+func TestClosableMutex_Concurrent(t *testing.T) {
+	cm := NewClosableMutex()
+	done := make(chan struct{})
+	go func() {
+		cm.MustLock()
+		time.Sleep(100 * time.Millisecond)
+		cm.Unlock()
+		close(done)
+	}()
+	time.Sleep(50 * time.Millisecond)
+	if cm.TryLock() {
+		t.Fatal("expected TryLock to fail when locked by another goroutine")
+	}
+	<-done
+	if !cm.TryLock() {
+		t.Fatal("expected TryLock to succeed after other goroutine unlocks")
+	}
+	cm.Unlock()
+}

--- a/internal/syncx/mutex_test.go
+++ b/internal/syncx/mutex_test.go
@@ -21,7 +21,7 @@ func TestClosableMutex_TryLock(t *testing.T) {
 		t.Fatal("expected TryLock to succeed after unlock")
 	}
 	cm.Close()
-	if cm.TryLock() {
+	if !cm.TryLock() {
 		t.Fatal("expected TryLock to fail after close")
 	}
 }

--- a/internal/syncx/mutex_test.go
+++ b/internal/syncx/mutex_test.go
@@ -46,7 +46,9 @@ func TestClosableMutex_Unlock(t *testing.T) {
 	cm.MustLock()
 	cm.Unlock()
 	defer func() {
-		if r := recover(); r == nil {
+		if r := recover(); r != nil {
+			t.Log("panic detected:", r) // Log the panic message
+		} else {
 			t.Fatal("expected Unlock to panic when already unlocked")
 		}
 	}()
@@ -60,8 +62,10 @@ func TestClosableMutex_Close(t *testing.T) {
 	cm.MustLock()
 	cm.Close()
 	defer func() {
-		if r := recover(); r == nil {
-			t.Fatal("expected Close to panic when already closed")
+		if r := recover(); r != nil {
+			t.Log("panic detected:", r) // Log the panic message
+		} else {
+			t.Fatal("expected Close to panic when already closed", r)
 		}
 	}()
 	cm.Close()


### PR DESCRIPTION
## Issue description

```go
func TestClosableMutex_TryLock(t *testing.T) {
	cm := NewClosableMutex()
	if !cm.TryLock() {
		t.Fatal("expected TryLock to succeed")
	}
	if cm.TryLock() {
		t.Fatal("expected TryLock to fail when already locked")
	}
	cm.Unlock()
	if !cm.TryLock() {
		t.Fatal("expected TryLock to succeed after unlock")
	}
	cm.Close()
	if cm.TryLock() {
		t.Fatal("expected TryLock to fail after close")
	}
}
```

I added this unit test and found the `syncx.ClosableMutex` exists `fatal error: all goroutines are asleep - deadlock!`

here is the detail error info
```
=== RUN   TestClosableMutex_TryLock
fatal error: all goroutines are asleep - deadlock!

goroutine 1 [chan receive]:
testing.(*T).Run(0x1400019a4e0, {0x104fc8fb5?, 0x140001d3b48?}, 0x105032e80)
	/Users/xx/sdk/go1.23.0/src/testing/testing.go:1751 +0x328
testing.runTests.func1(0x1400019a4e0)
	/Users/xx/sdk/go1.23.0/src/testing/testing.go:2168 +0x40
testing.tRunner(0x1400019a4e0, 0x140001d3c68)
	/Users/xx/sdk/go1.23.0/src/testing/testing.go:1690 +0xe4
testing.runTests(0x140001a4030, {0x105103e80, 0x1, 0x1}, {0x1a00000000000000?, 0x1a99828f5c3ca2ca?, 0x0?})
	/Users/xx/sdk/go1.23.0/src/testing/testing.go:2166 +0x3ac
testing.(*M).Run(0x140001c60a0)
	/Users/xx/sdk/go1.23.0/src/testing/testing.go:2034 +0x588
main.main()
	_testmain.go:45 +0x90

goroutine 34 [chan receive]:
github.com/ethereum/go-ethereum/internal/syncx.(*ClosableMutex).TryLock(...)
	/Users/xx/goproject/go-ethereum/internal/syncx/mutex.go:35
github.com/ethereum/go-ethereum/internal/syncx.TestClosableMutex_TryLock(0x1400019a680)
	/Users/xx/goproject/go-ethereum/internal/syncx/mutex_test.go:10 +0x8c
testing.tRunner(0x1400019a680, 0x105032e80)
	/Users/xx/sdk/go1.23.0/src/testing/testing.go:1690 +0xe4
created by testing.(*T).Run in goroutine 1
	/Users/xx/sdk/go1.23.0/src/testing/testing.go:1743 +0x314
```

This PR fixes this issue and adds some unit tests
