### PR TITLE
internal/testlog:  fix log output from sub-loggers

### DIFF
--- a/internal/testlog/testlog.go
+++ b/internal/testlog/testlog.go
@@ -170,7 +170,8 @@ func (l *logger) Crit(msg string, ctx ...interface{}) {
 }
 
 func (l *logger) With(ctx ...interface{}) log.Logger {
-	return &logger{l.t, l.l.With(ctx...), l.mu, l.h}
+	newLogger := l.l.With(ctx...)
+	return &logger{l.t, newLogger, l.mu, newLogger.Handler().(*bufHandler)}
 }
 
 func (l *logger) New(ctx ...interface{}) log.Logger {

--- a/internal/testlog/testlog.go
+++ b/internal/testlog/testlog.go
@@ -21,9 +21,10 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"github.com/ethereum/go-ethereum/log"
 	"log/slog"
 	"sync"
+
+	"github.com/ethereum/go-ethereum/log"
 )
 
 const (

--- a/internal/testlog/testlog.go
+++ b/internal/testlog/testlog.go
@@ -92,17 +92,6 @@ func Logger(t *testing.T, level slog.Level) log.Logger {
 	}
 }
 
-// LoggerWithHandler returns
-func LoggerWithHandler(t *testing.T, handler slog.Handler) log.Logger {
-	var bh bufHandler
-	return &logger{
-		t:  t,
-		l:  log.NewLogger(handler),
-		mu: new(sync.Mutex),
-		h:  &bh,
-	}
-}
-
 func (l *logger) Handler() slog.Handler {
 	return l.l.Handler()
 }

--- a/internal/testlog/testlog.go
+++ b/internal/testlog/testlog.go
@@ -21,23 +21,30 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"github.com/ethereum/go-ethereum/log"
 	"log/slog"
 	"sync"
-	"testing"
-
-	"github.com/ethereum/go-ethereum/log"
 )
 
 const (
 	termTimeFormat = "01-02|15:04:05.000"
 )
 
+// T wraps methods from testing.T used by the test logger into an interface.
+// It is specified so that unit tests can instantiate the logger with an
+// implementation of T which can capture the output of logging statements
+// from T.Logf, as this cannot be using testing.T.
+type T interface {
+	Logf(format string, args ...any)
+	Helper()
+}
+
 // logger implements log.Logger such that all output goes to the unit test log via
 // t.Logf(). All methods in between logger.Trace, logger.Debug, etc. are marked as test
 // helpers, so the file and line number in unit test output correspond to the call site
 // which emitted the log message.
 type logger struct {
-	t  *testing.T
+	t  T
 	l  log.Logger
 	mu *sync.Mutex
 	h  *bufHandler
@@ -78,7 +85,7 @@ func (h *bufHandler) WithGroup(_ string) slog.Handler {
 }
 
 // Logger returns a logger which logs to the unit test log of t.
-func Logger(t *testing.T, level slog.Level) log.Logger {
+func Logger(t T, level slog.Level) log.Logger {
 	handler := bufHandler{
 		buf:   []slog.Record{},
 		attrs: []slog.Attr{},

--- a/internal/testlog/testlog_test.go
+++ b/internal/testlog/testlog_test.go
@@ -1,0 +1,21 @@
+package testlog
+
+import (
+	"github.com/ethereum/go-ethereum/log"
+	"testing"
+)
+
+func TestLogging(t *testing.T) {
+	l := Logger(t, log.LevelInfo)
+	subLogger := l.New("foobar", 123)
+
+	l.Info("Visible")
+	subLogger.Info("Hide and seek") // not visible due to sub buffer never being flushed
+	l.Info("Also visible")
+
+	t.Log("flushed: ", l.Handler().(*bufHandler).buf)
+	t.Log("remaining: ", subLogger.Handler().(*bufHandler).buf)
+	// horrible hack to manually bring back the expected log data
+	l.Handler().(*bufHandler).buf = subLogger.Handler().(*bufHandler).buf
+	l.(*logger).flush()
+}

--- a/internal/testlog/testlog_test.go
+++ b/internal/testlog/testlog_test.go
@@ -22,7 +22,7 @@ func (t *mockT) Logf(format string, args ...any) {
 	// we could gate this operation in a mutex, but because testlogger
 	// only calls Logf with its internal mutex held, we just write output here
 	var lineBuf bytes.Buffer
-	if _, err := fmt.Fprintf(&lineBuf, fmt.Sprintf(format, args...)); err != nil {
+	if _, err := fmt.Fprintf(&lineBuf, format, args...); err != nil {
 		panic(err)
 	}
 	// The timestamp is locale-dependent, so we want to trim that off
@@ -67,5 +67,4 @@ func TestLogging(t *testing.T) {
 			fmt.Printf("'%s'\n", tc.expected)
 		}
 	}
-
 }

--- a/internal/testlog/testlog_test.go
+++ b/internal/testlog/testlog_test.go
@@ -1,8 +1,9 @@
 package testlog
 
 import (
-	"github.com/ethereum/go-ethereum/log"
 	"testing"
+
+	"github.com/ethereum/go-ethereum/log"
 )
 
 func TestLogging(t *testing.T) {
@@ -10,12 +11,6 @@ func TestLogging(t *testing.T) {
 	subLogger := l.New("foobar", 123)
 
 	l.Info("Visible")
-	subLogger.Info("Hide and seek") // not visible due to sub buffer never being flushed
+	subLogger.Info("Hide and seek") // this log is erroneously hidden in master, but fixed with this PR
 	l.Info("Also visible")
-
-	t.Log("flushed: ", l.Handler().(*bufHandler).buf)
-	t.Log("remaining: ", subLogger.Handler().(*bufHandler).buf)
-	// horrible hack to manually bring back the expected log data
-	l.Handler().(*bufHandler).buf = subLogger.Handler().(*bufHandler).buf
-	l.(*logger).flush()
 }

--- a/internal/testlog/testlog_test.go
+++ b/internal/testlog/testlog_test.go
@@ -61,10 +61,7 @@ func TestLogging(t *testing.T) {
 		mock := mockT{&outp}
 		tc.run(&mock)
 		if outp.String() != tc.expected {
-			fmt.Println("mismatch")
-			fmt.Printf("'%s'\n", outp.String())
-			fmt.Println("----")
-			fmt.Printf("'%s'\n", tc.expected)
+			fmt.Printf("output mismatch.\nwant: '%s'\ngot: '%s'\n", tc.expected, outp.String())
 		}
 	}
 }

--- a/internal/testlog/testlog_test.go
+++ b/internal/testlog/testlog_test.go
@@ -25,6 +25,8 @@ func (t *mockT) Logf(format string, args ...any) {
 	if _, err := fmt.Fprintf(&lineBuf, fmt.Sprintf(format, args...)); err != nil {
 		panic(err)
 	}
+	// The timestamp is locale-dependent, so we want to trim that off
+	// "INFO [01-01|00:00:00.000] a message ..." -> "a message..."
 	sanitized := strings.Split(lineBuf.String(), "]")[1]
 	if _, err := t.out.Write([]byte(sanitized)); err != nil {
 		panic(err)


### PR DESCRIPTION
When we instantiate a sub-logger via `go-ethereum/internal/testlog/logger.With`, we copy the reference to the `bufHandler` from the parent logger.  However, internally, `go-ethereum/internal/testlog/logger.With` calls `log/slog/Logger.With` which creates a new handler instance (via `internal/bufHandler.WithAttrs`).

This PR modifies sub-logger instantiation to use the newly-instantiated handler, instead of copying the reference from the parent instance.  The type cast from `slog.Handler` to `*bufHandler` in `internal/testlog/Logger.With` is safe here because a `internal/testlog/Logger` can only be instantiated with a `*bufHandler` as the underlying handler type.

Note, that I've also removed a pre-existing method that broke the above assumption.  However, this method is not used in our codebase.

I'm not sure if the assumption holds for forks of geth (e.g. optimism has modified the testlogger somewhat allowing test loggers to accept arbitrary handler types), but it seems okay to break API compatibility given that this is in the `internal` package.

closes https://github.com/ethereum/go-ethereum/issues/31533