### PR TITLE
Update Logging Level in Downloader

### DIFF
--- a/eth/downloader/downloader.go
+++ b/eth/downloader/downloader.go
@@ -278,7 +278,7 @@ func (d *Downloader) RegisterPeer(id string, version uint, peer Peer) error {
 	}
 	logger.Trace("Registering sync peer")
 	if err := d.peers.Register(newPeerConnection(id, version, peer, logger)); err != nil {
-		logger.Error("Failed to register sync peer", "err", err)
+		logger.Warn("Failed to register sync peer", "err", err)
 		return err
 	}
 	return nil
@@ -298,7 +298,7 @@ func (d *Downloader) UnregisterPeer(id string) error {
 	}
 	logger.Trace("Unregistering sync peer")
 	if err := d.peers.Unregister(id); err != nil {
-		logger.Error("Failed to unregister sync peer", "err", err)
+		logger.Warn("Failed to unregister sync peer", "err", err)
 		return err
 	}
 	d.queue.Revoke(id)


### PR DESCRIPTION


**Description:**  
This pull request updates the logging level for certain operations in the `downloader.go` file. Specifically, it changes the logging level from `Error` to `Warn` for failed peer registration and unregistration. This adjustment aims to reduce the severity of log messages for these operations, as they may not always indicate critical errors.
