### PR TITLE
eth: return context in normal condition

### DIFF
--- a/eth/state_accessor.go
+++ b/eth/state_accessor.go
@@ -245,7 +245,7 @@ func (eth *Ethereum) stateAtTransaction(ctx context.Context, block *types.Block,
 		core.ProcessParentBlockHash(block.ParentHash(), evm)
 	}
 	if txIndex == 0 && len(block.Transactions()) == 0 {
-		return nil, vm.BlockContext{}, statedb, release, nil
+		return nil, context, statedb, release, nil
 	}
 	// Recompute transactions up to the target index.
 	signer := types.MakeSigner(eth.blockchain.Config(), block.Number(), block.Time())


### PR DESCRIPTION
It's not to fix bug, here is a normal condition, so why not return the `context`?