### PR TITLE
crypto/kzg4844: remove kzg initialization

### DIFF
--- a/crypto/kzg4844/kzg4844.go
+++ b/crypto/kzg4844/kzg4844.go
@@ -86,10 +86,6 @@ type Claim [32]byte
 // useCKZG controls whether the cryptography should use the Go or C backend.
 var useCKZG atomic.Bool
 
-func init() {
-	UseCKZG(true)
-}
-
 // UseCKZG can be called to switch the default Go implementation of KZG to the C
 // library if for some reason the user wishes to do so (e.g. consensus bug in one
 // or the other).


### PR DESCRIPTION
This fixes a regression in the state tests where we always initialized the KZG library.
This was added to test some stuff in #31791 