### PR TITLE
eth/tracers: fix omitempty for memory, stack and storage

### DIFF
--- a/eth/tracers/logger/logger.go
+++ b/eth/tracers/logger/logger.go
@@ -167,7 +167,7 @@ func (s *StructLog) toLegacyJSON() json.RawMessage {
 		Error:         s.ErrorString(),
 		RefundCounter: s.RefundCounter,
 	}
-	if len(s.Stack) > 0 {
+	if s.Stack != nil {
 		stack := make([]string, len(s.Stack))
 		for i, stackValue := range s.Stack {
 			stack[i] = stackValue.Hex()


### PR DESCRIPTION
This fixes a regression in the opcode tracer API where we would log empty memory, stack and storage fields.