### PR TITLE
internal/debug: add debug_setMemoryLimit

### DIFF
--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -494,7 +494,7 @@ var (
 		Value:    "gokzg",
 		Category: flags.PerfCategory,
 	}
-	
+
 	// Miner settings
 	MinerGasLimitFlag = &cli.Uint64Flag{
 		Name:     "miner.gaslimit",

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -494,6 +494,7 @@ var (
 		Value:    "gokzg",
 		Category: flags.PerfCategory,
 	}
+	
 	// Miner settings
 	MinerGasLimitFlag = &cli.Uint64Flag{
 		Name:     "miner.gaslimit",

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -24,13 +24,11 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"math"
 	"math/big"
 	"net"
 	"net/http"
 	"os"
 	"path/filepath"
-	godebug "runtime/debug"
 	"strconv"
 	"strings"
 	"time"
@@ -76,7 +74,6 @@ import (
 	"github.com/ethereum/go-ethereum/triedb/hashdb"
 	"github.com/ethereum/go-ethereum/triedb/pathdb"
 	pcsclite "github.com/gballet/go-libpcsclite"
-	gopsutil "github.com/shirou/gopsutil/mem"
 	"github.com/urfave/cli/v2"
 )
 
@@ -494,7 +491,6 @@ var (
 		Value:    "gokzg",
 		Category: flags.PerfCategory,
 	}
-
 	// Miner settings
 	MinerGasLimitFlag = &cli.Uint64Flag{
 		Name:     "miner.gaslimit",
@@ -1579,38 +1575,18 @@ func SetEthConfig(ctx *cli.Context, stack *node.Node, cfg *ethconfig.Config) {
 	setRequiredBlocks(ctx, cfg)
 	setLes(ctx, cfg)
 
-	// Cap the cache allowance and tune the garbage collector
-	mem, err := gopsutil.VirtualMemory()
-	if err == nil {
-		if 32<<(^uintptr(0)>>63) == 32 && mem.Total > 2*1024*1024*1024 {
-			log.Warn("Lowering memory allowance on 32bit arch", "available", mem.Total/1024/1024, "addressable", 2*1024)
-			mem.Total = 2 * 1024 * 1024 * 1024
-		}
-		allowance := int(mem.Total / 1024 / 1024 / 3)
-		if cache := ctx.Int(CacheFlag.Name); cache > allowance {
-			log.Warn("Sanitizing cache to Go's GC limits", "provided", cache, "updated", allowance)
-			ctx.Set(CacheFlag.Name, strconv.Itoa(allowance))
-		}
-	}
-	// Ensure Go's GC ignores the database cache for trigger percentage
-	cache := ctx.Int(CacheFlag.Name)
-	gogc := math.Max(20, math.Min(100, 100/(float64(cache)/1024)))
-
-	log.Debug("Sanitizing Go's GC trigger", "percent", int(gogc))
-	godebug.SetGCPercent(int(gogc))
-
 	if ctx.IsSet(SyncTargetFlag.Name) {
 		cfg.SyncMode = ethconfig.FullSync // dev sync target forces full sync
 	} else if ctx.IsSet(SyncModeFlag.Name) {
 		value := ctx.String(SyncModeFlag.Name)
-		if err = cfg.SyncMode.UnmarshalText([]byte(value)); err != nil {
+		if err := cfg.SyncMode.UnmarshalText([]byte(value)); err != nil {
 			Fatalf("--%v: %v", SyncModeFlag.Name, err)
 		}
 	}
 
 	if ctx.IsSet(ChainHistoryFlag.Name) {
 		value := ctx.String(ChainHistoryFlag.Name)
-		if err = cfg.HistoryMode.UnmarshalText([]byte(value)); err != nil {
+		if err := cfg.HistoryMode.UnmarshalText([]byte(value)); err != nil {
 			Fatalf("--%s: %v", ChainHistoryFlag.Name, err)
 		}
 	}

--- a/internal/debug/api.go
+++ b/internal/debug/api.go
@@ -238,6 +238,9 @@ func (*HandlerT) SetGCPercent(v int) int {
 }
 
 // SetMemoryLimit sets the GOMEMLIMIT for the process. It returns the previous limit.
+// Note:
+//   - Geth also allocates memory off-heap, particularly for fastCache and Pebble, which can be non-trivial (a few gigabytes by default).
+//   - Setting the limit too low will cause Geth to become unresponsive.
 func (*HandlerT) SetMemoryLimit(limit int64) int64 {
 	return debug.SetMemoryLimit(limit)
 }

--- a/internal/debug/api.go
+++ b/internal/debug/api.go
@@ -237,6 +237,11 @@ func (*HandlerT) SetGCPercent(v int) int {
 	return debug.SetGCPercent(v)
 }
 
+// SetMemoryLimit sets the GOMEMLIMIT for the process. It returns the previous limit.
+func (*HandlerT) SetMemoryLimit(limit int64) int64 {
+	return debug.SetMemoryLimit(limit)
+}
+
 func writeProfile(name, file string) error {
 	p := pprof.Lookup(name)
 	log.Info("Writing profile records", "count", p.Count(), "type", name, "dump", file)

--- a/internal/debug/api.go
+++ b/internal/debug/api.go
@@ -239,7 +239,7 @@ func (*HandlerT) SetGCPercent(v int) int {
 
 // SetMemoryLimit sets the GOMEMLIMIT for the process. It returns the previous limit.
 // Note:
-//   - The input limit is provided as bytes, and includes all memory mapped, managed, and not released by the Go runtime.
+//   - The input limit is provided as bytes. A negative input does not adjust the limit
 //   - A zero limit or a limit that's lower than the amount of memory used by the Go runtime may cause the garbage collector to runnearly continuously. However, the application may still make progress.
 //   - Setting the limit too low will cause Geth to become unresponsive.
 //   - Geth also allocates memory off-heap, particularly for fastCache and Pebble, which can be non-trivial (a few gigabytes by default).

--- a/internal/debug/api.go
+++ b/internal/debug/api.go
@@ -35,6 +35,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/hashicorp/go-bexpr"
 )
@@ -239,12 +240,19 @@ func (*HandlerT) SetGCPercent(v int) int {
 
 // SetMemoryLimit sets the GOMEMLIMIT for the process. It returns the previous limit.
 // Note:
+//
 //   - The input limit is provided as bytes. A negative input does not adjust the limit
-//   - A zero limit or a limit that's lower than the amount of memory used by the Go runtime may cause the garbage collector to runnearly continuously. However, the application may still make progress.
+//
+//   - A zero limit or a limit that's lower than the amount of memory used by the Go
+//     runtime may cause the garbage collector to run nearly continuously. However,
+//     the application may still make progress.
+//
 //   - Setting the limit too low will cause Geth to become unresponsive.
-//   - Geth also allocates memory off-heap, particularly for fastCache and Pebble, which can be non-trivial (a few gigabytes by default).
+//
+//   - Geth also allocates memory off-heap, particularly for fastCache and Pebble,
+//     which can be non-trivial (a few gigabytes by default).
 func (*HandlerT) SetMemoryLimit(limit int64) int64 {
-	log.Info("Setting memory limit", "limit(MB)", limit/1024/1024)
+	log.Info("Setting memory limit", "size", common.PrettyDuration(limit))
 	return debug.SetMemoryLimit(limit)
 }
 

--- a/internal/debug/api.go
+++ b/internal/debug/api.go
@@ -239,9 +239,12 @@ func (*HandlerT) SetGCPercent(v int) int {
 
 // SetMemoryLimit sets the GOMEMLIMIT for the process. It returns the previous limit.
 // Note:
-//   - Geth also allocates memory off-heap, particularly for fastCache and Pebble, which can be non-trivial (a few gigabytes by default).
+//   - The input limit is provided as bytes, and includes all memory mapped, managed, and not released by the Go runtime.
+//   - A zero limit or a limit that's lower than the amount of memory used by the Go runtime may cause the garbage collector to runnearly continuously. However, the application may still make progress.
 //   - Setting the limit too low will cause Geth to become unresponsive.
+//   - Geth also allocates memory off-heap, particularly for fastCache and Pebble, which can be non-trivial (a few gigabytes by default).
 func (*HandlerT) SetMemoryLimit(limit int64) int64 {
+	log.Info("Setting memory limit", "limit(MB)", limit/1024/1024)
 	return debug.SetMemoryLimit(limit)
 }
 

--- a/internal/web3ext/web3ext.go
+++ b/internal/web3ext/web3ext.go
@@ -270,6 +270,11 @@ web3._extend({
 			params: 1,
 		}),
 		new web3._extend.Method({
+			name: 'setMemoryLimit',
+			call: 'debug_setMemoryLimit',
+			params: 1,
+		}),
+		new web3._extend.Method({
 			name: 'memStats',
 			call: 'debug_memStats',
 			params: 0,


### PR DESCRIPTION
when send too many transaction to txpool during my benchmark, the golang gc will take 1/3 CPU profile.

<img width="1793" alt="image" src="https://github.com/user-attachments/assets/09cdc6b4-1f93-4a2c-8a2e-7116186377aa" />

I want to use the `ballast` mechanism to reduce the gc times to reduce golang GC CPU cost. I try GOGC = 500 and GOMEMLIMIT=10G, but it doesn't work. mainly because this section of code limits the GOGC to never be over 100. 

https://github.com/ethereum/go-ethereum/blob/03cc2942c2c25208dac1b7c8fc1bc19f3d72fd97/cmd/utils/flags.go#L1583-L1597

Assuming the memory is 30G, GOGC value is 20 after the calculation. It also means the larger the memory, the smaller the gogc. This will make the Golang GC very frequent, wasting the CPU resources, so suggest removing this part.

If we wonder about the large number of txs that trigger the OOM, the suggestion is to set GOMEMLIMIT depending on the realistic situation.

For my benchmark, I have enough memory, I don't want the CPU waste on GC, I want to use `ballast` to reduce the GC times, I need a big GOGC value. here is the performance after the adjustment.

<img width="1786" alt="image" src="https://github.com/user-attachments/assets/d18edf61-071b-4b16-8074-d1bd70cb863e" />

The throughput increased 25% from 45Mgas/s to 55Mgas/s

### Before update
![Before update](https://github.com/user-attachments/assets/f736425a-4bca-47f0-b0af-02492a664cfb)

### After update.
![After update](https://github.com/user-attachments/assets/44577280-5b28-4691-ac4f-fa0451cc4c6e)

And most of the time, just keeping the GOGC = 100 is a good decision
