### PR TITLE
build: filter out .git folder for generation check

### DIFF
--- a/build/ci.go
+++ b/build/ci.go
@@ -380,7 +380,7 @@ func doCheckGenerate() {
 	var hashes map[string][32]byte
 
 	var err error
-	hashes, err = build.HashFolder(".", []string{"tests/testdata", "build/cache"})
+	hashes, err = build.HashFolder(".", []string{"tests/testdata", "build/cache", ".git"})
 	if err != nil {
 		log.Fatal("Error computing hashes", "err", err)
 	}
@@ -395,7 +395,7 @@ func doCheckGenerate() {
 	build.MustRun(c)
 
 	// Check if generate file hashes have changed
-	generated, err := build.HashFolder(".", []string{"tests/testdata", "build/cache"})
+	generated, err := build.HashFolder(".", []string{"tests/testdata", "build/cache", ".git"})
 	if err != nil {
 		log.Fatalf("Error re-computing hashes: %v", err)
 	}


### PR DESCRIPTION
Fix the lint error

```
go run build/ci.go check_generate
build/cache/protoc-27.1-linux-x86_64.zip is stale
downloading from https://github.com/protocolbuffers/protobuf/releases/download/v27.1/protoc-27.1-linux-x86_64.zip
10%...20%...30%...40%...50%...60%...70%...80%...90%...100%
build/cache/protoc-gen-go.v1.34.2.linux.amd64.tar.gz is stale
downloading from https://github.com/protocolbuffers/protobuf-go/releases/download/v1.34.2/protoc-gen-go.v1.34.2.linux.amd64.tar.gz
10%...20%...30%...40%...50%...60%...70%...80%...90%...100%
>>> /home/appveyor/.gvm/gos/go1.24.0/bin/go generate ./...
ci.go:404: File changed: .git/index
ci.go:407: One or more generated files were updated by running 'go generate ./...'
exit status 1
Command exited with code 1
```