### PR TITLE
tracers/prestate: always remove empty accounts from pre-state

### DIFF
--- a/eth/tracers/native/prestate.go
+++ b/eth/tracers/native/prestate.go
@@ -177,11 +177,9 @@ func (t *prestateTracer) OnTxEnd(receipt *types.Receipt, err error) {
 	if t.config.DiffMode {
 		t.processDiffState()
 	}
-	// the new created contracts' prestate were empty, so delete them
-	for a := range t.created {
-		// the created contract maybe exists in statedb before the creating tx
-		if s := t.pre[a]; s != nil && s.empty {
-			delete(t.pre, a)
+	for addr, s := range t.pre {
+		if s.empty {
+			delete(t.pre, addr)
 		}
 	}
 }


### PR DESCRIPTION
I am creating this PR to continue my chat with @s1na about the prestate native tracer.

The current code only removes empty accounts from the prestate if they are created contracts. Any other added empty accounts are left for the prestate output. 

A priori, this looked weird since I don't see a reason to keep _any_ empty account in the returned pre-state. If the tracer _always_ keeps empty accounts or _always_ removes them, that sounds reasonable (although adding empty accounts doesn't add much value).

Adding empty accounts to `pre` still makes sense since `pre` is used for `config.DiffMode==true`, so the pre vs. post diff can be generated.

Even if removing all empty accounts after generating the (potentially) state diff sounds reasonable, this might be considered a breaking change, i.e., maybe some users assume non-created empty accounts appear in the output.

I am leaving this as a draft PR to continue the discussion here, as requested by @s1na.