### PR TITLE
eth: add per-peer metrics

### DIFF
--- a/eth/fetcher/tx_fetcher.go
+++ b/eth/fetcher/tx_fetcher.go
@@ -310,6 +310,7 @@ func (f *TxFetcher) isKnownUnderpriced(hash common.Hash) bool {
 // direct request replies. The differentiation is important so the fetcher can
 // re-schedule missing transactions as soon as possible.
 func (f *TxFetcher) Enqueue(peer string, txs []*types.Transaction, direct bool) error {
+	// TODO: add peer metrics here
 	var (
 		inMeter          = txReplyInMeter
 		knownMeter       = txReplyKnownMeter

--- a/eth/fetcher/tx_fetcher.go
+++ b/eth/fetcher/tx_fetcher.go
@@ -310,7 +310,6 @@ func (f *TxFetcher) isKnownUnderpriced(hash common.Hash) bool {
 // direct request replies. The differentiation is important so the fetcher can
 // re-schedule missing transactions as soon as possible.
 func (f *TxFetcher) Enqueue(peer string, txs []*types.Transaction, direct bool) error {
-	// TODO: add peer metrics here
 	var (
 		inMeter          = txReplyInMeter
 		knownMeter       = txReplyKnownMeter

--- a/eth/protocols/eth/handlers.go
+++ b/eth/protocols/eth/handlers.go
@@ -448,6 +448,7 @@ func handleNewPooledTransactionHashes(backend Backend, msg Decoder, peer *Peer) 
 	for _, hash := range ann.Hashes {
 		peer.markTransaction(hash)
 	}
+	peer.meters.annReceived.Mark(int64(len(ann.Hashes)))
 	return backend.Handle(peer, ann)
 }
 
@@ -524,6 +525,7 @@ func handlePooledTransactions(backend Backend, msg Decoder, peer *Peer) error {
 	}
 	requestTracker.Fulfil(peer.id, peer.version, PooledTransactionsMsg, txs.RequestId)
 
+	peer.meters.pooledTxReceived.Mark(int64(len(txs.PooledTransactionsResponse)))
 	return backend.Handle(peer, &txs.PooledTransactionsResponse)
 }
 

--- a/eth/protocols/eth/handlers.go
+++ b/eth/protocols/eth/handlers.go
@@ -501,6 +501,7 @@ func handleTransactions(backend Backend, msg Decoder, peer *Peer) error {
 		}
 		peer.markTransaction(tx.Hash())
 	}
+	peer.meters.txReceived.Mark(int64(len(txs)))
 	return backend.Handle(peer, &txs)
 }
 

--- a/eth/protocols/eth/peer.go
+++ b/eth/protocols/eth/peer.go
@@ -59,6 +59,8 @@ type Peer struct {
 	reqCancel   chan *cancel   // Dispatch channel to cancel pending requests and untrack them
 	resDispatch chan *response // Dispatch channel to fulfil pending requests and untrack them
 
+	meters *peerMeters // Peer-specific metrics for diagnositics and to use in decision logic
+
 	term chan struct{} // Termination channel to stop the broadcasters
 }
 
@@ -77,6 +79,7 @@ func NewPeer(version uint, p *p2p.Peer, rw p2p.MsgReadWriter, txpool TxPool) *Pe
 		reqCancel:   make(chan *cancel),
 		resDispatch: make(chan *response),
 		txpool:      txpool,
+		meters:      newPeerMeters("peers/"+p.ID().String(), nil),
 		term:        make(chan struct{}),
 	}
 	// Start up all the broadcasters

--- a/eth/protocols/eth/peer.go
+++ b/eth/protocols/eth/peer.go
@@ -95,6 +95,7 @@ func NewPeer(version uint, p *p2p.Peer, rw p2p.MsgReadWriter, txpool TxPool) *Pe
 // clean it up!
 func (p *Peer) Close() {
 	close(p.term)
+	p.meters.Close()
 }
 
 // ID retrieves the peer's unique identifier.

--- a/eth/protocols/eth/peer_metrics.go
+++ b/eth/protocols/eth/peer_metrics.go
@@ -19,6 +19,9 @@ package eth
 import "github.com/ethereum/go-ethereum/metrics"
 
 type peerMeters struct {
+	base string
+	reg  metrics.Registry
+
 	txReceived *metrics.Meter
 	txSent     *metrics.Meter
 
@@ -30,7 +33,13 @@ type peerMeters struct {
 
 // newPeerMeters registers and returns peer-level meters.
 func newPeerMeters(base string, r metrics.Registry) *peerMeters {
+	if r == nil {
+		r = metrics.DefaultRegistry
+	}
 	return &peerMeters{
+		base: base,
+		reg:  r,
+
 		txReceived: metrics.NewRegisteredMeter(base+"/txReceived", r),
 		txSent:     metrics.NewRegisteredMeter(base+"/txSent", r),
 
@@ -39,4 +48,13 @@ func newPeerMeters(base string, r metrics.Registry) *peerMeters {
 		txReplyUnderpricedMeter: metrics.NewRegisteredMeter(base+"/eth/fetcher/transaction/replies/underpriced", r),
 		txReplyOtherRejectMeter: metrics.NewRegisteredMeter(base+"/eth/fetcher/transaction/replies/otherreject", r),
 	}
+}
+
+func (m *peerMeters) Close() {
+	m.reg.Unregister(m.base + "/txReceived")
+	m.reg.Unregister(m.base + "/txSent")
+	m.reg.Unregister(m.base + "/eth/fetcher/transaction/replies/in")
+	m.reg.Unregister(m.base + "/eth/fetcher/transaction/replies/known")
+	m.reg.Unregister(m.base + "/eth/fetcher/transaction/replies/underpriced")
+	m.reg.Unregister(m.base + "/eth/fetcher/transaction/replies/otherreject")
 }

--- a/eth/protocols/eth/peer_metrics.go
+++ b/eth/protocols/eth/peer_metrics.go
@@ -22,13 +22,12 @@ type peerMeters struct {
 	base string
 	reg  metrics.Registry
 
-	txReceived *metrics.Meter
-	txSent     *metrics.Meter
-
-	txReplyInMeter          *metrics.Meter
-	txReplyKnownMeter       *metrics.Meter
-	txReplyUnderpricedMeter *metrics.Meter
-	txReplyOtherRejectMeter *metrics.Meter
+	txReceived       *metrics.Meter
+	txSent           *metrics.Meter
+	pooledTxSent     *metrics.Meter
+	pooledTxReceived *metrics.Meter
+	annReceived      *metrics.Meter
+	annSent          *metrics.Meter
 }
 
 // newPeerMeters registers and returns peer-level meters.
@@ -40,21 +39,20 @@ func newPeerMeters(base string, r metrics.Registry) *peerMeters {
 		base: base,
 		reg:  r,
 
-		txReceived: metrics.NewRegisteredMeter(base+"/txReceived", r),
-		txSent:     metrics.NewRegisteredMeter(base+"/txSent", r),
-
-		txReplyInMeter:          metrics.NewRegisteredMeter(base+"/eth/fetcher/transaction/replies/in", r),
-		txReplyKnownMeter:       metrics.NewRegisteredMeter(base+"/eth/fetcher/transaction/replies/known", r),
-		txReplyUnderpricedMeter: metrics.NewRegisteredMeter(base+"/eth/fetcher/transaction/replies/underpriced", r),
-		txReplyOtherRejectMeter: metrics.NewRegisteredMeter(base+"/eth/fetcher/transaction/replies/otherreject", r),
+		txReceived:       metrics.NewRegisteredMeter(base+"/txReceived", r),
+		txSent:           metrics.NewRegisteredMeter(base+"/txSent", r),
+		pooledTxSent:     metrics.NewRegisteredMeter(base+"/pooledTxSent", r),
+		pooledTxReceived: metrics.NewRegisteredMeter(base+"/pooledTxReceived", r),
+		annReceived:      metrics.NewRegisteredMeter(base+"/annReceived", r),
+		annSent:          metrics.NewRegisteredMeter(base+"/annSent", r),
 	}
 }
 
 func (m *peerMeters) Close() {
 	m.reg.Unregister(m.base + "/txReceived")
 	m.reg.Unregister(m.base + "/txSent")
-	m.reg.Unregister(m.base + "/eth/fetcher/transaction/replies/in")
-	m.reg.Unregister(m.base + "/eth/fetcher/transaction/replies/known")
-	m.reg.Unregister(m.base + "/eth/fetcher/transaction/replies/underpriced")
-	m.reg.Unregister(m.base + "/eth/fetcher/transaction/replies/otherreject")
+	m.reg.Unregister(m.base + "/pooledTxSent")
+	m.reg.Unregister(m.base + "/pooledTxReceived")
+	m.reg.Unregister(m.base + "/annReceived")
+	m.reg.Unregister(m.base + "/annSent")
 }

--- a/eth/protocols/eth/peer_metrics.go
+++ b/eth/protocols/eth/peer_metrics.go
@@ -1,0 +1,42 @@
+// Copyright 2025 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+
+package eth
+
+import "github.com/ethereum/go-ethereum/metrics"
+
+type peerMeters struct {
+	txReceived *metrics.Meter
+	txSent     *metrics.Meter
+
+	txReplyInMeter          *metrics.Meter
+	txReplyKnownMeter       *metrics.Meter
+	txReplyUnderpricedMeter *metrics.Meter
+	txReplyOtherRejectMeter *metrics.Meter
+}
+
+// newPeerMeters registers and returns peer-level meters.
+func newPeerMeters(base string, r metrics.Registry) *peerMeters {
+	return &peerMeters{
+		txReceived: metrics.NewRegisteredMeter(base+"/txReceived", r),
+		txSent:     metrics.NewRegisteredMeter(base+"/txSent", r),
+
+		txReplyInMeter:          metrics.NewRegisteredMeter(base+"/eth/fetcher/transaction/replies/in", nil),
+		txReplyKnownMeter:       metrics.NewRegisteredMeter(base+"/eth/fetcher/transaction/replies/known", nil),
+		txReplyUnderpricedMeter: metrics.NewRegisteredMeter(base+"/eth/fetcher/transaction/replies/underpriced", nil),
+		txReplyOtherRejectMeter: metrics.NewRegisteredMeter(base+"/eth/fetcher/transaction/replies/otherreject", nil),
+	}
+}

--- a/eth/protocols/eth/peer_metrics.go
+++ b/eth/protocols/eth/peer_metrics.go
@@ -34,9 +34,9 @@ func newPeerMeters(base string, r metrics.Registry) *peerMeters {
 		txReceived: metrics.NewRegisteredMeter(base+"/txReceived", r),
 		txSent:     metrics.NewRegisteredMeter(base+"/txSent", r),
 
-		txReplyInMeter:          metrics.NewRegisteredMeter(base+"/eth/fetcher/transaction/replies/in", nil),
-		txReplyKnownMeter:       metrics.NewRegisteredMeter(base+"/eth/fetcher/transaction/replies/known", nil),
-		txReplyUnderpricedMeter: metrics.NewRegisteredMeter(base+"/eth/fetcher/transaction/replies/underpriced", nil),
-		txReplyOtherRejectMeter: metrics.NewRegisteredMeter(base+"/eth/fetcher/transaction/replies/otherreject", nil),
+		txReplyInMeter:          metrics.NewRegisteredMeter(base+"/eth/fetcher/transaction/replies/in", r),
+		txReplyKnownMeter:       metrics.NewRegisteredMeter(base+"/eth/fetcher/transaction/replies/known", r),
+		txReplyUnderpricedMeter: metrics.NewRegisteredMeter(base+"/eth/fetcher/transaction/replies/underpriced", r),
+		txReplyOtherRejectMeter: metrics.NewRegisteredMeter(base+"/eth/fetcher/transaction/replies/otherreject", r),
 	}
 }


### PR DESCRIPTION
WIP PR to add detailed metrics per peers. Currently only used to debug peer dynamics.

While this works, adding these meters to the default registry with the peerid as part of the prefix might not be the best idea.
I'm evaluating various options, including:
- using a different registry
- implementing tagged metrics
- putting this behind a flag