### PR TITLE
rpc: change constant value for "earliest" block

### DIFF
--- a/rpc/types.go
+++ b/rpc/types.go
@@ -63,11 +63,11 @@ type jsonWriter interface {
 type BlockNumber int64
 
 const (
+	EarliestBlockNumber  = BlockNumber(-5)
 	SafeBlockNumber      = BlockNumber(-4)
 	FinalizedBlockNumber = BlockNumber(-3)
 	LatestBlockNumber    = BlockNumber(-2)
 	PendingBlockNumber   = BlockNumber(-1)
-	EarliestBlockNumber  = BlockNumber(0)
 )
 
 // UnmarshalJSON parses the given JSON fragment into a BlockNumber. It supports:


### PR DESCRIPTION
With history pruning, we want to redefine what the "earliest" block tag means. We need to assign a special negative integer value to this constant, otherwise we cannot tell it apart from block zero, the genesis block.