### PR TITLE
build: update PPA Go bootstrap version to 1.23

### DIFF
--- a/build/checksums.txt
+++ b/build/checksums.txt
@@ -114,13 +114,17 @@ fc43f8c95d6bec8ba9a3557a0bb63cf9f504137ce6d24cfdc4c330d46f7779d2  golangci-lint-
 # This version is fine to be old and full of security holes, we just use it
 # to build the latest Go. Don't change it.
 #
-# version:ppa-builder-1 1.19.6
+# version:ppa-builder-1.19 1.19.6
 # https://go.dev/dl/
 d7f0013f82e6d7f862cc6cb5c8cdb48eef5f2e239b35baa97e2f1a7466043767  go1.19.6.src.tar.gz
 
-# version:ppa-builder-2 1.22.12
+# version:ppa-builder-1.21 1.21.9
 # https://go.dev/dl/
-012a7e1f37f362c0918c1dfa3334458ac2da1628c4b9cf4d9ca02db986e17d71  go1.22.12.src.tar.gz
+58f0c5ced45a0012bce2ff7a9df03e128abcc8818ebabe5027bb92bafe20e421  go1.21.9.src.tar.gz
+
+# version:ppa-builder-1.23 1.23.6
+# https://go.dev/dl/
+039c5b04e65279daceee8a6f71e70bd05cf5b801782b6f77c6e19e2ed0511222  go1.23.6.src.tar.gz
 
 # version:protoc 27.1
 # https://github.com/protocolbuffers/protobuf/releases/

--- a/build/checksums.txt
+++ b/build/checksums.txt
@@ -118,9 +118,9 @@ fc43f8c95d6bec8ba9a3557a0bb63cf9f504137ce6d24cfdc4c330d46f7779d2  golangci-lint-
 # https://go.dev/dl/
 d7f0013f82e6d7f862cc6cb5c8cdb48eef5f2e239b35baa97e2f1a7466043767  go1.19.6.src.tar.gz
 
-# version:ppa-builder-2 1.21.9
+# version:ppa-builder-2 1.22.12
 # https://go.dev/dl/
-58f0c5ced45a0012bce2ff7a9df03e128abcc8818ebabe5027bb92bafe20e421  go1.21.9.src.tar.gz
+012a7e1f37f362c0918c1dfa3334458ac2da1628c4b9cf4d9ca02db986e17d71  go1.22.12.src.tar.gz
 
 # version:protoc 27.1
 # https://github.com/protocolbuffers/protobuf/releases/

--- a/build/ci.go
+++ b/build/ci.go
@@ -843,7 +843,7 @@ func downloadGoBootstrapSources(cachedir string) []string {
 	csdb := build.MustLoadChecksums("build/checksums.txt")
 
 	var bundles []string
-	for _, booter := range []string{"ppa-builder-1", "ppa-builder-2"} {
+	for _, booter := range []string{"ppa-builder-1.19", "ppa-builder-1.21", "ppa-builder-1.23"} {
 		gobootVersion, err := build.Version(csdb, booter)
 		if err != nil {
 			log.Fatal(err)


### PR DESCRIPTION
This is for fixing the PPA build, which has been failing since the update to Go 1.24.
In Go 1.24, the required Go version for bootstrapping was updated to 1.22. In general, they
are following through with always depending on the Go version two releases ago for
bootstrapping.

Since we still support Ubuntu Xenial (16.04) until its EOL date of 04/2026, and Xenial only
has golang 1.10 as a package, we now need to build Go a total of four times to get the most
recent version. I'm adding a step for Go 1.23 here. This should last us until Go 1.25, which should
be out around 04/2026, and we can hopefully drop the first bootstrapping step at that time.