### PR TITLE
internal/reexec: fix broken link to Docker/Moby in comment

### DIFF
--- a/internal/reexec/reexec.go
+++ b/internal/reexec/reexec.go
@@ -1,5 +1,5 @@
 // This file originates from Docker/Moby,
-// https://github.com/moby/moby/blob/master/pkg/reexec/reexec.go
+// https://github.com/moby/moby/blob/master/pkg/reexec/reexec_deprecated.go
 // Licensed under Apache License 2.0: https://github.com/moby/moby/blob/master/LICENSE
 // Copyright 2013-2018 Docker, Inc.
 //


### PR DESCRIPTION
Hey team—noticed a dead link, replaced it with a working URL

https://github.com/moby/moby/blob/master/pkg/reexec/reexec.go - old link
https://github.com/moby/moby/blob/master/pkg/reexec/reexec_deprecated.go - new link