### PR TITLE
core: use unix time to check fork readiness

### DIFF
--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -2541,21 +2541,23 @@ func (bc *BlockChain) reportBlock(block *types.Block, res *ProcessResult, err er
 
 // logForkReadiness will write a log when a future fork is scheduled, but not
 // active. This is useful so operators know their client is ready for the fork.
-func (bc *BlockChain) logForkReadiness() {
-	c := bc.Config()
-	now := time.Now()
-	current, last := c.LatestFork(uint64(now.Unix())), c.LatestFork(math.MaxUint64)
-	t := c.Timestamp(last)
-	if t == nil {
+func (bc *BlockChain) logForkReadiness(block *types.Block) {
+	config := bc.Config()
+	current, last := config.LatestFork(block.Time()), config.LatestFork(math.MaxUint64)
+
+	// Short circuit if the timestamp of the last fork is undefined,
+	// or if the network has already passed the last configured fork.
+	t := config.Timestamp(last)
+	if t == nil || current >= last {
 		return
 	}
 	at := time.Unix(int64(*t), 0)
 
 	// Only log if:
-	// 1. Current fork is behind the latest fork
-	// 2. Current time is before the fork activation time
-	// 3. Enough time has passed since last alert
-	if current < last && now.Before(at) && now.After(bc.lastForkReadyAlert.Add(forkReadyInterval)) {
+	// - Current time is before the fork activation time
+	// - Enough time has passed since last alert
+	now := time.Now()
+	if now.Before(at) && now.After(bc.lastForkReadyAlert.Add(forkReadyInterval)) {
 		log.Info("Ready for fork activation", "fork", last, "date", at.Format(time.RFC822),
 			"remaining", time.Until(at).Round(time.Second), "timestamp", at.Unix())
 		bc.lastForkReadyAlert = time.Now()

--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -1838,7 +1838,7 @@ func (bc *BlockChain) insertChain(chain types.Blocks, setHead bool, makeWitness 
 		stats.report(chain, it.index, snapDiffItems, snapBufItems, trieDiffNodes, trieBufNodes, setHead)
 
 		// Print confirmation that a future fork is scheduled, but not yet active.
-		bc.logForkReadiness()
+		bc.logForkReadiness(block)
 
 		if !setHead {
 			// After merge we expect few side chains. Simply count


### PR DESCRIPTION
fixes:

1. use current timestamp to check the fork activation instead of the block's, so when syncing behind the head, it will not print the below log;
2. add a time check ensure current time is before the fork activation time


```
INFO [05-10|08:52:03.779] Ready for fork activation                fork=Prague date="07 May 25 18:05 CST" remaining=-62h46m53s timestamp=1,746,612,311
```