### PR TITLE
eth: fix to include start key in debug_storageRangeAt

### DIFF
--- a/eth/api_debug.go
+++ b/eth/api_debug.go
@@ -245,7 +245,7 @@ func storageRangeAt(statedb *state.StateDB, root common.Hash, address common.Add
 	}
 	it := trie.NewIterator(trieIt)
 	result := StorageRangeResult{Storage: storageMap{}}
-	for i := 0; i < maxResult && it.Next(); i++ {
+	for range maxResult {
 		_, content, _, err := rlp.Split(it.Value)
 		if err != nil {
 			return StorageRangeResult{}, err
@@ -256,6 +256,9 @@ func storageRangeAt(statedb *state.StateDB, root common.Hash, address common.Add
 			e.Key = &preimage
 		}
 		result.Storage[common.BytesToHash(it.Key)] = e
+		if !it.Next() {
+			break
+		}
 	}
 	// Add the 'next key' so clients can continue downloading.
 	if it.Next() {


### PR DESCRIPTION
### Description

This PR fixes an issue in the `debug_storageRangeAt` API where the start key was being skipped in the results. The current implementation calls `it.Next()` before processing any items, which causes the iterator to skip the start key specified in the query.

For example, if storage contains keys [1,2,3,4,5] and the query starts with key 1, the current implementation would return [2,3,4,5] instead of [1,2,3,4].