### PR TITLE
.gitignore: ignore binaries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,16 @@ profile.cov
 .vscode
 
 tests/spec-tests/
+
+# binaries
+cmd/abidump/abidump
+cmd/abigen/abigen
+cmd/blsync/blsync
+cmd/clef/clef
+cmd/devp2p/devp2p
+cmd/era/era
+cmd/ethkey/ethkey
+cmd/evm/evm
+cmd/geth/geth
+cmd/rlpdump/rlpdump
+cmd/workload/workload


### PR DESCRIPTION
Ignores all hand-built binaries (built with go build, everything built with make is already ignored)