### PR TITLE
core/types: reduce allocations for transaction comparison

### DIFF
--- a/core/txpool/legacypool/legacypool.go
+++ b/core/txpool/legacypool/legacypool.go
@@ -515,25 +515,14 @@ func (pool *LegacyPool) Pending(filter txpool.PendingFilter) map[common.Address]
 	pool.mu.Lock()
 	defer pool.mu.Unlock()
 
-	// Convert the new uint256.Int types to the old big.Int ones used by the legacy pool
-	var (
-		minTipBig  *big.Int
-		baseFeeBig *big.Int
-	)
-	if filter.MinTip != nil {
-		minTipBig = filter.MinTip.ToBig()
-	}
-	if filter.BaseFee != nil {
-		baseFeeBig = filter.BaseFee.ToBig()
-	}
 	pending := make(map[common.Address][]*txpool.LazyTransaction, len(pool.pending))
 	for addr, list := range pool.pending {
 		txs := list.Flatten()
 
 		// If the miner requests tip enforcement, cap the lists now
-		if minTipBig != nil {
+		if filter.MinTip != nil {
 			for i, tx := range txs {
-				if tx.EffectiveGasTipIntCmp(minTipBig, baseFeeBig) < 0 {
+				if tx.EffectiveGasTipIntCmp(filter.MinTip, filter.BaseFee) < 0 {
 					txs = txs[:i]
 					break
 				}

--- a/core/txpool/legacypool/list.go
+++ b/core/txpool/legacypool/list.go
@@ -475,7 +475,7 @@ func (l *list) subTotalCost(txs []*types.Transaction) {
 // then the heap is sorted based on the effective tip based on the given base fee.
 // If baseFee is nil then the sorting is based on gasFeeCap.
 type priceHeap struct {
-	baseFee *big.Int // heap should always be re-sorted after baseFee is changed
+	baseFee *uint256.Int // heap should always be re-sorted after baseFee is changed
 	list    []*types.Transaction
 }
 
@@ -677,6 +677,10 @@ func (l *pricedList) Reheap() {
 // SetBaseFee updates the base fee and triggers a re-heap. Note that Removed is not
 // necessary to call right before SetBaseFee when processing a new block.
 func (l *pricedList) SetBaseFee(baseFee *big.Int) {
-	l.urgent.baseFee = baseFee
+	base := new(uint256.Int)
+	if baseFee != nil {
+		base.SetFromBig(baseFee)
+	}
+	l.urgent.baseFee = base
 	l.Reheap()
 }


### PR DESCRIPTION
This PR should reduce overall allocations of a running node by ~10 percent. Since most allocations are coming from the re-heaping of the transaction pool.

```
(pprof) list EffectiveGasTipCmp
Total: 38197204475
ROUTINE ======================== github.com/ethereum/go-ethereum/core/types.(*Transaction).EffectiveGasTipCmp in github.com/ethereum/go-ethereum/core/types/transaction.go
         0 3766837369 (flat, cum)  9.86% of Total
         .          .    386:func (tx *Transaction) EffectiveGasTipCmp(other *Transaction, baseFee *big.Int) int {
         .          .    387: if baseFee == nil {
         .          .    388:  return tx.GasTipCapCmp(other)
         .          .    389: }
         .          .    390: // Use more efficient internal method.
         .          .    391: txTip, otherTip := new(big.Int), new(big.Int)
         . 1796172553    392: tx.calcEffectiveGasTip(txTip, baseFee)
         . 1970664816    393: other.calcEffectiveGasTip(otherTip, baseFee)
         .          .    394: return txTip.Cmp(otherTip)
         .          .    395:}
         .          .    396:
         .          .    397:// EffectiveGasTipIntCmp compares the effective gasTipCap of a transaction to the given gasTipCap.
         .          .    398:func (tx *Transaction) EffectiveGasTipIntCmp(other *big.Int, baseFee *big.Int) int {
```

This PR reduces the allocations for comparing two transactions from 2 to 0:
```
goos: linux
goarch: amd64
pkg: github.com/ethereum/go-ethereum/core/types
cpu: Intel(R) Core(TM) Ultra 7 155U
                               │ /tmp/old.txt │            /tmp/new.txt             │
                               │    sec/op    │   sec/op     vs base                │
EffectiveGasTipCmp/Original-14    64.67n ± 2%   25.13n ± 9%  -61.13% (p=0.000 n=10)

                               │ /tmp/old.txt │            /tmp/new.txt            │
                               │     B/op     │   B/op     vs base                 │
EffectiveGasTipCmp/Original-14     16.00 ± 0%   0.00 ± 0%  -100.00% (p=0.000 n=10)

                               │ /tmp/old.txt │            /tmp/new.txt             │
                               │  allocs/op   │ allocs/op   vs base                 │
EffectiveGasTipCmp/Original-14     2.000 ± 0%   0.000 ± 0%  -100.00% (p=0.000 n=10)
```

It also speeds up the process by ~60%

There are two minor caveats with this PR:
- We change the API for `EffectiveGasTipCmp` and `EffectiveGasTipIntCmp` (which are probably not used by much)
- We slightly change the behavior of `tx.EffectiveGasTip` when it returns an error. It would previously return a negative number on error, now it does not (since uint256 does not allow for negative numbers)