### PR TITLE
p2p/nat: remove test with default servers

### DIFF
--- a/p2p/nat/stun_test.go
+++ b/p2p/nat/stun_test.go
@@ -18,16 +18,7 @@ package nat
 
 import (
 	"testing"
-
-	"github.com/stretchr/testify/assert"
 )
-
-func TestNatStun(t *testing.T) {
-	nat, err := newSTUN("")
-	assert.NoError(t, err)
-	_, err = nat.ExternalIP()
-	assert.NoError(t, err)
-}
 
 func TestUnreachedNatServer(t *testing.T) {
 	stun := &stun{


### PR DESCRIPTION
The test occasionally fails when network connectivity is bad or if it hits the wrong server. We usually don't add tests with external network dependency so I'm removing them.

Fixes #31220 