### PR TITLE
internal/era: random access to header and receipts

### DIFF
--- a/internal/era/e2store/e2store.go
+++ b/internal/era/e2store/e2store.go
@@ -219,3 +219,15 @@ func (r *Reader) FindAll(want uint16) ([]*Entry, error) {
 		off += int64(headerSize + length)
 	}
 }
+
+// SkipN skips `n` entries starting from `offset` and returns the new offset.
+func (r *Reader) SkipN(offset int64, n uint64) (int64, error) {
+	for i := uint64(0); i < n; i++ {
+		length, err := r.LengthAt(offset)
+		if err != nil {
+			return 0, err
+		}
+		offset += length
+	}
+	return offset, nil
+}

--- a/internal/era/era.go
+++ b/internal/era/era.go
@@ -177,8 +177,8 @@ func (e *Era) GetBlockByNumber(num uint64) (*types.Block, error) {
 	return types.NewBlockWithHeader(&header).WithBody(body), nil
 }
 
-// GetReceipts returns the receipts for the given block number.
-func (e *Era) GetReceipts(num uint64) (types.Receipts, error) {
+// GetReceiptsByNumber returns the receipts for the given block number.
+func (e *Era) GetReceiptsByNumber(num uint64) (types.Receipts, error) {
 	if e.m.start > num || e.m.start+e.m.count <= num {
 		return nil, errors.New("out-of-bounds")
 	}

--- a/internal/era/era.go
+++ b/internal/era/era.go
@@ -187,19 +187,11 @@ func (e *Era) GetReceipts(num uint64) (types.Receipts, error) {
 		return nil, err
 	}
 
-	// Skip header entry
-	headerLength, err := e.s.LengthAt(off)
+	// Skip over header and body
+	off, err = e.s.SkipN(off, 2)
 	if err != nil {
 		return nil, err
 	}
-	off += headerLength
-
-	// Skip body entry
-	bodyLength, err := e.s.LengthAt(off)
-	if err != nil {
-		return nil, err
-	}
-	off += bodyLength
 
 	// Read and decompress receipts
 	r, _, err := newSnappyReader(e.s, TypeCompressedReceipts, off)

--- a/internal/era/era.go
+++ b/internal/era/era.go
@@ -70,7 +70,7 @@ func ReadDir(dir, network string) ([]string, error) {
 		}
 		parts := strings.Split(entry.Name(), "-")
 		if len(parts) != 3 || parts[0] != network {
-			// invalid era1 filename, skip
+			// Invalid era1 filename, skip.
 			continue
 		}
 		if epoch, err := strconv.ParseUint(parts[1], 10, 64); err != nil {
@@ -136,7 +136,7 @@ func (e *Era) GetHeaderByNumber(num uint64) (*types.Header, error) {
 		return nil, err
 	}
 
-	// Read and decompress header
+	// Read and decompress header.
 	r, _, err := newSnappyReader(e.s, TypeCompressedHeader, off)
 	if err != nil {
 		return nil, err
@@ -187,13 +187,13 @@ func (e *Era) GetReceipts(num uint64) (types.Receipts, error) {
 		return nil, err
 	}
 
-	// Skip over header and body
+	// Skip over header and body.
 	off, err = e.s.SkipN(off, 2)
 	if err != nil {
 		return nil, err
 	}
 
-	// Read and decompress receipts
+	// Read and decompress receipts.
 	r, _, err := newSnappyReader(e.s, TypeCompressedReceipts, off)
 	if err != nil {
 		return nil, err
@@ -238,13 +238,10 @@ func (e *Era) InitialTD() (*big.Int, error) {
 	}
 	off += n
 
-	// Skip over next two records.
-	for i := 0; i < 2; i++ {
-		length, err := e.s.LengthAt(off)
-		if err != nil {
-			return nil, err
-		}
-		off += length
+	// Skip over header and body.
+	off, err = e.s.SkipN(off, 2)
+	if err != nil {
+		return nil, err
 	}
 
 	// Read total difficulty after first block.

--- a/internal/era/era_test.go
+++ b/internal/era/era_test.go
@@ -208,9 +208,10 @@ func genTestChain(t *testing.T) (*core.Genesis, []*types.Block, []types.Receipts
 
 // exportChain creates a temporary era file with the given chain.
 func exportChain(t *testing.T, genesis *core.Genesis, chain []*types.Block, receipts []types.Receipts) (string, string) {
-	tmpDir, err := os.MkdirTemp("", "era-test-*")
-	require.NoError(t, err)
-	const fileName = "test.era1"
+	var (
+		tmpDir   = t.TempDir()
+		fileName = "test.era1"
+	)
 	tmpFile, err := os.Create(filepath.Join(tmpDir, fileName))
 	require.NoError(t, err)
 

--- a/internal/era/era_test.go
+++ b/internal/era/era_test.go
@@ -130,7 +130,7 @@ func TestEra1Builder(t *testing.T) {
 		if !bytes.Equal(rawReceipts, chain.receipts[i]) {
 			t.Fatalf("mismatched receipts: want %s, got %s", chain.receipts[i], rawReceipts)
 		}
-		receipts, err := e.GetReceipts(i)
+		receipts, err := e.GetReceiptsByNumber(i)
 		if err != nil {
 			t.Fatalf("error reading receipts: %v", err)
 		}


### PR DESCRIPTION
This will be required to serve API requests for header and receipts.