### PR TITLE
p2p: Filter Discv4 dial candidates based on forkID

### DIFF
--- a/eth/backend.go
+++ b/eth/backend.go
@@ -478,7 +478,7 @@ func (s *Ethereum) setupDiscovery() error {
 		if err != nil {
 			return err
 		}
-		s.discmix.AddSource(iter)
+		s.discmix.AddSource(iter, "DNSdiscEth")
 	}
 
 	// Add snap nodes from DNS.
@@ -487,14 +487,14 @@ func (s *Ethereum) setupDiscovery() error {
 		if err != nil {
 			return err
 		}
-		s.discmix.AddSource(iter)
+		s.discmix.AddSource(iter, "DNSdiscSnap")
 	}
 
 	// Add DHT nodes from discv5.
 	if s.p2pServer.DiscoveryV5() != nil {
 		filter := eth.NewNodeFilter(s.blockchain)
 		iter := enode.Filter(s.p2pServer.DiscoveryV5().RandomNodes(), filter)
-		s.discmix.AddSource(iter)
+		s.discmix.AddSource(iter, "DiscoveryV5")
 	}
 
 	return nil

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -490,6 +490,15 @@ func (s *Ethereum) setupDiscovery() error {
 		s.discmix.AddSource(iter, "DNSdiscSnap")
 	}
 
+	// Add DHT nodes from discv4.
+	if s.p2pServer.DiscoveryV4() != nil {
+		asyncFilter := s.p2pServer.DiscoveryV4().RequestENR
+		filter := eth.NewNodeFilter(s.blockchain)
+		iter := enode.AsyncFilter(s.p2pServer.DiscoveryV4().RandomNodes(), asyncFilter)
+		iter = enode.Filter(iter, filter)
+		s.discmix.AddSource(iter, "DiscoveryV4")
+	}
+
 	// Add DHT nodes from discv5.
 	if s.p2pServer.DiscoveryV5() != nil {
 		filter := eth.NewNodeFilter(s.blockchain)

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -494,7 +494,7 @@ func (s *Ethereum) setupDiscovery() error {
 	if s.p2pServer.DiscoveryV4() != nil {
 		asyncFilter := s.p2pServer.DiscoveryV4().RequestENR
 		filter := eth.NewNodeFilter(s.blockchain)
-		iter := enode.AsyncFilter(s.p2pServer.DiscoveryV4().RandomNodes(), asyncFilter)
+		iter := enode.AsyncFilter(s.p2pServer.DiscoveryV4().RandomNodes(), asyncFilter, 16)
 		iter = enode.Filter(iter, filter)
 		s.discmix.AddSource(iter, "DiscoveryV4")
 	}

--- a/p2p/enode/iter.go
+++ b/p2p/enode/iter.go
@@ -149,6 +149,7 @@ type mixSource struct {
 	it      Iterator
 	next    chan *Node
 	timeout time.Duration
+	name    string
 }
 
 // NewFairMix creates a mixer.
@@ -167,7 +168,7 @@ func NewFairMix(timeout time.Duration) *FairMix {
 }
 
 // AddSource adds a source of nodes.
-func (m *FairMix) AddSource(it Iterator) {
+func (m *FairMix) AddSource(it Iterator, name ...string) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
@@ -175,7 +176,10 @@ func (m *FairMix) AddSource(it Iterator) {
 		return
 	}
 	m.wg.Add(1)
-	source := &mixSource{it, make(chan *Node), m.timeout}
+	source := &mixSource{it, make(chan *Node), m.timeout, ""}
+	if len(name) > 0 {
+		source.name = name[0]
+	}
 	m.sources = append(m.sources, source)
 	go m.runSource(m.closed, source)
 }

--- a/p2p/enode/iter.go
+++ b/p2p/enode/iter.go
@@ -126,35 +126,38 @@ func (f *filterIter) Next() bool {
 // AsyncFilter wraps an iterator such that Next only returns nodes for which
 // the 'check' function returns a (possibly modified) node.
 func AsyncFilter(it Iterator, check func(*Node) (*Node, error), workers int) Iterator {
-	f := &AsyncFilterIter{it, nil, check, make(chan *Node), sync.WaitGroup{}}
+	f := &AsyncFilterIter{it, check, make(chan struct{}, workers), make(chan *Node), nil}
 
-	taskCh := make(chan *Node)
-
-	worker := func() {
-		for task := range taskCh {
-			if task == nil {
-				break
-			}
-			nn, err := f.check(task)
-			if err == nil {
-				f.passed <- nn
-			}
-		}
-		f.wg.Done()
-	}
-
-	for range workers {
-		f.wg.Add(1)
-		go worker()
+	// create slots
+	for range cap(f.slots) {
+		f.slots <- struct{}{}
 	}
 
 	go func() {
-		for f.it.Next() {
-			taskCh <- f.it.Node()
+		// read from the iterator and start checking nodes in parallel
+		// when a node is checked, it will be sent to the passed channel
+		// and the slot will be released
+		for range f.slots {
+			if f.it.Next() {
+				if n := f.it.Node(); n != nil {
+					// check the node async, in a separate goroutine
+					go func() {
+						if nn, err := f.check(n); err == nil {
+							f.passed <- nn
+						}
+						f.slots <- struct{}{}
+					}()
+				} else {
+					// this is not supposed to happen
+					f.slots <- struct{}{}
+					break
+				}
+			} else {
+				// the iterator has ended
+				f.slots <- struct{}{}
+				break
+			}
 		}
-		close(taskCh)
-		f.wg.Wait()
-		close(f.passed)
 	}()
 
 	return f
@@ -162,10 +165,10 @@ func AsyncFilter(it Iterator, check func(*Node) (*Node, error), workers int) Ite
 
 type AsyncFilterIter struct {
 	it     Iterator
-	buffer *Node
 	check  func(*Node) (*Node, error)
+	slots  chan struct{}
 	passed chan *Node
-	wg     sync.WaitGroup
+	buffer *Node
 }
 
 func (f *AsyncFilterIter) Next() bool {
@@ -179,7 +182,11 @@ func (f *AsyncFilterIter) Node() *Node {
 
 func (f *AsyncFilterIter) Close() {
 	f.it.Close()
-	f.wg.Wait()
+	for range cap(f.slots) {
+		<-f.slots
+	}
+	close(f.slots)
+	close(f.passed)
 }
 
 // FairMix aggregates multiple node iterators. The mixer itself is an iterator which ends

--- a/p2p/enode/iter.go
+++ b/p2p/enode/iter.go
@@ -125,25 +125,52 @@ func (f *filterIter) Next() bool {
 
 // AsyncFilter wraps an iterator such that Next only returns nodes for which
 // the 'check' function returns a (possibly modified) node.
-func AsyncFilter(it Iterator, check func(*Node) (*Node, error)) Iterator {
-	return &AsyncFilterIter{it, nil, check}
+func AsyncFilter(it Iterator, check func(*Node) (*Node, error), workers int) Iterator {
+	f := &AsyncFilterIter{it, nil, check, make(chan *Node), sync.WaitGroup{}}
+
+	taskCh := make(chan *Node)
+
+	worker := func() {
+		for task := range taskCh {
+			if task == nil {
+				break
+			}
+			nn, err := f.check(task)
+			if err == nil {
+				f.passed <- nn
+			}
+		}
+		f.wg.Done()
+	}
+
+	for range workers {
+		f.wg.Add(1)
+		go worker()
+	}
+
+	go func() {
+		for f.it.Next() {
+			taskCh <- f.it.Node()
+		}
+		close(taskCh)
+		f.wg.Wait()
+		close(f.passed)
+	}()
+
+	return f
 }
 
 type AsyncFilterIter struct {
 	it     Iterator
 	buffer *Node
 	check  func(*Node) (*Node, error)
+	passed chan *Node
+	wg     sync.WaitGroup
 }
 
 func (f *AsyncFilterIter) Next() bool {
-	for f.it.Next() {
-		nn, err := f.check(f.it.Node())
-		if err == nil {
-			f.buffer = nn
-			return true
-		}
-	}
-	return false
+	f.buffer = <-f.passed
+	return f.buffer != nil
 }
 
 func (f *AsyncFilterIter) Node() *Node {
@@ -152,6 +179,7 @@ func (f *AsyncFilterIter) Node() *Node {
 
 func (f *AsyncFilterIter) Close() {
 	f.it.Close()
+	f.wg.Wait()
 }
 
 // FairMix aggregates multiple node iterators. The mixer itself is an iterator which ends

--- a/p2p/enode/iter.go
+++ b/p2p/enode/iter.go
@@ -123,6 +123,37 @@ func (f *filterIter) Next() bool {
 	return false
 }
 
+// AsyncFilter wraps an iterator such that Next only returns nodes for which
+// the 'check' function returns a (possibly modified) node.
+func AsyncFilter(it Iterator, check func(*Node) (*Node, error)) Iterator {
+	return &AsyncFilterIter{it, nil, check}
+}
+
+type AsyncFilterIter struct {
+	it     Iterator
+	buffer *Node
+	check  func(*Node) (*Node, error)
+}
+
+func (f *AsyncFilterIter) Next() bool {
+	for f.it.Next() {
+		nn, err := f.check(f.it.Node())
+		if err == nil {
+			f.buffer = nn
+			return true
+		}
+	}
+	return false
+}
+
+func (f *AsyncFilterIter) Node() *Node {
+	return f.buffer
+}
+
+func (f *AsyncFilterIter) Close() {
+	f.it.Close()
+}
+
 // FairMix aggregates multiple node iterators. The mixer itself is an iterator which ends
 // only when Close is called. Source iterators added via AddSource are removed from the
 // mix when they end.

--- a/p2p/enode/iter.go
+++ b/p2p/enode/iter.go
@@ -123,8 +123,18 @@ func (f *filterIter) Next() bool {
 	return false
 }
 
-// AsyncFilter wraps an iterator such that Next only returns nodes for which
+// AsyncFilterIter wraps an iterator such that Next only returns nodes for which
 // the 'check' function returns a (possibly modified) node.
+type AsyncFilterIter struct {
+	it     Iterator                   // the iterator to filter
+	check  func(*Node) (*Node, error) // the blocking check function
+	slots  chan struct{}              // the slots for parallel checking
+	passed chan *Node                 // channel to collect passed nodes
+	closed chan struct{}              // channel to override passed when closing
+	buffer *Node                      // buffer to serve the Node call
+}
+
+// AsyncFilter creates an iterator which checks nodes in parallel.
 func AsyncFilter(it Iterator, check func(*Node) (*Node, error), workers int) Iterator {
 	f := &AsyncFilterIter{it, check, make(chan struct{}, workers), make(chan *Node), make(chan struct{}), nil}
 
@@ -166,24 +176,18 @@ func AsyncFilter(it Iterator, check func(*Node) (*Node, error), workers int) Ite
 	return f
 }
 
-type AsyncFilterIter struct {
-	it     Iterator
-	check  func(*Node) (*Node, error)
-	slots  chan struct{}
-	passed chan *Node
-	closed chan struct{}
-	buffer *Node
-}
-
+// Next blocks until a node is available or the iterator is closed.
 func (f *AsyncFilterIter) Next() bool {
 	f.buffer = <-f.passed
 	return f.buffer != nil
 }
 
+// Node returns the current node.
 func (f *AsyncFilterIter) Node() *Node {
 	return f.buffer
 }
 
+// Close ends the iterator, also closing the wrapped iterator.
 func (f *AsyncFilterIter) Close() {
 	f.it.Close()
 	close(f.closed) // override the passed channel

--- a/p2p/enode/iter.go
+++ b/p2p/enode/iter.go
@@ -126,7 +126,7 @@ func (f *filterIter) Next() bool {
 // AsyncFilter wraps an iterator such that Next only returns nodes for which
 // the 'check' function returns a (possibly modified) node.
 func AsyncFilter(it Iterator, check func(*Node) (*Node, error), workers int) Iterator {
-	f := &AsyncFilterIter{it, check, make(chan struct{}, workers), make(chan *Node), nil}
+	f := &AsyncFilterIter{it, check, make(chan struct{}, workers), make(chan *Node), make(chan struct{}), nil}
 
 	// create slots
 	for range cap(f.slots) {
@@ -143,7 +143,10 @@ func AsyncFilter(it Iterator, check func(*Node) (*Node, error), workers int) Ite
 					// check the node async, in a separate goroutine
 					go func() {
 						if nn, err := f.check(n); err == nil {
-							f.passed <- nn
+							select {
+							case f.passed <- nn:
+							case <-f.closed: // bale out if downstream is already closed and not calling Next
+							}
 						}
 						f.slots <- struct{}{}
 					}()
@@ -168,6 +171,7 @@ type AsyncFilterIter struct {
 	check  func(*Node) (*Node, error)
 	slots  chan struct{}
 	passed chan *Node
+	closed chan struct{}
 	buffer *Node
 }
 
@@ -182,6 +186,7 @@ func (f *AsyncFilterIter) Node() *Node {
 
 func (f *AsyncFilterIter) Close() {
 	f.it.Close()
+	close(f.closed) // override the passed channel
 	for range cap(f.slots) {
 		<-f.slots
 	}

--- a/p2p/enode/iter_test.go
+++ b/p2p/enode/iter_test.go
@@ -99,9 +99,9 @@ func TestFairMix(t *testing.T) {
 
 func testMixerFairness(t *testing.T) {
 	mix := NewFairMix(1 * time.Second)
-	mix.AddSource(&genIter{index: 1})
-	mix.AddSource(&genIter{index: 2})
-	mix.AddSource(&genIter{index: 3})
+	mix.AddSource(&genIter{index: 1}, "1")
+	mix.AddSource(&genIter{index: 2}, "2")
+	mix.AddSource(&genIter{index: 3}, "3")
 	defer mix.Close()
 
 	nodes := ReadNodes(mix, 500)

--- a/p2p/server.go
+++ b/p2p/server.go
@@ -479,7 +479,7 @@ func (srv *Server) setupDiscovery() error {
 			return err
 		}
 		srv.discv4 = ntab
-		srv.discmix.AddSource(ntab.RandomNodes())
+		srv.discmix.AddSource(ntab.RandomNodes(), "DiscoveryV4")
 	}
 	if srv.Config.DiscoveryV5 {
 		cfg := discover.Config{
@@ -498,7 +498,7 @@ func (srv *Server) setupDiscovery() error {
 	added := make(map[string]bool)
 	for _, proto := range srv.Protocols {
 		if proto.DialCandidates != nil && !added[proto.Name] {
-			srv.discmix.AddSource(proto.DialCandidates)
+			srv.discmix.AddSource(proto.DialCandidates, "DialCandidates-"+proto.Name)
 			added[proto.Name] = true
 		}
 	}

--- a/p2p/server.go
+++ b/p2p/server.go
@@ -479,7 +479,6 @@ func (srv *Server) setupDiscovery() error {
 			return err
 		}
 		srv.discv4 = ntab
-		srv.discmix.AddSource(ntab.RandomNodes(), "DiscoveryV4")
 	}
 	if srv.Config.DiscoveryV5 {
 		cfg := discover.Config{


### PR DESCRIPTION
Our Discovery/v4 based dial source was returning nodes without checking the `forkid` in the ENR, leading to lots of useless dials.

This PR adds a filter on top of the discovery/v4 stream of discovered nodes, returning only those that have a compatible forkID.

More in detail:
- to check the ENR, we need to retrieve it from the node first using an extra Discovery/v4 query. We add AsyncFilterIterator, which can filter a stream of nodes using a blocking filter function, doing several async checks in parallel.
- we set the AsyncFilterIterator to use the RetrieveENR function as both filter (retrieve could time out) and a modifier of the Node.
- we apply another filter on forkID, as we do in Discovery/v5.
- finally, we simplfy the mixing of discovery sources by moving the Discovery/v4 source from the Server to the Backend, next to the Discovery/v5 source.

Note: This PR is to be rebased after merging https://github.com/ethereum/go-ethereum/pull/31588