### PR TITLE
rpc:  lazily-instantiate package-level `rpcServingTimer` to prevent long-running go-routine spinup on package import

### DIFF
--- a/rpc/handler.go
+++ b/rpc/handler.go
@@ -523,7 +523,7 @@ func (h *handler) handleCall(cp *callProc, msg *jsonrpcMessage) *jsonrpcMessage 
 		} else {
 			successfulRequestGauge.Inc(1)
 		}
-		rpcServingTimer.UpdateSince(start)
+		rpcServingTimer().UpdateSince(start)
 		updateServeTimeHistogram(msg.Method, answer.Error == nil, time.Since(start))
 	}
 

--- a/rpc/metrics.go
+++ b/rpc/metrics.go
@@ -18,6 +18,7 @@ package rpc
 
 import (
 	"fmt"
+	"sync"
 	"time"
 
 	"github.com/ethereum/go-ethereum/metrics"
@@ -31,7 +32,9 @@ var (
 	// serveTimeHistName is the prefix of the per-request serving time histograms.
 	serveTimeHistName = "rpc/duration"
 
-	rpcServingTimer = metrics.NewRegisteredTimer("rpc/duration/all", nil)
+	rpcServingTimer = sync.OnceValue(func() *metrics.Timer {
+		return metrics.NewRegisteredTimer("rpc/duration/all", nil)
+	})
 )
 
 // updateServeTimeHistogram tracks the serving time of a remote RPC call.


### PR DESCRIPTION
closes https://github.com/ethereum/go-ethereum/issues/31244