### PR TITLE
internal: fix web3.isChecksumAddress raise TypeError

### DIFF
--- a/internal/jsre/deps/web3.js
+++ b/internal/jsre/deps/web3.js
@@ -2266,8 +2266,11 @@ var isAddress = function (address) {
  * @return {Boolean}
 */
 var isChecksumAddress = function (address) {
+    if (typeof address === 'undefined') return false;
+
     // Check each case
     address = address.replace('0x','');
+    if (address.length !== 40) return false;
     var addressHash = sha3(address.toLowerCase());
 
     for (var i = 0; i < 40; i++ ) {


### PR DESCRIPTION
The `web3.isChecksumAddress` was raised a TypeError when the input address is not a valid ethereum address, eg:

```
> web3.isChecksumAddress('0x0000')
TypeError: Cannot read property 'toUpperCase' of undefined or null
        at isChecksumAddress (web3.js:2275:57(32))
        at <eval>:1:23(3)
> web3.isChecksumAddress(undefined)
TypeError: Cannot read property 'replace' of undefined or null
        at isChecksumAddress (web3.js:2270:15(2))
        at <eval>:1:23(3)
```

While, the `web3.toChecksumAddress` was not raised a TypeError, so try to make them consistent:

```
> web3.toChecksumAddress('0x0000')
"0x0000"
> web3.toChecksumAddress(undefined)
""
```