### PR TITLE
p2p/enr: Add EIP-7636 information to the ENR library

### DIFF
--- a/p2p/enr/enr_test.go
+++ b/p2p/enr/enr_test.go
@@ -81,6 +81,33 @@ func TestGetSetUDP(t *testing.T) {
 	assert.Equal(t, port, port2)
 }
 
+// TestGetSetClientInfo tests encoding/decoding and setting/getting of the Client key.
+func TestGetSetClientInfo(t *testing.T) {
+	name := "go-ethereum"
+	ver := "1.0.0"
+	build := "build-example"
+
+	// Without build info
+
+	client := Client(Client{&name, &ver, nil})
+	var r Record
+	r.Set(client)
+
+	var client2 Client
+	require.NoError(t, r.Load(&client2))
+	assert.Equal(t, client, client2)
+
+	// With build info
+
+	clientWithBuild := Client(Client{&name, &ver, &build})
+	var r2 Record
+	r2.Set(clientWithBuild)
+
+	var clientWithBuild2 Client
+	require.NoError(t, r2.Load(&clientWithBuild2))
+	assert.Equal(t, clientWithBuild, clientWithBuild2)
+}
+
 func TestLoadErrors(t *testing.T) {
 	var r Record
 	ip4 := IPv4{127, 0, 0, 1}

--- a/p2p/enr/enr_test.go
+++ b/p2p/enr/enr_test.go
@@ -91,7 +91,7 @@ func TestGetSetClientInfo(t *testing.T) {
 
 	// Without build info
 
-	client := Client(Client{&name, &ver, nil})
+	client := Client{&name, &ver, nil}
 	var r Record
 	r.Set(client)
 
@@ -101,7 +101,7 @@ func TestGetSetClientInfo(t *testing.T) {
 
 	// With build info
 
-	clientWithBuild := Client(Client{&name, &ver, &build})
+	clientWithBuild := Client{&name, &ver, &build}
 	var r2 Record
 	r2.Set(clientWithBuild)
 
@@ -117,7 +117,7 @@ func TestDecodingENRWith7636(t *testing.T) {
 
 	if err != nil {
 		t.Error(err)
-		return;
+		return
 	}
 
 	record, _, err := decodeRecord(rlp.NewStream(bytes.NewReader(b), 0))

--- a/p2p/enr/entries.go
+++ b/p2p/enr/entries.go
@@ -153,6 +153,41 @@ func (v *IPv4) DecodeRLP(s *rlp.Stream) error {
 	return nil
 }
 
+// Client is the "client" key, which holds the EIP-7636 client info.
+type Client [3]*string;
+
+func (v Client) ENRKey() string { return "client" }
+
+// EncodeRLP implements rlp.Encoder.
+func (v Client) EncodeRLP(w io.Writer) error {
+	var list []string
+	for _, s := range v {
+		if s != nil {
+			list = append(list, *s)
+		}
+	}
+	if len(list) < 2 || len(list) > 3 {
+		return fmt.Errorf("invalid client info length: %d", len(list))
+	}
+	return rlp.Encode(w, list)
+}
+
+// DecodeRLP implements rlp.Decoder.
+func (v *Client) DecodeRLP(s *rlp.Stream) error {
+	var list []string
+	if err := s.Decode(&list); err != nil {
+		return err
+	}
+	if len(list) < 2 || len(list) > 3 {
+		return fmt.Errorf("invalid client info length: %d", len(list))
+	}
+	for i := 0; i < len(list); i++ {
+		str := list[i]
+		v[i] = &str
+	}
+	return nil
+}
+
 // IPv6 is the "ip6" key, which holds the IP address of the node.
 type IPv6 net.IP
 

--- a/p2p/enr/entries.go
+++ b/p2p/enr/entries.go
@@ -154,7 +154,7 @@ func (v *IPv4) DecodeRLP(s *rlp.Stream) error {
 }
 
 // Client is the "client" key, which holds the EIP-7636 client info.
-type Client [3]*string;
+type Client [3]*string
 
 func (v Client) ENRKey() string { return "client" }
 


### PR DESCRIPTION
This PR adds [EIP-7636 Support](https://eips.ethereum.org/EIPS/eip-7636) support the the ENR library.

FYI: I am somewhat new to golang