### PR TITLE
core/txpool/blobpool: downgrade "Blob transaction swapped out by sign…

### DIFF
--- a/core/txpool/blobpool/blobpool.go
+++ b/core/txpool/blobpool/blobpool.go
@@ -777,7 +777,7 @@ func (p *BlobPool) offload(addr common.Address, nonce uint64, id uint64, inclusi
 	}
 	block, ok := inclusions[tx.Hash()]
 	if !ok {
-		log.Warn("Blob transaction swapped out by signer", "from", addr, "nonce", nonce, "id", id)
+		log.Debug("Blob transaction swapped out by signer", "from", addr, "nonce", nonce, "id", id)
 		return
 	}
 	if err := p.limbo.push(&tx, block); err != nil {


### PR DESCRIPTION
…er" to debug level

This pull request changes the log level of the "Blob transaction swapped out by signer" 
message from Warn to Debug. This message appears when a transaction is being 
offloaded from the blob pool to the limbo, but its hash is not found in the 
inclusions map.

This is expected behavior when a transaction is replaced by another transaction 
from the same signer (with the same nonce), and should not be treated as a 
warning condition.

Fixes #31363