### PR TITLE
eth/catalyst: force sync of txpool before clearing subpools in Rollback

### DIFF
--- a/core/txpool/txpool.go
+++ b/core/txpool/txpool.go
@@ -486,6 +486,8 @@ func (p *TxPool) Sync() error {
 
 // Clear removes all tracked txs from the subpools.
 func (p *TxPool) Clear() {
+	// Invoke Sync to ensure that txs pending addition don't get added to the pool after
+	// the subpools are subsequently cleared
 	p.Sync()
 	for _, subpool := range p.subpools {
 		subpool.Clear()

--- a/core/txpool/txpool.go
+++ b/core/txpool/txpool.go
@@ -486,6 +486,7 @@ func (p *TxPool) Sync() error {
 
 // Clear removes all tracked txs from the subpools.
 func (p *TxPool) Clear() {
+	p.Sync()
 	for _, subpool := range p.subpools {
 		subpool.Clear()
 	}


### PR DESCRIPTION
This PR enforces a transaction pool synchronization before clearing it in the `(c *SimulatedBeacon) Rollback()` function.

An alternative approach would be to modify `(p *TxPool) Clear()` to call `(p *TxPool) Sync()` directly before clearing, but this PR opts to perform the synchronization explicitly in `Rollback()`.

### Issue Description

In the example below, without the enforced sync, transactions from blocks between `oldHead` and `newHead` are unexpectedly included in the newly committed block, rendering the rollback ineffective. 
```go
simulatedBeacon.Fork(newHead)
simulatedBeacon.Rollback()
simulatedBeacon.Commit()
```

However, introducing a `time.Sleep` between `Fork()` and `Rollback()` produces the expected behavior, where transactions from intermediate blocks are correctly dropped, confirming the flakey behavior:
```golang
simulatedBeacon.Fork(newHead)
time.Sleep(1 * time.Second)
simulatedBeacon.Rollback()
simulatedBeacon.Commit()
```