### PR TITLE
eth/tracers, core: fix pre cancun blocks output new opcodes

### DIFF
--- a/cmd/evm/internal/t8ntool/file_tracer.go
+++ b/cmd/evm/internal/t8ntool/file_tracer.go
@@ -128,9 +128,9 @@ func (l *fileWritingTracer) hooks() *tracing.Hooks {
 				l.inner.OnExit(depth, output, gasUsed, err, reverted)
 			}
 		},
-		OnOpcode: func(pc uint64, op byte, gas, cost uint64, scope tracing.OpContext, rData []byte, depth int, err error) {
+		OnOpcode: func(pc uint64, op byte, gas, cost uint64, scope tracing.OpContext, rData []byte, depth int, isCancun bool, err error) {
 			if l.inner != nil && l.inner.OnOpcode != nil {
-				l.inner.OnOpcode(pc, op, gas, cost, scope, rData, depth, err)
+				l.inner.OnOpcode(pc, op, gas, cost, scope, rData, depth, isCancun, err)
 			}
 		},
 		OnFault: func(pc uint64, op byte, gas, cost uint64, scope tracing.OpContext, depth int, err error) {

--- a/core/tracing/hooks.go
+++ b/core/tracing/hooks.go
@@ -108,7 +108,7 @@ type (
 	ExitHook = func(depth int, output []byte, gasUsed uint64, err error, reverted bool)
 
 	// OpcodeHook is invoked just prior to the execution of an opcode.
-	OpcodeHook = func(pc uint64, op byte, gas, cost uint64, scope OpContext, rData []byte, depth int, err error)
+	OpcodeHook = func(pc uint64, op byte, gas, cost uint64, scope OpContext, rData []byte, depth int, isCancun bool, err error)
 
 	// FaultHook is invoked when an error occurs during the execution of an opcode.
 	FaultHook = func(pc uint64, op byte, gas, cost uint64, scope OpContext, depth int, err error)

--- a/core/vm/interpreter.go
+++ b/core/vm/interpreter.go
@@ -298,7 +298,7 @@ func (in *EVMInterpreter) Run(contract *Contract, input []byte, readOnly bool) (
 				in.evm.Config.Tracer.OnGasChange(gasCopy, gasCopy-cost, tracing.GasChangeCallOpCode)
 			}
 			if in.evm.Config.Tracer.OnOpcode != nil {
-				in.evm.Config.Tracer.OnOpcode(pcCopy, byte(op), gasCopy, cost, callContext, in.returnData, in.evm.depth, in.evm.chainConfig.IsCancun(in.evm.Context.BlockNumber, in.evm.Context.Time), VMErrorFromErr(err))
+				in.evm.Config.Tracer.OnOpcode(pc, byte(op), gasCopy, cost, callContext, in.returnData, in.evm.depth, in.evm.chainConfig.IsCancun(in.evm.Context.BlockNumber, in.evm.Context.Time), VMErrorFromErr(err))
 				logged = true
 			}
 		}

--- a/core/vm/interpreter.go
+++ b/core/vm/interpreter.go
@@ -216,7 +216,7 @@ func (in *EVMInterpreter) Run(contract *Contract, input []byte, readOnly bool) (
 				return
 			}
 			if !logged && in.evm.Config.Tracer.OnOpcode != nil {
-				in.evm.Config.Tracer.OnOpcode(pcCopy, byte(op), gasCopy, cost, callContext, in.returnData, in.evm.depth, VMErrorFromErr(err))
+				in.evm.Config.Tracer.OnOpcode(pcCopy, byte(op), gasCopy, cost, callContext, in.returnData, in.evm.depth, in.evm.chainConfig.IsCancun(in.evm.Context.BlockNumber, in.evm.Context.Time), VMErrorFromErr(err))
 			}
 			if logged && in.evm.Config.Tracer.OnFault != nil {
 				in.evm.Config.Tracer.OnFault(pcCopy, byte(op), gasCopy, cost, callContext, in.evm.depth, VMErrorFromErr(err))
@@ -298,7 +298,7 @@ func (in *EVMInterpreter) Run(contract *Contract, input []byte, readOnly bool) (
 				in.evm.Config.Tracer.OnGasChange(gasCopy, gasCopy-cost, tracing.GasChangeCallOpCode)
 			}
 			if in.evm.Config.Tracer.OnOpcode != nil {
-				in.evm.Config.Tracer.OnOpcode(pc, byte(op), gasCopy, cost, callContext, in.returnData, in.evm.depth, VMErrorFromErr(err))
+				in.evm.Config.Tracer.OnOpcode(pcCopy, byte(op), gasCopy, cost, callContext, in.returnData, in.evm.depth, in.evm.chainConfig.IsCancun(in.evm.Context.BlockNumber, in.evm.Context.Time), VMErrorFromErr(err))
 				logged = true
 			}
 		}

--- a/core/vm/opcodes.go
+++ b/core/vm/opcodes.go
@@ -634,3 +634,11 @@ var stringToOp = map[string]OpCode{
 func StringToOp(str string) OpCode {
 	return stringToOp[str]
 }
+
+// IsCancunOpcode specifies if an opcode is added at Cancun fork.
+func (op OpCode) IsCancunOpcode() bool {
+	if op == BLOBHASH || op == BLOBBASEFEE || op == TLOAD || op == TSTORE || op == MCOPY {
+		return true
+	}
+	return false
+}

--- a/core/vm/runtime/runtime_test.go
+++ b/core/vm/runtime/runtime_test.go
@@ -680,7 +680,7 @@ func TestColdAccountAccessCost(t *testing.T) {
 		Execute(tc.code, nil, &Config{
 			EVMConfig: vm.Config{
 				Tracer: &tracing.Hooks{
-					OnOpcode: func(pc uint64, op byte, gas, cost uint64, scope tracing.OpContext, rData []byte, depth int, err error) {
+					OnOpcode: func(pc uint64, op byte, gas, cost uint64, scope tracing.OpContext, rData []byte, depth int, isCancun bool, err error) {
 						// Uncomment to investigate failures:
 						//t.Logf("%d: %v %d", step, vm.OpCode(op).String(), cost)
 						if step == tc.step {
@@ -934,7 +934,7 @@ func TestDelegatedAccountAccessCost(t *testing.T) {
 			State:       statedb,
 			EVMConfig: vm.Config{
 				Tracer: &tracing.Hooks{
-					OnOpcode: func(pc uint64, op byte, gas, cost uint64, scope tracing.OpContext, rData []byte, depth int, err error) {
+					OnOpcode: func(pc uint64, op byte, gas, cost uint64, scope tracing.OpContext, rData []byte, depth int, isCancun bool, err error) {
 						// Uncomment to investigate failures:
 						t.Logf("%d: %v %d", step, vm.OpCode(op).String(), cost)
 						if step == tc.step {

--- a/core/vm/runtime/runtime_test.go
+++ b/core/vm/runtime/runtime_test.go
@@ -682,7 +682,12 @@ func TestColdAccountAccessCost(t *testing.T) {
 				Tracer: &tracing.Hooks{
 					OnOpcode: func(pc uint64, op byte, gas, cost uint64, scope tracing.OpContext, rData []byte, depth int, isCancun bool, err error) {
 						// Uncomment to investigate failures:
-						//t.Logf("%d: %v %d", step, vm.OpCode(op).String(), cost)
+						// opString := vm.OpCode(op).String()
+						// Use hex string if Cancun is inactive but the opcode is invalid before Cancun fork
+						// if !isCancun &&  vm.OpCode(op).IsCancunOpcode() {
+						// 	opString = fmt.Sprintf("0x%x", byte(vm.OpCode(op)))
+						// }
+						//t.Logf("%d: %v %d", step, opString, cost)
 						if step == tc.step {
 							have = cost
 						}
@@ -936,7 +941,12 @@ func TestDelegatedAccountAccessCost(t *testing.T) {
 				Tracer: &tracing.Hooks{
 					OnOpcode: func(pc uint64, op byte, gas, cost uint64, scope tracing.OpContext, rData []byte, depth int, isCancun bool, err error) {
 						// Uncomment to investigate failures:
-						t.Logf("%d: %v %d", step, vm.OpCode(op).String(), cost)
+						opString := vm.OpCode(op).String()
+						// Use hex string if Cancun is inactive but the opcode is invalid before Cancun fork
+						if !isCancun && vm.OpCode(op).IsCancunOpcode() {
+							opString = fmt.Sprintf("0x%x", byte(vm.OpCode(op)))
+						}
+						t.Logf("%d: %v %d", step, opString, cost)
 						if step == tc.step {
 							have = cost
 						}

--- a/eth/tracers/js/goja.go
+++ b/eth/tracers/js/goja.go
@@ -329,7 +329,7 @@ func (t *jsTracer) onStart(from common.Address, to common.Address, create bool, 
 }
 
 // OnOpcode implements the Tracer interface to trace a single step of VM execution.
-func (t *jsTracer) OnOpcode(pc uint64, op byte, gas, cost uint64, scope tracing.OpContext, rData []byte, depth int, err error) {
+func (t *jsTracer) OnOpcode(pc uint64, op byte, gas, cost uint64, scope tracing.OpContext, rData []byte, depth int, isCancun bool, err error) {
 	if !t.traceStep {
 		return
 	}

--- a/eth/tracers/js/tracer_test.go
+++ b/eth/tracers/js/tracer_test.go
@@ -196,10 +196,10 @@ func TestHaltBetweenSteps(t *testing.T) {
 	evm.SetTxContext(vm.TxContext{GasPrice: big.NewInt(1)})
 	tracer.OnTxStart(evm.GetVMContext(), types.NewTx(&types.LegacyTx{}), common.Address{})
 	tracer.OnEnter(0, byte(vm.CALL), common.Address{}, common.Address{}, []byte{}, 0, big.NewInt(0))
-	tracer.OnOpcode(0, 0, 0, 0, scope, nil, 0, nil)
+	tracer.OnOpcode(0, 0, 0, 0, scope, nil, 0, true, nil)
 	timeout := errors.New("stahp")
 	tracer.Stop(timeout)
-	tracer.OnOpcode(0, 0, 0, 0, scope, nil, 0, nil)
+	tracer.OnOpcode(0, 0, 0, 0, scope, nil, 0, true, nil)
 
 	if _, err := tracer.GetResult(); !strings.Contains(err.Error(), timeout.Error()) {
 		t.Errorf("Expected timeout error, got %v", err)

--- a/eth/tracers/live/noop.go
+++ b/eth/tracers/live/noop.go
@@ -61,7 +61,7 @@ func newNoopTracer(_ json.RawMessage) (*tracing.Hooks, error) {
 	}, nil
 }
 
-func (t *noop) OnOpcode(pc uint64, op byte, gas, cost uint64, scope tracing.OpContext, rData []byte, depth int, err error) {
+func (t *noop) OnOpcode(pc uint64, op byte, gas, cost uint64, scope tracing.OpContext, rData []byte, depth int, isCancun bool, err error) {
 }
 
 func (t *noop) OnFault(pc uint64, op byte, gas, cost uint64, _ tracing.OpContext, depth int, err error) {

--- a/eth/tracers/logger/access_list_tracer.go
+++ b/eth/tracers/logger/access_list_tracer.go
@@ -132,7 +132,7 @@ func (a *AccessListTracer) Hooks() *tracing.Hooks {
 }
 
 // OnOpcode captures all opcodes that touch storage or addresses and adds them to the accesslist.
-func (a *AccessListTracer) OnOpcode(pc uint64, opcode byte, gas, cost uint64, scope tracing.OpContext, rData []byte, depth int, err error) {
+func (a *AccessListTracer) OnOpcode(pc uint64, opcode byte, gas, cost uint64, scope tracing.OpContext, rData []byte, depth int, isCancun bool, err error) {
 	stackData := scope.StackData()
 	stackLen := len(stackData)
 	op := vm.OpCode(opcode)

--- a/eth/tracers/logger/logger.go
+++ b/eth/tracers/logger/logger.go
@@ -254,7 +254,7 @@ func (l *StructLogger) Hooks() *tracing.Hooks {
 // OnOpcode logs a new structured log message and pushes it out to the environment
 //
 // OnOpcode also tracks SLOAD/SSTORE ops to track storage change.
-func (l *StructLogger) OnOpcode(pc uint64, opcode byte, gas, cost uint64, scope tracing.OpContext, rData []byte, depth int, err error) {
+func (l *StructLogger) OnOpcode(pc uint64, opcode byte, gas, cost uint64, scope tracing.OpContext, rData []byte, depth int, isCancun bool, err error) {
 	// If tracing was interrupted, exit
 	if l.interrupt.Load() {
 		return
@@ -491,7 +491,7 @@ func (t *mdLogger) OnExit(depth int, output []byte, gasUsed uint64, err error, r
 }
 
 // OnOpcode also tracks SLOAD/SSTORE ops to track storage change.
-func (t *mdLogger) OnOpcode(pc uint64, op byte, gas, cost uint64, scope tracing.OpContext, rData []byte, depth int, err error) {
+func (t *mdLogger) OnOpcode(pc uint64, op byte, gas, cost uint64, scope tracing.OpContext, rData []byte, depth int, isCancun bool, err error) {
 	if t.skip {
 		return
 	}

--- a/eth/tracers/logger/logger_json.go
+++ b/eth/tracers/logger/logger_json.go
@@ -97,11 +97,11 @@ func NewJSONLoggerWithCallFrames(cfg *Config, writer io.Writer) *tracing.Hooks {
 }
 
 func (l *jsonLogger) OnFault(pc uint64, op byte, gas uint64, cost uint64, scope tracing.OpContext, depth int, err error) {
-	// TODO: Add rData to this interface as well
-	l.OnOpcode(pc, op, gas, cost, scope, nil, depth, err)
+	// TODO: Add rData and Cancun status to this interface as well
+	l.OnOpcode(pc, op, gas, cost, scope, nil, depth, true, err)
 }
 
-func (l *jsonLogger) OnOpcode(pc uint64, op byte, gas, cost uint64, scope tracing.OpContext, rData []byte, depth int, err error) {
+func (l *jsonLogger) OnOpcode(pc uint64, op byte, gas, cost uint64, scope tracing.OpContext, rData []byte, depth int, isCancun bool, err error) {
 	memory := scope.MemoryData()
 	stack := scope.StackData()
 

--- a/eth/tracers/native/mux.go
+++ b/eth/tracers/native/mux.go
@@ -76,10 +76,10 @@ func newMuxTracer(ctx *tracers.Context, cfg json.RawMessage, chainConfig *params
 	}, nil
 }
 
-func (t *muxTracer) OnOpcode(pc uint64, op byte, gas, cost uint64, scope tracing.OpContext, rData []byte, depth int, err error) {
+func (t *muxTracer) OnOpcode(pc uint64, op byte, gas, cost uint64, scope tracing.OpContext, rData []byte, depth int, isCancun bool, err error) {
 	for _, t := range t.tracers {
 		if t.OnOpcode != nil {
-			t.OnOpcode(pc, op, gas, cost, scope, rData, depth, err)
+			t.OnOpcode(pc, op, gas, cost, scope, rData, depth, isCancun, err)
 		}
 	}
 }

--- a/eth/tracers/native/noop.go
+++ b/eth/tracers/native/noop.go
@@ -58,7 +58,7 @@ func newNoopTracer(ctx *tracers.Context, cfg json.RawMessage, chainConfig *param
 	}, nil
 }
 
-func (t *noopTracer) OnOpcode(pc uint64, op byte, gas, cost uint64, scope tracing.OpContext, rData []byte, depth int, err error) {
+func (t *noopTracer) OnOpcode(pc uint64, op byte, gas, cost uint64, scope tracing.OpContext, rData []byte, depth int, isCancun bool, err error) {
 }
 
 func (t *noopTracer) OnFault(pc uint64, op byte, gas, cost uint64, _ tracing.OpContext, depth int, err error) {

--- a/eth/tracers/native/prestate.go
+++ b/eth/tracers/native/prestate.go
@@ -101,7 +101,7 @@ func newPrestateTracer(ctx *tracers.Context, cfg json.RawMessage, chainConfig *p
 }
 
 // OnOpcode implements the EVMLogger interface to trace a single step of VM execution.
-func (t *prestateTracer) OnOpcode(pc uint64, opcode byte, gas, cost uint64, scope tracing.OpContext, rData []byte, depth int, err error) {
+func (t *prestateTracer) OnOpcode(pc uint64, opcode byte, gas, cost uint64, scope tracing.OpContext, rData []byte, depth int, isCancun bool, err error) {
 	if err != nil {
 		return
 	}


### PR DESCRIPTION
Hi @s1na @MariusVanDerWijden , could you please review this PR? It addresses issue #29464, which highlights that `debug_traceBlockBy{Number,Hash}` outputs new opcodes for pre-forks blocks. Below are the main changes covered in this PR:

    1. Modify the OpcodeHook type to pass the Cancun fork status and carry out checks on the opcode inside the hooks.
    This has the consequences of modifying the functions which have OpcodeHook signature
    2. Add a method IsCancunOpcode() to check if an opcode has been added at Cancun fork
