### PR TITLE
.travis.yml: remove master branch push builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ jobs:
   include:
     # This builder create and push the Docker images for all architectures
     - stage: build
-      if: type = push
+      if: type = push && tag ~= /^v[0-9]/
       os: linux
       arch: amd64
       dist: focal
@@ -21,9 +21,25 @@ jobs:
       script:
         - go run build/ci.go dockerx -platform "linux/amd64,linux/arm64,linux/riscv64" -hub ethereum/client-go -upload
 
+    # This builder does the Ubuntu PPA nightly uploads
+    - stage: build
+      if: type = push && tag ~= /^v[0-9]/
+      os: linux
+      dist: focal
+      go: 1.24.x
+      env:
+        - ubuntu-ppa
+      git:
+        submodules: false # avoid cloning ethereum/tests
+      before_install:
+        - sudo -E apt-get -yq --no-install-suggests --no-install-recommends install devscripts debhelper dput fakeroot
+      script:
+        - echo '|1|7SiYPr9xl3uctzovOTj4gMwAC1M=|t6ReES75Bo/PxlOPJ6/GsGbTrM0= ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEA0aKz5UTUndYgIGG7dQBV+HaeuEZJ2xPHo2DS2iSKvUL4xNMSAY4UguNW+pX56nAQmZKIZZ8MaEvSj6zMEDiq6HFfn5JcTlM80UwlnyKe8B8p7Nk06PPQLrnmQt5fh0HmEcZx+JU9TZsfCHPnX7MNz4ELfZE6cFsclClrKim3BHUIGq//t93DllB+h4O9LHjEUsQ1Sr63irDLSutkLJD6RXchjROXkNirlcNVHH/jwLWR5RcYilNX7S5bIkK8NlWPjsn/8Ua5O7I9/YoE97PpO6i73DTGLh5H9JN/SITwCKBkgSDWUt61uPK3Y11Gty7o2lWsBjhBUm2Y38CBsoGmBw==' >> ~/.ssh/known_hosts
+        - go run build/ci.go debsrc -upload ethereum/ethereum -sftp-user geth-ci -signer "Go Ethereum Linux Builder <geth-ci@ethereum.org>"
+
     # This builder does the Linux Azure uploads
     - stage: build
-      if: type = push
+      if: type = push && tag ~= /^v[0-9]/
       os: linux
       dist: focal
       sudo: required
@@ -56,40 +72,6 @@ jobs:
         - go run build/ci.go install -dlgo -arch arm64 -cc aarch64-linux-gnu-gcc
         - go run build/ci.go archive -arch arm64 -type tar -signer LINUX_SIGNING_KEY -signify SIGNIFY_KEY -upload gethstore/builds
 
-    # These builders run the tests
-    - stage: build
-      if: type = push
-      os: linux
-      arch: amd64
-      dist: focal
-      go: 1.24.x
-      script:
-        - travis_wait 45 go run build/ci.go test $TEST_PACKAGES
-
-    - stage: build
-      if: type = push
-      os: linux
-      dist: focal
-      go: 1.23.x
-      script:
-        - travis_wait 45 go run build/ci.go test $TEST_PACKAGES
-
-    # This builder does the Ubuntu PPA nightly uploads
-    - stage: build
-      if: type = cron || (type = push && tag ~= /^v[0-9]/)
-      os: linux
-      dist: focal
-      go: 1.24.x
-      env:
-        - ubuntu-ppa
-      git:
-        submodules: false # avoid cloning ethereum/tests
-      before_install:
-        - sudo -E apt-get -yq --no-install-suggests --no-install-recommends install devscripts debhelper dput fakeroot
-      script:
-        - echo '|1|7SiYPr9xl3uctzovOTj4gMwAC1M=|t6ReES75Bo/PxlOPJ6/GsGbTrM0= ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEA0aKz5UTUndYgIGG7dQBV+HaeuEZJ2xPHo2DS2iSKvUL4xNMSAY4UguNW+pX56nAQmZKIZZ8MaEvSj6zMEDiq6HFfn5JcTlM80UwlnyKe8B8p7Nk06PPQLrnmQt5fh0HmEcZx+JU9TZsfCHPnX7MNz4ELfZE6cFsclClrKim3BHUIGq//t93DllB+h4O9LHjEUsQ1Sr63irDLSutkLJD6RXchjROXkNirlcNVHH/jwLWR5RcYilNX7S5bIkK8NlWPjsn/8Ua5O7I9/YoE97PpO6i73DTGLh5H9JN/SITwCKBkgSDWUt61uPK3Y11Gty7o2lWsBjhBUm2Y38CBsoGmBw==' >> ~/.ssh/known_hosts
-        - go run build/ci.go debsrc -upload ethereum/ethereum -sftp-user geth-ci -signer "Go Ethereum Linux Builder <geth-ci@ethereum.org>"
-
     # This builder does the Azure archive purges to avoid accumulating junk
     - stage: build
       if: type = cron
@@ -102,14 +84,3 @@ jobs:
         submodules: false # avoid cloning ethereum/tests
       script:
         - go run build/ci.go purge -store gethstore/builds -days 14
-
-    # This builder executes race tests
-    - stage: build
-      if: type = cron
-      os: linux
-      dist: focal
-      go: 1.24.x
-      env:
-        - racetests
-      script:
-        - travis_wait 60 go run build/ci.go test -race $TEST_PACKAGES


### PR DESCRIPTION
Release artefact building has been migrated to another system (Gitea), so we can finally stop using Travis CI. However, in order to have a fail-safe for the release, I'm leaving the config in and it will still trigger builds on Travis for tagged releases. That way, if our new system fails to work for the next release, we will still have the option of using Travis.