### PR TITLE
consensus/misc/eip4844: more changes for blob gas calculation

### DIFF
--- a/cmd/evm/internal/t8ntool/execution.go
+++ b/cmd/evm/internal/t8ntool/execution.go
@@ -198,7 +198,7 @@ func (pre *Prestate) Apply(vmConfig vm.Config, chainConfig *params.ChainConfig, 
 				Time:          pre.Env.Timestamp,
 				ExcessBlobGas: &excessBlobGas,
 			}
-			excessBlobGas = eip4844.CalcExcessBlobGas(chainConfig, parent, header)
+			excessBlobGas = eip4844.CalcExcessBlobGas(chainConfig, parent, header.Time)
 			vmContext.BlobBaseFee = eip4844.CalcBlobFee(chainConfig, header)
 		}
 	}

--- a/consensus/misc/eip4844/eip4844.go
+++ b/consensus/misc/eip4844/eip4844.go
@@ -34,6 +34,9 @@ var (
 // if the current block contains no transactions, the excessBlobGas is updated
 // accordingly.
 func VerifyEIP4844Header(config *params.ChainConfig, parent, header *types.Header) error {
+	if header.Number.Uint64() != parent.Number.Uint64()+1 {
+		panic("bad header pair")
+	}
 	// Verify the header is not malformed
 	if header.ExcessBlobGas == nil {
 		return errors.New("header is missing excessBlobGas")

--- a/consensus/misc/eip4844/eip4844.go
+++ b/consensus/misc/eip4844/eip4844.go
@@ -53,7 +53,7 @@ func VerifyEIP4844Header(config *params.ChainConfig, parent, header *types.Heade
 		return fmt.Errorf("blob gas used %d not a multiple of blob gas per blob %d", header.BlobGasUsed, params.BlobTxBlobGasPerBlob)
 	}
 	// Verify the excessBlobGas is correct based on the parent header
-	expectedExcessBlobGas := CalcExcessBlobGas(config, parent, header)
+	expectedExcessBlobGas := CalcExcessBlobGas(config, parent, header.Time)
 	if *header.ExcessBlobGas != expectedExcessBlobGas {
 		return fmt.Errorf("invalid excessBlobGas: have %d, want %d", *header.ExcessBlobGas, expectedExcessBlobGas)
 	}
@@ -62,9 +62,8 @@ func VerifyEIP4844Header(config *params.ChainConfig, parent, header *types.Heade
 
 // CalcExcessBlobGas calculates the excess blob gas after applying the set of
 // blobs on top of the excess blob gas.
-func CalcExcessBlobGas(config *params.ChainConfig, parent, header *types.Header) uint64 {
+func CalcExcessBlobGas(config *params.ChainConfig, parent *types.Header, headTimestamp uint64) uint64 {
 	var (
-		targetGas           = uint64(targetBlobsPerBlock(config, header.Time)) * params.BlobTxBlobGasPerBlob
 		parentExcessBlobGas uint64
 		parentBlobGasUsed   uint64
 	)
@@ -73,6 +72,7 @@ func CalcExcessBlobGas(config *params.ChainConfig, parent, header *types.Header)
 		parentBlobGasUsed = *parent.BlobGasUsed
 	}
 	excessBlobGas := parentExcessBlobGas + parentBlobGasUsed
+	targetGas := uint64(targetBlobsPerBlock(config, headTimestamp)) * params.BlobTxBlobGasPerBlob
 	if excessBlobGas < targetGas {
 		return 0
 	}

--- a/consensus/misc/eip4844/eip4844_test.go
+++ b/consensus/misc/eip4844/eip4844_test.go
@@ -57,15 +57,11 @@ func TestCalcExcessBlobGas(t *testing.T) {
 	}
 	for i, tt := range tests {
 		blobGasUsed := uint64(tt.blobs) * params.BlobTxBlobGasPerBlob
-		head := &types.Header{
-			Time: *config.CancunTime,
-		}
-		parent := &types.Header{
-			Time:          *config.CancunTime,
+		header := &types.Header{
 			ExcessBlobGas: &tt.excess,
 			BlobGasUsed:   &blobGasUsed,
 		}
-		result := CalcExcessBlobGas(config, parent, head)
+		result := CalcExcessBlobGas(config, header, *config.CancunTime)
 		if result != tt.want {
 			t.Errorf("test %d: excess blob gas mismatch: have %v, want %v", i, result, tt.want)
 		}

--- a/core/state_processor_test.go
+++ b/core/state_processor_test.go
@@ -407,7 +407,7 @@ func GenerateBadBlock(parent *types.Block, engine consensus.Engine, txs types.Tr
 	}
 	header.Root = common.BytesToHash(hasher.Sum(nil))
 	if config.IsCancun(header.Number, header.Time) {
-		excess := eip4844.CalcExcessBlobGas(config, parent.Header(), header)
+		excess := eip4844.CalcExcessBlobGas(config, parent.Header(), header.Time)
 		used := uint64(nBlobs * params.BlobTxBlobGasPerBlob)
 		header.ExcessBlobGas = &excess
 		header.BlobGasUsed = &used

--- a/eth/gasprice/feehistory.go
+++ b/eth/gasprice/feehistory.go
@@ -97,7 +97,7 @@ func (oracle *Oracle) processBlock(bf *blockFees, percentiles []float64) {
 	// Fill in blob base fee and next blob base fee.
 	if excessBlobGas := bf.header.ExcessBlobGas; excessBlobGas != nil {
 		bf.results.blobBaseFee = eip4844.CalcBlobFee(config, bf.header)
-		excess := eip4844.CalcExcessBlobGas(config, bf.header, bf.header)
+		excess := eip4844.CalcExcessBlobGas(config, bf.header, bf.header.Time)
 		next := &types.Header{Number: bf.header.Number, Time: bf.header.Time, ExcessBlobGas: &excess}
 		bf.results.nextBlobBaseFee = eip4844.CalcBlobFee(config, next)
 	} else {

--- a/eth/tracers/internal/tracetest/util.go
+++ b/eth/tracers/internal/tracetest/util.go
@@ -55,7 +55,7 @@ func (c *callContext) toBlockContext(genesis *core.Genesis) vm.BlockContext {
 
 	if genesis.ExcessBlobGas != nil && genesis.BlobGasUsed != nil {
 		header := &types.Header{Number: genesis.Config.LondonBlock, Time: *genesis.Config.CancunTime}
-		excess := eip4844.CalcExcessBlobGas(genesis.Config, header, genesis.ToBlock().Header())
+		excess := eip4844.CalcExcessBlobGas(genesis.Config, header, genesis.Timestamp)
 		header.ExcessBlobGas = &excess
 		context.BlobBaseFee = eip4844.CalcBlobFee(genesis.Config, header)
 	}

--- a/internal/ethapi/simulate.go
+++ b/internal/ethapi/simulate.go
@@ -159,7 +159,7 @@ func (sim *simulator) processBlock(ctx context.Context, block *simBlock, header,
 	if sim.chainConfig.IsCancun(header.Number, header.Time) {
 		var excess uint64
 		if sim.chainConfig.IsCancun(parent.Number, parent.Time) {
-			excess = eip4844.CalcExcessBlobGas(sim.chainConfig, parent, header)
+			excess = eip4844.CalcExcessBlobGas(sim.chainConfig, parent, header.Time)
 		}
 		header.ExcessBlobGas = &excess
 	}

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -210,7 +210,7 @@ func (miner *Miner) prepareWork(genParams *generateParams, witness bool) (*envir
 	if miner.chainConfig.IsCancun(header.Number, header.Time) {
 		var excessBlobGas uint64
 		if miner.chainConfig.IsCancun(parent.Number, parent.Time) {
-			excessBlobGas = eip4844.CalcExcessBlobGas(miner.chainConfig, parent, header)
+			excessBlobGas = eip4844.CalcExcessBlobGas(miner.chainConfig, parent, timestamp)
 		}
 		header.BlobGasUsed = new(uint64)
 		header.ExcessBlobGas = &excessBlobGas


### PR DESCRIPTION
As noted in the review of #31101, it's a bit weird to pass two headers to `CalcExcessBlobGas`. We only use the second header to look up the fork timestamp, so I'm changing the function here to pass that timestamp. Most callers are not affected much, but it does make a difference in places like in tracetest which had to commit the genesis state and create a block just to get this header.

Also adding a small sanity check for the parent<->child relationship in `VerifyEIP4844Header`.