### PR TITLE
core/state: store storageOrigin in one map

### DIFF
--- a/core/state/statedb.go
+++ b/core/state/statedb.go
@@ -1213,7 +1213,7 @@ func (s *StateDB) commit(deleteEmptyObjects bool, noStorageWiping bool) (*stateU
 		// Run the storage updates concurrently to one another
 		workers.Go(func() error {
 			// Write any storage changes in the state object to its storage trie
-			update, set, err := obj.commit()
+			update, set, err := obj.commit(noStorageWiping)
 			if err != nil {
 				return err
 			}

--- a/core/state/stateupdate.go
+++ b/core/state/stateupdate.go
@@ -55,9 +55,10 @@ type accountUpdate struct {
 	// The map key refers to the **HASH** of the raw storage slot key.
 	storages map[common.Hash][]byte
 
-	// storagesOrigin store the original values of mutated slots in prefix-zero-trimmed RLP format.
-	// if `rawStorageKey` is true, the map key refers to the **RAW** storage slot key,
-	// else the **HASH** of the raw storage slot key.
+	// storagesOrigin store the original values of mutated slots in
+	// prefix-zero-trimmed RLP format.
+	// - the map key refers to the **RAW** slot key if `rawStorageKey` is true
+	// - the map key refers to the **HASH** of slot key if `rawStorageKey` is false
 	storagesOrigin map[common.Hash][]byte
 }
 


### PR DESCRIPTION
Seems we don't need to store the storagesOrigin in two maps, store in one map is enough.