### PR TITLE
core/types: reduce allocations in effectiveGasTip

### DIFF
--- a/core/types/transaction.go
+++ b/core/types/transaction.go
@@ -355,6 +355,9 @@ func (tx *Transaction) GasTipCapIntCmp(other *big.Int) int {
 // Note: if the effective gasTipCap is negative, this method returns both error
 // the actual negative value, _and_ ErrGasFeeCapTooLow
 func (tx *Transaction) EffectiveGasTip(baseFee *big.Int) (*big.Int, error) {
+	if baseFee == nil {
+		return tx.inner.gasTipCap(), nil
+	}
 	out, err := tx.effectiveGasTip(baseFee)
 	return new(big.Int).Set(out), err
 }
@@ -363,10 +366,8 @@ func (tx *Transaction) EffectiveGasTip(baseFee *big.Int) (*big.Int, error) {
 // Note: if the effective gasTipCap is negative, this method returns both error
 // the actual negative value, _and_ ErrGasFeeCapTooLow
 // Note: please copy the return value before modifying.
+// Note: assumes basefee to be non-nil.
 func (tx *Transaction) effectiveGasTip(baseFee *big.Int) (*big.Int, error) {
-	if baseFee == nil {
-		return tx.inner.gasTipCap(), nil
-	}
 	var err error
 	gasFeeCap := tx.inner.gasFeeCap()
 	if gasFeeCap.Cmp(baseFee) < 0 {

--- a/core/types/transaction.go
+++ b/core/types/transaction.go
@@ -365,9 +365,9 @@ func (tx *Transaction) EffectiveGasTip(baseFee *big.Int) (*big.Int, error) {
 	}
 	gasFeeCap = gasFeeCap.Sub(gasFeeCap, baseFee)
 
-	gasTipCap := tx.GasTipCap()
+	gasTipCap := tx.inner.gasTipCap()
 	if gasTipCap.Cmp(gasFeeCap) < 0 {
-		return gasTipCap, err
+		return gasFeeCap.Set(gasTipCap), err
 	}
 	return gasFeeCap, err
 }

--- a/core/types/transaction.go
+++ b/core/types/transaction.go
@@ -355,28 +355,30 @@ func (tx *Transaction) GasTipCapIntCmp(other *big.Int) int {
 // Note: if the effective gasTipCap is negative, this method returns both error
 // the actual negative value, _and_ ErrGasFeeCapTooLow
 func (tx *Transaction) EffectiveGasTip(baseFee *big.Int) (*big.Int, error) {
+	out, err := tx.effectiveGasTip(baseFee)
+	return new(big.Int).Set(out), err
+}
+
+// effectiveGasTip returns the effective miner gasTipCap for the given base fee but does not allocate.
+// Note: if the effective gasTipCap is negative, this method returns both error
+// the actual negative value, _and_ ErrGasFeeCapTooLow
+// Note: please copy the return value before modifying.
+func (tx *Transaction) effectiveGasTip(baseFee *big.Int) (*big.Int, error) {
 	if baseFee == nil {
-		return tx.GasTipCap(), nil
+		return tx.inner.gasTipCap(), nil
 	}
 	var err error
-	gasFeeCap := tx.GasFeeCap()
+	gasFeeCap := tx.inner.gasFeeCap()
 	if gasFeeCap.Cmp(baseFee) < 0 {
 		err = ErrGasFeeCapTooLow
 	}
-	gasFeeCap = gasFeeCap.Sub(gasFeeCap, baseFee)
+	gasFeeCap = new(big.Int).Sub(gasFeeCap, baseFee)
 
 	gasTipCap := tx.inner.gasTipCap()
 	if gasTipCap.Cmp(gasFeeCap) < 0 {
-		return gasFeeCap.Set(gasTipCap), err
+		return gasTipCap, err
 	}
 	return gasFeeCap, err
-}
-
-// EffectiveGasTipValue is identical to EffectiveGasTip, but does not return an
-// error in case the effective gasTipCap is negative
-func (tx *Transaction) EffectiveGasTipValue(baseFee *big.Int) *big.Int {
-	effectiveTip, _ := tx.EffectiveGasTip(baseFee)
-	return effectiveTip
 }
 
 // EffectiveGasTipCmp compares the effective gasTipCap of two transactions assuming the given base fee.
@@ -384,7 +386,9 @@ func (tx *Transaction) EffectiveGasTipCmp(other *Transaction, baseFee *big.Int) 
 	if baseFee == nil {
 		return tx.GasTipCapCmp(other)
 	}
-	return tx.EffectiveGasTipValue(baseFee).Cmp(other.EffectiveGasTipValue(baseFee))
+	effectiveGasTip, _ := tx.effectiveGasTip(baseFee)
+	otherEffectiveGasTip, _ := other.effectiveGasTip(baseFee)
+	return effectiveGasTip.Cmp(otherEffectiveGasTip)
 }
 
 // EffectiveGasTipIntCmp compares the effective gasTipCap of a transaction to the given gasTipCap.
@@ -392,7 +396,8 @@ func (tx *Transaction) EffectiveGasTipIntCmp(other *big.Int, baseFee *big.Int) i
 	if baseFee == nil {
 		return tx.GasTipCapIntCmp(other)
 	}
-	return tx.EffectiveGasTipValue(baseFee).Cmp(other)
+	effectiveGasTip, _ := tx.effectiveGasTip(baseFee)
+	return effectiveGasTip.Cmp(other)
 }
 
 // BlobGas returns the blob gas limit of the transaction for blob transactions, 0 otherwise.

--- a/eth/tracers/js/goja.go
+++ b/eth/tracers/js/goja.go
@@ -260,7 +260,8 @@ func (t *jsTracer) OnTxStart(env *tracing.VMContext, tx *types.Transaction, from
 	t.activePrecompiles = vm.ActivePrecompiles(rules)
 	t.ctx["block"] = t.vm.ToValue(t.env.BlockNumber.Uint64())
 	t.ctx["gas"] = t.vm.ToValue(tx.Gas())
-	gasPriceBig, err := t.toBig(t.vm, tx.EffectiveGasTipValue(env.BaseFee).String())
+	gasTip, _ := tx.EffectiveGasTip(env.BaseFee)
+	gasPriceBig, err := t.toBig(t.vm, gasTip.String())
 	if err != nil {
 		t.err = err
 		return


### PR DESCRIPTION
Reduces unnecessary allocations in (types.Transaction).EffectiveGasTip.
Halves the allocations, increases speed by 47%

```
ROUTINE ======================== github.com/ethereum/go-ethereum/core/types.(*Transaction).EffectiveGasTip in github.com/ethereum/go-ethereum/core/types/transaction.go
     4.40s    370.90s (flat, cum)  1.61% of Total
     480ms      480ms    357:func (tx *Transaction) EffectiveGasTip(baseFee *big.Int) (*big.Int, error) {
     450ms      450ms    358:	if baseFee == nil {
         .          .    359:		return tx.GasTipCap(), nil
         .          .    360:	}
         .          .    361:	var err error
     350ms    232.73s    362:	gasFeeCap := tx.GasFeeCap()
     430ms      8.51s    363:	if gasFeeCap.Cmp(baseFee) < 0 {
     180ms      180ms    364:		err = ErrGasFeeCapTooLow
         .          .    365:	}
     290ms     26.02s    366:	gasFeeCap = gasFeeCap.Sub(gasFeeCap, baseFee)
         .          .    367:
     200ms     95.63s    368:	gasTipCap := tx.GasTipCap()
     680ms      5.56s    369:	if gasTipCap.Cmp(gasFeeCap) < 0 {
     250ms      250ms    370:		return gasTipCap, err
         .          .    371:	}
     1.09s      1.09s    372:	return gasFeeCap, err
         .          .    373:}
```


Benchmark:
```
func BenchmarkEffectiveTip(b *testing.B) {
	to := common.Address{}
	tx := NewTx(&DynamicFeeTx{
		ChainID:   big.NewInt(123),
		Nonce:     1,
		Gas:       1000000,
		To:        &to,
		Value:     big.NewInt(1),
		GasTipCap: big.NewInt(500),
		GasFeeCap: big.NewInt(500),
	})
	basefee := big.NewInt(12)
	for i := 0; i < b.N; i++ {
		tx.EffectiveGasTip(basefee)
	}
}
```

```
                │ /tmp/old.txt │            /tmp/new.txt             │
                │    sec/op    │    sec/op     vs base               │
EffectiveTip-14   97.83n ± ∞ ¹   57.26n ± ∞ ¹  -41.47% (p=0.008 n=5)
¹ need >= 6 samples for confidence interval at level 0.95

                │ /tmp/old.txt │            /tmp/new.txt            │
                │     B/op     │    B/op      vs base               │
EffectiveTip-14    80.00 ± ∞ ¹   40.00 ± ∞ ¹  -50.00% (p=0.008 n=5)
¹ need >= 6 samples for confidence interval at level 0.95

                │ /tmp/old.txt │            /tmp/new.txt            │
                │  allocs/op   │  allocs/op   vs base               │
EffectiveTip-14    4.000 ± ∞ ¹   2.000 ± ∞ ¹  -50.00% (p=0.008 n=5)
¹ need >= 6 samples for confidence interval at level 0.95
```

