### PR TITLE
internal/ethapi: return code 3 in eth_simulate for reverts

### DIFF
--- a/internal/ethapi/errors.go
+++ b/internal/ethapi/errors.go
@@ -36,7 +36,7 @@ type revertError struct {
 // ErrorCode returns the JSON error code for a revert.
 // See: https://github.com/ethereum/wiki/wiki/JSON-RPC-Error-Codes-Improvement-Proposal
 func (e *revertError) ErrorCode() int {
-	return 3
+	return errCodeReverted
 }
 
 // ErrorData returns the hex encoded revert reason.
@@ -106,7 +106,7 @@ const (
 	errCodeClientLimitExceeded     = -38026
 	errCodeInternalError           = -32603
 	errCodeInvalidParams           = -32602
-	errCodeReverted                = -32000
+	errCodeReverted                = 3
 	errCodeVMError                 = -32015
 )
 

--- a/internal/ethapi/simulate.go
+++ b/internal/ethapi/simulate.go
@@ -248,7 +248,7 @@ func (sim *simulator) processBlock(ctx context.Context, block *simBlock, header,
 			if errors.Is(result.Err, vm.ErrExecutionReverted) {
 				// If the result contains a revert reason, try to unpack it.
 				revertErr := newRevertError(result.Revert())
-				callRes.Error = &callError{Message: revertErr.Error(), Code: errCodeReverted, Data: revertErr.ErrorData().(string)}
+				callRes.Error = &callError{Message: revertErr.Error(), Code: revertErr.ErrorCode(), Data: revertErr.ErrorData().(string)}
 			} else {
 				callRes.Error = &callError{Message: result.Err.Error(), Code: errCodeVMError}
 			}


### PR DESCRIPTION
Revert error has a special error code:

https://github.com/ethereum/go-ethereum/blob/main/internal/ethapi/errors.go#L36-L40

This changes the `errCodeReverted` to 3 and uses the `ErrorCode` function for the callError

the referenced wiki no longer exists, but is archived here: https://github.com/vapory-legacy/wiki/blob/master/JSON-RPC-Error-Codes-Improvement-Proposal.md

ref https://github.com/paradigmxyz/reth/issues/15126
