### PR TITLE
core: fix GenerateVerkleChain not processing EL requests

### DIFF
--- a/core/chain_makers.go
+++ b/core/chain_makers.go
@@ -504,6 +504,13 @@ func GenerateVerkleChain(config *params.ChainConfig, parent *types.Block, engine
 		if gen != nil {
 			gen(i, b)
 		}
+
+		requests := b.collectRequests(false)
+		if requests != nil {
+			reqHash := types.CalcRequestsHash(requests)
+			b.header.RequestsHash = &reqHash
+		}
+		
 		body := &types.Body{
 			Transactions: b.txs,
 			Uncles:       b.uncles,

--- a/core/chain_makers.go
+++ b/core/chain_makers.go
@@ -510,7 +510,7 @@ func GenerateVerkleChain(config *params.ChainConfig, parent *types.Block, engine
 			reqHash := types.CalcRequestsHash(requests)
 			b.header.RequestsHash = &reqHash
 		}
-		
+
 		body := &types.Body{
 			Transactions: b.txs,
 			Uncles:       b.uncles,


### PR DESCRIPTION
Verkle is post-Prague, so it must support EIP-7002 EL requests. However, it is not the case, so this PR fixes this.