### PR TITLE
cmd/geth: fix `initGenesis`

### DIFF
--- a/cmd/geth/chaincmd.go
+++ b/cmd/geth/chaincmd.go
@@ -246,9 +246,12 @@ func initGenesis(ctx *cli.Context) error {
 	triedb := utils.MakeTrieDatabase(ctx, chaindb, ctx.Bool(utils.CachePreimagesFlag.Name), false, genesis.IsVerkle())
 	defer triedb.Close()
 
-	_, hash, _, err := core.SetupGenesisBlockWithOverride(chaindb, triedb, genesis, &overrides)
+	_, hash, compatErr, err := core.SetupGenesisBlockWithOverride(chaindb, triedb, genesis, &overrides)
 	if err != nil {
 		utils.Fatalf("Failed to write genesis block: %v", err)
+	}
+	if compatErr != nil {
+		utils.Fatalf("Failed to write chain config: %v", err)
 	}
 	log.Info("Successfully wrote genesis state", "database", "chaindata", "hash", hash)
 


### PR DESCRIPTION
In the latest code, if `SetupGenesisBlockWithOverride` returns a `ConfigCompatError`, it will be ignored silently by `geth init`.

I think it should fail out loud since the new chain config isn't actually stored.

It's introduced in this pr 3 months ago: https://github.com/ethereum/go-ethereum/pull/30907