### PR TITLE
core/vm: fix typo callInexistant -> callInexistent in runtime_test.go

### DIFF
--- a/core/vm/runtime/runtime_test.go
+++ b/core/vm/runtime/runtime_test.go
@@ -453,7 +453,7 @@ func BenchmarkSimpleLoop(b *testing.B) {
 		Op(vm.POP).Jump(lbl).Bytes() // pop return value and jump to label
 
 	p, lbl = program.New().Jumpdest()
-	callInexistant := p.
+	callInexistent := p.
 		Call(nil, 0xff, 0, 0, 0, 0, 0).
 		Op(vm.POP).Jump(lbl).Bytes() // pop return value and jump to label
 
@@ -493,7 +493,7 @@ func BenchmarkSimpleLoop(b *testing.B) {
 	benchmarkNonModifyingCode(100000000, callIdentity, "call-identity-100M", "", b)
 	benchmarkNonModifyingCode(100000000, loopingCode, "loop-100M", "", b)
 	benchmarkNonModifyingCode(100000000, loopingCode2, "loop2-100M", "", b)
-	benchmarkNonModifyingCode(100000000, callInexistant, "call-nonexist-100M", "", b)
+	benchmarkNonModifyingCode(100000000, callInexistent, "call-nonexist-100M", "", b)
 	benchmarkNonModifyingCode(100000000, callEOA, "call-EOA-100M", "", b)
 	benchmarkNonModifyingCode(100000000, callRevertingContractWithInput, "call-reverting-100M", "", b)
 


### PR DESCRIPTION
# Fix typo: callInexistant -> callInexistent in runtime_test.go

## Summary

This PR fixes a spelling error in the variable name `callInexistant` which should be `callInexistent` (meaning "nonexistent").

## Changes

- **File**: `core/vm/runtime/runtime_test.go`
- **Change**: Renamed variable `callInexistant` to `callInexistent` (lines 455 and 495)
- **Type**: Spelling/typo fix
- **Impact**: Code readability improvement, no functional changes

## Details

The variable `callInexistant` was incorrectly spelled. The correct spelling is `callInexistent`, which properly conveys the meaning that it's calling a nonexistent contract address (0xff) for benchmarking purposes.

### Before:
```go
callInexistant := p.
    Call(nil, 0xff, 0, 0, 0, 0, 0).
    Op(vm.POP).Jump(lbl).Bytes()

benchmarkNonModifyingCode(100000000, callInexistant, "call-nonexist-100M", "", b)
```

### After:
```go
callInexistent := p.
    Call(nil, 0xff, 0, 0, 0, 0, 0).
    Op(vm.POP).Jump(lbl).Bytes()

benchmarkNonModifyingCode(100000000, callInexistent, "call-nonexist-100M", "", b)
```

## Testing

- [x] No functional changes, only variable naming
- [x] Existing tests should continue to pass
- [x] No new tests required

## Checklist

- [x] Code follows the project's coding standards
- [x] Changes are minimal and focused
- [x] No breaking changes
- [x] Documentation not needed (variable name change only)

This is a minor quality-of-life improvement that enhances code readability by fixing the spelling error.