### PR TITLE
core/rawdb,state: add preimage miss metric 

### DIFF
--- a/core/rawdb/accessors_state.go
+++ b/core/rawdb/accessors_state.go
@@ -27,7 +27,11 @@ import (
 // ReadPreimage retrieves a single preimage of the provided hash.
 func ReadPreimage(db ethdb.KeyValueReader, hash common.Hash) []byte {
 	data, _ := db.Get(preimageKey(hash))
-	preimageMissCounter.Inc(1)
+	if len(data) == 0 {
+		preimageMissCounter.Inc(1)
+	} else {
+		preimageHitsCounter.Inc(1)
+	}
 	return data
 }
 

--- a/core/rawdb/accessors_state.go
+++ b/core/rawdb/accessors_state.go
@@ -27,6 +27,7 @@ import (
 // ReadPreimage retrieves a single preimage of the provided hash.
 func ReadPreimage(db ethdb.KeyValueReader, hash common.Hash) []byte {
 	data, _ := db.Get(preimageKey(hash))
+	preimageMissCounter.Inc(1)
 	return data
 }
 
@@ -38,7 +39,6 @@ func WritePreimages(db ethdb.KeyValueWriter, preimages map[common.Hash][]byte) {
 		}
 	}
 	preimageCounter.Inc(int64(len(preimages)))
-	preimageHitCounter.Inc(int64(len(preimages)))
 }
 
 // ReadCode retrieves the contract code of the provided code hash.

--- a/core/rawdb/schema.go
+++ b/core/rawdb/schema.go
@@ -145,8 +145,8 @@ var (
 	FixedCommitteeRootKey = []byte("fixedRoot-") // bigEndian64(syncPeriod) -> committee root hash
 	SyncCommitteeKey      = []byte("committee-") // bigEndian64(syncPeriod) -> serialized committee
 
-	preimageCounter    = metrics.NewRegisteredCounter("db/preimage/total", nil)
-	preimageHitCounter = metrics.NewRegisteredCounter("db/preimage/hits", nil)
+	preimageCounter     = metrics.NewRegisteredCounter("db/preimage/total", nil)
+	preimageMissCounter = metrics.NewRegisteredCounter("db/preimage/miss", nil)
 )
 
 // LegacyTxLookupEntry is the legacy TxLookupEntry definition with some unnecessary

--- a/core/rawdb/schema.go
+++ b/core/rawdb/schema.go
@@ -146,6 +146,7 @@ var (
 	SyncCommitteeKey      = []byte("committee-") // bigEndian64(syncPeriod) -> serialized committee
 
 	preimageCounter     = metrics.NewRegisteredCounter("db/preimage/total", nil)
+	preimageHitsCounter = metrics.NewRegisteredCounter("db/preimage/hits", nil)
 	preimageMissCounter = metrics.NewRegisteredCounter("db/preimage/miss", nil)
 )
 

--- a/core/state/metrics.go
+++ b/core/state/metrics.go
@@ -19,7 +19,7 @@ package state
 import "github.com/ethereum/go-ethereum/metrics"
 
 var (
-	accountReadMeters        = metrics.NewRegisteredMeter("state/read/accounts", nil)
+	accountReadMeters        = metrics.NewRegisteredMeter("state/read/account", nil)
 	storageReadMeters        = metrics.NewRegisteredMeter("state/read/storage", nil)
 	accountUpdatedMeter      = metrics.NewRegisteredMeter("state/update/account", nil)
 	storageUpdatedMeter      = metrics.NewRegisteredMeter("state/update/storage", nil)


### PR DESCRIPTION
1. The metric of preimage/hits are always the same as preimage/total, prefer to replace the hits with miss instead.  
2. For the state/read/accounts metric, follow the same naming of others, change inot a singuar.