### PR TITLE
README: update broken JSON-RPC API documentation link

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,7 +162,7 @@ accessible from the outside.
 
 As a developer, sooner rather than later you'll want to start interacting with `geth` and the
 Ethereum network via your own programs and not manually through the console. To aid
-this, `geth` has built-in support for a JSON-RPC based APIs ([standard APIs](https://ethereum.github.io/execution-apis/api-documentation/)
+this, `geth` has built-in support for a JSON-RPC based APIs ([standard APIs](https://ethereum.org/en/developers/docs/apis/json-rpc/)
 and [`geth` specific APIs](https://geth.ethereum.org/docs/interacting-with-geth/rpc)).
 These can be exposed via HTTP, WebSockets and IPC (UNIX sockets on UNIX based
 platforms, and named pipes on Windows).


### PR DESCRIPTION
I've updated the broken link to point to the current official Ethereum JSON-RPC API documentation at https://ethereum.org/en/developers/docs/apis/json-rpc/. This is the correct and up-to-date location for the Ethereum Execution Layer APIs documentation. The link should now work properly.