### PR TITLE
oss-fuzz: remove deprecated targets

### DIFF
--- a/oss-fuzz.sh
+++ b/oss-fuzz.sh
@@ -161,27 +161,11 @@ compile_fuzzer github.com/ethereum/go-ethereum/tests/fuzzers/bls12381 \
   $repo/tests/fuzzers/bls12381/bls12381_test.go
 
 compile_fuzzer github.com/ethereum/go-ethereum/tests/fuzzers/bls12381 \
-  FuzzCrossG1Mul fuzz_cross_g1_mul\
-  $repo/tests/fuzzers/bls12381/bls12381_test.go
-
-compile_fuzzer github.com/ethereum/go-ethereum/tests/fuzzers/bls12381 \
-  FuzzG1Mul fuzz_g1_mul\
-  $repo/tests/fuzzers/bls12381/bls12381_test.go
-
-compile_fuzzer github.com/ethereum/go-ethereum/tests/fuzzers/bls12381 \
   FuzzG1MultiExp fuzz_g1_multiexp \
   $repo/tests/fuzzers/bls12381/bls12381_test.go
 
 compile_fuzzer github.com/ethereum/go-ethereum/tests/fuzzers/bls12381 \
   FuzzG2Add fuzz_g2_add \
-  $repo/tests/fuzzers/bls12381/bls12381_test.go
-
-compile_fuzzer github.com/ethereum/go-ethereum/tests/fuzzers/bls12381 \
-  FuzzCrossG2Mul fuzz_cross_g2_mul\
-  $repo/tests/fuzzers/bls12381/bls12381_test.go
-
-compile_fuzzer github.com/ethereum/go-ethereum/tests/fuzzers/bls12381 \
-  FuzzG2Mul fuzz_g2_mul\
   $repo/tests/fuzzers/bls12381/bls12381_test.go
 
 compile_fuzzer github.com/ethereum/go-ethereum/tests/fuzzers/bls12381 \


### PR DESCRIPTION
Fixes https://github.com/ethereum/go-ethereum/issues/31223

(sorry, I thought the fork fork would be created on my repo, not upstream, when I used the GH editor)