### PR TITLE
eth/catalyst: change warning to error for 'too many bad block attempts'

### DIFF
--- a/eth/catalyst/api.go
+++ b/eth/catalyst/api.go
@@ -742,7 +742,7 @@ func (api *ConsensusAPI) checkInvalidAncestor(check common.Hash, head common.Has
 
 	api.invalidBlocksHits[badHash]++
 	if api.invalidBlocksHits[badHash] >= invalidBlockHitEviction {
-		log.Warn("Too many bad block import attempt, trying", "number", invalid.Number, "hash", badHash)
+		log.Error("Too many bad block import attempt, trying", "number", invalid.Number, "hash", badHash)
 		delete(api.invalidBlocksHits, badHash)
 
 		for descendant, badHeader := range api.invalidTipsets {


### PR DESCRIPTION
This situation was failing quietly for me recently when I had a partial data corruption issue. Changing the log level to Error would increase visibility for me.