### PR TITLE
eth/traces: fix debug_standardTraceBadBlockToFile relate bugs.

### DIFF
--- a/eth/tracers/api.go
+++ b/eth/tracers/api.go
@@ -820,7 +820,11 @@ func (api *API) standardTraceBlockToFile(ctx context.Context, block *types.Block
 		}
 		vmRet, err := core.ApplyMessage(evm, msg, new(core.GasPool).AddGas(msg.GasLimit))
 		if vmConf.Tracer.OnTxEnd != nil {
-			vmConf.Tracer.OnTxEnd(&types.Receipt{GasUsed: vmRet.UsedGas}, err)
+			var receipt *types.Receipt
+			if err == nil {
+				receipt = &types.Receipt{GasUsed: vmRet.UsedGas}
+			}
+			vmConf.Tracer.OnTxEnd(receipt, err)
 		}
 		if writer != nil {
 			writer.Flush()

--- a/eth/tracers/api_test.go
+++ b/eth/tracers/api_test.go
@@ -1337,7 +1337,7 @@ func TestStandardTraceBlockToFile(t *testing.T) {
 		}
 		for j, tracer := range tracers {
 			data, _ := os.ReadFile(tracer)
-			if string(data[:len(data)-1]) != tc.wants[j] {
+			if len(data) == 0 || string(data[:len(data)-1]) != tc.wants[j] {
 				t.Errorf("test %d, result mismatch, want %s, have %s", i, tc.wants[j], string(data))
 			}
 		}


### PR DESCRIPTION
1. If txhash is set and is not the first tx, the `vmConf.Tracer` value is nil, so that the `vmConf.Tracer.OnTxStart` call will trigger panic.
2. If err != nil, the `vmRet` value is nil, so the `vmRet.UsedGas` call will trigger panic.
3. Fix this `standardTraceBlockToFile` method according to the function requirements.

Fix #31694 