### PR TITLE
core/txpool/blobpool: fix incorrect arguments in test

### DIFF
--- a/core/txpool/blobpool/blobpool_test.go
+++ b/core/txpool/blobpool/blobpool_test.go
@@ -1108,7 +1108,7 @@ func TestChangingSlotterSize(t *testing.T) {
 
 		// Try to add the big blob tx. In the initial iteration it should overflow
 		// the pool. On the subsequent iteration it should be accepted.
-		errs := pool.Add([]*types.Transaction{tx3}, false, true)
+		errs := pool.Add([]*types.Transaction{tx3}, true)
 		if _, ok := pool.index[addr3]; ok && maxBlobs == 6 {
 			t.Errorf("expected insert of oversized blob tx to fail: blobs=24, maxBlobs=%d, err=%v", maxBlobs, errs[0])
 		} else if !ok && maxBlobs == 10 {


### PR DESCRIPTION
Fixes the lint on master which was broken by https://github.com/ethereum/go-ethereum/pull/30559