### PR TITLE
Fix spelling errors in `triedb/pathdb` Metrics and Layer Files

### DIFF
--- a/triedb/pathdb/difflayer.go
+++ b/triedb/pathdb/difflayer.go
@@ -113,7 +113,7 @@ func (dl *diffLayer) account(hash common.Hash, depth int) ([]byte, error) {
 		dirtyStateReadMeter.Mark(int64(len(blob)))
 
 		if len(blob) == 0 {
-			stateAccountInexMeter.Mark(1)
+			stateAccountIndexMeter.Mark(1)
 		} else {
 			stateAccountExistMeter.Mark(1)
 		}
@@ -139,7 +139,7 @@ func (dl *diffLayer) storage(accountHash, storageHash common.Hash, depth int) ([
 		dirtyStateReadMeter.Mark(int64(len(blob)))
 
 		if len(blob) == 0 {
-			stateStorageInexMeter.Mark(1)
+			stateStorageIndexMeter.Mark(1)
 		} else {
 			stateStorageExistMeter.Mark(1)
 		}

--- a/triedb/pathdb/disklayer.go
+++ b/triedb/pathdb/disklayer.go
@@ -163,7 +163,7 @@ func (dl *diskLayer) account(hash common.Hash, depth int) ([]byte, error) {
 		dirtyStateHitDepthHist.Update(int64(depth))
 
 		if len(blob) == 0 {
-			stateAccountInexMeter.Mark(1)
+			stateAccountIndexMeter.Mark(1)
 		} else {
 			stateAccountExistMeter.Mark(1)
 		}
@@ -198,7 +198,7 @@ func (dl *diskLayer) storage(accountHash, storageHash common.Hash, depth int) ([
 		dirtyStateHitDepthHist.Update(int64(depth))
 
 		if len(blob) == 0 {
-			stateStorageInexMeter.Mark(1)
+			stateStorageIndexMeter.Mark(1)
 		} else {
 			stateStorageExistMeter.Mark(1)
 		}

--- a/triedb/pathdb/metrics.go
+++ b/triedb/pathdb/metrics.go
@@ -30,8 +30,8 @@ var (
 	dirtyNodeWriteMeter   = metrics.NewRegisteredMeter("pathdb/dirty/node/write", nil)
 	dirtyNodeHitDepthHist = metrics.NewRegisteredHistogram("pathdb/dirty/node/depth", nil, metrics.NewExpDecaySample(1028, 0.015))
 
-	stateAccountInexMeter  = metrics.NewRegisteredMeter("pathdb/state/account/inex/total", nil)
-	stateStorageInexMeter  = metrics.NewRegisteredMeter("pathdb/state/storage/inex/total", nil)
+	stateAccountIndexMeter  = metrics.NewRegisteredMeter("pathdb/state/account/index/total", nil)
+	stateStorageIndexMeter  = metrics.NewRegisteredMeter("pathdb/state/storage/index/total", nil)
 	stateAccountExistMeter = metrics.NewRegisteredMeter("pathdb/state/account/exist/total", nil)
 	stateStorageExistMeter = metrics.NewRegisteredMeter("pathdb/state/storage/exist/total", nil)
 


### PR DESCRIPTION
This PR corrects multiple spelling errors in `triedb/pathdb` files related to state indexing metrics.

## Changes Made
- Renamed `stateAccountInexMeter` → `stateAccountIndexMeter` in:
  - `metrics.go`
  - `difflayer.go`
  - `disklayer.go`
- Renamed `stateStorageInexMeter` → `stateStorageIndexMeter` in:
  - `metrics.go`
  - `difflayer.go`
  - `disklayer.go`