### PR TITLE
core/tracing: auto upgrade deprecated hooks

### DIFF
--- a/core/state/statedb_hooked.go
+++ b/core/state/statedb_hooked.go
@@ -184,8 +184,6 @@ func (s *hookedStateDB) SetNonce(address common.Address, nonce uint64, reason tr
 	s.inner.SetNonce(address, nonce, reason)
 	if s.hooks.OnNonceChangeV2 != nil {
 		s.hooks.OnNonceChangeV2(address, prev, nonce, reason)
-	} else if s.hooks.OnNonceChange != nil {
-		s.hooks.OnNonceChange(address, prev, nonce)
 	}
 }
 

--- a/core/state/statedb_hooked_test.go
+++ b/core/state/statedb_hooked_test.go
@@ -98,7 +98,7 @@ func TestHooks(t *testing.T) {
 		OnBalanceChange: func(addr common.Address, prev, new *big.Int, reason tracing.BalanceChangeReason) {
 			emitF("%v.balance: %v->%v (%v)", addr, prev, new, reason)
 		},
-		OnNonceChange: func(addr common.Address, prev, new uint64) {
+		OnNonceChangeV2: func(addr common.Address, prev, new uint64, reason tracing.NonceChangeReason) {
 			emitF("%v.nonce: %v->%v", addr, prev, new)
 		},
 		OnCodeChange: func(addr common.Address, prevCodeHash common.Hash, prevCode []byte, codeHash common.Hash, code []byte) {

--- a/core/tracing/journal_test.go
+++ b/core/tracing/journal_test.go
@@ -297,7 +297,9 @@ func newTracerAllHooks() *tracerAllHooks {
 	for i := 0; i < hooksType.NumField(); i++ {
 		t.hooksCalled[hooksType.Field(i).Name] = false
 	}
+	// Deprecated methods
 	delete(t.hooksCalled, "OnNonceChange")
+	delete(t.hooksCalled, "OnSystemCallStart")
 	return t
 }
 
@@ -322,7 +324,11 @@ func (t *tracerAllHooks) hooks() *Hooks {
 	hooksValue := reflect.ValueOf(h).Elem()
 	for i := 0; i < hooksValue.NumField(); i++ {
 		field := hooksValue.Type().Field(i)
+		// Skip deprecated methods
 		if field.Name == "OnNonceChange" {
+			continue
+		}
+		if field.Name == "OnSystemCallStart" {
 			continue
 		}
 		hookMethod := reflect.MakeFunc(field.Type, func(args []reflect.Value) []reflect.Value {

--- a/eth/tracers/live/supply.go
+++ b/eth/tracers/live/supply.go
@@ -120,6 +120,7 @@ func newSupplyTracer(cfg json.RawMessage) (*tracing.Hooks, error) {
 		OnGenesisBlock:   t.onGenesisBlock,
 		OnTxStart:        t.onTxStart,
 		OnBalanceChange:  t.onBalanceChange,
+		OnNonceChange:    t.onNonceChange,
 		OnEnter:          t.onEnter,
 		OnExit:           t.onExit,
 		OnClose:          t.onClose,
@@ -325,4 +326,7 @@ func (s *supplyTracer) write(data any) {
 	if _, err := s.logger.Write([]byte{'\n'}); err != nil {
 		log.Warn("failed to write to supply tracer log file", "error", err)
 	}
+}
+func (t *supplyTracer) onNonceChange(addr common.Address, prev, new uint64) {
+	fmt.Printf("Nonce change for %s: %d -> %d\n", addr, prev, new)
 }


### PR DESCRIPTION
In this release we have 2 deprecated methods:

- `OnSystemCallStart` which has been deprecated in favor of `OnSystemCallStartV2`
- `OnNonceChange` which has been deprecated in favor of `OnNonceChangeV2`

To not break tracers we opted to still call the deprecated methods. This shows itself in EVM, hooked statedb and causes also complications in the tracing journal.

This PR introduces a upgrading mechanism for tracers which haven't been updated with the new hooks. It proxies them and exposes only the most recent versions of the hooks to EVM, simplifying the hook calling code.