### PR TITLE
eth/filters: fix pruned history error for genesis block

### DIFF
--- a/eth/filters/api.go
+++ b/eth/filters/api.go
@@ -359,7 +359,7 @@ func (api *FilterAPI) GetLogs(ctx context.Context, crit FilterCriteria) ([]*type
 		if begin > 0 && end > 0 && begin > end {
 			return nil, errInvalidBlockRange
 		}
-		if begin > 0 && begin < int64(api.events.backend.HistoryPruningCutoff()) {
+		if begin >= 0 && begin < int64(api.events.backend.HistoryPruningCutoff()) {
 			return nil, &history.PrunedHistoryError{}
 		}
 		// Construct the range filter


### PR DESCRIPTION
# Fix Pruned History Error

Fix to raise pruned history error. Detail in https://github.com/ethereum/go-ethereum/issues/31939