### PR TITLE
core/state: reverse dependency relation between state and snapshot

### DIFF
--- a/core/state/database.go
+++ b/core/state/database.go
@@ -22,7 +22,6 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/lru"
 	"github.com/ethereum/go-ethereum/core/rawdb"
-	"github.com/ethereum/go-ethereum/core/state/snapshot"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/ethdb"
@@ -61,7 +60,7 @@ type Database interface {
 	TrieDB() *triedb.Database
 
 	// Snapshot returns the underlying state snapshot.
-	Snapshot() *snapshot.Tree
+	Snapshot() SnapshotTree
 }
 
 // Trie is a Ethereum Merkle Patricia trie.
@@ -147,14 +146,14 @@ type Trie interface {
 type CachingDB struct {
 	disk          ethdb.KeyValueStore
 	triedb        *triedb.Database
-	snap          *snapshot.Tree
+	snap          SnapshotTree
 	codeCache     *lru.SizeConstrainedCache[common.Hash, []byte]
 	codeSizeCache *lru.Cache[common.Hash, int]
 	pointCache    *utils.PointCache
 }
 
 // NewDatabase creates a state database with the provided data sources.
-func NewDatabase(triedb *triedb.Database, snap *snapshot.Tree) *CachingDB {
+func NewDatabase(triedb *triedb.Database, snap SnapshotTree) *CachingDB {
 	return &CachingDB{
 		disk:          triedb.Disk(),
 		triedb:        triedb,
@@ -272,7 +271,7 @@ func (db *CachingDB) PointCache() *utils.PointCache {
 }
 
 // Snapshot returns the underlying state snapshot.
-func (db *CachingDB) Snapshot() *snapshot.Tree {
+func (db *CachingDB) Snapshot() SnapshotTree {
 	return db.snap
 }
 

--- a/core/state/pruner/pruner.go
+++ b/core/state/pruner/pruner.go
@@ -29,6 +29,7 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/rawdb"
+	"github.com/ethereum/go-ethereum/core/state"
 	"github.com/ethereum/go-ethereum/core/state/snapshot"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/ethdb"
@@ -251,7 +252,7 @@ func (p *Pruner) Prune(root common.Hash) error {
 	// target. The reason for picking it is:
 	// - in most of the normal cases, the related state is available
 	// - the probability of this layer being reorg is very low
-	var layers []snapshot.Snapshot
+	var layers []state.Snapshot
 	if root == (common.Hash{}) {
 		// Retrieve all snapshot layers from the current HEAD.
 		// In theory there are 128 difflayers + 1 disk layer present,

--- a/core/state/snapshot.go
+++ b/core/state/snapshot.go
@@ -1,0 +1,114 @@
+// Copyright 2025 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+
+// Package state provides a caching layer atop the Ethereum state trie.
+package state
+
+import (
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+)
+
+// Snapshot represents the functionality supported by a snapshot storage layer.
+type Snapshot interface {
+	// Root returns the root hash for which this snapshot was made.
+	Root() common.Hash
+
+	// Account directly retrieves the account associated with a particular hash in
+	// the snapshot slim data format.
+	Account(hash common.Hash) (*types.SlimAccount, error)
+
+	// AccountRLP directly retrieves the account RLP associated with a particular
+	// hash in the snapshot slim data format.
+	AccountRLP(hash common.Hash) ([]byte, error)
+
+	// Storage directly retrieves the storage data associated with a particular hash,
+	// within a particular account.
+	Storage(accountHash, storageHash common.Hash) ([]byte, error)
+}
+
+// Tree is an Ethereum state snapshot tree. It consists of one persistent base
+// layer backed by a key-value store, on top of which arbitrarily many in-memory
+// diff layers are topped. The memory diffs can form a tree with branching, but
+// the disk layer is singleton and common to all. If a reorg goes deeper than the
+// disk layer, everything needs to be deleted.
+//
+// The goal of a state snapshot is twofold: to allow direct access to account and
+// storage data to avoid expensive multi-level trie lookups; and to allow sorted,
+// cheap iteration of the account/storage tries for sync aid.
+type SnapshotTree interface {
+	// Snapshot retrieves a snapshot belonging to the given block root, or nil if no
+	// snapshot is maintained for that block.
+	Snapshot(blockRoot common.Hash) Snapshot
+
+	// Update adds a new snapshot into the tree, if that can be linked to an existing
+	// old parent. It is disallowed to insert a disk layer (the origin of all).
+	Update(blockRoot common.Hash, parentRoot common.Hash, accounts map[common.Hash][]byte, storage map[common.Hash]map[common.Hash][]byte) error
+
+	// Cap traverses downwards the snapshot tree from a head block hash until the
+	// number of allowed layers are crossed. All layers beyond the permitted number
+	// are flattened downwards.
+	Cap(root common.Hash, layers int) error
+
+	// StorageIterator creates a new storage iterator for the specified root hash and
+	// account. The iterator will be move to the specific start position.
+	StorageIterator(root common.Hash, account common.Hash, seek common.Hash) (StorageIterator, error)
+
+	// AccountIterator creates a new account iterator for the specified root hash and
+	// seeks to a starting account hash.
+	AccountIterator(root common.Hash, seek common.Hash) (AccountIterator, error)
+}
+
+// Iterator is an iterator to step over all the accounts or the specific
+// storage in a snapshot which may or may not be composed of multiple layers.
+type Iterator interface {
+	// Next steps the iterator forward one element, returning false if exhausted,
+	// or an error if iteration failed for some reason (e.g. root being iterated
+	// becomes stale and garbage collected).
+	Next() bool
+
+	// Error returns any failure that occurred during iteration, which might have
+	// caused a premature iteration exit (e.g. snapshot stack becoming stale).
+	Error() error
+
+	// Hash returns the hash of the account or storage slot the iterator is
+	// currently at.
+	Hash() common.Hash
+
+	// Release releases associated resources. Release should always succeed and
+	// can be called multiple times without causing error.
+	Release()
+}
+
+// AccountIterator is an iterator to step over all the accounts in a snapshot,
+// which may or may not be composed of multiple layers.
+type AccountIterator interface {
+	Iterator
+
+	// Account returns the RLP encoded slim account the iterator is currently at.
+	// An error will be returned if the iterator becomes invalid
+	Account() []byte
+}
+
+// StorageIterator is an iterator to step over the specific storage in a snapshot,
+// which may or may not be composed of multiple layers.
+type StorageIterator interface {
+	Iterator
+
+	// Slot returns the storage slot the iterator is currently at. An error will
+	// be returned if the iterator becomes invalid
+	Slot() []byte
+}

--- a/core/state/snapshot/iterator_binary.go
+++ b/core/state/snapshot/iterator_binary.go
@@ -20,14 +20,15 @@ import (
 	"bytes"
 
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/state"
 )
 
 // binaryIterator is a simplistic iterator to step over the accounts or storage
 // in a snapshot, which may or may not be composed of multiple layers. Performance
 // wise this iterator is slow, it's meant for cross validating the fast one,
 type binaryIterator struct {
-	a               Iterator
-	b               Iterator
+	a               state.Iterator
+	b               state.Iterator
 	aDone           bool
 	bDone           bool
 	accountIterator bool
@@ -39,7 +40,7 @@ type binaryIterator struct {
 // initBinaryAccountIterator creates a simplistic iterator to step over all the
 // accounts in a slow, but easily verifiable way. Note this function is used for
 // initialization, use `newBinaryAccountIterator` as the API.
-func (dl *diffLayer) initBinaryAccountIterator(seek common.Hash) Iterator {
+func (dl *diffLayer) initBinaryAccountIterator(seek common.Hash) state.Iterator {
 	parent, ok := dl.parent.(*diffLayer)
 	if !ok {
 		l := &binaryIterator{
@@ -64,7 +65,7 @@ func (dl *diffLayer) initBinaryAccountIterator(seek common.Hash) Iterator {
 // initBinaryStorageIterator creates a simplistic iterator to step over all the
 // storage slots in a slow, but easily verifiable way. Note this function is used
 // for initialization, use `newBinaryStorageIterator` as the API.
-func (dl *diffLayer) initBinaryStorageIterator(account, seek common.Hash) Iterator {
+func (dl *diffLayer) initBinaryStorageIterator(account, seek common.Hash) state.Iterator {
 	parent, ok := dl.parent.(*diffLayer)
 	if !ok {
 		l := &binaryIterator{
@@ -192,14 +193,14 @@ func (it *binaryIterator) Release() {
 
 // newBinaryAccountIterator creates a simplistic account iterator to step over
 // all the accounts in a slow, but easily verifiable way.
-func (dl *diffLayer) newBinaryAccountIterator(seek common.Hash) AccountIterator {
+func (dl *diffLayer) newBinaryAccountIterator(seek common.Hash) state.AccountIterator {
 	iter := dl.initBinaryAccountIterator(seek)
-	return iter.(AccountIterator)
+	return iter.(state.AccountIterator)
 }
 
 // newBinaryStorageIterator creates a simplistic account iterator to step over
 // all the storage slots in a slow, but easily verifiable way.
-func (dl *diffLayer) newBinaryStorageIterator(account, seek common.Hash) StorageIterator {
+func (dl *diffLayer) newBinaryStorageIterator(account, seek common.Hash) state.StorageIterator {
 	iter := dl.initBinaryStorageIterator(account, seek)
-	return iter.(StorageIterator)
+	return iter.(state.StorageIterator)
 }

--- a/core/state/snapshot/iterator_fast.go
+++ b/core/state/snapshot/iterator_fast.go
@@ -24,13 +24,14 @@ import (
 	"sort"
 
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/state"
 )
 
 // weightedIterator is an iterator with an assigned weight. It is used to prioritise
 // which account or storage slot is the correct one if multiple iterators find the
 // same one (modified in multiple consecutive blocks).
 type weightedIterator struct {
-	it       Iterator
+	it       state.Iterator
 	priority int
 }
 
@@ -162,9 +163,9 @@ func (fi *fastIterator) Next() bool {
 		// do the sorting already
 		fi.initiated = true
 		if fi.account {
-			fi.curAccount = fi.iterators[0].it.(AccountIterator).Account()
+			fi.curAccount = fi.iterators[0].it.(state.AccountIterator).Account()
 		} else {
-			fi.curSlot = fi.iterators[0].it.(StorageIterator).Slot()
+			fi.curSlot = fi.iterators[0].it.(state.StorageIterator).Slot()
 		}
 		if innerErr := fi.iterators[0].it.Error(); innerErr != nil {
 			fi.fail = innerErr
@@ -188,9 +189,9 @@ func (fi *fastIterator) Next() bool {
 			return false // exhausted
 		}
 		if fi.account {
-			fi.curAccount = fi.iterators[0].it.(AccountIterator).Account()
+			fi.curAccount = fi.iterators[0].it.(state.AccountIterator).Account()
 		} else {
-			fi.curSlot = fi.iterators[0].it.(StorageIterator).Slot()
+			fi.curSlot = fi.iterators[0].it.(state.StorageIterator).Slot()
 		}
 		if innerErr := fi.iterators[0].it.Error(); innerErr != nil {
 			fi.fail = innerErr
@@ -319,13 +320,13 @@ func (fi *fastIterator) Debug() {
 // newFastAccountIterator creates a new hierarchical account iterator with one
 // element per diff layer. The returned combo iterator can be used to walk over
 // the entire snapshot diff stack simultaneously.
-func newFastAccountIterator(tree *Tree, root common.Hash, seek common.Hash) (AccountIterator, error) {
+func newFastAccountIterator(tree *Tree, root common.Hash, seek common.Hash) (state.AccountIterator, error) {
 	return newFastIterator(tree, root, common.Hash{}, seek, true)
 }
 
 // newFastStorageIterator creates a new hierarchical storage iterator with one
 // element per diff layer. The returned combo iterator can be used to walk over
 // the entire snapshot diff stack simultaneously.
-func newFastStorageIterator(tree *Tree, root common.Hash, account common.Hash, seek common.Hash) (StorageIterator, error) {
+func newFastStorageIterator(tree *Tree, root common.Hash, account common.Hash, seek common.Hash) (state.StorageIterator, error) {
 	return newFastIterator(tree, root, account, seek, false)
 }

--- a/core/state/statedb.go
+++ b/core/state/statedb.go
@@ -28,7 +28,6 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/rawdb"
-	"github.com/ethereum/go-ethereum/core/state/snapshot"
 	"github.com/ethereum/go-ethereum/core/stateless"
 	"github.com/ethereum/go-ethereum/core/tracing"
 	"github.com/ethereum/go-ethereum/core/types"
@@ -943,7 +942,7 @@ func (s *StateDB) clearJournalAndRefund() {
 // of a specific account. It leverages the associated state snapshot for fast
 // storage iteration and constructs trie node deletion markers by creating
 // stack trie with iterated slots.
-func (s *StateDB) fastDeleteStorage(snaps *snapshot.Tree, addrHash common.Hash, root common.Hash) (map[common.Hash][]byte, map[common.Hash][]byte, *trienode.NodeSet, error) {
+func (s *StateDB) fastDeleteStorage(snaps SnapshotTree, addrHash common.Hash, root common.Hash) (map[common.Hash][]byte, map[common.Hash][]byte, *trienode.NodeSet, error) {
 	iter, err := snaps.StorageIterator(s.originalRoot, addrHash, common.Hash{})
 	if err != nil {
 		return nil, nil, nil, err

--- a/core/state/statedb_fuzz_test.go
+++ b/core/state/statedb_fuzz_test.go
@@ -209,7 +209,7 @@ func (test *stateTest) run() bool {
 		if i != 0 {
 			root = roots[len(roots)-1]
 		}
-		state, err := New(root, NewDatabase(tdb, snaps))
+		state, err := New(root, NewDatabase(tdb, nil))
 		if err != nil {
 			panic(err)
 		}


### PR DESCRIPTION
snapshot package depends on encoding/gob, which we want to avoid in our tinygo builds. This allows state package to be compiled in isolation.