### PR TITLE
Added separate interface for WaitMined

### DIFF
--- a/accounts/abi/bind/v2/backend.go
+++ b/accounts/abi/bind/v2/backend.go
@@ -105,9 +105,14 @@ type ContractTransactor interface {
 	PendingNonceAt(ctx context.Context, account common.Address) (uint64, error)
 }
 
-// DeployBackend wraps the operations needed by WaitMined and WaitDeployed.
-type DeployBackend interface {
+// TxReceiptBackend wraps the operations needed by WaitMined.
+type TxReceiptBackend interface {
 	TransactionReceipt(ctx context.Context, txHash common.Hash) (*types.Receipt, error)
+}
+
+// DeployBackend wraps the operations needed by WaitDeployed.
+type DeployBackend interface {
+	TxReceiptBackend
 	CodeAt(ctx context.Context, account common.Address, blockNumber *big.Int) ([]byte, error)
 }
 

--- a/accounts/abi/bind/v2/util.go
+++ b/accounts/abi/bind/v2/util.go
@@ -29,7 +29,7 @@ import (
 
 // WaitMined waits for tx to be mined on the blockchain.
 // It stops waiting when the context is canceled.
-func WaitMined(ctx context.Context, b DeployBackend, txHash common.Hash) (*types.Receipt, error) {
+func WaitMined(ctx context.Context, b TxReceiptBackend, txHash common.Hash) (*types.Receipt, error) {
 	queryTicker := time.NewTicker(time.Second)
 	defer queryTicker.Stop()
 


### PR DESCRIPTION
Reason: you don't need `CodeAt` for it  and `WaitMined` don't use it.