### PR TITLE
eth/tracers: add console.log/error support to JS tracer

### DIFF
--- a/eth/tracers/js/tracer_test.go
+++ b/eth/tracers/js/tracer_test.go
@@ -146,6 +146,16 @@ func TestTracer(t *testing.T) {
 		}, { // tests ctx.coinbase
 			code: "{lengths: [], step: function(log) { }, fault: function() {}, result: function(ctx) { var coinbase = ctx.coinbase; return toAddress(coinbase); }}",
 			want: `{"0":0,"1":0,"2":0,"3":0,"4":0,"5":0,"6":0,"7":0,"8":0,"9":0,"10":0,"11":0,"12":0,"13":0,"14":0,"15":0,"16":0,"17":0,"18":0,"19":0}`,
+		}, {
+			code: `{
+				step: function() {
+					console.log("test log");
+					console.error("test error");
+				},
+				fault: function() {},
+				result: function() {},
+			}`,
+			want: `{}`,
 		},
 	} {
 		if have, err := execTracer(tt.code, tt.contract); tt.want != string(have) || tt.fail != err {


### PR DESCRIPTION
implemnt the console.log and console.error for js tracer