### PR TITLE
p2p: name dial sources to allow better diagnostics and stats

### DIFF
--- a/eth/backend.go
+++ b/eth/backend.go
@@ -478,7 +478,7 @@ func (s *Ethereum) setupDiscovery() error {
 		if err != nil {
 			return err
 		}
-		s.discmix.AddSource(iter)
+		s.discmix.AddSource(iter, "DNSdiscEth")
 	}
 
 	// Add snap nodes from DNS.
@@ -487,14 +487,14 @@ func (s *Ethereum) setupDiscovery() error {
 		if err != nil {
 			return err
 		}
-		s.discmix.AddSource(iter)
+		s.discmix.AddSource(iter, "DNSdiscSnap")
 	}
 
 	// Add DHT nodes from discv5.
 	if s.p2pServer.DiscoveryV5() != nil {
 		filter := eth.NewNodeFilter(s.blockchain)
 		iter := enode.Filter(s.p2pServer.DiscoveryV5().RandomNodes(), filter)
-		s.discmix.AddSource(iter)
+		s.discmix.AddSource(iter, "DiscoveryV5")
 	}
 
 	return nil

--- a/p2p/enode/iter.go
+++ b/p2p/enode/iter.go
@@ -149,6 +149,7 @@ type mixSource struct {
 	it      Iterator
 	next    chan *Node
 	timeout time.Duration
+	name    string
 }
 
 // NewFairMix creates a mixer.
@@ -167,7 +168,7 @@ func NewFairMix(timeout time.Duration) *FairMix {
 }
 
 // AddSource adds a source of nodes.
-func (m *FairMix) AddSource(it Iterator) {
+func (m *FairMix) AddSource(it Iterator, name ...string) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
@@ -175,7 +176,10 @@ func (m *FairMix) AddSource(it Iterator) {
 		return
 	}
 	m.wg.Add(1)
-	source := &mixSource{it, make(chan *Node), m.timeout}
+	source := &mixSource{it, make(chan *Node), m.timeout, ""}
+	if len(name) > 0 {
+		source.name = name[0]
+	}
 	m.sources = append(m.sources, source)
 	go m.runSource(m.closed, source)
 }

--- a/p2p/enode/iter_test.go
+++ b/p2p/enode/iter_test.go
@@ -99,9 +99,9 @@ func TestFairMix(t *testing.T) {
 
 func testMixerFairness(t *testing.T) {
 	mix := NewFairMix(1 * time.Second)
-	mix.AddSource(&genIter{index: 1})
-	mix.AddSource(&genIter{index: 2})
-	mix.AddSource(&genIter{index: 3})
+	mix.AddSource(&genIter{index: 1}, "1")
+	mix.AddSource(&genIter{index: 2}, "2")
+	mix.AddSource(&genIter{index: 3}, "3")
 	defer mix.Close()
 
 	nodes := ReadNodes(mix, 500)

--- a/p2p/server.go
+++ b/p2p/server.go
@@ -479,7 +479,7 @@ func (srv *Server) setupDiscovery() error {
 			return err
 		}
 		srv.discv4 = ntab
-		srv.discmix.AddSource(ntab.RandomNodes())
+		srv.discmix.AddSource(ntab.RandomNodes(), "DiscoveryV4")
 	}
 	if srv.Config.DiscoveryV5 {
 		cfg := discover.Config{
@@ -498,7 +498,7 @@ func (srv *Server) setupDiscovery() error {
 	added := make(map[string]bool)
 	for _, proto := range srv.Protocols {
 		if proto.DialCandidates != nil && !added[proto.Name] {
-			srv.discmix.AddSource(proto.DialCandidates)
+			srv.discmix.AddSource(proto.DialCandidates, "DialCandidates-"+proto.Name)
 			added[proto.Name] = true
 		}
 	}


### PR DESCRIPTION
Here we add optional names to dial sources. This allows better diagnostics of FairMix and the whole dial process. It also allows better statistics on top (TBD in a follow-up PR).