### PR TITLE
core,miner: implement EIP-7934 - RLP Execution Block Size Limit

### DIFF
--- a/core/block_validator.go
+++ b/core/block_validator.go
@@ -50,7 +50,7 @@ func NewBlockValidator(config *params.ChainConfig, blockchain *BlockChain) *Bloc
 // validated at this point.
 func (v *BlockValidator) ValidateBody(block *types.Block) error {
 	// check EIP 7934 RLP-encoded block size cap
-	if v.config.IsOsaka(block.Number(), block.Time()) && block.Size() > params.BlockRLPSizeCap {
+	if v.config.IsOsaka(block.Number(), block.Time()) && block.Size() > params.MaxBlockSize {
 		return ErrBlockOversized
 	}
 	// Check whether the block is already imported.

--- a/core/block_validator.go
+++ b/core/block_validator.go
@@ -49,6 +49,7 @@ func NewBlockValidator(config *params.ChainConfig, blockchain *BlockChain) *Bloc
 // header's transaction and uncle roots. The headers are assumed to be already
 // validated at this point.
 func (v *BlockValidator) ValidateBody(block *types.Block) error {
+	// check EIP 7934 RLP-encoded block size cap
 	if v.config.IsOsaka(block.Number(), block.Time()) && block.Size() > params.BlockRLPSizeCap {
 		return ErrBlockOversized
 	}

--- a/core/block_validator.go
+++ b/core/block_validator.go
@@ -49,6 +49,9 @@ func NewBlockValidator(config *params.ChainConfig, blockchain *BlockChain) *Bloc
 // header's transaction and uncle roots. The headers are assumed to be already
 // validated at this point.
 func (v *BlockValidator) ValidateBody(block *types.Block) error {
+	if v.config.IsOsaka(block.Number(), block.Time()) && block.Size() > params.BlockRLPSizeCap {
+		return ErrBlockOversized
+	}
 	// Check whether the block is already imported.
 	if v.bc.HasBlockAndState(block.Hash(), block.NumberU64()) {
 		return ErrKnownBlock

--- a/core/error.go
+++ b/core/error.go
@@ -28,10 +28,6 @@ var (
 
 	// ErrNoGenesis is returned when there is no Genesis Block.
 	ErrNoGenesis = errors.New("genesis not found in chain")
-
-	// ErrBlockOversized is returned if the size of the RLP-encoded block
-	// exceeds the cap established by EIP 7934
-	ErrBlockOversized = errors.New("block RLP-encoded size exceeds maximum")
 )
 
 // List of evm-call-message pre-checking errors. All state transition messages will

--- a/core/error.go
+++ b/core/error.go
@@ -28,6 +28,10 @@ var (
 
 	// ErrNoGenesis is returned when there is no Genesis Block.
 	ErrNoGenesis = errors.New("genesis not found in chain")
+
+	// ErrBlockOversized is returned if the size of the RLP-encoded block
+	// exceeds the cap established by EIP 7934
+	ErrBlockOversized = errors.New("block RLP-encoded size exceeds maximum")
 )
 
 // List of evm-call-message pre-checking errors. All state transition messages will

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -19,10 +19,11 @@ package miner
 import (
 	"errors"
 	"fmt"
-	"github.com/ethereum/go-ethereum/trie"
 	"math/big"
 	"sync/atomic"
 	"time"
+
+	"github.com/ethereum/go-ethereum/trie"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/consensus/misc/eip1559"

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -64,6 +64,11 @@ type environment struct {
 	witness *stateless.Witness
 }
 
+// txFits reports whether the transaction fits into the block size limit.
+func (env *environment) txFitsSize(tx *types.Transaction) bool {
+	return env.size+tx.Size() < params.BlockRLPSizeCap-blockRLPSizeCapBuffer
+}
+
 const (
 	commitInterruptNone int32 = iota
 	commitInterruptNewHead
@@ -417,7 +422,7 @@ func (miner *Miner) commitTransactions(env *environment, plainTxs, blobTxs *tran
 
 		// if inclusion of the transaction would put the block size over the
 		// maximum we allow, don't add any more txs to the payload.
-		if isOsaka && env.size+tx.Size() > params.BlockRLPSizeCap-blockRLPSizeCapBuffer {
+		if !env.txFitsSize(tx) {
 			break
 		}
 

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -131,7 +131,6 @@ func (miner *Miner) generateWork(genParam *generateParams, witness bool) *newPay
 			includedWithdrawals = append(includedWithdrawals, withdrawal)
 			work.size += params.WithdrawalSize
 		}
-
 	} else {
 		includedWithdrawals = genParam.withdrawals
 	}

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -305,7 +305,7 @@ func (miner *Miner) commitTransaction(env *environment, tx *types.Transaction) e
 	}
 	env.txs = append(env.txs, tx)
 	env.receipts = append(env.receipts, receipt)
-	env.size += tx.Size()
+	env.size += tx.WithoutBlobTxSidecar().Size()
 	env.tcount++
 	return nil
 }

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -305,7 +305,7 @@ func (miner *Miner) commitTransaction(env *environment, tx *types.Transaction) e
 	}
 	env.txs = append(env.txs, tx)
 	env.receipts = append(env.receipts, receipt)
-	env.size += tx.WithoutBlobTxSidecar().Size()
+	env.size += tx.Size()
 	env.tcount++
 	return nil
 }
@@ -331,6 +331,7 @@ func (miner *Miner) commitBlobTransaction(env *environment, tx *types.Transactio
 	env.receipts = append(env.receipts, receipt)
 	env.sidecars = append(env.sidecars, sc)
 	env.blobs += len(sc.Blobs)
+	env.size += tx.WithoutBlobTxSidecar().Size()
 	*env.header.BlobGasUsed += receipt.BlobGasUsed
 	env.tcount++
 	return nil

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -318,11 +318,12 @@ func (miner *Miner) commitBlobTransaction(env *environment, tx *types.Transactio
 	if err != nil {
 		return err
 	}
-	env.txs = append(env.txs, tx.WithoutBlobTxSidecar())
+	txNoBlob := tx.WithoutBlobTxSidecar()
+	env.txs = append(env.txs, txNoBlob)
 	env.receipts = append(env.receipts, receipt)
 	env.sidecars = append(env.sidecars, sc)
 	env.blobs += len(sc.Blobs)
-	env.size += tx.WithoutBlobTxSidecar().Size()
+	env.size += txNoBlob.Size()
 	*env.header.BlobGasUsed += receipt.BlobGasUsed
 	env.tcount++
 	return nil

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -95,7 +95,7 @@ type generateParams struct {
 	noTxs       bool              // Flag whether an empty block without any transaction is expected
 }
 
-func (env *environment) encodedSizeWithTxAndReceipt(tx *types.Transaction) uint64 {
+func (env *environment) encodedSizeWithTx(tx *types.Transaction) uint64 {
 	body := types.Body{Transactions: append(env.txs, tx), Withdrawals: make([]*types.Withdrawal, 0)}
 	env.header.RequestsHash = &common.Hash{}
 	block := types.NewBlock(env.header, &body, env.receipts, trie.NewStackTrie(nil))
@@ -399,7 +399,7 @@ func (miner *Miner) commitTransactions(env *environment, plainTxs, blobTxs *tran
 			continue
 		}
 
-		if miner.chainConfig.IsOsaka(env.header.Number, env.header.Time) && env.encodedSizeWithTxAndReceipt(tx) > params.BlockRLPSizeCap {
+		if miner.chainConfig.IsOsaka(env.header.Number, env.header.Time) && env.encodedSizeWithTx(tx) > params.BlockRLPSizeCap {
 			break
 		}
 

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -78,7 +78,7 @@ const (
 
 // Block size is capped by the protocol at params.MaxBlockSize. When producing blocks, we
 // try to say below the size including a buffer zone, this is to avoid going over the
-// maximum size with auxilary data added into the block.
+// maximum size with auxiliary data added into the block.
 const maxBlockSizeBufferZone = 1_000_000
 
 // newPayloadResult is the result of payload generation.

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -127,7 +127,6 @@ func (miner *Miner) generateWork(genParam *generateParams, witness bool) *newPay
 			if int(work.size)+params.WithdrawalSize > maxBlockSize {
 				break
 			}
-
 			includedWithdrawals = append(includedWithdrawals, withdrawal)
 			work.size += params.WithdrawalSize
 		}

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -23,8 +23,6 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/ethereum/go-ethereum/trie"
-
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/consensus/misc/eip1559"
 	"github.com/ethereum/go-ethereum/consensus/misc/eip4844"
@@ -95,13 +93,6 @@ type generateParams struct {
 	withdrawals types.Withdrawals // List of withdrawals to include in block (shanghai field)
 	beaconRoot  *common.Hash      // The beacon root (cancun field).
 	noTxs       bool              // Flag whether an empty block without any transaction is expected
-}
-
-func (env *environment) encodedSizeWithTx(tx *types.Transaction) uint64 {
-	body := types.Body{Transactions: append(env.txs, tx), Withdrawals: make([]*types.Withdrawal, 0)}
-	env.header.RequestsHash = &common.Hash{}
-	block := types.NewBlock(env.header, &body, env.receipts, trie.NewStackTrie(nil))
-	return block.Size()
 }
 
 // generateWork generates a sealing block based on the given parameters.
@@ -404,10 +395,6 @@ func (miner *Miner) commitTransactions(env *environment, plainTxs, blobTxs *tran
 		}
 
 		if miner.chainConfig.IsOsaka(env.header.Number, env.header.Time) && env.size+tx.Size() > params.BlockRLPSizeCap {
-			break
-		}
-
-		if miner.chainConfig.IsOsaka(env.header.Number, env.header.Time) && env.encodedSizeWithTx(tx) > params.BlockRLPSizeCap {
 			break
 		}
 

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -109,8 +109,9 @@ func (miner *Miner) generateWork(genParam *generateParams, witness bool) *newPay
 	var includedWithdrawals types.Withdrawals
 
 	// If we are post-osaka, incorporate the requested withdrawals into the
-	// block size up-front to ensure that all requested withdrawals can be
-	// included even if we hit the size cap when filling the block with txs.
+	// block size calculation up-front to ensure that all requested withdrawals
+	// can be included even if we hit the size cap when filling the block with
+	// txs.
 	//
 	// Also, ensure that including all requested withdrawals wouldn't bring us
 	// over the block size cap limit.  The withdrawal cap ensures that this can't

--- a/params/protocol_params.go
+++ b/params/protocol_params.go
@@ -179,6 +179,7 @@ const (
 
 	HistoryServeWindow = 8192 // Number of blocks to serve historical block hashes for, EIP-2935.
 
+	WithdrawalSize  = 23        // size of a withdrawal
 	BlockRLPSizeCap = 9_961_472 // maximum size of an RLP-encoded block
 )
 

--- a/params/protocol_params.go
+++ b/params/protocol_params.go
@@ -180,7 +180,7 @@ const (
 	HistoryServeWindow = 8192 // Number of blocks to serve historical block hashes for, EIP-2935.
 
 	WithdrawalSize  = 23        // size of a withdrawal
-	BlockRLPSizeCap = 9_961_472 // maximum size of an RLP-encoded block
+	BlockRLPSizeCap = 8_388_608 // maximum size of an RLP-encoded block
 )
 
 // Bls12381G1MultiExpDiscountTable is the gas discount table for BLS12-381 G1 multi exponentiation operation

--- a/params/protocol_params.go
+++ b/params/protocol_params.go
@@ -178,6 +178,8 @@ const (
 	BlobBaseCost                       = 1 << 13 // Base execution gas cost for a blob.
 
 	HistoryServeWindow = 8192 // Number of blocks to serve historical block hashes for, EIP-2935.
+
+	BlockRLPSizeCap = 9_961_472 // maximum size of an RLP-encoded block
 )
 
 // Bls12381G1MultiExpDiscountTable is the gas discount table for BLS12-381 G1 multi exponentiation operation

--- a/params/protocol_params.go
+++ b/params/protocol_params.go
@@ -179,7 +179,6 @@ const (
 
 	HistoryServeWindow = 8192 // Number of blocks to serve historical block hashes for, EIP-2935.
 
-	WithdrawalSize  = 23        // size of a withdrawal
 	BlockRLPSizeCap = 8_388_608 // maximum size of an RLP-encoded block
 )
 

--- a/params/protocol_params.go
+++ b/params/protocol_params.go
@@ -179,7 +179,7 @@ const (
 
 	HistoryServeWindow = 8192 // Number of blocks to serve historical block hashes for, EIP-2935.
 
-	BlockRLPSizeCap = 8_388_608 // maximum size of an RLP-encoded block
+	MaxBlockSize = 8_388_608 // maximum size of an RLP-encoded block
 )
 
 // Bls12381G1MultiExpDiscountTable is the gas discount table for BLS12-381 G1 multi exponentiation operation


### PR DESCRIPTION
This PR adds a check against the maximum block size, as required by EIP-7934, and also applies a slightly lower
size limit during block building.