### PR TITLE
pathdb: rename the slots metrics to storages

### DIFF
--- a/triedb/pathdb/difflayer.go
+++ b/triedb/pathdb/difflayer.go
@@ -91,7 +91,7 @@ func (dl *diffLayer) node(owner common.Hash, path []byte, depth int) ([]byte, co
 		dirtyNodeHitMeter.Mark(1)
 		dirtyNodeHitDepthHist.Update(int64(depth))
 		dirtyNodeReadMeter.Mark(int64(len(n.Blob)))
-		return n.Blob, n.Hash, &nodeLoc{loc: locDiffLayer, depth: depth}, nil
+		return n.Blob, n.Hash, &nodeLoc{loc: locDiffCache, depth: depth}, nil
 	}
 	// Trie node unknown to this layer, resolve from parent
 	return dl.parent.node(owner, path, depth+1)

--- a/triedb/pathdb/metrics.go
+++ b/triedb/pathdb/metrics.go
@@ -59,7 +59,7 @@ var (
 	commitTimeTimer     = metrics.NewRegisteredResettingTimer("pathdb/commit/time", nil)
 	commitNodesMeter    = metrics.NewRegisteredMeter("pathdb/commit/nodes", nil)
 	commitAccountsMeter = metrics.NewRegisteredMeter("pathdb/commit/accounts", nil)
-	commitStoragesMeter = metrics.NewRegisteredMeter("pathdb/commit/slots", nil)
+	commitStoragesMeter = metrics.NewRegisteredMeter("pathdb/commit/storages", nil)
 	commitBytesMeter    = metrics.NewRegisteredMeter("pathdb/commit/bytes", nil)
 
 	gcTrieNodeMeter      = metrics.NewRegisteredMeter("pathdb/gc/node/count", nil)

--- a/triedb/pathdb/reader.go
+++ b/triedb/pathdb/reader.go
@@ -29,10 +29,10 @@ import (
 
 // The types of locations where the node is found.
 const (
-	locDirtyCache = "dirty" // dirty cache
-	locCleanCache = "clean" // clean cache
-	locDiskLayer  = "disk"  // persistent state
-	locDiffLayer  = "diff"  // diff layers
+	locDiffCache  = "diff"  // in-memory cache for nodes from the diff layer
+	locDirtyCache = "dirty" // not yet persisted write buffer for modified nodes
+	locCleanCache = "clean" // fastcache for clean nodes from the disk layer
+	locDiskLayer  = "disk"  // on-disk persistent state
 )
 
 // nodeLoc is a helpful structure that contains the location where the node
@@ -67,12 +67,12 @@ func (r *reader) Node(owner common.Hash, path []byte, hash common.Hash) ([]byte,
 		// Location is always available even if the node
 		// is not found.
 		switch loc.loc {
-		case locCleanCache:
-			nodeCleanFalseMeter.Mark(1)
+		case locDiffCache:
+			nodeDiffFalseMeter.Mark(1)
 		case locDirtyCache:
 			nodeDirtyFalseMeter.Mark(1)
-		case locDiffLayer:
-			nodeDiffFalseMeter.Mark(1)
+		case locCleanCache:
+			nodeCleanFalseMeter.Mark(1)
 		case locDiskLayer:
 			nodeDiskFalseMeter.Mark(1)
 		}


### PR DESCRIPTION
1. follow the other metric name, renaming the `pathdb/commit/slots` to `pathdb/commit/storages`
2. arrange the location in the order of read, also add some comments of each location