### PR TITLE
eth/downloader: introduce stricter block body throttle throttling

### DIFF
--- a/eth/downloader/resultstore.go
+++ b/eth/downloader/resultstore.go
@@ -60,12 +60,7 @@ func (r *resultStore) SetThrottleThreshold(threshold uint64) uint64 {
 	defer r.lock.Unlock()
 
 	fmt.Printf("set throttle threshold: %d\n", threshold)
-
-	limit := uint64(len(r.items))
-	if threshold >= limit {
-		threshold = limit
-	}
-	r.throttleThreshold = threshold
+	r.throttleThreshold = min(uint64(len(r.items)), threshold)
 	return r.throttleThreshold
 }
 

--- a/eth/downloader/resultstore.go
+++ b/eth/downloader/resultstore.go
@@ -59,6 +59,8 @@ func (r *resultStore) SetThrottleThreshold(threshold uint64) uint64 {
 	r.lock.Lock()
 	defer r.lock.Unlock()
 
+	fmt.Printf("set throttle threshold: %d\n", threshold)
+
 	limit := uint64(len(r.items))
 	if threshold >= limit {
 		threshold = limit


### PR DESCRIPTION
Currently, Geth calculates an exponentially-weighted moving average for the size of recently downloaded blocks, and uses this as a heuristic to figure out how many recently-downloaded blocks Geth is willing to keep in memory while they are pending addition to the chain.  If we hit this number, we will throttle preventing subsequent requests for new blocks until the ones we have are imported into the chain.

Because this heuristic for expected average block size looks at recently downloaded blocks, we can have a situation where a prolonged lull in average block size drives the average down, causing Geth to increase the number of blocks it will simultaneously request.  Then, if the newly-downloaded blocks are much larger than we expected, Geth can choke and go OOM.

In practice, this can't actually happen in a real-world setting:  An attacker would have to be able to control the creation of a large sequence of hundreds of blocks.

However, we are seeing some OOMs in contrived attack scenarios, and this change intends to prevent those from occurring while  hopefully not having a measurable effect on the sync speed.