### PR TITLE
cmd/clef: Link to relevant EIPs in readme

### DIFF
--- a/cmd/clef/intapi_changelog.md
+++ b/cmd/clef/intapi_changelog.md
@@ -94,7 +94,7 @@ type Account struct {
 >  Notifications are not confirmable by definition, since they do not have a Response object to be returned. As such, the Client would not be aware of any errors (like e.g. "Invalid params","Internal error"
 ### 3.1.0
 
-* Add `ContentType` `string` to `SignDataRequest` to accommodate the latest EIP-191 and EIP-712 implementations.
+* Add `ContentType` `string` to `SignDataRequest` to accommodate the latest [EIP-191](https://github.com/ethereum/ercs/blob/master/ERCS/erc-191.md) and [EIP-712](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-712.md) implementations.
 
 ### 3.0.0
 

--- a/cmd/clef/intapi_changelog.md
+++ b/cmd/clef/intapi_changelog.md
@@ -94,7 +94,7 @@ type Account struct {
 >  Notifications are not confirmable by definition, since they do not have a Response object to be returned. As such, the Client would not be aware of any errors (like e.g. "Invalid params","Internal error"
 ### 3.1.0
 
-* Add `ContentType` `string` to `SignDataRequest` to accommodate the latest [EIP-191](https://github.com/ethereum/ercs/blob/master/ERCS/erc-191.md) and [EIP-712](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-712.md) implementations.
+* Add `ContentType` `string` to `SignDataRequest` to accommodate the latest [EIP-191](https://eips.ethereum.org/EIPS/eip-191) and [EIP-712](https://eips.ethereum.org/EIPS/eip-712) implementations.
 
 ### 3.0.0
 

--- a/signer/core/testdata/README.md
+++ b/signer/core/testdata/README.md
@@ -1,5 +1,5 @@
-### EIP 712 tests
+### EIP-712 tests
 
-These tests are json files which are converted into eip-712 typed data. 
+These tests are json files which are converted into [EIP-712](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-712.md) typed data. 
 All files are expected to be proper json, and tests will fail if they are not. 
 Files that begin with `expfail' are expected to not pass the hashstruct construction. 

--- a/signer/core/testdata/README.md
+++ b/signer/core/testdata/README.md
@@ -1,5 +1,5 @@
 ### EIP-712 tests
 
-These tests are json files which are converted into [EIP-712](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-712.md) typed data. 
+These tests are json files which are converted into [EIP-712](https://eips.ethereum.org/EIPS/eip-712) typed data. 
 All files are expected to be proper json, and tests will fail if they are not. 
 Files that begin with `expfail' are expected to not pass the hashstruct construction. 


### PR DESCRIPTION
Fixed broken or outdated links and improved documentation formatting to ensure consistency and correct references.

**Notes to Reviewers**  
This PR contains only documentation updates to correct broken links and ensure proper references. No functional changes were made.

**How has it been tested?**

- Manually verified that all updated links point to the correct locations.
- Checked markdown syntax and formatting to ensure consistency.
