### PR TITLE
log: allow --vmodule to downgrade the log level

### DIFF
--- a/log/handler_glog.go
+++ b/log/handler_glog.go
@@ -179,11 +179,6 @@ func (h *GlogHandler) WithGroup(name string) slog.Handler {
 // Handle implements slog.Handler, filtering a log record through the global,
 // local and backtrace filters, finally emitting it if either allow it through.
 func (h *GlogHandler) Handle(_ context.Context, r slog.Record) error {
-	// If the global log level allows, fast track logging
-	if slog.Level(h.level.Load()) <= r.Level {
-		return h.origin.Handle(context.Background(), r)
-	}
-
 	// Check callsite cache for previously calculated log levels
 	h.lock.RLock()
 	lvl, ok := h.siteCache[r.PC]


### PR DESCRIPTION
This PR allows `--vmodule` to also downgrade the log level for packages. closes https://github.com/ethereum/go-ethereum/issues/30717

This does have some performance implications that I'm not sure about yet


Before
```
 ./build/bin/geth --dev --vmodule="*=1" console
WARN [04-01|12:38:38.561] The flag '--vmodule' is deprecated, please use '--log.vmodule' instead
INFO [04-01|12:38:38.569] Starting Geth in ephemeral dev mode...
WARN [04-01|12:38:38.569] You are running Geth in --dev mode. Please note the following:

  1. This mode is only intended for fast, iterative development without assumptions on
     security or persistence.
...
```

After
```
./build/bin/geth --dev --vmodule="*=1" console
ERROR[04-01|12:37:46.896] Head block is not reachable
Welcome to the Geth JavaScript console!
```