### PR TITLE
Fix "hooks.OnTxEnd" that is passing nil receipt

### DIFF
--- a/core/state_processor.go
+++ b/core/state_processor.go
@@ -161,7 +161,8 @@ func ApplyTransactionWithEVM(msg *Message, gp *GasPool, statedb *state.StateDB, 
 		statedb.AccessEvents().Merge(evm.AccessEvents)
 	}
 
-	return MakeReceipt(evm, result, statedb, blockNumber, blockHash, tx, *usedGas, root), nil
+	receipt = MakeReceipt(evm, result, statedb, blockNumber, blockHash, tx, *usedGas, root)
+	return receipt, nil
 }
 
 // MakeReceipt generates the receipt object for a transaction given its execution result.


### PR DESCRIPTION
This pull request includes a small but important change to the `core/state_processor.go` file. The change involves modifying the return statement in the `ApplyTransactionWithEVM` function to assign the result of `MakeReceipt` to a variable before returning it in order the `hooks.OnTxEnd` can pass it to the tracers.