### PR TITLE
cmd/evm: link to relevant EIPs in readme

### DIFF
--- a/cmd/evm/testdata/10/readme.md
+++ b/cmd/evm/testdata/10/readme.md
@@ -1,6 +1,6 @@
 ## EIP-1559 testing
 
-This test contains testcases for EIP-1559, which were reported by Ori as misbehaving. 
+This test contains testcases for [EIP-1559](https://eips.ethereum.org/EIPS/eip-1559) , which were reported by Ori as misbehaving. 
 
 ```
 [user@work evm]$ dir=./testdata/10 && ./evm t8n --state.fork=London --input.alloc=$dir/alloc.json --input.txs=$dir/txs.json --input.env=$dir/env.json --output.alloc=stdout --output.result=stdout 2>&1

--- a/cmd/evm/testdata/8/readme.md
+++ b/cmd/evm/testdata/8/readme.md
@@ -1,6 +1,6 @@
 ## EIP-2930 testing
 
-This test contains testcases for EIP-2930, which uses transactions with access lists. 
+This test contains testcases for [EIP-2930](https://eips.ethereum.org/EIPS/eip-2930), which uses transactions with access lists. 
 
 ### Prestate
 


### PR DESCRIPTION
Fixed broken or outdated links and improved documentation formatting to ensure consistency and correct references.

