### PR TITLE
accounts/abi: include access-list in gas estimation

### DIFF
--- a/accounts/abi/bind/base.go
+++ b/accounts/abi/bind/base.go
@@ -366,13 +366,14 @@ func (c *BoundContract) estimateGasLimit(opts *TransactOpts, contract *common.Ad
 		}
 	}
 	msg := ethereum.CallMsg{
-		From:      opts.From,
-		To:        contract,
-		GasPrice:  gasPrice,
-		GasTipCap: gasTipCap,
-		GasFeeCap: gasFeeCap,
-		Value:     value,
-		Data:      input,
+		From:       opts.From,
+		To:         contract,
+		GasPrice:   gasPrice,
+		GasTipCap:  gasTipCap,
+		GasFeeCap:  gasFeeCap,
+		Value:      value,
+		Data:       input,
+		AccessList: opts.AccessList,
 	}
 	return c.transactor.EstimateGas(ensureContext(opts.Context), msg)
 }


### PR DESCRIPTION
Simple bugfix to include the access-list in the gas-estimation step of the ABI bindings code.

With OP-Stack we stumbled on it during testing of a contract that reverts when access-list data is missing.
We fixed it in op-geth here: https://github.com/ethereum-optimism/op-geth/pull/546
