### PR TITLE
syncx: add closeable mutex test

### DIFF
--- a/internal/syncx/mutex_test.go
+++ b/internal/syncx/mutex_test.go
@@ -1,3 +1,19 @@
+// Copyright 2021 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+
 package syncx
 
 import (
@@ -7,6 +23,7 @@ import (
 	"time"
 )
 
+// TestClosableMutex tests the ClosableMutex type.
 func TestClosableMutex(t *testing.T) {
 	t.Run("basic lock/unlock", func(t *testing.T) {
 		cm := NewClosableMutex()


### PR DESCRIPTION
Introduces a new test suite for the `ClosableMutex` type in the `syncx` package.