### PR TITLE
cmd/geth, internal: fix flaky console tests

### DIFF
--- a/cmd/geth/consolecmd_test.go
+++ b/cmd/geth/consolecmd_test.go
@@ -102,17 +102,17 @@ func TestAttachWelcome(t *testing.T) {
 		"--http", "--http.port", httpPort,
 		"--ws", "--ws.port", wsPort)
 	t.Run("ipc", func(t *testing.T) {
-		waitForEndpoint(t, ipc, 4*time.Second)
+		waitForEndpoint(t, ipc, 2*time.Minute)
 		testAttachWelcome(t, geth, "ipc:"+ipc, ipcAPIs)
 	})
 	t.Run("http", func(t *testing.T) {
 		endpoint := "http://127.0.0.1:" + httpPort
-		waitForEndpoint(t, endpoint, 4*time.Second)
+		waitForEndpoint(t, endpoint, 2*time.Minute)
 		testAttachWelcome(t, geth, endpoint, httpAPIs)
 	})
 	t.Run("ws", func(t *testing.T) {
 		endpoint := "ws://127.0.0.1:" + wsPort
-		waitForEndpoint(t, endpoint, 4*time.Second)
+		waitForEndpoint(t, endpoint, 2*time.Minute)
 		testAttachWelcome(t, geth, endpoint, httpAPIs)
 	})
 	geth.Kill()

--- a/cmd/geth/run_test.go
+++ b/cmd/geth/run_test.go
@@ -97,7 +97,7 @@ func runGeth(t *testing.T, args ...string) *testgeth {
 // waitForEndpoint attempts to connect to an RPC endpoint until it succeeds.
 func waitForEndpoint(t *testing.T, endpoint string, timeout time.Duration) {
 	probe := func() bool {
-		ctx, cancel := context.WithTimeout(context.Background(), timeout)
+		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
 		c, err := rpc.DialContext(ctx, endpoint)
 		if c != nil {

--- a/cmd/geth/run_test.go
+++ b/cmd/geth/run_test.go
@@ -97,7 +97,7 @@ func runGeth(t *testing.T, args ...string) *testgeth {
 // waitForEndpoint attempts to connect to an RPC endpoint until it succeeds.
 func waitForEndpoint(t *testing.T, endpoint string, timeout time.Duration) {
 	probe := func() bool {
-		ctx, cancel := context.WithCancel(context.Background())
+		ctx, cancel := context.WithTimeout(context.Background(), timeout)
 		defer cancel()
 		c, err := rpc.DialContext(ctx, endpoint)
 		if c != nil {

--- a/eth/api_backend_test.go
+++ b/eth/api_backend_test.go
@@ -134,13 +134,17 @@ func TestSendTx(t *testing.T) {
 func testSendTx(t *testing.T, withLocal bool) {
 	b := initBackend(withLocal)
 
-	txA := pricedSetCodeTx(0, 250000, uint256.NewInt(params.GWei), uint256.NewInt(params.GWei), key, []unsignedAuth{
-		{
-			nonce: 0,
-			key:   key,
-		},
-	})
-	b.SendTx(context.Background(), txA)
+	txA := pricedSetCodeTx(0, 250000, uint256.NewInt(params.GWei), uint256.NewInt(params.GWei), key, []unsignedAuth{{nonce: 0, key: key}})
+	if err := b.SendTx(context.Background(), txA); err != nil {
+		t.Fatalf("Failed to submit tx: %v", err)
+	}
+	for {
+		pending, _ := b.TxPool().ContentFrom(address)
+		if len(pending) == 1 {
+			break
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
 
 	txB := makeTx(1, nil, nil, key)
 	err := b.SendTx(context.Background(), txB)

--- a/internal/cmdtest/test_cmd.go
+++ b/internal/cmdtest/test_cmd.go
@@ -237,7 +237,7 @@ func (tt *TestCmd) Kill() {
 }
 
 func (tt *TestCmd) withKillTimeout(fn func()) {
-	timeout := time.AfterFunc(30*time.Second, func() {
+	timeout := time.AfterFunc(2*time.Minute, func() {
 		tt.Log("killing the child process (timeout)")
 		tt.Kill()
 	})


### PR DESCRIPTION
This pull request bumps the timeout for flaky console tests on appveyor.

