### PR TITLE
core: standardize log message format for log indexer

### DIFF
--- a/core/filtermaps/indexer.go
+++ b/core/filtermaps/indexer.go
@@ -40,7 +40,7 @@ func (f *FilterMaps) indexerLoop() {
 		close(f.disabledCh)
 		return
 	}
-	log.Info("Started log indexer")
+	log.Info("Log indexer started")
 
 	for !f.stop {
 		// Note: acquiring the indexLock read lock is unnecessary here,


### PR DESCRIPTION
Standardizes the log message format for the log indexer startup to maintain consistency with other log messages in the codebase.

The other log messsages as below:

```
INFO [05-14|08:26:09.420] IPC endpoint opened                      url=/data/geth.ipc
INFO [05-14|08:26:09.421] Loaded JWT secret file                   path=/jwt/jwt.hex crc32=0xbafaf7e2
INFO [05-14|08:26:09.422] HTTP server started                      endpoint=[::]:7545 auth=false prefix= cors=* vhosts=*
INFO [05-14|08:26:09.422] GraphQL enabled                          url=http://[::]:7545/graphql
INFO [05-14|08:26:09.422] GraphQL UI enabled                       url=http://[::]:7545/graphql/ui
INFO [05-14|08:26:09.422] WebSocket enabled                        url=ws://[::]:7546
INFO [05-14|08:26:09.422] WebSocket enabled                        url=ws://[::]:8551
INFO [05-14|08:26:09.422] HTTP server started                      endpoint=[::]:8551 auth=true  prefix= cors=localhost vhosts=*
INFO [05-14|08:26:09.422] Loaded local transaction journal         transactions=0 dropped=0
```

But the log indexer message is:

```
INFO [05-14|08:26:09.423] Started log indexer
```

So change into the same standard.