### PR TITLE
cmd/evm: fix statetest with multi-fork statetest fixtures

### DIFF
--- a/cmd/evm/staterunner.go
+++ b/cmd/evm/staterunner.go
@@ -53,7 +53,9 @@ var stateTestCommand = &cli.Command{
 	Flags: slices.Concat([]cli.Flag{
 		BenchFlag,
 		DumpFlag,
+		forkFlag,
 		HumanReadableFlag,
+		idxFlag,
 		RunFlag,
 	}, traceFlags),
 }


### PR DESCRIPTION
Fixes `evm statetest` for state test fixtures with multiple fork entries in their `post` field (e.g., [chainId.json](https://github.com/ethereum/tests/blob/81862e4848585a438d64f911a19b3825f0f4cd95/GeneralStateTests/stChainId/chainId.json#L39)). 

When these re-activated flags aren't exposed, `statetest` only executes the fixture for a single fork entry instead of all of the forks as expected.

This only affects ethereum/tests state test fixtures, not ethereum/execution-spec-tests (EEST) state tests. EEST writes a separate fixture/test case (i.e. a separate top-level dict entry in the .json) for each fork configuration as apposed to combining multiple forks in one fixture test case: New EEST state tests targeting Prague behavior are not affected.
