### PR TITLE
internal: remove eth_{compile,getWork,submitWork} from console

### DIFF
--- a/internal/jsre/deps/web3.js
+++ b/internal/jsre/deps/web3.js
@@ -5435,36 +5435,6 @@ var methods = function () {
         outputFormatter: utils.toDecimal
     });
 
-    var compileSolidity = new Method({
-        name: 'compile.solidity',
-        call: 'eth_compileSolidity',
-        params: 1
-    });
-
-    var compileLLL = new Method({
-        name: 'compile.lll',
-        call: 'eth_compileLLL',
-        params: 1
-    });
-
-    var compileSerpent = new Method({
-        name: 'compile.serpent',
-        call: 'eth_compileSerpent',
-        params: 1
-    });
-
-    var submitWork = new Method({
-        name: 'submitWork',
-        call: 'eth_submitWork',
-        params: 3
-    });
-
-    var getWork = new Method({
-        name: 'getWork',
-        call: 'eth_getWork',
-        params: 0
-    });
-
     return [
         getBalance,
         getStorageAt,
@@ -5483,12 +5453,7 @@ var methods = function () {
         sendRawTransaction,
         signTransaction,
         sendTransaction,
-        sign,
-        compileSolidity,
-        compileLLL,
-        compileSerpent,
-        submitWork,
-        getWork
+        sign
     ];
 };
 


### PR DESCRIPTION
The `compile` and `eth_getWork` `eth_submitWork` apis were not available anymore, so try to remove them