### PR TITLE
core/txpool/legacypool: remove duplicate lock

### DIFF
--- a/core/txpool/legacypool/legacypool.go
+++ b/core/txpool/legacypool/legacypool.go
@@ -438,9 +438,6 @@ func (pool *LegacyPool) SetGasTip(tip *big.Int) {
 // Nonce returns the next nonce of an account, with all transactions executable
 // by the pool already applied on top.
 func (pool *LegacyPool) Nonce(addr common.Address) uint64 {
-	pool.mu.RLock()
-	defer pool.mu.RUnlock()
-
 	return pool.pendingNonces.get(addr)
 }
 


### PR DESCRIPTION
Since the `get nonce` function is already protected by a lock, is this additional one unnecessary?