### PR TITLE
trie: no need to store preimage if not enabled

### DIFF
--- a/trie/database_test.go
+++ b/trie/database_test.go
@@ -86,6 +86,10 @@ func (db *testDb) InsertPreimage(preimages map[common.Hash][]byte) {
 	rawdb.WritePreimages(db.disk, preimages)
 }
 
+func (db *testDb) PreimageEnabled() bool {
+	return true
+}
+
 func (db *testDb) Scheme() string { return db.scheme }
 
 func (db *testDb) Update(root common.Hash, parent common.Hash, nodes *trienode.MergedNodeSet) error {

--- a/trie/secure_trie.go
+++ b/trie/secure_trie.go
@@ -240,11 +240,11 @@ func (t *StateTrie) DeleteAccount(address common.Address) error {
 // GetKey returns the sha3 preimage of a hashed key that was
 // previously used to store a value.
 func (t *StateTrie) GetKey(shaKey []byte) []byte {
-	if key, ok := t.getSecKeyCache()[common.BytesToHash(shaKey)]; ok {
-		return key
-	}
 	if t.preimages == nil {
 		return nil
+	}
+	if key, ok := t.getSecKeyCache()[common.BytesToHash(shaKey)]; ok {
+		return key
 	}
 	return t.preimages.Preimage(common.BytesToHash(shaKey))
 }

--- a/trie/secure_trie.go
+++ b/trie/secure_trie.go
@@ -159,7 +159,9 @@ func (t *StateTrie) GetNode(path []byte) ([]byte, int, error) {
 func (t *StateTrie) MustUpdate(key, value []byte) {
 	hk := crypto.Keccak256(key)
 	t.trie.MustUpdate(hk, value)
-	t.getSecKeyCache()[common.Hash(hk)] = common.CopyBytes(key)
+	if t.preimages != nil {
+		t.getSecKeyCache()[common.Hash(hk)] = common.CopyBytes(key)
+	}
 }
 
 // UpdateStorage associates key with value in the trie. Subsequent calls to
@@ -177,7 +179,9 @@ func (t *StateTrie) UpdateStorage(_ common.Address, key, value []byte) error {
 	if err != nil {
 		return err
 	}
-	t.getSecKeyCache()[common.Hash(hk)] = common.CopyBytes(key)
+	if t.preimages != nil {
+		t.getSecKeyCache()[common.Hash(hk)] = common.CopyBytes(key)
+	}
 	return nil
 }
 
@@ -191,7 +195,9 @@ func (t *StateTrie) UpdateAccount(address common.Address, acc *types.StateAccoun
 	if err := t.trie.Update(hk, data); err != nil {
 		return err
 	}
-	t.getSecKeyCache()[common.Hash(hk)] = address.Bytes()
+	if t.preimages != nil {
+		t.getSecKeyCache()[common.Hash(hk)] = address.Bytes()
+	}
 	return nil
 }
 
@@ -203,7 +209,9 @@ func (t *StateTrie) UpdateContractCode(_ common.Address, _ common.Hash, _ []byte
 // will omit any encountered error but just print out an error message.
 func (t *StateTrie) MustDelete(key []byte) {
 	hk := crypto.Keccak256(key)
-	delete(t.getSecKeyCache(), common.Hash(hk))
+	if t.preimages != nil {
+		delete(t.getSecKeyCache(), common.Hash(hk))
+	}
 	t.trie.MustDelete(hk)
 }
 
@@ -212,14 +220,18 @@ func (t *StateTrie) MustDelete(key []byte) {
 // If a node is not found in the database, a MissingNodeError is returned.
 func (t *StateTrie) DeleteStorage(_ common.Address, key []byte) error {
 	hk := crypto.Keccak256(key)
-	delete(t.getSecKeyCache(), common.Hash(hk))
+	if t.preimages != nil {
+		delete(t.getSecKeyCache(), common.Hash(hk))
+	}
 	return t.trie.Delete(hk)
 }
 
 // DeleteAccount abstracts an account deletion from the trie.
 func (t *StateTrie) DeleteAccount(address common.Address) error {
 	hk := crypto.Keccak256(address.Bytes())
-	delete(t.getSecKeyCache(), common.Hash(hk))
+	if t.preimages != nil {
+		delete(t.getSecKeyCache(), common.Hash(hk))
+	}
 	return t.trie.Delete(hk)
 }
 

--- a/trie/secure_trie.go
+++ b/trie/secure_trie.go
@@ -33,6 +33,9 @@ type preimageStore interface {
 
 	// InsertPreimage commits a set of preimages along with their hashes.
 	InsertPreimage(preimages map[common.Hash][]byte)
+
+	// PreimageEnabled returns true if the preimage store is enabled.
+	PreimageEnabled() bool
 }
 
 // SecureTrie is the old name of StateTrie.
@@ -84,8 +87,7 @@ func NewStateTrie(id *ID, db database.NodeDatabase) (*StateTrie, error) {
 	tr := &StateTrie{trie: *trie, db: db}
 
 	// link the preimage store if it's supported
-	preimages, ok := db.(preimageStore)
-	if ok {
+	if preimages, ok := db.(preimageStore); ok && preimages.PreimageEnabled() {
 		tr.preimages = preimages
 	}
 	return tr, nil

--- a/triedb/database.go
+++ b/triedb/database.go
@@ -213,6 +213,11 @@ func (db *Database) InsertPreimage(preimages map[common.Hash][]byte) {
 	db.preimages.insertPreimage(preimages)
 }
 
+// PreimageEnabled returns the indicator if the pre-image store is enabled.
+func (db *Database) PreimageEnabled() bool {
+	return db.preimages != nil
+}
+
 // Cap iteratively flushes old but still referenced trie nodes until the total
 // memory usage goes below the given threshold. The held pre-images accumulated
 // up to this point will be flushed in case the size exceeds the threshold.


### PR DESCRIPTION
As the preimage will only be stored if `t.preimages != nil`, so no need to save them into local cache if not enabled, ref https://github.com/ethereum/go-ethereum/blob/959f00d9226135ec94d0fb32460e1661d41de456/trie/secure_trie.go#L265-L267

This will reduce the memory wasted to copy the bytes
