### PR TITLE
Cleaner shutdown logic

### DIFF
--- a/node/node.go
+++ b/node/node.go
@@ -28,6 +28,7 @@ import (
 	"slices"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/ethereum/go-ethereum/accounts"
 	"github.com/ethereum/go-ethereum/common"
@@ -519,6 +520,7 @@ func (n *Node) stopRPC() {
 	n.ws.stop()
 	n.httpAuth.stop()
 	n.wsAuth.stop()
+	time.Sleep(rpc.StopPendingRequestTimeout)
 	n.ipc.stop()
 	n.stopInProc()
 }

--- a/rpc/http.go
+++ b/rpc/http.go
@@ -309,7 +309,11 @@ func (t *httpServerConn) SetWriteDeadline(time.Time) error { return nil }
 func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	// Permit dumb empty requests for remote health-checks (AWS)
 	if r.Method == http.MethodGet && r.ContentLength == 0 && r.URL.RawQuery == "" {
-		w.WriteHeader(http.StatusOK)
+		if s.ready {
+			w.WriteHeader(http.StatusOK)
+		} else {
+			w.WriteHeader(http.StatusServiceUnavailable)
+		}
 		return
 	}
 	if code, err := s.validateRequest(r); err != nil {


### PR DESCRIPTION
Implement functionality to
* fail health check when node shutdown is initiated.
* allow 5 second for existing requests to drain before shutting down RPC servers and before database is closed.