### PR TITLE
p2p: make dial faster by streamlined discovery process

### DIFF
--- a/eth/backend.go
+++ b/eth/backend.go
@@ -487,6 +487,15 @@ func (s *Ethereum) setupDiscovery() error {
 		s.discmix.AddSource(iter)
 	}
 
+	// Add DHT nodes from discv4.
+	if s.p2pServer.DiscoveryV4() != nil {
+		asyncFilter := s.p2pServer.DiscoveryV4().RequestENR
+		filter := eth.NewNodeFilter(s.blockchain)
+		iter := enode.AsyncFilter(s.p2pServer.DiscoveryV4().RandomNodes(), asyncFilter)
+		iter = enode.Filter(iter, filter)
+		s.discmix.AddSource(iter)
+	}
+
 	// Add DHT nodes from discv5.
 	if s.p2pServer.DiscoveryV5() != nil {
 		filter := eth.NewNodeFilter(s.blockchain)

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -505,9 +505,12 @@ func (s *Ethereum) setupDiscovery() error {
 	// Add DHT nodes from discv4.
 	if s.p2pServer.DiscoveryV4() != nil {
 		iter := s.p2pServer.DiscoveryV4().RandomNodes()
-		resolverFunc := func(ctx context.Context, enr *enode.Node) (*enode.Node, error) {
+		resolverFunc := func(ctx context.Context, enr *enode.Node) *enode.Node {
 			// RequestENR does not yet support context. It will simply time out.
-			return s.p2pServer.DiscoveryV4().RequestENR(enr)
+			// If the ENR can't be resolved, RequestENR will return nil. We don't
+			// care about the specific error here, so we ignore it.
+			nn, _ := s.p2pServer.DiscoveryV4().RequestENR(enr)
+			return nn
 		}
 		iter = enode.AsyncFilter(iter, resolverFunc, maxParallelENRRequests)
 		iter = enode.Filter(iter, eth.NewNodeFilter(s.blockchain))

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -70,6 +70,10 @@ const (
 	// in the next rounds, giving it overall more time but a proportionally smaller share.
 	// We expect a normal source to produce ~10 candidates per second.
 	discmixTimeout = 100 * time.Millisecond
+
+	// maxParallelENRRequests is the maximum number of parallel ENR requests that can be
+	// performed by a disc/v4 source.
+	maxParallelENRRequests = 16
 )
 
 // Config contains the configuration options of the ETH protocol.
@@ -501,7 +505,7 @@ func (s *Ethereum) setupDiscovery() error {
 	if s.p2pServer.DiscoveryV4() != nil {
 		asyncFilter := s.p2pServer.DiscoveryV4().RequestENR
 		filter := eth.NewNodeFilter(s.blockchain)
-		iter := enode.AsyncFilter(s.p2pServer.DiscoveryV4().RandomNodes(), asyncFilter, 16)
+		iter := enode.AsyncFilter(s.p2pServer.DiscoveryV4().RandomNodes(), asyncFilter, maxParallelENRRequests)
 		iter = enode.Filter(iter, filter)
 		s.discmix.AddSource(iter)
 	}

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -62,6 +62,16 @@ import (
 	gethversion "github.com/ethereum/go-ethereum/version"
 )
 
+const (
+	// This is the fairness knob for the discovery mixer. When looking for peers, we'll
+	// wait this long for a single source of candidates before moving on and trying other
+	// sources. If this timeout expires, the source will be skipped in this round, but it
+	// will continue to fetch in the background and will have a chance with a new timeout
+	// in the next rounds, giving it overall more time but a proportionally smaller share.
+	// We expect a normal source to produce ~10 candidates per second.
+	discmixTimeout = 100 * time.Millisecond
+)
+
 // Config contains the configuration options of the ETH protocol.
 // Deprecated: use ethconfig.Config instead.
 type Config = ethconfig.Config
@@ -169,7 +179,7 @@ func New(stack *node.Node, config *ethconfig.Config) (*Ethereum, error) {
 		networkID:       networkID,
 		gasPrice:        config.Miner.GasPrice,
 		p2pServer:       stack.Server(),
-		discmix:         enode.NewFairMix(0),
+		discmix:         enode.NewFairMix(discmixTimeout),
 		shutdownTracker: shutdowncheck.NewShutdownTracker(chainDb),
 	}
 	bcVersion := rawdb.ReadDatabaseVersion(chainDb)

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -491,7 +491,7 @@ func (s *Ethereum) setupDiscovery() error {
 	if s.p2pServer.DiscoveryV4() != nil {
 		asyncFilter := s.p2pServer.DiscoveryV4().RequestENR
 		filter := eth.NewNodeFilter(s.blockchain)
-		iter := enode.AsyncFilter(s.p2pServer.DiscoveryV4().RandomNodes(), asyncFilter)
+		iter := enode.AsyncFilter(s.p2pServer.DiscoveryV4().RandomNodes(), asyncFilter, 16)
 		iter = enode.Filter(iter, filter)
 		s.discmix.AddSource(iter)
 	}

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -72,6 +72,13 @@ const (
 	// We expect a normal source to produce ~10 candidates per second.
 	discmixTimeout = 100 * time.Millisecond
 
+	// discoveryParallelLookups is the number of parallel lookups to perform by DHT
+	// sources (disc/v4 and disc/v5). We set this number large enough to be able to
+	// feed the dial queue with enough peers. Since the whole discovery process is triggered
+	// only when dial candidates are needed, we can keep this number high without worrying
+	// about overloading the DHT.
+	discoveryParallelLookups = 3
+
 	// discoveryPrefetchBuffer is the number of peers to pre-fetch from a discovery
 	// source. It is useful to avoid the negative effects of potential longer timeouts
 	// in the discovery, keeping dial progress while waiting for the next batch of
@@ -510,7 +517,6 @@ func (s *Ethereum) setupDiscovery() error {
 
 	// Add DHT nodes from discv4.
 	if s.p2pServer.DiscoveryV4() != nil {
-		iter := s.p2pServer.DiscoveryV4().RandomNodes()
 		resolverFunc := func(ctx context.Context, enr *enode.Node) *enode.Node {
 			// RequestENR does not yet support context. It will simply time out.
 			// If the ENR can't be resolved, RequestENR will return nil. We don't
@@ -518,18 +524,27 @@ func (s *Ethereum) setupDiscovery() error {
 			nn, _ := s.p2pServer.DiscoveryV4().RequestENR(enr)
 			return nn
 		}
-		iter = enode.AsyncFilter(iter, resolverFunc, maxParallelENRRequests)
-		iter = enode.Filter(iter, eth.NewNodeFilter(s.blockchain))
-		iter = enode.NewBufferIter(iter, discoveryPrefetchBuffer)
-		s.discmix.AddSource(iter)
+		fairmix := enode.NewFairMix(0)
+		for i := 0; i < discoveryParallelLookups; i++ {
+			iter := s.p2pServer.DiscoveryV4().RandomNodes()
+			iter = enode.AsyncFilter(iter, resolverFunc, maxParallelENRRequests)
+			iter = enode.Filter(iter, eth.NewNodeFilter(s.blockchain))
+			iter = enode.NewBufferIter(iter, discoveryPrefetchBuffer)
+			fairmix.AddSource(iter)
+		}
+		s.discmix.AddSource(fairmix)
 	}
 
 	// Add DHT nodes from discv5.
 	if s.p2pServer.DiscoveryV5() != nil {
-		filter := eth.NewNodeFilter(s.blockchain)
-		iter := enode.Filter(s.p2pServer.DiscoveryV5().RandomNodes(), filter)
-		iter = enode.NewBufferIter(iter, discoveryPrefetchBuffer)
-		s.discmix.AddSource(iter)
+		fairmix := enode.NewFairMix(0)
+		for i := 0; i < discoveryParallelLookups; i++ {
+			iter := s.p2pServer.DiscoveryV5().RandomNodes()
+			iter = enode.Filter(iter, eth.NewNodeFilter(s.blockchain))
+			iter = enode.NewBufferIter(iter, discoveryPrefetchBuffer)
+			fairmix.AddSource(iter)
+		}
+		s.discmix.AddSource(fairmix)
 	}
 
 	return nil

--- a/p2p/enode/iter.go
+++ b/p2p/enode/iter.go
@@ -243,7 +243,7 @@ type BufferIter struct {
 }
 
 // NewBufferIter creates a new pre-fetch buffer of a given size.
-func NewBufferIter(it Iterator, size int) *BufferIter {
+func NewBufferIter(it Iterator, size int) Iterator {
 	b := BufferIter{
 		it:     it,
 		buffer: make(chan *Node, size),

--- a/p2p/enode/iter.go
+++ b/p2p/enode/iter.go
@@ -163,7 +163,7 @@ type AsyncFilterIter struct {
 	cancel    context.CancelFunc
 	closeOnce sync.Once
 }
-type AsyncFilterFunc func(context.Context, *Node) (*Node, error)
+type AsyncFilterFunc func(context.Context, *Node) *Node
 
 // AsyncFilter creates an iterator which checks nodes in parallel.
 func AsyncFilter(it Iterator, check AsyncFilterFunc, workers int) Iterator {
@@ -192,7 +192,7 @@ func AsyncFilter(it Iterator, check AsyncFilterFunc, workers int) Iterator {
 			<-f.slots
 			// check the node async, in a separate goroutine
 			go func() {
-				if nn, err := check(ctx, n); err == nil {
+				if nn := check(ctx, n); nn != nil {
 					select {
 					case f.passed <- nn:
 					case <-ctx.Done(): // bale out if downstream is already closed and not calling Next

--- a/p2p/enode/iter.go
+++ b/p2p/enode/iter.go
@@ -239,6 +239,7 @@ type BufferIter struct {
 	buffer chan *Node
 	head   *Node
 	closed chan struct{}
+	mu     sync.Mutex
 }
 
 // NewBufferIter creates a new pre-fetch buffer of a given size.
@@ -266,6 +267,9 @@ func NewBufferIter(it Iterator, size int) *BufferIter {
 }
 
 func (b *BufferIter) Next() bool {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
 	select {
 	case b.head = <-b.buffer:
 	case <-b.closed:
@@ -275,6 +279,8 @@ func (b *BufferIter) Next() bool {
 }
 
 func (b *BufferIter) Node() *Node {
+	b.mu.Lock()
+	defer b.mu.Unlock()
 	return b.head
 }
 
@@ -282,6 +288,9 @@ func (b *BufferIter) Close() {
 	// Close the wrapped iterator first.
 	b.it.Close()
 	close(b.closed)
+	// Wait for Next to terminate, then drain the buffer.
+	b.mu.Lock()
+	defer b.mu.Unlock()
 	for range b.buffer {
 	}
 	b.buffer = nil

--- a/p2p/server.go
+++ b/p2p/server.go
@@ -483,7 +483,6 @@ func (srv *Server) setupDiscovery() error {
 			return err
 		}
 		srv.discv4 = ntab
-		srv.discmix.AddSource(ntab.RandomNodes())
 	}
 	if srv.Config.DiscoveryV5 {
 		cfg := discover.Config{

--- a/p2p/server.go
+++ b/p2p/server.go
@@ -47,8 +47,9 @@ const (
 
 	// This is the fairness knob for the discovery mixer. When looking for peers, we'll
 	// wait this long for a single source of candidates before moving on and trying other
-	// sources.
-	discmixTimeout = 5 * time.Second
+	// sources. Currently there is only one source at the Server level, so this has no effect.
+	// Check the fairMox tineout in the Backend for the actual timeout.
+	discmixTimeout = 100 * time.Millisecond
 
 	// Connectivity defaults.
 	defaultMaxPendingPeers = 50


### PR DESCRIPTION
This PR improves the speed of Disc/v4 and Disc/v5 based discovery. It builds on https://github.com/ethereum/go-ethereum/pull/31592. To be rebased after merging that PR.

Our dial process is rate-limited, but until now, during startup, our discovery was too slow to serve dial. So the bottleneck was discovery, not the rate limit in dial, resulting in slow ramp-up of outgoing peer count.
 
This PR making discovery fast enough to serve dial's needs. The rate-limit of dial is still limiting the discovery process, so we are not risking being too aggressive in our discovery.

The PR adds:
- a pre-fetch buffer to discovery sources, eliminating slowdowns due to timeouts and rate mismatch between the two precesses
-  multiple parallel lookups to make sure enough dial candidates are available all the time