### PR TITLE
common: add IsZero methods for Hash and Address types

### DIFF
--- a/common/types.go
+++ b/common/types.go
@@ -194,6 +194,11 @@ func (h *Hash) UnmarshalGraphQL(input interface{}) error {
 	return err
 }
 
+// IsZero returns true if the hash is the zero hash.
+func (h Hash) IsZero() bool {
+	return h == Hash{}
+}
+
 // UnprefixedHash allows marshaling a Hash without 0x prefix.
 type UnprefixedHash Hash
 
@@ -369,6 +374,11 @@ func (a *Address) UnmarshalGraphQL(input interface{}) error {
 		err = fmt.Errorf("unexpected type %T for Address", input)
 	}
 	return err
+}
+
+// IsZero returns true if the address is the zero address.
+func (a Address) IsZero() bool {
+	return a == Address{}
 }
 
 // UnprefixedAddress allows marshaling an Address without 0x prefix.

--- a/ethclient/types_test.go
+++ b/ethclient/types_test.go
@@ -151,3 +151,55 @@ func TestToFilterArg(t *testing.T) {
 		})
 	}
 }
+func TestAddress_IsZero(t *testing.T) {
+	tests := []struct {
+		name    string
+		address common.Address
+		want    bool
+	}{
+		{
+			"zero address",
+			common.Address{},
+			true,
+		},
+		{
+			"non-zero address",
+			common.HexToAddress("0xD36722ADeC3EdCB29c8e7b5a47f352D701393462"),
+			false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.address.IsZero(); got != tt.want {
+				t.Errorf("Address.IsZero() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+func TestHash_IsZero(t *testing.T) {
+	tests := []struct {
+		name string
+		hash common.Hash
+		want bool
+	}{
+		{
+			"zero hash",
+			common.Hash{},
+			true,
+		},
+		{
+			"non-zero hash",
+			common.HexToHash("0xaba98c3b293961bb1bbd754e148cfd2ad50f887e3eebee0135d77b841a6daac9"),
+			false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.hash.IsZero(); got != tt.want {
+				t.Errorf("Hash.IsZero() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
2 reasons to add the `IsZero() bool` method.

1. go 1.24 adds it to standard json package and some codes that use `omitempty` tag doesn't work as expected e.g. https://github.com/ethereum/go-ethereum/blob/da71839a270a353bac92e3108e4b74fb0eefec29/params/config.go#L375

2. In the go-ethereum codespace, there are too many `someVar == common.Hash{}`, it should be a good begin to replace them in the future

```console
$ grep -r -o '== (common.Hash{})' . | wc -l
109
$ grep -r -o '== (common.Address{})' . | wc -l
8
```