### PR TITLE
core: add gas used ratio in the inserting report log

### DIFF
--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -1844,6 +1844,7 @@ func (bc *BlockChain) insertChain(chain types.Blocks, setHead bool, makeWitness 
 		// Report the import stats before returning the various results
 		stats.processed++
 		stats.usedGas += res.usedGas
+		stats.gasLimit += block.GasLimit()
 		witness = res.witness
 
 		var snapDiffItems, snapBufItems common.StorageSize


### PR DESCRIPTION
Add a `gasused` field in the inserting report log, to help us to monitor the gas used ratio.