### PR TITLE
eth/catalyst:  in tests, manually sync txpool after initial chain insertion to prevent race between txpool head reset and promotion of txs that will be subsequently added

### DIFF
--- a/eth/catalyst/api_test.go
+++ b/eth/catalyst/api_test.go
@@ -447,6 +447,9 @@ func startEthService(t *testing.T, genesis *core.Genesis, blocks []*types.Block)
 		n.Close()
 		t.Fatal("can't import test blocks:", err)
 	}
+	if err := ethservice.TxPool().Sync(); err != nil {
+		t.Fatal("failed to sync txpool after initial blockchain import:", err)
+	}
 
 	ethservice.SetSynced()
 	return n, ethservice


### PR DESCRIPTION
before this changes, this will result in numerous test failures:
```
> go test -run=Eth2AssembleBlock -c
> stress ./catalyst.test
```

The reason is that after creating/inserting the test chain, there is a race between the txpool head reset and the promotion of txs added from tests.

Ensuring that the txpool state is up to date with the head of the chain before proceeding fixes these flaky tests.