### PR TITLE
eth/tracers: Fix traceBlock early abort

### DIFF
--- a/eth/tracers/api.go
+++ b/eth/tracers/api.go
@@ -634,7 +634,8 @@ func (api *API) traceBlock(ctx context.Context, block *types.Block, config *Trac
 		}
 		res, err := api.traceTx(ctx, tx, msg, txctx, blockCtx, statedb, config)
 		if err != nil {
-			return nil, err
+			results[i] = &txTraceResult{TxHash: tx.Hash(), Error: err.Error()}
+			continue
 		}
 		results[i] = &txTraceResult{TxHash: tx.Hash(), Result: res}
 	}


### PR DESCRIPTION
Reverted txs are common in blocks. However, when tracing a set of txs in a block using `traceBlock`, the loop returns early if the call to `traceTx` returns an error (for example, if the tx reverted). This PR fixes this, which mimics the behavior of `traceBlockParallel`:

[https://github.com/ethereum/go-ethereum/blob/68de26e34649e50c1f8f8a858a686c38274848b6/eth/tracers/api.go#L680C1-L683C6](https://github.com/ethereum/go-ethereum/blob/68de26e34649e50c1f8f8a858a686c38274848b6/eth/tracers/api.go#L680C1-L683C6)

```go
				if err != nil {
					results[task.index] = &txTraceResult{TxHash: txs[task.index].Hash(), Error: err.Error()}
					continue
				}
```