### PR TITLE
eth/catalyst: fix a bug about using null PayLoadID

### DIFF
--- a/eth/catalyst/simulated_beacon.go
+++ b/eth/catalyst/simulated_beacon.go
@@ -208,6 +208,11 @@ func (c *SimulatedBeacon) sealBlock(withdrawals []*types.Withdrawal, timestamp u
 		return errors.New("chain rewind prevented invocation of payload creation")
 	}
 
+	// If the payload was already known, we can skip the rest of the process.
+	if fcResponse.PayloadStatus.Status == engine.VALID && fcResponse.PayloadID == nil {
+		return nil
+	}
+
 	envelope, err := c.engineAPI.getPayload(*fcResponse.PayloadID, true)
 	if err != nil {
 		return err


### PR DESCRIPTION
geth cmd: `geth --dev --dev.period 5`
call: `debug.setHead`

If the `debug.setHead` call is delayed, it will trigger a panic with a small probability, due to using the null of `fcResponse.PayloadID`.