### PR TITLE
core/state: return hex format of next value

### DIFF
--- a/core/state/dump.go
+++ b/core/state/dump.go
@@ -65,7 +65,7 @@ type Dump struct {
 	Accounts map[string]DumpAccount `json:"accounts"`
 	// Next can be set to represent that this dump is only partial, and Next
 	// is where an iterator should be positioned in order to continue the dump.
-	Next []byte `json:"next,omitempty"` // nil if no more accounts
+	Next hexutil.Bytes `json:"next,omitempty"` // nil if no more accounts
 }
 
 // OnRoot implements DumpCollector interface
@@ -188,7 +188,7 @@ func (s *StateDB) DumpToCollector(c DumpCollector, conf *DumpConfig) (nextKey []
 		c.OnAccount(address, account)
 		accounts++
 		if time.Since(logged) > 8*time.Second {
-			log.Info("Trie dumping in progress", "at", it.Key, "accounts", accounts,
+			log.Info("Trie dumping in progress", "at", common.Bytes2Hex(it.Key), "accounts", accounts,
 				"elapsed", common.PrettyDuration(time.Since(start)))
 			logged = time.Now()
 		}


### PR DESCRIPTION
closes https://github.com/ethereum/go-ethereum/issues/31388
- Return hex format of the next value
- Fix log.