### PR TITLE
core: downgrade from error to warn

### DIFF
--- a/core/state/state_object.go
+++ b/core/state/state_object.go
@@ -328,11 +328,11 @@ func (s *stateObject) updateTrie() (Trie, error) {
 		// Skip noop changes, persist actual changes
 		value, exist := s.pendingStorage[key]
 		if value == origin {
-			log.Error("Storage update was noop", "address", s.address, "slot", key)
+			log.Warn("Storage update was noop", "address", s.address, "slot", key)
 			continue
 		}
 		if !exist {
-			log.Error("Storage slot is not found in pending area", s.address, "slot", key)
+			log.Warn("Storage slot is not found in pending area", s.address, "slot", key)
 			continue
 		}
 		if (value != common.Hash{}) {


### PR DESCRIPTION
This change is safe because the lack of changes to the store or the lack of a slot in the pending area is not a critical error, but rather indicates a potential inefficiency or logic problem in the code of the application using the contract.