### PR TITLE
p2p/discover: cache raw bytes of whoareyou packet

### DIFF
--- a/p2p/discover/v5_udp_test.go
+++ b/p2p/discover/v5_udp_test.go
@@ -775,6 +775,8 @@ type testCodecFrame struct {
 }
 
 func (c *testCodec) Encode(toID enode.ID, addr string, p v5wire.Packet, _ *v5wire.Whoareyou) ([]byte, v5wire.Nonce, error) {
+	// To match the behavior of v5wire.Codec, we return the cached encoding of
+	// WHOAREYOU challenges.
 	if wp, ok := p.(*v5wire.Whoareyou); ok && len(wp.Encoded) > 0 {
 		return wp.Encoded, wp.Nonce, nil
 	}

--- a/p2p/discover/v5_udp_test.go
+++ b/p2p/discover/v5_udp_test.go
@@ -181,18 +181,16 @@ func TestUDPv5_handshakeRepeatChallenge(t *testing.T) {
 	nonce1 := v5wire.Nonce{1}
 	nonce2 := v5wire.Nonce{2}
 	nonce3 := v5wire.Nonce{3}
-	var authTag1 v5wire.Nonce
-	check := func(p *v5wire.Whoareyou, actualAuthTag, wantNonce v5wire.Nonce) {
+	var firstAuthTag *v5wire.Nonce
+	check := func(p *v5wire.Whoareyou, authTag, wantNonce v5wire.Nonce) {
 		t.Helper()
 		if p.Nonce != wantNonce {
-			t.Error("wrong nonce in WHOAREYOU:", p.Nonce, wantNonce)
+			t.Error("wrong nonce in WHOAREYOU:", p.Nonce, "want:", wantNonce)
 		}
-		if authTag1 == (v5wire.Nonce{}) {
-			authTag1 = actualAuthTag
-		} else {
-			if authTag1 != authTag1 {
-				t.Error("wrong auth tag in WHOAREYOU header:", authTag1, wantNonce)
-			}
+		if firstAuthTag == nil {
+			firstAuthTag = &authTag
+		} else if authTag != *firstAuthTag {
+			t.Error("wrong auth tag in WHOAREYOU header:", authTag, "want:", *firstAuthTag)
 		}
 	}
 

--- a/p2p/discover/v5_udp_test.go
+++ b/p2p/discover/v5_udp_test.go
@@ -182,7 +182,6 @@ func TestUDPv5_handshakeRepeatChallenge(t *testing.T) {
 	nonce2 := v5wire.Nonce{2}
 	nonce3 := v5wire.Nonce{3}
 	var authTag1 v5wire.Nonce
-	//var record *v5wire.Whoareyou
 	check := func(p *v5wire.Whoareyou, actualAuthTag, wantNonce v5wire.Nonce) {
 		t.Helper()
 		if p.Nonce != wantNonce {

--- a/p2p/discover/v5wire/encoding.go
+++ b/p2p/discover/v5wire/encoding.go
@@ -190,8 +190,9 @@ func (c *Codec) Encode(id enode.ID, addr string, packet Packet, challenge *Whoar
 	switch {
 	case packet.Kind() == WhoareyouPacket:
 		// just send the WHOAREYOU packet raw again, rather than the re-encoded challenge data
-		if sentWhoareyou := c.sc.getHandshake(id, addr); sentWhoareyou != nil {
-			return sentWhoareyou.Encoded, sentWhoareyou.Nonce, nil
+		w := packet.(*Whoareyou)
+		if len(w.Encoded) > 0 {
+			return w.Encoded, w.Nonce, nil
 		}
 		head, err = c.encodeWhoareyou(id, packet.(*Whoareyou))
 	case challenge != nil:
@@ -227,7 +228,7 @@ func (c *Codec) Encode(id enode.ID, addr string, packet Packet, challenge *Whoar
 		if err != nil {
 			return nil, Nonce{}, err
 		}
-		challenge.Encoded = enc
+		challenge.Encoded = bytes.Clone(enc)
 		c.sc.storeSentHandshake(id, addr, challenge)
 		return enc, head.Nonce, err
 	}

--- a/p2p/discover/v5wire/encoding.go
+++ b/p2p/discover/v5wire/encoding.go
@@ -220,11 +220,10 @@ func (c *Codec) Encode(id enode.ID, addr string, packet Packet, challenge *Whoar
 	// Encode header data.
 	c.writeHeaders(&head)
 
-	var enc []byte
 	// Store sent WHOAREYOU challenges.
 	if challenge, ok := packet.(*Whoareyou); ok {
 		challenge.ChallengeData = bytesCopy(&c.buf)
-		enc, err = c.EncodeRaw(id, head, msgData)
+		enc, err := c.EncodeRaw(id, head, msgData)
 		if err != nil {
 			return nil, Nonce{}, err
 		}
@@ -240,7 +239,7 @@ func (c *Codec) Encode(id enode.ID, addr string, packet Packet, challenge *Whoar
 			return nil, Nonce{}, err
 		}
 	}
-	enc, err = c.EncodeRaw(id, head, msgData)
+	enc, err := c.EncodeRaw(id, head, msgData)
 	return enc, head.Nonce, err
 }
 

--- a/p2p/discover/v5wire/msg.go
+++ b/p2p/discover/v5wire/msg.go
@@ -73,6 +73,9 @@ type (
 		Node *enode.Node
 
 		sent mclock.AbsTime // for handshake GC.
+
+		// Encoded is packet raw data for sending out, but should not be include in the RLP encoding.
+		Encoded []byte `rlp:"-"`
 	}
 
 	// PING is sent during liveness checks.


### PR DESCRIPTION
When resending the whoareyou packet data, a new nonce and random IV will not be generated.