### PR TITLE
accounts/abi: Improve unpack performance

### DIFF
--- a/accounts/abi/argument.go
+++ b/accounts/abi/argument.go
@@ -182,10 +182,20 @@ func (arguments Arguments) copyTuple(v interface{}, marshalledValues []interface
 // without supplying a struct to unpack into. Instead, this method returns a list containing the
 // values. An atomic argument will be a list with one element.
 func (arguments Arguments) UnpackValues(data []byte) ([]interface{}, error) {
-	nonIndexedArgs := arguments.NonIndexed()
-	retval := make([]interface{}, 0, len(nonIndexedArgs))
+	size := 0
+	for _, arg := range arguments {
+		if arg.Indexed {
+			continue
+		}
+		size++
+	}
+
+	retval := make([]interface{}, 0, size)
 	virtualArgs := 0
-	for index, arg := range nonIndexedArgs {
+	for index, arg := range arguments {
+		if arg.Indexed {
+			continue
+		}
 		marshalledValue, err := toGoType((index+virtualArgs)*32, arg.Type, data)
 		if err != nil {
 			return nil, err

--- a/accounts/abi/argument.go
+++ b/accounts/abi/argument.go
@@ -192,7 +192,8 @@ func (arguments Arguments) UnpackValues(data []byte) ([]interface{}, error) {
 
 	retval := make([]interface{}, 0, size)
 	virtualArgs := 0
-	for index, arg := range arguments {
+	index := 0
+	for _, arg := range arguments {
 		if arg.Indexed {
 			continue
 		}
@@ -218,6 +219,7 @@ func (arguments Arguments) UnpackValues(data []byte) ([]interface{}, error) {
 			virtualArgs += getTypeSize(arg.Type)/32 - 1
 		}
 		retval = append(retval, marshalledValue)
+		index++
 	}
 	return retval, nil
 }


### PR DESCRIPTION
Reduces alloc by extra loop iteration, slight performance improvement on my local machine
```
            │   MASTER    │                 PR                 │
            │   sec/op    │   sec/op     vs base               │
Unpack/0-32   217.9n ± 5%   170.3n ± 2%  -21.84% (p=0.002 n=6)
Unpack/1-32   628.7n ± 9%   573.5n ± 7%   -8.78% (p=0.002 n=6)
```