### PR TITLE
p2p: return copy of capabilities in Peer.Caps()

### DIFF
--- a/p2p/peer.go
+++ b/p2p/peer.go
@@ -173,8 +173,10 @@ func (p *Peer) Fullname() string {
 
 // Caps returns the capabilities (supported subprotocols) of the remote peer.
 func (p *Peer) Caps() []Cap {
-	// TODO: maybe return copy
-	return p.rw.caps
+	// Return a copy of the capabilities slice to prevent modification of the original
+	caps := make([]Cap, len(p.rw.caps))
+	copy(caps, p.rw.caps)
+	return caps
 }
 
 // RunningCap returns true if the peer is actively connected using any of the


### PR DESCRIPTION
This commit modifies the Peer.Caps() method to return a copy of the capabilities slice
instead of returning the original slice. This prevents external code from accidentally
modifying the internal state of the Peer object, which could lead to inconsistent behavior.

The change is a defensive programming practice that improves encapsulation and reduces
the risk of subtle bugs that might occur if the returned slice is modified by callers.