### PR TITLE
ethclient: add BlobBaseFee method to retrieve base fee per blob gas

### DIFF
--- a/ethclient/ethclient.go
+++ b/ethclient/ethclient.go
@@ -598,6 +598,15 @@ func (ec *Client) SuggestGasTipCap(ctx context.Context) (*big.Int, error) {
 	return (*big.Int)(&hex), nil
 }
 
+// BlobBaseFee returns the base fee per blob gas in wei.
+func (ec *Client) BlobBaseFee(ctx context.Context) (*big.Int, error) {
+	var hex hexutil.Big
+	if err := ec.c.CallContext(ctx, &hex, "eth_blobBaseFee"); err != nil {
+		return nil, err
+	}
+	return (*big.Int)(&hex), nil
+}
+
 type feeHistoryResultMarshaling struct {
 	OldestBlock  *hexutil.Big     `json:"oldestBlock"`
 	Reward       [][]*hexutil.Big `json:"reward,omitempty"`

--- a/ethclient/ethclient.go
+++ b/ethclient/ethclient.go
@@ -598,7 +598,7 @@ func (ec *Client) SuggestGasTipCap(ctx context.Context) (*big.Int, error) {
 	return (*big.Int)(&hex), nil
 }
 
-// BlobBaseFee returns the base fee per blob gas in wei.
+// BlobBaseFee retrieves the current blob base fee.
 func (ec *Client) BlobBaseFee(ctx context.Context) (*big.Int, error) {
 	var hex hexutil.Big
 	if err := ec.c.CallContext(ctx, &hex, "eth_blobBaseFee"); err != nil {

--- a/ethclient/ethclient_test.go
+++ b/ethclient/ethclient_test.go
@@ -404,6 +404,15 @@ func testStatusFunctions(t *testing.T, client *rpc.Client) {
 		t.Fatalf("unexpected gas tip cap: %v", gasTipCap)
 	}
 
+	// BlobBaseFee
+	blobBaseFee, err := ec.BlobBaseFee(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if blobBaseFee.Cmp(big.NewInt(1)) != 0 {
+		t.Fatalf("unexpected blob base fee: %v", blobBaseFee)
+	}
+
 	// FeeHistory
 	history, err := ec.FeeHistory(context.Background(), 1, big.NewInt(2), []float64{95, 99})
 	if err != nil {


### PR DESCRIPTION
Ref:

https://ethereum.github.io/execution-apis/api-documentation/

https://docs.metamask.io/services/reference/ethereum/json-rpc-methods/eth_blobbasefee/