### PR TITLE
simulated: add WithHTTPRPCServer config

### DIFF
--- a/ethclient/simulated/options.go
+++ b/ethclient/simulated/options.go
@@ -53,3 +53,17 @@ func WithMinerMinTip(tip *big.Int) func(nodeConf *node.Config, ethConf *ethconfi
 		ethConf.Miner.GasPrice = tip
 	}
 }
+
+// WithHTTPRPCServer configures the simulated backend so that the node runs an HTTP server
+// on the specified host and port, and enables the specified HTTP modules.
+// Example usage:
+//
+//	NewBackend(alloc, WithHTTPRPCServer("localhost", 8545, []string{"eth", "net", "web3"}))
+func WithHTTPRPCServer(host string, port int,
+	modules []string) func(nodeConf *node.Config, ethConf *ethconfig.Config) {
+	return func(nodeConf *node.Config, ethConf *ethconfig.Config) {
+		nodeConf.HTTPHost = host
+		nodeConf.HTTPPort = port
+		nodeConf.HTTPModules = modules
+	}
+}


### PR DESCRIPTION
## Summary
This PR adds `WithHTTPRPCServer` option to the simulated backend, enabling an HTTP RPC server easily.

By specifying host, port, and modules, developers can run a test node accessible via HTTP with minimal setup.

```go
backend := NewBackend(
    alloc,
    WithHTTPRPCServer("localhost", 8545, []string{"eth", "net", "web3"}),
)
```

related https://github.com/ethereum/go-ethereum/issues/21457