### PR TITLE
core/rawdb: skip setting flushOffset in read-only mode

### DIFF
--- a/core/rawdb/freezer_table.go
+++ b/core/rawdb/freezer_table.go
@@ -405,6 +405,13 @@ func (t *freezerTable) repairIndex() error {
 	// If legacy metadata is detected, attempt to recover the offset from the
 	// index file to avoid clearing the entire table.
 	if t.metadata.version == freezerTableV1 {
+		// Skip truncation if the legacy metadata is opened in read-only mode.
+		// Since all items in the legacy index file were forcibly synchronized,
+		// data integrity is guaranteed. Therefore, it's safe to leave any extra
+		// items untruncated in this special scenario.
+		if t.readonly {
+			return nil
+		}
 		t.logger.Info("Recovering freezer flushOffset for legacy table", "offset", size)
 		return t.metadata.setFlushOffset(size, true)
 	}


### PR DESCRIPTION
This PR addresses a flaw in the freezer table upgrade path.

In v1.15.0, freezer table v2 was introduced, including an additional 
field (`flushOffset`) maintained in the metadata file. To ensure 
backward compatibility, an upgrade path was implemented for legacy
freezer tables by setting `flushOffset` to the size of the index file.

However, if the freezer table is opened in read-only mode, this file 
write operation is rejected, causing Geth to shut down entirely.

Given that invalid items in the freezer index file can be detected and 
truncated, all items in freezer v0 index files are guaranteed to be complete.
Therefore, when operating in read-only mode, it is safe to use the 
freezer data without performing an upgrade.