### PR TITLE
core/txpool/legacypool: fix data race of pricedList access

### DIFF
--- a/core/txpool/legacypool/legacypool.go
+++ b/core/txpool/legacypool/legacypool.go
@@ -1934,7 +1934,7 @@ func (pool *LegacyPool) Clear() {
 		pool.reserver.Release(addr)
 	}
 	pool.all.Clear()
-	pool.priced = newPricedList(pool.all)
+	pool.priced.Reheap()
 	pool.pending = make(map[common.Address]*list)
 	pool.queue = make(map[common.Address]*list)
 	pool.pendingNonces = newNoncer(pool.currentState)


### PR DESCRIPTION
I believe this was missed in https://github.com/ethereum/go-ethereum/pull/31641 where fixing one data race created another. Should only apply to the simulated backend.

go-ethereum v1.15.10

The race detector flagged this in some automated tests I run against the simulated backend.
```
==================
WARNING: DATA RACE
Write at 0x00c00177bba8 by goroutine 36573:
  github.com/ethereum/go-ethereum/core/txpool/legacypool.(*LegacyPool).Clear()
      /home/repo/vendor/github.com/ethereum/go-ethereum/core/txpool/legacypool/legacypool.go:1937 +0x44d
  github.com/ethereum/go-ethereum/core/txpool.(*TxPool).Clear()
      /home/repo/vendor/github.com/ethereum/go-ethereum/core/txpool/txpool.go:508 +0x1af
  github.com/ethereum/go-ethereum/eth/catalyst.(*SimulatedBeacon).Rollback()
      /home/repo/vendor/github.com/ethereum/go-ethereum/eth/catalyst/simulated_beacon.go:320 +0xed5
  github.com/ethereum/go-ethereum/ethclient/simulated.(*Backend).Rollback()
      /home/repo/vendor/github.com/ethereum/go-ethereum/ethclient/simulated/backend.go:164 +0xe0b
  ...

Previous read at 0x00c00177bba8 by goroutine 36536:
  github.com/ethereum/go-ethereum/core/txpool/legacypool.(*LegacyPool).loop()
      /home/repo/vendor/github.com/ethereum/go-ethereum/core/txpool/legacypool/legacypool.go:363 +0x93b
  github.com/ethereum/go-ethereum/core/txpool/legacypool.(*LegacyPool).Init.gowrap2()
      /home/repo/vendor/github.com/ethereum/go-ethereum/core/txpool/legacypool/legacypool.go:330 +0x33
  ...
==================

```