### PR TITLE
trie: reduce allocations in trie hasher

### DIFF
--- a/trie/hasher.go
+++ b/trie/hasher.go
@@ -148,7 +148,9 @@ func (h *hasher) shortnodeToHash(n *shortNode, force bool) node {
 	if len(enc) < 32 && !force {
 		return n // Nodes smaller than 32 bytes are stored inside their parent
 	}
-	return h.hashData(enc)
+	var hn hashNode
+	h.hashDataTo(hn, enc)
+	return hn
 }
 
 // fullnodeToHash is used to create a hashNode from a fullNode, (which
@@ -160,7 +162,9 @@ func (h *hasher) fullnodeToHash(n *fullNode, force bool) node {
 	if len(enc) < 32 && !force {
 		return n // Nodes smaller than 32 bytes are stored inside their parent
 	}
-	return h.hashData(enc)
+	var hn hashNode
+	h.hashDataTo(hn, enc)
+	return hn
 }
 
 // encodedBytes returns the result of the last encoding operation on h.encbuf.


### PR DESCRIPTION
This one is a bit of a weird one, this should be caught by the compiler but apparently not.
```
(pprof) list fullnodeToHash
Total: 17328110501
ROUTINE ======================== github.com/ethereum/go-ethereum/trie.(*hasher).fullnodeToHash in github.com/ethereum/go-ethereum/trie/hasher.go
 197617393  395176563 (flat, cum)  2.28% of Total
         .          .    156:func (h *hasher) fullnodeToHash(n *fullNode, force bool) node {
         .      93187    157:	n.encode(h.encbuf)
         .          .    158:	enc := h.encodedBytes()
         .          .    159:
         .          .    160:	if len(enc) < 32 && !force {
         .          .    161:		return n // Nodes smaller than 32 bytes are stored inside their parent
         .          .    162:	}
 197617393  395083376    163:	return h.hashData(enc)
         .          .    164:}
         .          .    165:
         .          .    166:// encodedBytes returns the result of the last encoding operation on h.encbuf.
         .          .    167:// This also resets the encoder buffer.
         .          .    168://
(pprof) list shortnodeT  
Total: 17328110501
ROUTINE ======================== github.com/ethereum/go-ethereum/trie.(*hasher).shortnodeToHash in github.com/ethereum/go-ethereum/trie/hasher.go
  58830816  115690484 (flat, cum)  0.67% of Total
         .          .    144:func (h *hasher) shortnodeToHash(n *shortNode, force bool) node {
         .       5461    145:	n.encode(h.encbuf)
         .          .    146:	enc := h.encodedBytes()
         .          .    147:
         .          .    148:	if len(enc) < 32 && !force {
         .          .    149:		return n // Nodes smaller than 32 bytes are stored inside their parent
         .          .    150:	}
  58830816  115685023    151:	var hashed hashNode
         .          .    152:	h.hashDataTo(hashed, enc)
         .          .    153:	return hashed
         .          .    154:}
         .          .    155:
         .          .    156:// fullnodeToHash is used to create a hashNode from a fullNode, (which
```

# Benchmark
```
BenchmarkHasher/hashData-14         	 3270034	       371.9 ns/op	      56 B/op	       2 allocs/op
BenchmarkHasher/hashDataTo-14       	 3869163	       312.0 ns/op	       0 B/op	       0 allocs/op
```

```go
func BenchmarkHasher(b *testing.B) {
	n := &fullNode{}
	//data := make([]byte, 256)
	hasher := newHasher(false)
	b.Run("hashData", func(b *testing.B) {
		for i := 0; i < b.N; i++ {
			hash := hasher.fullnodeToHash(n, true)
			_ = hash
		}
	})
	b.Run("hashDataTo", func(b *testing.B) {
		for i := 0; i < b.N; i++ {
			hash := hasher.fullnodeToHash(n, true)
			_ = hash
		}
	})
}
```