### PR TITLE
all: not add or subtract one when compare integers

### DIFF
--- a/cmd/devp2p/nodesetcmd.go
+++ b/cmd/devp2p/nodesetcmd.go
@@ -151,7 +151,7 @@ func parseFilters(args []string) ([]nodeFilter, error) {
 		if !ok {
 			return nil, fmt.Errorf("invalid filter %q", args[0])
 		}
-		if len(args)-1 < fc.narg {
+		if len(args) <= fc.narg {
 			return nil, fmt.Errorf("filter %q wants %d arguments, have %d", args[0], fc.narg, len(args)-1)
 		}
 		filter, err := fc.fn(args[1 : 1+fc.narg])

--- a/core/rawdb/chain_freezer.go
+++ b/core/rawdb/chain_freezer.go
@@ -195,7 +195,7 @@ func (f *chainFreezer) freeze(db ethdb.KeyValueStore) {
 			first = frozen    // the first block to freeze
 			last  = threshold // the last block to freeze
 		)
-		if last-first+1 > freezerBatchLimit {
+		if last-first >= freezerBatchLimit {
 			last = freezerBatchLimit + first - 1
 		}
 		ancients, err := f.freezeRange(nfdb, first, last)

--- a/rpc/ipc_unix.go
+++ b/rpc/ipc_unix.go
@@ -40,7 +40,7 @@ const (
 // ipcListen will create a Unix socket on the given endpoint.
 func ipcListen(endpoint string) (net.Listener, error) {
 	// account for null-terminator too
-	if len(endpoint)+1 > maxPathSize {
+	if len(endpoint) >= maxPathSize {
 		log.Warn(fmt.Sprintf("The ipc endpoint is longer than %d characters. ", maxPathSize-1),
 			"endpoint", endpoint)
 	}


### PR DESCRIPTION
when we compare integers:

- `a >= b` should be faster than `a+1 > b`
- `a <= b` should be faster than `a-1 < b`