### PR TITLE
eth: return null for not-found in BlockByNumberOrHash

### DIFF
--- a/eth/api_backend.go
+++ b/eth/api_backend.go
@@ -196,7 +196,9 @@ func (b *EthAPIBackend) BlockByNumberOrHash(ctx context.Context, blockNrOrHash r
 	if hash, ok := blockNrOrHash.Hash(); ok {
 		header := b.eth.blockchain.GetHeaderByHash(hash)
 		if header == nil {
-			return nil, errors.New("header for hash not found")
+			// Return 'null' and no error if block is not found.
+			// This behavior is required by RPC spec.
+			return nil, nil
 		}
 		if blockNrOrHash.RequireCanonical && b.eth.blockchain.GetCanonicalHash(header.Number.Uint64()) != hash {
 			return nil, errors.New("hash is not currently canonical")


### PR DESCRIPTION
This changes the API backend to return null for not-found blocks. This behavior is required by the RPC When `BlockByNumberOrHash` always returned an error for this case ever since being added in https://github.com/ethereum/go-ethereum/pull/19491. The backend method has a couple of call sites, and all of them handle a `nil` block result because `BlockByNumber` returns `nil` for not-found. 

The only case where this makes a real difference is for `eth_getBlockReceipts`, which was changed in #31361 to actually forward the error from `BlockByNumberOrHash` to the caller. 