### PR TITLE
docs: add alternative build command in README if make geth fails

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,12 @@ or, to build the full suite of utilities:
 make all
 ```
 
+If make `geth fails` due to a missing `build/ci.go` file  or related error, you can instead build Geth directly using:
+
+```shell
+go build -o geth ./cmd/geth
+```
+
 ## Executables
 
 The go-ethereum project comes with several wrappers/executables found in the `cmd`


### PR DESCRIPTION
## Problem

Following the current README instructions, running `make geth` on a clean clone may fail with:

This happens because the Makefile relies on `build/ci.go`, which may not exist in a fresh environment.

## Solution

This PR updates the README with an alternative `go build -o geth ./cmd/geth` command as a fallback when `make geth` fails.

✅ This only affects documentation  
✅ No code logic was changed
