### PR TITLE
cmd/workload: fixed filter test request error handling

### DIFF
--- a/cmd/workload/filtertest.go
+++ b/cmd/workload/filtertest.go
@@ -109,6 +109,9 @@ func (s *filterTestSuite) filterFullRange(t *utesting.T) {
 
 func (s *filterTestSuite) queryAndCheck(t *utesting.T, query *filterQuery) {
 	query.run(s.cfg.client, s.cfg.historyPruneBlock)
+	if query.Err == errPrunedHistory {
+		return
+	}
 	if query.Err != nil {
 		t.Errorf("Filter query failed (fromBlock: %d toBlock: %d addresses: %v topics: %v error: %v)", query.FromBlock, query.ToBlock, query.Address, query.Topics, query.Err)
 		return
@@ -126,6 +129,9 @@ func (s *filterTestSuite) fullRangeQueryAndCheck(t *utesting.T, query *filterQue
 		Topics:    query.Topics,
 	}
 	frQuery.run(s.cfg.client, s.cfg.historyPruneBlock)
+	if frQuery.Err == errPrunedHistory {
+		return
+	}
 	if frQuery.Err != nil {
 		t.Errorf("Full range filter query failed (addresses: %v topics: %v error: %v)", frQuery.Address, frQuery.Topics, frQuery.Err)
 		return
@@ -206,14 +212,10 @@ func (fq *filterQuery) run(client *client, historyPruneBlock *uint64) {
 		Addresses: fq.Address,
 		Topics:    fq.Topics,
 	})
-	if err != nil {
-		if err = validateHistoryPruneErr(fq.Err, uint64(fq.FromBlock), historyPruneBlock); err == errPrunedHistory {
-			return
-		} else if err != nil {
-			fmt.Printf("Filter query failed: fromBlock: %d toBlock: %d addresses: %v topics: %v error: %v\n",
-				fq.FromBlock, fq.ToBlock, fq.Address, fq.Topics, err)
-		}
-		fq.Err = err
-	}
 	fq.results = logs
+	fq.Err = validateHistoryPruneErr(err, uint64(fq.FromBlock), historyPruneBlock)
+	if fq.Err != nil && fq.Err != errPrunedHistory {
+		fmt.Printf("Filter query failed: fromBlock: %d toBlock: %d addresses: %v topics: %v error: %v\n",
+			fq.FromBlock, fq.ToBlock, fq.Address, fq.Topics, err)
+	}
 }

--- a/cmd/workload/filtertest.go
+++ b/cmd/workload/filtertest.go
@@ -214,8 +214,9 @@ func (fq *filterQuery) run(client *client, historyPruneBlock *uint64) {
 	})
 	fq.results = logs
 	fq.Err = validateHistoryPruneErr(err, uint64(fq.FromBlock), historyPruneBlock)
-	if fq.Err != nil && fq.Err != errPrunedHistory {
-		fmt.Printf("Filter query failed: fromBlock: %d toBlock: %d addresses: %v topics: %v error: %v\n",
-			fq.FromBlock, fq.ToBlock, fq.Address, fq.Topics, err)
-	}
+}
+
+func (fq *filterQuery) printError() {
+	fmt.Printf("Filter query failed: fromBlock: %d toBlock: %d addresses: %v topics: %v error: %v\n",
+		fq.FromBlock, fq.ToBlock, fq.Address, fq.Topics, fq.Err)
 }

--- a/cmd/workload/filtertestgen.go
+++ b/cmd/workload/filtertestgen.go
@@ -40,7 +40,6 @@ var (
 		Action:    filterGenCmd,
 		Flags: []cli.Flag{
 			filterQueryFileFlag,
-			filterErrorFileFlag,
 		},
 	}
 	filterQueryFileFlag = &cli.StringFlag{
@@ -73,8 +72,7 @@ func filterGenCmd(ctx *cli.Context) error {
 		query.run(f.client, nil)
 		if query.Err != nil {
 			query.printError()
-			f.errors = append(f.errors, query)
-			continue
+			exit("filter query failed")
 		}
 		if len(query.results) > 0 && len(query.results) <= maxFilterResultSize {
 			for {
@@ -92,8 +90,7 @@ func filterGenCmd(ctx *cli.Context) error {
 				}
 				if extQuery.Err != nil {
 					extQuery.printError()
-					f.errors = append(f.errors, extQuery)
-					break
+					exit("filter query failed")
 				}
 				if len(extQuery.results) > maxFilterResultSize {
 					break
@@ -103,7 +100,6 @@ func filterGenCmd(ctx *cli.Context) error {
 			f.storeQuery(query)
 			if time.Since(lastWrite) > time.Second*10 {
 				f.writeQueries()
-				f.writeErrors()
 				lastWrite = time.Now()
 			}
 		}
@@ -114,18 +110,15 @@ func filterGenCmd(ctx *cli.Context) error {
 type filterTestGen struct {
 	client    *client
 	queryFile string
-	errorFile string
 
 	finalizedBlock int64
 	queries        [filterBuckets][]*filterQuery
-	errors         []*filterQuery
 }
 
 func newFilterTestGen(ctx *cli.Context) *filterTestGen {
 	return &filterTestGen{
 		client:    makeClient(ctx),
 		queryFile: ctx.String(filterQueryFileFlag.Name),
-		errorFile: ctx.String(filterErrorFileFlag.Name),
 	}
 }
 
@@ -360,17 +353,6 @@ func (s *filterTestGen) writeQueries() {
 	}
 	json.NewEncoder(file).Encode(&s.queries)
 	file.Close()
-}
-
-// writeQueries serializes the generated errors to the error file.
-func (s *filterTestGen) writeErrors() {
-	file, err := os.Create(s.errorFile)
-	if err != nil {
-		exit(fmt.Errorf("Error creating filter error file %s: %v", s.errorFile, err))
-		return
-	}
-	defer file.Close()
-	json.NewEncoder(file).Encode(s.errors)
 }
 
 func mustGetFinalizedBlock(client *client) int64 {

--- a/cmd/workload/filtertestgen.go
+++ b/cmd/workload/filtertestgen.go
@@ -71,6 +71,9 @@ func filterGenCmd(ctx *cli.Context) error {
 		f.updateFinalizedBlock()
 		query := f.newQuery()
 		query.run(f.client, nil)
+		if query.Err == errPrunedHistory {
+			continue
+		}
 		if query.Err != nil {
 			f.errors = append(f.errors, query)
 			continue
@@ -82,6 +85,9 @@ func filterGenCmd(ctx *cli.Context) error {
 					break
 				}
 				extQuery.run(f.client, nil)
+				if extQuery.Err == errPrunedHistory {
+					break
+				}
 				if extQuery.Err == nil && len(extQuery.results) < len(query.results) {
 					extQuery.Err = fmt.Errorf("invalid result length; old range %d %d; old length %d; new range %d %d; new length %d; address %v; Topics %v",
 						query.FromBlock, query.ToBlock, len(query.results),

--- a/cmd/workload/filtertestgen.go
+++ b/cmd/workload/filtertestgen.go
@@ -71,10 +71,8 @@ func filterGenCmd(ctx *cli.Context) error {
 		f.updateFinalizedBlock()
 		query := f.newQuery()
 		query.run(f.client, nil)
-		if query.Err == errPrunedHistory {
-			continue
-		}
 		if query.Err != nil {
+			query.printError()
 			f.errors = append(f.errors, query)
 			continue
 		}
@@ -85,9 +83,6 @@ func filterGenCmd(ctx *cli.Context) error {
 					break
 				}
 				extQuery.run(f.client, nil)
-				if extQuery.Err == errPrunedHistory {
-					break
-				}
 				if extQuery.Err == nil && len(extQuery.results) < len(query.results) {
 					extQuery.Err = fmt.Errorf("invalid result length; old range %d %d; old length %d; new range %d %d; new length %d; address %v; Topics %v",
 						query.FromBlock, query.ToBlock, len(query.results),
@@ -96,6 +91,7 @@ func filterGenCmd(ctx *cli.Context) error {
 					)
 				}
 				if extQuery.Err != nil {
+					extQuery.printError()
 					f.errors = append(f.errors, extQuery)
 					break
 				}

--- a/cmd/workload/filtertestperf.go
+++ b/cmd/workload/filtertestperf.go
@@ -79,6 +79,7 @@ func filterPerfCmd(ctx *cli.Context) error {
 			slices.Sort(qt.runtime)
 			qt.medianTime = qt.runtime[len(qt.runtime)/2]
 			if qt.query.Err != nil {
+				qt.query.printError()
 				failed++
 				continue
 			}
@@ -119,8 +120,10 @@ func filterPerfCmd(ctx *cli.Context) error {
 	sort.Slice(queries, func(i, j int) bool {
 		return queries[i].medianTime > queries[j].medianTime
 	})
-	for i := 0; i < 10; i++ {
-		q := queries[i]
+	for i, q := range queries {
+		if i >= 10 {
+			break
+		}
 		fmt.Printf("Most expensive query #%-2d   median runtime: %13v  max runtime: %13v  result count: %4d  fromBlock: %9d  toBlock: %9d  addresses: %v  topics: %v\n",
 			i+1, q.medianTime, q.runtime[len(q.runtime)-1], len(q.query.results), q.query.FromBlock, q.query.ToBlock, q.query.Address, q.query.Topics)
 	}


### PR DESCRIPTION
This PR fixes the broken request error handling of the workload filter tests. Until now `validateHistoryPruneErr` was invoked with `fq.Err` as an input which was always nil and a timeout or http error was reported as a result content mismatch.
Also, in case of `errPrunedHistory` it is wrong to return here without setting an error because then it will look like a valid empty result and the check will later fail. So instead `errPrunedHistory` is always returned now (without printing an error message) and the callers of `run` should handle this special case (typically ignore silently).