### PR TITLE
accounts/bind/v2: Some upgrades about abigen v2

### DIFF
--- a/accounts/abi/abigen/source2.go.tpl
+++ b/accounts/abi/abigen/source2.go.tpl
@@ -145,7 +145,7 @@ var (
 				out{{$i}} := *abi.ConvertType(out[{{$i}}], new({{bindtype .Type $structs}})).(*{{bindtype .Type $structs}})
 				{{- end }}
 				{{- end}}
-				return {{range $i, $t := .Normalized.Outputs}}out{{$i}}, {{end}} err
+				return {{range $i, $t := .Normalized.Outputs}}out{{$i}}, {{end}} nil
                 {{- end}}
 			}
 		{{end}}

--- a/accounts/abi/bind/v2/internal/contracts/db/bindings.go
+++ b/accounts/abi/bind/v2/internal/contracts/db/bindings.go
@@ -80,7 +80,7 @@ func (dB *DB) UnpackGet(data []byte) (*big.Int, error) {
 		return new(big.Int), err
 	}
 	out0 := abi.ConvertType(out[0], new(big.Int)).(*big.Int)
-	return out0, err
+	return out0, nil
 }
 
 // PackGetNamedStatParams is the Go binding used to pack the parameters required for calling
@@ -179,7 +179,7 @@ func (dB *DB) UnpackGetStatsStruct(data []byte) (DBStats, error) {
 		return *new(DBStats), err
 	}
 	out0 := *abi.ConvertType(out[0], new(DBStats)).(*DBStats)
-	return out0, err
+	return out0, nil
 }
 
 // PackInsert is the Go binding used to pack the parameters required for calling
@@ -204,7 +204,7 @@ func (dB *DB) UnpackInsert(data []byte) (*big.Int, error) {
 		return new(big.Int), err
 	}
 	out0 := abi.ConvertType(out[0], new(big.Int)).(*big.Int)
-	return out0, err
+	return out0, nil
 }
 
 // DBInsert represents a Insert event raised by the DB contract.

--- a/accounts/abi/bind/v2/internal/contracts/db/bindings.go
+++ b/accounts/abi/bind/v2/internal/contracts/db/bindings.go
@@ -62,12 +62,8 @@ func (c *DB) Instance(backend bind.ContractBackend, addr common.Address) *bind.B
 // the contract method with ID 0x9507d39a.
 //
 // Solidity: function get(uint256 k) returns(uint256)
-func (dB *DB) PackGet(k *big.Int) []byte {
-	enc, err := dB.abi.Pack("get", k)
-	if err != nil {
-		panic(err)
-	}
-	return enc
+func (dB *DB) PackGet(k *big.Int) ([]byte, error) {
+	return dB.abi.Pack("get", k)
 }
 
 // UnpackGet is the Go binding that unpacks the parameters returned
@@ -87,12 +83,8 @@ func (dB *DB) UnpackGet(data []byte) (*big.Int, error) {
 // the contract method with ID 0xe369ba3b.
 //
 // Solidity: function getNamedStatParams() view returns(uint256 gets, uint256 inserts, uint256 mods)
-func (dB *DB) PackGetNamedStatParams() []byte {
-	enc, err := dB.abi.Pack("getNamedStatParams")
-	if err != nil {
-		panic(err)
-	}
-	return enc
+func (dB *DB) PackGetNamedStatParams() ([]byte, error) {
+	return dB.abi.Pack("getNamedStatParams")
 }
 
 // GetNamedStatParamsOutput serves as a container for the return parameters of contract
@@ -107,29 +99,24 @@ type GetNamedStatParamsOutput struct {
 // from invoking the contract method with ID 0xe369ba3b.
 //
 // Solidity: function getNamedStatParams() view returns(uint256 gets, uint256 inserts, uint256 mods)
-func (dB *DB) UnpackGetNamedStatParams(data []byte) (GetNamedStatParamsOutput, error) {
+func (dB *DB) UnpackGetNamedStatParams(data []byte) (*GetNamedStatParamsOutput, error) {
 	out, err := dB.abi.Unpack("getNamedStatParams", data)
 	outstruct := new(GetNamedStatParamsOutput)
 	if err != nil {
-		return *outstruct, err
+		return outstruct, nil
 	}
 	outstruct.Gets = abi.ConvertType(out[0], new(big.Int)).(*big.Int)
 	outstruct.Inserts = abi.ConvertType(out[1], new(big.Int)).(*big.Int)
 	outstruct.Mods = abi.ConvertType(out[2], new(big.Int)).(*big.Int)
-	return *outstruct, err
-
+	return outstruct, nil
 }
 
 // PackGetStatParams is the Go binding used to pack the parameters required for calling
 // the contract method with ID 0x6fcb9c70.
 //
 // Solidity: function getStatParams() view returns(uint256, uint256, uint256)
-func (dB *DB) PackGetStatParams() []byte {
-	enc, err := dB.abi.Pack("getStatParams")
-	if err != nil {
-		panic(err)
-	}
-	return enc
+func (dB *DB) PackGetStatParams() ([]byte, error) {
+	return dB.abi.Pack("getStatParams")
 }
 
 // GetStatParamsOutput serves as a container for the return parameters of contract
@@ -144,29 +131,24 @@ type GetStatParamsOutput struct {
 // from invoking the contract method with ID 0x6fcb9c70.
 //
 // Solidity: function getStatParams() view returns(uint256, uint256, uint256)
-func (dB *DB) UnpackGetStatParams(data []byte) (GetStatParamsOutput, error) {
+func (dB *DB) UnpackGetStatParams(data []byte) (*GetStatParamsOutput, error) {
 	out, err := dB.abi.Unpack("getStatParams", data)
 	outstruct := new(GetStatParamsOutput)
 	if err != nil {
-		return *outstruct, err
+		return outstruct, nil
 	}
 	outstruct.Arg0 = abi.ConvertType(out[0], new(big.Int)).(*big.Int)
 	outstruct.Arg1 = abi.ConvertType(out[1], new(big.Int)).(*big.Int)
 	outstruct.Arg2 = abi.ConvertType(out[2], new(big.Int)).(*big.Int)
-	return *outstruct, err
-
+	return outstruct, nil
 }
 
 // PackGetStatsStruct is the Go binding used to pack the parameters required for calling
 // the contract method with ID 0xee8161e0.
 //
 // Solidity: function getStatsStruct() view returns((uint256,uint256,uint256))
-func (dB *DB) PackGetStatsStruct() []byte {
-	enc, err := dB.abi.Pack("getStatsStruct")
-	if err != nil {
-		panic(err)
-	}
-	return enc
+func (dB *DB) PackGetStatsStruct() ([]byte, error) {
+	return dB.abi.Pack("getStatsStruct")
 }
 
 // UnpackGetStatsStruct is the Go binding that unpacks the parameters returned
@@ -186,12 +168,8 @@ func (dB *DB) UnpackGetStatsStruct(data []byte) (DBStats, error) {
 // the contract method with ID 0x1d834a1b.
 //
 // Solidity: function insert(uint256 k, uint256 v) returns(uint256)
-func (dB *DB) PackInsert(k *big.Int, v *big.Int) []byte {
-	enc, err := dB.abi.Pack("insert", k, v)
-	if err != nil {
-		panic(err)
-	}
-	return enc
+func (dB *DB) PackInsert(k *big.Int, v *big.Int) ([]byte, error) {
+	return dB.abi.Pack("insert", k, v)
 }
 
 // UnpackInsert is the Go binding that unpacks the parameters returned

--- a/accounts/abi/bind/v2/internal/contracts/events/bindings.go
+++ b/accounts/abi/bind/v2/internal/contracts/events/bindings.go
@@ -55,24 +55,16 @@ func (c *C) Instance(backend bind.ContractBackend, addr common.Address) *bind.Bo
 // the contract method with ID 0xcb493749.
 //
 // Solidity: function EmitMulti() returns()
-func (c *C) PackEmitMulti() []byte {
-	enc, err := c.abi.Pack("EmitMulti")
-	if err != nil {
-		panic(err)
-	}
-	return enc
+func (c *C) PackEmitMulti() ([]byte, error) {
+	return c.abi.Pack("EmitMulti")
 }
 
 // PackEmitOne is the Go binding used to pack the parameters required for calling
 // the contract method with ID 0xe8e49a71.
 //
 // Solidity: function EmitOne() returns()
-func (c *C) PackEmitOne() []byte {
-	enc, err := c.abi.Pack("EmitOne")
-	if err != nil {
-		panic(err)
-	}
-	return enc
+func (c *C) PackEmitOne() ([]byte, error) {
+	return c.abi.Pack("EmitOne")
 }
 
 // CBasic1 represents a basic1 event raised by the C contract.

--- a/accounts/abi/bind/v2/internal/contracts/nested_libraries/bindings.go
+++ b/accounts/abi/bind/v2/internal/contracts/nested_libraries/bindings.go
@@ -71,12 +71,8 @@ func (c1 *C1) PackConstructor(v1 *big.Int, v2 *big.Int) []byte {
 // the contract method with ID 0x2ad11272.
 //
 // Solidity: function Do(uint256 val) pure returns(uint256 res)
-func (c1 *C1) PackDo(val *big.Int) []byte {
-	enc, err := c1.abi.Pack("Do", val)
-	if err != nil {
-		panic(err)
-	}
-	return enc
+func (c1 *C1) PackDo(val *big.Int) ([]byte, error) {
+	return c1.abi.Pack("Do", val)
 }
 
 // UnpackDo is the Go binding that unpacks the parameters returned
@@ -139,12 +135,8 @@ func (c2 *C2) PackConstructor(v1 *big.Int, v2 *big.Int) []byte {
 // the contract method with ID 0x2ad11272.
 //
 // Solidity: function Do(uint256 val) pure returns(uint256 res)
-func (c2 *C2) PackDo(val *big.Int) []byte {
-	enc, err := c2.abi.Pack("Do", val)
-	if err != nil {
-		panic(err)
-	}
-	return enc
+func (c2 *C2) PackDo(val *big.Int) ([]byte, error) {
+	return c2.abi.Pack("Do", val)
 }
 
 // UnpackDo is the Go binding that unpacks the parameters returned
@@ -191,12 +183,8 @@ func (c *L1) Instance(backend bind.ContractBackend, addr common.Address) *bind.B
 // the contract method with ID 0x2ad11272.
 //
 // Solidity: function Do(uint256 val) pure returns(uint256)
-func (l1 *L1) PackDo(val *big.Int) []byte {
-	enc, err := l1.abi.Pack("Do", val)
-	if err != nil {
-		panic(err)
-	}
-	return enc
+func (l1 *L1) PackDo(val *big.Int) ([]byte, error) {
+	return l1.abi.Pack("Do", val)
 }
 
 // UnpackDo is the Go binding that unpacks the parameters returned
@@ -246,12 +234,8 @@ func (c *L2) Instance(backend bind.ContractBackend, addr common.Address) *bind.B
 // the contract method with ID 0x2ad11272.
 //
 // Solidity: function Do(uint256 val) pure returns(uint256)
-func (l2 *L2) PackDo(val *big.Int) []byte {
-	enc, err := l2.abi.Pack("Do", val)
-	if err != nil {
-		panic(err)
-	}
-	return enc
+func (l2 *L2) PackDo(val *big.Int) ([]byte, error) {
+	return l2.abi.Pack("Do", val)
 }
 
 // UnpackDo is the Go binding that unpacks the parameters returned
@@ -301,12 +285,8 @@ func (c *L2b) Instance(backend bind.ContractBackend, addr common.Address) *bind.
 // the contract method with ID 0x2ad11272.
 //
 // Solidity: function Do(uint256 val) pure returns(uint256)
-func (l2b *L2b) PackDo(val *big.Int) []byte {
-	enc, err := l2b.abi.Pack("Do", val)
-	if err != nil {
-		panic(err)
-	}
-	return enc
+func (l2b *L2b) PackDo(val *big.Int) ([]byte, error) {
+	return l2b.abi.Pack("Do", val)
 }
 
 // UnpackDo is the Go binding that unpacks the parameters returned
@@ -353,12 +333,8 @@ func (c *L3) Instance(backend bind.ContractBackend, addr common.Address) *bind.B
 // the contract method with ID 0x2ad11272.
 //
 // Solidity: function Do(uint256 val) pure returns(uint256)
-func (l3 *L3) PackDo(val *big.Int) []byte {
-	enc, err := l3.abi.Pack("Do", val)
-	if err != nil {
-		panic(err)
-	}
-	return enc
+func (l3 *L3) PackDo(val *big.Int) ([]byte, error) {
+	return l3.abi.Pack("Do", val)
 }
 
 // UnpackDo is the Go binding that unpacks the parameters returned
@@ -409,12 +385,8 @@ func (c *L4) Instance(backend bind.ContractBackend, addr common.Address) *bind.B
 // the contract method with ID 0x2ad11272.
 //
 // Solidity: function Do(uint256 val) pure returns(uint256)
-func (l4 *L4) PackDo(val *big.Int) []byte {
-	enc, err := l4.abi.Pack("Do", val)
-	if err != nil {
-		panic(err)
-	}
-	return enc
+func (l4 *L4) PackDo(val *big.Int) ([]byte, error) {
+	return l4.abi.Pack("Do", val)
 }
 
 // UnpackDo is the Go binding that unpacks the parameters returned
@@ -464,12 +436,8 @@ func (c *L4b) Instance(backend bind.ContractBackend, addr common.Address) *bind.
 // the contract method with ID 0x2ad11272.
 //
 // Solidity: function Do(uint256 val) pure returns(uint256)
-func (l4b *L4b) PackDo(val *big.Int) []byte {
-	enc, err := l4b.abi.Pack("Do", val)
-	if err != nil {
-		panic(err)
-	}
-	return enc
+func (l4b *L4b) PackDo(val *big.Int) ([]byte, error) {
+	return l4b.abi.Pack("Do", val)
 }
 
 // UnpackDo is the Go binding that unpacks the parameters returned

--- a/accounts/abi/bind/v2/internal/contracts/nested_libraries/bindings.go
+++ b/accounts/abi/bind/v2/internal/contracts/nested_libraries/bindings.go
@@ -89,7 +89,7 @@ func (c1 *C1) UnpackDo(data []byte) (*big.Int, error) {
 		return new(big.Int), err
 	}
 	out0 := abi.ConvertType(out[0], new(big.Int)).(*big.Int)
-	return out0, err
+	return out0, nil
 }
 
 // C2MetaData contains all meta data concerning the C2 contract.
@@ -157,7 +157,7 @@ func (c2 *C2) UnpackDo(data []byte) (*big.Int, error) {
 		return new(big.Int), err
 	}
 	out0 := abi.ConvertType(out[0], new(big.Int)).(*big.Int)
-	return out0, err
+	return out0, nil
 }
 
 // L1MetaData contains all meta data concerning the L1 contract.
@@ -209,7 +209,7 @@ func (l1 *L1) UnpackDo(data []byte) (*big.Int, error) {
 		return new(big.Int), err
 	}
 	out0 := abi.ConvertType(out[0], new(big.Int)).(*big.Int)
-	return out0, err
+	return out0, nil
 }
 
 // L2MetaData contains all meta data concerning the L2 contract.
@@ -264,7 +264,7 @@ func (l2 *L2) UnpackDo(data []byte) (*big.Int, error) {
 		return new(big.Int), err
 	}
 	out0 := abi.ConvertType(out[0], new(big.Int)).(*big.Int)
-	return out0, err
+	return out0, nil
 }
 
 // L2bMetaData contains all meta data concerning the L2b contract.
@@ -319,7 +319,7 @@ func (l2b *L2b) UnpackDo(data []byte) (*big.Int, error) {
 		return new(big.Int), err
 	}
 	out0 := abi.ConvertType(out[0], new(big.Int)).(*big.Int)
-	return out0, err
+	return out0, nil
 }
 
 // L3MetaData contains all meta data concerning the L3 contract.
@@ -371,7 +371,7 @@ func (l3 *L3) UnpackDo(data []byte) (*big.Int, error) {
 		return new(big.Int), err
 	}
 	out0 := abi.ConvertType(out[0], new(big.Int)).(*big.Int)
-	return out0, err
+	return out0, nil
 }
 
 // L4MetaData contains all meta data concerning the L4 contract.
@@ -427,7 +427,7 @@ func (l4 *L4) UnpackDo(data []byte) (*big.Int, error) {
 		return new(big.Int), err
 	}
 	out0 := abi.ConvertType(out[0], new(big.Int)).(*big.Int)
-	return out0, err
+	return out0, nil
 }
 
 // L4bMetaData contains all meta data concerning the L4b contract.
@@ -482,5 +482,5 @@ func (l4b *L4b) UnpackDo(data []byte) (*big.Int, error) {
 		return new(big.Int), err
 	}
 	out0 := abi.ConvertType(out[0], new(big.Int)).(*big.Int)
-	return out0, err
+	return out0, nil
 }

--- a/accounts/abi/bind/v2/internal/contracts/solc_errors/bindings.go
+++ b/accounts/abi/bind/v2/internal/contracts/solc_errors/bindings.go
@@ -55,24 +55,16 @@ func (c *C) Instance(backend bind.ContractBackend, addr common.Address) *bind.Bo
 // the contract method with ID 0xb0a378b0.
 //
 // Solidity: function Bar() pure returns()
-func (c *C) PackBar() []byte {
-	enc, err := c.abi.Pack("Bar")
-	if err != nil {
-		panic(err)
-	}
-	return enc
+func (c *C) PackBar() ([]byte, error) {
+	return c.abi.Pack("Bar")
 }
 
 // PackFoo is the Go binding used to pack the parameters required for calling
 // the contract method with ID 0xbfb4ebcf.
 //
 // Solidity: function Foo() pure returns()
-func (c *C) PackFoo() []byte {
-	enc, err := c.abi.Pack("Foo")
-	if err != nil {
-		panic(err)
-	}
-	return enc
+func (c *C) PackFoo() ([]byte, error) {
+	return c.abi.Pack("Foo")
 }
 
 // UnpackError attempts to decode the provided error data using user-defined
@@ -172,12 +164,8 @@ func (c *C2) Instance(backend bind.ContractBackend, addr common.Address) *bind.B
 // the contract method with ID 0xbfb4ebcf.
 //
 // Solidity: function Foo() pure returns()
-func (c2 *C2) PackFoo() []byte {
-	enc, err := c2.abi.Pack("Foo")
-	if err != nil {
-		panic(err)
-	}
-	return enc
+func (c2 *C2) PackFoo() ([]byte, error) {
+	return c2.abi.Pack("Foo")
 }
 
 // UnpackError attempts to decode the provided error data using user-defined

--- a/accounts/abi/bind/v2/internal/contracts/uint256arrayreturn/bindings.go
+++ b/accounts/abi/bind/v2/internal/contracts/uint256arrayreturn/bindings.go
@@ -55,12 +55,8 @@ func (c *MyContract) Instance(backend bind.ContractBackend, addr common.Address)
 // the contract method with ID 0xbd6d1007.
 //
 // Solidity: function GetNums() pure returns(uint256[5])
-func (myContract *MyContract) PackGetNums() []byte {
-	enc, err := myContract.abi.Pack("GetNums")
-	if err != nil {
-		panic(err)
-	}
-	return enc
+func (myContract *MyContract) PackGetNums() ([]byte, error) {
+	return myContract.abi.Pack("GetNums")
 }
 
 // UnpackGetNums is the Go binding that unpacks the parameters returned

--- a/accounts/abi/bind/v2/internal/contracts/uint256arrayreturn/bindings.go
+++ b/accounts/abi/bind/v2/internal/contracts/uint256arrayreturn/bindings.go
@@ -73,5 +73,5 @@ func (myContract *MyContract) UnpackGetNums(data []byte) ([5]*big.Int, error) {
 		return *new([5]*big.Int), err
 	}
 	out0 := *abi.ConvertType(out[0], new([5]*big.Int)).(*[5]*big.Int)
-	return out0, err
+	return out0, nil
 }


### PR DESCRIPTION
1. Fix the error return format, todo: `bindtype` needs more complex logic to fix it.
`
if err != nil {
  return nil, err
}
if err == nil {
  return obj, nil
}
`
2. Return pointer type to avoid copying the whole struct content.
3. Leave the panic decision to the user.
4. Fix empty line at the end of function.

TODO: fix some related test cases.