### PR TITLE
accounts: fix data race when closing manager

### DIFF
--- a/accounts/manager.go
+++ b/accounts/manager.go
@@ -93,9 +93,6 @@ func NewManager(config *Config, backends ...Backend) *Manager {
 
 // Close terminates the account manager's internal notification processes.
 func (am *Manager) Close() error {
-	for _, w := range am.wallets {
-		w.Close()
-	}
 	errc := make(chan error)
 	am.quit <- errc
 	return <-errc
@@ -149,6 +146,10 @@ func (am *Manager) update() {
 			am.lock.Unlock()
 			close(event.processed)
 		case errc := <-am.quit:
+			// Close all owned wallets
+			for _, w := range am.wallets {
+				w.Close()
+			}
 			// Manager terminating, return
 			errc <- nil
 			// Signals event emitters the loop is not receiving values


### PR DESCRIPTION
Fixes a data race on the `wallets` slice when closing an account Manager.

At the moment, there is a data race between a go-routine calling the Manager's `Close` function and the background go-routine handling most operations on the `Manager`. The `Manager`'s `wallets` field is accessed without proper synchronization.

By moving the closing of wallets from the `Close()` function into the background thread, this issue can be resolved.