### PR TITLE
trie: make deletion of Trie more readable when match shortNode

### DIFF
--- a/trie/trie.go
+++ b/trie/trie.go
@@ -452,7 +452,7 @@ func (t *Trie) delete(n node, prefix, key []byte) (bool, node, error) {
 		// from the subtrie. Child can never be nil here since the
 		// subtrie must contain at least two other values with keys
 		// longer than n.Key.
-		dirty, child, err := t.delete(n.Val, append(prefix, key[:len(n.Key)]...), key[len(n.Key):])
+		dirty, child, err := t.delete(n.Val, append(prefix, key[:matchlen]...), key[matchlen:])
 		if !dirty || err != nil {
 			return false, n, err
 		}


### PR DESCRIPTION
This PR refactors the delete logic for `shortNode` in the MPT implementation to improve code readability and consistency with the `insert` function.

Motivation
Previously, the code used:
```go
dirty, child, err := t.delete(n.Val, append(prefix, key[:len(n.Key)]...), key[len(n.Key):])
```
However, at this point in the code, `matchlen` is always equal to `len(n.Key)`, so using `key[:matchlen]` and `key[matchlen:]` is both clearer and stylistically consistent with the `insert` function. This change makes the code easier to read and maintain, and reduces potential confusion for future contributors.