### PR TITLE
eth/protocols/eth: add discovery iterator to protocol

### DIFF
--- a/eth/protocols/eth/handler.go
+++ b/eth/protocols/eth/handler.go
@@ -89,7 +89,7 @@ type TxPool interface {
 }
 
 // MakeProtocols constructs the P2P protocol definitions for `eth`.
-func MakeProtocols(backend Backend, network uint64, dnsdisc enode.Iterator) []p2p.Protocol {
+func MakeProtocols(backend Backend, network uint64, disc enode.Iterator) []p2p.Protocol {
 	protocols := make([]p2p.Protocol, 0, len(ProtocolVersions))
 	for _, version := range ProtocolVersions {
 		protocols = append(protocols, p2p.Protocol{
@@ -110,7 +110,8 @@ func MakeProtocols(backend Backend, network uint64, dnsdisc enode.Iterator) []p2
 			PeerInfo: func(id enode.ID) interface{} {
 				return backend.PeerInfo(id)
 			},
-			Attributes: []enr.Entry{currentENREntry(backend.Chain())},
+			DialCandidates: disc,
+			Attributes:     []enr.Entry{currentENREntry(backend.Chain())},
 		})
 	}
 	return protocols


### PR DESCRIPTION
We somehow forgot to add this in #30302, so discv5 and DNS have actually been disabled since then.

Fixes #31168 