### PR TITLE
eth: check blob transaction validity on the peer goroutine when received

### DIFF
--- a/cmd/devp2p/internal/ethtest/conn.go
+++ b/cmd/devp2p/internal/ethtest/conn.go
@@ -130,11 +130,16 @@ func (c *Conn) Write(proto Proto, code uint64, msg any) error {
 	return err
 }
 
+var errDisc error = fmt.Errorf("disconnect")
+
 // ReadEth reads an Eth sub-protocol wire message.
 func (c *Conn) ReadEth() (any, error) {
 	c.SetReadDeadline(time.Now().Add(timeout))
 	for {
 		code, data, _, err := c.Conn.Read()
+		if code == discMsg {
+			return nil, errDisc
+		}
 		if err != nil {
 			return nil, err
 		}

--- a/cmd/devp2p/internal/ethtest/suite.go
+++ b/cmd/devp2p/internal/ethtest/suite.go
@@ -64,27 +64,26 @@ func NewSuite(dest *enode.Node, chainDir, engineURL, jwt string) (*Suite, error)
 
 func (s *Suite) EthTests() []utesting.Test {
 	return []utesting.Test{
-		/*
-			// status
-			{Name: "Status", Fn: s.TestStatus},
-			// get block headers
-			{Name: "GetBlockHeaders", Fn: s.TestGetBlockHeaders},
-			{Name: "SimultaneousRequests", Fn: s.TestSimultaneousRequests},
-			{Name: "SameRequestID", Fn: s.TestSameRequestID},
-			{Name: "ZeroRequestID", Fn: s.TestZeroRequestID},
-			// get block bodies
-			{Name: "GetBlockBodies", Fn: s.TestGetBlockBodies},
-			// // malicious handshakes + status
-			{Name: "MaliciousHandshake", Fn: s.TestMaliciousHandshake},
-			// test transactions
-			{Name: "LargeTxRequest", Fn: s.TestLargeTxRequest, Slow: true},
-			{Name: "Transaction", Fn: s.TestTransaction},
-			{Name: "InvalidTxs", Fn: s.TestInvalidTxs},
-			{Name: "NewPooledTxs", Fn: s.TestNewPooledTxs},
-			{Name: "BlobViolations", Fn: s.TestBlobViolations},
-		*/
+		// status
+		{Name: "Status", Fn: s.TestStatus},
+		// get block headers
+		{Name: "GetBlockHeaders", Fn: s.TestGetBlockHeaders},
+		{Name: "SimultaneousRequests", Fn: s.TestSimultaneousRequests},
+		{Name: "SameRequestID", Fn: s.TestSameRequestID},
+		{Name: "ZeroRequestID", Fn: s.TestZeroRequestID},
+		// get block bodies
+		{Name: "GetBlockBodies", Fn: s.TestGetBlockBodies},
+		// // malicious handshakes + status
+		{Name: "MaliciousHandshake", Fn: s.TestMaliciousHandshake},
+		// test transactions
+		{Name: "LargeTxRequest", Fn: s.TestLargeTxRequest, Slow: true},
+		{Name: "Transaction", Fn: s.TestTransaction},
+		{Name: "InvalidTxs", Fn: s.TestInvalidTxs},
+		{Name: "NewPooledTxs", Fn: s.TestNewPooledTxs},
+		{Name: "BlobViolations", Fn: s.TestBlobViolations},
+
 		{Name: "TestBlobTxWithoutSidecar", Fn: s.TestBlobTxWithoutSidecar},
-		//{Name: "TestBlobTxWithMismatchedSidecar", Fn: s.TestBlobTxWithMismatchedSidecar},
+		{Name: "TestBlobTxWithMismatchedSidecar", Fn: s.TestBlobTxWithMismatchedSidecar},
 	}
 }
 

--- a/cmd/devp2p/internal/ethtest/suite.go
+++ b/cmd/devp2p/internal/ethtest/suite.go
@@ -877,9 +877,9 @@ func readUntil[T any](ctx context.Context, conn *Conn) (*T, error) {
 			}
 			continue
 		}
-		switch received.(type) {
+
+		switch res := received.(type) {
 		case *T:
-			res := received.(*T)
 			return res, nil
 		}
 	}
@@ -888,7 +888,8 @@ func readUntil[T any](ctx context.Context, conn *Conn) (*T, error) {
 // readUntilDisconnect reads eth protocol messages until the peer disconnects.
 // It returns whether the peer disconnects in the next 100ms.
 func readUntilDisconnect(conn *Conn) (disconnected bool) {
-	ctx, _ := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
 	_, err := readUntil[struct{}](ctx, conn)
 	return err == errDisc
 }

--- a/cmd/devp2p/internal/ethtest/suite.go
+++ b/cmd/devp2p/internal/ethtest/suite.go
@@ -66,7 +66,6 @@ func NewSuite(dest *enode.Node, chainDir, engineURL, jwt string) (*Suite, error)
 
 func (s *Suite) EthTests() []utesting.Test {
 	return []utesting.Test{
-
 		// status
 		{Name: "Status", Fn: s.TestStatus},
 		// get block headers

--- a/cmd/devp2p/internal/ethtest/suite.go
+++ b/cmd/devp2p/internal/ethtest/suite.go
@@ -64,26 +64,24 @@ func NewSuite(dest *enode.Node, chainDir, engineURL, jwt string) (*Suite, error)
 
 func (s *Suite) EthTests() []utesting.Test {
 	return []utesting.Test{
-		/*
-			// status
-			{Name: "Status", Fn: s.TestStatus},
-			// get block headers
-			{Name: "GetBlockHeaders", Fn: s.TestGetBlockHeaders},
-			{Name: "SimultaneousRequests", Fn: s.TestSimultaneousRequests},
-			{Name: "SameRequestID", Fn: s.TestSameRequestID},
-			{Name: "ZeroRequestID", Fn: s.TestZeroRequestID},
-			// get block bodies
-			{Name: "GetBlockBodies", Fn: s.TestGetBlockBodies},
-			// // malicious handshakes + status
-			{Name: "MaliciousHandshake", Fn: s.TestMaliciousHandshake},
-			// test transactions
-			{Name: "LargeTxRequest", Fn: s.TestLargeTxRequest, Slow: true},
-			{Name: "Transaction", Fn: s.TestTransaction},
-			{Name: "InvalidTxs", Fn: s.TestInvalidTxs},
-			{Name: "NewPooledTxs", Fn: s.TestNewPooledTxs},
-			{Name: "BlobViolations", Fn: s.TestBlobViolations},
-			{Name: "TestBlobTxMangledSidecar", Fn: s.TestBlobTxMangledSidecar},
-		*/
+		// status
+		{Name: "Status", Fn: s.TestStatus},
+		// get block headers
+		{Name: "GetBlockHeaders", Fn: s.TestGetBlockHeaders},
+		{Name: "SimultaneousRequests", Fn: s.TestSimultaneousRequests},
+		{Name: "SameRequestID", Fn: s.TestSameRequestID},
+		{Name: "ZeroRequestID", Fn: s.TestZeroRequestID},
+		// get block bodies
+		{Name: "GetBlockBodies", Fn: s.TestGetBlockBodies},
+		// // malicious handshakes + status
+		{Name: "MaliciousHandshake", Fn: s.TestMaliciousHandshake},
+		// test transactions
+		{Name: "LargeTxRequest", Fn: s.TestLargeTxRequest, Slow: true},
+		{Name: "Transaction", Fn: s.TestTransaction},
+		{Name: "InvalidTxs", Fn: s.TestInvalidTxs},
+		{Name: "NewPooledTxs", Fn: s.TestNewPooledTxs},
+		{Name: "BlobViolations", Fn: s.TestBlobViolations},
+		{Name: "TestBlobTxMangledSidecar", Fn: s.TestBlobTxMangledSidecar},
 		{Name: "TestBlobTxWithoutSidecar", Fn: s.TestBlobTxWithoutSidecar},
 	}
 }

--- a/cmd/devp2p/internal/ethtest/suite.go
+++ b/cmd/devp2p/internal/ethtest/suite.go
@@ -76,12 +76,11 @@ func (s *Suite) EthTests() []utesting.Test {
 		// // malicious handshakes + status
 		{Name: "MaliciousHandshake", Fn: s.TestMaliciousHandshake},
 		// test transactions
-		{Name: "LargeTxRequest", Fn: s.TestLargeTxRequest, Slow: true},
+		//{Name: "LargeTxRequest", Fn: s.TestLargeTxRequest, Slow: true},
 		{Name: "Transaction", Fn: s.TestTransaction},
 		{Name: "InvalidTxs", Fn: s.TestInvalidTxs},
 		{Name: "NewPooledTxs", Fn: s.TestNewPooledTxs},
 		{Name: "BlobViolations", Fn: s.TestBlobViolations},
-
 		{Name: "TestBlobTxWithoutSidecar", Fn: s.TestBlobTxWithoutSidecar},
 		{Name: "TestBlobTxWithMismatchedSidecar", Fn: s.TestBlobTxWithMismatchedSidecar},
 	}
@@ -861,13 +860,13 @@ proceeds as so:
   - Only bad peers are disconnected from while good peer is not.
 */
 func (s *Suite) TestBlobTxWithoutSidecar(t *utesting.T) {
-	tx := s.makeBlobTxs(1, 2, 1)[0]
+	tx := s.makeBlobTxs(1, 2, 42)[0]
 	badTx := tx.WithoutBlobTxSidecar()
 	s.testBadBlobTx(t, tx, badTx)
 }
 
 func (s *Suite) TestBlobTxWithMismatchedSidecar(t *utesting.T) {
-	tx := s.makeBlobTxs(1, 2, 1)[0]
+	tx := s.makeBlobTxs(1, 2, 43)[0]
 	badTx := mangleSidecar(tx)
 	s.testBadBlobTx(t, tx, badTx)
 }

--- a/cmd/devp2p/internal/ethtest/suite.go
+++ b/cmd/devp2p/internal/ethtest/suite.go
@@ -847,14 +847,14 @@ func mangleSidecar(tx *types.Transaction) *types.Transaction {
 }
 
 func (s *Suite) TestBlobTxWithoutSidecar(t *utesting.T) {
-	t.Log(`This test tests that a transaction first advertised/transmitted without a sidecar will result in the sending peer being disconnected, and the full transaction should be successfully retrieved from another peer.`)
+	t.Log(`This test checks that a blob transaction first advertised/transmitted without blobs will result in the sending peer being disconnected, and the full transaction should be successfully retrieved from another peer.`)
 	tx := s.makeBlobTxs(1, 2, 42)[0]
 	badTx := tx.WithoutBlobTxSidecar()
 	s.testBadBlobTx(t, tx, badTx)
 }
 
 func (s *Suite) TestBlobTxWithMismatchedSidecar(t *utesting.T) {
-	t.Log(`This test tests that a transaction first advertised/transmitted with a sidecar whose commitment don't correspond to the blob_versioned_hashes in the transaction header will result in the sending peer being disconnected, and the full transaction should be successfully retrieved from another peer.`)
+	t.Log(`This test checks that a blob transaction first advertised/transmitted without blobs, whose commitment don't correspond to the blob_versioned_hashes in the transaction, will result in the sending peer being disconnected, and the full transaction should be successfully retrieved from another peer.`)
 	tx := s.makeBlobTxs(1, 2, 43)[0]
 	badTx := mangleSidecar(tx)
 	s.testBadBlobTx(t, tx, badTx)

--- a/core/txpool/validation.go
+++ b/core/txpool/validation.go
@@ -17,7 +17,6 @@
 package txpool
 
 import (
-	"crypto/sha256"
 	"errors"
 	"fmt"
 	"math/big"
@@ -170,20 +169,11 @@ func validateBlobSidecar(hashes []common.Hash, sidecar *types.BlobTxSidecar) err
 	if len(sidecar.Blobs) != len(hashes) {
 		return fmt.Errorf("invalid number of %d blobs compared to %d blob hashes", len(sidecar.Blobs), len(hashes))
 	}
-	if len(sidecar.Commitments) != len(hashes) {
-		return fmt.Errorf("invalid number of %d blob commitments compared to %d blob hashes", len(sidecar.Commitments), len(hashes))
-	}
 	if len(sidecar.Proofs) != len(hashes) {
 		return fmt.Errorf("invalid number of %d blob proofs compared to %d blob hashes", len(sidecar.Proofs), len(hashes))
 	}
-	// Blob quantities match up, validate that the provers match with the
-	// transaction hash before getting to the cryptography
-	hasher := sha256.New()
-	for i, vhash := range hashes {
-		computed := kzg4844.CalcBlobHashV1(hasher, &sidecar.Commitments[i])
-		if vhash != computed {
-			return fmt.Errorf("blob %d: computed hash %#x mismatches transaction one %#x", i, computed, vhash)
-		}
+	if err := sidecar.ValidateBlobCommitmentHashes(hashes); err != nil {
+		return err
 	}
 	// Blob commitments match with the hashes in the transaction, verify the
 	// blobs themselves via KZG

--- a/core/types/tx_blob.go
+++ b/core/types/tx_blob.go
@@ -19,6 +19,7 @@ package types
 import (
 	"bytes"
 	"crypto/sha256"
+	"fmt"
 	"math/big"
 
 	"github.com/ethereum/go-ethereum/common"
@@ -83,6 +84,28 @@ func (sc *BlobTxSidecar) encodedSize() uint64 {
 		proofs += rlp.BytesSize(sc.Proofs[i][:])
 	}
 	return rlp.ListSize(blobs) + rlp.ListSize(commitments) + rlp.ListSize(proofs)
+}
+
+func (sc *BlobTxSidecar) ValidateBlobCommitmentHashes(hashes []common.Hash) error {
+	if len(sc.Blobs) != len(hashes) {
+		return fmt.Errorf("invalid number of %d blobs compared to %d blob hashes", len(sc.Blobs), len(hashes))
+	}
+	if len(sc.Commitments) != len(hashes) {
+		return fmt.Errorf("invalid number of %d blob commitments compared to %d blob hashes", len(sc.Commitments), len(hashes))
+	}
+	if len(sc.Proofs) != len(hashes) {
+		return fmt.Errorf("invalid number of %d blob proofs compared to %d blob hashes", len(sc.Proofs), len(hashes))
+	}
+	// Blob quantities match up, validate that the provers match with the
+	// transaction hash before getting to the cryptography
+	hasher := sha256.New()
+	for i, vhash := range hashes {
+		computed := kzg4844.CalcBlobHashV1(hasher, &sc.Commitments[i])
+		if vhash != computed {
+			return fmt.Errorf("blob %d: computed hash %#x mismatches transaction one %#x", i, computed, vhash)
+		}
+	}
+	return nil
 }
 
 // blobTxWithBlobs is used for encoding of transactions when blobs are present.

--- a/core/types/tx_blob.go
+++ b/core/types/tx_blob.go
@@ -86,18 +86,12 @@ func (sc *BlobTxSidecar) encodedSize() uint64 {
 	return rlp.ListSize(blobs) + rlp.ListSize(commitments) + rlp.ListSize(proofs)
 }
 
+// ValidateBlobCommitmentHashes checks whether the given hashes correspond to the
+// commitments in the sidecar
 func (sc *BlobTxSidecar) ValidateBlobCommitmentHashes(hashes []common.Hash) error {
-	if len(sc.Blobs) != len(hashes) {
-		return fmt.Errorf("invalid number of %d blobs compared to %d blob hashes", len(sc.Blobs), len(hashes))
-	}
 	if len(sc.Commitments) != len(hashes) {
 		return fmt.Errorf("invalid number of %d blob commitments compared to %d blob hashes", len(sc.Commitments), len(hashes))
 	}
-	if len(sc.Proofs) != len(hashes) {
-		return fmt.Errorf("invalid number of %d blob proofs compared to %d blob hashes", len(sc.Proofs), len(hashes))
-	}
-	// Blob quantities match up, validate that the provers match with the
-	// transaction hash before getting to the cryptography
 	hasher := sha256.New()
 	for i, vhash := range hashes {
 		computed := kzg4844.CalcBlobHashV1(hasher, &sc.Commitments[i])

--- a/eth/handler_eth.go
+++ b/eth/handler_eth.go
@@ -68,6 +68,9 @@ func (h *ethHandler) Handle(peer *eth.Peer, packet eth.Packet) error {
 		return h.txFetcher.Enqueue(peer.ID(), *packet, false)
 
 	case *eth.PooledTransactionsResponse:
+		// If we receive any blob transactions missing sidecars, or with
+		// sidecars that don't correspond to the versioned hashes reported
+		// in the header, disconnect from the sending peer.
 		for _, tx := range *packet {
 			if tx.Type() == types.BlobTxType {
 				if tx.BlobTxSidecar() == nil {

--- a/eth/handler_eth.go
+++ b/eth/handler_eth.go
@@ -19,6 +19,7 @@ package eth
 import (
 	"errors"
 	"fmt"
+
 	"github.com/ethereum/go-ethereum/core"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/eth/protocols/eth"


### PR DESCRIPTION
This ensures that if we receive a blob transaction where we cannot link the tx header to the sidecar commitments, we will drop the sending peer.  This check is added in the protocol handler for the `PooledTransactions` message.

closes https://github.com/ethereum/go-ethereum/issues/31162