### PR TITLE
cmd/geth: fix era1 download location to match store

### DIFF
--- a/cmd/geth/chaincmd.go
+++ b/cmd/geth/chaincmd.go
@@ -723,8 +723,12 @@ func downloadEra(ctx *cli.Context) error {
 	// Resolve the destination directory.
 	stack, _ := makeConfigNode(ctx)
 	defer stack.Close()
-	ancients := stack.ResolveAncient("chaindata", "")
+
+	ancients := stack.ResolveAncient("chaindata", "chain")
 	dir := filepath.Join(ancients, "era")
+	if ctx.IsSet(utils.EraFlag.Name) {
+		dir = filepath.Join(ancients, ctx.String(utils.EraFlag.Name))
+	}
 
 	baseURL := ctx.String(eraServerFlag.Name)
 	if baseURL == "" {


### PR DESCRIPTION
This changes the era1 downloader to place the files into the correct location where geth will actually use them. Also adds integration with the new --datadir.era flag.