### PR TITLE
downgrade from error to warn

### DIFF
--- a/eth/downloader/fetchers_concurrent.go
+++ b/eth/downloader/fetchers_concurrent.go
@@ -254,7 +254,7 @@ func (d *Downloader) concurrentFetch(queue typedQueue) error {
 			// timeout firing for a non-existent event.
 			req, exp := timeouts.Peek()
 			if now, at := time.Now(), time.Unix(0, -exp); now.Before(at) {
-				log.Error("Timeout triggered but not reached", "left", at.Sub(now))
+				log.Warn("Timeout triggered but not reached", "left", at.Sub(now))
 				timeout.Reset(at.Sub(now))
 				continue
 			}


### PR DESCRIPTION
This message may be downgraded to a WARN because it indicates an unexpected order of events that should not occur in a properly running program, but it is not a fatal error and the system can continue to operate.