### PR TITLE
metrics: add chain/mgasps to track gas usage rate

### DIFF
--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -65,7 +65,8 @@ var (
 	headFinalizedBlockGauge = metrics.NewRegisteredGauge("chain/head/finalized", nil)
 	headSafeBlockGauge      = metrics.NewRegisteredGauge("chain/head/safe", nil)
 
-	chainInfoGauge = metrics.NewRegisteredGaugeInfo("chain/info", nil)
+	chainInfoGauge   = metrics.NewRegisteredGaugeInfo("chain/info", nil)
+	chainMgaspsGauge = metrics.NewRegisteredGauge("chain/mgasps", nil)
 
 	accountReadTimer   = metrics.NewRegisteredResettingTimer("chain/account/reads", nil)
 	accountHashTimer   = metrics.NewRegisteredResettingTimer("chain/account/hashes", nil)

--- a/core/blockchain_insert.go
+++ b/core/blockchain_insert.go
@@ -43,10 +43,7 @@ func (st *insertStats) report(chain []*types.Block, index int, snapDiffItems, sn
 	// Fetch the timings for the batch
 	var (
 		now     = mclock.Now()
-		elapsed = now.Sub(st.startTime)
-		if elapsed == 0 { // prevent zero division
-			elapsed = 1
-		}	
+		elapsed = now.Sub(st.startTime) + 1 // prevent zero division
 		mgasps  = float64(st.usedGas) * 1000 / float64(elapsed)
 	)
 	// Update the Mgas per second gauge

--- a/core/blockchain_insert.go
+++ b/core/blockchain_insert.go
@@ -44,7 +44,11 @@ func (st *insertStats) report(chain []*types.Block, index int, snapDiffItems, sn
 	var (
 		now     = mclock.Now()
 		elapsed = now.Sub(st.startTime)
+		mgasps  = float64(st.usedGas) * 1000 / float64(elapsed)
 	)
+	// Update the Mgas per second gauge
+	chainMgaspsGauge.Update(int64(mgasps))
+
 	// If we're at the last block of the batch or report period reached, log
 	if index == len(chain)-1 || elapsed >= statsReportLimit {
 		// Count the number of transactions in this segment
@@ -58,7 +62,7 @@ func (st *insertStats) report(chain []*types.Block, index int, snapDiffItems, sn
 		context := []interface{}{
 			"number", end.Number(), "hash", end.Hash(),
 			"blocks", st.processed, "txs", txs, "mgas", float64(st.usedGas) / 1000000,
-			"elapsed", common.PrettyDuration(elapsed), "mgasps", float64(st.usedGas) * 1000 / float64(elapsed),
+			"elapsed", common.PrettyDuration(elapsed), "mgasps", mgasps,
 		}
 		if timestamp := time.Unix(int64(end.Time()), 0); time.Since(timestamp) > time.Minute {
 			context = append(context, []interface{}{"age", common.PrettyAge(timestamp)}...)

--- a/core/blockchain_insert.go
+++ b/core/blockchain_insert.go
@@ -44,6 +44,9 @@ func (st *insertStats) report(chain []*types.Block, index int, snapDiffItems, sn
 	var (
 		now     = mclock.Now()
 		elapsed = now.Sub(st.startTime)
+		if elapsed == 0 { // prevent zero division
+			elapsed = 1
+		}	
 		mgasps  = float64(st.usedGas) * 1000 / float64(elapsed)
 	)
 	// Update the Mgas per second gauge


### PR DESCRIPTION
This adds a metric called `chain/mgasps`, which records how many million gas per second are being used during block insertion.

The value is calculated as `usedGas * 1000 / elapsed`, and it's updated in the `insertStats.report` method. Also cleaned up the log output to reuse the same value instead of recalculating it.

Useful for monitoring block processing throughput.
