### PR TITLE
trie: reduce the memory allocation in trie hashing

### DIFF
--- a/trie/hasher.go
+++ b/trie/hasher.go
@@ -17,6 +17,7 @@
 package trie
 
 import (
+	"fmt"
 	"sync"
 
 	"github.com/ethereum/go-ethereum/crypto"
@@ -54,7 +55,7 @@ func returnHasherToPool(h *hasher) {
 }
 
 // hash collapses a node down into a hash node.
-func (h *hasher) hash(n node, force bool) node {
+func (h *hasher) hash(n node, force bool) []byte {
 	// Return the cached hash if it's available
 	if hash, _ := n.cache(); hash != nil {
 		return hash
@@ -62,57 +63,68 @@ func (h *hasher) hash(n node, force bool) node {
 	// Trie not processed yet, walk the children
 	switch n := n.(type) {
 	case *shortNode:
-		collapsed := h.hashShortNodeChildren(n)
-		hashed := h.shortnodeToHash(collapsed, force)
-		if hn, ok := hashed.(hashNode); ok {
-			n.flags.hash = hn
-		} else {
-			n.flags.hash = nil
+		enc := h.encodeShortNode(n)
+		if len(enc) < 32 && !force {
+			buf := make([]byte, len(enc))
+			copy(buf, enc)
+			return buf // Nodes smaller than 32 bytes are stored inside their parent
 		}
-		return hashed
+		hash := h.hashData(enc)
+		n.flags.hash = hash
+		return hash
+
 	case *fullNode:
-		collapsed := h.hashFullNodeChildren(n)
-		hashed := h.fullnodeToHash(collapsed, force)
-		if hn, ok := hashed.(hashNode); ok {
-			n.flags.hash = hn
-		} else {
-			n.flags.hash = nil
+		enc := h.encodeFullNode(n)
+		if len(enc) < 32 && !force {
+			buf := make([]byte, len(enc))
+			copy(buf, enc)
+			return buf // Nodes smaller than 32 bytes are stored inside their parent
 		}
-		return hashed
-	default:
-		// Value and hash nodes don't have children, so they're left as were
+		hash := h.hashData(enc)
+		n.flags.hash = hash
+		return hash
+
+	case hashNode:
+		// hash nodes don't have children, so they're left as were
 		return n
-	}
-}
 
-// hashShortNodeChildren returns a copy of the supplied shortNode, with its child
-// being replaced by either the hash or an embedded node if the child is small.
-func (h *hasher) hashShortNodeChildren(n *shortNode) *shortNode {
-	var collapsed shortNode
-	collapsed.Key = hexToCompact(n.Key)
-	switch n.Val.(type) {
-	case *fullNode, *shortNode:
-		collapsed.Val = h.hash(n.Val, false)
 	default:
-		collapsed.Val = n.Val
+		panic(fmt.Errorf("unexpected node type, %T", n))
 	}
-	return &collapsed
 }
 
-// hashFullNodeChildren returns a copy of the supplied fullNode, with its child
+func (h *hasher) encodeShortNode(n *shortNode) []byte {
+	// Encode leaf node
+	if hasTerm(n.Key) {
+		var ln leafNodeEncoder
+		ln.Key = hexToCompact(n.Key)
+		ln.Val = n.Val.(valueNode)
+		ln.encode(h.encbuf)
+		return h.encodedBytes()
+	}
+	// Encode extension node
+	var en extNodeEncoder
+	en.Key = hexToCompact(n.Key)
+	en.Val = h.hash(n.Val, false)
+	en.encode(h.encbuf)
+	return h.encodedBytes()
+}
+
+// encodeFullNode returns a copy of the supplied fullNode, with its child
 // being replaced by either the hash or an embedded node if the child is small.
-func (h *hasher) hashFullNodeChildren(n *fullNode) *fullNode {
-	var children [17]node
+func (h *hasher) encodeFullNode(n *fullNode) []byte {
+	var fn fullnodeEncoder
 	if h.parallel {
 		var wg sync.WaitGroup
-		wg.Add(16)
 		for i := 0; i < 16; i++ {
+			if n.Children[i] == nil {
+				continue
+			}
+			wg.Add(1)
 			go func(i int) {
 				hasher := newHasher(false)
 				if child := n.Children[i]; child != nil {
-					children[i] = hasher.hash(child, false)
-				} else {
-					children[i] = nilValueNode
+					fn.Children[i] = hasher.hash(child, false)
 				}
 				returnHasherToPool(hasher)
 				wg.Done()
@@ -122,41 +134,15 @@ func (h *hasher) hashFullNodeChildren(n *fullNode) *fullNode {
 	} else {
 		for i := 0; i < 16; i++ {
 			if child := n.Children[i]; child != nil {
-				children[i] = h.hash(child, false)
-			} else {
-				children[i] = nilValueNode
+				fn.Children[i] = h.hash(child, false)
 			}
 		}
 	}
 	if n.Children[16] != nil {
-		children[16] = n.Children[16]
+		fn.Children[16] = n.Children[16].(valueNode)
 	}
-	return &fullNode{flags: nodeFlag{}, Children: children}
-}
-
-// shortNodeToHash computes the hash of the given shortNode. The shortNode must
-// first be collapsed, with its key converted to compact form. If the RLP-encoded
-// node data is smaller than 32 bytes, the node itself is returned.
-func (h *hasher) shortnodeToHash(n *shortNode, force bool) node {
-	n.encode(h.encbuf)
-	enc := h.encodedBytes()
-
-	if len(enc) < 32 && !force {
-		return n // Nodes smaller than 32 bytes are stored inside their parent
-	}
-	return h.hashData(enc)
-}
-
-// fullnodeToHash computes the hash of the given fullNode. If the RLP-encoded
-// node data is smaller than 32 bytes, the node itself is returned.
-func (h *hasher) fullnodeToHash(n *fullNode, force bool) node {
-	n.encode(h.encbuf)
-	enc := h.encodedBytes()
-
-	if len(enc) < 32 && !force {
-		return n // Nodes smaller than 32 bytes are stored inside their parent
-	}
-	return h.hashData(enc)
+	fn.encode(h.encbuf)
+	return h.encodedBytes()
 }
 
 // encodedBytes returns the result of the last encoding operation on h.encbuf.
@@ -176,8 +162,8 @@ func (h *hasher) encodedBytes() []byte {
 }
 
 // hashData hashes the provided data
-func (h *hasher) hashData(data []byte) hashNode {
-	n := make(hashNode, 32)
+func (h *hasher) hashData(data []byte) []byte {
+	n := make([]byte, 32)
 	h.sha.Reset()
 	h.sha.Write(data)
 	h.sha.Read(n)
@@ -196,16 +182,13 @@ func (h *hasher) hashDataTo(dst, data []byte) {
 // node (for later RLP encoding) as well as the hashed node -- unless the
 // node is smaller than 32 bytes, in which case it will be returned as is.
 // This method does not do anything on value- or hash-nodes.
-func (h *hasher) proofHash(original node) (collapsed, hashed node) {
+func (h *hasher) proofHash(original node) []byte {
 	switch n := original.(type) {
 	case *shortNode:
-		sn := h.hashShortNodeChildren(n)
-		return sn, h.shortnodeToHash(sn, false)
+		return h.encodeShortNode(n)
 	case *fullNode:
-		fn := h.hashFullNodeChildren(n)
-		return fn, h.fullnodeToHash(fn, false)
+		return h.encodeFullNode(n)
 	default:
-		// Value and hash nodes don't have children, so they're left as were
-		return n, n
+		panic(fmt.Errorf("unexpected node type, %T", original))
 	}
 }

--- a/trie/iterator.go
+++ b/trie/iterator.go
@@ -20,6 +20,7 @@ import (
 	"bytes"
 	"container/heap"
 	"errors"
+
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 )

--- a/trie/iterator.go
+++ b/trie/iterator.go
@@ -20,7 +20,6 @@ import (
 	"bytes"
 	"container/heap"
 	"errors"
-
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 )
@@ -240,9 +239,9 @@ func (it *nodeIterator) LeafProof() [][]byte {
 
 			for i, item := range it.stack[:len(it.stack)-1] {
 				// Gather nodes that end up as hash nodes (or the root)
-				node, hashed := hasher.proofHash(item.node)
-				if _, ok := hashed.(hashNode); ok || i == 0 {
-					proofs = append(proofs, nodeToBytes(node))
+				enc := hasher.proofHash(item.node)
+				if len(enc) >= 32 || i == 0 {
+					proofs = append(proofs, common.CopyBytes(enc))
 				}
 			}
 			return proofs

--- a/trie/node.go
+++ b/trie/node.go
@@ -68,10 +68,6 @@ type (
 	}
 )
 
-// nilValueNode is used when collapsing internal trie nodes for hashing, since
-// unset children need to serialize correctly.
-var nilValueNode = valueNode(nil)
-
 // EncodeRLP encodes a full node into the consensus RLP format.
 func (n *fullNode) EncodeRLP(w io.Writer) error {
 	eb := rlp.NewEncoderBuffer(w)

--- a/trie/node_enc.go
+++ b/trie/node_enc.go
@@ -46,14 +46,11 @@ func (n *fullnodeEncoder) encode(w rlp.EncoderBuffer) {
 		if len(c) == 0 {
 			w.Write(rlp.EmptyString)
 		} else {
-			if i == 16 {
-				w.WriteBytes(c) // valueNode
+			// valueNode or hashNode
+			if i == 16 || len(c) >= 32 {
+				w.WriteBytes(c)
 			} else {
-				if len(c) < 32 {
-					w.Write(c) // rawNode
-				} else {
-					w.WriteBytes(c) // hashNode
-				}
+				w.Write(c) // rawNode
 			}
 		}
 	}
@@ -84,7 +81,7 @@ func (n *extNodeEncoder) encode(w rlp.EncoderBuffer) {
 	w.WriteBytes(n.Key)
 
 	if n.Val == nil {
-		w.Write(rlp.EmptyString)
+		w.Write(rlp.EmptyString) // theoretically impossible to happen
 	} else if len(n.Val) < 32 {
 		w.Write(n.Val) // rawNode
 	} else {

--- a/trie/node_enc.go
+++ b/trie/node_enc.go
@@ -43,7 +43,7 @@ func (n *fullNode) encode(w rlp.EncoderBuffer) {
 func (n *fullnodeEncoder) encode(w rlp.EncoderBuffer) {
 	offset := w.List()
 	for i, c := range n.Children {
-		if c == nil {
+		if len(c) == 0 {
 			w.Write(rlp.EmptyString)
 		} else {
 			if i == 16 {
@@ -58,6 +58,14 @@ func (n *fullnodeEncoder) encode(w rlp.EncoderBuffer) {
 		}
 	}
 	w.ListEnd(offset)
+}
+
+func (n *fullnodeEncoder) reset() {
+	for i, c := range n.Children {
+		if len(c) != 0 {
+			n.Children[i] = n.Children[i][:0]
+		}
+	}
 }
 
 func (n *shortNode) encode(w rlp.EncoderBuffer) {

--- a/trie/node_enc.go
+++ b/trie/node_enc.go
@@ -42,13 +42,19 @@ func (n *fullNode) encode(w rlp.EncoderBuffer) {
 
 func (n *fullnodeEncoder) encode(w rlp.EncoderBuffer) {
 	offset := w.List()
-	for _, c := range n.Children {
+	for i, c := range n.Children {
 		if c == nil {
 			w.Write(rlp.EmptyString)
-		} else if len(c) < 32 {
-			w.Write(c) // rawNode
 		} else {
-			w.WriteBytes(c) // hashNode
+			if i == 16 {
+				w.WriteBytes(c) // valueNode
+			} else {
+				if len(c) < 32 {
+					w.Write(c) // rawNode
+				} else {
+					w.WriteBytes(c) // hashNode
+				}
+			}
 		}
 	}
 	w.ListEnd(offset)

--- a/trie/proof.go
+++ b/trie/proof.go
@@ -87,9 +87,6 @@ func (t *Trie) Prove(key []byte, proofDb ethdb.KeyValueWriter) error {
 
 	for i, n := range nodes {
 		enc := hasher.proofHash(n)
-		if len(enc) == 32 {
-			fmt.Println("DEBUG")
-		}
 		if len(enc) >= 32 || i == 0 {
 			proofDb.Put(crypto.Keccak256(enc), enc)
 		}

--- a/trie/proof.go
+++ b/trie/proof.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/ethdb"
 	"github.com/ethereum/go-ethereum/log"
 )
@@ -85,16 +86,12 @@ func (t *Trie) Prove(key []byte, proofDb ethdb.KeyValueWriter) error {
 	defer returnHasherToPool(hasher)
 
 	for i, n := range nodes {
-		var hn node
-		n, hn = hasher.proofHash(n)
-		if hash, ok := hn.(hashNode); ok || i == 0 {
-			// If the node's database encoding is a hash (or is the
-			// root node), it becomes a proof element.
-			enc := nodeToBytes(n)
-			if !ok {
-				hash = hasher.hashData(enc)
-			}
-			proofDb.Put(hash, enc)
+		enc := hasher.proofHash(n)
+		if len(enc) == 32 {
+			fmt.Println("DEBUG")
+		}
+		if len(enc) >= 32 || i == 0 {
+			proofDb.Put(crypto.Keccak256(enc), enc)
 		}
 	}
 	return nil

--- a/trie/trie.go
+++ b/trie/trie.go
@@ -626,7 +626,7 @@ func (t *Trie) resolveAndTrack(n hashNode, prefix []byte) (node, error) {
 // Hash returns the root hash of the trie. It does not write to the
 // database and can be used even if the trie doesn't have one.
 func (t *Trie) Hash() common.Hash {
-	return common.BytesToHash(t.hashRoot().(hashNode))
+	return common.BytesToHash(t.hashRoot())
 }
 
 // Commit collects all dirty nodes in the trie and replaces them with the
@@ -677,9 +677,9 @@ func (t *Trie) Commit(collectLeaf bool) (common.Hash, *trienode.NodeSet) {
 }
 
 // hashRoot calculates the root hash of the given trie
-func (t *Trie) hashRoot() node {
+func (t *Trie) hashRoot() []byte {
 	if t.root == nil {
-		return hashNode(types.EmptyRootHash.Bytes())
+		return types.EmptyRootHash.Bytes()
 	}
 	// If the number of changes is below 100, we let one thread handle it
 	h := newHasher(t.unhashed >= 100)

--- a/trie/trie_test.go
+++ b/trie/trie_test.go
@@ -863,7 +863,7 @@ func (s *spongeDb) Flush() {
 		s.sponge.Write([]byte(key))
 		s.sponge.Write([]byte(s.values[key]))
 	}
-	fmt.Println(len(s.keys))
+	//fmt.Println(len(s.keys))
 }
 
 // spongeBatch is a dummy batch which immediately writes to the underlying spongedb


### PR DESCRIPTION
This pull request optimizes trie hashing by reducing memory allocation overhead. Specifically:

- define a fullNodeEncoder pool to reuse encoders and avoid memory allocations.
- simplify the encoding logic for shortNode and fullNode by getting rid of the Go interfaces.

---

**Benchmark results**
- The memory allocation has been reduced significantly
- The CPU IOWait is constantly higher with unknown reason
- The overall performance is slightly slower

<img width="1506" alt="截屏2025-05-26 09 38 14" src="https://github.com/user-attachments/assets/0dc5e59e-d100-476b-b25e-75387837bc06" />
<img width="1496" alt="截屏2025-05-26 09 39 13" src="https://github.com/user-attachments/assets/24b77db0-5e35-48af-b8fb-22c851ec2892" />
