### PR TITLE
eth, p2p: improve dial speed by pre-fetching dial candidates

### DIFF
--- a/eth/backend.go
+++ b/eth/backend.go
@@ -487,6 +487,15 @@ func (s *Ethereum) setupDiscovery() error {
 		s.discmix.AddSource(iter)
 	}
 
+	// Add DHT nodes from discv4.
+	if s.p2pServer.DiscoveryV4() != nil {
+		asyncFilter := s.p2pServer.DiscoveryV4().RequestENR
+		filter := eth.NewNodeFilter(s.blockchain)
+		iter := enode.AsyncFilter(s.p2pServer.DiscoveryV4().RandomNodes(), asyncFilter)
+		iter = enode.Filter(iter, filter)
+		s.discmix.AddSource(iter)
+	}
+
 	// Add DHT nodes from discv5.
 	if s.p2pServer.DiscoveryV5() != nil {
 		filter := eth.NewNodeFilter(s.blockchain)

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -505,9 +505,12 @@ func (s *Ethereum) setupDiscovery() error {
 	// Add DHT nodes from discv4.
 	if s.p2pServer.DiscoveryV4() != nil {
 		iter := s.p2pServer.DiscoveryV4().RandomNodes()
-		resolverFunc := func(ctx context.Context, enr *enode.Node) (*enode.Node, error) {
+		resolverFunc := func(ctx context.Context, enr *enode.Node) *enode.Node {
 			// RequestENR does not yet support context. It will simply time out.
-			return s.p2pServer.DiscoveryV4().RequestENR(enr)
+			// If the ENR can't be resolved, RequestENR will return nil. We don't
+			// care about the specific error here, so we ignore it.
+			nn, _ := s.p2pServer.DiscoveryV4().RequestENR(enr)
+			return nn
 		}
 		iter = enode.AsyncFilter(iter, resolverFunc, maxParallelENRRequests)
 		iter = enode.Filter(iter, eth.NewNodeFilter(s.blockchain))

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -70,6 +70,10 @@ const (
 	// in the next rounds, giving it overall more time but a proportionally smaller share.
 	// We expect a normal source to produce ~10 candidates per second.
 	discmixTimeout = 100 * time.Millisecond
+
+	// maxParallelENRRequests is the maximum number of parallel ENR requests that can be
+	// performed by a disc/v4 source.
+	maxParallelENRRequests = 16
 )
 
 // Config contains the configuration options of the ETH protocol.
@@ -501,7 +505,7 @@ func (s *Ethereum) setupDiscovery() error {
 	if s.p2pServer.DiscoveryV4() != nil {
 		asyncFilter := s.p2pServer.DiscoveryV4().RequestENR
 		filter := eth.NewNodeFilter(s.blockchain)
-		iter := enode.AsyncFilter(s.p2pServer.DiscoveryV4().RandomNodes(), asyncFilter, 16)
+		iter := enode.AsyncFilter(s.p2pServer.DiscoveryV4().RandomNodes(), asyncFilter, maxParallelENRRequests)
 		iter = enode.Filter(iter, filter)
 		s.discmix.AddSource(iter)
 	}

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -62,6 +62,16 @@ import (
 	gethversion "github.com/ethereum/go-ethereum/version"
 )
 
+const (
+	// This is the fairness knob for the discovery mixer. When looking for peers, we'll
+	// wait this long for a single source of candidates before moving on and trying other
+	// sources. If this timeout expires, the source will be skipped in this round, but it
+	// will continue to fetch in the background and will have a chance with a new timeout
+	// in the next rounds, giving it overall more time but a proportionally smaller share.
+	// We expect a normal source to produce ~10 candidates per second.
+	discmixTimeout = 100 * time.Millisecond
+)
+
 // Config contains the configuration options of the ETH protocol.
 // Deprecated: use ethconfig.Config instead.
 type Config = ethconfig.Config
@@ -169,7 +179,7 @@ func New(stack *node.Node, config *ethconfig.Config) (*Ethereum, error) {
 		networkID:       networkID,
 		gasPrice:        config.Miner.GasPrice,
 		p2pServer:       stack.Server(),
-		discmix:         enode.NewFairMix(0),
+		discmix:         enode.NewFairMix(discmixTimeout),
 		shutdownTracker: shutdowncheck.NewShutdownTracker(chainDb),
 	}
 	bcVersion := rawdb.ReadDatabaseVersion(chainDb)

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -491,7 +491,7 @@ func (s *Ethereum) setupDiscovery() error {
 	if s.p2pServer.DiscoveryV4() != nil {
 		asyncFilter := s.p2pServer.DiscoveryV4().RequestENR
 		filter := eth.NewNodeFilter(s.blockchain)
-		iter := enode.AsyncFilter(s.p2pServer.DiscoveryV4().RandomNodes(), asyncFilter)
+		iter := enode.AsyncFilter(s.p2pServer.DiscoveryV4().RandomNodes(), asyncFilter, 16)
 		iter = enode.Filter(iter, filter)
 		s.discmix.AddSource(iter)
 	}

--- a/p2p/enode/iter.go
+++ b/p2p/enode/iter.go
@@ -243,7 +243,7 @@ type BufferIter struct {
 }
 
 // NewBufferIter creates a new pre-fetch buffer of a given size.
-func NewBufferIter(it Iterator, size int) *BufferIter {
+func NewBufferIter(it Iterator, size int) Iterator {
 	b := BufferIter{
 		it:     it,
 		buffer: make(chan *Node, size),

--- a/p2p/enode/iter.go
+++ b/p2p/enode/iter.go
@@ -172,6 +172,9 @@ type asyncFilterIter struct {
 type AsyncFilterFunc func(context.Context, *Node) *Node
 
 // AsyncFilter creates an iterator which checks nodes in parallel.
+// The 'check' function is called on multiple goroutines to filter each node
+// from the upstream iterator. When check returns nil, the node will be skipped.
+// It can also return a new node to be returned by the iterator instead of the .
 func AsyncFilter(it Iterator, check AsyncFilterFunc, workers int) Iterator {
 	f := &asyncFilterIter{
 		it:     ensureSourceIter(it),

--- a/p2p/enode/iter.go
+++ b/p2p/enode/iter.go
@@ -163,7 +163,7 @@ type AsyncFilterIter struct {
 	cancel    context.CancelFunc
 	closeOnce sync.Once
 }
-type AsyncFilterFunc func(context.Context, *Node) (*Node, error)
+type AsyncFilterFunc func(context.Context, *Node) *Node
 
 // AsyncFilter creates an iterator which checks nodes in parallel.
 func AsyncFilter(it Iterator, check AsyncFilterFunc, workers int) Iterator {
@@ -192,7 +192,7 @@ func AsyncFilter(it Iterator, check AsyncFilterFunc, workers int) Iterator {
 			<-f.slots
 			// check the node async, in a separate goroutine
 			go func() {
-				if nn, err := check(ctx, n); err == nil {
+				if nn := check(ctx, n); nn != nil {
 					select {
 					case f.passed <- nn:
 					case <-ctx.Done(): // bale out if downstream is already closed and not calling Next

--- a/p2p/enode/iter.go
+++ b/p2p/enode/iter.go
@@ -239,6 +239,7 @@ type BufferIter struct {
 	buffer chan *Node
 	head   *Node
 	closed chan struct{}
+	mu     sync.Mutex
 }
 
 // NewBufferIter creates a new pre-fetch buffer of a given size.
@@ -266,6 +267,9 @@ func NewBufferIter(it Iterator, size int) *BufferIter {
 }
 
 func (b *BufferIter) Next() bool {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
 	select {
 	case b.head = <-b.buffer:
 	case <-b.closed:
@@ -275,6 +279,8 @@ func (b *BufferIter) Next() bool {
 }
 
 func (b *BufferIter) Node() *Node {
+	b.mu.Lock()
+	defer b.mu.Unlock()
 	return b.head
 }
 
@@ -282,6 +288,9 @@ func (b *BufferIter) Close() {
 	// Close the wrapped iterator first.
 	b.it.Close()
 	close(b.closed)
+	// Wait for Next to terminate, then drain the buffer.
+	b.mu.Lock()
+	defer b.mu.Unlock()
 	for range b.buffer {
 	}
 	b.buffer = nil

--- a/p2p/server.go
+++ b/p2p/server.go
@@ -483,7 +483,6 @@ func (srv *Server) setupDiscovery() error {
 			return err
 		}
 		srv.discv4 = ntab
-		srv.discmix.AddSource(ntab.RandomNodes())
 	}
 	if srv.Config.DiscoveryV5 {
 		cfg := discover.Config{

--- a/p2p/server.go
+++ b/p2p/server.go
@@ -45,12 +45,6 @@ import (
 const (
 	defaultDialTimeout = 15 * time.Second
 
-	// This is the fairness knob for the discovery mixer. When looking for peers, we'll
-	// wait this long for a single source of candidates before moving on and trying other
-	// sources. Currently there is only one source at the Server level, so this has no effect.
-	// Check the fairMox tineout in the Backend for the actual timeout.
-	discmixTimeout = 100 * time.Millisecond
-
 	// Connectivity defaults.
 	defaultMaxPendingPeers = 50
 	defaultDialRatio       = 3
@@ -448,7 +442,9 @@ func (srv *Server) setupLocalNode() error {
 }
 
 func (srv *Server) setupDiscovery() error {
-	srv.discmix = enode.NewFairMix(discmixTimeout)
+	// Set up the discovery source mixer. Here, we don't care about the
+	// fairness of the mix, it's just for putting the
+	srv.discmix = enode.NewFairMix(0)
 
 	// Don't listen on UDP endpoint if DHT is disabled.
 	if srv.NoDiscovery {
@@ -504,6 +500,19 @@ func (srv *Server) setupDiscovery() error {
 		if proto.DialCandidates != nil && !added[proto.Name] {
 			srv.discmix.AddSource(proto.DialCandidates)
 			added[proto.Name] = true
+		}
+	}
+
+	// Set up default non-protocol-specific discovery feeds if no protocol
+	// has configured discovery.
+	if len(added) == 0 {
+		if srv.discv4 != nil {
+			it := srv.discv4.RandomNodes()
+			srv.discmix.AddSource(enode.WithSourceName("discv4-default", it))
+		}
+		if srv.discv5 != nil {
+			it := srv.discv5.RandomNodes()
+			srv.discmix.AddSource(enode.WithSourceName("discv5-default", it))
 		}
 	}
 	return nil

--- a/p2p/server.go
+++ b/p2p/server.go
@@ -47,8 +47,9 @@ const (
 
 	// This is the fairness knob for the discovery mixer. When looking for peers, we'll
 	// wait this long for a single source of candidates before moving on and trying other
-	// sources.
-	discmixTimeout = 5 * time.Second
+	// sources. Currently there is only one source at the Server level, so this has no effect.
+	// Check the fairMox tineout in the Backend for the actual timeout.
+	discmixTimeout = 100 * time.Millisecond
 
 	// Connectivity defaults.
 	defaultMaxPendingPeers = 50


### PR DESCRIPTION
This PR improves the speed of Disc/v4 and Disc/v5 based discovery by adding a pre-fetch buffer to discovery sources, eliminating slowdowns due to timeouts and rate mismatch between the two precesses.

The PR was split out from #31678, builds on #31592

