### PR TITLE
metrics: add chain/gas for cumulative gas usage

### DIFF
--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -66,7 +66,7 @@ var (
 	headSafeBlockGauge      = metrics.NewRegisteredGauge("chain/head/safe", nil)
 
 	chainInfoGauge   = metrics.NewRegisteredGaugeInfo("chain/info", nil)
-	chainMgaspsMeter = metrics.NewRegisteredMeter("chain/mgasps", nil)
+	chainMgaspsMeter = metrics.NewRegisteredResettingTimer("chain/mgasps", nil)
 
 	accountReadTimer   = metrics.NewRegisteredResettingTimer("chain/account/reads", nil)
 	accountHashTimer   = metrics.NewRegisteredResettingTimer("chain/account/hashes", nil)
@@ -2067,8 +2067,12 @@ func (bc *BlockChain) processBlock(parentRoot common.Hash, block *types.Block, s
 	triedbCommitTimer.Update(statedb.TrieDBCommits)     // Trie database commits are complete, we can mark them
 
 	blockWriteTimer.Update(time.Since(wstart) - max(statedb.AccountCommits, statedb.StorageCommits) /* concurrent */ - statedb.SnapshotCommits - statedb.TrieDBCommits)
-	blockInsertTimer.UpdateSince(startTime)
-	chainMgaspsMeter.Mark(int64(float64(res.GasUsed) / 1000_000))
+	elapsed := time.Since(startTime) + 1 // prevent zero division
+	blockInsertTimer.Update(elapsed)
+
+	// TODO(rjl493456442) generalize the ResettingTimer
+	mgasps := float64(res.GasUsed) * 1000 / float64(elapsed)
+	chainMgaspsMeter.Update(time.Duration(mgasps))
 
 	return &blockProcessingResult{
 		usedGas:  res.GasUsed,

--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -67,6 +67,7 @@ var (
 
 	chainInfoGauge   = metrics.NewRegisteredGaugeInfo("chain/info", nil)
 	chainMgaspsGauge = metrics.NewRegisteredGauge("chain/mgasps", nil)
+	chainGasCounter  = metrics.NewRegisteredCounter("chain/gas/total", nil)
 
 	accountReadTimer   = metrics.NewRegisteredResettingTimer("chain/account/reads", nil)
 	accountHashTimer   = metrics.NewRegisteredResettingTimer("chain/account/hashes", nil)
@@ -1844,6 +1845,7 @@ func (bc *BlockChain) insertChain(chain types.Blocks, setHead bool, makeWitness 
 		// Report the import stats before returning the various results
 		stats.processed++
 		stats.usedGas += res.usedGas
+		chainGasCounter.Inc(int64(res.usedGas))
 		witness = res.witness
 
 		var snapDiffItems, snapBufItems common.StorageSize

--- a/core/blockchain_insert.go
+++ b/core/blockchain_insert.go
@@ -46,9 +46,6 @@ func (st *insertStats) report(chain []*types.Block, index int, snapDiffItems, sn
 		elapsed = now.Sub(st.startTime) + 1 // prevent zero division
 		mgasps  = float64(st.usedGas) * 1000 / float64(elapsed)
 	)
-	// Update the Mgas per second gauge
-	chainMgaspsGauge.Update(int64(mgasps))
-
 	// If we're at the last block of the batch or report period reached, log
 	if index == len(chain)-1 || elapsed >= statsReportLimit {
 		// Count the number of transactions in this segment


### PR DESCRIPTION
This is a followup to #31753.

A cumulative counter is more useful when we need to measure / aggregate the metric over a longer period of time.
It also means we won't miss data,
e.g. our prometheus scrapes every 30 seconds,
and so may miss a transient spike in the preaggregated mgas/s.