### PR TITLE
eth: allow changing maxPeers on the fly

### DIFF
--- a/eth/backend.go
+++ b/eth/backend.go
@@ -411,7 +411,7 @@ func (s *Ethereum) Start() error {
 }
 
 func (s *Ethereum) setMaxPeers(max int) {
-	s.p2pServer.MaxPeers = max
+	s.p2pServer.SetMaxPeers(max)
 	s.handler.SetMaxPeers(max)
 	s.dropper.SetMaxPeers(s.p2pServer.MaxDialedConns(), s.p2pServer.MaxInboundConns())
 }

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -410,6 +410,12 @@ func (s *Ethereum) Start() error {
 	return nil
 }
 
+func (s *Ethereum) setMaxPeers(max int) {
+	s.p2pServer.MaxPeers = max
+	s.handler.SetMaxPeers(max)
+	s.dropper.SetMaxPeers(s.p2pServer.MaxDialedConns(), s.p2pServer.MaxInboundConns())
+}
+
 func (s *Ethereum) newChainView(head *types.Header) *filtermaps.ChainView {
 	if head == nil {
 		return nil

--- a/eth/dropper.go
+++ b/eth/dropper.go
@@ -88,6 +88,11 @@ func newDropper(maxDialPeers, maxInboundPeers int) *dropper {
 	return cm
 }
 
+func (cm *dropper) SetMaxPeers(maxDialPeers, maxInboundPeers int) {
+	cm.maxDialPeers = maxDialPeers
+	cm.maxInboundPeers = maxInboundPeers
+}
+
 // Start the dropper.
 func (cm *dropper) Start(srv *p2p.Server, syncingFunc getSyncingFunc) {
 	cm.peersFunc = srv.Peers

--- a/eth/handler.go
+++ b/eth/handler.go
@@ -425,6 +425,10 @@ func (h *handler) unregisterPeer(id string) {
 	}
 }
 
+func (h *handler) SetMaxPeers(maxPeers int) {
+	h.maxPeers = maxPeers
+}
+
 func (h *handler) Start(maxPeers int) {
 	h.maxPeers = maxPeers
 

--- a/p2p/dial.go
+++ b/p2p/dial.go
@@ -185,6 +185,10 @@ func newDialScheduler(config dialConfig, it enode.Iterator, setupFunc dialSetupF
 	return d
 }
 
+func (d *dialScheduler) setMaxDialPeers(maxDialPeers int) {
+	d.maxDialPeers = maxDialPeers
+}
+
 // stop shuts down the dialer, canceling all current dial tasks.
 func (d *dialScheduler) stop() {
 	d.cancel()

--- a/p2p/server.go
+++ b/p2p/server.go
@@ -420,6 +420,13 @@ func (srv *Server) Start() (err error) {
 	return nil
 }
 
+func (srv *Server) SetMaxPeers(max int) {
+	srv.lock.Lock()
+	defer srv.lock.Unlock()
+	srv.MaxPeers = max
+	srv.dialsched.setMaxDialPeers(srv.MaxDialedConns())
+}
+
 func (srv *Server) setupLocalNode() error {
 	// Create the devp2p handshake.
 	pubkey := crypto.FromECDSAPub(&srv.PrivateKey.PublicKey)


### PR DESCRIPTION
Allow setting maxPeers on-the-fly.

This PR makes sure maxPeers can be changed in every module that has logic based on it.

In its current form, if maxPeers is reduced, this is not enforced immediately. It will be reached slowly by the dropper. We could eventually add a flag to force-drop. In my code I've done this externally, after calling SetMaxPeers.