### PR TITLE
core/types: add timestamp to derived logs

### DIFF
--- a/core/types/log.go
+++ b/core/types/log.go
@@ -45,6 +45,8 @@ type Log struct {
 	TxIndex uint `json:"transactionIndex" rlp:"-"`
 	// hash of the block in which the transaction was included
 	BlockHash common.Hash `json:"blockHash" rlp:"-"`
+	// timestamp of the block in which the transaction was included
+	BlockTimestamp uint64 `json:"blockTimestamp" rlp:"-"`
 	// index of the log in the block
 	Index uint `json:"logIndex" rlp:"-"`
 

--- a/core/types/receipt.go
+++ b/core/types/receipt.go
@@ -367,6 +367,7 @@ func (rs Receipts) DeriveFields(config *params.ChainConfig, hash common.Hash, nu
 		for j := 0; j < len(rs[i].Logs); j++ {
 			rs[i].Logs[j].BlockNumber = number
 			rs[i].Logs[j].BlockHash = hash
+			rs[i].Logs[j].BlockTimestamp = time
 			rs[i].Logs[j].TxHash = rs[i].TxHash
 			rs[i].Logs[j].TxIndex = uint(i)
 			rs[i].Logs[j].Index = logIndex

--- a/eth/filters/filter.go
+++ b/eth/filters/filter.go
@@ -463,7 +463,7 @@ func (f *Filter) checkMatches(ctx context.Context, header *types.Header) ([]*typ
 	// such as tx index, block hash, etc.
 	// Notably tx hash is NOT filled in because it needs
 	// access to block body data.
-	cached, err := f.sys.cachedLogElem(ctx, hash, header.Number.Uint64())
+	cached, err := f.sys.cachedLogElem(ctx, hash, header.Number.Uint64(), header.Time)
 	if err != nil {
 		return nil, err
 	}

--- a/eth/filters/filter_system.go
+++ b/eth/filters/filter_system.go
@@ -98,7 +98,7 @@ type logCacheElem struct {
 }
 
 // cachedLogElem loads block logs from the backend and caches the result.
-func (sys *FilterSystem) cachedLogElem(ctx context.Context, blockHash common.Hash, number uint64) (*logCacheElem, error) {
+func (sys *FilterSystem) cachedLogElem(ctx context.Context, blockHash common.Hash, number, time uint64) (*logCacheElem, error) {
 	cached, ok := sys.logsCache.Get(blockHash)
 	if ok {
 		return cached, nil
@@ -119,6 +119,7 @@ func (sys *FilterSystem) cachedLogElem(ctx context.Context, blockHash common.Has
 		for _, log := range txLogs {
 			log.BlockHash = blockHash
 			log.BlockNumber = number
+			log.BlockTimestamp = time
 			log.TxIndex = uint(i)
 			log.Index = logIdx
 			logIdx++


### PR DESCRIPTION
Implements https://github.com/ethereum/execution-apis/pull/639.