### PR TITLE
p2p/nat: Return error from internalAddress in AddMapping

### DIFF
--- a/p2p/nat/natupnp.go
+++ b/p2p/nat/natupnp.go
@@ -82,7 +82,7 @@ func (n *upnp) ExternalIP() (addr net.IP, err error) {
 func (n *upnp) AddMapping(protocol string, extport, intport int, desc string, lifetime time.Duration) (uint16, error) {
 	ip, err := n.internalAddress()
 	if err != nil {
-		return 0, nil // TODO: Shouldn't we return the error?
+		return 0, err
 	}
 	protocol = strings.ToUpper(protocol)
 	lifetimeS := uint32(lifetime / time.Second)


### PR DESCRIPTION
This pull request fixes a TODO in the UPnP NAT implementation by properly returning the error from internalAddress() in the AddMapping method. Previously, when internalAddress() failed, the method would return nil as the error, which could lead to silent failures and make debugging difficult. Now, the actual error is propagated to the caller, allowing for better error handling and debugging.