### PR TITLE
eth/68: fixed the protocol length

### DIFF
--- a/eth/protocols/eth/protocol.go
+++ b/eth/protocols/eth/protocol.go
@@ -43,7 +43,7 @@ var ProtocolVersions = []uint{ETH68}
 
 // protocolLengths are the number of implemented message corresponding to
 // different protocol versions.
-var protocolLengths = map[uint]uint64{ETH68: 17}
+var protocolLengths = map[uint]uint64{ETH68: 13}
 
 // maxMessageSize is the maximum cap on the size of a protocol message.
 const maxMessageSize = 10 * 1024 * 1024


### PR DESCRIPTION
The current protocol length for `eth/68` is 17, but I only see 13 different messages.
Maybe I am making a dumb mistake.