### PR TITLE
Remove drainning timer due to new implementation as of 1.23

### DIFF
--- a/rpc/websocket.go
+++ b/rpc/websocket.go
@@ -356,9 +356,7 @@ func (wc *websocketCodec) pingLoop() {
 			return
 
 		case <-wc.pingReset:
-			if !pingTimer.Stop() {
-				<-pingTimer.C
-			}
+			pingTimer.Stop()
 			pingTimer.Reset(wsPingInterval)
 
 		case <-pingTimer.C:


### PR DESCRIPTION
- The implementation of go [timer](https://pkg.go.dev/time@go1.23.0#Timer.Stop) as of go1.23 has changed. 
Quoting the godocs of method `Stop()`:
`For a chan-based timer created with NewTimer(d), as of Go 1.23, any receive from t.C after Stop has returned is guaranteed to block rather than receive a stale time value from before the Stop`

In the current implementation of `pingLoop()` [method](https://github.com/ethereum/go-ethereum/blob/master/rpc/websocket.go#L348) for rpc-websocket, the method `Stop()` is called, and if it returns false, then the channel timer.C is received. In that case, the goroutine will get blocked forever, in consequence getting leaked.
`pingTimer` is exclusively handled inside the method `pingLoop()`, so now `Stop()` is returning always true, making the risk of goroutine-leak zero. In that sense, this change is just to completely erase the possibility of getting indefinitely block and adapt the usage of the timer to 1.23+.