### PR TITLE
core/txpool: add 7702 protection to blobpool

### DIFF
--- a/core/txpool/blobpool/blobpool.go
+++ b/core/txpool/blobpool/blobpool.go
@@ -1124,11 +1124,12 @@ func (p *BlobPool) checkDelegationLimit(tx *types.Transaction) error {
 			return nil
 		}
 	}
+	// Allow a single in-flight pending transaction.
 	pending := p.index[from]
 	if len(pending) == 0 {
 		return nil
 	}
-	// Transaction replacement is supported
+	// If account already has a pending transaction, allow replacement only.
 	if len(pending) == 1 && pending[0].nonce == tx.Nonce() {
 		return nil
 	}

--- a/core/txpool/blobpool/blobpool_test.go
+++ b/core/txpool/blobpool/blobpool_test.go
@@ -405,6 +405,10 @@ func verifyBlobRetrievals(t *testing.T, pool *BlobPool) {
 	}
 }
 
+func newReserver() *txpool.Reserver {
+	return txpool.NewReservationTracker().NewHandle(42)
+}
+
 // Tests that transactions can be loaded from disk on startup and that they are
 // correctly discarded if invalid.
 //
@@ -672,7 +676,7 @@ func TestOpenDrops(t *testing.T) {
 		statedb: statedb,
 	}
 	pool := New(Config{Datadir: storage}, chain, nil)
-	if err := pool.Init(1, chain.CurrentBlock(), txpool.NewReserver()); err != nil {
+	if err := pool.Init(1, chain.CurrentBlock(), newReserver()); err != nil {
 		t.Fatalf("failed to create blob pool: %v", err)
 	}
 	defer pool.Close()
@@ -790,7 +794,7 @@ func TestOpenIndex(t *testing.T) {
 		statedb: statedb,
 	}
 	pool := New(Config{Datadir: storage}, chain, nil)
-	if err := pool.Init(1, chain.CurrentBlock(), txpool.NewReserver()); err != nil {
+	if err := pool.Init(1, chain.CurrentBlock(), newReserver()); err != nil {
 		t.Fatalf("failed to create blob pool: %v", err)
 	}
 	defer pool.Close()
@@ -891,7 +895,7 @@ func TestOpenHeap(t *testing.T) {
 		statedb: statedb,
 	}
 	pool := New(Config{Datadir: storage}, chain, nil)
-	if err := pool.Init(1, chain.CurrentBlock(), txpool.NewReserver()); err != nil {
+	if err := pool.Init(1, chain.CurrentBlock(), newReserver()); err != nil {
 		t.Fatalf("failed to create blob pool: %v", err)
 	}
 	defer pool.Close()
@@ -970,7 +974,7 @@ func TestOpenCap(t *testing.T) {
 			statedb: statedb,
 		}
 		pool := New(Config{Datadir: storage, Datacap: datacap}, chain, nil)
-		if err := pool.Init(1, chain.CurrentBlock(), txpool.NewReserver()); err != nil {
+		if err := pool.Init(1, chain.CurrentBlock(), newReserver()); err != nil {
 			t.Fatalf("failed to create blob pool: %v", err)
 		}
 		// Verify that enough transactions have been dropped to get the pool's size
@@ -1071,7 +1075,7 @@ func TestChangingSlotterSize(t *testing.T) {
 			statedb: statedb,
 		}
 		pool := New(Config{Datadir: storage}, chain, nil)
-		if err := pool.Init(1, chain.CurrentBlock(), txpool.NewReserver()); err != nil {
+		if err := pool.Init(1, chain.CurrentBlock(), newReserver()); err != nil {
 			t.Fatalf("failed to create blob pool: %v", err)
 		}
 
@@ -1514,7 +1518,7 @@ func TestAdd(t *testing.T) {
 			statedb: statedb,
 		}
 		pool := New(Config{Datadir: storage}, chain, nil)
-		if err := pool.Init(1, chain.CurrentBlock(), txpool.NewReserver()); err != nil {
+		if err := pool.Init(1, chain.CurrentBlock(), newReserver()); err != nil {
 			t.Fatalf("test %d: failed to create blob pool: %v", i, err)
 		}
 		verifyPoolInternals(t, pool)
@@ -1613,7 +1617,7 @@ func benchmarkPoolPending(b *testing.B, datacap uint64) {
 		pool = New(Config{Datadir: ""}, chain, nil)
 	)
 
-	if err := pool.Init(1, chain.CurrentBlock(), txpool.NewReserver()); err != nil {
+	if err := pool.Init(1, chain.CurrentBlock(), newReserver()); err != nil {
 		b.Fatalf("failed to create blob pool: %v", err)
 	}
 	// Make the pool not use disk (just drop everything). This test never reads

--- a/core/txpool/blobpool/blobpool_test.go
+++ b/core/txpool/blobpool/blobpool_test.go
@@ -699,8 +699,8 @@ func TestOpenDrops(t *testing.T) {
 		blobfee: uint256.NewInt(params.BlobTxMinBlobGasprice),
 		statedb: statedb,
 	}
-	pool := New(Config{Datadir: storage}, chain)
-	if err := pool.Init(1, chain.CurrentBlock(), makeAddressReserver()); err != nil {
+	pool := New(Config{Datadir: storage}, chain, nil)
+	if err := pool.Init(1, chain.CurrentBlock(), makeAddressReserver(), nil); err != nil {
 		t.Fatalf("failed to create blob pool: %v", err)
 	}
 	defer pool.Close()
@@ -817,8 +817,8 @@ func TestOpenIndex(t *testing.T) {
 		blobfee: uint256.NewInt(params.BlobTxMinBlobGasprice),
 		statedb: statedb,
 	}
-	pool := New(Config{Datadir: storage}, chain)
-	if err := pool.Init(1, chain.CurrentBlock(), makeAddressReserver()); err != nil {
+	pool := New(Config{Datadir: storage}, chain, nil)
+	if err := pool.Init(1, chain.CurrentBlock(), makeAddressReserver(), nil); err != nil {
 		t.Fatalf("failed to create blob pool: %v", err)
 	}
 	defer pool.Close()
@@ -918,8 +918,8 @@ func TestOpenHeap(t *testing.T) {
 		blobfee: uint256.NewInt(105),
 		statedb: statedb,
 	}
-	pool := New(Config{Datadir: storage}, chain)
-	if err := pool.Init(1, chain.CurrentBlock(), makeAddressReserver()); err != nil {
+	pool := New(Config{Datadir: storage}, chain, nil)
+	if err := pool.Init(1, chain.CurrentBlock(), makeAddressReserver(), nil); err != nil {
 		t.Fatalf("failed to create blob pool: %v", err)
 	}
 	defer pool.Close()
@@ -997,8 +997,8 @@ func TestOpenCap(t *testing.T) {
 			blobfee: uint256.NewInt(105),
 			statedb: statedb,
 		}
-		pool := New(Config{Datadir: storage, Datacap: datacap}, chain)
-		if err := pool.Init(1, chain.CurrentBlock(), makeAddressReserver()); err != nil {
+		pool := New(Config{Datadir: storage, Datacap: datacap}, chain, nil)
+		if err := pool.Init(1, chain.CurrentBlock(), makeAddressReserver(), nil); err != nil {
 			t.Fatalf("failed to create blob pool: %v", err)
 		}
 		// Verify that enough transactions have been dropped to get the pool's size
@@ -1098,8 +1098,8 @@ func TestChangingSlotterSize(t *testing.T) {
 			blobfee: uint256.NewInt(105),
 			statedb: statedb,
 		}
-		pool := New(Config{Datadir: storage}, chain)
-		if err := pool.Init(1, chain.CurrentBlock(), makeAddressReserver()); err != nil {
+		pool := New(Config{Datadir: storage}, chain, nil)
+		if err := pool.Init(1, chain.CurrentBlock(), makeAddressReserver(), nil); err != nil {
 			t.Fatalf("failed to create blob pool: %v", err)
 		}
 
@@ -1541,8 +1541,8 @@ func TestAdd(t *testing.T) {
 			blobfee: uint256.NewInt(105),
 			statedb: statedb,
 		}
-		pool := New(Config{Datadir: storage}, chain)
-		if err := pool.Init(1, chain.CurrentBlock(), makeAddressReserver()); err != nil {
+		pool := New(Config{Datadir: storage}, chain, nil)
+		if err := pool.Init(1, chain.CurrentBlock(), makeAddressReserver(), nil); err != nil {
 			t.Fatalf("test %d: failed to create blob pool: %v", i, err)
 		}
 		verifyPoolInternals(t, pool)
@@ -1638,10 +1638,10 @@ func benchmarkPoolPending(b *testing.B, datacap uint64) {
 			blobfee: uint256.NewInt(blobfee),
 			statedb: statedb,
 		}
-		pool = New(Config{Datadir: ""}, chain)
+		pool = New(Config{Datadir: ""}, chain, nil)
 	)
 
-	if err := pool.Init(1, chain.CurrentBlock(), makeAddressReserver()); err != nil {
+	if err := pool.Init(1, chain.CurrentBlock(), makeAddressReserver(), nil); err != nil {
 		b.Fatalf("failed to create blob pool: %v", err)
 	}
 	// Make the pool not use disk (just drop everything). This test never reads

--- a/core/txpool/errors.go
+++ b/core/txpool/errors.go
@@ -56,4 +56,8 @@ var (
 	// input transaction of non-blob type when a blob transaction from this sender
 	// remains pending (and vice-versa).
 	ErrAlreadyReserved = errors.New("address already reserved")
+
+	// ErrInflightTxLimitReached is returned when the maximum number of in-flight
+	// transactions is reached for specific accounts.
+	ErrInflightTxLimitReached = errors.New("in-flight transaction limit reached for delegated accounts")
 )

--- a/core/txpool/legacypool/legacypool2_test.go
+++ b/core/txpool/legacypool/legacypool2_test.go
@@ -86,7 +86,9 @@ func TestTransactionFutureAttack(t *testing.T) {
 	config.GlobalQueue = 100
 	config.GlobalSlots = 100
 	pool := New(config, blockchain)
-	pool.Init(config.PriceLimit, blockchain.CurrentBlock(), makeAddressReserver())
+
+	reserver, isReserved := makeAddressReserver()
+	pool.Init(config.PriceLimit, blockchain.CurrentBlock(), reserver, isReserved)
 	defer pool.Close()
 	fillPool(t, pool)
 	pending, _ := pool.Stats()
@@ -120,7 +122,9 @@ func TestTransactionFuture1559(t *testing.T) {
 	statedb, _ := state.New(types.EmptyRootHash, state.NewDatabaseForTesting())
 	blockchain := newTestBlockChain(eip1559Config, 1000000, statedb, new(event.Feed))
 	pool := New(testTxPoolConfig, blockchain)
-	pool.Init(testTxPoolConfig.PriceLimit, blockchain.CurrentBlock(), makeAddressReserver())
+
+	reserver, isReserved := makeAddressReserver()
+	pool.Init(testTxPoolConfig.PriceLimit, blockchain.CurrentBlock(), reserver, isReserved)
 	defer pool.Close()
 
 	// Create a number of test accounts, fund them and make transactions
@@ -153,7 +157,9 @@ func TestTransactionZAttack(t *testing.T) {
 	statedb, _ := state.New(types.EmptyRootHash, state.NewDatabaseForTesting())
 	blockchain := newTestBlockChain(eip1559Config, 1000000, statedb, new(event.Feed))
 	pool := New(testTxPoolConfig, blockchain)
-	pool.Init(testTxPoolConfig.PriceLimit, blockchain.CurrentBlock(), makeAddressReserver())
+
+	reserver, isReserved := makeAddressReserver()
+	pool.Init(testTxPoolConfig.PriceLimit, blockchain.CurrentBlock(), reserver, isReserved)
 	defer pool.Close()
 	// Create a number of test accounts, fund them and make transactions
 	fillPool(t, pool)
@@ -224,7 +230,9 @@ func BenchmarkFutureAttack(b *testing.B) {
 	config.GlobalQueue = 100
 	config.GlobalSlots = 100
 	pool := New(config, blockchain)
-	pool.Init(testTxPoolConfig.PriceLimit, blockchain.CurrentBlock(), makeAddressReserver())
+
+	reserver, isReserved := makeAddressReserver()
+	pool.Init(testTxPoolConfig.PriceLimit, blockchain.CurrentBlock(), reserver, isReserved)
 	defer pool.Close()
 	fillPool(b, pool)
 

--- a/core/txpool/legacypool/legacypool2_test.go
+++ b/core/txpool/legacypool/legacypool2_test.go
@@ -24,7 +24,6 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/state"
 	"github.com/ethereum/go-ethereum/core/tracing"
-	"github.com/ethereum/go-ethereum/core/txpool"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/event"
@@ -87,7 +86,7 @@ func TestTransactionFutureAttack(t *testing.T) {
 	config.GlobalQueue = 100
 	config.GlobalSlots = 100
 	pool := New(config, blockchain)
-	pool.Init(config.PriceLimit, blockchain.CurrentBlock(), txpool.NewReserver())
+	pool.Init(config.PriceLimit, blockchain.CurrentBlock(), newReserver())
 	defer pool.Close()
 	fillPool(t, pool)
 	pending, _ := pool.Stats()
@@ -121,7 +120,7 @@ func TestTransactionFuture1559(t *testing.T) {
 	statedb, _ := state.New(types.EmptyRootHash, state.NewDatabaseForTesting())
 	blockchain := newTestBlockChain(eip1559Config, 1000000, statedb, new(event.Feed))
 	pool := New(testTxPoolConfig, blockchain)
-	pool.Init(testTxPoolConfig.PriceLimit, blockchain.CurrentBlock(), txpool.NewReserver())
+	pool.Init(testTxPoolConfig.PriceLimit, blockchain.CurrentBlock(), newReserver())
 	defer pool.Close()
 
 	// Create a number of test accounts, fund them and make transactions
@@ -154,7 +153,7 @@ func TestTransactionZAttack(t *testing.T) {
 	statedb, _ := state.New(types.EmptyRootHash, state.NewDatabaseForTesting())
 	blockchain := newTestBlockChain(eip1559Config, 1000000, statedb, new(event.Feed))
 	pool := New(testTxPoolConfig, blockchain)
-	pool.Init(testTxPoolConfig.PriceLimit, blockchain.CurrentBlock(), txpool.NewReserver())
+	pool.Init(testTxPoolConfig.PriceLimit, blockchain.CurrentBlock(), newReserver())
 	defer pool.Close()
 	// Create a number of test accounts, fund them and make transactions
 	fillPool(t, pool)
@@ -225,7 +224,7 @@ func BenchmarkFutureAttack(b *testing.B) {
 	config.GlobalQueue = 100
 	config.GlobalSlots = 100
 	pool := New(config, blockchain)
-	pool.Init(testTxPoolConfig.PriceLimit, blockchain.CurrentBlock(), txpool.NewReserver())
+	pool.Init(testTxPoolConfig.PriceLimit, blockchain.CurrentBlock(), newReserver())
 	defer pool.Close()
 	fillPool(b, pool)
 

--- a/core/txpool/legacypool/legacypool2_test.go
+++ b/core/txpool/legacypool/legacypool2_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/state"
 	"github.com/ethereum/go-ethereum/core/tracing"
+	"github.com/ethereum/go-ethereum/core/txpool"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/event"
@@ -86,9 +87,7 @@ func TestTransactionFutureAttack(t *testing.T) {
 	config.GlobalQueue = 100
 	config.GlobalSlots = 100
 	pool := New(config, blockchain)
-
-	reserver, isReserved := makeAddressReserver()
-	pool.Init(config.PriceLimit, blockchain.CurrentBlock(), reserver, isReserved)
+	pool.Init(config.PriceLimit, blockchain.CurrentBlock(), txpool.NewReserver())
 	defer pool.Close()
 	fillPool(t, pool)
 	pending, _ := pool.Stats()
@@ -122,9 +121,7 @@ func TestTransactionFuture1559(t *testing.T) {
 	statedb, _ := state.New(types.EmptyRootHash, state.NewDatabaseForTesting())
 	blockchain := newTestBlockChain(eip1559Config, 1000000, statedb, new(event.Feed))
 	pool := New(testTxPoolConfig, blockchain)
-
-	reserver, isReserved := makeAddressReserver()
-	pool.Init(testTxPoolConfig.PriceLimit, blockchain.CurrentBlock(), reserver, isReserved)
+	pool.Init(testTxPoolConfig.PriceLimit, blockchain.CurrentBlock(), txpool.NewReserver())
 	defer pool.Close()
 
 	// Create a number of test accounts, fund them and make transactions
@@ -157,9 +154,7 @@ func TestTransactionZAttack(t *testing.T) {
 	statedb, _ := state.New(types.EmptyRootHash, state.NewDatabaseForTesting())
 	blockchain := newTestBlockChain(eip1559Config, 1000000, statedb, new(event.Feed))
 	pool := New(testTxPoolConfig, blockchain)
-
-	reserver, isReserved := makeAddressReserver()
-	pool.Init(testTxPoolConfig.PriceLimit, blockchain.CurrentBlock(), reserver, isReserved)
+	pool.Init(testTxPoolConfig.PriceLimit, blockchain.CurrentBlock(), txpool.NewReserver())
 	defer pool.Close()
 	// Create a number of test accounts, fund them and make transactions
 	fillPool(t, pool)
@@ -230,9 +225,7 @@ func BenchmarkFutureAttack(b *testing.B) {
 	config.GlobalQueue = 100
 	config.GlobalSlots = 100
 	pool := New(config, blockchain)
-
-	reserver, isReserved := makeAddressReserver()
-	pool.Init(testTxPoolConfig.PriceLimit, blockchain.CurrentBlock(), reserver, isReserved)
+	pool.Init(testTxPoolConfig.PriceLimit, blockchain.CurrentBlock(), txpool.NewReserver())
 	defer pool.Close()
 	fillPool(b, pool)
 

--- a/core/txpool/reserver.go
+++ b/core/txpool/reserver.go
@@ -35,40 +35,51 @@ var (
 	reservationsGaugeName = "txpool/reservations"
 )
 
-// Reserver is a struct shared between different subpools. It is used to reserve
+// ReservationTracker is a struct shared between different subpools. It is used to reserve
 // the account and ensure that one address cannot initiate transactions, authorizations,
 // and other state-changing behaviors in different pools at the same time.
-type Reserver struct {
-	accounts map[common.Address]string
+type ReservationTracker struct {
+	accounts map[common.Address]int
 	lock     sync.RWMutex
 }
 
-// NewReserver initializes the account reserver.
-func NewReserver() *Reserver {
-	return &Reserver{
-		accounts: make(map[common.Address]string),
+// NewReservationTracker initializes the account reservation tracker.
+func NewReservationTracker() *ReservationTracker {
+	return &ReservationTracker{
+		accounts: make(map[common.Address]int),
 	}
+}
+
+// NewHandle creates a named handle on the ReservationTracker.
+func (r *ReservationTracker) NewHandle(id int) *Reserver {
+	return &Reserver{r, id}
+}
+
+// Reserver is a named handle on ReservationTracker.
+type Reserver struct {
+	tracker *ReservationTracker
+	id      int
 }
 
 // Hold attempts to reserve the specified account address for the given pool.
 // Returns an error if the account is already reserved.
-func (r *Reserver) Hold(addr common.Address, id string) error {
-	r.lock.Lock()
-	defer r.lock.Unlock()
+func (h *Reserver) Hold(addr common.Address) error {
+	h.tracker.lock.Lock()
+	defer h.tracker.lock.Unlock()
 
 	// Double reservations are forbidden even from the same pool to
 	// avoid subtle bugs in the long term.
-	owner, exists := r.accounts[addr]
+	owner, exists := h.tracker.accounts[addr]
 	if exists {
-		if owner == id {
+		if owner == h.id {
 			log.Error("pool attempted to reserve already-owned address", "address", addr)
 			return nil // Ignore fault to give the pool a chance to recover while the bug gets fixed
 		}
 		return ErrAlreadyReserved
 	}
-	r.accounts[addr] = id
+	h.tracker.accounts[addr] = h.id
 	if metrics.Enabled() {
-		m := fmt.Sprintf("%s/%s", reservationsGaugeName, id)
+		m := fmt.Sprintf("%s/%d", reservationsGaugeName, h.id)
 		metrics.GetOrRegisterGauge(m, nil).Inc(1)
 	}
 	return nil
@@ -76,34 +87,34 @@ func (r *Reserver) Hold(addr common.Address, id string) error {
 
 // Release attempts to release the reservation for the specified account.
 // Returns an error if the address is not reserved or is reserved by another pool.
-func (r *Reserver) Release(addr common.Address, id string) error {
-	r.lock.Lock()
-	defer r.lock.Unlock()
+func (h *Reserver) Release(addr common.Address) error {
+	h.tracker.lock.Lock()
+	defer h.tracker.lock.Unlock()
 
 	// Ensure subpools only attempt to unreserve their own owned addresses,
 	// otherwise flag as a programming error.
-	owner, exists := r.accounts[addr]
+	owner, exists := h.tracker.accounts[addr]
 	if !exists {
 		log.Error("pool attempted to unreserve non-reserved address", "address", addr)
 		return errors.New("address not reserved")
 	}
-	if id != owner {
+	if owner != h.id {
 		log.Error("pool attempted to unreserve non-owned address", "address", addr)
 		return errors.New("address not owned")
 	}
-	delete(r.accounts, addr)
+	delete(h.tracker.accounts, addr)
 	if metrics.Enabled() {
-		m := fmt.Sprintf("%s/%s", reservationsGaugeName, id)
+		m := fmt.Sprintf("%s/%d", reservationsGaugeName, h.id)
 		metrics.GetOrRegisterGauge(m, nil).Dec(1)
 	}
 	return nil
 }
 
 // Has returns a flag indicating if the address has been reserved or not.
-func (r *Reserver) Has(address common.Address) bool {
-	r.lock.RLock()
-	defer r.lock.RUnlock()
+func (h *Reserver) Has(address common.Address) bool {
+	h.tracker.lock.RLock()
+	defer h.tracker.lock.RUnlock()
 
-	_, exists := r.accounts[address]
+	_, exists := h.tracker.accounts[address]
 	return exists
 }

--- a/core/txpool/reserver.go
+++ b/core/txpool/reserver.go
@@ -50,12 +50,16 @@ func NewReservationTracker() *ReservationTracker {
 	}
 }
 
-// NewHandle creates a named handle on the ReservationTracker.
+// NewHandle creates a named handle on the ReservationTracker. The handle
+// identifies the subpool so ownership of reservations can be determined.
 func (r *ReservationTracker) NewHandle(id int) *Reserver {
 	return &Reserver{r, id}
 }
 
-// Reserver is a named handle on ReservationTracker.
+// Reserver is a named handle on ReservationTracker. It is held by subpools to
+// make reservations for accounts it is tracking. The id is used to determine
+// which pool owns an address and disallows non-owners to hold or release
+// addresses it doesn't own.
 type Reserver struct {
 	tracker *ReservationTracker
 	id      int

--- a/core/txpool/reserver.go
+++ b/core/txpool/reserver.go
@@ -1,0 +1,109 @@
+// Copyright 2025 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+
+package txpool
+
+import (
+	"errors"
+	"fmt"
+	"sync"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/log"
+	"github.com/ethereum/go-ethereum/metrics"
+)
+
+var (
+	// reservationsGaugeName is the prefix of a per-subpool address reservation
+	// metric.
+	//
+	// This is mostly a sanity metric to ensure there's no bug that would make
+	// some subpool hog all the reservations due to mis-accounting.
+	reservationsGaugeName = "txpool/reservations"
+)
+
+// Reserver is a struct shared between different subpools. It is used to reserve
+// the account and ensure that one address cannot initiate transactions, authorizations,
+// and other state-changing behaviors in different pools at the same time.
+type Reserver struct {
+	accounts map[common.Address]string
+	lock     sync.RWMutex
+}
+
+// NewReserver initializes the account reserver.
+func NewReserver() *Reserver {
+	return &Reserver{
+		accounts: make(map[common.Address]string),
+	}
+}
+
+// Hold attempts to reserve the specified account address for the given pool.
+// Returns an error if the account is already reserved.
+func (r *Reserver) Hold(addr common.Address, id string) error {
+	r.lock.Lock()
+	defer r.lock.Unlock()
+
+	// Double reservations are forbidden even from the same pool to
+	// avoid subtle bugs in the long term.
+	owner, exists := r.accounts[addr]
+	if exists {
+		if owner == id {
+			log.Error("pool attempted to reserve already-owned address", "address", addr)
+			return nil // Ignore fault to give the pool a chance to recover while the bug gets fixed
+		}
+		return ErrAlreadyReserved
+	}
+	r.accounts[addr] = id
+	if metrics.Enabled() {
+		m := fmt.Sprintf("%s/%s", reservationsGaugeName, id)
+		metrics.GetOrRegisterGauge(m, nil).Inc(1)
+	}
+	return nil
+}
+
+// Release attempts to release the reservation for the specified account.
+// Returns an error if the address is not reserved or is reserved by another pool.
+func (r *Reserver) Release(addr common.Address, id string) error {
+	r.lock.Lock()
+	defer r.lock.Unlock()
+
+	// Ensure subpools only attempt to unreserve their own owned addresses,
+	// otherwise flag as a programming error.
+	owner, exists := r.accounts[addr]
+	if !exists {
+		log.Error("pool attempted to unreserve non-reserved address", "address", addr)
+		return errors.New("address not reserved")
+	}
+	if id != owner {
+		log.Error("pool attempted to unreserve non-owned address", "address", addr)
+		return errors.New("address not owned")
+	}
+	delete(r.accounts, addr)
+	if metrics.Enabled() {
+		m := fmt.Sprintf("%s/%s", reservationsGaugeName, id)
+		metrics.GetOrRegisterGauge(m, nil).Dec(1)
+	}
+	return nil
+}
+
+// Has returns a flag indicating if the address has been reserved or not.
+func (r *Reserver) Has(address common.Address) bool {
+	r.lock.RLock()
+	defer r.lock.RUnlock()
+
+	_, exists := r.accounts[address]
+	return exists
+}

--- a/core/txpool/subpool.go
+++ b/core/txpool/subpool.go
@@ -71,6 +71,10 @@ type LazyResolver interface {
 // may request (and relinquish) exclusive access to certain addresses.
 type AddressReserver func(addr common.Address, reserve bool) error
 
+// IsAddressReserved is passed by the main transaction pool to subpools, so they
+// can query whether the address has been reserved or not.
+type IsAddressReserved func(addr common.Address) bool
+
 // PendingFilter is a collection of filter rules to allow retrieving a subset
 // of transactions for announcement or mining.
 //
@@ -109,7 +113,7 @@ type SubPool interface {
 	// These should not be passed as a constructor argument - nor should the pools
 	// start by themselves - in order to keep multiple subpools in lockstep with
 	// one another.
-	Init(gasTip uint64, head *types.Header, reserve AddressReserver) error
+	Init(gasTip uint64, head *types.Header, reserve AddressReserver, isReserved IsAddressReserved) error
 
 	// Close terminates any background processing threads and releases any held
 	// resources.

--- a/core/txpool/subpool.go
+++ b/core/txpool/subpool.go
@@ -67,14 +67,6 @@ type LazyResolver interface {
 	Get(hash common.Hash) *types.Transaction
 }
 
-// AddressReserver is passed by the main transaction pool to subpools, so they
-// may request (and relinquish) exclusive access to certain addresses.
-type AddressReserver func(addr common.Address, reserve bool) error
-
-// IsAddressReserved is passed by the main transaction pool to subpools, so they
-// can query whether the address has been reserved or not.
-type IsAddressReserved func(addr common.Address) bool
-
 // PendingFilter is a collection of filter rules to allow retrieving a subset
 // of transactions for announcement or mining.
 //
@@ -113,7 +105,7 @@ type SubPool interface {
 	// These should not be passed as a constructor argument - nor should the pools
 	// start by themselves - in order to keep multiple subpools in lockstep with
 	// one another.
-	Init(gasTip uint64, head *types.Header, reserve AddressReserver, isReserved IsAddressReserved) error
+	Init(gasTip uint64, head *types.Header, reserver *Reserver) error
 
 	// Close terminates any background processing threads and releases any held
 	// resources.

--- a/core/txpool/txpool.go
+++ b/core/txpool/txpool.go
@@ -29,7 +29,6 @@ import (
 	"github.com/ethereum/go-ethereum/crypto/kzg4844"
 	"github.com/ethereum/go-ethereum/event"
 	"github.com/ethereum/go-ethereum/log"
-	"github.com/ethereum/go-ethereum/metrics"
 	"github.com/ethereum/go-ethereum/params"
 )
 
@@ -41,15 +40,6 @@ const (
 	TxStatusQueued
 	TxStatusPending
 	TxStatusIncluded
-)
-
-var (
-	// reservationsGaugeName is the prefix of a per-subpool address reservation
-	// metric.
-	//
-	// This is mostly a sanity metric to ensure there's no bug that would make
-	// some subpool hog all the reservations due to mis-accounting.
-	reservationsGaugeName = "txpool/reservations"
 )
 
 // BlockChain defines the minimal set of methods needed to back a tx pool with
@@ -81,9 +71,6 @@ type TxPool struct {
 	stateLock sync.RWMutex   // The lock for protecting state instance
 	state     *state.StateDB // Current state at the blockchain head
 
-	reservations map[common.Address]SubPool // Map with the account to pool reservations
-	reserveLock  sync.RWMutex               // Lock protecting the account reservations
-
 	subs event.SubscriptionScope // Subscription scope to unsubscribe all on shutdown
 	quit chan chan error         // Quit channel to tear down the head updater
 	term chan struct{}           // Termination channel to detect a closed pool
@@ -110,17 +97,17 @@ func New(gasTip uint64, chain BlockChain, subpools []SubPool) (*TxPool, error) {
 		return nil, err
 	}
 	pool := &TxPool{
-		subpools:     subpools,
-		chain:        chain,
-		signer:       types.LatestSigner(chain.Config()),
-		state:        statedb,
-		reservations: make(map[common.Address]SubPool),
-		quit:         make(chan chan error),
-		term:         make(chan struct{}),
-		sync:         make(chan chan error),
+		subpools: subpools,
+		chain:    chain,
+		signer:   types.LatestSigner(chain.Config()),
+		state:    statedb,
+		quit:     make(chan chan error),
+		term:     make(chan struct{}),
+		sync:     make(chan chan error),
 	}
+	reserver := NewReserver()
 	for i, subpool := range subpools {
-		if err := subpool.Init(gasTip, head, pool.reserver(i, subpool), pool.isReserved); err != nil {
+		if err := subpool.Init(gasTip, head, reserver); err != nil {
 			for j := i - 1; j >= 0; j-- {
 				subpools[j].Close()
 			}
@@ -129,61 +116,6 @@ func New(gasTip uint64, chain BlockChain, subpools []SubPool) (*TxPool, error) {
 	}
 	go pool.loop(head)
 	return pool, nil
-}
-
-// isReserved returns a flag indicating if the address has been reserved or not.
-func (p *TxPool) isReserved(address common.Address) bool {
-	p.reserveLock.RLock()
-	defer p.reserveLock.RUnlock()
-
-	_, exists := p.reservations[address]
-	return exists
-}
-
-// reserver is a method to create an address reservation callback to exclusively
-// assign/deassign addresses to/from subpools. This can ensure that at any point
-// in time, only a single subpool is able to manage an account, avoiding cross
-// subpool eviction issues and nonce conflicts.
-func (p *TxPool) reserver(id int, subpool SubPool) AddressReserver {
-	return func(addr common.Address, reserve bool) error {
-		p.reserveLock.Lock()
-		defer p.reserveLock.Unlock()
-
-		owner, exists := p.reservations[addr]
-		if reserve {
-			// Double reservations are forbidden even from the same pool to
-			// avoid subtle bugs in the long term.
-			if exists {
-				if owner == subpool {
-					log.Error("pool attempted to reserve already-owned address", "address", addr)
-					return nil // Ignore fault to give the pool a chance to recover while the bug gets fixed
-				}
-				return ErrAlreadyReserved
-			}
-			p.reservations[addr] = subpool
-			if metrics.Enabled() {
-				m := fmt.Sprintf("%s/%d", reservationsGaugeName, id)
-				metrics.GetOrRegisterGauge(m, nil).Inc(1)
-			}
-			return nil
-		}
-		// Ensure subpools only attempt to unreserve their own owned addresses,
-		// otherwise flag as a programming error.
-		if !exists {
-			log.Error("pool attempted to unreserve non-reserved address", "address", addr)
-			return errors.New("address not reserved")
-		}
-		if subpool != owner {
-			log.Error("pool attempted to unreserve non-owned address", "address", addr)
-			return errors.New("address not owned")
-		}
-		delete(p.reservations, addr)
-		if metrics.Enabled() {
-			m := fmt.Sprintf("%s/%d", reservationsGaugeName, id)
-			metrics.GetOrRegisterGauge(m, nil).Dec(1)
-		}
-		return nil
-	}
 }
 
 // Close terminates the transaction pool and all its subpools.

--- a/core/txpool/txpool.go
+++ b/core/txpool/txpool.go
@@ -105,9 +105,9 @@ func New(gasTip uint64, chain BlockChain, subpools []SubPool) (*TxPool, error) {
 		term:     make(chan struct{}),
 		sync:     make(chan chan error),
 	}
-	reserver := NewReserver()
+	reserver := NewReservationTracker()
 	for i, subpool := range subpools {
-		if err := subpool.Init(gasTip, head, reserver); err != nil {
+		if err := subpool.Init(gasTip, head, reserver.NewHandle(i)); err != nil {
 			for j := i - 1; j >= 0; j-- {
 				subpools[j].Close()
 			}

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -260,15 +260,15 @@ func New(stack *node.Node, config *ethconfig.Config) (*Ethereum, error) {
 	eth.filterMaps = filtermaps.NewFilterMaps(chainDb, chainView, historyCutoff, finalBlock, filtermaps.DefaultParams, fmConfig)
 	eth.closeFilterMaps = make(chan chan struct{})
 
-	if config.BlobPool.Datadir != "" {
-		config.BlobPool.Datadir = stack.ResolvePath(config.BlobPool.Datadir)
-	}
-	blobPool := blobpool.New(config.BlobPool, eth.blockchain)
-
 	if config.TxPool.Journal != "" {
 		config.TxPool.Journal = stack.ResolvePath(config.TxPool.Journal)
 	}
 	legacyPool := legacypool.New(config.TxPool, eth.blockchain)
+
+	if config.BlobPool.Datadir != "" {
+		config.BlobPool.Datadir = stack.ResolvePath(config.BlobPool.Datadir)
+	}
+	blobPool := blobpool.New(config.BlobPool, eth.blockchain, legacyPool.HasPendingAuth)
 
 	eth.txPool, err = txpool.New(config.TxPool.PriceLimit, eth.blockchain, []txpool.SubPool{legacyPool, blobPool})
 	if err != nil {

--- a/eth/protocols/eth/handler_test.go
+++ b/eth/protocols/eth/handler_test.go
@@ -135,7 +135,7 @@ func newTestBackendWithGenerator(blocks int, shanghai bool, cancun bool, generat
 	storage, _ := os.MkdirTemp("", "blobpool-")
 	defer os.RemoveAll(storage)
 
-	blobPool := blobpool.New(blobpool.Config{Datadir: storage}, chain)
+	blobPool := blobpool.New(blobpool.Config{Datadir: storage}, chain, nil)
 	legacyPool := legacypool.New(txconfig, chain)
 	txpool, _ := txpool.New(txconfig.PriceLimit, chain, []txpool.SubPool{legacyPool, blobPool})
 


### PR DESCRIPTION
This pull request introduces two constraints in the blobPool:

(a) If the sender has a pending authorization or delegation, only one in-flight 
executable transaction can be cached.
(b) If the authority address in a SetCode transaction is already reserved by 
the blobPool, the transaction will be rejected.

These constraints mitigate an attack where an attacker spams the pool with 
numerous blob transactions, evicts other transactions, and then cancels all 
pending blob transactions by draining the sender’s funds if they have a delegation.

Note,  because there is no exclusive lock held between different subpools
when processing transactions, it's totally possible the SetCode transaction
and blob transactions with conflict sender and authorities are accepted
simultaneously. I think it's acceptable as it's very hard to be exploited.