### PR TITLE
triedb/pathdb: improve perf by separating nodes map

### DIFF
--- a/triedb/pathdb/nodes.go
+++ b/triedb/pathdb/nodes.go
@@ -36,8 +36,9 @@ import (
 // transition, typically corresponding to a block execution. It can also represent
 // the combined trie node set from several aggregated state transitions.
 type nodeSet struct {
-	size  uint64                                    // aggregated size of the trie node
-	nodes map[common.Hash]map[string]*trienode.Node // node set, mapped by owner and path
+	size         uint64                                    // aggregated size of the trie node
+	accountNodes map[string]*trienode.Node                 // account trie nodes, mapped by path
+	storageNodes map[common.Hash]map[string]*trienode.Node // storage trie nodes, mapped by owner and path
 }
 
 // newNodeSet constructs the set with the provided dirty trie nodes.
@@ -46,7 +47,22 @@ func newNodeSet(nodes map[common.Hash]map[string]*trienode.Node) *nodeSet {
 	if nodes == nil {
 		nodes = make(map[common.Hash]map[string]*trienode.Node)
 	}
-	s := &nodeSet{nodes: nodes}
+
+	// Create the new structure with separate maps
+	s := &nodeSet{
+		accountNodes: make(map[string]*trienode.Node),
+		storageNodes: make(map[common.Hash]map[string]*trienode.Node),
+	}
+
+	// Migrate the nodes to the appropriate maps
+	for owner, subset := range nodes {
+		if owner == (common.Hash{}) {
+			maps.Copy(s.accountNodes, subset)
+		} else {
+			s.storageNodes[owner] = maps.Clone(subset)
+		}
+	}
+
 	s.computeSize()
 	return s
 }
@@ -54,11 +70,13 @@ func newNodeSet(nodes map[common.Hash]map[string]*trienode.Node) *nodeSet {
 // computeSize calculates the database size of the held trie nodes.
 func (s *nodeSet) computeSize() {
 	var size uint64
-	for owner, subset := range s.nodes {
-		var prefix int
-		if owner != (common.Hash{}) {
-			prefix = common.HashLength // owner (32 bytes) for storage trie nodes
-		}
+
+	for path, n := range s.accountNodes {
+		size += uint64(len(n.Blob) + len(path))
+	}
+
+	for _, subset := range s.storageNodes {
+		prefix := common.HashLength // owner (32 bytes) for storage trie nodes
 		for path, n := range subset {
 			size += uint64(prefix + len(n.Blob) + len(path))
 		}
@@ -79,15 +97,19 @@ func (s *nodeSet) updateSize(delta int64) {
 
 // node retrieves the trie node with node path and its trie identifier.
 func (s *nodeSet) node(owner common.Hash, path []byte) (*trienode.Node, bool) {
-	subset, ok := s.nodes[owner]
+	if owner == (common.Hash{}) {
+		// Account trie node
+		n, ok := s.accountNodes[string(path)]
+		return n, ok
+	}
+
+	// Storage trie node
+	subset, ok := s.storageNodes[owner]
 	if !ok {
 		return nil, false
 	}
 	n, ok := subset[string(path)]
-	if !ok {
-		return nil, false
-	}
-	return n, true
+	return n, ok
 }
 
 // merge integrates the provided dirty nodes into the set. The provided nodeset
@@ -97,12 +119,22 @@ func (s *nodeSet) merge(set *nodeSet) {
 		delta     int64   // size difference resulting from node merging
 		overwrite counter // counter of nodes being overwritten
 	)
-	for owner, subset := range set.nodes {
-		var prefix int
-		if owner != (common.Hash{}) {
-			prefix = common.HashLength
+
+	// Merge account nodes
+	for path, n := range set.accountNodes {
+		if orig, exist := s.accountNodes[path]; !exist {
+			delta += int64(len(n.Blob) + len(path))
+		} else {
+			delta += int64(len(n.Blob) - len(orig.Blob))
+			overwrite.add(len(orig.Blob) + len(path))
 		}
-		current, exist := s.nodes[owner]
+		s.accountNodes[path] = n
+	}
+
+	// Merge storage nodes
+	for owner, subset := range set.storageNodes {
+		prefix := common.HashLength
+		current, exist := s.storageNodes[owner]
 		if !exist {
 			for path, n := range subset {
 				delta += int64(prefix + len(n.Blob) + len(path))
@@ -113,7 +145,7 @@ func (s *nodeSet) merge(set *nodeSet) {
 			// accessible even after merging. Therefore, ownership of the nodes map
 			// should still belong to the original layer, and any modifications to it
 			// should be prevented.
-			s.nodes[owner] = maps.Clone(subset)
+			s.storageNodes[owner] = maps.Clone(subset)
 			continue
 		}
 		for path, n := range subset {
@@ -125,7 +157,7 @@ func (s *nodeSet) merge(set *nodeSet) {
 			}
 			current[path] = n
 		}
-		s.nodes[owner] = current
+		s.storageNodes[owner] = current
 	}
 	overwrite.report(gcTrieNodeMeter, gcTrieNodeBytesMeter)
 	s.updateSize(delta)
@@ -136,34 +168,38 @@ func (s *nodeSet) merge(set *nodeSet) {
 func (s *nodeSet) revertTo(db ethdb.KeyValueReader, nodes map[common.Hash]map[string]*trienode.Node) {
 	var delta int64
 	for owner, subset := range nodes {
-		current, ok := s.nodes[owner]
-		if !ok {
-			panic(fmt.Sprintf("non-existent subset (%x)", owner))
-		}
-		for path, n := range subset {
-			orig, ok := current[path]
-			if !ok {
-				// There is a special case in merkle tree that one child is removed
-				// from a fullNode which only has two children, and then a new child
-				// with different position is immediately inserted into the fullNode.
-				// In this case, the clean child of the fullNode will also be marked
-				// as dirty because of node collapse and expansion. In case of database
-				// rollback, don't panic if this "clean" node occurs which is not
-				// present in buffer.
-				var blob []byte
-				if owner == (common.Hash{}) {
-					blob = rawdb.ReadAccountTrieNode(db, []byte(path))
-				} else {
-					blob = rawdb.ReadStorageTrieNode(db, owner, []byte(path))
+		if owner == (common.Hash{}) {
+			// Account trie nodes
+			for path, n := range subset {
+				orig, ok := s.accountNodes[path]
+				if !ok {
+					blob := rawdb.ReadAccountTrieNode(db, []byte(path))
+					if bytes.Equal(blob, n.Blob) {
+						continue
+					}
+					panic(fmt.Sprintf("non-existent node (account %v) blob: %v", path, crypto.Keccak256Hash(n.Blob).Hex()))
 				}
-				// Ignore the clean node in the case described above.
-				if bytes.Equal(blob, n.Blob) {
-					continue
-				}
-				panic(fmt.Sprintf("non-existent node (%x %v) blob: %v", owner, path, crypto.Keccak256Hash(n.Blob).Hex()))
+				s.accountNodes[path] = n
+				delta += int64(len(n.Blob)) - int64(len(orig.Blob))
 			}
-			current[path] = n
-			delta += int64(len(n.Blob)) - int64(len(orig.Blob))
+		} else {
+			// Storage trie nodes
+			current, ok := s.storageNodes[owner]
+			if !ok {
+				panic(fmt.Sprintf("non-existent subset (%x)", owner))
+			}
+			for path, n := range subset {
+				orig, ok := current[path]
+				if !ok {
+					blob := rawdb.ReadStorageTrieNode(db, owner, []byte(path))
+					if bytes.Equal(blob, n.Blob) {
+						continue
+					}
+					panic(fmt.Sprintf("non-existent node (%x %v) blob: %v", owner, path, crypto.Keccak256Hash(n.Blob).Hex()))
+				}
+				current[path] = n
+				delta += int64(len(n.Blob)) - int64(len(orig.Blob))
+			}
 		}
 	}
 	s.updateSize(delta)
@@ -184,8 +220,22 @@ type journalNodes struct {
 
 // encode serializes the content of trie nodes into the provided writer.
 func (s *nodeSet) encode(w io.Writer) error {
-	nodes := make([]journalNodes, 0, len(s.nodes))
-	for owner, subset := range s.nodes {
+	nodes := make([]journalNodes, 0, len(s.storageNodes)+len(s.accountNodes))
+
+	// Encode account nodes
+	if len(s.accountNodes) > 0 {
+		entry := journalNodes{Owner: common.Hash{}}
+		for path, node := range s.accountNodes {
+			entry.Nodes = append(entry.Nodes, journalNode{
+				Path: []byte(path),
+				Blob: node.Blob,
+			})
+		}
+		nodes = append(nodes, entry)
+	}
+
+	// Encode storage nodes
+	for owner, subset := range s.storageNodes {
 		entry := journalNodes{Owner: owner}
 		for path, node := range subset {
 			entry.Nodes = append(entry.Nodes, journalNode{
@@ -204,43 +254,73 @@ func (s *nodeSet) decode(r *rlp.Stream) error {
 	if err := r.Decode(&encoded); err != nil {
 		return fmt.Errorf("load nodes: %v", err)
 	}
-	nodes := make(map[common.Hash]map[string]*trienode.Node)
+
+	// Initialize the maps
+	s.accountNodes = make(map[string]*trienode.Node)
+	s.storageNodes = make(map[common.Hash]map[string]*trienode.Node)
+
+	// Decode the nodes
 	for _, entry := range encoded {
-		subset := make(map[string]*trienode.Node)
-		for _, n := range entry.Nodes {
-			if len(n.Blob) > 0 {
-				subset[string(n.Path)] = trienode.New(crypto.Keccak256Hash(n.Blob), n.Blob)
-			} else {
-				subset[string(n.Path)] = trienode.NewDeleted()
+		if entry.Owner == (common.Hash{}) {
+			// Account nodes
+			for _, n := range entry.Nodes {
+				if len(n.Blob) > 0 {
+					s.accountNodes[string(n.Path)] = trienode.New(crypto.Keccak256Hash(n.Blob), n.Blob)
+				} else {
+					s.accountNodes[string(n.Path)] = trienode.NewDeleted()
+				}
 			}
+		} else {
+			// Storage nodes
+			subset := make(map[string]*trienode.Node)
+			for _, n := range entry.Nodes {
+				if len(n.Blob) > 0 {
+					subset[string(n.Path)] = trienode.New(crypto.Keccak256Hash(n.Blob), n.Blob)
+				} else {
+					subset[string(n.Path)] = trienode.NewDeleted()
+				}
+			}
+			s.storageNodes[entry.Owner] = subset
 		}
-		nodes[entry.Owner] = subset
 	}
-	s.nodes = nodes
 	s.computeSize()
 	return nil
 }
 
 // write flushes nodes into the provided database batch as a whole.
 func (s *nodeSet) write(batch ethdb.Batch, clean *fastcache.Cache) int {
-	return writeNodes(batch, s.nodes, clean)
+	// Convert the separate maps back to the format expected by writeNodes
+	nodes := make(map[common.Hash]map[string]*trienode.Node)
+
+	// Add account nodes
+	if len(s.accountNodes) > 0 {
+		nodes[common.Hash{}] = s.accountNodes
+	}
+
+	// Add storage nodes
+	for owner, subset := range s.storageNodes {
+		nodes[owner] = subset
+	}
+
+	return writeNodes(batch, nodes, clean)
 }
 
 // reset clears all cached trie node data.
 func (s *nodeSet) reset() {
-	s.nodes = make(map[common.Hash]map[string]*trienode.Node)
+	s.accountNodes = make(map[string]*trienode.Node)
+	s.storageNodes = make(map[common.Hash]map[string]*trienode.Node)
 	s.size = 0
 }
 
 // dbsize returns the approximate size of db write.
 func (s *nodeSet) dbsize() int {
 	var m int
-	for owner, nodes := range s.nodes {
-		if owner == (common.Hash{}) {
-			m += len(nodes) * len(rawdb.TrieNodeAccountPrefix) // database key prefix
-		} else {
-			m += len(nodes) * (len(rawdb.TrieNodeStoragePrefix)) // database key prefix
-		}
+
+	m += len(s.accountNodes) * len(rawdb.TrieNodeAccountPrefix) // database key prefix
+
+	for _, nodes := range s.storageNodes {
+		m += len(nodes) * (len(rawdb.TrieNodeStoragePrefix)) // database key prefix
 	}
+
 	return m + int(s.size)
 }


### PR DESCRIPTION
### Description
This PR refactors the `nodeSet` structure in the path database to use separate maps for account and storage trie nodes, resulting in performance improvements. The change maintains the same API while optimizing the internal data structure.

### Motivation
The original implementation used a single nested map structure for both account and storage nodes:
```
nodes map[common.Hash]map[string]*trienode.Node // node set, mapped by owner and path
```
This required two map lookups for account nodes (first by owner hash, then by path). By separating account nodes into their own dedicated map, we can eliminate one level of indirection for account operations.

### Changes
Refactored `nodeSet` to use two separate maps:
```
accountNodes map[string]*trienode.Node // for account trie nodes
storageNodes map[common.Hash]map[string]*trienode.Node // for storage trie nodes
```
This change maintains full backward compatibility as all method signatures remain unchanged. The refactoring is purely internal to the `nodeSet` structure. 

### Benchmark Results
```
goos: darwin
goarch: arm64
pkg: github.com/ethereum/go-ethereum/triedb/pathdb
cpu: Apple M3 Pro
                                                          │   old.txt    │               new.txt                │
                                                          │    sec/op    │    sec/op     vs base                │
Search128Layers-11                                          9.890µ ± 12%   6.651µ ± 16%  -32.75% (p=0.000 n=10)
Search512Layers-11                                          46.13µ ±  5%   32.45µ ±  2%  -29.66% (p=0.000 n=10)
Search1Layer-11                                             51.03n ±  1%   43.95n ±  5%  -13.86% (p=0.000 n=10)
Persist-11                                                  97.51m ±  9%   84.45m ± 11%  -13.39% (p=0.000 n=10)
AccountIteratorTraversal/binary_iterator_keys-11            9.184µ ±  1%   9.336µ ± 25%   +1.66% (p=0.005 n=10)
AccountIteratorTraversal/binary_iterator_values-11          14.05µ ± 12%   13.88µ ±  0%   -1.19% (p=0.000 n=10)
AccountIteratorTraversal/fast_iterator_keys-11              8.479µ ± 10%   7.881µ ±  1%   -7.05% (p=0.000 n=10)
AccountIteratorTraversal/fast_iterator_values-11            8.326µ ±  4%   8.066µ ±  2%   -3.13% (p=0.001 n=10)
AccountIteratorLargeBaselayer/binary_iterator_(keys)-11     11.05m ±  3%   10.59m ±  0%   -4.17% (p=0.000 n=10)
AccountIteratorLargeBaselayer/binary_iterator_(values)-11   17.45m ±  0%   16.83m ±  1%   -3.53% (p=0.000 n=10)
AccountIteratorLargeBaselayer/fast_iterator_(keys)-11       133.8µ ±  0%   131.2µ ±  0%   -1.96% (p=0.000 n=10)
AccountIteratorLargeBaselayer/fast_iterator_(values)-11     135.8µ ±  2%   133.2µ ±  3%   -1.89% (p=0.015 n=10)
geomean                                                     80.35µ         72.35µ         -9.96%
```