### PR TITLE
core/filtermaps: allow log search while head indexing

### DIFF
--- a/core/filtermaps/map_renderer.go
+++ b/core/filtermaps/map_renderer.go
@@ -392,7 +392,9 @@ func (r *mapRenderer) writeFinishedMaps(pauseCb func() bool) error {
 			}
 			// do not exit while in partially written state but do allow processing
 			// events and pausing while block processing is in progress
+			r.f.indexLock.Unlock()
 			pauseCb()
+			r.f.indexLock.Lock()
 			batch = r.f.db.NewBatch()
 		}
 	}

--- a/core/filtermaps/map_renderer.go
+++ b/core/filtermaps/map_renderer.go
@@ -397,7 +397,9 @@ func (r *mapRenderer) writeFinishedMaps(pauseCb func() bool) error {
 		}
 	}
 
-	r.f.setRange(batch, r.f.indexedView, tempRange)
+	if tempRange != r.f.indexedRange {
+		r.f.setRange(batch, r.f.indexedView, tempRange, true)
+	}
 	// add or update filter rows
 	for rowIndex := uint32(0); rowIndex < r.f.mapHeight; rowIndex++ {
 		var (
@@ -469,7 +471,7 @@ func (r *mapRenderer) writeFinishedMaps(pauseCb func() bool) error {
 	}
 	r.finishedMaps = make(map[uint32]*renderedMap)
 	r.finished.SetFirst(r.finished.AfterLast())
-	r.f.setRange(batch, renderedView, newRange)
+	r.f.setRange(batch, renderedView, newRange, false)
 	if err := batch.Write(); err != nil {
 		log.Crit("Error writing log index update batch", "error", err)
 	}

--- a/core/filtermaps/matcher_backend.go
+++ b/core/filtermaps/matcher_backend.go
@@ -125,7 +125,7 @@ func (fm *FilterMapsMatcherBackend) synced() {
 		indexedBlocks.SetAfterLast(indexedBlocks.Last()) // remove partially indexed last block
 	}
 	fm.syncCh <- SyncRange{
-		HeadNumber:    fm.f.indexedView.headNumber,
+		HeadNumber:    fm.f.targetView.headNumber,
 		ValidBlocks:   fm.validBlocks,
 		IndexedBlocks: indexedBlocks,
 	}


### PR DESCRIPTION
This PR changes the matcher syncing conditions so that it is possible to run a search while head indexing is in progress. Previously it was a requirement to have the head indexed in order to perform matcher sync before and after a search. This was unnecessarily strict as the purpose was just to avoid syncing the valid range with the temporary shortened indexed range applied while updating existing head maps. Now the sync condition explicitly checks whether the indexer has a temporary indexed range with some head maps being partially updated.
It also fixes a deadlock that happened when matcher synchronization was attempted in the event handler called from the `writeFinishedMaps` periodical callback.