### PR TITLE
[WIP] eth: register tx source peer

### DIFF
--- a/eth/fetcher/tx_fetcher.go
+++ b/eth/fetcher/tx_fetcher.go
@@ -203,7 +203,7 @@ type TxFetcher struct {
 	// txFromPeer stores where we received a transaction from
 	txFromPeer map[common.Hash]string
 	// should be protected by mutex
-	txFromPeerMutex sync.Mutex
+	txFromPeerMutex sync.RWMutex
 
 	// Callbacks
 	hasTx    func(common.Hash) bool             // Retrieves a tx from the local txpool
@@ -1047,6 +1047,8 @@ func rotateStrings(slice []string, n int) {
 }
 
 func (f *TxFetcher) TxFromPeer(hash common.Hash) (string, bool) {
+	f.txFromPeerMutex.RLock()
+	defer f.txFromPeerMutex.RUnlock()
 	provenance, ok := f.txFromPeer[hash]
 	return provenance, ok
 }


### PR DESCRIPTION
For each transaction, register which peer sent it to us first

This can e.g. later be queried to see which peers provided transactions that made it to a block.

This is not the right place to add this functionality, so still WIP.