### PR TITLE
Adding support for configuring the template file to be used for generating the bindings

### DIFF
--- a/accounts/abi/abigen/bindv2.go
+++ b/accounts/abi/abigen/bindv2.go
@@ -294,7 +294,7 @@ func iterSorted[V any](inp map[string]V, onItem func(string, V) error) error {
 // to be used as is in client code, but rather as an intermediate struct which
 // enforces compile time type safety and naming convention as opposed to having to
 // manually maintain hard coded strings that break on runtime.
-func BindV2(types []string, abis []string, bytecodes []string, pkg string, libs map[string]string, aliases map[string]string) (string, error) {
+func BindV2(types []string, abis []string, bytecodes []string, pkg string, libs map[string]string, aliases map[string]string, templateContent string) (string, error) {
 	b := binder{
 		contracts: make(map[string]*tmplContractV2),
 		structs:   make(map[string]*tmplStruct),
@@ -360,7 +360,7 @@ func BindV2(types []string, abis []string, bytecodes []string, pkg string, libs 
 		"ispointertype":      isPointerType,
 		"underlyingbindtype": underlyingBindType,
 	}
-	tmpl := template.Must(template.New("").Funcs(funcs).Parse(tmplSourceV2))
+	tmpl := template.Must(template.New("").Funcs(funcs).Parse(templateContent))
 	if err := tmpl.Execute(buffer, data); err != nil {
 		return "", err
 	}

--- a/accounts/abi/abigen/bindv2_test.go
+++ b/accounts/abi/abigen/bindv2_test.go
@@ -58,7 +58,7 @@ func bindCombinedJSON(test *bindV2Test) (string, error) {
 	if test.aliases == nil {
 		test.aliases = make(map[string]string)
 	}
-	code, err := BindV2(types, abis, bins, "bindtests", libs, test.aliases)
+	code, err := BindV2(types, abis, bins, "bindtests", libs, test.aliases, TmplSourceV2)
 	if err != nil {
 		return "", fmt.Errorf("error creating bindings: %v", err)
 	}

--- a/accounts/abi/abigen/template.go
+++ b/accounts/abi/abigen/template.go
@@ -133,4 +133,4 @@ var tmplSource string
 // for abigen v2 is based on.
 //
 //go:embed source2.go.tpl
-var tmplSourceV2 string
+var TmplSourceV2 string


### PR DESCRIPTION
Adding a new configuration option to abigen to customize the go template file to use for generating the go bindings. 

This _template_ option allows to pass a location to a go template file that, only when using abigen v2 flag, will be used to generate the go bindings instead of using the default template file.