### PR TITLE
cmd/utils: update SepoliaFlag usage

### DIFF
--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -150,7 +150,7 @@ var (
 	}
 	SepoliaFlag = &cli.BoolFlag{
 		Name:     "sepolia",
-		Usage:    "Sepolia network: pre-configured proof-of-work test network",
+		Usage:    "Sepolia network: pre-configured proof-of-stake test network",
 		Category: flags.EthCategory,
 	}
 	HoleskyFlag = &cli.BoolFlag{


### PR DESCRIPTION
The Sepolia testnet has transitioned to pos following The Merge.