### PR TITLE
core: add overflow checks to IntrinsicGas

### DIFF
--- a/core/state_transition.go
+++ b/core/state_transition.go
@@ -107,10 +107,20 @@ func IntrinsicGas(data []byte, accessList types.AccessList, authList []types.Set
 		}
 	}
 	if accessList != nil {
+		if (math.MaxUint64-gas)/params.TxAccessListAddressGas < uint64(len(accessList)) {
+			return 0, ErrGasUintOverflow
+		}
 		gas += uint64(len(accessList)) * params.TxAccessListAddressGas
+
+		if (math.MaxUint64-gas)/params.TxAccessListStorageKeyGas < uint64(accessList.StorageKeys()) {
+			return 0, ErrGasUintOverflow
+		}
 		gas += uint64(accessList.StorageKeys()) * params.TxAccessListStorageKeyGas
 	}
 	if authList != nil {
+		if (math.MaxUint64-gas)/params.CallNewAccountGas < uint64(len(authList)) {
+			return 0, ErrGasUintOverflow
+		}
 		gas += uint64(len(authList)) * params.CallNewAccountGas
 	}
 	return gas, nil


### PR DESCRIPTION
This is some nit I feel we should add. It's true this is not an issue right now, as overflowing uint64 with arbitrarily large `AL/auths * gasCost` would require sending an unrealistic big tx (the most cost effective would be spamming auths, as they are `27` bytes when RLP encoded for a gas cost of `25000`, plus we do not enforce neither in clients nor in the EIP a maximum number of auths per tx). However, in the future, when we add more txs with more expensive "fields", this can be an issue, so better to have the checks already in place.