### PR TITLE
core, triedb/pathdb: bail out error if write state history fails

### DIFF
--- a/core/rawdb/accessors_state.go
+++ b/core/rawdb/accessors_state.go
@@ -258,13 +258,21 @@ func ReadStateHistory(db ethdb.AncientReaderOp, id uint64) ([]byte, []byte, []by
 // WriteStateHistory writes the provided state history to database. Compute the
 // position of state history in freezer by minus one since the id of first state
 // history starts from one(zero for initial state).
-func WriteStateHistory(db ethdb.AncientWriter, id uint64, meta []byte, accountIndex []byte, storageIndex []byte, accounts []byte, storages []byte) {
-	db.ModifyAncients(func(op ethdb.AncientWriteOp) error {
-		op.AppendRaw(stateHistoryMeta, id-1, meta)
-		op.AppendRaw(stateHistoryAccountIndex, id-1, accountIndex)
-		op.AppendRaw(stateHistoryStorageIndex, id-1, storageIndex)
-		op.AppendRaw(stateHistoryAccountData, id-1, accounts)
-		op.AppendRaw(stateHistoryStorageData, id-1, storages)
-		return nil
+func WriteStateHistory(db ethdb.AncientWriter, id uint64, meta []byte, accountIndex []byte, storageIndex []byte, accounts []byte, storages []byte) error {
+	_, err := db.ModifyAncients(func(op ethdb.AncientWriteOp) error {
+		if err := op.AppendRaw(stateHistoryMeta, id-1, meta); err != nil {
+			return err
+		}
+		if err := op.AppendRaw(stateHistoryAccountIndex, id-1, accountIndex); err != nil {
+			return err
+		}
+		if err := op.AppendRaw(stateHistoryStorageIndex, id-1, storageIndex); err != nil {
+			return err
+		}
+		if err := op.AppendRaw(stateHistoryAccountData, id-1, accounts); err != nil {
+			return err
+		}
+		return op.AppendRaw(stateHistoryStorageData, id-1, storages)
 	})
+	return err
 }

--- a/triedb/pathdb/disklayer.go
+++ b/triedb/pathdb/disklayer.go
@@ -231,6 +231,8 @@ func (dl *diskLayer) commit(bottom *diffLayer, force bool) (*diskLayer, error) {
 		oldest   uint64
 	)
 	if dl.db.freezer != nil {
+		// Bail out with an error if writing the state history fails.
+		// This can happen, for example, if the device is full.
 		err := writeHistory(dl.db.freezer, bottom)
 		if err != nil {
 			return nil, err

--- a/triedb/pathdb/history.go
+++ b/triedb/pathdb/history.go
@@ -542,8 +542,9 @@ func writeHistory(writer ethdb.AncientWriter, dl *diffLayer) error {
 	indexSize := common.StorageSize(len(accountIndex) + len(storageIndex))
 
 	// Write history data into five freezer table respectively.
-	rawdb.WriteStateHistory(writer, dl.stateID(), history.meta.encode(), accountIndex, storageIndex, accountData, storageData)
-
+	if err := rawdb.WriteStateHistory(writer, dl.stateID(), history.meta.encode(), accountIndex, storageIndex, accountData, storageData); err != nil {
+		return err
+	}
 	historyDataBytesMeter.Mark(int64(dataSize))
 	historyIndexBytesMeter.Mark(int64(indexSize))
 	historyBuildTimeMeter.UpdateSince(start)


### PR DESCRIPTION
This PR fixes an issue that could lead to data corruption.

Writing the state history may fail due to insufficient disk space or other potential errors. 
With this change, the entire state insertion will be aborted instead of silently ignoring 
the error.

Without this fix, state transitions would continue while the associated state history is 
lost. After a restart, the resulting gap would be detected, making recovery impossible.


```sh
INFO [05-07|20:51:57.886] Chain freezer table opened               database=/home/gary/hdd/geth-ancient-mainnet-2/ancient/chain table=bodies items=17,312,882 deleted=0 hidden=0 tailId=0 headId=177 size=1,009,617,077
INFO [05-07|20:52:09.085] Opened ancient database                  database=/home/gary/hdd/geth-ancient-mainnet-2/ancient/chain readonly=false
INFO [05-07|20:52:09.087] State scheme set by user                 scheme=path
INFO [05-07|20:52:09.091] Initialising Ethereum protocol           network=1 dbversion=9
ERROR[05-07|20:52:09.146] Error in block freeze operation          err="can't write body to Freezer: write /home/gary/hdd/geth-ancient-mainnet-2/ancient/chain/bodies.0177.cdat: no space left on device"
WARN [05-07|20:52:09.146] Sanitizing invalid node buffer size      provided=1024.00MiB updated=256.00MiB
WARN [05-07|20:52:21.662] Truncating dangling head                 database=/home/gary/hdd/geth-ancient-mainnet-2/ancient/state table=account.index indexed=858,957,481 stored=858,959,872
INFO [05-07|20:52:21.736] Chain freezer table opened               database=/home/gary/hdd/geth-ancient-mainnet-2/ancient/state table=account.index items=17,404,737 deleted=0 hidden=0 tailId=0 headId=49 size=858,957,481
INFO [05-07|20:52:28.953] Opened ancient database                  database=/home/gary/hdd/geth-ancient-mainnet-2/ancient/state readonly=false
CRIT [05-07|20:52:28.953] Failed to truncate extra state histories err="out of range, tail: 0, head: 17404737, target: 17486117"
```