### PR TITLE
p2p/nat: fix UPnP port reset

### DIFF
--- a/p2p/nat/natupnp.go
+++ b/p2p/nat/natupnp.go
@@ -83,7 +83,6 @@ func (n *upnp) ExternalIP() (addr net.IP, err error) {
 }
 
 func (n *upnp) AddMapping(protocol string, extport, intport int, desc string, lifetime time.Duration) (uint16, error) {
-
 	ip, err := n.internalAddress()
 	if err != nil {
 		return 0, err

--- a/p2p/nat/natupnp.go
+++ b/p2p/nat/natupnp.go
@@ -35,9 +35,8 @@ import (
 const (
 	soapRequestTimeout = 3 * time.Second
 	rateLimit          = 200 * time.Millisecond
-	retryInterval      = 1 * time.Second // time to wait between retries
-	retryCount         = 3               // number of retries after a failed AddPortMapping
-	randomCount        = 3               // number of random ports to try
+	retryCount         = 3 // number of retries after a failed AddPortMapping
+	randomCount        = 3 // number of random ports to try
 )
 
 type upnp struct {
@@ -101,30 +100,26 @@ func (n *upnp) AddMapping(protocol string, extport, intport int, desc string, li
 	}
 
 	// Try to add port mapping, preferring the specified external port.
-	err = n.withRateLimit(func() error {
-		p, err := n.addAnyPortMapping(protocol, extport, intport, ip, desc, lifetimeS)
-		if err == nil {
-			extport = int(p)
-		}
-		return err
-	})
-	return uint16(extport), err
+	return n.addAnyPortMapping(protocol, extport, intport, ip, desc, lifetimeS)
 }
 
 // addAnyPortMapping tries to add a port mapping with the specified external port.
 // If the external port is already in use, it will try to assign another port.
 func (n *upnp) addAnyPortMapping(protocol string, extport, intport int, ip net.IP, desc string, lifetimeS uint32) (uint16, error) {
 	if client, ok := n.client.(*internetgateway2.WANIPConnection2); ok {
-		return client.AddAnyPortMapping("", uint16(extport), protocol, uint16(intport), ip.String(), true, desc, lifetimeS)
+		return n.portWithRateLimit(func() (uint16, error) {
+			return client.AddAnyPortMapping("", uint16(extport), protocol, uint16(intport), ip.String(), true, desc, lifetimeS)
+		})
 	}
 	// For IGDv1 and v1 services we should first try to add with extport.
 	for i := 0; i < retryCount+1; i++ {
-		err := n.client.AddPortMapping("", uint16(extport), protocol, uint16(intport), ip.String(), true, desc, lifetimeS)
+		err := n.withRateLimit(func() error {
+			return n.client.AddPortMapping("", uint16(extport), protocol, uint16(intport), ip.String(), true, desc, lifetimeS)
+		})
 		if err == nil {
 			return uint16(extport), nil
 		}
 		log.Trace("Failed to add port mapping", "protocol", protocol, "extport", extport, "intport", intport, "err", err)
-		time.Sleep(retryInterval)
 	}
 
 	// If above fails, we retry with a random port.
@@ -132,12 +127,13 @@ func (n *upnp) addAnyPortMapping(protocol string, extport, intport int, ip net.I
 	var err error
 	for i := 0; i < randomCount; i++ {
 		extport = n.randomPort()
-		err = n.client.AddPortMapping("", uint16(extport), protocol, uint16(intport), ip.String(), true, desc, lifetimeS)
+		err := n.withRateLimit(func() error {
+			return n.client.AddPortMapping("", uint16(extport), protocol, uint16(intport), ip.String(), true, desc, lifetimeS)
+		})
 		if err == nil {
 			return uint16(extport), nil
 		}
 		log.Trace("Failed to add random port mapping", "protocol", protocol, "extport", extport, "intport", intport, "err", err)
-		time.Sleep(retryInterval)
 	}
 	return 0, err
 }
@@ -180,6 +176,17 @@ func (n *upnp) DeleteMapping(protocol string, extport, intport int) error {
 
 func (n *upnp) String() string {
 	return "UPNP " + n.service
+}
+
+func (n *upnp) portWithRateLimit(pfn func() (uint16, error)) (uint16, error) {
+	var port uint16
+	var err error
+	fn := func() error {
+		port, err = pfn()
+		return err
+	}
+	n.withRateLimit(fn)
+	return port, err
 }
 
 func (n *upnp) withRateLimit(fn func() error) error {

--- a/p2p/nat/natupnp.go
+++ b/p2p/nat/natupnp.go
@@ -114,7 +114,7 @@ func (n *upnp) addAnyPortMapping(protocol string, extport, intport int, ip net.I
 		if err == nil {
 			return uint16(extport), nil
 		}
-		log.Trace("Failed to add port mapping", "protocol", protocol, "extport", extport, "intport", intport, "err", err)
+		log.Debug("Failed to add port mapping", "protocol", protocol, "extport", extport, "intport", intport, "err", err)
 	}
 
 	// If above fails, we retry with a random port.
@@ -128,7 +128,7 @@ func (n *upnp) addAnyPortMapping(protocol string, extport, intport int, ip net.I
 		if err == nil {
 			return uint16(extport), nil
 		}
-		log.Trace("Failed to add random port mapping", "protocol", protocol, "extport", extport, "intport", intport, "err", err)
+		log.Debug("Failed to add random port mapping", "protocol", protocol, "extport", extport, "intport", intport, "err", err)
 	}
 	return 0, err
 }

--- a/p2p/nat/natupnp.go
+++ b/p2p/nat/natupnp.go
@@ -37,6 +37,13 @@ const (
 	rateLimit          = 200 * time.Millisecond
 	retryCount         = 3 // number of retries after a failed AddPortMapping
 	randomCount        = 3 // number of random ports to try
+
+	// According to the UPnP spec delete before add is not needed if the
+	// private IP remained the same. However, we have seen this workaround
+	// being used in practice. It could also create problems, so we keep it
+	// disabled by default. If the private IP changed, an external port change
+	// should be OK.
+	deleteBeforeAdd = false
 )
 
 type upnp struct {
@@ -93,7 +100,7 @@ func (n *upnp) AddMapping(protocol string, extport, intport int, desc string, li
 
 	if extport == 0 {
 		extport = intport
-	} else {
+	} else if deleteBeforeAdd {
 		// Only delete port mapping if the external port was already used by geth.
 		err := n.DeleteMapping(protocol, extport, intport)
 		log.Trace("Deleting port mapping", "protocol", protocol, "extport", extport, "intport", intport, "err", err)

--- a/p2p/nat/natupnp.go
+++ b/p2p/nat/natupnp.go
@@ -37,13 +37,6 @@ const (
 	rateLimit          = 200 * time.Millisecond
 	retryCount         = 3 // number of retries after a failed AddPortMapping
 	randomCount        = 3 // number of random ports to try
-
-	// According to the UPnP spec delete before add is not needed if the
-	// private IP remained the same. However, we have seen this workaround
-	// being used in practice. It could also create problems, so we keep it
-	// disabled by default. If the private IP changed, an external port change
-	// should be OK.
-	deleteBeforeAdd = false
 )
 
 type upnp struct {
@@ -100,10 +93,6 @@ func (n *upnp) AddMapping(protocol string, extport, intport int, desc string, li
 
 	if extport == 0 {
 		extport = intport
-	} else if deleteBeforeAdd {
-		// Only delete port mapping if the external port was already used by geth.
-		err := n.DeleteMapping(protocol, extport, intport)
-		log.Trace("Deleting port mapping", "protocol", protocol, "extport", extport, "intport", intport, "err", err)
 	}
 
 	// Try to add port mapping, preferring the specified external port.

--- a/p2p/server_nat.go
+++ b/p2p/server_nat.go
@@ -198,7 +198,6 @@ func (srv *Server) portMappingLoop() {
 					}
 				}
 				m.nextTime = srv.clock.Now().Add(portMapRefreshInterval)
-
 			}
 		}
 	}

--- a/p2p/server_nat.go
+++ b/p2p/server_nat.go
@@ -160,11 +160,11 @@ func (srv *Server) portMappingLoop() {
 					if m.extPort == 0 {
 						log.Debug("Couldn't add port mapping", "err", err)
 					} else {
-						// Failed refresh. Since UPnP implementation are often buggy, and lifetime is
-						// larger than the retry interval, this does not mean we lost our existing
-						// mapping. We do not reset the external port, as it is still our best chance,
-						// but we do retry soon.
-						// We could check the error code, but again, UPnP implementations are buggy.
+						// Failed refresh. Since UPnP implementation are often buggy,
+						// and lifetime is larger than the retry interval, this does not
+						// mean we lost our existing mapping. We do not reset the external
+						// port, as it is still our best chance, but we do retry soon.
+						// We could check the error code, but UPnP implementations are buggy.
 						log.Debug("Couldn't refresh port mapping", "err", err)
 						m.retries++
 						if m.retries > maxRetries {

--- a/p2p/server_nat.go
+++ b/p2p/server_nat.go
@@ -164,7 +164,7 @@ func (srv *Server) portMappingLoop() {
 						// larger than the retry interval, this does not mean we lost our existing
 						// mapping. We do not reset the external port, as it is still our best chance,
 						// but we do retry soon.
-						// TODO: we could check the error code, but again, UPnP implementations are buggy.
+						// We could check the error code, but again, UPnP implementations are buggy.
 						log.Debug("Couldn't refresh port mapping", "err", err)
 						m.retries++
 						if m.retries > maxRetries {
@@ -175,7 +175,8 @@ func (srv *Server) portMappingLoop() {
 						}
 					}
 					m.nextTime = srv.clock.Now().Add(portMapRetryInterval)
-					continue //TODO: this means we never reset the ENR. Is that what we want?
+					// Note ENR is not updated here, i.e. we keep the last port.
+					continue
 				}
 
 				// It was mapped!


### PR DESCRIPTION
Make UPnP more robust

- Once a random port was mapped, we try to stick to it even if a UPnP refresh fails. Previously we were immediately moving back to try the default port, leading to frequent ENR changes.

- We were deleting port mappings before refresh as a possible workaround. This created issues in some UPnP servers. The UPnP (and PMP) specification is explicit about the refresh requirements, and delete is clearly not needed (see https://github.com/ethereum/go-ethereum/pull/30265#issuecomment-2766987859). From now on we only delete when closing.

- We were trying to add port mappings only once, and then moved on to random ports. Now we insist a bit more,  so that a simple failed request won't lead to ENR changes.

Fixes https://github.com/ethereum/go-ethereum/issues/31418 