### PR TITLE
eth: report error from setupDiscovery at startup

### DIFF
--- a/eth/backend.go
+++ b/eth/backend.go
@@ -368,7 +368,9 @@ func (s *Ethereum) Protocols() []p2p.Protocol {
 // Start implements node.Lifecycle, starting all internal goroutines needed by the
 // Ethereum protocol implementation.
 func (s *Ethereum) Start() error {
-	s.setupDiscovery()
+	if err := s.setupDiscovery(); err != nil {
+		return err
+	}
 
 	// Start the bloom bits servicing goroutines
 	s.startBloomHandlers(params.BloomBitsBlocks)

--- a/p2p/dnsdisc/client.go
+++ b/p2p/dnsdisc/client.go
@@ -263,7 +263,7 @@ func (it *randomIterator) Next() bool {
 func (it *randomIterator) addTree(url string) error {
 	le, err := parseLink(url)
 	if err != nil {
-		return fmt.Errorf("invalid enrtree URL: %v", err)
+		return fmt.Errorf("invalid DNS discovery URL %q: %v", url, err)
 	}
 	it.lc.addLink("", le.str)
 	return nil


### PR DESCRIPTION
I ran into this while trying to debug a discv5 thing. I tried to disable DNS discovery using `--discovery.dns=false`, which doesn't work. Annoyingly, geth started anyway and discarded the error silently. I eventually found my mistake, but it took way longer than it should have.

Also including a small change to the error message for invalid DNS URLs here. The user actually needs to see the URL to make sense of the error.