### PR TITLE
Advance SimulatedBeacon based on lastBlockTime

### DIFF
--- a/eth/catalyst/simulated_beacon.go
+++ b/eth/catalyst/simulated_beacon.go
@@ -309,7 +309,7 @@ func (c *SimulatedBeacon) setCurrentState(headHash, finalizedHash common.Hash) {
 // Commit seals a block on demand.
 func (c *SimulatedBeacon) Commit() common.Hash {
 	withdrawals := c.withdrawals.pop(10)
-	if err := c.sealBlock(withdrawals, uint64(time.Now().Unix())); err != nil {
+	if err := c.sealBlock(withdrawals, c.lastBlockTime+1); err != nil {
 		log.Warn("Error performing sealing work", "err", err)
 	}
 	return c.eth.BlockChain().CurrentBlock().Hash()


### PR DESCRIPTION
The SimulatedBeacon currently sets block timestamps using `time.Now()` which makes testing timestamp based logic quite hard. This changes the current behavior to simply increment the timestamp of the last block by 1 on `Commit()`. 
Was also contemplating a clock-based solution but that will probably require adding or changing some interfaces, so I thought I'll start by proposing the simplest solution first. Let me know what you think.