### PR TITLE
core,triedb: add fastcache metrics

### DIFF
--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -444,7 +444,7 @@ var (
 	// Performance tuning settings
 	CacheFlag = &cli.IntFlag{
 		Name:     "cache",
-		Usage:    "Megabytes of memory allocated to internal caching (default = 4096 mainnet full node, 128 light mode)",
+		Usage:    "Megabytes of memory allocated to internal caching (default = 4096 mainnet full node, 1024 for other networks)",
 		Value:    1024,
 		Category: flags.PerfCategory,
 	}

--- a/core/state/snapshot/snapshot.go
+++ b/core/state/snapshot/snapshot.go
@@ -390,15 +390,17 @@ func (t *Tree) Cap(root common.Hash, layers int) error {
 	}
 
 	// Update the cache stats
-	var stats fastcache.Stats
-	diff.origin.cache.UpdateStats(&stats)
-	snapshotCacheGetGauge.Update(int64(stats.GetCalls))
-	snapshotCacheSetGauge.Update(int64(stats.SetCalls))
-	snapshotCacheMissGauge.Update(int64(stats.Misses))
-	snapshotCacheSizeGauge.Update(int64(stats.BytesSize))
-	snapshotCacheCapacityGauge.Update(int64(stats.MaxBytesSize))
-	snapshotCacheEntriesGauge.Update(int64(stats.EntriesCount))
-	snapshotCacheCollisionGauge.Update(int64(stats.Collisions))
+	if diff.origin != nil && diff.origin.cache != nil {
+		var stats fastcache.Stats
+		diff.origin.cache.UpdateStats(&stats)
+		snapshotCacheGetGauge.Update(int64(stats.GetCalls))
+		snapshotCacheSetGauge.Update(int64(stats.SetCalls))
+		snapshotCacheMissGauge.Update(int64(stats.Misses))
+		snapshotCacheSizeGauge.Update(int64(stats.BytesSize))
+		snapshotCacheCapacityGauge.Update(int64(stats.MaxBytesSize))
+		snapshotCacheEntriesGauge.Update(int64(stats.EntriesCount))
+		snapshotCacheCollisionGauge.Update(int64(stats.Collisions))
+	}
 
 	// If the generator is still running, use a more aggressive cap
 	diff.origin.lock.RLock()

--- a/triedb/pathdb/disklayer.go
+++ b/triedb/pathdb/disklayer.go
@@ -306,6 +306,16 @@ func (dl *diskLayer) update(root common.Hash, id uint64, block uint64, nodes *no
 // and returns a newly constructed disk layer. Note the current disk
 // layer must be tagged as stale first to prevent re-access.
 func (dl *diskLayer) commit(bottom *diffLayer, force bool) (*diskLayer, error) {
+	var stats fastcache.Stats
+	dl.nodes.UpdateStats(&stats)
+	snapshotCacheGetGauge.Update(int64(stats.GetCalls))
+	snapshotCacheSetGauge.Update(int64(stats.SetCalls))
+	snapshotCacheMissGauge.Update(int64(stats.Misses))
+	snapshotCacheSizeGauge.Update(int64(stats.BytesSize))
+	snapshotCacheCapacityGauge.Update(int64(stats.MaxBytesSize))
+	snapshotCacheEntriesGauge.Update(int64(stats.EntriesCount))
+	snapshotCacheCollisionGauge.Update(int64(stats.Collisions))
+
 	dl.lock.Lock()
 	defer dl.lock.Unlock()
 

--- a/triedb/pathdb/disklayer.go
+++ b/triedb/pathdb/disklayer.go
@@ -306,15 +306,17 @@ func (dl *diskLayer) update(root common.Hash, id uint64, block uint64, nodes *no
 // and returns a newly constructed disk layer. Note the current disk
 // layer must be tagged as stale first to prevent re-access.
 func (dl *diskLayer) commit(bottom *diffLayer, force bool) (*diskLayer, error) {
-	var stats fastcache.Stats
-	dl.nodes.UpdateStats(&stats)
-	snapshotCacheGetGauge.Update(int64(stats.GetCalls))
-	snapshotCacheSetGauge.Update(int64(stats.SetCalls))
-	snapshotCacheMissGauge.Update(int64(stats.Misses))
-	snapshotCacheSizeGauge.Update(int64(stats.BytesSize))
-	snapshotCacheCapacityGauge.Update(int64(stats.MaxBytesSize))
-	snapshotCacheEntriesGauge.Update(int64(stats.EntriesCount))
-	snapshotCacheCollisionGauge.Update(int64(stats.Collisions))
+	if dl.nodes != nil {
+		var stats fastcache.Stats
+		dl.nodes.UpdateStats(&stats)
+		snapshotCacheGetGauge.Update(int64(stats.GetCalls))
+		snapshotCacheSetGauge.Update(int64(stats.SetCalls))
+		snapshotCacheMissGauge.Update(int64(stats.Misses))
+		snapshotCacheSizeGauge.Update(int64(stats.BytesSize))
+		snapshotCacheCapacityGauge.Update(int64(stats.MaxBytesSize))
+		snapshotCacheEntriesGauge.Update(int64(stats.EntriesCount))
+		snapshotCacheCollisionGauge.Update(int64(stats.Collisions))
+	}
 
 	dl.lock.Lock()
 	defer dl.lock.Unlock()

--- a/triedb/pathdb/metrics.go
+++ b/triedb/pathdb/metrics.go
@@ -72,6 +72,14 @@ var (
 	historyBuildTimeMeter  = metrics.NewRegisteredResettingTimer("pathdb/history/time", nil)
 	historyDataBytesMeter  = metrics.NewRegisteredMeter("pathdb/history/bytes/data", nil)
 	historyIndexBytesMeter = metrics.NewRegisteredMeter("pathdb/history/bytes/index", nil)
+
+	snapshotCacheGetGauge       = metrics.NewRegisteredGauge("pathdb/snapshot/cache/get", nil)
+	snapshotCacheSetGauge       = metrics.NewRegisteredGauge("pathdb/snapshot/cache/set", nil)
+	snapshotCacheMissGauge      = metrics.NewRegisteredGauge("pathdb/snapshot/cache/miss", nil)
+	snapshotCacheSizeGauge      = metrics.NewRegisteredGauge("pathdb/snapshot/cache/size", nil)
+	snapshotCacheCapacityGauge  = metrics.NewRegisteredGauge("pathdb/snapshot/cache/capacity", nil)
+	snapshotCacheCollisionGauge = metrics.NewRegisteredGauge("pathdb/snapshot/cache/collision", nil)
+	snapshotCacheEntriesGauge   = metrics.NewRegisteredGauge("pathdb/snapshot/cache/entries", nil)
 )
 
 // Metrics in generation


### PR DESCRIPTION
Add more metrics about the fastcache, so the users have a clear understanding of the use of cache and know how to configure the size of each cache.

I'm running with 

```
geth 
--cache=6144 # 6GB
--cache.database=20 # 20%
--cache.snapshot=20 # 20%
--cache.gc=5        # 5%
--cache.trie=40     # 40%
```

This is the metrics in grafana dashboard:

<img width="744" alt="image" src="https://github.com/user-attachments/assets/75d464ae-a395-486d-8094-5c30b433abaf" />

I can see that the disk layer cache(`--cache.snapshot`) is not used much, given 6*0.2=1.2GB, but only 30% was in use; and for the trie cache(`--cache.trie`) is fully used, so in my case, I now know I need to reduce the cache used for snapshot, and increase it for trie.