### PR TITLE
eth/catalyst: Fix success condition for TestSimulatedBeaconSendWithdrawal

### DIFF
--- a/eth/catalyst/simulated_beacon_test.go
+++ b/eth/catalyst/simulated_beacon_test.go
@@ -119,6 +119,7 @@ func TestSimulatedBeaconSendWithdrawals(t *testing.T) {
 
 	includedTxs := make(map[common.Hash]struct{})
 	var includedWithdrawals []uint64
+	lastHeaderNumber := big.NewInt(0)
 
 	timer := time.NewTimer(12 * time.Second)
 	for {
@@ -131,12 +132,13 @@ func TestSimulatedBeaconSendWithdrawals(t *testing.T) {
 			for _, includedWithdrawal := range block.Withdrawals() {
 				includedWithdrawals = append(includedWithdrawals, includedWithdrawal.Index)
 			}
-			// ensure all withdrawals/txs included. this will take two blocks b/c number of withdrawals > 10
-			if len(includedTxs) == len(txs) && len(includedWithdrawals) == len(withdrawals) && ev.Header.Number.Cmp(big.NewInt(2)) == 0 {
+			lastHeaderNumber = ev.Header.Number
+			// ensure all withdrawals/txs included. this will take at least two blocks b/c number of withdrawals > 10
+			if len(includedTxs) == len(txs) && len(includedWithdrawals) == len(withdrawals) && ev.Header.Number.Cmp(big.NewInt(1)) == 1 {
 				return
 			}
 		case <-timer.C:
-			t.Fatal("timed out without including all withdrawals/txs")
+			t.Fatalf("timed out without including all withdrawals/txs, includedTxs len =  %d, includedWithdrawls = %d, lastHeaderNumber = %d", len(includedTxs), len(includedWithdrawals), lastHeaderNumber)
 		}
 	}
 }


### PR DESCRIPTION
I was able to reproduce the issue in https://github.com/ethereum/go-ethereum/issues/31169 consistently by running `go test` with the `-race` flag (https://go.dev/doc/articles/race_detector#Runtime_Overheads), which I'm attributing to the overhead of `-race`, not that this is related to being a data race condition.

With some debug logging, we can see that it can take more that 2 blocks to see all the withdraws.
```
    simulated_beacon_test.go:136: Testing: includedTxs len =  17, includedWithdrawls = 2, lastHeaderNumber = 1
    simulated_beacon_test.go:136: Testing: includedTxs len =  20, includedWithdrawls = 12, lastHeaderNumber = 2
    simulated_beacon_test.go:136: Testing: includedTxs len =  20, includedWithdrawls = 20, lastHeaderNumber = 3
```

I'll need someone with more context on withdraws to confirm, but I believe this test is valid as long as we get `at least` 2 blocks, not exactly 2.

The change updates the test condition to allow for 2+ blocks instead of exactly 2.
