### PR TITLE
refactor: use a more straightforward return value

### DIFF
--- a/accounts/keystore/presale.go
+++ b/accounts/keystore/presale.go
@@ -110,7 +110,7 @@ func aesCTRXOR(key, inText, iv []byte) ([]byte, error) {
 	stream := cipher.NewCTR(aesBlock, iv)
 	outText := make([]byte, len(inText))
 	stream.XORKeyStream(outText, inText)
-	return outText, err
+	return outText, nil
 }
 
 func aesCBCDecrypt(key, cipherText, iv []byte) ([]byte, error) {
@@ -125,7 +125,7 @@ func aesCBCDecrypt(key, cipherText, iv []byte) ([]byte, error) {
 	if plaintext == nil {
 		return nil, ErrDecrypt
 	}
-	return plaintext, err
+	return plaintext, nil
 }
 
 // From https://leanpub.com/gocrypto/read#leanpub-auto-block-cipher-modes


### PR DESCRIPTION
use a more straightforward return value