### PR TITLE
eth/gasprice: sanity check ratio values

### DIFF
--- a/eth/gasprice/feehistory_test.go
+++ b/eth/gasprice/feehistory_test.go
@@ -84,8 +84,18 @@ func TestFeeHistory(t *testing.T) {
 		if len(ratio) != c.expCount {
 			t.Fatalf("Test case %d: gasUsedRatio array length mismatch, want %d, got %d", i, c.expCount, len(ratio))
 		}
+		for _, ratio := range ratio {
+			if ratio > 1 {
+				t.Fatalf("Test case %d: gasUsedRatio greater than 1, got %f", i, ratio)
+			}
+		}
 		if len(blobRatio) != c.expCount {
 			t.Fatalf("Test case %d: blobGasUsedRatio array length mismatch, want %d, got %d", i, c.expCount, len(blobRatio))
+		}
+		for _, ratio := range blobRatio {
+			if ratio > 1 {
+				t.Fatalf("Test case %d: blobGasUsedRatio greater than 1, got %f", i, ratio)
+			}
 		}
 		if len(blobBaseFee) != len(baseFee) {
 			t.Fatalf("Test case %d: blobBaseFee array length mismatch, want %d, got %d", i, len(baseFee), len(blobBaseFee))


### PR DESCRIPTION
Follow on to #31246. Adds a sanity check in the test to make sure the ratio value never goes over 1. Would have avoided the issue in #31245.