### PR TITLE
build: fix execution-spec-tests sanitycheck URL

### DIFF
--- a/build/checksums.txt
+++ b/build/checksums.txt
@@ -2,7 +2,7 @@
 
 # version:spec-tests pectra-devnet-6@v1.0.0
 # https://github.com/ethereum/execution-spec-tests/releases
-# https://github.com/ethereum/execution-spec-tests/releases/download/pectra-devnet-6%40v1.0.0/fixtures_pectra-devnet-6.tar.gz
+# https://github.com/ethereum/execution-spec-tests/releases/download/pectra-devnet-6%40v1.0.0/
 b69211752a3029083c020dc635fe12156ca1a6725a08559da540a0337586a77e  fixtures_pectra-devnet-6.tar.gz
 
 # version:golang 1.24.0


### PR DESCRIPTION
This error was introduced by #31088

```shell
$ go run build/ci.go sanitycheck

/tmp/fixtures_pectra-devnet-6.tar.gz is stale
downloading from https://github.com/ethereum/execution-spec-tests/releases/download/pectra-devnet-6%40v1.0.0/fixtures_pectra-devnet-6.tar.gzfixtures_pectra-devnet-6.tar.gz
gotool.go:177: download error: status 404
```