### PR TITLE
internal/era: update link to documentation

### DIFF
--- a/internal/era/accumulator.go
+++ b/internal/era/accumulator.go
@@ -49,7 +49,7 @@ func ComputeAccumulator(hashes []common.Hash, tds []*big.Int) (common.Hash, erro
 
 // headerRecord is an individual record for a historical header.
 //
-// See https://github.com/ethereum/portal-network-specs/blob/master/history-network.md#the-header-accumulator
+// See https://github.com/ethereum/portal-network-specs/blob/master/history/history-network.md#the-historical-hashes-accumulator
 // for more information.
 type headerRecord struct {
 	Hash            common.Hash


### PR DESCRIPTION
Updated reference URL in accumulator.go comment to point to the correct location of the historical-hashes-accumulator documentation in the Ethereum portal network specs
