### PR TITLE
cmd/geth: fix ctrl-c interrupt in import command

### DIFF
--- a/cmd/geth/chaincmd.go
+++ b/cmd/geth/chaincmd.go
@@ -103,11 +103,15 @@ if one is set.  Otherwise it prints the genesis from the datadir.`,
 			utils.StateHistoryFlag,
 		}, utils.DatabaseFlags),
 		Description: `
-The import command imports blocks from an RLP-encoded form. The form can be one file
-with several RLP-encoded blocks, or several files can be used.
+The import command allows the import of blocks from an RLP-encoded format. This format can be a single file
+containing multiple RLP-encoded blocks, or multiple files can be utilized.
 
-If only one file is used, import error will result in failure. If several files are used,
-processing will proceed even if an individual RLP-file import failure occurs.`,
+If only one file is used, an import error will result in the entire import process failing. Conversely, if
+multiple files are employed, the import process will continue even if an individual RLP file fails to import
+successfully.
+
+The import command will batch-import 2500 blocks into the database at a time. The import process can be
+interrupted using Ctrl-C, and it will halt at the end of the current batch.`,
 	}
 	exportCommand = &cli.Command{
 		Action:    exportChain,

--- a/cmd/geth/chaincmd.go
+++ b/cmd/geth/chaincmd.go
@@ -104,14 +104,11 @@ if one is set.  Otherwise it prints the genesis from the datadir.`,
 		}, utils.DatabaseFlags),
 		Description: `
 The import command allows the import of blocks from an RLP-encoded format. This format can be a single file
-containing multiple RLP-encoded blocks, or multiple files can be utilized.
+containing multiple RLP-encoded blocks, or multiple files can be given.
 
-If only one file is used, an import error will result in the entire import process failing. Conversely, if
-multiple files are employed, the import process will continue even if an individual RLP file fails to import
-successfully.
-
-The import command will batch-import 2500 blocks into the database at a time. The import process can be
-interrupted using Ctrl-C, and it will halt at the end of the current batch.`,
+If only one file is used, an import error will result in the entire import process failing. If
+multiple files are processed, the import process will continue even if an individual RLP file fails
+to import successfully.`,
 	}
 	exportCommand = &cli.Command{
 		Action:    exportChain,

--- a/cmd/geth/chaincmd.go
+++ b/cmd/geth/chaincmd.go
@@ -319,6 +319,9 @@ func importChain(ctx *cli.Context) error {
 			if err := utils.ImportChain(chain, arg); err != nil {
 				importErr = err
 				log.Error("Import error", "file", arg, "err", err)
+				if err == utils.ErrImportInterrupted {
+					break
+				}
 			}
 		}
 	}

--- a/cmd/utils/cmd.go
+++ b/cmd/utils/cmd.go
@@ -55,6 +55,9 @@ const (
 	importBatchSize = 2500
 )
 
+// ErrImportInterrupted is returned when the user interrupts the import process.
+var ErrImportInterrupted = errors.New("interrupted")
+
 // Fatalf formats a message to standard error and exits the program.
 // The message is also printed to standard output if standard error
 // is redirected to a different file.
@@ -191,7 +194,7 @@ func ImportChain(chain *core.BlockChain, fn string) error {
 	for batch := 0; ; batch++ {
 		// Load a batch of RLP blocks.
 		if checkInterrupt() {
-			return errors.New("interrupted")
+			return ErrImportInterrupted
 		}
 		i := 0
 		for ; i < importBatchSize; i++ {


### PR DESCRIPTION
When I press Ctrl-C during the import of multiple files, the import process will still attempt to import the subsequent files. However, in normal circumstances, users would expect the import to stop immediately upon pressing Ctrl-C.

And because the current file was not finished importing, subsequent import tasks often fail due to an `unknown ancestor` error.