### PR TITLE
eth/tracers:  refactor tracers to deduplicate code, use same underlying block/tx tracing methods for all code paths

### DIFF
--- a/eth/tracers/api.go
+++ b/eth/tracers/api.go
@@ -783,9 +783,8 @@ func (api *API) standardTraceTxToFile(ctx context.Context, block *types.Block, t
 		Stop:      func(err error) {},
 		GetResult: func() (json.RawMessage, error) { return nil, nil },
 	}
-	traceTimeout := new(time.Duration)
-	*traceTimeout = 1 * time.Hour
-	_, err = api.execTx(ctx, tx, msg, txctx, blockCtx, statedb, &tracer, nil, *traceTimeout, api.backend.ChainConfig())
+	traceTimeout := 1 * time.Hour
+	_, err = api.execTx(ctx, tx, msg, txctx, blockCtx, statedb, &tracer, nil, traceTimeout, api.backend.ChainConfig())
 	if err != nil {
 		return "", err
 	}

--- a/eth/tracers/api_test.go
+++ b/eth/tracers/api_test.go
@@ -1056,6 +1056,7 @@ func newStates(keys []common.Hash, vals []common.Hash) map[common.Hash]common.Ha
 	return m
 }
 
+// TODO: modify tracechain so that each transaction in the chain prints out a different trace dependent on the current state
 func TestTraceChain(t *testing.T) {
 	// Initialize test accounts
 	accounts := newAccounts(3)

--- a/eth/tracers/api_test.go
+++ b/eth/tracers/api_test.go
@@ -1124,7 +1124,7 @@ func TestTraceChain(t *testing.T) {
 			next += 1
 		}
 		if next != c.end+1 {
-			t.Error("Missing tracing block")
+			t.Fatal("Missing tracing block")
 		}
 
 		if nref, nrel := ref.Load(), rel.Load(); nref != nrel {


### PR DESCRIPTION
Currently, tracers duplicate transaction execution logic three times.  This PR modifies the implementation of the tracers so that block/transaction trace logic is only implemented once, and used by all tracers.