### PR TITLE
cmd/utils: force hash scheme for archive mode

### DIFF
--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -1659,12 +1659,16 @@ func SetEthConfig(ctx *cli.Context, stack *node.Node, cfg *ethconfig.Config) {
 		log.Warn("The flag --txlookuplimit is deprecated and will be removed, please use --history.transactions")
 		cfg.TransactionHistory = ctx.Uint64(TxLookupLimitFlag.Name)
 	}
-	if ctx.String(GCModeFlag.Name) == "archive" && cfg.TransactionHistory != 0 {
-		cfg.TransactionHistory = 0
-		log.Warn("Disabled transaction unindexing for archive node")
+	if ctx.String(GCModeFlag.Name) == "archive" {
+		if cfg.TransactionHistory != 0 {
+			cfg.TransactionHistory = 0
+			log.Warn("Disabled transaction unindexing for archive node")
+		}
 
-		cfg.StateScheme = rawdb.HashScheme
-		log.Warn("Forcing hash state-scheme for archive mode")
+		if cfg.StateScheme != rawdb.HashScheme {
+			cfg.StateScheme = rawdb.HashScheme
+			log.Warn("Forcing hash state-scheme for archive mode")
+		}
 	}
 	if ctx.IsSet(LogHistoryFlag.Name) {
 		cfg.LogHistory = ctx.Uint64(LogHistoryFlag.Name)


### PR DESCRIPTION
`geth` can't catch this situation:
- Init geth db
`geth init genesis.json --state.scheme=path`
- `geth` can start normally with `archive` mode and `path` scheme, but it's not right
```geth --gcmode=archive --history.transactions=0 --state.scheme=path```


