### PR TITLE
eth,core: add a state size live tracer

### DIFF
--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -45,6 +45,7 @@ import (
 	"github.com/ethereum/go-ethereum/core/tracing"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/core/vm"
+	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/ethdb"
 	"github.com/ethereum/go-ethereum/event"
 	"github.com/ethereum/go-ethereum/internal/syncx"
@@ -1583,15 +1584,18 @@ func (bc *BlockChain) writeBlockWithState(block *types.Block, receipts []*types.
 		log.Crit("Failed to write block into disk", "err", err)
 	}
 	// Commit all cached state changes into underlying memory database.
-	root, err := statedb.Commit(block.NumberU64(), bc.chainConfig.IsEIP158(block.Number()), bc.chainConfig.IsCancun(block.Number(), block.Time()))
+	update, err := statedb.CommitWithUpdate(block.NumberU64(), bc.chainConfig.IsEIP158(block.Number()), bc.chainConfig.IsCancun(block.Number(), block.Time()))
 	if err != nil {
 		return err
 	}
+	// Tracing the state changes if the logger is enabled.
+	bc.handleStateUpdates(block, update)
 	// If node is running in path mode, skip explicit gc operation
 	// which is unnecessary in this mode.
 	if bc.triedb.Scheme() == rawdb.PathScheme {
 		return nil
 	}
+	root := update.Root
 	// If we're running an archive node, always flush
 	if bc.cfg.ArchiveMode {
 		return bc.triedb.Commit(root, false)
@@ -1645,6 +1649,98 @@ func (bc *BlockChain) writeBlockWithState(block *types.Block, receipts []*types.
 		bc.triedb.Dereference(root)
 	}
 	return nil
+}
+
+func (bc *BlockChain) handleStateUpdates(block *types.Block, update *state.StateUpdate) {
+	if bc.logger == nil || bc.logger.OnStateCommit != nil {
+		return
+	}
+
+	var (
+		accountSize, storageSize, nodeSize, codeSize int
+		accounts, storages, nodes, codes             int
+	)
+
+	for addr, oldValue := range update.AccountsOrigin {
+		addrHash := crypto.Keccak256Hash(addr.Bytes())
+		newValue, exists := update.Accounts[addrHash]
+		if !exists {
+			log.Warn("State update missing account", "address", addr)
+			continue
+		}
+		if len(newValue) == 0 {
+			accounts -= 1
+			accountSize -= common.AddressLength
+		}
+		if len(oldValue) == 0 {
+			accounts += 1
+			accountSize += common.AddressLength
+		}
+		accountSize += len(newValue) - len(oldValue)
+	}
+	for addr, slots := range update.StoragesOrigin {
+		addrHash := crypto.Keccak256Hash(addr.Bytes())
+		subset, exists := update.Storages[addrHash]
+		if !exists {
+			log.Warn("State update missing storage", "address", addr)
+			continue
+		}
+		for key, oldValue := range slots {
+			var (
+				exists   bool
+				newValue []byte
+			)
+			if update.RawStorageKey {
+				newValue, exists = subset[crypto.Keccak256Hash(key.Bytes())]
+			} else {
+				newValue, exists = subset[key]
+			}
+			if !exists {
+				log.Warn("State update missing storage slot", "address", addr, "key", key)
+				continue
+			}
+			if len(newValue) == 0 {
+				storages -= 1
+				storageSize -= common.HashLength
+			}
+			if len(oldValue) == 0 {
+				storages += 1
+				storageSize += common.HashLength
+			}
+			storageSize += len(newValue) - len(oldValue)
+		}
+	}
+	for _, subset := range update.Nodes.Sets {
+		for path, n := range subset.Nodes {
+			if len(n.Blob) == 0 {
+				nodes -= 1
+				nodeSize -= len(path) + common.HashLength
+			}
+			if n.OriginLen() == 0 {
+				nodes += 1
+				nodeSize += len(path) + common.HashLength
+			}
+			nodeSize += len(n.Blob) - n.OriginLen()
+		}
+	}
+	for _, code := range update.Codes {
+		codes += 1
+		codeSize += code.CodeLen() + common.HashLength // no deduplication
+	}
+
+	bc.logger.OnStateCommit(&tracing.StateUpdate{
+		Number:       block.NumberU64(),
+		Hash:         block.Hash(),
+		Time:         block.Time(),
+		Accounts:     int64(accounts),
+		AccountSize:  int64(accountSize),
+		Storages:     int64(storages),
+		StorageSize:  int64(storageSize),
+		Trienodes:    int64(nodes),
+		TrienodeSize: int64(nodeSize),
+		Codes:        int64(codes),
+		CodeSize:     int64(codeSize),
+	})
 }
 
 // writeBlockAndSetHead is the internal implementation of WriteBlockAndSetHead.

--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -1652,7 +1652,7 @@ func (bc *BlockChain) writeBlockWithState(block *types.Block, receipts []*types.
 }
 
 func (bc *BlockChain) handleStateUpdates(block *types.Block, update *state.StateUpdate) {
-	if bc.logger == nil || bc.logger.OnStateCommit != nil {
+	if bc.logger == nil || bc.logger.OnStateCommit == nil {
 		return
 	}
 

--- a/core/state/statedb.go
+++ b/core/state/statedb.go
@@ -1348,12 +1348,12 @@ func (s *StateDB) commitAndFlush(block uint64, deleteEmptyObjects bool, noStorag
 // Since self-destruction was deprecated with the Cancun fork and there are
 // no empty accounts left that could be deleted by EIP-158, storage wiping
 // should not occur.
-func (s *StateDB) Commit(block uint64, deleteEmptyObjects bool, noStorageWiping bool) (*StateUpdate, error) {
+func (s *StateDB) Commit(block uint64, deleteEmptyObjects bool, noStorageWiping bool) (common.Hash, error) {
 	ret, err := s.commitAndFlush(block, deleteEmptyObjects, noStorageWiping)
 	if err != nil {
-		return nil, err
+		return common.Hash{}, err
 	}
-	return ret, nil
+	return ret.Root, nil
 }
 
 // Prepare handles the preparatory steps for executing a state transition with.

--- a/core/state/statedb.go
+++ b/core/state/statedb.go
@@ -1348,12 +1348,12 @@ func (s *StateDB) commitAndFlush(block uint64, deleteEmptyObjects bool, noStorag
 // Since self-destruction was deprecated with the Cancun fork and there are
 // no empty accounts left that could be deleted by EIP-158, storage wiping
 // should not occur.
-func (s *StateDB) Commit(block uint64, deleteEmptyObjects bool, noStorageWiping bool) (common.Hash, error) {
+func (s *StateDB) Commit(block uint64, deleteEmptyObjects bool, noStorageWiping bool) (*StateUpdate, error) {
 	ret, err := s.commitAndFlush(block, deleteEmptyObjects, noStorageWiping)
 	if err != nil {
-		return common.Hash{}, err
+		return nil, err
 	}
-	return ret.Root, nil
+	return ret, nil
 }
 
 // Prepare handles the preparatory steps for executing a state transition with.

--- a/core/state/statedb.go
+++ b/core/state/statedb.go
@@ -1356,6 +1356,16 @@ func (s *StateDB) Commit(block uint64, deleteEmptyObjects bool, noStorageWiping 
 	return ret.Root, nil
 }
 
+// CommitWithUpdate is similar to Commit, commits the state mutations,
+// it returns the state update instead of the root hash.
+func (s *StateDB) CommitWithUpdate(block uint64, deleteEmptyObjects bool, noStorageWiping bool) (*StateUpdate, error) {
+	ret, err := s.commitAndFlush(block, deleteEmptyObjects, noStorageWiping)
+	if err != nil {
+		return nil, err
+	}
+	return ret, nil
+}
+
 // Prepare handles the preparatory steps for executing a state transition with.
 // This method must be invoked before state transition.
 //

--- a/core/state/statedb_fuzz_test.go
+++ b/core/state/statedb_fuzz_test.go
@@ -182,11 +182,11 @@ func (test *stateTest) run() bool {
 		accountOrigin []map[common.Address][]byte
 		storages      []map[common.Hash]map[common.Hash][]byte
 		storageOrigin []map[common.Address]map[common.Hash][]byte
-		copyUpdate    = func(update *stateUpdate) {
-			accounts = append(accounts, maps.Clone(update.accounts))
-			accountOrigin = append(accountOrigin, maps.Clone(update.accountsOrigin))
-			storages = append(storages, maps.Clone(update.storages))
-			storageOrigin = append(storageOrigin, maps.Clone(update.storagesOrigin))
+		copyUpdate    = func(update *StateUpdate) {
+			accounts = append(accounts, maps.Clone(update.Accounts))
+			accountOrigin = append(accountOrigin, maps.Clone(update.AccountsOrigin))
+			storages = append(storages, maps.Clone(update.Storages))
+			storageOrigin = append(storageOrigin, maps.Clone(update.StoragesOrigin))
 		}
 		disk      = rawdb.NewMemoryDatabase()
 		tdb       = triedb.NewDatabase(disk, &triedb.Config{PathDB: pathdb.Defaults})
@@ -236,7 +236,7 @@ func (test *stateTest) run() bool {
 			return true
 		}
 		copyUpdate(ret)
-		roots = append(roots, ret.root)
+		roots = append(roots, ret.Root)
 	}
 	for i := 0; i < len(test.actions); i++ {
 		root := types.EmptyRootHash

--- a/core/state/stateupdate.go
+++ b/core/state/stateupdate.go
@@ -254,11 +254,11 @@ func (sc *StateUpdate) IntoChangeset() *StateChangeset {
 			}
 			if len(newValue) == 0 {
 				storages -= 1
-				storageSize -= common.HashLength
+				storageSize -= 2 * common.HashLength
 			}
 			if len(oldValue) == 0 {
 				storages += 1
-				storageSize += common.HashLength
+				storageSize += 2 * common.HashLength
 			}
 			storageSize += len(newValue) - len(oldValue)
 		}

--- a/core/state/stateupdate.go
+++ b/core/state/stateupdate.go
@@ -223,11 +223,11 @@ func (sc *StateUpdate) IntoChangeset() *StateChangeset {
 		}
 		if len(newValue) == 0 {
 			accounts -= 1
-			accountSize -= common.AddressLength
+			accountSize -= common.HashLength
 		}
 		if len(oldValue) == 0 {
 			accounts += 1
-			accountSize += common.AddressLength
+			accountSize += common.HashLength
 		}
 		accountSize += len(newValue) - len(oldValue)
 	}

--- a/core/state/stateupdate.go
+++ b/core/state/stateupdate.go
@@ -30,6 +30,11 @@ type contractCode struct {
 	blob []byte      // blob is the binary representation of the contract code.
 }
 
+// CodeLen returns the length of the contract code blob.
+func (c *contractCode) CodeLen() int {
+	return len(c.blob)
+}
+
 // accountDelete represents an operation for deleting an Ethereum account.
 type accountDelete struct {
 	address common.Address // address is the unique account identifier

--- a/core/state/stateupdate.go
+++ b/core/state/stateupdate.go
@@ -60,33 +60,33 @@ type accountUpdate struct {
 	storagesOriginByHash map[common.Hash][]byte
 }
 
-// stateUpdate represents the difference between two states resulting from state
+// StateUpdate represents the difference between two states resulting from state
 // execution. It contains information about mutated contract codes, accounts,
 // and storage slots, along with their original values.
-type stateUpdate struct {
-	originRoot     common.Hash               // hash of the state before applying mutation
-	root           common.Hash               // hash of the state after applying mutation
-	accounts       map[common.Hash][]byte    // accounts stores mutated accounts in 'slim RLP' encoding
-	accountsOrigin map[common.Address][]byte // accountsOrigin stores the original values of mutated accounts in 'slim RLP' encoding
+type StateUpdate struct {
+	OriginRoot     common.Hash               // hash of the state before applying mutation
+	Root           common.Hash               // hash of the state after applying mutation
+	Accounts       map[common.Hash][]byte    // accounts stores mutated accounts in 'slim RLP' encoding
+	AccountsOrigin map[common.Address][]byte // accountsOrigin stores the original values of mutated accounts in 'slim RLP' encoding
 
-	// storages stores mutated slots in 'prefix-zero-trimmed' RLP format.
+	// Storages stores mutated slots in 'prefix-zero-trimmed' RLP format.
 	// The value is keyed by account hash and **storage slot key hash**.
-	storages map[common.Hash]map[common.Hash][]byte
+	Storages map[common.Hash]map[common.Hash][]byte
 
-	// storagesOrigin stores the original values of mutated slots in
+	// StoragesOrigin stores the original values of mutated slots in
 	// 'prefix-zero-trimmed' RLP format.
 	// (a) the value is keyed by account hash and **storage slot key** if rawStorageKey is true;
 	// (b) the value is keyed by account hash and **storage slot key hash** if rawStorageKey is false;
-	storagesOrigin map[common.Address]map[common.Hash][]byte
-	rawStorageKey  bool
+	StoragesOrigin map[common.Address]map[common.Hash][]byte
+	RawStorageKey  bool
 
-	codes map[common.Address]contractCode // codes contains the set of dirty codes
-	nodes *trienode.MergedNodeSet         // Aggregated dirty nodes caused by state changes
+	Codes map[common.Address]contractCode // codes contains the set of dirty codes
+	Nodes *trienode.MergedNodeSet         // Aggregated dirty nodes caused by state changes
 }
 
 // empty returns a flag indicating the state transition is empty or not.
-func (sc *stateUpdate) empty() bool {
-	return sc.originRoot == sc.root
+func (sc *StateUpdate) empty() bool {
+	return sc.OriginRoot == sc.Root
 }
 
 // newStateUpdate constructs a state update object by identifying the differences
@@ -95,7 +95,7 @@ func (sc *stateUpdate) empty() bool {
 //
 // rawStorageKey is a flag indicating whether to use the raw storage slot key or
 // the hash of the slot key for constructing state update object.
-func newStateUpdate(rawStorageKey bool, originRoot common.Hash, root common.Hash, deletes map[common.Hash]*accountDelete, updates map[common.Hash]*accountUpdate, nodes *trienode.MergedNodeSet) *stateUpdate {
+func newStateUpdate(rawStorageKey bool, originRoot common.Hash, root common.Hash, deletes map[common.Hash]*accountDelete, updates map[common.Hash]*accountUpdate, nodes *trienode.MergedNodeSet) *StateUpdate {
 	var (
 		accounts       = make(map[common.Hash][]byte)
 		accountsOrigin = make(map[common.Address][]byte)
@@ -161,16 +161,16 @@ func newStateUpdate(rawStorageKey bool, originRoot common.Hash, root common.Hash
 			}
 		}
 	}
-	return &stateUpdate{
-		originRoot:     originRoot,
-		root:           root,
-		accounts:       accounts,
-		accountsOrigin: accountsOrigin,
-		storages:       storages,
-		storagesOrigin: storagesOrigin,
-		rawStorageKey:  rawStorageKey,
-		codes:          codes,
-		nodes:          nodes,
+	return &StateUpdate{
+		OriginRoot:     originRoot,
+		Root:           root,
+		Accounts:       accounts,
+		AccountsOrigin: accountsOrigin,
+		Storages:       storages,
+		StoragesOrigin: storagesOrigin,
+		RawStorageKey:  rawStorageKey,
+		Codes:          codes,
+		Nodes:          nodes,
 	}
 }
 
@@ -178,12 +178,12 @@ func newStateUpdate(rawStorageKey bool, originRoot common.Hash, root common.Hash
 // object. This function extracts the necessary data from the stateUpdate
 // struct and formats it into the StateSet structure consumed by the triedb
 // package.
-func (sc *stateUpdate) stateSet() *triedb.StateSet {
+func (sc *StateUpdate) stateSet() *triedb.StateSet {
 	return &triedb.StateSet{
-		Accounts:       sc.accounts,
-		AccountsOrigin: sc.accountsOrigin,
-		Storages:       sc.storages,
-		StoragesOrigin: sc.storagesOrigin,
-		RawStorageKey:  sc.rawStorageKey,
+		Accounts:       sc.Accounts,
+		AccountsOrigin: sc.AccountsOrigin,
+		Storages:       sc.Storages,
+		StoragesOrigin: sc.StoragesOrigin,
+		RawStorageKey:  sc.RawStorageKey,
 	}
 }

--- a/core/tracing/hooks.go
+++ b/core/tracing/hooks.go
@@ -77,17 +77,17 @@ type BlockEvent struct {
 
 // StateUpdate represents a state mutations that occurred during the execution of a block.
 type StateUpdate struct {
-	Number       uint64      // Block number corresponding to this state snapshot
-	Hash         common.Hash // Block hash corresponding to this state snapshot
-	Time         uint64      // Timestamp indicating when the block was produced
-	Accounts     int64       // Total number of accounts present in the state at this block
-	Storages     int64       // Total number of storage entries across all accounts in the state at this block
-	Trienodes    int64       // Total number of trie nodes present in the state at this block
-	Codes        int64       // Total number of contract codes present in the state at this block, with 32 bytes hash as the identifier
-	AccountSize  int64       // Combined size of all accounts in the state, with 20 bytes address as the identifier
-	StorageSize  int64       // Combined size of all storage entries, with 32 bytes key as the identifier
-	TrienodeSize int64       // Combined size of all trie nodes, with varying size node path as the identifier (up to 64 bytes)
-	CodeSize     int64       // Combined size of all contract codes in the state, with 20 bytes address as the identifier
+	Number       uint64      `json:"number"`       // Block number corresponding to this state snapshot
+	Hash         common.Hash `json:"hash"`         // Block hash corresponding to this state snapshot
+	Time         uint64      `json:"time"`         // Timestamp indicating when the block was produced
+	Accounts     int64       `json:"accounts"`     // Total number of accounts present in the state at this block
+	Storages     int64       `json:"storages"`     // Total number of storage entries across all accounts in the state at this block
+	Trienodes    int64       `json:"trienodes"`    // Total number of trie nodes present in the state at this block
+	Codes        int64       `json:"codes"`        // Total number of contract codes present in the state at this block, with 32 bytes hash as the identifier
+	AccountSize  int64       `json:"accountSize"`  // Combined size of all accounts in the state, with 20 bytes address as the identifier
+	StorageSize  int64       `json:"storageSize"`  // Combined size of all storage entries, with 32 bytes key as the identifier
+	TrienodeSize int64       `json:"trienodeSize"` // Combined size of all trie nodes, with varying size node path as the identifier (up to 64 bytes)
+	CodeSize     int64       `json:"codeSize"`     // Combined size of all contract codes in the state, with 20 bytes address as the identifier
 }
 
 type (

--- a/core/tracing/hooks.go
+++ b/core/tracing/hooks.go
@@ -75,6 +75,21 @@ type BlockEvent struct {
 	Safe      *types.Header
 }
 
+// StateUpdate represents a state mutations that occurred during the execution of a block.
+type StateUpdate struct {
+	Number       uint64      // Block number corresponding to this state snapshot
+	Hash         common.Hash // Block hash corresponding to this state snapshot
+	Time         uint64      // Timestamp indicating when the block was produced
+	Accounts     int64       // Total number of accounts present in the state at this block
+	Storages     int64       // Total number of storage entries across all accounts in the state at this block
+	Trienodes    int64       // Total number of trie nodes present in the state at this block
+	Codes        int64       // Total number of contract codes present in the state at this block, with 32 bytes hash as the identifier
+	AccountSize  int64       // Combined size of all accounts in the state, with 20 bytes address as the identifier
+	StorageSize  int64       // Combined size of all storage entries, with 32 bytes key as the identifier
+	TrienodeSize int64       // Combined size of all trie nodes, with varying size node path as the identifier (up to 64 bytes)
+	CodeSize     int64       // Combined size of all contract codes in the state, with 20 bytes address as the identifier
+}
+
 type (
 	/*
 		- VM events -
@@ -183,6 +198,9 @@ type (
 	// LogHook is called when a log is emitted.
 	LogHook = func(log *types.Log)
 
+	// StateCommitHook is called when the state is committed.
+	StateCommitHook = func(update *StateUpdate)
+
 	// BlockHashReadHook is called when EVM reads the blockhash of a block.
 	BlockHashReadHook = func(blockNumber uint64, hash common.Hash)
 )
@@ -213,6 +231,7 @@ type Hooks struct {
 	OnCodeChange    CodeChangeHook
 	OnStorageChange StorageChangeHook
 	OnLog           LogHook
+	OnStateCommit   StateCommitHook
 	// Block hash read
 	OnBlockHashRead BlockHashReadHook
 }

--- a/eth/tracers/live/noop.go
+++ b/eth/tracers/live/noop.go
@@ -56,6 +56,7 @@ func newNoopTracer(_ json.RawMessage) (*tracing.Hooks, error) {
 		OnNonceChange:    t.OnNonceChange,
 		OnCodeChange:     t.OnCodeChange,
 		OnStorageChange:  t.OnStorageChange,
+		OnStateCommit:    t.OnStateCommit,
 		OnLog:            t.OnLog,
 		OnBlockHashRead:  t.OnBlockHashRead,
 	}, nil
@@ -103,6 +104,9 @@ func (t *noop) OnCodeChange(a common.Address, prevCodeHash common.Hash, prev []b
 }
 
 func (t *noop) OnStorageChange(a common.Address, k, prev, new common.Hash) {
+}
+
+func (t *noop) OnStateCommit(u *tracing.StateUpdate) {
 }
 
 func (t *noop) OnLog(l *types.Log) {

--- a/eth/tracers/live/state.go
+++ b/eth/tracers/live/state.go
@@ -77,7 +77,7 @@ func (s *stateTracer) onGenesisBlock(b *types.Block, alloc types.GenesisAlloc) {
 	)
 	for _, account := range alloc {
 		accounts++
-		accountSize += common.AddressLength
+		accountSize += common.HashLength
 		storages += len(account.Storage)
 		storageSize += len(account.Storage) * 2 * common.HashLength
 		if len(account.Code) > 0 {

--- a/eth/tracers/live/state.go
+++ b/eth/tracers/live/state.go
@@ -111,10 +111,8 @@ func (s *stateTracer) onClose() {
 
 func (s *stateTracer) write(update *tracing.StateUpdate) {
 	out, _ := json.Marshal(update)
+	out = append(out, '\n')
 	if _, err := s.logger.Write(out); err != nil {
-		log.Warn("failed to write to state tracer log file", "error", err)
-	}
-	if _, err := s.logger.Write([]byte{'\n'}); err != nil {
 		log.Warn("failed to write to state tracer log file", "error", err)
 	}
 }

--- a/eth/tracers/live/state.go
+++ b/eth/tracers/live/state.go
@@ -86,7 +86,7 @@ func (s *stateTracer) onGenesisBlock(b *types.Block, alloc types.GenesisAlloc) {
 		}
 	}
 	update := &tracing.StateUpdate{
-		Number:      0,
+		Number:      b.NumberU64(),
 		Hash:        b.Hash(),
 		Time:        b.Time(),
 		Accounts:    int64(accounts),

--- a/eth/tracers/live/state.go
+++ b/eth/tracers/live/state.go
@@ -1,0 +1,120 @@
+// Copyright 2024 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+
+package live
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"path/filepath"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/tracing"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/eth/tracers"
+	"github.com/ethereum/go-ethereum/log"
+	"gopkg.in/natefinch/lumberjack.v2"
+)
+
+func init() {
+	tracers.LiveDirectory.Register("state", newStateTracer)
+}
+
+type stateTracer struct {
+	logger *lumberjack.Logger
+}
+
+type stateTracerConfig struct {
+	Path    string `json:"path"`    // Path to the directory where the tracer logs will be stored
+	MaxSize int    `json:"maxSize"` // MaxSize is the maximum size in megabytes of the tracer log file before it gets rotated. It defaults to 100 megabytes.
+}
+
+func newStateTracer(cfg json.RawMessage) (*tracing.Hooks, error) {
+	var config stateTracerConfig
+	if err := json.Unmarshal(cfg, &config); err != nil {
+		return nil, fmt.Errorf("failed to parse config: %v", err)
+	}
+	if config.Path == "" {
+		return nil, errors.New("state tracer output path is required")
+	}
+
+	// Store traces in a rotating file
+	logger := &lumberjack.Logger{
+		Filename: filepath.Join(config.Path, "state.jsonl"),
+	}
+	if config.MaxSize > 0 {
+		logger.MaxSize = config.MaxSize
+	}
+
+	t := &stateTracer{
+		logger: logger,
+	}
+	return &tracing.Hooks{
+		OnGenesisBlock: t.onGenesisBlock,
+		OnStateCommit:  t.onStateCommit,
+		OnClose:        t.onClose,
+	}, nil
+}
+
+func (s *stateTracer) onGenesisBlock(b *types.Block, alloc types.GenesisAlloc) {
+	var (
+		accountSize, storageSize, codeSize int
+		accounts, storages, codes          int
+	)
+	for _, account := range alloc {
+		accounts++
+		accountSize += common.AddressLength
+		storages += len(account.Storage)
+		storageSize += len(account.Storage) * 2 * common.HashLength
+		if len(account.Code) > 0 {
+			codes++
+			codeSize += len(account.Code) + common.HashLength
+		}
+	}
+	update := &tracing.StateUpdate{
+		Number:      0,
+		Hash:        b.Hash(),
+		Time:        b.Time(),
+		Accounts:    int64(accounts),
+		AccountSize: int64(accountSize),
+		Storages:    int64(storages),
+		StorageSize: int64(storageSize),
+		Codes:       int64(codes),
+		CodeSize:    int64(codeSize),
+	}
+	s.write(update)
+}
+
+func (s *stateTracer) onStateCommit(update *tracing.StateUpdate) {
+	s.write(update)
+}
+
+func (s *stateTracer) onClose() {
+	if err := s.logger.Close(); err != nil {
+		log.Warn("failed to close state tracer log file", "error", err)
+	}
+}
+
+func (s *stateTracer) write(update *tracing.StateUpdate) {
+	out, _ := json.Marshal(update)
+	if _, err := s.logger.Write(out); err != nil {
+		log.Warn("failed to write to state tracer log file", "error", err)
+	}
+	if _, err := s.logger.Write([]byte{'\n'}); err != nil {
+		log.Warn("failed to write to state tracer log file", "error", err)
+	}
+}

--- a/eth/tracers/live/supply.go
+++ b/eth/tracers/live/supply.go
@@ -319,10 +319,8 @@ func (s *supplyTracer) write(data any) {
 	}
 
 	out, _ := json.Marshal(supply)
+	out = append(out, '\n')
 	if _, err := s.logger.Write(out); err != nil {
-		log.Warn("failed to write to supply tracer log file", "error", err)
-	}
-	if _, err := s.logger.Write([]byte{'\n'}); err != nil {
 		log.Warn("failed to write to supply tracer log file", "error", err)
 	}
 }

--- a/trie/trienode/node.go
+++ b/trie/trienode/node.go
@@ -31,6 +31,8 @@ import (
 type Node struct {
 	Hash common.Hash // Node hash, empty for deleted node
 	Blob []byte      // Encoded node blob, nil for the deleted node
+
+	length int // The length of the original value of the node
 }
 
 // Size returns the total memory size used by this node.
@@ -43,13 +45,18 @@ func (n *Node) IsDeleted() bool {
 	return len(n.Blob) == 0
 }
 
+// OriginLen returns the length of the original value of the node.
+func (n *Node) OriginLen() int {
+	return n.length
+}
+
 // New constructs a node with provided node information.
-func New(hash common.Hash, blob []byte) *Node {
-	return &Node{Hash: hash, Blob: blob}
+func New(hash common.Hash, blob []byte, length int) *Node {
+	return &Node{Hash: hash, Blob: blob, length: length}
 }
 
 // NewDeleted constructs a node which is deleted.
-func NewDeleted() *Node { return New(common.Hash{}, nil) }
+func NewDeleted(length int) *Node { return New(common.Hash{}, nil, length) }
 
 // NodeWithPrev is a wrapper over Node by tracking the original value of node.
 type NodeWithPrev struct {

--- a/triedb/pathdb/difflayer_test.go
+++ b/triedb/pathdb/difflayer_test.go
@@ -68,7 +68,7 @@ func benchmarkSearch(b *testing.B, depth int, total int) {
 			var (
 				path = testrand.Bytes(32)
 				blob = testrand.Bytes(100)
-				node = trienode.New(crypto.Keccak256Hash(blob), blob)
+				node = trienode.New(crypto.Keccak256Hash(blob), blob, 0)
 			)
 			nodes[common.Hash{}][string(path)] = node
 			if npath == nil && depth == index {
@@ -114,7 +114,7 @@ func BenchmarkPersist(b *testing.B) {
 			var (
 				path = testrand.Bytes(32)
 				blob = testrand.Bytes(100)
-				node = trienode.New(crypto.Keccak256Hash(blob), blob)
+				node = trienode.New(crypto.Keccak256Hash(blob), blob, 0)
 			)
 			nodes[common.Hash{}][string(path)] = node
 		}
@@ -152,7 +152,7 @@ func BenchmarkJournal(b *testing.B) {
 			var (
 				path = testrand.Bytes(32)
 				blob = testrand.Bytes(100)
-				node = trienode.New(crypto.Keccak256Hash(blob), blob)
+				node = trienode.New(crypto.Keccak256Hash(blob), blob, 0)
 			)
 			nodes[common.Hash{}][string(path)] = node
 		}

--- a/triedb/pathdb/nodes.go
+++ b/triedb/pathdb/nodes.go
@@ -251,9 +251,9 @@ func (s *nodeSet) decode(r *rlp.Stream) error {
 			// Account nodes
 			for _, n := range entry.Nodes {
 				if len(n.Blob) > 0 {
-					s.accountNodes[string(n.Path)] = trienode.New(crypto.Keccak256Hash(n.Blob), n.Blob)
+					s.accountNodes[string(n.Path)] = trienode.New(crypto.Keccak256Hash(n.Blob), n.Blob, 0)
 				} else {
-					s.accountNodes[string(n.Path)] = trienode.NewDeleted()
+					s.accountNodes[string(n.Path)] = trienode.NewDeleted(0)
 				}
 			}
 		} else {
@@ -261,9 +261,9 @@ func (s *nodeSet) decode(r *rlp.Stream) error {
 			subset := make(map[string]*trienode.Node)
 			for _, n := range entry.Nodes {
 				if len(n.Blob) > 0 {
-					subset[string(n.Path)] = trienode.New(crypto.Keccak256Hash(n.Blob), n.Blob)
+					subset[string(n.Path)] = trienode.New(crypto.Keccak256Hash(n.Blob), n.Blob, 0)
 				} else {
-					subset[string(n.Path)] = trienode.NewDeleted()
+					subset[string(n.Path)] = trienode.NewDeleted(0)
 				}
 			}
 			s.storageNodes[entry.Owner] = subset


### PR DESCRIPTION
Based on @rjl493456442's https://github.com/rjl493456442/go-ethereum/tree/state-float, register a live tracer to track the state size diff for each block.

As we have 

- account
- storage
- code
- trienode

and trienode is the most large part of the statedb, while current tracing can't capture trienodes' changes, so add a `StateCommit` hook, triggered when a `statedb.Commit` was invoked.

In this PR, also add 4 metrics to track the statedb size(only count the delta after geth restarted):
- chain_account_bytes
- chain_storage_bytes
- chain_triedb_bytes
- chain_contract_bytes


### TBD

1. contract destructions are not counted


### how to use it

start geth with `--vmtrace=state --vmtrace.jsonconfig={"path": "/data/geth-dev-trace", "maxSize": 0}'`

And then in the file `/data/geth-dev-trace/state.jsonl` you can see the below records:

```jsonl
{"number":141,"hash":"0x81bfd49d2bb8800e6e3edddc0e66286bff7e3cec35d56665c5b1dae376eb005b","time":1748419461,"accounts":0,"storages":2,"trienodes":2,"codes":0,"accountSize":0,"storageSize":102,"trienodeSize":241,"codeSize":0}
{"number":142,"hash":"0x667c5618b5e7da83eae12acf08f6c0dd4844784209e47871ede6df05f5753a87","time":1748419462,"accounts":0,"storages":2,"trienodes":2,"codes":0,"accountSize":0,"storageSize":102,"trienodeSize":241,"codeSize":0}
{"number":143,"hash":"0xd7f882e1d7e770ef44f53ce083845a6d295a0ded2bebd4296299a752e71a61de","time":1748419463,"accounts":0,"storages":2,"trienodes":2,"codes":0,"accountSize":0,"storageSize":102,"trienodeSize":241,"codeSize":0}
{"number":144,"hash":"0x1f7463dc3715153b04b3bcce0fce3a1988b2f46f43166c7772644ca1cd9fea47","time":1748419464,"accounts":0,"storages":2,"trienodes":2,"codes":0,"accountSize":0,"storageSize":102,"trienodeSize":243,"codeSize":0}
{"number":145,"hash":"0x68ac80bad19b82a50a9d975bfa05f741955de867f89316630e13cbcb7ba8ce72","time":1748419465,"accounts":0,"storages":2,"trienodes":2,"codes":0,"accountSize":0,"storageSize":102,"trienodeSize":241,"codeSize":0}
```
