### PR TITLE
core: back-up to kvdb for a pruned block

### DIFF
--- a/core/rawdb/accessors_chain.go
+++ b/core/rawdb/accessors_chain.go
@@ -440,6 +440,12 @@ func ReadBodyRLP(db ethdb.Reader, hash common.Hash, number uint64) rlp.RawValue 
 		// Check if the data is in ancients
 		if isCanon(reader, number, hash) {
 			data, _ = reader.Ancient(ChainFreezerBodiesTable, number)
+			// The freezer might be pruned. In the particular case of genesis, the block
+			// will be still available in kvdb. The full genesis block is needed on startup
+			// sometimes for repair.
+			if data == nil {
+				data, _ = db.Get(blockBodyKey(number, hash))
+			}
 			return nil
 		}
 		// If not, try reading from leveldb


### PR DESCRIPTION
This is an attempt at fixing #31601. I think what happens is the startup logic will try to get the full block body and fail because genesis block has been pruned from the freezer. This will cause it to keep repeating the reset logic, causing a deadlock.

This can happen when due to an unsuccessful sync we don't have the state for the head (or any other state) fully, and try to redo the snap sync.