### PR TITLE
refactor(triedb): replace manual map copy with maps.Copy for clarity

### DIFF
--- a/triedb/pathdb/nodes.go
+++ b/triedb/pathdb/nodes.go
@@ -279,9 +279,7 @@ func (s *nodeSet) write(batch ethdb.Batch, clean *fastcache.Cache) int {
 	if len(s.accountNodes) > 0 {
 		nodes[common.Hash{}] = s.accountNodes
 	}
-	for owner, subset := range s.storageNodes {
-		nodes[owner] = subset
-	}
+	maps.Copy(nodes, s.storageNodes)
 	return writeNodes(batch, nodes, clean)
 }
 


### PR DESCRIPTION
Replaced the `for` loop that manually copies `s.storageNodes` into `nodes` with `maps.Copy`.
Makes the code a bit cleaner and the intent more obvious.

No behavior change.