### PR TITLE
core/vm: optimize push1, push2 opcode

### DIFF
--- a/core/vm/instructions.go
+++ b/core/vm/instructions.go
@@ -964,10 +964,9 @@ func opPush1(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([]by
 	)
 	*pc += 1
 	if *pc < codeLen {
-		scope.Stack.push(integer.SetUint64(uint64(scope.Contract.Code[*pc])))
-	} else {
-		scope.Stack.push(integer.Clear())
+		integer.SetUint64(uint64(scope.Contract.Code[*pc]))
 	}
+	scope.Stack.push(integer)
 	return nil, nil
 }
 
@@ -978,12 +977,11 @@ func opPush2(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([]by
 		integer = new(uint256.Int)
 	)
 	if *pc+2 < codeLen {
-		scope.Stack.push(integer.SetBytes2(scope.Contract.Code[*pc+1 : *pc+3]))
+		integer.SetBytes2(scope.Contract.Code[*pc+1 : *pc+3])
 	} else if *pc+1 < codeLen {
-		scope.Stack.push(integer.SetUint64(uint64(scope.Contract.Code[*pc+1]) << 8))
-	} else {
-		scope.Stack.push(integer.Clear())
+		integer.SetUint64(uint64(scope.Contract.Code[*pc+1]) << 8)
 	}
+	scope.Stack.push(integer)
 	*pc += 2
 	return nil, nil
 }


### PR DESCRIPTION
This PR is inspired by #31267 and further optimizes the instructions `opPush1`, `opPush2`. `opPush1` becomes inlineable. 

* dropped `integer.Clear()` of fresh `integer = new(uint256.Int)`
* use single `scope.Stack.push(..)`

## Before
![before](https://github.com/user-attachments/assets/5b1162a3-25a9-4d19-a992-397ef30c90a0)

## After
![after](https://github.com/user-attachments/assets/ad46c8c7-f1e6-49a5-8591-a651f38c4a88)
