### PR TITLE
Avoid calling `OnBlockEnd` on panic

### DIFF
--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -1962,7 +1962,11 @@ func (bc *BlockChain) processBlock(parentRoot common.Hash, block *types.Block, s
 	}
 	if bc.logger != nil && bc.logger.OnBlockEnd != nil {
 		defer func() {
-			bc.logger.OnBlockEnd(blockEndErr)
+			if recovered := recover(); recovered != nil {
+				panic(recovered)
+			} else {
+				bc.logger.OnBlockEnd(blockEndErr)
+			}
 		}()
 	}
 

--- a/core/blockchain_test.go
+++ b/core/blockchain_test.go
@@ -36,6 +36,7 @@ import (
 	"github.com/ethereum/go-ethereum/core/history"
 	"github.com/ethereum/go-ethereum/core/rawdb"
 	"github.com/ethereum/go-ethereum/core/state"
+	"github.com/ethereum/go-ethereum/core/tracing"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/core/vm"
 	"github.com/ethereum/go-ethereum/core/vm/program"
@@ -4388,5 +4389,45 @@ func testInsertChainWithCutoff(t *testing.T, cutoff uint64, ancientLimit uint64,
 				t.Fatalf("Missed block receipts: %d, cutoff: %d", num, cutoffBlock.NumberU64())
 			}
 		}
+	}
+}
+
+func TestTracingBlockEndNotCalledOnPanic(t *testing.T) {
+	genDb, _, blockchain, err := newCanonical(ethash.NewFaker(), 0, true, "path")
+	if err != nil {
+		t.Fatalf("failed to create pristine chain: %v", err)
+	}
+	defer blockchain.Stop()
+
+	blockEndCalled := false
+	hooks := &tracing.Hooks{
+		// This simulates a panic in the tracer
+		OnBalanceChange: func(addr common.Address, prev, new *big.Int, reason tracing.BalanceChangeReason) {
+			panic("panic")
+		},
+		OnBlockEnd: func(err error) {
+			blockEndCalled = true
+		},
+	}
+
+	blockchain.logger = hooks
+	blockchain.vmConfig.Tracer = hooks
+
+	blocks := makeBlockChain(blockchain.chainConfig, blockchain.GetBlockByHash(blockchain.CurrentBlock().Hash()), 1, ethash.NewFullFaker(), genDb, 0)
+
+	func() {
+		defer func() {
+			if r := recover(); r == nil {
+				t.Fatalf("Expected panic, but got none, ensure that OnBalanceChange hook is called correctly to generate the panic")
+			}
+		}()
+
+		if _, err := blockchain.InsertChain(blocks); err != nil {
+			t.Fatalf("Failed to insert block: %v", err)
+		}
+	}()
+
+	if blockEndCalled {
+		t.Fatalf("OnBlockEnd should not be called on panic within the tracer")
 	}
 }


### PR DESCRIPTION
This avoid problem where the tracer receives `OnBlockEnd(nil)` and thus cannot know that an error happen, in which case it could flush data out.

Technically, shouldn't be a big problem as since there is a panic, the block will not be committed to geth storage and will be replayed correctly.

The other possibility would be to still call the tracer but passing the recovered error to `OnBlockEnd`, but this would require transforming the recovered `any` type into an `error`.

Relates to [#31226](https://github.com/ethereum/go-ethereum/pull/31226), unsure if it would handle the case here.