### PR TITLE
cmd/era: add full-tx flag for transaction detail control

### DIFF
--- a/cmd/era/main.go
+++ b/cmd/era/main.go
@@ -57,7 +57,11 @@ var (
 	}
 	txsFlag = &cli.BoolFlag{
 		Name:  "txs",
-		Usage: "print full transaction values",
+		Usage: "include transaction data in output",
+	}
+	fullTxFlag = &cli.BoolFlag{
+		Name:  "full-tx",
+		Usage: "show full transaction details (requires --txs)",
 	}
 )
 
@@ -69,6 +73,7 @@ var (
 		Action:    block,
 		Flags: []cli.Flag{
 			txsFlag,
+			fullTxFlag,
 		},
 	}
 	infoCommand = &cli.Command{
@@ -122,7 +127,7 @@ func block(ctx *cli.Context) error {
 		return fmt.Errorf("error reading block %d: %w", num, err)
 	}
 	// Convert block to JSON and print.
-	val := ethapi.RPCMarshalBlock(block, ctx.Bool(txsFlag.Name), ctx.Bool(txsFlag.Name), params.MainnetChainConfig)
+	val := ethapi.RPCMarshalBlock(block, ctx.Bool(txsFlag.Name), ctx.Bool(fullTxFlag.Name), params.MainnetChainConfig)
 	b, err := json.MarshalIndent(val, "", "  ")
 	if err != nil {
 		return fmt.Errorf("error marshaling json: %w", err)


### PR DESCRIPTION
For https://github.com/ethereum/go-ethereum/issues/31358

Fix incorrect dual usage of --txs flag by introducing --full-tx flag to control transaction detail level. Now:
- --txs controls transaction inclusion (includeTxs)
- --full-tx controls full transaction formatting (fullTx)

This enables proper granularity matching RPCMarshalBlock's parameters:
1. Default: transaction hashes only
2. --txs: basic transaction data
3. --txs --full-tx: full transaction details

