### PR TITLE
core/state: state copy bugfixes with Verkle Trees

### DIFF
--- a/core/state/journal.go
+++ b/core/state/journal.go
@@ -408,6 +408,7 @@ func (ch storageChange) copy() journalEntry {
 		account:   ch.account,
 		key:       ch.key,
 		prevvalue: ch.prevvalue,
+		origvalue: ch.origvalue,
 	}
 }
 

--- a/core/state/state_object.go
+++ b/core/state/state_object.go
@@ -28,6 +28,7 @@ import (
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/rlp"
+	"github.com/ethereum/go-ethereum/trie"
 	"github.com/ethereum/go-ethereum/trie/trienode"
 	"github.com/holiman/uint256"
 )
@@ -494,8 +495,15 @@ func (s *stateObject) deepCopy(db *StateDB) *stateObject {
 		selfDestructed:     s.selfDestructed,
 		newContract:        s.newContract,
 	}
-	if s.trie != nil {
+
+	switch s.trie.(type) {
+	case *trie.VerkleTrie:
+		// In the Verkle case, the stateObject's trie shares the same reference as the StateDB's trie.
+		obj.trie = db.trie
+	case *trie.StateTrie:
 		obj.trie = mustCopyTrie(s.trie)
+	case nil:
+		// do nothing
 	}
 	return obj
 }


### PR DESCRIPTION
This change addresses critical issues in the state object duplication process specific to Verkle trie implementations. Without these modifications, updates to state objects fail to propagate correctly through the trie structure after a statedb copy operation, leading to inaccuracies in the computation of the state root hash. 