### PR TITLE
core: don't emit the warning of log indexing if the db was not initialized

### DIFF
--- a/core/filtermaps/filtermaps.go
+++ b/core/filtermaps/filtermaps.go
@@ -227,7 +227,7 @@ type Config struct {
 // NewFilterMaps creates a new FilterMaps and starts the indexer.
 func NewFilterMaps(db ethdb.KeyValueStore, initView *ChainView, historyCutoff, finalBlock uint64, params Params, config Config) *FilterMaps {
 	rs, initialized, err := rawdb.ReadFilterMapsRange(db)
-	if err != nil || rs.Version != databaseVersion {
+	if err != nil || (initialized && rs.Version != databaseVersion) {
 		rs, initialized = rawdb.FilterMapsRange{}, false
 		log.Warn("Invalid log index database version; resetting log index")
 	}

--- a/core/rawdb/accessors_indexes.go
+++ b/core/rawdb/accessors_indexes.go
@@ -446,7 +446,7 @@ type FilterMapsRange struct {
 // database entry is not present, that is interpreted as a valid non-initialized
 // state and returns a blank range structure and no error.
 func ReadFilterMapsRange(db ethdb.KeyValueReader) (FilterMapsRange, bool, error) {
-	if has, err := db.Has(filterMapsRangeKey); !has || err != nil {
+	if has, err := db.Has(filterMapsRangeKey); err != nil || !has {
 		return FilterMapsRange{}, false, err
 	}
 	encRange, err := db.Get(filterMapsRangeKey)
@@ -457,7 +457,8 @@ func ReadFilterMapsRange(db ethdb.KeyValueReader) (FilterMapsRange, bool, error)
 	if err := rlp.DecodeBytes(encRange, &fmRange); err != nil {
 		return FilterMapsRange{}, false, err
 	}
-	return fmRange, true, err
+
+	return fmRange, true, nil
 }
 
 // WriteFilterMapsRange stores the filter maps range data.


### PR DESCRIPTION
When I'm running the geth node, I found this warning log, it's annoying, because my node is just started, and it should not log the `invalid log index database version` warning.

```
WARN [05-14|12:14:22.393] Invalid log index database version; resetting log index
```

commits:

1. core/rawdb: implicitly return nil if no error, check error first
2. core/filtermaps: don't warning if not initialized