### PR TITLE
eth: fix transaction sender cache miss before broadcast

### DIFF
--- a/eth/handler.go
+++ b/eth/handler.go
@@ -484,7 +484,7 @@ func (h *handler) BroadcastTransactions(txs types.Transactions) {
 	total := new(big.Int).Exp(direct, big.NewInt(2), nil) // Stabilise total peer count a bit based on sqrt peers
 
 	var (
-		signer = types.LatestSignerForChainID(h.chain.Config().ChainID) // Don't care about chain status, we just need *a* sender
+		signer = types.LatestSigner(h.chain.Config()) // Don't care about chain status, we just need *a* sender
 		hasher = crypto.NewKeccakState()
 		hash   = make([]byte, 32)
 	)


### PR DESCRIPTION
BroadcastTransactions needs the Sender address to route message flows from the same Sender address consistently to the same random subset of peers.
It however spent considerable time calculating the Sender addresses, even if the Sender address was already calculated and cached in other parts of the code.

Since we only need the mapping, we can use any signer, and the one that had already been used is a better choice because of cache reuse.