### PR TITLE
eth/ethconfig: add HistoryMode

### DIFF
--- a/cmd/geth/main.go
+++ b/cmd/geth/main.go
@@ -86,6 +86,7 @@ var (
 		utils.SnapshotFlag,
 		utils.TxLookupLimitFlag, // deprecated
 		utils.TransactionHistoryFlag,
+		utils.ChainHistoryFlag,
 		utils.StateHistoryFlag,
 		utils.LightServeFlag,    // deprecated
 		utils.LightIngressFlag,  // deprecated

--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -154,6 +154,10 @@ type CacheConfig struct {
 
 	SnapshotNoBuild bool // Whether the background generation is allowed
 	SnapshotWait    bool // Wait for snapshot construction on startup. TODO(karalabe): This is a dirty hack for testing, nuke it
+
+	// This defines the cutoff block for history expiry.
+	// Blocks before this number may be unavailable in the chain database.
+	HistoryPruningCutoff uint64
 }
 
 // triedbConfig derives the configures for trie database.
@@ -2518,4 +2522,10 @@ func (bc *BlockChain) SetTrieFlushInterval(interval time.Duration) {
 // GetTrieFlushInterval gets the in-memory tries flushAlloc interval
 func (bc *BlockChain) GetTrieFlushInterval() time.Duration {
 	return time.Duration(bc.flushInterval.Load())
+}
+
+// HistoryPruningCutoff returns the configured history pruning point.
+// Blocks before this might not be available in the database.
+func (bc *BlockChain) HistoryPruningCutoff() uint64 {
+	return bc.cacheConfig.HistoryPruningCutoff
 }

--- a/eth/ethconfig/config.go
+++ b/eth/ethconfig/config.go
@@ -48,6 +48,7 @@ var FullNodeGPO = gasprice.Config{
 
 // Defaults contains default settings for use on the Ethereum main net.
 var Defaults = Config{
+	HistoryMode:        AllHistory,
 	SyncMode:           SnapSync,
 	NetworkId:          0, // enable auto configuration of networkID == chainID
 	TxLookupLimit:      2350000,
@@ -80,6 +81,9 @@ type Config struct {
 	// zero, the chain ID is used as network ID.
 	NetworkId uint64
 	SyncMode  SyncMode
+
+	// HistoryMode configures chain history retention.
+	HistoryMode HistoryMode
 
 	// This can be set to list of enrtree:// URLs which will be queried for
 	// nodes to connect to.

--- a/eth/ethconfig/gen_config.go
+++ b/eth/ethconfig/gen_config.go
@@ -19,6 +19,7 @@ func (c Config) MarshalTOML() (interface{}, error) {
 		Genesis                 *core.Genesis `toml:",omitempty"`
 		NetworkId               uint64
 		SyncMode                SyncMode
+		HistoryMode             HistoryMode
 		EthDiscoveryURLs        []string
 		SnapDiscoveryURLs       []string
 		NoPruning               bool
@@ -55,6 +56,7 @@ func (c Config) MarshalTOML() (interface{}, error) {
 	enc.Genesis = c.Genesis
 	enc.NetworkId = c.NetworkId
 	enc.SyncMode = c.SyncMode
+	enc.HistoryMode = c.HistoryMode
 	enc.EthDiscoveryURLs = c.EthDiscoveryURLs
 	enc.SnapDiscoveryURLs = c.SnapDiscoveryURLs
 	enc.NoPruning = c.NoPruning
@@ -95,6 +97,7 @@ func (c *Config) UnmarshalTOML(unmarshal func(interface{}) error) error {
 		Genesis                 *core.Genesis `toml:",omitempty"`
 		NetworkId               *uint64
 		SyncMode                *SyncMode
+		HistoryMode             *HistoryMode
 		EthDiscoveryURLs        []string
 		SnapDiscoveryURLs       []string
 		NoPruning               *bool
@@ -139,6 +142,9 @@ func (c *Config) UnmarshalTOML(unmarshal func(interface{}) error) error {
 	}
 	if dec.SyncMode != nil {
 		c.SyncMode = *dec.SyncMode
+	}
+	if dec.HistoryMode != nil {
+		c.HistoryMode = *dec.HistoryMode
 	}
 	if dec.EthDiscoveryURLs != nil {
 		c.EthDiscoveryURLs = dec.EthDiscoveryURLs

--- a/eth/ethconfig/historymode.go
+++ b/eth/ethconfig/historymode.go
@@ -1,0 +1,90 @@
+// Copyright 2025 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+
+package ethconfig
+
+import (
+	"fmt"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/params"
+)
+
+// HistoryMode configures history pruning.
+type HistoryMode uint32
+
+const (
+	// AllHistory (default) means that all chain history down to genesis block will be kept.
+	AllHistory HistoryMode = iota
+
+	// PostMergeHistory sets the history pruning point to the merge activation block.
+	PostMergeHistory
+)
+
+func (m HistoryMode) IsValid() bool {
+	return m <= PostMergeHistory
+}
+
+func (m HistoryMode) String() string {
+	switch m {
+	case AllHistory:
+		return "all"
+	case PostMergeHistory:
+		return "postmerge"
+	default:
+		return fmt.Sprintf("invalid HistoryMode(%d)", m)
+	}
+}
+
+// MarshalText implements encoding.TextMarshaler.
+func (m HistoryMode) MarshalText() ([]byte, error) {
+	if m.IsValid() {
+		return []byte(m.String()), nil
+	}
+	return nil, fmt.Errorf("unknown history mode %d", m)
+}
+
+// UnmarshalText implements encoding.TextUnmarshaler.
+func (m *HistoryMode) UnmarshalText(text []byte) error {
+	switch string(text) {
+	case "all":
+		*m = AllHistory
+	case "postmerge":
+		*m = PostMergeHistory
+	default:
+		return fmt.Errorf(`unknown sync mode %q, want "all" or "postmerge"`, text)
+	}
+	return nil
+}
+
+type HistoryPrunePoint struct {
+	BlockNumber uint64
+	BlockHash   common.Hash
+}
+
+// HistoryPrunePoints contains the pre-defined history pruning cutoff blocks for known networks.
+var HistoryPrunePoints = map[common.Hash]*HistoryPrunePoint{
+	// mainnet
+	params.MainnetGenesisHash: {
+		BlockNumber: 15537394,
+		BlockHash:   common.HexToHash("0x56a9bb0302da44b8c0b3df540781424684c3af04d0b7a38d72842b762076a664"),
+	},
+	// sepolia
+	params.SepoliaGenesisHash: {
+		BlockNumber: 1735371,
+		BlockHash:   common.HexToHash("0x36fb89fba5b7857cf0ca78b5a9625b4043ff4555dfce9b7bcdcdd758a11eb946"),
+	},
+}


### PR DESCRIPTION
Here I am adding a config option and geth flag (`--history.chain`) for configuring history pruning. There are two options available:

- `--history.chain all` is the default and will keep all history like before.
- `--history.chain postmerge` will configure the history cutoff point to the merge block. 

The option doesn't actually do anything right now, but we need it as a precursor for other history pruning changes.