### PR TITLE
eth/gasprice: fix eth_feeHistory blobGasUsedRatio divide zero

### DIFF
--- a/eth/gasprice/feehistory.go
+++ b/eth/gasprice/feehistory.go
@@ -108,10 +108,9 @@ func (oracle *Oracle) processBlock(bf *blockFees, percentiles []float64) {
 	bf.results.gasUsedRatio = float64(bf.header.GasUsed) / float64(bf.header.GasLimit)
 	if blobGasUsed := bf.header.BlobGasUsed; blobGasUsed != nil {
 		maxBlobGas := eip4844.MaxBlobGasPerBlock(config, bf.header.Time)
-		if maxBlobGas == 0 {
-			return
+		if maxBlobGas != 0 {
+			bf.results.blobGasUsedRatio = float64(*blobGasUsed) / float64(maxBlobGas)
 		}
-		bf.results.blobGasUsedRatio = float64(*blobGasUsed) / float64(maxBlobGas)
 	}
 
 	if len(percentiles) == 0 {

--- a/eth/gasprice/feehistory.go
+++ b/eth/gasprice/feehistory.go
@@ -108,6 +108,9 @@ func (oracle *Oracle) processBlock(bf *blockFees, percentiles []float64) {
 	bf.results.gasUsedRatio = float64(bf.header.GasUsed) / float64(bf.header.GasLimit)
 	if blobGasUsed := bf.header.BlobGasUsed; blobGasUsed != nil {
 		maxBlobGas := eip4844.MaxBlobGasPerBlock(config, bf.header.Time)
+		if maxBlobGas == 0 {
+			return
+		}
 		bf.results.blobGasUsedRatio = float64(*blobGasUsed) / float64(maxBlobGas)
 	}
 


### PR DESCRIPTION
The API `eth_feeHistory` returns `{"jsonrpc":"2.0","id":1,"error":{"code":-32603,"message":"json: unsupported value: NaN"}}`, when we query `eth_feeHistory` with a old block that without a blob, or when the field `config.blobSchedule.cancun.max` in genesis.config is 0 (that happens for some projects fork geth but they don't have blob).

So here we specially handle the case when maxBlobGas == 0 to prevent this issue from happening.