### PR TITLE
eth/gasprice: fix eth_feeHistory blobGasRatio

### DIFF
--- a/eth/gasprice/feehistory.go
+++ b/eth/gasprice/feehistory.go
@@ -107,8 +107,8 @@ func (oracle *Oracle) processBlock(bf *blockFees, percentiles []float64) {
 	// Compute gas used ratio for normal and blob gas.
 	bf.results.gasUsedRatio = float64(bf.header.GasUsed) / float64(bf.header.GasLimit)
 	if blobGasUsed := bf.header.BlobGasUsed; blobGasUsed != nil {
-		maxBlobs := eip4844.MaxBlobsPerBlock(config, bf.header.Time)
-		bf.results.blobGasUsedRatio = float64(*blobGasUsed) / float64(maxBlobs)
+		maxBlobGas := eip4844.MaxBlobGasPerBlock(config, bf.header.Time)
+		bf.results.blobGasUsedRatio = float64(*blobGasUsed) / float64(maxBlobGas)
 	}
 
 	if len(percentiles) == 0 {


### PR DESCRIPTION
This change divides BlobGasUsed by MaxBlobGasPerBlock instead of MaxBlobsPerBlock. Dividing by MaxBlobsPerBlock 
 meant the blobGasUsedRatio was an incorrect large number. This bug was introduced by a typo [here](https://github.com/ethereum/go-ethereum/commit/e6f3ce7b168b8f346de621a8f60d2fa57c2ebfb0#diff-3357b2399699d7cf954c543cbfb02ff442eb24491e55f5e813e3cc85829b3e8dR110)

Fixes https://github.com/ethereum/go-ethereum/issues/31245