### PR TITLE
txpool: set gasTip's type as normal value, no need to set as an atomic value

### DIFF
--- a/core/txpool/legacypool/legacypool_test.go
+++ b/core/txpool/legacypool/legacypool_test.go
@@ -434,7 +434,7 @@ func TestInvalidTransactions(t *testing.T) {
 	}
 
 	tx = transaction(1, 100000, key)
-	pool.gasTip.Store(uint256.NewInt(1000))
+	pool.gasTip = uint256.NewInt(1000)
 	if err, want := pool.addRemote(tx), txpool.ErrTxGasPriceTooLow; !errors.Is(err, want) {
 		t.Errorf("want %v have %v", want, err)
 	}


### PR DESCRIPTION
As the legacypool's gasTip updating was already protected by a mutex, so no need to set it as an atomic value. And as in the blob pool the gasTip was also set as a normal value, so try to make them consistent.