### PR TITLE
blobpool: fix blob validation rule

### DIFF
--- a/core/txpool/blobpool/blobpool.go
+++ b/core/txpool/blobpool/blobpool.go
@@ -1097,7 +1097,7 @@ func (p *BlobPool) ValidateTxBasics(tx *types.Transaction) error {
 	opts := &txpool.ValidationOptions{
 		Config:  p.chain.Config(),
 		Accept:  1 << types.BlobTxType,
-		MaxSize: txMaxSize,
+		MaxSize: txMaxSize + uint64(eip4844.LatestMaxBlobsPerBlock(p.chain.Config())*blobSize),
 		MinTip:  p.gasTip.ToBig(),
 	}
 	return txpool.ValidateTransaction(tx, p.head, p.signer, opts)


### PR DESCRIPTION
Currently if we try to submit transactions over 7 blobs, we'll get `oversized data: transaction size 1049793, limit 1048576` [error](https://github.com/ethereum/go-ethereum/blob/master/core/txpool/validation.go#L69)

This PR fixes that by taking the blob count into consideration when validating blob transactions