### PR TITLE
core/state: reduce allocation in updateStateObject

### DIFF
--- a/core/state/statedb.go
+++ b/core/state/statedb.go
@@ -562,9 +562,8 @@ func (s *StateDB) GetTransientState(addr common.Address, key common.Hash) common
 // updateStateObject writes the given object to the trie.
 func (s *StateDB) updateStateObject(obj *stateObject) {
 	// Encode the account and update the account trie
-	addr := obj.Address()
-	if err := s.trie.UpdateAccount(addr, &obj.data, len(obj.code)); err != nil {
-		s.setError(fmt.Errorf("updateStateObject (%x) error: %v", addr[:], err))
+	if err := s.trie.UpdateAccount(obj.Address(), &obj.data, len(obj.code)); err != nil {
+		s.setError(fmt.Errorf("updateStateObject (%x) error: %v", obj.Address(), err))
 	}
 	if obj.dirtyCode {
 		s.trie.UpdateContractCode(obj.Address(), common.BytesToHash(obj.CodeHash()), obj.code)


### PR DESCRIPTION
I couldn't really believe it myself, but turns out this saves us one heap allocation

```
goos: linux
goarch: amd64
pkg: github.com/ethereum/go-ethereum/core/state
cpu: Intel(R) Core(TM) Ultra 7 155U
                     │ /tmp/old.txt │            /tmp/new.txt             │
                     │    sec/op    │   sec/op     vs base                │
UpdateStateObject-14   782.6n ± 19%   674.1n ± 6%  -13.86% (p=0.002 n=10)

                     │ /tmp/old.txt │           /tmp/new.txt            │
                     │     B/op     │    B/op     vs base               │
UpdateStateObject-14     368.0 ± 0%   344.0 ± 0%  -6.52% (p=0.000 n=10)

                     │ /tmp/old.txt │            /tmp/new.txt            │
                     │  allocs/op   │ allocs/op   vs base                │
UpdateStateObject-14     8.000 ± 0%   7.000 ± 0%  -12.50% (p=0.000 n=10)
```


Benchmark:
```go
func BenchmarkUpdateStateObject(b *testing.B) {
	db := NewDatabaseForTesting()
	orig, _ := New(types.EmptyRootHash, db)

	// Fill up the initial states
	obj := orig.getOrNewStateObject(common.BytesToAddress([]byte{}))
	obj.AddBalance(uint256.NewInt(uint64(1)))
	obj.data.Root = common.HexToHash("0xdeadbeef")
	for range b.N {
		orig.updateStateObject(obj)
	}
}
```