### PR TITLE
feat: upgrade Containerfile to use stagex

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,31 +3,31 @@ ARG COMMIT=""
 ARG VERSION=""
 ARG BUILDNUM=""
 
-# Build Geth in a stock Go builder container
-FROM golang:1.24-alpine AS builder
+FROM stagex/core-ca-certificates@sha256:d6fca6c0080e8e5360cd85fc1c4bd3eab71ce626f40602e38488bfd61fd3e89d AS ca-certificates
 
-RUN apk add --no-cache gcc musl-dev linux-headers git
+# Build Geth using a hermetic, full-source bootstrapped and deterministic toolchain
+FROM stagex/pallet-go@sha256:7ffeced176cf8c3035d918618ade8b824f9553ade8b0510df55df9012f35b0a8 AS build
 
 # Get dependencies - will also be cached if we won't change go.mod/go.sum
-COPY go.mod /go-ethereum/
-COPY go.sum /go-ethereum/
-RUN cd /go-ethereum && go mod download
+WORKDIR /go-ethereum
+COPY go.mod go.sum ./
+RUN go mod download
+COPY . .
 
-ADD . /go-ethereum
-RUN cd /go-ethereum && go run build/ci.go install -static ./cmd/geth
+RUN --network=none <<-EOF
+  go run build/ci.go install -static ./cmd/geth
+EOF
 
-# Pull Geth into a second stage deploy alpine container
-FROM alpine:latest
-
-RUN apk add --no-cache ca-certificates
-COPY --from=builder /go-ethereum/build/bin/geth /usr/local/bin/
-
+# Pull Geth into a clean layer with only required dependencies
+FROM scratch 
+COPY --from=ca-certificates . /
+COPY --from=build /go-ethereum/build/bin/geth /usr/bin/geth
 EXPOSE 8545 8546 30303 30303/udp
+
 ENTRYPOINT ["geth"]
 
 # Add some metadata labels to help programmatic image consumption
 ARG COMMIT=""
 ARG VERSION=""
 ARG BUILDNUM=""
-
 LABEL commit="$COMMIT" version="$VERSION" buildnum="$BUILDNUM"


### PR DESCRIPTION
Hi Ethereum community and maintainers,

I wasn't sure what the best way to suggest this change would be so I wrote code to show you what I had in mind. If this needs to go through some sort of proposal process let me know.

## Changes

Main Dockerfile switched from Alpine to [Stagex](https://codeberg.org/stagex/stagex). Stagex improves on a number of supply chain security gaps most current distributions are exposed to. It achieves this via being:
* Hermetic (everything is hashlocked)
* Full source bootstrapped
* Bit-for-bit deterministic all the way down
* Easy to reproduce by anyone (and each release is fully reproduced by at least two maintainers)

## Relevance

Supply chain attacks are a reality, not a hypothetical (SolarWinds, xcode ghost, xz backdoor etc.), and as such, a Linux distribution used in high risk scenarios should be designed and maintained as such. More on the importance of reproducibility, full source bootstrapping can be found here:
* [Reproducible Builds](https://reproducible-builds.org/)
* [Bootstrappable](https://bootstrappable.org/)

Organizations like [Talos Linux](https://github.com/siderolabs/talos/releases/tag/v1.10.0), [Mysten Labs](https://github.com/MystenLabs/sui/tree/main/docker/sui-node-deterministic), and [Turnkey](https://whitepaper.turnkey.com/foundations) are already using StageX in production as they recognize the value it brings. It's the same software you are already using, built in a more secure manner.

Additionally, this distribution was designed because even though there are some distributions such as Guix and Nix whicn get close to being adequate for high risk contexts, they dilute their security rigor for a number of reasons, typically because their threat models are not addressing sophisticated attacks and nation state actors, or often in exchange for removal of friction for hobby maintainers.

## Additional

While this improves a portion of the risk, some issues still remain:

* `geth` itself is still not deterministic
* Debian images are not reproducible and built using a secure toolchain

## Conclusion

Thank you for your attention and let me know if there are any questions.
