### PR TITLE
core,params: add fork readiness indicator in logs

### DIFF
--- a/params/config.go
+++ b/params/config.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"math"
 	"math/big"
+	"time"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/params/forks"
@@ -872,6 +873,23 @@ func (c *ChainConfig) LatestFork(time uint64) forks.Fork {
 		return forks.Shanghai
 	default:
 		return forks.Paris
+	}
+}
+
+// Timestamp returns the timestamp associated with the fork or returns nil if
+// the fork isn't defined or isn't a time-based fork.
+func (c *ChainConfig) Timestamp(fork forks.Fork) *uint64 {
+	switch {
+	case fork == forks.Osaka:
+		return c.OsakaTime
+	case fork == forks.Prague:
+		return c.PragueTime
+	case fork == forks.Cancun:
+		return c.CancunTime
+	case fork == forks.Shanghai:
+		return c.ShanghaiTime
+	default:
+		panic("unknown timestamp fork requested")
 	}
 }
 

--- a/params/forks/forks.go
+++ b/params/forks/forks.go
@@ -20,7 +20,7 @@ package forks
 type Fork int
 
 const (
-	Frontier = iota
+	Frontier Fork = iota
 	FrontierThawing
 	Homestead
 	DAO
@@ -41,3 +41,35 @@ const (
 	Prague
 	Osaka
 )
+
+// String implements fmt.Stringer.
+func (f Fork) String() string {
+	s, ok := forkToString[f]
+	if !ok {
+		return "Unknown fork"
+	}
+	return s
+}
+
+var forkToString = map[Fork]string{
+	Frontier:         "Frontier",
+	FrontierThawing:  "Frontier Thawing",
+	Homestead:        "Homestead",
+	DAO:              "DAO",
+	TangerineWhistle: "Tangerine Whistle",
+	SpuriousDragon:   "Spurious Dragon",
+	Byzantium:        "Byzantium",
+	Constantinople:   "Constantinople",
+	Petersburg:       "Petersburg",
+	Istanbul:         "Istanbul",
+	MuirGlacier:      "Muir Glacier",
+	Berlin:           "Berlin",
+	London:           "London",
+	ArrowGlacier:     "Arrow Glacier",
+	GrayGlacier:      "Gray Glacier",
+	Paris:            "Paris",
+	Shanghai:         "Shanghai",
+	Cancun:           "Cancun",
+	Prague:           "Prague",
+	Osaka:            "Osaka",
+}


### PR DESCRIPTION
closes #31310 

This has been requested a few times in the past and I think it is a nice quality-of-life improvement for users. At a predetermined interval, there will now be a "Fork ready" log when a future fork is scheduled, but not yet active.

It can only possibly print after block import, which kinda avoids the scenario where the client isn't progressing or is syncing and the user thinks it's "ready" because it sees a ready log.

New output:

```console
INFO [03-08|21:32:57.472] Imported new potential chain segment     number=7 hash=aa24ee..f09e62 blocks=1 txs=0 mgas=0.000 elapsed="874.916µs" mgasps=0.000 snapdiffs=973.00B triediffs=7.05KiB triedirty=0.00B
INFO [03-08|21:32:57.473] Ready for fork activation                fork=Prague date="18 Mar 25 19:29 CET" remaining=237h57m0s timestamp=1,742,322,597
INFO [03-08|21:32:57.475] Chain head was updated                   number=7 hash=aa24ee..f09e62 root=19b0de..8d32f2 elapsed="129.125µs"
```

Easiest way to verify this behavior is to apply this patch and run `geth --dev --dev.period=12`

```patch
diff --git a/params/config.go b/params/config.go
index 9c7719d901..030c4f80e7 100644
--- a/params/config.go
+++ b/params/config.go
@@ -174,7 +174,7 @@ var (
                ShanghaiTime:            newUint64(0),
                CancunTime:              newUint64(0),
                TerminalTotalDifficulty: big.NewInt(0),
-               PragueTime:              newUint64(0),
+               PragueTime:              newUint64(uint64(time.Now().Add(time.Hour * 300).Unix())),
                BlobScheduleConfig: &BlobScheduleConfig{
                        Cancun: DefaultCancunBlobConfig,
                        Prague: DefaultPragueBlobConfig,
```