### PR TITLE
core: fix history pruning initialization for empty DB

### DIFF
--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -620,7 +620,7 @@ func (bc *BlockChain) initializeHistoryPruning(latest uint64) error {
 		if predefinedPoint == nil {
 			log.Error("Chain history pruning is not supported for this network", "genesis", bc.genesisBlock.Hash())
 			return fmt.Errorf("history pruning requested for unknown network")
-		} else if freezerTail != predefinedPoint.BlockNumber {
+		} else if freezerTail > 0 && freezerTail != predefinedPoint.BlockNumber {
 			log.Error("Chain history database is pruned to unknown block", "tail", freezerTail)
 			return fmt.Errorf("unexpected database tail")
 		}


### PR DESCRIPTION
This fixes an issue where running geth with `--history.chain postmerge` would not work on an empty database.

```
ERROR[04-16|23:11:12.913] Chain history database is pruned to unknown block tail=0
Fatal: Failed to register the Ethereum service: unexpected database tail
```