### PR TITLE
cmd/devp2p: add domain flag to key command for public domain specific…

### DIFF
--- a/cmd/devp2p/keycmd.go
+++ b/cmd/devp2p/keycmd.go
@@ -56,7 +56,7 @@ var (
 		Usage:     "Creates an enode URL from a node key file",
 		ArgsUsage: "keyfile",
 		Action:    keyToURL,
-		Flags:     []cli.Flag{hostFlag, tcpPortFlag, udpPortFlag},
+		Flags:     []cli.Flag{domainFlag, hostFlag, tcpPortFlag, udpPortFlag},
 	}
 	keyToRecordCommand = &cli.Command{
 		Name:      "to-enr",
@@ -68,6 +68,10 @@ var (
 )
 
 var (
+	domainFlag = &cli.StringFlag{
+		Name:  "domain",
+		Usage: "Public domain of the node",
+	}
 	hostFlag = &cli.StringFlag{
 		Name:  "ip",
 		Usage: "IP address of the node",
@@ -112,6 +116,7 @@ func keyToURL(ctx *cli.Context) error {
 	if err != nil {
 		return err
 	}
+	n = n.WithHostname(ctx.String(domainFlag.Name))
 	fmt.Println(n.URLv4())
 	return nil
 }


### PR DESCRIPTION
1. Command `devp2p key to-enode` to generate encode, often showing IP instead of domain name. When running in a container, the hostname is not accurate or even unavailable. https://github.com/ethereum/go-ethereum/blob/804d45cc2eddd92ee4b9940875e4a6914ec5256f/p2p/enode/urlv4.go#L177-L178
2. This pr generates the encode by adding a custom domain flag, which is convenient for sending to others.
    ```bash
    ~ devp2p git:(master) ✗ ./devp2p key to-enode --domain node1.someone.com /tmp/el1.key
    enode://8b3f8deeaa247310c2d7e207160e3e78a43af5c4c0cacfd6991bf7a0d381bb1b897cb9e1516e0548bdf018cf628f30b0876e358f6c5938413c260b41a965d590@node1.someone.com:30303
    ```