### PR TITLE
core: effectiveTip = `GasPrice - BaseFee` instead of `GasFeeCap - BaseFee`

### DIFF
--- a/core/state_transition.go
+++ b/core/state_transition.go
@@ -532,7 +532,7 @@ func (st *stateTransition) execute() (*ExecutionResult, error) {
 
 	effectiveTip := msg.GasPrice
 	if rules.IsLondon {
-		effectiveTip = new(big.Int).Sub(msg.GasFeeCap, st.evm.Context.BaseFee)
+		effectiveTip = new(big.Int).Sub(msg.GasPrice, st.evm.Context.BaseFee)
 		if effectiveTip.Cmp(msg.GasTipCap) > 0 {
 			effectiveTip = msg.GasTipCap
 		}


### PR DESCRIPTION
In `buyGas`, `GasPrice` is [used](https://github.com/ethereum/go-ethereum/blob/51b34efebcf36c4fd083b13b78ec49eb081623b9/core/state_transition.go#L262) to conduct the gas cost.

However when computing effectiveTip, `GasFeeCap` is [used](https://github.com/ethereum/go-ethereum/blob/51b34efebcf36c4fd083b13b78ec49eb081623b9/core/state_transition.go#L535) instead.

In theory, `GasFeeCap` >=  `GasPrice`, so it may happen that the tip fee is larger than it should be.

This PR tries to reduce such confusion by computing `effectiveTip` by `GasPrice - BaseFee` instead of `GasFeeCap - BaseFee`.

Note that for all tx types, `GasFeeCap` ==  `GasPrice` always holds, so there's no problem for tx. But it's still better to make it consistent .