### PR TITLE
chore: refine wlock to rlock

### DIFF
--- a/core/txpool/legacypool/legacypool.go
+++ b/core/txpool/legacypool/legacypool.go
@@ -474,8 +474,8 @@ func (pool *LegacyPool) stats() (int, int) {
 // Content retrieves the data content of the transaction pool, returning all the
 // pending as well as queued transactions, grouped by account and sorted by nonce.
 func (pool *LegacyPool) Content() (map[common.Address][]*types.Transaction, map[common.Address][]*types.Transaction) {
-	pool.mu.Lock()
-	defer pool.mu.Unlock()
+	pool.mu.RLock()
+	defer pool.mu.RUnlock()
 
 	pending := make(map[common.Address][]*types.Transaction, len(pool.pending))
 	for addr, list := range pool.pending {
@@ -516,8 +516,8 @@ func (pool *LegacyPool) Pending(filter txpool.PendingFilter) map[common.Address]
 	if filter.OnlyBlobTxs {
 		return nil
 	}
-	pool.mu.Lock()
-	defer pool.mu.Unlock()
+	pool.mu.RLock()
+	defer pool.mu.RUnlock()
 
 	// Convert the new uint256.Int types to the old big.Int ones used by the legacy pool
 	var (


### PR DESCRIPTION
LegacyPool Context()/Pending() method is read-only and does not modify txpool inner status, so rlock is enough and make more clear.

wlock is used due to list.flatten is not thread-safe in the past https://github.com/ethereum/go-ethereum/pull/27324, and this https://github.com/ethereum/go-ethereum/pull/27898 has ensured `list` is thread-safe.