### PR TITLE
core: fix wrong refundGas when gasUsed < floorDataGas

### DIFF
--- a/core/state_transition.go
+++ b/core/state_transition.go
@@ -515,6 +515,7 @@ func (st *stateTransition) execute() (*ExecutionResult, error) {
 	if rules.IsPrague {
 		// After EIP-7623: Data-heavy transactions pay the floor gas.
 		if st.gasUsed() < floorDataGas {
+			gasRefund = 0
 			prev := st.gasRemaining
 			st.gasRemaining = st.initialGas - floorDataGas
 			if t := st.evm.Config.Tracer; t != nil && t.OnGasChange != nil {


### PR DESCRIPTION
This PR addresses an issue reported on the Cantina contest. In short, when the gas used by the execution of a transaction is less than the floor gas from EIP 7623, the refunded gas must be zero, as done by other clients like [reth](https://github.com/bluealloy/revm/blob/fd72c65c550d626b218acd3df12a2e9424755e6d/crates/handler/src/post_execution.rs#L12). However, Geth does not set `gasRefund` to `0` if that condition is met, so the returned gas refund is wrong.

This does not pose an issue to the protocol as, when creating the associated receipt with `MakeReceipt`, the field `GasRefunded` is ignored.