### PR TITLE
build: Update EEST to v4.5.0

### DIFF
--- a/build/checksums.txt
+++ b/build/checksums.txt
@@ -1,9 +1,9 @@
 # This file contains sha256 checksums of optional build dependencies.
 
-# version:spec-tests pectra-devnet-6@v1.0.0
+# version:spec-tests v4.5.0
 # https://github.com/ethereum/execution-spec-tests/releases
-# https://github.com/ethereum/execution-spec-tests/releases/download/pectra-devnet-6%40v1.0.0/
-b69211752a3029083c020dc635fe12156ca1a6725a08559da540a0337586a77e  fixtures_pectra-devnet-6.tar.gz
+# https://github.com/ethereum/execution-spec-tests/releases/download/v4.5.0/
+58afb92a0075a2cb7c4dec1281f7cb88b21b02afbedad096b580f3f8cc14c54c  fixtures_develop.tar.gz
 
 # version:golang 1.24.3
 # https://go.dev/dl/

--- a/build/ci.go
+++ b/build/ci.go
@@ -332,7 +332,7 @@ func doTest(cmdline []string) {
 // downloadSpecTestFixtures downloads and extracts the execution-spec-tests fixtures.
 func downloadSpecTestFixtures(csdb *download.ChecksumDB, cachedir string) string {
 	ext := ".tar.gz"
-	base := "fixtures_pectra-devnet-6" // TODO(s1na) rename once the version becomes part of the filename
+	base := "fixtures_develop"
 	archivePath := filepath.Join(cachedir, base+ext)
 	if err := csdb.DownloadFileFromKnownURL(archivePath); err != nil {
 		log.Fatal(err)


### PR DESCRIPTION
We deleted outdated pectra-devnet-6@v1.0.0 release by mistake, so this PR updates the referenced EEST release to the correct latest version.

@s1na I removed the TODO comment because I think this solves it, unless it meant something else.