### PR TITLE
ethclient: add Version method to retrieve client version

### DIFF
--- a/ethclient/ethclient.go
+++ b/ethclient/ethclient.go
@@ -77,6 +77,15 @@ func (ec *Client) ChainID(ctx context.Context) (*big.Int, error) {
 	return (*big.Int)(&result), err
 }
 
+// Version retrieves the current client version.
+func (ec *Client) Version(ctx context.Context) (string, error) {
+	var version string
+	if err := ec.c.CallContext(ctx, &version, "web3_clientVersion"); err != nil {
+		return "", err
+	}
+	return version, nil
+}
+
 // BlockByHash returns the given full block.
 //
 // Note that loading full blocks requires two requests. Use HeaderByHash

--- a/ethclient/ethclient_test.go
+++ b/ethclient/ethclient_test.go
@@ -22,7 +22,10 @@ import (
 	"errors"
 	"fmt"
 	"math/big"
+	"os"
+	"path/filepath"
 	"reflect"
+	"runtime"
 	"testing"
 	"time"
 
@@ -164,6 +167,9 @@ func TestEthClient(t *testing.T) {
 		},
 		"ChainID": {
 			func(t *testing.T) { testChainID(t, client) },
+		},
+		"Version": {
+			func(t *testing.T) { testVersion(t, client) },
 		},
 		"GetBlock": {
 			func(t *testing.T) { testGetBlock(t, client) },
@@ -317,6 +323,17 @@ func testChainID(t *testing.T, client *rpc.Client) {
 	}
 	if id == nil || id.Cmp(params.AllDevChainProtocolChanges.ChainID) != 0 {
 		t.Fatalf("ChainID returned wrong number: %+v", id)
+	}
+}
+
+func testVersion(t *testing.T, client *rpc.Client) {
+	ec := ethclient.NewClient(client)
+	v, err := ec.Version(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if v != fmt.Sprintf("%s/%s-%s/%s", filepath.Base(os.Args[0]), runtime.GOOS, runtime.GOARCH, runtime.Version()) {
+		t.Fatalf("Version returned wrong value: %s", v)
 	}
 }
 

--- a/ethclient/ethclient_test.go
+++ b/ethclient/ethclient_test.go
@@ -333,8 +333,9 @@ func testVersion(t *testing.T, client *rpc.Client) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if v != fmt.Sprintf("%s/%s-%s/%s", strings.TrimSuffix(filepath.Base(os.Args[0]), ".exe"), runtime.GOOS, runtime.GOARCH, runtime.Version()) {
-		t.Fatalf("Version returned wrong value: %s", v)
+	exp := fmt.Sprintf("%s/%s-%s/%s", strings.TrimSuffix(filepath.Base(os.Args[0]), ".exe"), runtime.GOOS, runtime.GOARCH, runtime.Version())
+	if v != exp {
+		t.Fatalf("Version returned wrong value: %s, expected: %s", v, exp)
 	}
 }
 

--- a/ethclient/ethclient_test.go
+++ b/ethclient/ethclient_test.go
@@ -26,6 +26,7 @@ import (
 	"path/filepath"
 	"reflect"
 	"runtime"
+	"strings"
 	"testing"
 	"time"
 
@@ -332,7 +333,7 @@ func testVersion(t *testing.T, client *rpc.Client) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if v != fmt.Sprintf("%s/%s-%s/%s", filepath.Base(os.Args[0]), runtime.GOOS, runtime.GOARCH, runtime.Version()) {
+	if v != fmt.Sprintf("%s/%s-%s/%s", strings.TrimSuffix(filepath.Base(os.Args[0]), ".exe"), runtime.GOOS, runtime.GOARCH, runtime.Version()) {
 		t.Fatalf("Version returned wrong value: %s", v)
 	}
 }


### PR DESCRIPTION
- Add `func (ec *ethclient.Client) Version` to process JSON-RPC API method `web3_clientVersion`.
- Add a test for the new `Version` method.