### PR TITLE
core: sanity-check fork configuration in genesis init

### DIFF
--- a/core/genesis.go
+++ b/core/genesis.go
@@ -364,6 +364,11 @@ func SetupGenesisBlockWithOverride(db ethdb.Database, triedb *triedb.Database, g
 	}
 	newCfg := genesis.chainConfigOrDefault(ghash, storedCfg)
 
+	// Sanity-check the new configuration.
+	if err := newCfg.CheckConfigForkOrder(); err != nil {
+		return nil, common.Hash{}, nil, err
+	}
+
 	// TODO(rjl493456442) better to define the comparator of chain config
 	// and short circuit if the chain config is not changed.
 	compatErr := storedCfg.CheckCompatible(newCfg, head.Number.Uint64(), head.Time)

--- a/params/config.go
+++ b/params/config.go
@@ -735,13 +735,13 @@ func (c *ChainConfig) CheckConfigForkOrder() error {
 	} {
 		if cur.config != nil {
 			if err := cur.config.validate(); err != nil {
-				return fmt.Errorf("invalid blob configuration for fork %s: %v", cur.name, err)
+				return fmt.Errorf("invalid chain configuration in blobSchedule for fork %q: %v", cur.name, err)
 			}
 		}
 		if cur.timestamp != nil {
 			// If the fork is configured, a blob schedule must be defined for it.
 			if cur.config == nil {
-				return fmt.Errorf("unsupported fork configuration: missing blob configuration entry for %v in schedule", cur.name)
+				return fmt.Errorf("invalid chain configuration: missing entry for fork %q in blobSchedule", cur.name)
 			}
 		}
 	}


### PR DESCRIPTION
This is to prevent a crash on startup with a custom genesis configuration. With this change in place, upgrading a chain created by geth v1.14.x and below will now print an error instead of crashing:

```
Fatal: Failed to register the Ethereum service: invalid chain configuration: missing entry for fork "cancun" in blobSchedule
```

Arguably this is not great, and it should just auto-upgrade the config. We'll address this in a follow-up PR for geth v1.15.2