### PR TITLE
all: create storage unit constants for readability

### DIFF
--- a/cmd/devp2p/internal/ethtest/suite.go
+++ b/cmd/devp2p/internal/ethtest/suite.go
@@ -377,7 +377,7 @@ func (s *Suite) TestGetBlockBodies(t *utesting.T) {
 
 // randBuf makes a random buffer size kilobytes large.
 func randBuf(size int) []byte {
-	buf := make([]byte, size*1024)
+	buf := make([]byte, size*common.Kilobytes)
 	rand.Read(buf)
 	return buf
 }

--- a/cmd/evm/eofparse.go
+++ b/cmd/evm/eofparse.go
@@ -26,6 +26,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/vm"
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/urfave/cli/v2"
@@ -105,7 +106,7 @@ func eofParseAction(ctx *cli.Context) error {
 	}
 	// If neither are passed in, read input from stdin.
 	scanner := bufio.NewScanner(os.Stdin)
-	scanner.Buffer(make([]byte, 1024*1024), 10*1024*1024)
+	scanner.Buffer(make([]byte, common.Megabytes), 10*common.Megabytes)
 	for scanner.Scan() {
 		l := strings.TrimSpace(scanner.Text())
 		if strings.HasPrefix(l, "#") || l == "" {
@@ -197,7 +198,7 @@ func eofDumpAction(ctx *cli.Context) error {
 	}
 	// Otherwise read from stdin
 	scanner := bufio.NewScanner(os.Stdin)
-	scanner.Buffer(make([]byte, 1024*1024), 10*1024*1024)
+	scanner.Buffer(make([]byte, common.Megabytes), 10*common.Megabytes)
 	for scanner.Scan() {
 		l := strings.TrimSpace(scanner.Text())
 		if strings.HasPrefix(l, "#") || l == "" {

--- a/cmd/evm/internal/t8ntool/tx_iterator.go
+++ b/cmd/evm/internal/t8ntool/tx_iterator.go
@@ -176,7 +176,7 @@ type rlpTxIterator struct {
 }
 
 func newRlpTxIterator(rlpData []byte) txIterator {
-	in := rlp.NewStream(bytes.NewBuffer(rlpData), 1024*1024)
+	in := rlp.NewStream(bytes.NewBuffer(rlpData), common.Megabytes)
 	in.List()
 	return &rlpTxIterator{in}
 }

--- a/cmd/geth/chaincmd.go
+++ b/cmd/geth/chaincmd.go
@@ -351,8 +351,8 @@ func importChain(ctx *cli.Context) error {
 	mem := new(runtime.MemStats)
 	runtime.ReadMemStats(mem)
 
-	fmt.Printf("Object memory: %.3f MB current, %.3f MB peak\n", float64(mem.Alloc)/1024/1024, float64(peakMemAlloc.Load())/1024/1024)
-	fmt.Printf("System memory: %.3f MB current, %.3f MB peak\n", float64(mem.Sys)/1024/1024, float64(peakMemSys.Load())/1024/1024)
+	fmt.Printf("Object memory: %.3f MB current, %.3f MB peak\n", float64(mem.Alloc)/common.Megabytes, float64(peakMemAlloc.Load())/common.Megabytes)
+	fmt.Printf("System memory: %.3f MB current, %.3f MB peak\n", float64(mem.Sys)/common.Megabytes, float64(peakMemSys.Load())/common.Megabytes)
 	fmt.Printf("Allocations:   %.3f million\n", float64(mem.Mallocs)/1000000)
 	fmt.Printf("GC pause:      %v\n\n", time.Duration(mem.PauseTotalNs))
 

--- a/cmd/utils/cmd.go
+++ b/cmd/utils/cmd.go
@@ -94,7 +94,7 @@ func StartNode(ctx *cli.Context, stack *node.Node, isConsole bool) {
 			minFreeDiskSpace = 2 * ctx.Int(CacheFlag.Name) * ctx.Int(CacheGCFlag.Name) / 100
 		}
 		if minFreeDiskSpace > 0 {
-			go monitorFreeDiskSpace(sigc, stack.InstanceDir(), uint64(minFreeDiskSpace)*1024*1024)
+			go monitorFreeDiskSpace(sigc, stack.InstanceDir(), uint64(minFreeDiskSpace)*common.Megabytes)
 		}
 
 		shutdown := func() {
@@ -523,7 +523,7 @@ func ImportPreimages(db ethdb.Database, fn string) error {
 		}
 		// Accumulate the preimages and flush when enough ws gathered
 		preimages[crypto.Keccak256Hash(blob)] = common.CopyBytes(blob)
-		if len(preimages) > 1024 {
+		if len(preimages) > common.Kilobytes {
 			rawdb.WritePreimages(db, preimages)
 			preimages = make(map[common.Hash][]byte)
 		}

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -1587,11 +1587,11 @@ func SetEthConfig(ctx *cli.Context, stack *node.Node, cfg *ethconfig.Config) {
 	// Cap the cache allowance and tune the garbage collector
 	mem, err := gopsutil.VirtualMemory()
 	if err == nil {
-		if 32<<(^uintptr(0)>>63) == 32 && mem.Total > 2*1024*1024*1024 {
-			log.Warn("Lowering memory allowance on 32bit arch", "available", mem.Total/1024/1024, "addressable", 2*1024)
-			mem.Total = 2 * 1024 * 1024 * 1024
+		if 32<<(^uintptr(0)>>63) == 32 && mem.Total > 2*common.Gigabytes {
+			log.Warn("Lowering memory allowance on 32bit arch", "available", mem.Total/common.Megabytes, "addressable", 2*common.Kilobytes)
+			mem.Total = 2 * common.Gigabytes
 		}
-		allowance := int(mem.Total / 1024 / 1024 / 3)
+		allowance := int(mem.Total / common.Megabytes / 3)
 		if cache := ctx.Int(CacheFlag.Name); cache > allowance {
 			log.Warn("Sanitizing cache to Go's GC limits", "provided", cache, "updated", allowance)
 			ctx.Set(CacheFlag.Name, strconv.Itoa(allowance))

--- a/common/bytes.go
+++ b/common/bytes.go
@@ -24,6 +24,13 @@ import (
 	"github.com/ethereum/go-ethereum/common/hexutil"
 )
 
+const (
+	Kilobytes = 1024
+	Megabytes = 1024 * Kilobytes
+	Gigabytes = 1024 * Megabytes
+	Terabytes = 1024 * Gigabytes
+)
+
 // FromHex returns the bytes represented by the hexadecimal string s.
 // s may be prefixed with "0x".
 func FromHex(s string) []byte {

--- a/common/size.go
+++ b/common/size.go
@@ -26,14 +26,14 @@ type StorageSize float64
 
 // String implements the stringer interface.
 func (s StorageSize) String() string {
-	if s > 1099511627776 {
-		return fmt.Sprintf("%.2f TiB", s/1099511627776)
-	} else if s > 1073741824 {
-		return fmt.Sprintf("%.2f GiB", s/1073741824)
-	} else if s > 1048576 {
-		return fmt.Sprintf("%.2f MiB", s/1048576)
-	} else if s > 1024 {
-		return fmt.Sprintf("%.2f KiB", s/1024)
+	if s > Terabytes {
+		return fmt.Sprintf("%.2f TiB", s/Terabytes)
+	} else if s > Gigabytes {
+		return fmt.Sprintf("%.2f GiB", s/Gigabytes)
+	} else if s > Megabytes {
+		return fmt.Sprintf("%.2f MiB", s/Megabytes)
+	} else if s > Kilobytes {
+		return fmt.Sprintf("%.2f KiB", s/Kilobytes)
 	} else {
 		return fmt.Sprintf("%.2f B", s)
 	}
@@ -42,14 +42,14 @@ func (s StorageSize) String() string {
 // TerminalString implements log.TerminalStringer, formatting a string for console
 // output during logging.
 func (s StorageSize) TerminalString() string {
-	if s > 1099511627776 {
-		return fmt.Sprintf("%.2fTiB", s/1099511627776)
-	} else if s > 1073741824 {
-		return fmt.Sprintf("%.2fGiB", s/1073741824)
-	} else if s > 1048576 {
-		return fmt.Sprintf("%.2fMiB", s/1048576)
-	} else if s > 1024 {
-		return fmt.Sprintf("%.2fKiB", s/1024)
+	if s > Terabytes {
+		return fmt.Sprintf("%.2fTiB", s/Terabytes)
+	} else if s > Gigabytes {
+		return fmt.Sprintf("%.2fGiB", s/Gigabytes)
+	} else if s > Megabytes {
+		return fmt.Sprintf("%.2fMiB", s/Megabytes)
+	} else if s > Kilobytes {
+		return fmt.Sprintf("%.2fKiB", s/Kilobytes)
 	} else {
 		return fmt.Sprintf("%.2fB", s)
 	}

--- a/core/rawdb/accessors_chain.go
+++ b/core/rawdb/accessors_chain.go
@@ -324,7 +324,7 @@ func ReadHeaderRange(db ethdb.Reader, number uint64, count uint64) []rlp.RawValu
 		return rlpHeaders
 	}
 	// read remaining from ancients, cap at 2M
-	data, err := db.AncientRange(ChainFreezerHeaderTable, i+1-count, count, 2*1024*1024)
+	data, err := db.AncientRange(ChainFreezerHeaderTable, i+1-count, count, 2*common.Megabytes)
 	if err != nil {
 		log.Error("Failed to read headers from freezer", "err", err)
 		return rlpHeaders

--- a/core/rawdb/freezer_batch.go
+++ b/core/rawdb/freezer_batch.go
@@ -21,13 +21,14 @@ import (
 	"math"
 	"time"
 
+	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/rlp"
 	"github.com/golang/snappy"
 )
 
 // This is the maximum amount of data that will be buffered in memory
 // for a single freezer table batch.
-const freezerBatchBufferLimit = 2 * 1024 * 1024
+const freezerBatchBufferLimit = 2 * common.Megabytes
 
 // freezerBatch is a write operation of multiple items on a freezer.
 type freezerBatch struct {

--- a/core/state/database.go
+++ b/core/state/database.go
@@ -37,7 +37,7 @@ const (
 	codeSizeCacheSize = 100000
 
 	// Cache size granted for caching clean code.
-	codeCacheSize = 64 * 1024 * 1024
+	codeCacheSize = 64 * common.Megabytes
 
 	// Number of address->curve point associations to keep.
 	pointCacheSize = 4096

--- a/core/state/pruner/bloom.go
+++ b/core/state/pruner/bloom.go
@@ -56,7 +56,7 @@ type stateBloom struct {
 // to the https://hur.st/bloomfilter/?n=600000000&p=&m=2048MB&k=4, the parameters
 // are picked so that the false-positive rate for mainnet is low enough.
 func newStateBloomWithSize(size uint64) (*stateBloom, error) {
-	bloom, err := bloomfilter.New(size*1024*1024*8, 4)
+	bloom, err := bloomfilter.New(size*common.Megabytes*8, 4)
 	if err != nil {
 		return nil, err
 	}

--- a/core/state/snapshot/difflayer.go
+++ b/core/state/snapshot/difflayer.go
@@ -41,7 +41,7 @@ var (
 	// Note, bumping this up might drastically increase the size of the bloom
 	// filters that's stored in every diff layer. Don't do that without fully
 	// understanding all the implications.
-	aggregatorMemoryLimit = uint64(4 * 1024 * 1024)
+	aggregatorMemoryLimit = uint64(4 * common.Megabytes)
 
 	// aggregatorItemLimit is an approximate number of items that will end up
 	// in the aggregator layer before it's flushed out to disk. A plain account

--- a/core/state/snapshot/generate.go
+++ b/core/state/snapshot/generate.go
@@ -71,7 +71,7 @@ func generateSnapshot(diskdb ethdb.KeyValueStore, triedb *triedb.Database, cache
 		diskdb:     diskdb,
 		triedb:     triedb,
 		root:       root,
-		cache:      fastcache.New(cache * 1024 * 1024),
+		cache:      fastcache.New(cache * common.Megabytes),
 		genMarker:  genMarker,
 		genPending: make(chan struct{}),
 		genAbort:   make(chan chan *generatorStats),

--- a/core/state/snapshot/journal.go
+++ b/core/state/snapshot/journal.go
@@ -139,7 +139,7 @@ func loadSnapshot(diskdb ethdb.KeyValueStore, triedb *triedb.Database, root comm
 	base := &diskLayer{
 		diskdb: diskdb,
 		triedb: triedb,
-		cache:  fastcache.New(cache * 1024 * 1024),
+		cache:  fastcache.New(cache * common.Megabytes),
 		root:   baseRoot,
 	}
 	snapshot, generator, err := loadAndParseJournal(diskdb, base)

--- a/core/state/snapshot/snapshot.go
+++ b/core/state/snapshot/snapshot.go
@@ -560,7 +560,7 @@ func diffToDisk(bottom *diffLayer) *diskLayer {
 		// Ensure we don't write too much data blindly. It's ok to flush, the
 		// root will go missing in case of a crash and we'll detect and regen
 		// the snapshot.
-		if batch.ValueSize() > 64*1024*1024 {
+		if batch.ValueSize() > 64*common.Megabytes {
 			if err := batch.Write(); err != nil {
 				log.Crit("Failed to write state changes", "err", err)
 			}
@@ -595,7 +595,7 @@ func diffToDisk(bottom *diffLayer) *diskLayer {
 			// Ensure we don't write too much data blindly. It's ok to flush, the
 			// root will go missing in case of a crash and we'll detect and regen
 			// the snapshot.
-			if batch.ValueSize() > 64*1024*1024 {
+			if batch.ValueSize() > 64*common.Megabytes {
 				if err := batch.Write(); err != nil {
 					log.Crit("Failed to write state changes", "err", err)
 				}

--- a/core/txpool/blobpool/blobpool.go
+++ b/core/txpool/blobpool/blobpool.go
@@ -53,14 +53,14 @@ const (
 
 	// txAvgSize is an approximate byte size of a transaction metadata to avoid
 	// tiny overflows causing all txs to move a shelf higher, wasting disk space.
-	txAvgSize = 4 * 1024
+	txAvgSize = 4 * common.Kilobytes
 
 	// txMaxSize is the maximum size a single transaction can have, outside
 	// the included blobs. Since blob transactions are pulled instead of pushed,
 	// and only a small metadata is kept in ram, the rest is on disk, there is
 	// no critical limit that should be enforced. Still, capping it to some sane
 	// limit can never hurt.
-	txMaxSize = 1024 * 1024
+	txMaxSize = common.Megabytes
 
 	// maxTxsPerAccount is the maximum number of blob transactions admitted from
 	// a single account. The limit is enforced to minimize the DoS potential of

--- a/core/txpool/blobpool/config.go
+++ b/core/txpool/blobpool/config.go
@@ -17,6 +17,7 @@
 package blobpool
 
 import (
+	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/log"
 )
 
@@ -30,8 +31,8 @@ type Config struct {
 // DefaultConfig contains the default configurations for the transaction pool.
 var DefaultConfig = Config{
 	Datadir:   "blobpool",
-	Datacap:   10 * 1024 * 1024 * 1024 / 4, // TODO(karalabe): /4 handicap for rollout, gradually bump back up to 10GB
-	PriceBump: 100,                         // either have patience or be aggressive, no mushy ground
+	Datacap:   10 * common.Gigabytes / 4, // TODO(karalabe): /4 handicap for rollout, gradually bump back up to 10GB
+	PriceBump: 100,                       // either have patience or be aggressive, no mushy ground
 }
 
 // sanitize checks the provided user configurations and changes anything that's

--- a/core/txpool/legacypool/legacypool.go
+++ b/core/txpool/legacypool/legacypool.go
@@ -49,7 +49,7 @@ const (
 	// takes up based on its size. The slots are used as DoS protection, ensuring
 	// that validating a new transaction remains a constant operation (in reality
 	// O(maxslots), where max slots are 4 currently).
-	txSlotSize = 32 * 1024
+	txSlotSize = 32 * common.Kilobytes
 
 	// txMaxSize is the maximum size a single transaction can have. This field has
 	// non-trivial consequences: larger transactions are significantly harder and

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -126,7 +126,7 @@ func New(stack *node.Node, config *ethconfig.Config) (*Ethereum, error) {
 		}
 		config.TrieDirtyCache = 0
 	}
-	log.Info("Allocated trie memory caches", "clean", common.StorageSize(config.TrieCleanCache)*1024*1024, "dirty", common.StorageSize(config.TrieDirtyCache)*1024*1024)
+	log.Info("Allocated trie memory caches", "clean", common.StorageSize(config.TrieCleanCache)*common.Megabytes, "dirty", common.StorageSize(config.TrieDirtyCache)*common.Megabytes)
 
 	chainDb, err := stack.OpenDatabaseWithFreezer("chaindata", config.DatabaseCache, config.DatabaseHandles, config.DatabaseFreezer, "eth/db/chaindata/", false)
 	if err != nil {

--- a/eth/downloader/queue.go
+++ b/eth/downloader/queue.go
@@ -42,10 +42,10 @@ const (
 )
 
 var (
-	blockCacheMaxItems     = 8192              // Maximum number of blocks to cache before throttling the download
-	blockCacheInitialItems = 2048              // Initial number of blocks to start fetching, before we know the sizes of the blocks
-	blockCacheMemory       = 256 * 1024 * 1024 // Maximum amount of memory to use for block caching
-	blockCacheSizeWeight   = 0.1               // Multiplier to approximate the average block size based on past ones
+	blockCacheMaxItems     = 8192                   // Maximum number of blocks to cache before throttling the download
+	blockCacheInitialItems = 2048                   // Initial number of blocks to start fetching, before we know the sizes of the blocks
+	blockCacheMemory       = 256 * common.Megabytes // Maximum amount of memory to use for block caching
+	blockCacheSizeWeight   = 0.1                    // Multiplier to approximate the average block size based on past ones
 )
 
 var (
@@ -400,7 +400,8 @@ func (q *queue) ReserveReceipts(p *peerConnection, count int) (*fetchRequest, bo
 //	progress - whether any progress was made
 //	throttle - if the caller should throttle for a while
 func (q *queue) reserveHeaders(p *peerConnection, count int, taskPool map[common.Hash]*types.Header, taskQueue *prque.Prque[int64, *types.Header],
-	pendPool map[string]*fetchRequest, kind uint) (*fetchRequest, bool, bool) {
+	pendPool map[string]*fetchRequest, kind uint,
+) (*fetchRequest, bool, bool) {
 	// Short circuit if the pool has been depleted, or if the peer's already
 	// downloading something (sanity check not to corrupt state)
 	if taskQueue.Empty() {
@@ -658,7 +659,8 @@ func (q *queue) deliver(id string, taskPool map[common.Hash]*types.Header,
 	taskQueue *prque.Prque[int64, *types.Header], pendPool map[string]*fetchRequest,
 	reqTimer *metrics.Timer, resInMeter, resDropMeter *metrics.Meter,
 	results int, validate func(index int, header *types.Header) error,
-	reconstruct func(index int, result *fetchResult)) (int, error) {
+	reconstruct func(index int, result *fetchResult),
+) (int, error) {
 	// Short circuit if the data was never requested
 	request := pendPool[id]
 	if request == nil {

--- a/eth/protocols/eth/handler.go
+++ b/eth/protocols/eth/handler.go
@@ -33,7 +33,7 @@ import (
 
 const (
 	// softResponseLimit is the target maximum size of replies to data retrievals.
-	softResponseLimit = 2 * 1024 * 1024
+	softResponseLimit = 2 * common.Megabytes
 
 	// maxHeadersServe is the maximum number of block headers to serve. This number
 	// is there to limit the number of disk lookups.

--- a/eth/protocols/eth/protocol.go
+++ b/eth/protocols/eth/protocol.go
@@ -46,7 +46,7 @@ var ProtocolVersions = []uint{ETH68}
 var protocolLengths = map[uint]uint64{ETH68: 17}
 
 // maxMessageSize is the maximum cap on the size of a protocol message.
-const maxMessageSize = 10 * 1024 * 1024
+const maxMessageSize = 10 * common.Megabytes
 
 const (
 	StatusMsg                     = 0x00

--- a/eth/protocols/snap/handler.go
+++ b/eth/protocols/snap/handler.go
@@ -35,7 +35,7 @@ import (
 
 const (
 	// softResponseLimit is the target maximum size of replies to data retrievals.
-	softResponseLimit = 2 * 1024 * 1024
+	softResponseLimit = 2 * common.Megabytes
 
 	// maxCodeLookups is the maximum number of bytecodes to serve. This number is
 	// there to limit the number of disk lookups.

--- a/eth/protocols/snap/protocol.go
+++ b/eth/protocols/snap/protocol.go
@@ -43,7 +43,7 @@ var ProtocolVersions = []uint{SNAP1}
 var protocolLengths = map[uint]uint64{SNAP1: 8}
 
 // maxMessageSize is the maximum cap on the size of a protocol message.
-const maxMessageSize = 10 * 1024 * 1024
+const maxMessageSize = 10 * common.Megabytes
 
 const (
 	GetAccountRangeMsg  = 0x00

--- a/eth/protocols/snap/sync.go
+++ b/eth/protocols/snap/sync.go
@@ -48,12 +48,12 @@ const (
 	// minRequestSize is the minimum number of bytes to request from a remote peer.
 	// This number is used as the low cap for account and storage range requests.
 	// Bytecode and trienode are limited inherently by item count (1).
-	minRequestSize = 64 * 1024
+	minRequestSize = 64 * common.Kilobytes
 
 	// maxRequestSize is the maximum number of bytes to request from a remote peer.
 	// This number is used as the high cap for account and storage range requests.
 	// Bytecode and trienode are limited more explicitly by the caps below.
-	maxRequestSize = 512 * 1024
+	maxRequestSize = 512 * common.Kilobytes
 
 	// maxCodeRequestCount is the maximum number of bytecode blobs to request in a
 	// single query. If this number is too low, we're not filling responses fully
@@ -63,7 +63,7 @@ const (
 	// Deployed bytecodes are currently capped at 24KB, so the minimum request
 	// size should be maxRequestSize / 24K. Assuming that most contracts do not
 	// come close to that, requesting 4x should be a good approximation.
-	maxCodeRequestCount = maxRequestSize / (24 * 1024) * 4
+	maxCodeRequestCount = maxRequestSize / (24 * common.Kilobytes) * 4
 
 	// maxTrieRequestCount is the maximum number of trie node blobs to request in
 	// a single query. If this number is too low, we're not filling responses fully
@@ -95,7 +95,7 @@ const (
 	trienodeHealThrottleDecrease = 1.25
 
 	// batchSizeThreshold is the maximum size allowed for gentrie batch.
-	batchSizeThreshold = 8 * 1024 * 1024
+	batchSizeThreshold = 8 * common.Megabytes
 )
 
 var (

--- a/eth/tracers/api.go
+++ b/eth/tracers/api.go
@@ -61,7 +61,7 @@ const (
 	// on top of memory.
 	// For non-archive nodes, this limit _will_ be overblown, as disk-backed tries
 	// will only be found every ~15K blocks or so.
-	defaultTracechainMemLimit = common.StorageSize(500 * 1024 * 1024)
+	defaultTracechainMemLimit = common.StorageSize(500 * common.Megabytes)
 
 	// maximumPendingTraceStates is the maximum number of states allowed waiting
 	// for tracing. The creation of trace state will be paused if the unused

--- a/eth/tracers/internal/util.go
+++ b/eth/tracers/internal/util.go
@@ -20,11 +20,12 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/ethereum/go-ethereum/common"
 	"github.com/holiman/uint256"
 )
 
 const (
-	memoryPadLimit = 1024 * 1024
+	memoryPadLimit = common.Megabytes
 )
 
 // GetMemoryCopyPadded returns offset + size as a new slice.

--- a/ethdb/batch.go
+++ b/ethdb/batch.go
@@ -16,9 +16,11 @@
 
 package ethdb
 
+import "github.com/ethereum/go-ethereum/common"
+
 // IdealBatchSize defines the size of the data batches should ideally add in one
 // write.
-const IdealBatchSize = 100 * 1024
+const IdealBatchSize = 100 * common.Kilobytes
 
 // Batch is a write-only database that commits changes to its host database
 // when Write is called. A batch cannot be used concurrently.

--- a/ethdb/pebble/pebble.go
+++ b/ethdb/pebble/pebble.go
@@ -153,7 +153,7 @@ func New(file string, cache int, handles int, namespace string, readonly bool, e
 		handles = minHandles
 	}
 	logger := log.New("database", file)
-	logger.Info("Allocated cache and file handles", "cache", common.StorageSize(cache*1024*1024), "handles", handles)
+	logger.Info("Allocated cache and file handles", "cache", common.StorageSize(cache*common.Megabytes), "handles", handles)
 
 	// The max memtable size is limited by the uint32 offsets stored in
 	// internal/arenaskl.node, DeferredBatchOp, and flushableBatchEntry.
@@ -170,7 +170,7 @@ func New(file string, cache int, handles int, namespace string, readonly bool, e
 	// Two memory tables is configured which is identical to leveldb,
 	// including a frozen memory table and another live one.
 	memTableLimit := 2
-	memTableSize := cache * 1024 * 1024 / 2 / memTableLimit
+	memTableSize := cache * common.Megabytes / 2 / memTableLimit
 
 	// The memory table size is currently capped at maxMemTableSize-1 due to a
 	// known bug in the pebble where maxMemTableSize is not recognized as a
@@ -191,7 +191,7 @@ func New(file string, cache int, handles int, namespace string, readonly bool, e
 		// Pebble has a single combined cache area and the write
 		// buffers are taken from this too. Assign all available
 		// memory allowance for cache.
-		Cache:        pebble.NewCache(int64(cache * 1024 * 1024)),
+		Cache:        pebble.NewCache(int64(cache * common.Megabytes)),
 		MaxOpenFiles: handles,
 
 		// The size of memory table(as well as the write buffer).
@@ -212,13 +212,13 @@ func New(file string, cache int, handles int, namespace string, readonly bool, e
 		// Per-level options. Options for at least one level must be specified. The
 		// options for the last level are used for all subsequent levels.
 		Levels: []pebble.LevelOptions{
-			{TargetFileSize: 2 * 1024 * 1024, FilterPolicy: bloom.FilterPolicy(10)},
-			{TargetFileSize: 4 * 1024 * 1024, FilterPolicy: bloom.FilterPolicy(10)},
-			{TargetFileSize: 8 * 1024 * 1024, FilterPolicy: bloom.FilterPolicy(10)},
-			{TargetFileSize: 16 * 1024 * 1024, FilterPolicy: bloom.FilterPolicy(10)},
-			{TargetFileSize: 32 * 1024 * 1024, FilterPolicy: bloom.FilterPolicy(10)},
-			{TargetFileSize: 64 * 1024 * 1024, FilterPolicy: bloom.FilterPolicy(10)},
-			{TargetFileSize: 128 * 1024 * 1024, FilterPolicy: bloom.FilterPolicy(10)},
+			{TargetFileSize: 2 * common.Megabytes, FilterPolicy: bloom.FilterPolicy(10)},
+			{TargetFileSize: 4 * common.Megabytes, FilterPolicy: bloom.FilterPolicy(10)},
+			{TargetFileSize: 8 * common.Megabytes, FilterPolicy: bloom.FilterPolicy(10)},
+			{TargetFileSize: 16 * common.Megabytes, FilterPolicy: bloom.FilterPolicy(10)},
+			{TargetFileSize: 32 * common.Megabytes, FilterPolicy: bloom.FilterPolicy(10)},
+			{TargetFileSize: 64 * common.Megabytes, FilterPolicy: bloom.FilterPolicy(10)},
+			{TargetFileSize: 128 * common.Megabytes, FilterPolicy: bloom.FilterPolicy(10)},
 		},
 		ReadOnly: readonly,
 		EventListener: &pebble.EventListener{

--- a/ethstats/ethstats.go
+++ b/ethstats/ethstats.go
@@ -56,7 +56,7 @@ const (
 	// chainHeadChanSize is the size of channel listening to ChainHeadEvent.
 	chainHeadChanSize = 10
 
-	messageSizeLimit = 15 * 1024 * 1024
+	messageSizeLimit = 15 * common.Megabytes
 )
 
 // backend encompasses the bare-minimum functionality needed for ethstats reporting

--- a/internal/era/e2store/e2store.go
+++ b/internal/era/e2store/e2store.go
@@ -21,11 +21,13 @@ import (
 	"errors"
 	"fmt"
 	"io"
+
+	"github.com/ethereum/go-ethereum/common"
 )
 
 const (
 	headerSize     = 8
-	valueSizeLimit = 1024 * 1024 * 50
+	valueSizeLimit = 50 * common.Megabytes
 )
 
 // Entry is a variable-length-data record in an e2store.

--- a/rpc/http.go
+++ b/rpc/http.go
@@ -30,10 +30,12 @@ import (
 	"strconv"
 	"sync"
 	"time"
+
+	"github.com/ethereum/go-ethereum/common"
 )
 
 const (
-	defaultBodyLimit = 5 * 1024 * 1024
+	defaultBodyLimit = 5 * common.Megabytes
 	contentType      = "application/json"
 )
 

--- a/rpc/websocket.go
+++ b/rpc/websocket.go
@@ -28,6 +28,7 @@ import (
 	"time"
 
 	mapset "github.com/deckarep/golang-set/v2"
+	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/gorilla/websocket"
 )
@@ -38,7 +39,7 @@ const (
 	wsPingInterval     = 30 * time.Second
 	wsPingWriteTimeout = 5 * time.Second
 	wsPongTimeout      = 30 * time.Second
-	wsDefaultReadLimit = 32 * 1024 * 1024
+	wsDefaultReadLimit = 32 * common.Megabytes
 )
 
 var wsBufferPool = new(sync.Pool)

--- a/triedb/pathdb/database.go
+++ b/triedb/pathdb/database.go
@@ -36,20 +36,20 @@ import (
 
 const (
 	// defaultCleanSize is the default memory allowance of clean cache.
-	defaultCleanSize = 16 * 1024 * 1024
+	defaultCleanSize = 16 * common.Megabytes
 
 	// maxBufferSize is the maximum memory allowance of node buffer.
 	// Too large buffer will cause the system to pause for a long
 	// time when write happens. Also, the largest batch that pebble can
 	// support is 4GB, node will panic if batch size exceeds this limit.
-	maxBufferSize = 256 * 1024 * 1024
+	maxBufferSize = 256 * common.Megabytes
 
 	// defaultBufferSize is the default memory allowance of node buffer
 	// that aggregates the writes from above until it's flushed into the
 	// disk. It's meant to be used once the initial sync is finished.
 	// Do not increase the buffer size arbitrarily, otherwise the system
 	// pause time will increase when the database writes happen.
-	defaultBufferSize = 64 * 1024 * 1024
+	defaultBufferSize = 64 * common.Megabytes
 )
 
 var (

--- a/triedb/preimages.go
+++ b/triedb/preimages.go
@@ -74,7 +74,7 @@ func (store *preimageStore) commit(force bool) error {
 	store.lock.Lock()
 	defer store.lock.Unlock()
 
-	if store.preimagesSize <= 4*1024*1024 && !force {
+	if store.preimagesSize <= 4*common.Megabytes && !force {
 		return nil
 	}
 	batch := store.disk.NewBatch()


### PR DESCRIPTION
Introduces storage unit constants (Kilobytes, Megabytes, Gigabytes, Terabytes) in `common/bytes.go` to replace hard-coded calculations like `1024 * 1024` throughout the codebase. This change improves code readability and maintainability by:

- Eliminating magic numbers for storage units
- Reducing the chance of calculation errors
- Making storage size declarations more explicit and self-documenting

No functional changes, purely readability improvement.