### PR TITLE
blockchain,triedb: avoid checking recoverable twice

### DIFF
--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -867,6 +867,9 @@ func (bc *BlockChain) rewindPathHead(head *types.Header, root common.Hash) (*typ
 	}
 	// Recover if the target state if it's not available yet.
 	if !bc.HasState(head.Root) {
+		if !bc.stateRecoverable(head.Root) {
+			log.Crit("State is unrecoverable, failed to rollback")
+		}
 		if err := bc.triedb.Recover(head.Root); err != nil {
 			log.Crit("Failed to rollback state", "err", err)
 		}

--- a/triedb/pathdb/database.go
+++ b/triedb/pathdb/database.go
@@ -430,10 +430,6 @@ func (db *Database) Recover(root common.Hash) error {
 	if db.freezer == nil {
 		return errors.New("state rollback is non-supported")
 	}
-	// Short circuit if the target state is not recoverable
-	if !db.Recoverable(root) {
-		return errStateUnrecoverable
-	}
 	// Apply the state histories upon the disk layer in order
 	var (
 		start = time.Now()


### PR DESCRIPTION
`Database.Recover` is only called in 3 separate locations, primarily by the `blockchain` struct. In 2 out of these 3 locations, `Database.Recoverable` is already called before executing `Database.Recover`. Hence, we don't need to do an additional `Database.Recoverable` call internally in `Database.Recover`. Removing the redundant call will help to reduce DB IO on checking the state ID and histories in the database.