### PR TITLE
eth/catlyst,cmd/geth: improve devnet experience

### DIFF
--- a/cmd/geth/config.go
+++ b/cmd/geth/config.go
@@ -233,7 +233,7 @@ func makeFullNode(ctx *cli.Context) *node.Node {
 
 	if ctx.IsSet(utils.DeveloperFlag.Name) {
 		// Start dev mode.
-		simBeacon, err := catalyst.NewSimulatedBeacon(ctx.Uint64(utils.DeveloperPeriodFlag.Name), eth)
+		simBeacon, err := catalyst.NewSimulatedBeacon(ctx.Uint64(utils.DeveloperPeriodFlag.Name), cfg.Eth.Miner.Etherbase, eth)
 		if err != nil {
 			utils.Fatalf("failed to register dev mode catalyst service: %v", err)
 		}

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -1730,20 +1730,21 @@ func SetEthConfig(ctx *cli.Context, stack *node.Node, cfg *ethconfig.Config) {
 		// setEtherbase has been called above, configuring the miner address from command line flags.
 		if cfg.Miner.PendingFeeRecipient != (common.Address{}) {
 			developer = accounts.Account{Address: cfg.Miner.PendingFeeRecipient}
-		} else if accs := ks.Accounts(); len(accs) > 0 {
-			developer = ks.Accounts()[0]
 		} else {
-			developer, err = ks.NewAccount(passphrase)
-			if err != nil {
-				Fatalf("Failed to create developer account: %v", err)
+			if accs := ks.Accounts(); len(accs) > 0 {
+				developer = ks.Accounts()[0]
+			} else {
+				developer, err = ks.NewAccount(passphrase)
+				if err != nil {
+					Fatalf("Failed to create developer account: %v", err)
+				}
 			}
-		}
-		// Make sure the address is configured as fee recipient, otherwise
-		// the miner will fail to start.
-		cfg.Miner.PendingFeeRecipient = developer.Address
-
-		if err := ks.Unlock(developer, passphrase); err != nil {
-			Fatalf("Failed to unlock developer account: %v", err)
+			if err := ks.Unlock(developer, passphrase); err != nil {
+				Fatalf("Failed to unlock developer account: %v", err)
+			}
+			// Make sure the address is configured as fee recipient, otherwise
+			// the miner will fail to start.
+			cfg.Miner.PendingFeeRecipient = developer.Address
 		}
 		log.Info("Using developer account", "address", developer.Address)
 

--- a/eth/catalyst/simulated_beacon.go
+++ b/eth/catalyst/simulated_beacon.go
@@ -108,7 +108,7 @@ func payloadVersion(config *params.ChainConfig, time uint64) engine.PayloadVersi
 }
 
 // NewSimulatedBeacon constructs a new simulated beacon chain.
-func NewSimulatedBeacon(period uint64, eth *eth.Ethereum) (*SimulatedBeacon, error) {
+func NewSimulatedBeacon(period uint64, feeRecipient common.Address, eth *eth.Ethereum) (*SimulatedBeacon, error) {
 	block := eth.BlockChain().CurrentBlock()
 	current := engine.ForkchoiceStateV1{
 		HeadBlockHash:      block.Hash(),
@@ -131,6 +131,7 @@ func NewSimulatedBeacon(period uint64, eth *eth.Ethereum) (*SimulatedBeacon, err
 		engineAPI:          engineAPI,
 		lastBlockTime:      block.Time,
 		curForkchoiceState: current,
+		feeRecipient:       feeRecipient,
 	}, nil
 }
 

--- a/eth/catalyst/simulated_beacon_test.go
+++ b/eth/catalyst/simulated_beacon_test.go
@@ -55,7 +55,7 @@ func startSimulatedBeaconEthService(t *testing.T, genesis *core.Genesis, period 
 		t.Fatal("can't create eth service:", err)
 	}
 
-	simBeacon, err := NewSimulatedBeacon(period, ethservice)
+	simBeacon, err := NewSimulatedBeacon(period, common.Address{}, ethservice)
 	if err != nil {
 		t.Fatal("can't create simulated beacon:", err)
 	}

--- a/ethclient/simulated/backend.go
+++ b/ethclient/simulated/backend.go
@@ -120,7 +120,7 @@ func newWithNode(stack *node.Node, conf *eth.Config, blockPeriod uint64) (*Backe
 		return nil, err
 	}
 	// Set up the simulated beacon
-	beacon, err := catalyst.NewSimulatedBeacon(blockPeriod, backend)
+	beacon, err := catalyst.NewSimulatedBeacon(blockPeriod, common.Address{}, backend)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
this adds 2 features to improve `geth --dev` experience.

1. we don't need to use `dev_SetFeeRecipient` to set initial coinbase address. it was a pain.
2. we don't need to unlock keystore if we don't use it. we had it because of clique.