### PR TITLE
log: Change "Sanitizing fee history length" from WARN to INFO

### DIFF
--- a/eth/gasprice/feehistory.go
+++ b/eth/gasprice/feehistory.go
@@ -248,7 +248,7 @@ func (oracle *Oracle) FeeHistory(ctx context.Context, blocks uint64, unresolvedL
 		return common.Big0, nil, nil, nil, nil, nil, fmt.Errorf("%w: over the query limit %d", errInvalidPercentile, maxQueryLimit)
 	}
 	if blocks > maxFeeHistory {
-		log.Warn("Sanitizing fee history length", "requested", blocks, "truncated", maxFeeHistory)
+		log.Info("Sanitizing fee history length", "requested", blocks, "truncated", maxFeeHistory)
 		blocks = maxFeeHistory
 	}
 	for i, p := range rewardPercentiles {


### PR DESCRIPTION
This commit changes the log level of the "Sanitizing fee history length" message 
from WARN to INFO to maintain consistency with similar sanitization messages
throughout the codebase. This automatic truncation is normal behavior and not
a warning condition, similar to other parameter sanitization logs that already
use INFO level.

Most sanitization messages in the codebase (including those in the same gasprice
package) already use INFO level, making this change align with established
logging practices in the codebase.