### PR TITLE
internal/ethapi: return code 3 from call/estimateGas even if a revert reason was not returned

### DIFF
--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -761,8 +761,7 @@ func (api *BlockChainAPI) Call(ctx context.Context, args TransactionArgs, blockN
 	if err != nil {
 		return nil, err
 	}
-	// If the result contains a revert reason, try to unpack and return it.
-	if len(result.Revert()) > 0 {
+	if errors.Is(result.Err, vm.ErrExecutionReverted) {
 		return nil, newRevertError(result.Revert())
 	}
 	return result.Return(), result.Err
@@ -842,7 +841,7 @@ func DoEstimateGas(ctx context.Context, b Backend, args TransactionArgs, blockNr
 	// Run the gas estimation and wrap any revertals into a custom return
 	estimate, revert, err := gasestimator.Estimate(ctx, call, opts, gasCap)
 	if err != nil {
-		if len(revert) > 0 {
+		if errors.Is(err, vm.ErrExecutionReverted) {
 			return 0, newRevertError(revert)
 		}
 		return 0, err


### PR DESCRIPTION
Currently we only return a `revertError` from `BlockchainAPI.(DoCall,EstimateGas)` when execution reverts with non-empty revert reason.

If the revert data is empty, the RPC response is constructed with a generic `errCodeDefault` code [here](https://github.com/ethereum/go-ethereum/blob/master/rpc/json.go#L125).

By altering the behavior to return a `revertError` from `DoCall`/`DoEstimateGas` upon revert regardless of whether there was a reason supplied, we consistently return the same revert error code whenever a revert occurs from `eth_estimateGas`/`eth_call`.

## Steps to Verify this PR is Correct

Using the genesis files I have attached in [this](https://gist.github.com/jwasinger/013eb28996f63549bbf7f63dba4ec819) gist:

Spin up a dev-mode instance of Geth.  The genesis contains an account `0x1000000000000000000000000000000000000001` which when called will revert with no data.
```
./build/bin/geth --datadir ./data init genesis-empty-revert.json
./build/bin/geth --dev --datadir ./data --http --http.api eth
```

In a separate terminal:
```
> curl http://localhost:8545 \
  -X POST \
  -H "Content-Type: application/json" \
  --data '{"jsonrpc":"2.0","method":"eth_call","params":[{"to": "0x1000000000000000000000000000000000000001"}],"id":1}'
```

which on master outputs:
```
{"jsonrpc":"2.0","id":1,"error":{"code":-32000,"message":"execution reverted"}}
```

with this PR:
```
{"jsonrpc":"2.0","id":1,"error":{"code":3,"message":"execution reverted","data":"0x"}}
```

Now repeat the process again, except this time instantiating the datadir with `genesis-nonempty-revert.json`:  The `0x1000000000000000000000000000000000000001` account now contains code that reverts with a single byte of revert data.

On master, and this PR:
```
{"jsonrpc":"2.0","id":1,"error":{"code":3,"message":"execution reverted","data":"0x00"}}
```

The same instructions can be repeated except with `eth_call` instead of `eth_estimateGas` and produce the same results as above.