### PR TITLE
core/filtermaps: remove filter base row cache, add group read

### DIFF
--- a/core/filtermaps/indexer_test.go
+++ b/core/filtermaps/indexer_test.go
@@ -428,10 +428,12 @@ func (ts *testSetup) matcherViewHash() common.Hash {
 		binary.LittleEndian.PutUint32(enc[:4], r)
 		for m := uint32(0); m <= headMap; m++ {
 			binary.LittleEndian.PutUint32(enc[4:8], m)
-			row, _ := mb.GetFilterMapRow(ctx, m, r, false)
-			for _, v := range row {
-				binary.LittleEndian.PutUint32(enc[8:], v)
-				hasher.Write(enc[:])
+			rows, _ := mb.GetFilterMapRows(ctx, []uint32{m}, r, false)
+			for _, row := range rows {
+				for _, v := range row {
+					binary.LittleEndian.PutUint32(enc[8:], v)
+					hasher.Write(enc[:])
+				}
 			}
 		}
 	}

--- a/core/filtermaps/matcher.go
+++ b/core/filtermaps/matcher.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"math"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -45,7 +44,7 @@ var ErrMatchAll = errors.New("match all patterns not supported")
 type MatcherBackend interface {
 	GetParams() *Params
 	GetBlockLvPointer(ctx context.Context, blockNumber uint64) (uint64, error)
-	GetFilterMapRow(ctx context.Context, mapIndex, rowIndex uint32, baseLayerOnly bool) (FilterRow, error)
+	GetFilterMapRows(ctx context.Context, mapIndices []uint32, rowIndex uint32, baseLayerOnly bool) ([]FilterRow, error)
 	GetLogByLvIndex(ctx context.Context, lvIndex uint64) (*types.Log, error)
 	SyncLogIndex(ctx context.Context) (SyncRange, error)
 	Close()
@@ -365,50 +364,57 @@ func (m *singleMatcherInstance) getMatchesForLayer(ctx context.Context, layerInd
 	var st int
 	m.stats.setState(&st, stOther)
 	params := m.backend.GetParams()
-	maskedMapIndex, rowIndex := uint32(math.MaxUint32), uint32(0)
-	for _, mapIndex := range m.mapIndices {
-		filterRows, ok := m.filterRows[mapIndex]
-		if !ok {
-			continue
-		}
-		if mm := params.maskedMapIndex(mapIndex, layerIndex); mm != maskedMapIndex {
-			// only recalculate rowIndex when necessary
-			maskedMapIndex = mm
-			rowIndex = params.rowIndex(mapIndex, layerIndex, m.value)
+	var ptr int
+	for len(m.mapIndices) > ptr {
+		// find next group of map indices mapped onto the same row
+		maskedMapIndex := params.maskedMapIndex(m.mapIndices[ptr], layerIndex)
+		rowIndex := params.rowIndex(m.mapIndices[ptr], layerIndex, m.value)
+		groupLength := 1
+		for ptr+groupLength < len(m.mapIndices) && params.maskedMapIndex(m.mapIndices[ptr+groupLength], layerIndex) == maskedMapIndex {
+			groupLength++
 		}
 		if layerIndex == 0 {
 			m.stats.setState(&st, stFetchFirst)
 		} else {
 			m.stats.setState(&st, stFetchMore)
 		}
-		filterRow, err := m.backend.GetFilterMapRow(ctx, mapIndex, rowIndex, layerIndex == 0)
+		groupRows, err := m.backend.GetFilterMapRows(ctx, m.mapIndices[ptr:ptr+groupLength], rowIndex, layerIndex == 0)
 		if err != nil {
 			m.stats.setState(&st, stNone)
-			return nil, fmt.Errorf("failed to retrieve filter map %d row %d: %v", mapIndex, rowIndex, err)
+			return nil, fmt.Errorf("failed to retrieve filter map %d row %d: %v", m.mapIndices[ptr], rowIndex, err)
 		}
-		if layerIndex == 0 {
-			matchBaseRowAccessMeter.Mark(1)
-			matchBaseRowSizeMeter.Mark(int64(len(filterRow)))
-		} else {
-			matchExtRowAccessMeter.Mark(1)
-			matchExtRowSizeMeter.Mark(int64(len(filterRow)))
-		}
-		m.stats.addAmount(st, int64(len(filterRow)))
 		m.stats.setState(&st, stOther)
-		filterRows = append(filterRows, filterRow)
-		if uint32(len(filterRow)) < params.maxRowLength(layerIndex) {
-			m.stats.setState(&st, stProcess)
-			matches := params.potentialMatches(filterRows, mapIndex, m.value)
-			m.stats.addAmount(st, int64(len(matches)))
-			results = append(results, matcherResult{
-				mapIndex: mapIndex,
-				matches:  matches,
-			})
-			m.stats.setState(&st, stOther)
-			delete(m.filterRows, mapIndex)
-		} else {
-			m.filterRows[mapIndex] = filterRows
+		for i := range groupLength {
+			mapIndex := m.mapIndices[ptr+i]
+			filterRow := groupRows[i]
+			filterRows, ok := m.filterRows[mapIndex]
+			if !ok {
+				panic("dropped map in mapIndices")
+			}
+			if layerIndex == 0 {
+				matchBaseRowAccessMeter.Mark(1)
+				matchBaseRowSizeMeter.Mark(int64(len(filterRow)))
+			} else {
+				matchExtRowAccessMeter.Mark(1)
+				matchExtRowSizeMeter.Mark(int64(len(filterRow)))
+			}
+			m.stats.addAmount(st, int64(len(filterRow)))
+			filterRows = append(filterRows, filterRow)
+			if uint32(len(filterRow)) < params.maxRowLength(layerIndex) {
+				m.stats.setState(&st, stProcess)
+				matches := params.potentialMatches(filterRows, mapIndex, m.value)
+				m.stats.addAmount(st, int64(len(matches)))
+				results = append(results, matcherResult{
+					mapIndex: mapIndex,
+					matches:  matches,
+				})
+				m.stats.setState(&st, stOther)
+				delete(m.filterRows, mapIndex)
+			} else {
+				m.filterRows[mapIndex] = filterRows
+			}
 		}
+		ptr += groupLength
 	}
 	m.cleanMapIndices()
 	m.stats.setState(&st, stNone)

--- a/core/filtermaps/matcher_backend.go
+++ b/core/filtermaps/matcher_backend.go
@@ -67,18 +67,15 @@ func (fm *FilterMapsMatcherBackend) Close() {
 	delete(fm.f.matchers, fm)
 }
 
-// GetFilterMapRow returns the given row of the given map. If the row is empty
+// GetFilterMapRows returns the given row of the given map. If the row is empty
 // then a non-nil zero length row is returned. If baseLayerOnly is true then
 // only the first baseRowLength entries of the row are guaranteed to be
 // returned.
 // Note that the returned slices should not be modified, they should be copied
 // on write.
-// GetFilterMapRow implements MatcherBackend.
-func (fm *FilterMapsMatcherBackend) GetFilterMapRow(ctx context.Context, mapIndex, rowIndex uint32, baseLayerOnly bool) (FilterRow, error) {
-	fm.f.indexLock.RLock()
-	defer fm.f.indexLock.RUnlock()
-
-	return fm.f.getFilterMapRow(mapIndex, rowIndex, baseLayerOnly)
+// GetFilterMapRows implements MatcherBackend.
+func (fm *FilterMapsMatcherBackend) GetFilterMapRows(ctx context.Context, mapIndices []uint32, rowIndex uint32, baseLayerOnly bool) ([]FilterRow, error) {
+	return fm.f.getFilterMapRows(mapIndices, rowIndex, baseLayerOnly)
 }
 
 // GetBlockLvPointer returns the starting log value index where the log values


### PR DESCRIPTION
This PR changes the database access of the base part of filter rows that are stored in groups of 32 adjacent maps for improved database storage size and data access efficiency.
Before this grouped storage was introduced, filter rows were not cached because the access pattern of either the index rendering or the search does not really benefit from caching. Also no mutex was necessary for filter row access. Storing adjacent rows in groups complicated the situation as a search typically required reading all or most of adjacent rows of a group, so in order to implement the single row read operation without having to read the entire group up to 32 times, a cache for the base row groups was added. This also introduced data race issues for concurrenct read/write in the same group which was avoided by locking the `indexLock` mutex. Unfortunately this also led to slowed down or temporarily blocked search operations when indexing was in progress.
This PR returns to the original concept of uncached, no-mutex filter map access by increasing read efficiency in a better way; similiarly to write operations that already operate on groups of filter maps, now `getFilterMapRow` is also replaced by `getFilterMapRows` that accepts a single `rowIndex` and a list of `mapIndices`. It slightly complicates `singleMatcherInstance.getMatchesForLayer` which now has to collect groups of map indices accessed in the same row, but in exchange it guarantees maximum read efficiency while avoiding read/write mutex interference.

Note: a follow-up refactoring is WIP that further changes the database access scheme by prodiving an immutable index view to the matcher, makes the whole indexer more straightforward with no callbacks, and entirely removes the concept of matcher syncing with `validBlocks` and the resulting multiple retry logic in `eth/filters/filter.go`. This might take a bit longer to finish though and in the meantime this change could hopefully already solve the blocked request issues.