### PR TITLE
core/filtermaps: properly handle history cutoff while rendering index head (WIP)

### DIFF
--- a/core/filtermaps/filtermaps.go
+++ b/core/filtermaps/filtermaps.go
@@ -41,6 +41,8 @@ const (
 	cachedRenderSnapshots = 8    // saved map renderer data at block boundaries
 )
 
+var errHistoryCutoff = errors.New("cannot start indexing before history cutoff point")
+
 // FilterMaps is the in-memory representation of the log index structure that is
 // responsible for building and updating the index according to the canonical
 // chain.
@@ -278,8 +280,13 @@ func (f *FilterMaps) initChainView(chainView *ChainView) *ChainView {
 }
 
 // reset un-initializes the FilterMaps structure and removes all related data from
-// the database. The function returns true if everything was successfully removed.
-func (f *FilterMaps) reset() bool {
+// the database.
+// Note that in case of leveldb database the fallback implementation of DeleteRange
+// might take a long time to finish and deleting the entire database may be
+// interrupted by a shutdown. Deleting the filterMapsRange entry first does
+// guarantee though that the next init() will not return successfully until the
+// entire database has been cleaned.
+func (f *FilterMaps) reset() {
 	f.indexLock.Lock()
 	f.indexedRange = filterMapsRange{}
 	f.indexedView = nil
@@ -292,11 +299,16 @@ func (f *FilterMaps) reset() bool {
 	// deleting the range first ensures that resetDb will be called again at next
 	// startup and any leftover data will be removed even if it cannot finish now.
 	rawdb.DeleteFilterMapsRange(f.db)
-	return f.safeDeleteRange(rawdb.DeleteFilterMapsDb, "Resetting log index database")
+	f.safeDeleteRange(rawdb.DeleteFilterMapsDb, "Resetting log index database")
 }
 
 // init initializes an empty log index according to the current targetView.
 func (f *FilterMaps) init() error {
+	// ensure that there is no remaining data in the filter maps key range
+	if !f.safeDeleteRange(rawdb.DeleteFilterMapsDb, "Resetting log index database") {
+		return errors.New("could not reset log index database")
+	}
+
 	f.indexLock.Lock()
 	defer f.indexLock.Unlock()
 
@@ -316,6 +328,13 @@ func (f *FilterMaps) init() error {
 		if max > bestLen {
 			bestIdx, bestLen = idx, max
 		}
+	}
+	var initBlockNumber uint64
+	if bestLen > 0 {
+		initBlockNumber = checkpoints[bestIdx][bestLen-1].BlockNumber
+	}
+	if initBlockNumber < f.historyCutoff {
+		return errHistoryCutoff
 	}
 	batch := f.db.NewBatch()
 	for epoch := range bestLen {

--- a/core/filtermaps/indexer.go
+++ b/core/filtermaps/indexer.go
@@ -42,6 +42,11 @@ func (f *FilterMaps) indexerLoop() {
 
 	for !f.stop {
 		if !f.indexedRange.initialized {
+			if f.targetView.headNumber == 0 {
+				// initialize when chain head is available
+				f.processSingleEvent(true)
+				continue
+			}
 			if err := f.init(); err != nil {
 				log.Error("Error initializing log index", "error", err)
 				// unexpected error; there is not a lot we can do here, maybe it

--- a/core/filtermaps/map_renderer.go
+++ b/core/filtermaps/map_renderer.go
@@ -681,7 +681,7 @@ func (f *FilterMaps) newLogIteratorFromMapBoundary(mapIndex uint32, startBlock, 
 	// get block receipts
 	receipts := f.targetView.getReceipts(startBlock)
 	if receipts == nil {
-		return nil, fmt.Errorf("receipts not found for start block %d", startBlock)
+		return nil, errHistoryCutoff
 	}
 	// initialize iterator at block start
 	l := &logIterator{
@@ -748,7 +748,7 @@ func (l *logIterator) next() error {
 		l.blockNumber++
 		l.receipts = l.chainView.getReceipts(l.blockNumber)
 		if l.receipts == nil {
-			return fmt.Errorf("receipts not found for block %d", l.blockNumber)
+			return errHistoryCutoff
 		}
 		l.txIndex, l.logIndex, l.topicIndex, l.blockStart = 0, 0, 0, true
 	} else {


### PR DESCRIPTION
This PR ensures safe behavior of the log indexer when head indexing cannot be performed because of history cutoff. Previously only the tail indexing conditions were aware of the cutoff point.
Now if a receipt is missing, the renderer returns `errHistoryCutoff` in which case the indexer main loop will not reattempt the same thing but instead it will reset the database, triggering a new checkpoint initialization attempt (maybe the database was old but the client has been updated and has recent checkpoints). If the latest checkpoint is also older than the cutoff point then the `init` function also returns `errHistoryCutoff` and the indexer goes into disabled state.
Another issue fixed here is that in case of unexpected errors `waitForEvent` was called which was incorrect because what it really did was that it waited for a new target head and if there was already an unindexed target head then it did not block at all, letting the indexer loop to spin on max speed with the same error, not even noticing node shutdown.

This PR is based on top of https://github.com/ethereum/go-ethereum/pull/31081 because it also touches the database reset logic which has been refactored in that previous PR.