### PR TITLE
eth, debug: make txIndex parameter optional in storageRangeAt

### DIFF
--- a/eth/api_debug.go
+++ b/eth/api_debug.go
@@ -28,6 +28,7 @@ import (
 	"github.com/ethereum/go-ethereum/core/state"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/ethereum/go-ethereum/eth/tracers"
 	"github.com/ethereum/go-ethereum/internal/ethapi"
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/rlp"
@@ -210,7 +211,8 @@ type storageEntry struct {
 }
 
 // StorageRangeAt returns the storage at the given block height and transaction index.
-func (api *DebugAPI) StorageRangeAt(ctx context.Context, blockNrOrHash rpc.BlockNumberOrHash, txIndex int, contractAddress common.Address, keyStart hexutil.Bytes, maxResult int) (StorageRangeResult, error) {
+// If txIndex is nil, it returns the storage at the end of the given block.
+func (api *DebugAPI) StorageRangeAt(ctx context.Context, blockNrOrHash rpc.BlockNumberOrHash, txIndex *int, contractAddress common.Address, keyStart hexutil.Bytes, maxResult int) (StorageRangeResult, error) {
 	var block *types.Block
 
 	block, err := api.eth.APIBackend.BlockByNumberOrHash(ctx, blockNrOrHash)
@@ -220,7 +222,16 @@ func (api *DebugAPI) StorageRangeAt(ctx context.Context, blockNrOrHash rpc.Block
 	if block == nil {
 		return StorageRangeResult{}, fmt.Errorf("block %v not found", blockNrOrHash)
 	}
-	_, _, statedb, release, err := api.eth.stateAtTransaction(ctx, block, txIndex, 0)
+
+	var statedb *state.StateDB
+	var release tracers.StateReleaseFunc
+
+	if txIndex != nil {
+		_, _, statedb, release, err = api.eth.stateAtTransaction(ctx, block, *txIndex, 0)
+	} else {
+		statedb, release, err = api.eth.stateAtBlock(ctx, block, 0, nil, true, false)
+	}
+
 	if err != nil {
 		return StorageRangeResult{}, err
 	}

--- a/internal/web3ext/web3ext.go
+++ b/internal/web3ext/web3ext.go
@@ -419,6 +419,7 @@ web3._extend({
 			name: 'storageRangeAt',
 			call: 'debug_storageRangeAt',
 			params: 5,
+			inputFormatter: [null, null, null, null, null]
 		}),
 		new web3._extend.Method({
 			name: 'getModifiedAccountsByNumber',


### PR DESCRIPTION
Closes #31344
## Rationale
This PR addresses an inconsistency in the `debug_storageRangeAt` RPC query compared to other query types like `debug_traceCall`. Currently, the `txIndex` parameter is required in `storageRangeAt`, making it impossible to query state after the last transaction in the latest block.

In other debug queries, the `txIndex` parameter is optional, and when omitted, the state after all transactions in the block is returned. This PR brings `storageRangeAt` in line with this convention.

## Implementation
- Made the `txIndex` parameter optional (changed from `int` to `*int`)
- When `txIndex` is provided, call `StateAtTransaction` to get state from the backend
- When `txIndex` is not provided, call `StateAtBlock`, same as in other API endpoints
- Updated the JavaScript API in web3ext.go to properly handle the optional parameter

## Testing
All tests pass - no new tests were needed as the existing test functions target the underlying `storageRangeAt` function, not the API endpoint itself.

This change ensures consistency in the API behavior across different debug endpoints.