### PR TITLE
core/txpool/legacypool: fix data race of txlookup access

### DIFF
--- a/core/txpool/legacypool/legacypool.go
+++ b/core/txpool/legacypool/legacypool.go
@@ -943,8 +943,11 @@ func (pool *LegacyPool) Add(txs []*types.Transaction, sync bool) []error {
 		news = make([]*types.Transaction, 0, len(txs))
 	)
 	for i, tx := range txs {
+		pool.mu.Lock()
+		hash := pool.all.Get(tx.Hash())
+		pool.mu.Unlock()
 		// If the transaction is known, pre-set the error slot
-		if pool.all.Get(tx.Hash()) != nil {
+		if hash != nil {
 			errs[i] = txpool.ErrAlreadyKnown
 			knownTxMeter.Mark(1)
 			continue

--- a/core/txpool/legacypool/legacypool.go
+++ b/core/txpool/legacypool/legacypool.go
@@ -1827,6 +1827,7 @@ func (t *lookup) Remove(hash common.Hash) {
 	delete(t.txs, hash)
 }
 
+// Clear resets the lookup structure, removing all stored entries.
 func (t *lookup) Clear() {
 	t.lock.Lock()
 	defer t.lock.Unlock()


### PR DESCRIPTION
The race detector flagged this in some automated tests I run against the simulated backend.

LegacyPool.Clear is only called by the simulated beacon chain so i'm not sure if this applies to anything other than the simulated backend. But other methods, like LegacyPool.SetGasTip, access pool.all while holding the pool lock, which could create a data race with LegacyPool.Add.

```
==================
WARNING: DATA RACE
Read at 0x00c004f8bf18 by goroutine 38690:
  github.com/ethereum/go-ethereum/core/txpool/legacypool.(*LegacyPool).Add()
      /home/runner/work/exchange/exchange/vendor/github.com/ethereum/go-ethereum/core/txpool/legacypool/legacypool.go:932 +0x12c
  github.com/ethereum/go-ethereum/core/txpool.(*TxPool).Add()
      /home/runner/work/exchange/exchange/vendor/github.com/ethereum/go-ethereum/core/txpool/txpool.go:428 +0x426
  github.com/ethereum/go-ethereum/eth.(*EthAPIBackend).SendTx()
      /home/runner/work/exchange/exchange/vendor/github.com/ethereum/go-ethereum/eth/api_backend.go:284 +0x144
  github.com/ethereum/go-ethereum/internal/ethapi.SubmitTransaction()
      /home/runner/work/exchange/exchange/vendor/github.com/ethereum/go-ethereum/internal/ethapi/api.go:1459 +0x1d0
  github.com/ethereum/go-ethereum/internal/ethapi.(*TransactionAPI).SendRawTransaction()
      /home/runner/work/exchange/exchange/vendor/github.com/ethereum/go-ethereum/internal/ethapi/api.go:1540 +0x115
  runtime.call128()
      /home/runner/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.24.2.linux-amd64/src/runtime/asm_amd64.s:778 +0x57
  reflect.Value.Call()
      /home/runner/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.24.2.linux-amd64/src/reflect/value.go:368 +0xb5
  github.com/ethereum/go-ethereum/rpc.(*callback).call()
      /home/runner/work/exchange/exchange/vendor/github.com/ethereum/go-ethereum/rpc/service.go:205 +0x488
  github.com/ethereum/go-ethereum/rpc.(*handler).runMethod()
      /home/runner/work/exchange/exchange/vendor/github.com/ethereum/go-ethereum/rpc/handler.go:568 +0xab
  github.com/ethereum/go-ethereum/rpc.(*handler).handleCall()
      /home/runner/work/exchange/exchange/vendor/github.com/ethereum/go-ethereum/rpc/handler.go:515 +0x369
  github.com/ethereum/go-ethereum/rpc.(*handler).handleCallMsg()
      /home/runner/work/exchange/exchange/vendor/github.com/ethereum/go-ethereum/rpc/handler.go:473 +0x4a4
  github.com/ethereum/go-ethereum/rpc.(*handler).handleNonBatchCall()
      /home/runner/work/exchange/exchange/vendor/github.com/ethereum/go-ethereum/rpc/handler.go:299 +0x311
  github.com/ethereum/go-ethereum/rpc.(*handler).handleMsg.func1.1()
      /home/runner/work/exchange/exchange/vendor/github.com/ethereum/go-ethereum/rpc/handler.go:272 +0x44
  github.com/ethereum/go-ethereum/rpc.(*handler).startCallProc.func1()
      /home/runner/work/exchange/exchange/vendor/github.com/ethereum/go-ethereum/rpc/handler.go:390 +0x19c

Previous write at 0x00c004f8bf18 by goroutine 38137:
  github.com/ethereum/go-ethereum/core/txpool/legacypool.(*LegacyPool).Clear()
      /home/runner/work/exchange/exchange/vendor/github.com/ethereum/go-ethereum/core/txpool/legacypool/legacypool.go:1888 +0x35a
  github.com/ethereum/go-ethereum/core/txpool.(*TxPool).Clear()
      /home/runner/work/exchange/exchange/vendor/github.com/ethereum/go-ethereum/core/txpool/txpool.go:572 +0x1af
  github.com/ethereum/go-ethereum/eth/catalyst.(*SimulatedBeacon).Rollback()
      /home/runner/work/exchange/exchange/vendor/github.com/ethereum/go-ethereum/eth/catalyst/simulated_beacon.go:315 +0xed5
  github.com/ethereum/go-ethereum/ethclient/simulated.(*Backend).Rollback()
      /home/runner/work/exchange/exchange/vendor/github.com/ethereum/go-ethereum/ethclient/simulated/backend.go:164 +0xe0b
  <calling code>

Goroutine 38690 (running) created at:
  github.com/ethereum/go-ethereum/rpc.(*handler).startCallProc()
      /home/runner/work/exchange/exchange/vendor/github.com/ethereum/go-ethereum/rpc/handler.go:386 +0xe4
  github.com/ethereum/go-ethereum/rpc.(*handler).handleMsg.func1()
      /home/runner/work/exchange/exchange/vendor/github.com/ethereum/go-ethereum/rpc/handler.go:271 +0xd5
  github.com/ethereum/go-ethereum/rpc.(*handler).handleResponses()
      /home/runner/work/exchange/exchange/vendor/github.com/ethereum/go-ethereum/rpc/handler.go:442 +0x72b
  github.com/ethereum/go-ethereum/rpc.(*handler).handleMsg()
      /home/runner/work/exchange/exchange/vendor/github.com/ethereum/go-ethereum/rpc/handler.go:270 +0xb3
  github.com/ethereum/go-ethereum/rpc.(*Client).dispatch()
      /home/runner/work/exchange/exchange/vendor/github.com/ethereum/go-ethereum/rpc/client.go:651 +0x66e
  github.com/ethereum/go-ethereum/rpc.initClient.gowrap1()
      /home/runner/work/exchange/exchange/vendor/github.com/ethereum/go-ethereum/rpc/client.go:270 +0x4f

Goroutine 38137 (running) created at:
  <calling code>
  testing.tRunner()
      /home/runner/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.24.2.linux-amd64/src/testing/testing.go:1792 +0x225
  testing.(*T).Run.gowrap1()
      /home/runner/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.24.2.linux-amd64/src/testing/testing.go:1851 +0x44
==================
```