### PR TITLE
cmd/geth:Implement freezer truncation as a subcommand(fixes #31135)

### DIFF
--- a/cmd/geth/dbcmd.go
+++ b/cmd/geth/dbcmd.go
@@ -1314,7 +1314,6 @@ func extractHeaders(ancientDb ethdb.AncientReader, headersFreezer *rawdb.Freezer
 	// Create a progress reporter
 	log.Info("Starting to copy headers to temporary freezer", "count", mergeBlock)
 
-
 	for i := uint64(0); i < mergeBlock; i += batchSize {
 		end := i + batchSize
 		if end > mergeBlock {
@@ -1372,7 +1371,6 @@ func reinsertHeaders(freezerDb ethdb.AncientStore, headersFreezer *rawdb.Freezer
 
 		_, err := freezerDb.ModifyAncients(func(op ethdb.AncientWriteOp) error {
 			for j := i; j < end; j++ {
-	log.Info("Completed copying headers back to main freezer", "count", mergeBlock)
 				// Read from temporary freezer
 				headerBytes, err := headersFreezer.Ancient(rawdb.ChainFreezerHeaderTable, j)
 				if err != nil {
@@ -1400,6 +1398,7 @@ func reinsertHeaders(freezerDb ethdb.AncientStore, headersFreezer *rawdb.Freezer
 		// Update progress
 	}
 
+	log.Info("Completed copying headers back to main freezer", "count", mergeBlock)
 	return nil
 }
 

--- a/cmd/geth/dbcmd.go
+++ b/cmd/geth/dbcmd.go
@@ -1447,7 +1447,7 @@ func findMergeBlock(ctx *cli.Context, db ethdb.Database) (uint64, error) {
 		}))
 
 		// Check if we found a valid merge block
-		if mergeBlock < uint64(*headNumber) {
+		if mergeBlock < *headNumber {
 			header := rawdb.ReadHeader(db, rawdb.ReadCanonicalHash(db, mergeBlock), mergeBlock)
 			if header != nil && header.Difficulty.Sign() == 0 {
 				found = true

--- a/cmd/geth/dbcmd_test.go
+++ b/cmd/geth/dbcmd_test.go
@@ -33,10 +33,7 @@ import (
 // in the truncate-freezer command.
 func TestTruncateFreezerBatching(t *testing.T) {
 	// Create a temporary directory for the test
-	datadir, err := os.MkdirTemp("", "geth-test-freezer-truncation-*")
-	if err != nil {
-		t.Fatalf("Failed to create temporary directory: %v", err)
-	}
+	datadir := t.TempDir()
 	defer os.RemoveAll(datadir)
 
 	// Create a freezer database
@@ -100,11 +97,7 @@ func TestTruncateFreezerBatching(t *testing.T) {
 	rawdb.WriteHeadBlockHash(db, parentHash)
 
 	// Create a temporary directory for the headers freezer
-	tmpDir, err := os.MkdirTemp("", "geth-headers-freezer-*")
-	if err != nil {
-		t.Fatalf("Failed to create temporary directory: %v", err)
-	}
-	defer os.RemoveAll(tmpDir)
+	tmpDir := t.TempDir()
 
 	// Create a new freezer for headers and hashes
 	headersFreezer, err := rawdb.NewFreezer(tmpDir, "headers", false, 2*1000*1000*1000, map[string]bool{

--- a/cmd/geth/dbcmd_test.go
+++ b/cmd/geth/dbcmd_test.go
@@ -1,0 +1,222 @@
+// Copyright 2023 The go-ethereum Authors
+// This file is part of go-ethereum.
+//
+// go-ethereum is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// go-ethereum is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with go-ethereum. If not, see <http://www.gnu.org/licenses/>.
+
+package main
+
+import (
+	"math/big"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/rawdb"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/ethdb"
+	"github.com/ethereum/go-ethereum/params"
+)
+
+// TestTruncateFreezerBatching tests the batch processing approach for headers
+// in the truncate-freezer command.
+func TestTruncateFreezerBatching(t *testing.T) {
+	// Create a temporary directory for the test
+	datadir, err := os.MkdirTemp("", "geth-test-freezer-truncation-*")
+	if err != nil {
+		t.Fatalf("Failed to create temporary directory: %v", err)
+	}
+	defer os.RemoveAll(datadir)
+
+	// Create a freezer database
+	freezerDir := filepath.Join(datadir, "freezer")
+	db, err := rawdb.NewDatabaseWithFreezer(rawdb.NewMemoryDatabase(), freezerDir, "", false)
+	if err != nil {
+		t.Fatalf("Failed to create freezer database: %v", err)
+	}
+	defer db.Close()
+
+	// Create test data: 100 pre-merge blocks and 10 post-merge blocks
+	// The merge block will be at index 100
+	const (
+		preMergeBlocks  = 100
+		postMergeBlocks = 10
+		mergeBlock      = preMergeBlocks
+		totalBlocks     = preMergeBlocks + postMergeBlocks
+	)
+
+	// Generate and insert blocks
+	var (
+		parentHash = common.Hash{}
+		genesis    = types.Header{
+			Number:     big.NewInt(0),
+			Difficulty: big.NewInt(params.GenesisDifficulty.Int64()),
+			ParentHash: parentHash,
+		}
+	)
+
+	// Insert genesis header
+	rawdb.WriteHeader(db, &genesis)
+	parentHash = genesis.Hash()
+
+	// Insert pre-merge blocks with non-zero difficulty
+	for i := 1; i <= preMergeBlocks; i++ {
+		header := types.Header{
+			Number:     big.NewInt(int64(i)),
+			Difficulty: big.NewInt(params.GenesisDifficulty.Int64()),
+			ParentHash: parentHash,
+		}
+		hash := header.Hash()
+		rawdb.WriteHeader(db, &header)
+		rawdb.WriteCanonicalHash(db, hash, uint64(i))
+		parentHash = hash
+	}
+
+	// Insert post-merge blocks with zero difficulty
+	for i := preMergeBlocks + 1; i <= totalBlocks; i++ {
+		header := types.Header{
+			Number:     big.NewInt(int64(i)),
+			Difficulty: big.NewInt(0), // Zero difficulty = post-merge
+			ParentHash: parentHash,
+		}
+		hash := header.Hash()
+		rawdb.WriteHeader(db, &header)
+		rawdb.WriteCanonicalHash(db, hash, uint64(i))
+		parentHash = hash
+	}
+
+	// Set the head block
+	rawdb.WriteHeadBlockHash(db, parentHash)
+
+	// Create a temporary directory for the headers freezer
+	tmpDir, err := os.MkdirTemp("", "geth-headers-freezer-*")
+	if err != nil {
+		t.Fatalf("Failed to create temporary directory: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	// Create a new freezer for headers and hashes
+	headersFreezer, err := rawdb.NewFreezer(tmpDir, "headers", false, 2*1000*1000*1000, map[string]bool{
+		rawdb.ChainFreezerHeaderTable: false,
+		rawdb.ChainFreezerHashTable:   false,
+	})
+	if err != nil {
+		t.Fatalf("Failed to create headers freezer: %v", err)
+	}
+	defer headersFreezer.Close()
+
+	// Get the ancient reader
+	ancientDb, ok := db.(ethdb.AncientReader)
+	if !ok {
+		t.Fatal("Database doesn't support ancient storage")
+	}
+
+	// Get the number of items in the freezer
+	ancients, err := ancientDb.Ancients()
+	if err != nil {
+		t.Fatalf("Failed to get ancients count: %v", err)
+	}
+	t.Logf("Number of items in freezer: %d", ancients)
+
+	// Test batch processing by copying headers to the temporary freezer
+	const batchSize = 10 // Small batch size for testing
+	for i := uint64(0); i < mergeBlock; i += batchSize {
+		end := i + batchSize
+		if end > mergeBlock {
+			end = mergeBlock
+		}
+
+		// Process this batch
+		_, err = headersFreezer.ModifyAncients(func(op ethdb.AncientWriteOp) error {
+			for j := i; j < end; j++ {
+				// Skip if j is out of range
+				if j >= ancients {
+					continue
+				}
+
+				// Read header and hash
+				headerBytes, err := ancientDb.Ancient(rawdb.ChainFreezerHeaderTable, j)
+				if err != nil {
+					return err
+				}
+				hashBytes, err := ancientDb.Ancient(rawdb.ChainFreezerHashTable, j)
+				if err != nil {
+					return err
+				}
+
+				// Write to temporary freezer
+				if err := op.AppendRaw(rawdb.ChainFreezerHeaderTable, j, headerBytes); err != nil {
+					return err
+				}
+				if err := op.AppendRaw(rawdb.ChainFreezerHashTable, j, hashBytes); err != nil {
+					return err
+				}
+			}
+			return nil
+		})
+		if err != nil {
+			t.Fatalf("Failed to copy headers batch: %v", err)
+		}
+	}
+
+	// Verify that the headers were copied correctly
+	headersFreezerAncients, err := headersFreezer.Ancients()
+	if err != nil {
+		t.Fatalf("Failed to get ancients count from headers freezer: %v", err)
+	}
+
+	// The number of items in the headers freezer should be equal to the merge block
+	// or the number of items in the original freezer, whichever is smaller
+	expectedCount := mergeBlock
+	if ancients < mergeBlock {
+		expectedCount = ancients
+	}
+
+	if headersFreezerAncients != expectedCount {
+		t.Fatalf("Expected %d items in headers freezer, got %d", expectedCount, headersFreezerAncients)
+	}
+
+	// Verify that the headers in the temporary freezer match the originals
+	for i := uint64(0); i < expectedCount; i++ {
+		// Read from original freezer
+		originalHeader, err := ancientDb.Ancient(rawdb.ChainFreezerHeaderTable, i)
+		if err != nil {
+			t.Fatalf("Failed to read header %d from original freezer: %v", i, err)
+		}
+		originalHash, err := ancientDb.Ancient(rawdb.ChainFreezerHashTable, i)
+		if err != nil {
+			t.Fatalf("Failed to read hash %d from original freezer: %v", i, err)
+		}
+
+		// Read from temporary freezer
+		tempHeader, err := headersFreezer.Ancient(rawdb.ChainFreezerHeaderTable, i)
+		if err != nil {
+			t.Fatalf("Failed to read header %d from temporary freezer: %v", i, err)
+		}
+		tempHash, err := headersFreezer.Ancient(rawdb.ChainFreezerHashTable, i)
+		if err != nil {
+			t.Fatalf("Failed to read hash %d from temporary freezer: %v", i, err)
+		}
+
+		// Compare
+		if string(originalHeader) != string(tempHeader) {
+			t.Fatalf("Header %d mismatch", i)
+		}
+		if string(originalHash) != string(tempHash) {
+			t.Fatalf("Hash %d mismatch", i)
+		}
+	}
+
+	t.Log("Batch processing test passed successfully")
+}

--- a/cmd/geth/dbcmd_test.go
+++ b/cmd/geth/dbcmd_test.go
@@ -180,15 +180,15 @@ func TestTruncateFreezerBatching(t *testing.T) {
 	// or the number of items in the original freezer, whichever is smaller
 	expectedCount := mergeBlock
 	if ancients < mergeBlock {
-		expectedCount = ancients
+		expectedCount = int(ancients)
 	}
 
-	if headersFreezerAncients != expectedCount {
+	if int(headersFreezerAncients) != expectedCount {
 		t.Fatalf("Expected %d items in headers freezer, got %d", expectedCount, headersFreezerAncients)
 	}
 
 	// Verify that the headers in the temporary freezer match the originals
-	for i := uint64(0); i < expectedCount; i++ {
+	for i := uint64(0); i < uint64(expectedCount); i++ {
 		// Read from original freezer
 		originalHeader, err := ancientDb.Ancient(rawdb.ChainFreezerHeaderTable, i)
 		if err != nil {

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/ethereum/go-ethereum
 
-go 1.23.0
+go 1.23
 
 require (
 	github.com/Azure/azure-sdk-for-go/sdk/storage/azblob v1.2.0

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/ethereum/go-ethereum
 
-go 1.23
+go 1.23.0
 
 require (
 	github.com/Azure/azure-sdk-for-go/sdk/storage/azblob v1.2.0


### PR DESCRIPTION
Hii, I have implemented a new subcommand `geth db truncate-freezer` that truncates the freezer at the merge block, keeping headers but removing bodies. This addresses issue #31135.

## These are the Implementation Details

- Added a new subcommand `truncate-freezer` to the `db` command
- Consolidated flags into reusable variables
- Implemented the truncation logic that:
  - Finds the merge block using binary search
  - Preserves headers and hashes before truncation
  - Truncates all tables
  - Re-inserts the preserved headers and hashes

This implementation follows the same pattern as the existing `prune-history` command and uses the same underlying `truncateAncientStore` method.

Fixes #31135