### PR TITLE
p2p: add random nodes as discovery source in setupDiscovery

### DIFF
--- a/p2p/server.go
+++ b/p2p/server.go
@@ -492,6 +492,7 @@ func (srv *Server) setupDiscovery() error {
 		if err != nil {
 			return err
 		}
+		srv.discmix.AddSource(srv.discv5.RandomNodes())
 	}
 
 	// Add protocol-specific discovery sources.


### PR DESCRIPTION
I'm not sure if it's correct, but if there is no this line for v5 only node, the node won't have any peers.