### PR TITLE
core/filtermaps: fixed indexer checkpoint initialization

### DIFF
--- a/core/filtermaps/indexer.go
+++ b/core/filtermaps/indexer.go
@@ -346,6 +346,9 @@ func (f *FilterMaps) needTailEpoch(epoch uint32) bool {
 	if epoch > firstEpoch {
 		return true
 	}
+	if (epoch+1)<<f.logMapsPerEpoch >= f.indexedRange.maps.AfterLast() {
+		return true
+	}
 	if epoch+1 < firstEpoch {
 		return false
 	}


### PR DESCRIPTION
This PR fixes a bug in the `lastMapBoundaryBefore` logic that resulted in failed checkpoint initialization. Apparently the bug was present before but was not triggered because the indexer behaved slightly differently and started a tail indexing before the first head update.
Fixes https://github.com/ethereum/go-ethereum/issues/31413
