### PR TITLE
ethdb: introduce workaround to database range deleter

### DIFF
--- a/core/filtermaps/filtermaps.go
+++ b/core/filtermaps/filtermaps.go
@@ -29,7 +29,6 @@ import (
 	"github.com/ethereum/go-ethereum/core/rawdb"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/ethdb"
-	"github.com/ethereum/go-ethereum/ethdb/leveldb"
 	"github.com/ethereum/go-ethereum/log"
 )
 
@@ -377,7 +376,7 @@ func (f *FilterMaps) safeDeleteRange(removeFn func(ethdb.KeyValueRangeDeleter) e
 			}
 			return true
 		}
-		if err != leveldb.ErrTooManyKeys {
+		if errors.Is(err, ethdb.ErrTooManyKeys) {
 			log.Error(action+" failed", "error", err)
 			return false
 		}

--- a/ethdb/errors.go
+++ b/ethdb/errors.go
@@ -1,0 +1,23 @@
+// Copyright 2025 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+
+package ethdb
+
+import "errors"
+
+// ErrTooManyKeys is returned when the number of keys pending range
+// deletion exceeds the allowed limit.
+var ErrTooManyKeys = errors.New("exceeded maximum keys for range deletion")

--- a/ethdb/leveldb/leveldb.go
+++ b/ethdb/leveldb/leveldb.go
@@ -232,7 +232,7 @@ func (db *Database) DeleteRange(start, end []byte) error {
 	}()
 	for it.Next() && bytes.Compare(end, it.Key()) > 0 {
 		// Prevent deletion for trie nodes in hash mode
-		if h := crypto.HashData(buff, it.Value()); h == common.BytesToHash(it.Key()) {
+		if len(it.Key()) == 32 && crypto.HashData(buff, it.Value()) == common.BytesToHash(it.Key()) {
 			ignored++
 			continue
 		}

--- a/ethdb/pebble/pebble.go
+++ b/ethdb/pebble/pebble.go
@@ -370,7 +370,7 @@ func (d *Database) DeleteRange(start, end []byte) error {
 	}()
 	for it.Next() && bytes.Compare(end, it.Key()) > 0 {
 		// Prevent deletion for trie nodes in hash mode
-		if h := crypto.HashData(buff, it.Value()); h == common.BytesToHash(it.Key()) {
+		if len(it.Key()) == 32 && crypto.HashData(buff, it.Value()) == common.BytesToHash(it.Key()) {
 			ignored++
 			continue
 		}

--- a/ethdb/pebble/pebble.go
+++ b/ethdb/pebble/pebble.go
@@ -359,12 +359,19 @@ func (d *Database) DeleteRange(start, end []byte) error {
 	defer it.Release()
 
 	var (
-		count int
-		buff  = crypto.NewKeccakState()
+		count   int
+		ignored int
+		buff    = crypto.NewKeccakState()
 	)
+	defer func() {
+		if ignored > 0 {
+			log.Info("Skipped entries from deletion", "number", ignored)
+		}
+	}()
 	for it.Next() && bytes.Compare(end, it.Key()) > 0 {
 		// Prevent deletion for trie nodes in hash mode
 		if h := crypto.HashData(buff, it.Value()); h == common.BytesToHash(it.Key()) {
+			ignored++
 			continue
 		}
 		count++


### PR DESCRIPTION
This pull request introduces a workaround in the database range deleter:
if key == hash(value), the entry will be excluded from deletion.

In hash mode, trie nodes are stored using their hash as the database key
without any prefix. As a result, they may unintentionally collide with
entries marked for deletion. This workaround will remain in place until
hash mode is fully deprecated.