### PR TITLE
metrics: spin up meter ticker routine when enabling metric system

### DIFF
--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -30,6 +30,7 @@ func Enabled() bool {
 // the program, before any metrics collection will happen.
 func Enable() {
 	metricsEnabled = true
+	startMeterTickerLoop()
 }
 
 var threadCreateProfile = pprof.Lookup("threadcreate")


### PR DESCRIPTION
Addresses https://github.com/ethereum/go-ethereum/issues/31244

> ... Can't we move the startup into package metrics somehow? Like launching the goroutine the first time a value is reported on a timer?

We could launch the goroutine the first time we hit Meter.Mark (some meters are not behind timers) but I feel the most logical place to initialize the routine is when we enable the metrics system. It seems this ticker is fundamental to the metrics system, it doesn't appear to ever make sense to run metrics without it.