### PR TITLE
rpc, eth/filters: use non-blocking timer drain pattern

### DIFF
--- a/eth/filters/api.go
+++ b/eth/filters/api.go
@@ -435,7 +435,10 @@ func (api *FilterAPI) GetFilterChanges(id rpc.ID) (interface{}, error) {
 		if !f.deadline.Stop() {
 			// timer expired but filter is not yet removed in timeout loop
 			// receive timer value and reset timer
-			<-f.deadline.C
+			select {
+			case <-f.deadline.C:
+			default:
+			}
 		}
 		f.deadline.Reset(api.timeout)
 

--- a/rpc/websocket.go
+++ b/rpc/websocket.go
@@ -357,7 +357,10 @@ func (wc *websocketCodec) pingLoop() {
 
 		case <-wc.pingReset:
 			if !pingTimer.Stop() {
-				<-pingTimer.C
+				select {
+				case <-pingTimer.C:
+				default:
+				}
 			}
 			pingTimer.Reset(wsPingInterval)
 


### PR DESCRIPTION
Using a direct channel receive after `Stop()` may block in edge cases. A safer approach is to use `select` with a default case for timer cleanup.

PS: I noticed other instances in the code where `Reset` is used without draining the timer channel via `Stop()`. While this is fixed in Go 1.23+, it could cause undefined behavior in earlier versions. Would the team be open to addressing this for compatibility with pre-1.23 Go versions?I’d be happy to fix this in this PR if needed.


Ref: https://github.com/golang/go/issues/37196


