### PR TITLE
node: avoid double close resp.Body

### DIFF
--- a/node/rpcstack_test.go
+++ b/node/rpcstack_test.go
@@ -570,7 +570,6 @@ func TestHTTPWriteTimeout(t *testing.T) {
 	// Send normal request
 	t.Run("message", func(t *testing.T) {
 		resp := rpcRequest(t, url, "test_sleep")
-		defer resp.Body.Close()
 		body, err := io.ReadAll(resp.Body)
 		if err != nil {
 			t.Fatal(err)
@@ -584,7 +583,6 @@ func TestHTTPWriteTimeout(t *testing.T) {
 	t.Run("batch", func(t *testing.T) {
 		want := fmt.Sprintf("[%s,%s,%s]", greetRes, timeoutRes, timeoutRes)
 		resp := batchRpcRequest(t, url, []string{"test_greet", "test_sleep", "test_greet"})
-		defer resp.Body.Close()
 		body, err := io.ReadAll(resp.Body)
 		if err != nil {
 			t.Fatal(err)


### PR DESCRIPTION
The functions `rpcRequest` and `batchRpcRequest` call `baseRpcRequest`. And `resp.Body` will be closed in the function `baseRpcRequest` later by `t.Cleanup`:

```go
func baseRpcRequest(t *testing.T, url, bodyStr string, extraHeaders ...string) *http.Response {
        // ......
	t.Cleanup(func() { resp.Body.Close() })
	return resp
}
```