### PR TITLE
cmd/geth: bloomfilter.size not used in the geth main process

### DIFF
--- a/cmd/geth/main.go
+++ b/cmd/geth/main.go
@@ -100,7 +100,6 @@ var (
 		utils.LightNoSyncServeFlag, // deprecated
 		utils.EthRequiredBlocksFlag,
 		utils.LegacyWhitelistFlag, // deprecated
-		utils.BloomFilterSizeFlag,
 		utils.CacheFlag,
 		utils.CacheDatabaseFlag,
 		utils.CacheTrieFlag,


### PR DESCRIPTION
`--blooomfilter.size` is only used in the `geth prune` subcommand, not used for the main process, remove it.