### PR TITLE
core/types: reduce allocs in transaction signing

### DIFF
--- a/core/types/transaction.go
+++ b/core/types/transaction.go
@@ -100,6 +100,9 @@ type TxData interface {
 
 	encode(*bytes.Buffer) error
 	decode([]byte) error
+
+	// sigHash returns the hash of the transaction that is ought to be signed
+	sigHash(*big.Int) common.Hash
 }
 
 // EncodeRLP implements rlp.Encoder

--- a/core/types/transaction_signing.go
+++ b/core/types/transaction_signing.go
@@ -366,21 +366,22 @@ func (s londonSigner) SignatureValues(tx *Transaction, sig []byte) (R, S, V *big
 // Hash returns the hash to be signed by the sender.
 // It does not uniquely identify the transaction.
 func (s londonSigner) Hash(tx *Transaction) common.Hash {
-	if tx.Type() != DynamicFeeTxType {
+	inner, ok := tx.inner.(*DynamicFeeTx)
+	if !ok {
 		return s.eip2930Signer.Hash(tx)
 	}
 	return prefixedRlpHash(
-		tx.Type(),
+		inner.txType(),
 		[]interface{}{
 			s.chainId,
-			tx.Nonce(),
-			tx.GasTipCap(),
-			tx.GasFeeCap(),
-			tx.Gas(),
-			tx.To(),
-			tx.Value(),
-			tx.Data(),
-			tx.AccessList(),
+			inner.nonce(),
+			inner.gasTipCap(),
+			inner.gasFeeCap(),
+			inner.gas(),
+			inner.to(),
+			inner.value(),
+			inner.data(),
+			inner.accessList(),
 		})
 }
 

--- a/core/types/transaction_signing.go
+++ b/core/types/transaction_signing.go
@@ -233,20 +233,7 @@ func (s pragueSigner) Hash(tx *Transaction) common.Hash {
 	if tx.Type() != SetCodeTxType {
 		return s.cancunSigner.Hash(tx)
 	}
-	return prefixedRlpHash(
-		tx.Type(),
-		[]interface{}{
-			s.chainId,
-			tx.Nonce(),
-			tx.GasTipCap(),
-			tx.GasFeeCap(),
-			tx.Gas(),
-			tx.To(),
-			tx.Value(),
-			tx.Data(),
-			tx.AccessList(),
-			tx.SetCodeAuthorizations(),
-		})
+	return tx.inner.sigHash(s.chainId)
 }
 
 type cancunSigner struct{ londonSigner }

--- a/core/types/transaction_test.go
+++ b/core/types/transaction_test.go
@@ -593,6 +593,3 @@ func BenchmarkHash(b *testing.B) {
 		signer.Hash(tx)
 	}
 }
-
-// BenchmarkHash-8   	  440082	      2639 ns/op	     384 B/op	      13 allocs/op
-// BenchmarkHash-8   	  493566	      2033 ns/op	     240 B/op	       6 allocs/op

--- a/core/types/transaction_test.go
+++ b/core/types/transaction_test.go
@@ -576,3 +576,22 @@ func TestYParityJSONUnmarshalling(t *testing.T) {
 		}
 	}
 }
+
+func BenchmarkHash(b *testing.B) {
+	signer := NewLondonSigner(big.NewInt(1))
+	to := common.Address{}
+	tx := NewTx(&DynamicFeeTx{
+		ChainID:   big.NewInt(123),
+		Nonce:     1,
+		Gas:       1000000,
+		To:        &to,
+		Value:     big.NewInt(1),
+		GasTipCap: big.NewInt(500),
+		GasFeeCap: big.NewInt(500),
+	})
+	for i := 0; i < b.N; i++ {
+		signer.Hash(tx)
+	}
+}
+
+// BenchmarkHash-8   	  541969	      2320 ns/op	     240 B/op	       6 allocs/op

--- a/core/types/transaction_test.go
+++ b/core/types/transaction_test.go
@@ -594,4 +594,5 @@ func BenchmarkHash(b *testing.B) {
 	}
 }
 
-// BenchmarkHash-8   	  541969	      2320 ns/op	     240 B/op	       6 allocs/op
+// BenchmarkHash-8   	  440082	      2639 ns/op	     384 B/op	      13 allocs/op
+// BenchmarkHash-8   	  493566	      2033 ns/op	     240 B/op	       6 allocs/op

--- a/core/types/tx_access_list.go
+++ b/core/types/tx_access_list.go
@@ -127,3 +127,18 @@ func (tx *AccessListTx) encode(b *bytes.Buffer) error {
 func (tx *AccessListTx) decode(input []byte) error {
 	return rlp.DecodeBytes(input, tx)
 }
+
+func (tx *AccessListTx) sigHash(chainID *big.Int) common.Hash {
+	return prefixedRlpHash(
+		AccessListTxType,
+		[]any{
+			chainID,
+			tx.Nonce,
+			tx.GasPrice,
+			tx.Gas,
+			tx.To,
+			tx.Value,
+			tx.Data,
+			tx.AccessList,
+		})
+}

--- a/core/types/tx_blob.go
+++ b/core/types/tx_blob.go
@@ -259,3 +259,21 @@ func (tx *BlobTx) decode(input []byte) error {
 	}
 	return nil
 }
+
+func (tx *BlobTx) sigHash(chainID *big.Int) common.Hash {
+	return prefixedRlpHash(
+		BlobTxType,
+		[]any{
+			chainID,
+			tx.Nonce,
+			tx.GasTipCap,
+			tx.GasFeeCap,
+			tx.Gas,
+			tx.To,
+			tx.Value,
+			tx.Data,
+			tx.AccessList,
+			tx.BlobFeeCap,
+			tx.BlobHashes,
+		})
+}

--- a/core/types/tx_dynamic_fee.go
+++ b/core/types/tx_dynamic_fee.go
@@ -123,3 +123,19 @@ func (tx *DynamicFeeTx) encode(b *bytes.Buffer) error {
 func (tx *DynamicFeeTx) decode(input []byte) error {
 	return rlp.DecodeBytes(input, tx)
 }
+
+func (tx *DynamicFeeTx) sigHash(chainID *big.Int) common.Hash {
+	return prefixedRlpHash(
+		DynamicFeeTxType,
+		[]any{
+			chainID,
+			tx.Nonce,
+			tx.GasTipCap,
+			tx.GasFeeCap,
+			tx.Gas,
+			tx.To,
+			tx.Value,
+			tx.Data,
+			tx.AccessList,
+		})
+}

--- a/core/types/tx_legacy.go
+++ b/core/types/tx_legacy.go
@@ -123,3 +123,16 @@ func (tx *LegacyTx) encode(*bytes.Buffer) error {
 func (tx *LegacyTx) decode([]byte) error {
 	panic("decode called on LegacyTx)")
 }
+
+// OBS: This is the post-frontier hash, the pre-frontier does not contain a chainID
+func (tx *LegacyTx) sigHash(chainID *big.Int) common.Hash {
+	return rlpHash([]any{
+		tx.Nonce,
+		tx.GasPrice,
+		tx.Gas,
+		tx.To,
+		tx.Value,
+		tx.Data,
+		chainID, uint(0), uint(0),
+	})
+}

--- a/core/types/tx_legacy.go
+++ b/core/types/tx_legacy.go
@@ -124,7 +124,7 @@ func (tx *LegacyTx) decode([]byte) error {
 	panic("decode called on LegacyTx)")
 }
 
-// OBS: This is the post-frontier hash, the pre-frontier does not contain a chainID
+// OBS: This is the post-EIP155 hash, the pre-EIP155 does not contain a chainID.
 func (tx *LegacyTx) sigHash(chainID *big.Int) common.Hash {
 	return rlpHash([]any{
 		tx.Nonce,

--- a/core/types/tx_setcode.go
+++ b/core/types/tx_setcode.go
@@ -223,3 +223,20 @@ func (tx *SetCodeTx) encode(b *bytes.Buffer) error {
 func (tx *SetCodeTx) decode(input []byte) error {
 	return rlp.DecodeBytes(input, tx)
 }
+
+func (tx *SetCodeTx) sigHash(chainID *big.Int) common.Hash {
+	return prefixedRlpHash(
+		SetCodeTxType,
+		[]any{
+			chainID,
+			tx.Nonce,
+			tx.GasTipCap,
+			tx.GasFeeCap,
+			tx.Gas,
+			tx.To,
+			tx.Value,
+			tx.Data,
+			tx.AccessList,
+			tx.AuthList,
+		})
+}


### PR DESCRIPTION
This PR roughly halves the number of allocations needed to compute the sigHash for a transaction.
This sigHash is used whenever we recover a signature of a transaction, so quite often. During a recent benchmark full syncing on Holesky, roughly 2.8% of all allocations were happening here because the fields from the transaction would be copied multiple times.

```
66168733  153175654 (flat, cum)  2.80% of Total
         .          .    368:func (s londonSigner) Hash(tx *Transaction) common.Hash {
         .          .    369:	if tx.Type() != DynamicFeeTxType {
         .          .    370:		return s.eip2930Signer.Hash(tx)
         .          .    371:	}
         .   19169966    372:	return prefixedRlpHash(
         .          .    373:		tx.Type(),
  26442187   26442187    374:		[]interface{}{
         .          .    375:			s.chainId,
   6848616    6848616    376:			tx.Nonce(),
         .   19694077    377:			tx.GasTipCap(),
         .   18956774    378:			tx.GasFeeCap(),
   6357089    6357089    379:			tx.Gas(),
         .   12321050    380:			tx.To(),
         .   16865054    381:			tx.Value(),
  13435187   13435187    382:			tx.Data(),
  13085654   13085654    383:			tx.AccessList(),
         .          .    384:		})
         .          .    385:}
```

This PR reduces the allocations and speeds up the computation of the sigHash by ~22%, which is quite significantly given that this operation involves a call to Keccak
```
// BenchmarkHash-8   	  440082	      2639 ns/op	     384 B/op	      13 allocs/op
// BenchmarkHash-8   	  493566	      2033 ns/op	     240 B/op	       6 allocs/op
```

```
Hash-8   2.691µ ± 8%   2.097µ ± 9%  -22.07% (p=0.000 n=10)
```

It also kinda cleans up stuff in my opinion, since the transaction should itself know best how to compute the sighash 



![Screenshot_2025-02-25_13-52-41](https://github.com/user-attachments/assets/e2b268aa-e137-417d-926b-f3619daef748)
