### PR TITLE
ethdb: no need to check the metric nilness

### DIFF
--- a/ethdb/leveldb/leveldb.go
+++ b/ethdb/leveldb/leveldb.go
@@ -368,29 +368,17 @@ func (db *Database) meter(refresh time.Duration, namespace string) {
 		compactions[i%2][2] = stats.LevelRead.Sum()
 		compactions[i%2][3] = stats.LevelWrite.Sum()
 		// Update all the requested meters
-		if db.diskSizeGauge != nil {
-			db.diskSizeGauge.Update(compactions[i%2][0])
-		}
-		if db.compTimeMeter != nil {
-			db.compTimeMeter.Mark(compactions[i%2][1] - compactions[(i-1)%2][1])
-		}
-		if db.compReadMeter != nil {
-			db.compReadMeter.Mark(compactions[i%2][2] - compactions[(i-1)%2][2])
-		}
-		if db.compWriteMeter != nil {
-			db.compWriteMeter.Mark(compactions[i%2][3] - compactions[(i-1)%2][3])
-		}
+		db.diskSizeGauge.Update(compactions[i%2][0])
+		db.compTimeMeter.Mark(compactions[i%2][1] - compactions[(i-1)%2][1])
+		db.compReadMeter.Mark(compactions[i%2][2] - compactions[(i-1)%2][2])
+		db.compWriteMeter.Mark(compactions[i%2][3] - compactions[(i-1)%2][3])
 		var (
 			delayN   = int64(stats.WriteDelayCount)
 			duration = stats.WriteDelayDuration
 			paused   = stats.WritePaused
 		)
-		if db.writeDelayNMeter != nil {
-			db.writeDelayNMeter.Mark(delayN - delaystats[0])
-		}
-		if db.writeDelayMeter != nil {
-			db.writeDelayMeter.Mark(duration.Nanoseconds() - delaystats[1])
-		}
+		db.writeDelayNMeter.Mark(delayN - delaystats[0])
+		db.writeDelayMeter.Mark(duration.Nanoseconds() - delaystats[1])
 		// If a warning that db is performing compaction has been displayed, any subsequent
 		// warnings will be withheld for one minute not to overwhelm the user.
 		if paused && delayN-delaystats[0] == 0 && duration.Nanoseconds()-delaystats[1] == 0 &&
@@ -404,12 +392,8 @@ func (db *Database) meter(refresh time.Duration, namespace string) {
 			nRead  = int64(stats.IORead)
 			nWrite = int64(stats.IOWrite)
 		)
-		if db.diskReadMeter != nil {
-			db.diskReadMeter.Mark(nRead - iostats[0])
-		}
-		if db.diskWriteMeter != nil {
-			db.diskWriteMeter.Mark(nWrite - iostats[1])
-		}
+		db.diskReadMeter.Mark(nRead - iostats[0])
+		db.diskWriteMeter.Mark(nWrite - iostats[1])
 		iostats[0], iostats[1] = nRead, nWrite
 
 		db.memCompGauge.Update(int64(stats.MemComp))


### PR DESCRIPTION
The metric always has a value, no need to check for the nil. 

Seems this code was first introduced here https://github.com/ethereum/go-ethereum/blob/054412e33528e53f6deae940c870217b614707b9/metrics/meter.go#L45-L48

As the `nilMeter` was removed, so this check seems is useless.