### PR TITLE
p2p: fix dial metrics not picking up the right error

### DIFF
--- a/p2p/metrics.go
+++ b/p2p/metrics.go
@@ -68,6 +68,7 @@ func markDialError(err error) {
 		return
 	}
 
+	var e *protoHandshakeError
 	switch {
 	case errors.Is(err, DiscTooManyPeers):
 		dialTooManyPeers.Mark(1)
@@ -81,7 +82,7 @@ func markDialError(err error) {
 		dialUnexpectedIdentity.Mark(1)
 	case errors.Is(err, errEncHandshakeError):
 		dialEncHandshakeError.Mark(1)
-	case errors.Is(err, errProtoHandshakeError):
+	case errors.As(err, &e):
 		dialProtoHandshakeError.Mark(1)
 	}
 }

--- a/p2p/metrics.go
+++ b/p2p/metrics.go
@@ -60,7 +60,7 @@ var (
 	dialEncHandshakeError   = metrics.NewRegisteredMeter("p2p/dials/error/rlpx/enc", nil)   // EOF; connection reset during handshake; message too big; i/o timeout
 	dialProtoHandshakeError = metrics.NewRegisteredMeter("p2p/dials/error/rlpx/proto", nil) // EOF
 
-	// capure the rest of errors that are not handled by the above meters
+	// capture the rest of errors that are not handled by the above meters
 	dialOtherError = metrics.NewRegisteredMeter("p2p/dials/error/other", nil)
 )
 
@@ -91,8 +91,8 @@ func markDialError(err error) {
 	case errors.As(err, &phe):
 		dialProtoHandshakeError.Mark(1)
 	default:
-		// catch all for any other error, not supposed to happen, only here for cross-checking
-		// that all errors are captured by the above meters
+		// dialOtherError is a catch-all for any other error, which are not supposed to happen.
+		// Only here for cross-checking that all errors are captured by the above meters.
 		dialOtherError.Mark(1)
 	}
 }

--- a/p2p/metrics.go
+++ b/p2p/metrics.go
@@ -49,7 +49,7 @@ var (
 	serveSuccessMeter   = metrics.NewRegisteredMeter("p2p/serves/success", nil)
 	dialMeter           = metrics.NewRegisteredMeter("p2p/dials", nil)
 	dialSuccessMeter    = metrics.NewRegisteredMeter("p2p/dials/success", nil)
-	dialConnectionError = metrics.NewRegisteredMeter("p2p/dials/error/connection", nil)
+	dialConnectionError = metrics.NewRegisteredMeter("p2p/dials/error/connection", nil) // dial timeout; no route to host; connection refused; network is unreachable
 
 	// handshake error meters
 	dialTooManyPeers        = metrics.NewRegisteredMeter("p2p/dials/error/saturated", nil)
@@ -57,8 +57,8 @@ var (
 	dialSelf                = metrics.NewRegisteredMeter("p2p/dials/error/self", nil)
 	dialUselessPeer         = metrics.NewRegisteredMeter("p2p/dials/error/useless", nil)
 	dialUnexpectedIdentity  = metrics.NewRegisteredMeter("p2p/dials/error/id/unexpected", nil)
-	dialEncHandshakeError   = metrics.NewRegisteredMeter("p2p/dials/error/rlpx/enc", nil)
-	dialProtoHandshakeError = metrics.NewRegisteredMeter("p2p/dials/error/rlpx/proto", nil)
+	dialEncHandshakeError   = metrics.NewRegisteredMeter("p2p/dials/error/rlpx/enc", nil)   // EOF; connection reset during handshake; message too big; i/o timeout
+	dialProtoHandshakeError = metrics.NewRegisteredMeter("p2p/dials/error/rlpx/proto", nil) // EOF
 
 	// capure the rest of errors that are not handled by the above meters
 	dialOtherError = metrics.NewRegisteredMeter("p2p/dials/error/other", nil)

--- a/p2p/metrics.go
+++ b/p2p/metrics.go
@@ -68,7 +68,7 @@ func markDialError(err error) {
 		return
 	}
 
-	var e *protoHandshakeError
+	var phe *protoHandshakeError
 	switch {
 	case errors.Is(err, DiscTooManyPeers):
 		dialTooManyPeers.Mark(1)
@@ -82,7 +82,7 @@ func markDialError(err error) {
 		dialUnexpectedIdentity.Mark(1)
 	case errors.Is(err, errEncHandshakeError):
 		dialEncHandshakeError.Mark(1)
-	case errors.As(err, &e):
+	case errors.As(err, &phe):
 		dialProtoHandshakeError.Mark(1)
 	}
 }

--- a/p2p/metrics.go
+++ b/p2p/metrics.go
@@ -67,23 +67,21 @@ func markDialError(err error) {
 	if !metrics.Enabled() {
 		return
 	}
-	if err2 := errors.Unwrap(err); err2 != nil {
-		err = err2
-	}
-	switch err {
-	case DiscTooManyPeers:
+
+	switch {
+	case errors.Is(err, DiscTooManyPeers):
 		dialTooManyPeers.Mark(1)
-	case DiscAlreadyConnected:
+	case errors.Is(err, DiscAlreadyConnected):
 		dialAlreadyConnected.Mark(1)
-	case DiscSelf:
+	case errors.Is(err, DiscSelf):
 		dialSelf.Mark(1)
-	case DiscUselessPeer:
+	case errors.Is(err, DiscUselessPeer):
 		dialUselessPeer.Mark(1)
-	case DiscUnexpectedIdentity:
+	case errors.Is(err, DiscUnexpectedIdentity):
 		dialUnexpectedIdentity.Mark(1)
-	case errEncHandshakeError:
+	case errors.Is(err, errEncHandshakeError):
 		dialEncHandshakeError.Mark(1)
-	case errProtoHandshakeError:
+	case errors.Is(err, errProtoHandshakeError):
 		dialProtoHandshakeError.Mark(1)
 	}
 }

--- a/p2p/server.go
+++ b/p2p/server.go
@@ -907,7 +907,8 @@ func (srv *Server) setupConn(c *conn, dialDest *enode.Node) error {
 	phs, err := c.doProtoHandshake(srv.ourHandshake)
 	if err != nil {
 		clog.Trace("Failed p2p handshake", "err", err)
-		return fmt.Errorf("%w: %v", errProtoHandshakeError, err)
+		//Wrapping both errors for later inspection
+		return fmt.Errorf("%w: %w", errProtoHandshakeError, err)
 	}
 	if id := c.node.ID(); !bytes.Equal(crypto.Keccak256(phs.ID), id[:]) {
 		clog.Trace("Wrong devp2p handshake identity", "phsid", hex.EncodeToString(phs.ID))

--- a/p2p/server.go
+++ b/p2p/server.go
@@ -911,7 +911,6 @@ func (srv *Server) setupConn(c *conn, dialDest *enode.Node) error {
 	phs, err := c.doProtoHandshake(srv.ourHandshake)
 	if err != nil {
 		clog.Trace("Failed p2p handshake", "err", err)
-		//Wrapping both errors for later inspection
 		return &protoHandshakeError{err: err}
 	}
 	if id := c.node.ID(); !bytes.Equal(crypto.Keccak256(phs.ID), id[:]) {

--- a/p2p/server.go
+++ b/p2p/server.go
@@ -72,7 +72,7 @@ var (
 
 type protoHandshakeError struct{ err error }
 
-func (e *protoHandshakeError) Error() string { return fmt.Sprintf("rlpx proto error: %s", e.err) }
+func (e *protoHandshakeError) Error() string { return fmt.Sprintf("rlpx proto error: %v", e.err) }
 func (e *protoHandshakeError) Unwrap() error { return e.err }
 
 // Server manages all peer connections.

--- a/p2p/server_test.go
+++ b/p2p/server_test.go
@@ -410,11 +410,11 @@ func TestServerSetupConn(t *testing.T) {
 			wantCloseErr: DiscUnexpectedIdentity,
 		},
 		{
-			tt:           &setupTransport{pubkey: clientpub, protoHandshakeErr: errProtoHandshakeError},
+			tt:           &setupTransport{pubkey: clientpub, protoHandshakeErr: DiscTooManyPeers},
 			dialDest:     enode.NewV4(clientpub, nil, 0, 0),
 			flags:        dynDialedConn,
 			wantCalls:    "doEncHandshake,doProtoHandshake,close,",
-			wantCloseErr: errProtoHandshakeError,
+			wantCloseErr: DiscTooManyPeers,
 		},
 		{
 			tt:           &setupTransport{pubkey: srvpub, phs: protoHandshake{ID: crypto.FromECDSAPub(srvpub)[1:]}},


### PR DESCRIPTION
Our metrics related to dial errors were off. The original error was not wrapped, so the caller function had no chance of picking it up. Therefore the most common error, which is "TooManyPeers", was not correctly counted.

The metrics were originally introduced in https://github.com/ethereum/go-ethereum/pull/27621

I was thinking of various possible solutions.
- the one proposed here wraps both the new error and the origial error. It is not a pattern we use in other parts of the code, but works. This is maybe the smallest possible change.
- as an alternate, I could write a proper `errProtoHandshakeError` with it's own wrapped error
- finally, I'm not even sure we need `errProtoHandshakeError`, maybe we could just pass up the original error.