### PR TITLE
eth/catalyst: sanitize simulated beacon period to avoid overflowing time.Duration

### DIFF
--- a/core/era_backend.go
+++ b/core/era_backend.go
@@ -1,1 +1,0 @@
-package core

--- a/core/era_backend.go
+++ b/core/era_backend.go
@@ -1,0 +1,1 @@
+package core

--- a/eth/catalyst/simulated_beacon.go
+++ b/eth/catalyst/simulated_beacon.go
@@ -126,7 +126,7 @@ func NewSimulatedBeacon(period uint64, feeRecipient common.Address, eth *eth.Eth
 	}
 
 	// cap the dev mode period to a reasonable maximum value to avoid overflowing the time.Duration (int64) that it will occupy
-	var maxPeriod uint64 = 9223372036 // math.Floor(math.MaxInt64 / 1000000000)
+	var maxPeriod uint64 = math.Floor(math.MaxInt64 / 1_000_000_000)
 	if period > maxPeriod {
 		log.Warn(fmt.Sprintf("period exceeds maximum possible value (have: %d, max: %d).  Sanitizing period to maximum possible value.", period, maxPeriod))
 		period = maxPeriod

--- a/eth/catalyst/simulated_beacon.go
+++ b/eth/catalyst/simulated_beacon.go
@@ -127,7 +127,7 @@ func NewSimulatedBeacon(period uint64, feeRecipient common.Address, eth *eth.Eth
 	}
 
 	// cap the dev mode period to a reasonable maximum value to avoid overflowing the time.Duration (int64) that it will occupy
-	maxPeriod := uint64(math.Floor(math.MaxInt64 / 1_000_000_000))
+	maxPeriod := uint64(math.Floor(math.MaxInt64 / time.Second))
 	if period > maxPeriod {
 		log.Warn(fmt.Sprintf("period exceeds maximum possible value (have: %d, max: %d).  Sanitizing period to maximum possible value.", period, maxPeriod))
 		period = maxPeriod

--- a/eth/catalyst/simulated_beacon.go
+++ b/eth/catalyst/simulated_beacon.go
@@ -126,10 +126,11 @@ func NewSimulatedBeacon(period uint64, feeRecipient common.Address, eth *eth.Eth
 		}
 	}
 
-	// cap the dev mode period to a reasonable maximum value to avoid overflowing the time.Duration (int64) that it will occupy
+	// cap the dev mode period to a reasonable maximum value to avoid
+	// overflowing the time.Duration (int64) that it will occupy
 	maxPeriod := uint64(math.MaxInt64 / time.Second)
 	if period > maxPeriod {
-		log.Warn(fmt.Sprintf("period exceeds maximum possible value (have: %d, max: %d).  Sanitizing period to maximum possible value.", period, maxPeriod))
+		log.Warn("sanitizing period exceeding maximum possible value", "was", period, "now", maxPeriod)
 		period = maxPeriod
 	}
 

--- a/eth/catalyst/simulated_beacon.go
+++ b/eth/catalyst/simulated_beacon.go
@@ -128,7 +128,7 @@ func NewSimulatedBeacon(period uint64, feeRecipient common.Address, eth *eth.Eth
 
 	// cap the dev mode period to a reasonable maximum value to avoid
 	// overflowing the time.Duration (int64) that it will occupy
-	const maxPeriod = math.MaxInt64 / time.Second
+	const maxPeriod = uint64(math.MaxInt64 / time.Second)
 	return &SimulatedBeacon{
 		eth:                eth,
 		period:             min(period, maxPeriod),

--- a/eth/catalyst/simulated_beacon.go
+++ b/eth/catalyst/simulated_beacon.go
@@ -128,15 +128,10 @@ func NewSimulatedBeacon(period uint64, feeRecipient common.Address, eth *eth.Eth
 
 	// cap the dev mode period to a reasonable maximum value to avoid
 	// overflowing the time.Duration (int64) that it will occupy
-	maxPeriod := uint64(math.MaxInt64 / time.Second)
-	if period > maxPeriod {
-		log.Warn("sanitizing period exceeding maximum possible value", "was", period, "now", maxPeriod)
-		period = maxPeriod
-	}
-
+	const maxPeriod = math.MaxInt64 / time.Second
 	return &SimulatedBeacon{
 		eth:                eth,
-		period:             period,
+		period:             min(period, maxPeriod),
 		shutdownCh:         make(chan struct{}),
 		engineAPI:          engineAPI,
 		lastBlockTime:      block.Time,

--- a/eth/catalyst/simulated_beacon.go
+++ b/eth/catalyst/simulated_beacon.go
@@ -21,6 +21,7 @@ import (
 	"crypto/sha256"
 	"errors"
 	"fmt"
+	"math"
 	"sync"
 	"time"
 
@@ -126,7 +127,7 @@ func NewSimulatedBeacon(period uint64, feeRecipient common.Address, eth *eth.Eth
 	}
 
 	// cap the dev mode period to a reasonable maximum value to avoid overflowing the time.Duration (int64) that it will occupy
-	var maxPeriod uint64 = math.Floor(math.MaxInt64 / 1_000_000_000)
+	maxPeriod := uint64(math.Floor(math.MaxInt64 / 1_000_000_000))
 	if period > maxPeriod {
 		log.Warn(fmt.Sprintf("period exceeds maximum possible value (have: %d, max: %d).  Sanitizing period to maximum possible value.", period, maxPeriod))
 		period = maxPeriod

--- a/eth/catalyst/simulated_beacon.go
+++ b/eth/catalyst/simulated_beacon.go
@@ -127,7 +127,7 @@ func NewSimulatedBeacon(period uint64, feeRecipient common.Address, eth *eth.Eth
 	}
 
 	// cap the dev mode period to a reasonable maximum value to avoid overflowing the time.Duration (int64) that it will occupy
-	maxPeriod := uint64(math.Floor(math.MaxInt64 / time.Second))
+	maxPeriod := uint64(math.MaxInt64 / time.Second)
 	if period > maxPeriod {
 		log.Warn(fmt.Sprintf("period exceeds maximum possible value (have: %d, max: %d).  Sanitizing period to maximum possible value.", period, maxPeriod))
 		period = maxPeriod

--- a/eth/catalyst/simulated_beacon.go
+++ b/eth/catalyst/simulated_beacon.go
@@ -124,6 +124,14 @@ func NewSimulatedBeacon(period uint64, feeRecipient common.Address, eth *eth.Eth
 			return nil, err
 		}
 	}
+
+	// cap the dev mode period to a reasonable maximum value to avoid overflowing the time.Duration (int64) that it will occupy
+	var maxPeriod uint64 = 9223372036 // math.Floor(math.MaxInt64 / 1000000000)
+	if period > maxPeriod {
+		log.Warn(fmt.Sprintf("period exceeds maximum possible value (have: %d, max: %d).  Sanitizing period to maximum possible value.", period, maxPeriod))
+		period = maxPeriod
+	}
+
 	return &SimulatedBeacon{
 		eth:                eth,
 		period:             period,


### PR DESCRIPTION
closes #31401