### PR TITLE
core/state: the metric of accountLoaded added once more

### DIFF
--- a/core/state/statedb.go
+++ b/core/state/statedb.go
@@ -600,7 +600,6 @@ func (s *StateDB) getStateObject(addr common.Address) *stateObject {
 	// Insert into the live set
 	obj := newObject(s, addr, acct)
 	s.setStateObject(obj)
-	s.AccountLoaded++
 	return obj
 }
 


### PR DESCRIPTION
The measurement `s.AccountLoaded` has been updated here, so no need to increase again https://github.com/ethereum/go-ethereum/blob/c49aadc4b628c55da9948b0a1f37f487129ce28a/core/state/statedb.go#L580-L603