### PR TITLE
core/txpool: remove concept of "remote"

### DIFF
--- a/core/txpool/legacypool/legacypool.go
+++ b/core/txpool/legacypool/legacypool.go
@@ -907,28 +907,23 @@ func (pool *LegacyPool) promoteTx(addr common.Address, hash common.Hash, tx *typ
 	return true
 }
 
-// addRemotes enqueues a batch of transactions into the pool if they are valid.
-// Full pricing constraints will apply.
-//
-// This method is used to add transactions from the p2p network and does not wait for pool
-// reorganization and internal event propagation.
-func (pool *LegacyPool) addRemotes(txs []*types.Transaction) []error {
+// addAsync is a convenience wrapper around Add. Tests use this method.
+func (pool *LegacyPool) addAsync(txs []*types.Transaction) []error {
 	return pool.Add(txs, false)
 }
 
-// addRemote enqueues a single transaction into the pool if it is valid. This is a convenience
-// wrapper around addRemotes.
-func (pool *LegacyPool) addRemote(tx *types.Transaction) error {
-	return pool.addRemotes([]*types.Transaction{tx})[0]
+// addTxAsync is a convenience wrapper around Add. Tests use this method.
+func (pool *LegacyPool) addTxAsync(tx *types.Transaction) error {
+	return pool.Add([]*types.Transaction{tx}, false)[0]
 }
 
-// addRemotesSync is like addRemotes, but waits for pool reorganization. Tests use this method.
-func (pool *LegacyPool) addRemotesSync(txs []*types.Transaction) []error {
+// addSync is a convenience wrapper around Add. Tests use this method.
+func (pool *LegacyPool) addSync(txs []*types.Transaction) []error {
 	return pool.Add(txs, true)
 }
 
-// This is like addRemotes with a single transaction, but waits for pool reorganization. Tests use this method.
-func (pool *LegacyPool) addRemoteSync(tx *types.Transaction) error {
+// addTxSync is a convenience wrapper around Add. Tests use this method.
+func (pool *LegacyPool) addTxSync(tx *types.Transaction) error {
 	return pool.Add([]*types.Transaction{tx}, true)[0]
 }
 

--- a/core/txpool/legacypool/legacypool2_test.go
+++ b/core/txpool/legacypool/legacypool2_test.go
@@ -58,8 +58,8 @@ func fillPool(t testing.TB, pool *LegacyPool) {
 		}
 	}
 	// Import the batch and verify that limits have been enforced
-	pool.addRemotesSync(executableTxs)
-	pool.addRemotesSync(nonExecutableTxs)
+	pool.addSync(executableTxs)
+	pool.addSync(nonExecutableTxs)
 	pending, queued := pool.Stats()
 	slots := pool.all.Slots()
 	// sanity-check that the test prerequisites are ok (pending full)
@@ -101,7 +101,7 @@ func TestTransactionFutureAttack(t *testing.T) {
 			futureTxs = append(futureTxs, pricedTransaction(1000+uint64(j), 100000, big.NewInt(500), key))
 		}
 		for i := 0; i < 5; i++ {
-			pool.addRemotesSync(futureTxs)
+			pool.addSync(futureTxs)
 			newPending, newQueued := count(t, pool)
 			t.Logf("pending: %d queued: %d, all: %d\n", newPending, newQueued, pool.all.Slots())
 		}
@@ -137,7 +137,7 @@ func TestTransactionFuture1559(t *testing.T) {
 		for j := 0; j < int(pool.config.GlobalSlots+pool.config.GlobalQueue); j++ {
 			futureTxs = append(futureTxs, dynamicFeeTx(1000+uint64(j), 100000, big.NewInt(200), big.NewInt(101), key))
 		}
-		pool.addRemotesSync(futureTxs)
+		pool.addSync(futureTxs)
 	}
 	newPending, _ := pool.Stats()
 	// Pending should not have been touched
@@ -190,7 +190,7 @@ func TestTransactionZAttack(t *testing.T) {
 		key, _ := crypto.GenerateKey()
 		pool.currentState.AddBalance(crypto.PubkeyToAddress(key.PublicKey), uint256.NewInt(100000000000), tracing.BalanceChangeUnspecified)
 		futureTxs = append(futureTxs, pricedTransaction(1000+uint64(j), 21000, big.NewInt(500), key))
-		pool.addRemotesSync(futureTxs)
+		pool.addSync(futureTxs)
 	}
 
 	overDraftTxs := types.Transactions{}
@@ -201,11 +201,11 @@ func TestTransactionZAttack(t *testing.T) {
 			overDraftTxs = append(overDraftTxs, pricedValuedTransaction(uint64(j), 600000000000, 21000, big.NewInt(500), key))
 		}
 	}
-	pool.addRemotesSync(overDraftTxs)
-	pool.addRemotesSync(overDraftTxs)
-	pool.addRemotesSync(overDraftTxs)
-	pool.addRemotesSync(overDraftTxs)
-	pool.addRemotesSync(overDraftTxs)
+	pool.addSync(overDraftTxs)
+	pool.addSync(overDraftTxs)
+	pool.addSync(overDraftTxs)
+	pool.addSync(overDraftTxs)
+	pool.addSync(overDraftTxs)
 
 	newPending, newQueued := count(t, pool)
 	newIvPending := countInvalidPending()
@@ -241,6 +241,6 @@ func BenchmarkFutureAttack(b *testing.B) {
 	}
 	b.ResetTimer()
 	for i := 0; i < 5; i++ {
-		pool.addRemotesSync(futureTxs)
+		pool.addSync(futureTxs)
 	}
 }


### PR DESCRIPTION
Now that the concept of "local" has been removed for the txpool since [this](https://github.com/ethereum/go-ethereum/pull/30559) PR, it's confusing to keep the concept of "remote" there.

This PR renames the `addRemotes/addRemote/addRemotesSync/addTxSync` to `addAsync/addTxAsync/addSync/addTxSync` and makes it clear that these functions are all convenience wrapper around `Add` and only used in tests.