### PR TITLE
core/rawdb: remove LES database stats

### DIFF
--- a/core/rawdb/database.go
+++ b/core/rawdb/database.go
@@ -388,10 +388,6 @@ func InspectDatabase(db ethdb.Database, keyPrefix, keyStart []byte) error {
 		verkleTries        stat
 		verkleStateLookups stat
 
-		// Les statistic
-		chtTrieNodes   stat
-		bloomTrieNodes stat
-
 		// Meta- and unaccounted data
 		metadata    stat
 		unaccounted stat
@@ -465,16 +461,6 @@ func InspectDatabase(db ethdb.Database, keyPrefix, keyStart []byte) error {
 		case bytes.HasPrefix(key, bloomBitsMetaPrefix) && len(key) < len(bloomBitsMetaPrefix)+8:
 			bloomBits.Add(size)
 
-		// LES indexes (deprecated)
-		case bytes.HasPrefix(key, chtTablePrefix) ||
-			bytes.HasPrefix(key, chtIndexTablePrefix) ||
-			bytes.HasPrefix(key, chtPrefix): // Canonical hash trie
-			chtTrieNodes.Add(size)
-		case bytes.HasPrefix(key, bloomTrieTablePrefix) ||
-			bytes.HasPrefix(key, bloomTrieIndexPrefix) ||
-			bytes.HasPrefix(key, bloomTriePrefix): // Bloomtrie sub
-			bloomTrieNodes.Add(size)
-
 		// Verkle trie data is detected, determine the sub-category
 		case bytes.HasPrefix(key, VerklePrefix):
 			remain := key[len(VerklePrefix):]
@@ -538,8 +524,6 @@ func InspectDatabase(db ethdb.Database, keyPrefix, keyStart []byte) error {
 		{"Key-Value store", "Beacon sync headers", beaconHeaders.Size(), beaconHeaders.Count()},
 		{"Key-Value store", "Clique snapshots", cliqueSnaps.Size(), cliqueSnaps.Count()},
 		{"Key-Value store", "Singleton metadata", metadata.Size(), metadata.Count()},
-		{"Light client", "CHT trie nodes", chtTrieNodes.Size(), chtTrieNodes.Count()},
-		{"Light client", "Bloom trie nodes", bloomTrieNodes.Size(), bloomTrieNodes.Count()},
 	}
 	// Inspect all registered append-only file store then.
 	ancients, err := inspectFreezers(db)

--- a/core/rawdb/schema.go
+++ b/core/rawdb/schema.go
@@ -144,14 +144,6 @@ var (
 	// old log index
 	bloomBitsMetaPrefix = []byte("iB")
 
-	// LES indexes
-	chtPrefix            = []byte("chtRootV2-") // ChtPrefix + chtNum (uint64 big endian) -> trie root hash
-	chtTablePrefix       = []byte("cht-")
-	chtIndexTablePrefix  = []byte("chtIndexV2-")
-	bloomTriePrefix      = []byte("bltRoot-") // BloomTriePrefix + bloomTrieNum (uint64 big endian) -> trie root hash
-	bloomTrieTablePrefix = []byte("blt-")
-	bloomTrieIndexPrefix = []byte("bltIndex-")
-
 	preimageCounter     = metrics.NewRegisteredCounter("db/preimage/total", nil)
 	preimageHitsCounter = metrics.NewRegisteredCounter("db/preimage/hits", nil)
 	preimageMissCounter = metrics.NewRegisteredCounter("db/preimage/miss", nil)


### PR DESCRIPTION
LES has been deprecated since Paris fork https://ethereum.org/en/history/#paris

It makes no sense to keep tracking LES data and should be safe to deprecate them