### PR TITLE
eth: downgrade peer removal error to warning level

### DIFF
--- a/eth/handler.go
+++ b/eth/handler.go
@@ -403,7 +403,7 @@ func (h *handler) unregisterPeer(id string) {
 	// Abort if the peer does not exist
 	peer := h.peers.peer(id)
 	if peer == nil {
-		logger.Error("Ethereum peer removal failed", "err", errPeerNotRegistered)
+		logger.Warn("Ethereum peer removal failed", "err", errPeerNotRegistered)
 		return
 	}
 	// Remove the `eth` peer if it exists


### PR DESCRIPTION
Lowers the logging level when a missing Ethereum peer is unsuccessfully deleted 
from ERROR to WARN, since this situation is not a critical system error.

The absence of a pir in the list when attempting to delete it may be expected in some 
situations, such as if the pir has been deleted by another process or has shut down on its own. 
Such events do not require immediate intervention and do not affect core network processes.

This change will reduce false positives in monitoring systems 
and improve the readability of the event log by keeping ERROR-level error messages 
only for truly critical situations.
