### PR TITLE
all: fix typos and improve comment clarity in contract and state transition code

### DIFF
--- a/accounts/abi/bind/v2/internal/contracts/db/contract.sol
+++ b/accounts/abi/bind/v2/internal/contracts/db/contract.sol
@@ -25,7 +25,7 @@ contract DB {
         if (v == 0) {
             return _keys.length;
         }
-        // Check if a key is being overriden
+        // Check if a key is being overridden
         if (_store[k] == 0) {
             _keys.push(k);
             _stats.inserts++;

--- a/core/state_transition.go
+++ b/core/state_transition.go
@@ -480,7 +480,7 @@ func (st *stateTransition) execute() (*ExecutionResult, error) {
 
 	var (
 		ret   []byte
-		vmerr error // vm errors do not effect consensus and are therefore not assigned to err
+		vmerr error // vm errors do not affect consensus and are therefore not assigned to err
 	)
 	if contractCreation {
 		ret, _, st.gasRemaining, vmerr = st.evm.Create(msg.From, msg.Data, st.gasRemaining, value)
@@ -572,7 +572,7 @@ func (st *stateTransition) validateAuthorization(auth *types.SetCodeAuthorizatio
 		return authority, fmt.Errorf("%w: %v", ErrAuthorizationInvalidSignature, err)
 	}
 	// Check the authority account
-	//  1) doesn't have code or has exisiting delegation
+	//  1) doesn't have code or has existing delegation
 	//  2) matches the auth's nonce
 	//
 	// Note it is added to the access list even if the authorization is invalid.

--- a/core/verkle_witness_test.go
+++ b/core/verkle_witness_test.go
@@ -1048,7 +1048,7 @@ func TestProcessVerkleSelfDestructInSameTxWithSelfBeneficiaryAndPrefundedAccount
 		contract   = crypto.CreateAddress(deployer, 0)
 	)
 	// Prefund the account, at an address that the contract will be deployed at,
-	// before it selfdestrucs. We can therefore check that the account itseld is
+	// before it selfdestructs. We can therefore check that the account itself is
 	// NOT destroyed, which is what the current version of the spec requires.
 	// TODO(gballet) revisit after the spec has been modified.
 	gspec.Alloc[contract] = types.Account{


### PR DESCRIPTION
This PR includes minor text improvements:

- Fix typo in comment: "overriden" -> "overridden" in contract.sol
- Fix typo in comment: "effect" -> "affect" in state_transition.go  
- Fix typo in comment: "existing" -> "existing" in state_transition.go
- Improve clarity in comment: "itseld" -> "itself" in verkle_witness_test.go

These changes are purely cosmetic and do not affect any functionality.