### PR TITLE
eth/tracers: fix `standardTraceBlockToFile`

### DIFF
--- a/eth/tracers/api.go
+++ b/eth/tracers/api.go
@@ -822,10 +822,7 @@ func (api *API) standardTraceBlockToFile(ctx context.Context, block *types.Block
 		if tracer.OnTxStart != nil {
 			tracer.OnTxStart(evm.GetVMContext(), tx, msg.From)
 		}
-		vmRet, err := core.ApplyMessage(evm, msg, new(core.GasPool).AddGas(msg.GasLimit))
-		if tracer.OnTxEnd != nil {
-			tracer.OnTxEnd(&types.Receipt{GasUsed: vmRet.UsedGas}, err)
-		}
+		_, err = core.ApplyMessage(evm, msg, new(core.GasPool).AddGas(msg.GasLimit))
 		if writer != nil {
 			writer.Flush()
 		}

--- a/eth/tracers/api.go
+++ b/eth/tracers/api.go
@@ -815,9 +815,6 @@ func (api *API) standardTraceBlockToFile(ctx context.Context, block *types.Block
 			// Swap out the noop logger to the standard tracer
 			writer = bufio.NewWriter(dump)
 			*tracer = *logger.NewJSONLogger(&logConfig, writer)
-		} else {
-			writer = bufio.NewWriter(io.Discard)
-			*tracer = *logger.NewJSONLogger(&logConfig, writer)
 		}
 
 		// Execute the transaction and flush any traces to disk

--- a/eth/tracers/api.go
+++ b/eth/tracers/api.go
@@ -779,7 +779,7 @@ func (api *API) standardTraceBlockToFile(ctx context.Context, block *types.Block
 		chainConfig, canon = overrideConfig(chainConfig, config.Overrides)
 	}
 
-	evm := vm.NewEVM(vmctx, statedb, api.backend.ChainConfig(), vm.Config{})
+	evm := vm.NewEVM(vmctx, statedb, chainConfig, vm.Config{})
 	if beaconRoot := block.BeaconRoot(); beaconRoot != nil {
 		core.ProcessBeaconBlockRoot(*beaconRoot, evm)
 	}

--- a/eth/tracers/api_test.go
+++ b/eth/tracers/api_test.go
@@ -23,6 +23,7 @@ import (
 	"errors"
 	"fmt"
 	"math/big"
+	"os"
 	"reflect"
 	"slices"
 	"sync/atomic"
@@ -1215,6 +1216,123 @@ func TestTraceBlockWithBasefee(t *testing.T) {
 		want := tc.want
 		if string(have) != want {
 			t.Errorf("test %d, result mismatch\nhave: %v\nwant: %v\n", i, string(have), want)
+		}
+	}
+}
+
+func TestStandardTraceBlockToFile(t *testing.T) {
+	var (
+		// A sender who makes transactions, has some funds
+		key, _  = crypto.HexToECDSA("b71c71a67e1177ad4e901695e1b4b9ee17ae16c6668d313eac2f96dbcda3f291")
+		address = crypto.PubkeyToAddress(key.PublicKey)
+		funds   = big.NewInt(1000000000000000)
+
+		aa     = common.HexToAddress("0x7217d81b76bdd8707601e959454e3d776aee5f43")
+		aaCode = []byte{byte(vm.PUSH1), 0x00, byte(vm.POP)}
+
+		bb     = common.HexToAddress("0x7217d81b76bdd8707601e959454e3d776aee5f44")
+		bbCode = []byte{byte(vm.PUSH2), 0x00, 0x01, byte(vm.POP)}
+	)
+
+	genesis := &core.Genesis{
+		Config: params.TestChainConfig,
+		Alloc: types.GenesisAlloc{
+			address: {Balance: funds},
+			aa: {
+				Code:    aaCode,
+				Nonce:   1,
+				Balance: big.NewInt(0),
+			},
+			bb: {
+				Code:    bbCode,
+				Nonce:   1,
+				Balance: big.NewInt(0),
+			},
+		},
+	}
+	txHashs := make([]common.Hash, 0, 2)
+	backend := newTestBackend(t, 1, genesis, func(i int, b *core.BlockGen) {
+		b.SetCoinbase(common.Address{1})
+		// first tx to aa
+		tx, _ := types.SignTx(types.NewTx(&types.LegacyTx{
+			Nonce:    0,
+			To:       &aa,
+			Value:    big.NewInt(0),
+			Gas:      50000,
+			GasPrice: b.BaseFee(),
+			Data:     nil,
+		}), types.HomesteadSigner{}, key)
+		b.AddTx(tx)
+		txHashs = append(txHashs, tx.Hash())
+		// second tx to bb
+		tx, _ = types.SignTx(types.NewTx(&types.LegacyTx{
+			Nonce:    1,
+			To:       &bb,
+			Value:    big.NewInt(1),
+			Gas:      100000,
+			GasPrice: b.BaseFee(),
+			Data:     nil,
+		}), types.HomesteadSigner{}, key)
+		b.AddTx(tx)
+		txHashs = append(txHashs, tx.Hash())
+	})
+	defer backend.chain.Stop()
+
+	var testSuite = []struct {
+		blockNumber rpc.BlockNumber
+		config      *StdTraceConfig
+		want        []string
+	}{
+		{
+			// test that all traces in the block were outputted if no trace config is specified
+			blockNumber: rpc.LatestBlockNumber,
+			config:      nil,
+			want: []string{`{"pc":0,"op":96,"gas":"0x7148","gasCost":"0x3","memSize":0,"stack":[],"depth":1,"refund":0,"opName":"PUSH1"}
+{"pc":2,"op":80,"gas":"0x7145","gasCost":"0x2","memSize":0,"stack":["0x0"],"depth":1,"refund":0,"opName":"POP"}
+{"pc":3,"op":0,"gas":"0x7143","gasCost":"0x0","memSize":0,"stack":[],"depth":1,"refund":0,"opName":"STOP"}
+{"output":"","gasUsed":"0x5"}
+`,
+				`{"pc":0,"op":97,"gas":"0x13498","gasCost":"0x3","memSize":0,"stack":[],"depth":1,"refund":0,"opName":"PUSH2"}
+{"pc":3,"op":80,"gas":"0x13495","gasCost":"0x2","memSize":0,"stack":["0x1"],"depth":1,"refund":0,"opName":"POP"}
+{"pc":4,"op":0,"gas":"0x13493","gasCost":"0x0","memSize":0,"stack":[],"depth":1,"refund":0,"opName":"STOP"}
+{"output":"","gasUsed":"0x5"}
+`,
+			},
+		},
+		{
+			// test that only a specific tx is traced if specified
+			blockNumber: rpc.LatestBlockNumber,
+			config:      &StdTraceConfig{TxHash: txHashs[1]},
+			want: []string{
+				`{"pc":0,"op":97,"gas":"0x13498","gasCost":"0x3","memSize":0,"stack":[],"depth":1,"refund":0,"opName":"PUSH2"}
+{"pc":3,"op":80,"gas":"0x13495","gasCost":"0x2","memSize":0,"stack":["0x1"],"depth":1,"refund":0,"opName":"POP"}
+{"pc":4,"op":0,"gas":"0x13493","gasCost":"0x0","memSize":0,"stack":[],"depth":1,"refund":0,"opName":"STOP"}
+{"output":"","gasUsed":"0x5"}
+`,
+			},
+		},
+	}
+
+	api := NewAPI(backend)
+	for i, tc := range testSuite {
+		block, _ := api.blockByNumber(context.Background(), tc.blockNumber)
+		results, err := api.StandardTraceBlockToFile(context.Background(), block.Hash(), tc.config)
+		if err != nil {
+			t.Errorf("test %d, want no error, have %v", i, err)
+			continue
+		}
+
+		for j, traceFileName := range results {
+			traceReceived, err := os.ReadFile(traceFileName)
+			if err != nil {
+				t.Fatalf("could not read trace file: %v", err)
+			}
+			if tc.want[j] != string(traceReceived) {
+				fmt.Println(tc.want[j])
+				fmt.Println("foobar")
+				fmt.Println(string(traceReceived))
+				t.Fatalf("fuck")
+			}
 		}
 	}
 }

--- a/eth/tracers/api_test.go
+++ b/eth/tracers/api_test.go
@@ -1227,9 +1227,11 @@ func TestStandardTraceBlockToFile(t *testing.T) {
 		address = crypto.PubkeyToAddress(key.PublicKey)
 		funds   = big.NewInt(1000000000000000)
 
+		// first contract the sender transacts with
 		aa     = common.HexToAddress("0x7217d81b76bdd8707601e959454e3d776aee5f43")
 		aaCode = []byte{byte(vm.PUSH1), 0x00, byte(vm.POP)}
 
+		// second contract the sender transacts with
 		bb     = common.HexToAddress("0x7217d81b76bdd8707601e959454e3d776aee5f44")
 		bbCode = []byte{byte(vm.PUSH2), 0x00, 0x01, byte(vm.POP)}
 	)
@@ -1317,11 +1319,11 @@ func TestStandardTraceBlockToFile(t *testing.T) {
 	api := NewAPI(backend)
 	for i, tc := range testSuite {
 		block, _ := api.blockByNumber(context.Background(), tc.blockNumber)
-		results, err := api.StandardTraceBlockToFile(context.Background(), block.Hash(), tc.config)
+		txTraces, err := api.StandardTraceBlockToFile(context.Background(), block.Hash(), tc.config)
 		if err != nil {
 			t.Fatalf("test index %d received error %v", i, err)
 		}
-		for j, traceFileName := range results {
+		for j, traceFileName := range txTraces {
 			traceReceived, err := os.ReadFile(traceFileName)
 			if err != nil {
 				t.Fatalf("could not read trace file: %v", err)

--- a/eth/tracers/api_test.go
+++ b/eth/tracers/api_test.go
@@ -1319,10 +1319,8 @@ func TestStandardTraceBlockToFile(t *testing.T) {
 		block, _ := api.blockByNumber(context.Background(), tc.blockNumber)
 		results, err := api.StandardTraceBlockToFile(context.Background(), block.Hash(), tc.config)
 		if err != nil {
-			t.Errorf("test %d, want no error, have %v", i, err)
-			continue
+			t.Fatalf("test index %d received error %v", i, err)
 		}
-
 		for j, traceFileName := range results {
 			traceReceived, err := os.ReadFile(traceFileName)
 			if err != nil {

--- a/eth/tracers/api_test.go
+++ b/eth/tracers/api_test.go
@@ -1287,7 +1287,8 @@ func TestStandardTraceBlockToFile(t *testing.T) {
 			// test that all traces in the block were outputted if no trace config is specified
 			blockNumber: rpc.LatestBlockNumber,
 			config:      nil,
-			want: []string{`{"pc":0,"op":96,"gas":"0x7148","gasCost":"0x3","memSize":0,"stack":[],"depth":1,"refund":0,"opName":"PUSH1"}
+			want: []string{
+				`{"pc":0,"op":96,"gas":"0x7148","gasCost":"0x3","memSize":0,"stack":[],"depth":1,"refund":0,"opName":"PUSH1"}
 {"pc":2,"op":80,"gas":"0x7145","gasCost":"0x2","memSize":0,"stack":["0x0"],"depth":1,"refund":0,"opName":"POP"}
 {"pc":3,"op":0,"gas":"0x7143","gasCost":"0x0","memSize":0,"stack":[],"depth":1,"refund":0,"opName":"STOP"}
 {"output":"","gasUsed":"0x5"}
@@ -1328,10 +1329,7 @@ func TestStandardTraceBlockToFile(t *testing.T) {
 				t.Fatalf("could not read trace file: %v", err)
 			}
 			if tc.want[j] != string(traceReceived) {
-				fmt.Println(tc.want[j])
-				fmt.Println("foobar")
-				fmt.Println(string(traceReceived))
-				t.Fatalf("fuck")
+				t.Fatalf("unexpected trace result.  expected\n'%s'\n\nreceived\n'%s'\n", tc.want[j], string(traceReceived))
 			}
 		}
 	}


### PR DESCRIPTION
Previously, we were only setting a default `vm.Config` on the EVM instance which kept the tracer disabled.

With this PR, the tracer is always enabled.  However, the output is discarded unless we are tracing a transaction that we want the dump of the output from.