### PR TITLE
Fix incorrect transaction hash access in syncTransactions function

### DIFF
--- a/eth/sync.go
+++ b/eth/sync.go
@@ -27,7 +27,7 @@ func (h *handler) syncTransactions(p *eth.Peer) {
 	var hashes []common.Hash
 	for _, batch := range h.txpool.Pending(txpool.PendingFilter{OnlyPlainTxs: true}) {
 		for _, tx := range batch {
-			hashes = append(hashes, tx.Hash)
+			hashes = append(hashes, tx.Hash())
 		}
 	}
 	if len(hashes) == 0 {


### PR DESCRIPTION
Previously, the syncTransactions function attempted to access the Hash field of transactions retrieved from the transaction pool. However, transactions in the go-ethereum txpool are stored as pointers to types.Transaction, meaning they do not have a direct Hash field. Instead, they provide a Hash() method that must be called to obtain the transaction hash. This commit fixes the issue by replacing tx.Hash with tx.Hash(), ensuring correct retrieval of transaction hashes before sending them to the peer.