### PR TITLE
eth, eth/filters: implement API error code for pruned blocks

### DIFF
--- a/core/blockchain_reader.go
+++ b/core/blockchain_reader.go
@@ -86,6 +86,11 @@ func (bc *BlockChain) GetHeaderByNumber(number uint64) *types.Header {
 	return bc.hc.GetHeaderByNumber(number)
 }
 
+// GetBlockNumber retrieves the block number associated with a block hash.
+func (bc *BlockChain) GetBlockNumber(hash common.Hash) *uint64 {
+	return bc.hc.GetBlockNumber(hash)
+}
+
 // GetHeadersFrom returns a contiguous segment of headers, in rlp-form, going
 // backwards from the given number.
 func (bc *BlockChain) GetHeadersFrom(number, count uint64) []rlp.RawValue {
@@ -436,4 +441,11 @@ func (bc *BlockChain) SubscribeLogsEvent(ch chan<- []*types.Log) event.Subscript
 // block processing has started while false means it has stopped.
 func (bc *BlockChain) SubscribeBlockProcessingEvent(ch chan<- bool) event.Subscription {
 	return bc.scope.Track(bc.blockProcFeed.Subscribe(ch))
+}
+
+// HistoryCutoff returns the tail of the block history.
+func (bc *BlockChain) HistoryCutoff() uint64 {
+	// Only nofreezedb returns an error.
+	tail, _ := bc.db.Tail()
+	return tail
 }

--- a/core/blockchain_reader.go
+++ b/core/blockchain_reader.go
@@ -442,10 +442,3 @@ func (bc *BlockChain) SubscribeLogsEvent(ch chan<- []*types.Log) event.Subscript
 func (bc *BlockChain) SubscribeBlockProcessingEvent(ch chan<- bool) event.Subscription {
 	return bc.scope.Track(bc.blockProcFeed.Subscribe(ch))
 }
-
-// HistoryCutoff returns the tail of the block history.
-func (bc *BlockChain) HistoryCutoff() uint64 {
-	// Only nofreezedb returns an error.
-	tail, _ := bc.db.Tail()
-	return tail
-}

--- a/core/rawdb/accessors_metadata.go
+++ b/core/rawdb/accessors_metadata.go
@@ -187,3 +187,5 @@ func WriteTransitionStatus(db ethdb.KeyValueWriter, data []byte) {
 		log.Crit("Failed to store the eth2 transition status", "err", err)
 	}
 }
+
+// ReadHistoryTail retrieves the first

--- a/core/rawdb/accessors_metadata.go
+++ b/core/rawdb/accessors_metadata.go
@@ -187,5 +187,3 @@ func WriteTransitionStatus(db ethdb.KeyValueWriter, data []byte) {
 		log.Crit("Failed to store the eth2 transition status", "err", err)
 	}
 }
-
-// ReadHistoryTail retrieves the first

--- a/eth/api_backend.go
+++ b/eth/api_backend.go
@@ -93,7 +93,7 @@ func (b *EthAPIBackend) HeaderByNumber(ctx context.Context, number rpc.BlockNumb
 	}
 	var bn uint64
 	if number == rpc.EarliestBlockNumber {
-		bn = b.eth.blockchain.HistoryCutoff()
+		bn = b.eth.blockchain.HistoryPruningCutoff()
 	} else {
 		bn = uint64(number)
 	}
@@ -151,9 +151,9 @@ func (b *EthAPIBackend) BlockByNumber(ctx context.Context, number rpc.BlockNumbe
 	}
 	bn := uint64(number)
 	if number == rpc.EarliestBlockNumber {
-		bn = b.eth.blockchain.HistoryCutoff()
+		bn = b.eth.blockchain.HistoryPruningCutoff()
 	}
-	if bn < b.eth.blockchain.HistoryCutoff() {
+	if bn < b.eth.blockchain.HistoryPruningCutoff() {
 		return nil, &prunedHistoryError{}
 	}
 	return b.eth.blockchain.GetBlockByNumber(bn), nil
@@ -164,7 +164,7 @@ func (b *EthAPIBackend) BlockByHash(ctx context.Context, hash common.Hash) (*typ
 	if number == nil {
 		return nil, nil
 	}
-	if *number < b.eth.blockchain.HistoryCutoff() {
+	if *number < b.eth.blockchain.HistoryPruningCutoff() {
 		return nil, &prunedHistoryError{}
 	}
 	return b.eth.blockchain.GetBlock(hash, *number), nil
@@ -193,7 +193,7 @@ func (b *EthAPIBackend) BlockByNumberOrHash(ctx context.Context, blockNrOrHash r
 		if blockNrOrHash.RequireCanonical && b.eth.blockchain.GetCanonicalHash(header.Number.Uint64()) != hash {
 			return nil, errors.New("hash is not currently canonical")
 		}
-		if header.Number.Uint64() < b.eth.blockchain.HistoryCutoff() {
+		if header.Number.Uint64() < b.eth.blockchain.HistoryPruningCutoff() {
 			return nil, &prunedHistoryError{}
 		}
 		block := b.eth.blockchain.GetBlock(hash, header.Number.Uint64())
@@ -257,8 +257,8 @@ func (b *EthAPIBackend) StateAndHeaderByNumberOrHash(ctx context.Context, blockN
 	return nil, nil, errors.New("invalid arguments; neither block nor hash specified")
 }
 
-func (b *EthAPIBackend) HistoryCutoff() uint64 {
-	return b.eth.blockchain.HistoryCutoff()
+func (b *EthAPIBackend) HistoryPruningCutoff() uint64 {
+	return b.eth.blockchain.HistoryPruningCutoff()
 }
 
 func (b *EthAPIBackend) GetReceipts(ctx context.Context, hash common.Hash) (types.Receipts, error) {

--- a/eth/api_backend.go
+++ b/eth/api_backend.go
@@ -260,9 +260,6 @@ func (b *EthAPIBackend) GetReceipts(ctx context.Context, hash common.Hash) (type
 }
 
 func (b *EthAPIBackend) GetLogs(ctx context.Context, hash common.Hash, number uint64) ([][]*types.Log, error) {
-	if number < b.eth.blockchain.HistoryCutoff() {
-		return nil, &prunedHistoryError{}
-	}
 	return rawdb.ReadLogs(b.eth.chainDb, hash, number), nil
 }
 

--- a/eth/api_backend.go
+++ b/eth/api_backend.go
@@ -251,11 +251,18 @@ func (b *EthAPIBackend) StateAndHeaderByNumberOrHash(ctx context.Context, blockN
 	return nil, nil, errors.New("invalid arguments; neither block nor hash specified")
 }
 
+func (b *EthAPIBackend) HistoryCutoff() uint64 {
+	return b.eth.blockchain.HistoryCutoff()
+}
+
 func (b *EthAPIBackend) GetReceipts(ctx context.Context, hash common.Hash) (types.Receipts, error) {
 	return b.eth.blockchain.GetReceiptsByHash(hash), nil
 }
 
 func (b *EthAPIBackend) GetLogs(ctx context.Context, hash common.Hash, number uint64) ([][]*types.Log, error) {
+	if number < b.eth.blockchain.HistoryCutoff() {
+		return nil, &prunedHistoryError{}
+	}
 	return rawdb.ReadLogs(b.eth.chainDb, hash, number), nil
 }
 

--- a/eth/api_backend.go
+++ b/eth/api_backend.go
@@ -91,7 +91,13 @@ func (b *EthAPIBackend) HeaderByNumber(ctx context.Context, number rpc.BlockNumb
 		}
 		return block, nil
 	}
-	return b.eth.blockchain.GetHeaderByNumber(uint64(number)), nil
+	var bn uint64
+	if number == rpc.EarliestBlockNumber {
+		bn = b.eth.blockchain.HistoryCutoff()
+	} else {
+		bn = uint64(number)
+	}
+	return b.eth.blockchain.GetHeaderByNumber(bn), nil
 }
 
 func (b *EthAPIBackend) HeaderByNumberOrHash(ctx context.Context, blockNrOrHash rpc.BlockNumberOrHash) (*types.Header, error) {

--- a/eth/api_backend.go
+++ b/eth/api_backend.go
@@ -150,17 +150,15 @@ func (b *EthAPIBackend) BlockByNumber(ctx context.Context, number rpc.BlockNumbe
 		}
 		return b.eth.blockchain.GetBlock(header.Hash(), header.Number.Uint64()), nil
 	}
-	bn := uint64(number)
+	bn := uint64(number) // the resolved number
 	if number == rpc.EarliestBlockNumber {
 		bn = b.eth.blockchain.HistoryPruningCutoff()
 	}
-
-	// bn is the resolved number.
 	block := b.eth.blockchain.GetBlockByNumber(bn)
 	if block == nil && bn < b.eth.blockchain.HistoryPruningCutoff() {
 		return nil, &ethconfig.PrunedHistoryError{}
 	}
-	return nil, nil
+	return block, nil
 }
 
 func (b *EthAPIBackend) BlockByHash(ctx context.Context, hash common.Hash) (*types.Block, error) {
@@ -172,7 +170,7 @@ func (b *EthAPIBackend) BlockByHash(ctx context.Context, hash common.Hash) (*typ
 	if block == nil && *number < b.eth.blockchain.HistoryPruningCutoff() {
 		return nil, &ethconfig.PrunedHistoryError{}
 	}
-	return nil, nil
+	return block, nil
 }
 
 // GetBody returns body of a block. It does not resolve special block numbers.

--- a/eth/ethconfig/historymode.go
+++ b/eth/ethconfig/historymode.go
@@ -90,3 +90,9 @@ var HistoryPrunePoints = map[common.Hash]*HistoryPrunePoint{
 		BlockHash:   common.HexToHash("0x229f6b18ca1552f1d5146deceb5387333f40dc6275aebee3f2c5c4ece07d02db"),
 	},
 }
+
+// PrunedHistoryError is returned when the requested history is pruned.
+type PrunedHistoryError struct{}
+
+func (e *PrunedHistoryError) Error() string  { return "pruned history unavailable" }
+func (e *PrunedHistoryError) ErrorCode() int { return 4444 }

--- a/eth/filters/api.go
+++ b/eth/filters/api.go
@@ -358,7 +358,7 @@ func (api *FilterAPI) GetLogs(ctx context.Context, crit FilterCriteria) ([]*type
 		if begin > 0 && end > 0 && begin > end {
 			return nil, errInvalidBlockRange
 		}
-		if begin < int64(api.events.backend.HistoryCutoff()) {
+		if begin < int64(api.events.backend.HistoryPruningCutoff()) {
 			return nil, &prunedHistoryError{}
 		}
 		// Construct the range filter
@@ -406,7 +406,7 @@ func (api *FilterAPI) GetFilterLogs(ctx context.Context, id rpc.ID) ([]*types.Lo
 		if err != nil {
 			return nil, err
 		}
-		if header.Number.Uint64() < api.events.backend.HistoryCutoff() {
+		if header.Number.Uint64() < api.events.backend.HistoryPruningCutoff() {
 			return nil, &prunedHistoryError{}
 		}
 		// Block filter requested, construct a single-shot filter

--- a/eth/filters/api.go
+++ b/eth/filters/api.go
@@ -29,6 +29,7 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/eth"
 	"github.com/ethereum/go-ethereum/internal/ethapi"
 	"github.com/ethereum/go-ethereum/rpc"
 )
@@ -359,7 +360,7 @@ func (api *FilterAPI) GetLogs(ctx context.Context, crit FilterCriteria) ([]*type
 			return nil, errInvalidBlockRange
 		}
 		if begin > 0 && begin < int64(api.events.backend.HistoryPruningCutoff()) {
-			return nil, &prunedHistoryError{}
+			return nil, &eth.ErrorPrunedHistory{}
 		}
 		// Construct the range filter
 		filter = api.sys.NewRangeFilter(begin, end, crit.Addresses, crit.Topics)

--- a/eth/filters/api.go
+++ b/eth/filters/api.go
@@ -400,6 +400,15 @@ func (api *FilterAPI) GetFilterLogs(ctx context.Context, id rpc.ID) ([]*types.Lo
 
 	var filter *Filter
 	if f.crit.BlockHash != nil {
+		// ensure the filter criteria does not specify block hash below the
+		// history prune point
+		header, err := api.sys.backend.HeaderByHash(ctx, *f.crit.BlockHash)
+		if err != nil {
+			return nil, err
+		}
+		if header.Number.Uint64() < api.events.backend.HistoryCutoff() {
+			return nil, &prunedHistoryError{}
+		}
 		// Block filter requested, construct a single-shot filter
 		filter = api.sys.NewBlockFilter(*f.crit.BlockHash, f.crit.Addresses, f.crit.Topics)
 	} else {

--- a/eth/filters/api.go
+++ b/eth/filters/api.go
@@ -29,7 +29,7 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/core/types"
-	"github.com/ethereum/go-ethereum/eth"
+	"github.com/ethereum/go-ethereum/eth/ethconfig"
 	"github.com/ethereum/go-ethereum/internal/ethapi"
 	"github.com/ethereum/go-ethereum/rpc"
 )
@@ -360,7 +360,7 @@ func (api *FilterAPI) GetLogs(ctx context.Context, crit FilterCriteria) ([]*type
 			return nil, errInvalidBlockRange
 		}
 		if begin > 0 && begin < int64(api.events.backend.HistoryPruningCutoff()) {
-			return nil, &eth.ErrorPrunedHistory{}
+			return nil, &ethconfig.PrunedHistoryError{}
 		}
 		// Construct the range filter
 		filter = api.sys.NewRangeFilter(begin, end, crit.Addresses, crit.Topics)

--- a/eth/filters/api.go
+++ b/eth/filters/api.go
@@ -400,15 +400,6 @@ func (api *FilterAPI) GetFilterLogs(ctx context.Context, id rpc.ID) ([]*types.Lo
 
 	var filter *Filter
 	if f.crit.BlockHash != nil {
-		// ensure the filter criteria does not specify block hash below the
-		// history prune point
-		header, err := api.sys.backend.HeaderByHash(ctx, *f.crit.BlockHash)
-		if err != nil {
-			return nil, err
-		}
-		if header.Number.Uint64() < api.events.backend.HistoryPruningCutoff() {
-			return nil, &prunedHistoryError{}
-		}
 		// Block filter requested, construct a single-shot filter
 		filter = api.sys.NewBlockFilter(*f.crit.BlockHash, f.crit.Addresses, f.crit.Topics)
 	} else {

--- a/eth/filters/filter.go
+++ b/eth/filters/filter.go
@@ -86,6 +86,9 @@ func (f *Filter) Logs(ctx context.Context) ([]*types.Log, error) {
 		if header == nil {
 			return nil, errors.New("unknown block")
 		}
+		if header.Number.Uint64() < f.sys.backend.HistoryPruningCutoff() {
+			return nil, &prunedHistoryError{}
+		}
 		return f.blockLogs(ctx, header)
 	}
 
@@ -114,11 +117,19 @@ func (f *Filter) Logs(ctx context.Context) ([]*types.Log, error) {
 				return 0, errors.New("safe header not found")
 			}
 			return hdr.Number.Uint64(), nil
+		case rpc.EarliestBlockNumber.Int64():
+			earliest := f.sys.backend.HistoryPruningCutoff()
+			hdr, _ := f.sys.backend.HeaderByNumber(ctx, rpc.BlockNumber(earliest))
+			if hdr == nil {
+				return 0, errors.New("earliest header not found")
+			}
+			return hdr.Number.Uint64(), nil
+		default:
+			if number < 0 {
+				return 0, errors.New("negative block number")
+			}
+			return uint64(number), nil
 		}
-		if number < 0 {
-			return 0, errors.New("negative block number")
-		}
-		return uint64(number), nil
 	}
 
 	// range query need to resolve the special begin/end block number

--- a/eth/filters/filter.go
+++ b/eth/filters/filter.go
@@ -27,7 +27,7 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/filtermaps"
 	"github.com/ethereum/go-ethereum/core/types"
-	"github.com/ethereum/go-ethereum/eth"
+	"github.com/ethereum/go-ethereum/eth/ethconfig"
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/rpc"
 )
@@ -88,7 +88,7 @@ func (f *Filter) Logs(ctx context.Context) ([]*types.Log, error) {
 			return nil, errors.New("unknown block")
 		}
 		if header.Number.Uint64() < f.sys.backend.HistoryPruningCutoff() {
-			return nil, &eth.ErrorPrunedHistory{}
+			return nil, &ethconfig.PrunedHistoryError{}
 		}
 		return f.blockLogs(ctx, header)
 	}

--- a/eth/filters/filter.go
+++ b/eth/filters/filter.go
@@ -27,6 +27,7 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/filtermaps"
 	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/eth"
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/rpc"
 )
@@ -87,7 +88,7 @@ func (f *Filter) Logs(ctx context.Context) ([]*types.Log, error) {
 			return nil, errors.New("unknown block")
 		}
 		if header.Number.Uint64() < f.sys.backend.HistoryPruningCutoff() {
-			return nil, &prunedHistoryError{}
+			return nil, &eth.ErrorPrunedHistory{}
 		}
 		return f.blockLogs(ctx, header)
 	}

--- a/eth/filters/filter_system.go
+++ b/eth/filters/filter_system.go
@@ -31,7 +31,7 @@ import (
 	"github.com/ethereum/go-ethereum/core"
 	"github.com/ethereum/go-ethereum/core/filtermaps"
 	"github.com/ethereum/go-ethereum/core/types"
-	"github.com/ethereum/go-ethereum/eth"
+	"github.com/ethereum/go-ethereum/eth/ethconfig"
 	"github.com/ethereum/go-ethereum/ethdb"
 	"github.com/ethereum/go-ethereum/event"
 	"github.com/ethereum/go-ethereum/log"
@@ -311,7 +311,7 @@ func (es *EventSystem) SubscribeLogs(crit ethereum.FilterQuery, logs chan []*typ
 	}
 	// Queries beyond the pruning cutoff are not supported.
 	if uint64(from) < es.backend.HistoryPruningCutoff() {
-		return nil, &eth.ErrorPrunedHistory{}
+		return nil, &ethconfig.PrunedHistoryError{}
 	}
 
 	// only interested in new mined logs

--- a/eth/filters/filter_system.go
+++ b/eth/filters/filter_system.go
@@ -64,7 +64,7 @@ type Backend interface {
 
 	CurrentHeader() *types.Header
 	ChainConfig() *params.ChainConfig
-	HistoryCutoff() uint64
+	HistoryPruningCutoff() uint64
 	SubscribeNewTxsEvent(chan<- core.NewTxsEvent) event.Subscription
 	SubscribeChainEvent(ch chan<- core.ChainEvent) event.Subscription
 	SubscribeRemovedLogsEvent(ch chan<- core.RemovedLogsEvent) event.Subscription

--- a/eth/filters/filter_system.go
+++ b/eth/filters/filter_system.go
@@ -64,6 +64,7 @@ type Backend interface {
 
 	CurrentHeader() *types.Header
 	ChainConfig() *params.ChainConfig
+	HistoryCutoff() uint64
 	SubscribeNewTxsEvent(chan<- core.NewTxsEvent) event.Subscription
 	SubscribeChainEvent(ch chan<- core.ChainEvent) event.Subscription
 	SubscribeRemovedLogsEvent(ch chan<- core.RemovedLogsEvent) event.Subscription
@@ -138,6 +139,11 @@ func (sys *FilterSystem) cachedGetBody(ctx context.Context, elem *logCacheElem, 
 	elem.body.Store(body)
 	return body, nil
 }
+
+type prunedHistoryError struct{}
+
+func (e *prunedHistoryError) Error() string  { return "Pruned history unavailable" }
+func (e *prunedHistoryError) ErrorCode() int { return 4444 }
 
 // Type determines the kind of filter and is used to put the filter in to
 // the correct bucket when added.

--- a/eth/filters/filter_system.go
+++ b/eth/filters/filter_system.go
@@ -31,6 +31,7 @@ import (
 	"github.com/ethereum/go-ethereum/core"
 	"github.com/ethereum/go-ethereum/core/filtermaps"
 	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/eth"
 	"github.com/ethereum/go-ethereum/ethdb"
 	"github.com/ethereum/go-ethereum/event"
 	"github.com/ethereum/go-ethereum/log"
@@ -139,11 +140,6 @@ func (sys *FilterSystem) cachedGetBody(ctx context.Context, elem *logCacheElem, 
 	elem.body.Store(body)
 	return body, nil
 }
-
-type prunedHistoryError struct{}
-
-func (e *prunedHistoryError) Error() string  { return "Pruned history unavailable" }
-func (e *prunedHistoryError) ErrorCode() int { return 4444 }
 
 // Type determines the kind of filter and is used to put the filter in to
 // the correct bucket when added.
@@ -315,7 +311,7 @@ func (es *EventSystem) SubscribeLogs(crit ethereum.FilterQuery, logs chan []*typ
 	}
 	// Queries beyond the pruning cutoff are not supported.
 	if uint64(from) < es.backend.HistoryPruningCutoff() {
-		return nil, &prunedHistoryError{}
+		return nil, &eth.ErrorPrunedHistory{}
 	}
 
 	// only interested in new mined logs

--- a/eth/filters/filter_system.go
+++ b/eth/filters/filter_system.go
@@ -310,6 +310,14 @@ func (es *EventSystem) SubscribeLogs(crit ethereum.FilterQuery, logs chan []*typ
 		return nil, errPendingLogsUnsupported
 	}
 
+	if from == rpc.EarliestBlockNumber {
+		from = rpc.BlockNumber(es.backend.HistoryPruningCutoff())
+	}
+	// Queries beyond the pruning cutoff are not supported.
+	if uint64(from) < es.backend.HistoryPruningCutoff() {
+		return nil, &prunedHistoryError{}
+	}
+
 	// only interested in new mined logs
 	if from == rpc.LatestBlockNumber && to == rpc.LatestBlockNumber {
 		return es.subscribeLogs(crit, logs), nil

--- a/eth/filters/filter_system_test.go
+++ b/eth/filters/filter_system_test.go
@@ -181,15 +181,11 @@ func (b *testBackend) setPending(block *types.Block, receipts types.Receipts) {
 	b.pendingReceipts = receipts
 }
 
-<<<<<<< HEAD
-func newTestFilterSystem(db ethdb.Database, cfg Config) (*testBackend, *FilterSystem) {
-=======
-func (b *testBackend) HistoryCutoff() uint64 {
+func (b *testBackend) HistoryPruningCutoff() uint64 {
 	return 0
 }
 
-func newTestFilterSystem(t testing.TB, db ethdb.Database, cfg Config) (*testBackend, *FilterSystem) {
->>>>>>> 7139f930b0 (return prunedHistoryError from GetLogs/FilterLogs if accessing pruned state.  duplicate prunedHistoryError into eth/filters package.  add HistoryCutoff method to eth backend)
+func newTestFilterSystem(db ethdb.Database, cfg Config) (*testBackend, *FilterSystem) {
 	backend := &testBackend{db: db}
 	sys := NewFilterSystem(backend, cfg)
 	return backend, sys

--- a/eth/filters/filter_system_test.go
+++ b/eth/filters/filter_system_test.go
@@ -181,7 +181,15 @@ func (b *testBackend) setPending(block *types.Block, receipts types.Receipts) {
 	b.pendingReceipts = receipts
 }
 
+<<<<<<< HEAD
 func newTestFilterSystem(db ethdb.Database, cfg Config) (*testBackend, *FilterSystem) {
+=======
+func (b *testBackend) HistoryCutoff() uint64 {
+	return 0
+}
+
+func newTestFilterSystem(t testing.TB, db ethdb.Database, cfg Config) (*testBackend, *FilterSystem) {
+>>>>>>> 7139f930b0 (return prunedHistoryError from GetLogs/FilterLogs if accessing pruned state.  duplicate prunedHistoryError into eth/filters package.  add HistoryCutoff method to eth backend)
 	backend := &testBackend{db: db}
 	sys := NewFilterSystem(backend, cfg)
 	return backend, sys

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -1369,7 +1369,6 @@ func (api *TransactionAPI) GetRawTransactionByHash(ctx context.Context, hash com
 
 // GetTransactionReceipt returns the transaction receipt for the given transaction hash.
 func (api *TransactionAPI) GetTransactionReceipt(ctx context.Context, hash common.Hash) (map[string]interface{}, error) {
-	// TODO(s1na): transaction lookup should be pruned as well.
 	found, tx, blockHash, blockNumber, index, err := api.b.GetTransaction(ctx, hash)
 	if err != nil {
 		return nil, NewTxIndexingError() // transaction is not fully indexed

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -549,21 +549,23 @@ func (api *BlockChainAPI) GetUncleByBlockHashAndIndex(ctx context.Context, block
 }
 
 // GetUncleCountByBlockNumber returns number of uncles in the block for the given block number
-func (api *BlockChainAPI) GetUncleCountByBlockNumber(ctx context.Context, blockNr rpc.BlockNumber) *hexutil.Uint {
-	if block, _ := api.b.BlockByNumber(ctx, blockNr); block != nil {
+func (api *BlockChainAPI) GetUncleCountByBlockNumber(ctx context.Context, blockNr rpc.BlockNumber) (*hexutil.Uint, error) {
+	block, err := api.b.BlockByNumber(ctx, blockNr)
+	if block != nil {
 		n := hexutil.Uint(len(block.Uncles()))
-		return &n
+		return &n, nil
 	}
-	return nil
+	return nil, err
 }
 
 // GetUncleCountByBlockHash returns number of uncles in the block for the given block hash
-func (api *BlockChainAPI) GetUncleCountByBlockHash(ctx context.Context, blockHash common.Hash) *hexutil.Uint {
-	if block, _ := api.b.BlockByHash(ctx, blockHash); block != nil {
+func (api *BlockChainAPI) GetUncleCountByBlockHash(ctx context.Context, blockHash common.Hash) (*hexutil.Uint, error) {
+	block, err := api.b.BlockByHash(ctx, blockHash)
+	if block != nil {
 		n := hexutil.Uint(len(block.Uncles()))
-		return &n
+		return &n, nil
 	}
-	return nil
+	return nil, err
 }
 
 // GetCode returns the code stored at the given address in the state for the given block number.
@@ -596,9 +598,7 @@ func (api *BlockChainAPI) GetStorageAt(ctx context.Context, address common.Addre
 func (api *BlockChainAPI) GetBlockReceipts(ctx context.Context, blockNrOrHash rpc.BlockNumberOrHash) ([]map[string]interface{}, error) {
 	block, err := api.b.BlockByNumberOrHash(ctx, blockNrOrHash)
 	if block == nil || err != nil {
-		// When the block doesn't exist, the RPC method should return JSON null
-		// as per specification.
-		return nil, nil
+		return nil, err
 	}
 	receipts, err := api.b.GetReceipts(ctx, block.Hash())
 	if err != nil {
@@ -1258,37 +1258,41 @@ func NewTransactionAPI(b Backend, nonceLock *AddrLocker) *TransactionAPI {
 }
 
 // GetBlockTransactionCountByNumber returns the number of transactions in the block with the given block number.
-func (api *TransactionAPI) GetBlockTransactionCountByNumber(ctx context.Context, blockNr rpc.BlockNumber) *hexutil.Uint {
-	if block, _ := api.b.BlockByNumber(ctx, blockNr); block != nil {
+func (api *TransactionAPI) GetBlockTransactionCountByNumber(ctx context.Context, blockNr rpc.BlockNumber) (*hexutil.Uint, error) {
+	block, err := api.b.BlockByNumber(ctx, blockNr)
+	if block != nil {
 		n := hexutil.Uint(len(block.Transactions()))
-		return &n
+		return &n, nil
 	}
-	return nil
+	return nil, err
 }
 
 // GetBlockTransactionCountByHash returns the number of transactions in the block with the given hash.
-func (api *TransactionAPI) GetBlockTransactionCountByHash(ctx context.Context, blockHash common.Hash) *hexutil.Uint {
-	if block, _ := api.b.BlockByHash(ctx, blockHash); block != nil {
+func (api *TransactionAPI) GetBlockTransactionCountByHash(ctx context.Context, blockHash common.Hash) (*hexutil.Uint, error) {
+	block, err := api.b.BlockByHash(ctx, blockHash)
+	if block != nil {
 		n := hexutil.Uint(len(block.Transactions()))
-		return &n
+		return &n, nil
 	}
-	return nil
+	return nil, err
 }
 
 // GetTransactionByBlockNumberAndIndex returns the transaction for the given block number and index.
-func (api *TransactionAPI) GetTransactionByBlockNumberAndIndex(ctx context.Context, blockNr rpc.BlockNumber, index hexutil.Uint) *RPCTransaction {
-	if block, _ := api.b.BlockByNumber(ctx, blockNr); block != nil {
-		return newRPCTransactionFromBlockIndex(block, uint64(index), api.b.ChainConfig())
+func (api *TransactionAPI) GetTransactionByBlockNumberAndIndex(ctx context.Context, blockNr rpc.BlockNumber, index hexutil.Uint) (*RPCTransaction, error) {
+	block, err := api.b.BlockByNumber(ctx, blockNr)
+	if block != nil {
+		return newRPCTransactionFromBlockIndex(block, uint64(index), api.b.ChainConfig()), nil
 	}
-	return nil
+	return nil, err
 }
 
 // GetTransactionByBlockHashAndIndex returns the transaction for the given block hash and index.
-func (api *TransactionAPI) GetTransactionByBlockHashAndIndex(ctx context.Context, blockHash common.Hash, index hexutil.Uint) *RPCTransaction {
-	if block, _ := api.b.BlockByHash(ctx, blockHash); block != nil {
-		return newRPCTransactionFromBlockIndex(block, uint64(index), api.b.ChainConfig())
+func (api *TransactionAPI) GetTransactionByBlockHashAndIndex(ctx context.Context, blockHash common.Hash, index hexutil.Uint) (*RPCTransaction, error) {
+	block, err := api.b.BlockByHash(ctx, blockHash)
+	if block != nil {
+		return newRPCTransactionFromBlockIndex(block, uint64(index), api.b.ChainConfig()), nil
 	}
-	return nil
+	return nil, err
 }
 
 // GetRawTransactionByBlockNumberAndIndex returns the bytes of the transaction for the given block number and index.
@@ -1365,6 +1369,7 @@ func (api *TransactionAPI) GetRawTransactionByHash(ctx context.Context, hash com
 
 // GetTransactionReceipt returns the transaction receipt for the given transaction hash.
 func (api *TransactionAPI) GetTransactionReceipt(ctx context.Context, hash common.Hash) (map[string]interface{}, error) {
+	// TODO(s1na): transaction lookup should be pruned as well.
 	found, tx, blockHash, blockNumber, index, err := api.b.GetTransaction(ctx, hash)
 	if err != nil {
 		return nil, NewTxIndexingError() // transaction is not fully indexed

--- a/internal/ethapi/api_test.go
+++ b/internal/ethapi/api_test.go
@@ -520,8 +520,12 @@ func (b testBackend) BlockByNumber(ctx context.Context, number rpc.BlockNumber) 
 	if number == rpc.PendingBlockNumber {
 		return b.pending, nil
 	}
+	if number == rpc.EarliestBlockNumber {
+		number = 0
+	}
 	return b.chain.GetBlockByNumber(uint64(number)), nil
 }
+
 func (b testBackend) BlockByHash(ctx context.Context, hash common.Hash) (*types.Block, error) {
 	return b.chain.GetBlockByHash(hash), nil
 }

--- a/internal/ethapi/api_test.go
+++ b/internal/ethapi/api_test.go
@@ -623,7 +623,7 @@ func (b testBackend) NewMatcherBackend() filtermaps.MatcherBackend {
 	panic("implement me")
 }
 
-func (b testBackend) HistoryCutoff() uint64 { return b.chain.HistoryCutoff() }
+func (b testBackend) HistoryPruningCutoff() uint64 { return b.chain.HistoryPruningCutoff() }
 
 func TestEstimateGas(t *testing.T) {
 	t.Parallel()

--- a/internal/ethapi/api_test.go
+++ b/internal/ethapi/api_test.go
@@ -618,6 +618,9 @@ func (b testBackend) SubscribeLogsEvent(ch chan<- []*types.Log) event.Subscripti
 func (b testBackend) NewMatcherBackend() filtermaps.MatcherBackend {
 	panic("implement me")
 }
+
+func (b testBackend) HistoryCutoff() uint64 { return b.chain.HistoryCutoff() }
+
 func TestEstimateGas(t *testing.T) {
 	t.Parallel()
 	// Initialize test accounts

--- a/internal/ethapi/backend.go
+++ b/internal/ethapi/backend.go
@@ -85,6 +85,7 @@ type Backend interface {
 
 	ChainConfig() *params.ChainConfig
 	Engine() consensus.Engine
+	HistoryCutoff() uint64
 
 	// This is copied from filters.Backend
 	// eth/filters needs to be initialized from this backend type, so methods needed by

--- a/internal/ethapi/backend.go
+++ b/internal/ethapi/backend.go
@@ -85,7 +85,7 @@ type Backend interface {
 
 	ChainConfig() *params.ChainConfig
 	Engine() consensus.Engine
-	HistoryCutoff() uint64
+	HistoryPruningCutoff() uint64
 
 	// This is copied from filters.Backend
 	// eth/filters needs to be initialized from this backend type, so methods needed by

--- a/internal/ethapi/transaction_args_test.go
+++ b/internal/ethapi/transaction_args_test.go
@@ -403,4 +403,4 @@ func (b *backendMock) Engine() consensus.Engine { return nil }
 
 func (b *backendMock) NewMatcherBackend() filtermaps.MatcherBackend { return nil }
 
-func (b *backendMock) HistoryCutoff() uint64 { return b.HistoryCutoff() }
+func (b *backendMock) HistoryCutoff() uint64 { return 0 }

--- a/internal/ethapi/transaction_args_test.go
+++ b/internal/ethapi/transaction_args_test.go
@@ -402,3 +402,5 @@ func (b *backendMock) SubscribeRemovedLogsEvent(ch chan<- core.RemovedLogsEvent)
 func (b *backendMock) Engine() consensus.Engine { return nil }
 
 func (b *backendMock) NewMatcherBackend() filtermaps.MatcherBackend { return nil }
+
+func (b *backendMock) HistoryCutoff() uint64 { return b.HistoryCutoff() }

--- a/internal/ethapi/transaction_args_test.go
+++ b/internal/ethapi/transaction_args_test.go
@@ -403,4 +403,4 @@ func (b *backendMock) Engine() consensus.Engine { return nil }
 
 func (b *backendMock) NewMatcherBackend() filtermaps.MatcherBackend { return nil }
 
-func (b *backendMock) HistoryCutoff() uint64 { return 0 }
+func (b *backendMock) HistoryPruningCutoff() uint64 { return 0 }

--- a/rpc/types.go
+++ b/rpc/types.go
@@ -63,11 +63,11 @@ type jsonWriter interface {
 type BlockNumber int64
 
 const (
+	EarliestBlockNumber  = BlockNumber(-5)
 	SafeBlockNumber      = BlockNumber(-4)
 	FinalizedBlockNumber = BlockNumber(-3)
 	LatestBlockNumber    = BlockNumber(-2)
 	PendingBlockNumber   = BlockNumber(-1)
-	EarliestBlockNumber  = BlockNumber(0)
 )
 
 // UnmarshalJSON parses the given JSON fragment into a BlockNumber. It supports:


### PR DESCRIPTION
Implements #31275 

I find it a bit weird to define the error type in `eth/` but I feel like that is the place to return it.