### PR TITLE
core: don't crit on rewind during sync

### DIFF
--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -782,7 +782,8 @@ func (bc *BlockChain) rewindPathHead(head *types.Header, root common.Hash) (*typ
 	// Recover if the target state if it's not available yet.
 	if !bc.HasState(head.Root) {
 		if err := bc.triedb.Recover(head.Root); err != nil {
-			log.Crit("Failed to rollback state", "err", err)
+			log.Error("Failed to rollback state, resetting to genesis", "err", err)
+			return bc.genesisBlock.Header(), rootNumber
 		}
 	}
 	log.Info("Rewound to block with state", "number", head.Number, "hash", head.Hash())


### PR DESCRIPTION
This PR aims to close https://github.com/ethereum/go-ethereum/issues/31320#event-17201879654

Basically we get the signal to revert to a block before our sync block during sync. In this case there is very little that we can do. We can just try to reorg back to the genesis or exit. It seems like exit is not a really good behavior since this can prevent nodes from syncing un-finalized networks.