### PR TITLE
accounts/abi:  return an error if attempting to pack a negative `big.Int` value for a parameter that is defined as `uint*` in the ABI

### DIFF
--- a/accounts/abi/error_handling.go
+++ b/accounts/abi/error_handling.go
@@ -23,15 +23,16 @@ import (
 )
 
 var (
-	errBadBool   = errors.New("abi: improperly encoded boolean value")
-	errBadUint8  = errors.New("abi: improperly encoded uint8 value")
-	errBadUint16 = errors.New("abi: improperly encoded uint16 value")
-	errBadUint32 = errors.New("abi: improperly encoded uint32 value")
-	errBadUint64 = errors.New("abi: improperly encoded uint64 value")
-	errBadInt8   = errors.New("abi: improperly encoded int8 value")
-	errBadInt16  = errors.New("abi: improperly encoded int16 value")
-	errBadInt32  = errors.New("abi: improperly encoded int32 value")
-	errBadInt64  = errors.New("abi: improperly encoded int64 value")
+	errBadBool     = errors.New("abi: improperly encoded boolean value")
+	errBadUint8    = errors.New("abi: improperly encoded uint8 value")
+	errBadUint16   = errors.New("abi: improperly encoded uint16 value")
+	errBadUint32   = errors.New("abi: improperly encoded uint32 value")
+	errBadUint64   = errors.New("abi: improperly encoded uint64 value")
+	errBadInt8     = errors.New("abi: improperly encoded int8 value")
+	errBadInt16    = errors.New("abi: improperly encoded int16 value")
+	errBadInt32    = errors.New("abi: improperly encoded int32 value")
+	errBadInt64    = errors.New("abi: improperly encoded int64 value")
+	errInvalidSign = errors.New("abi: negatively-signed value cannot be packed into uint parameter")
 )
 
 // formatSliceString formats the reflection kind with the given slice size

--- a/accounts/abi/pack.go
+++ b/accounts/abi/pack.go
@@ -39,7 +39,7 @@ func validateNum(t Type, reflectValue reflect.Value) error {
 	if t.T == UintTy && reflectValue.Kind() == reflect.Ptr {
 		val := new(big.Int).Set(reflectValue.Interface().(*big.Int))
 		if val.Sign() == -1 {
-			return fmt.Errorf("cannot pack negative big.Int value to a uint type")
+			return errInvalidSign
 		}
 	}
 	return nil

--- a/accounts/abi/pack.go
+++ b/accounts/abi/pack.go
@@ -33,6 +33,8 @@ func packBytesSlice(bytes []byte, l int) []byte {
 	return append(len, common.RightPadBytes(bytes, (l+31)/32*32)...)
 }
 
+// validateNum returns an error if the underlying type of t is uint and the
+// value of reflectValue is a negative big.Int
 func validateNum(t Type, reflectValue reflect.Value) error {
 	if t.T == UintTy && reflectValue.Kind() == reflect.Ptr {
 		val := new(big.Int).Set(reflectValue.Interface().(*big.Int))

--- a/accounts/abi/pack_test.go
+++ b/accounts/abi/pack_test.go
@@ -177,6 +177,13 @@ func TestMethodPack(t *testing.T) {
 	if !bytes.Equal(packed, sig) {
 		t.Errorf("expected %x got %x", sig, packed)
 	}
+
+	_, err = abi.Pack("send", big.NewInt(-1))
+	if err == nil {
+		t.Fatal("expected error when trying to pack negative big.Int into uint256 value")
+	}
+
+	// TODO: examine what happens if we supply a negative non-big int to a method expect smaller uint val
 }
 
 func TestPackNumber(t *testing.T) {

--- a/accounts/abi/pack_test.go
+++ b/accounts/abi/pack_test.go
@@ -178,12 +178,11 @@ func TestMethodPack(t *testing.T) {
 		t.Errorf("expected %x got %x", sig, packed)
 	}
 
+	// test that we can't pack a negative value for a parameter that is specified as a uint
 	_, err = abi.Pack("send", big.NewInt(-1))
 	if err == nil {
 		t.Fatal("expected error when trying to pack negative big.Int into uint256 value")
 	}
-
-	// TODO: examine what happens if we supply a negative non-big int to a method expect smaller uint val
 }
 
 func TestPackNumber(t *testing.T) {


### PR DESCRIPTION
This is an alternative approach to https://github.com/ethereum/go-ethereum/pull/31607 , that doesn't break backwards-compatibility with abigen.