### PR TITLE
core/blockchain: remove unnecessary fmt.Sprintf in log.Error calls

### DIFF
--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -652,8 +652,8 @@ func (bc *BlockChain) initializeHistoryPruning(latest uint64) error {
 			// postmerge directly on an existing DB. We could just trigger the pruning
 			// here, but it'd be a bit dangerous since they may not have intended this
 			// action to happen. So just tell them how to do it.
-			log.Error(fmt.Sprintf("Chain history mode is configured as %q, but database is not pruned.", bc.cacheConfig.ChainHistoryMode.String()))
-			log.Error(fmt.Sprintf("Run 'geth prune-history' to prune pre-merge history."))
+			log.Error("Chain history mode is configured as %q, but database is not pruned.", bc.cacheConfig.ChainHistoryMode.String())
+			log.Error("Run 'geth prune-history' to prune pre-merge history.")
 			return fmt.Errorf("history pruning requested via configuration")
 		}
 		predefinedPoint := history.PrunePoints[bc.genesisBlock.Hash()]


### PR DESCRIPTION
Replaced redundant usage of fmt.Sprintf inside log.Error calls with direct formatting arguments. 
This change improves code clarity and performance.
No functional changes were made.