### PR TITLE
core/rawdb: don't decode the full block body in ReadTransaction

### DIFF
--- a/core/rawdb/accessors_indexes.go
+++ b/core/rawdb/accessors_indexes.go
@@ -161,11 +161,11 @@ func ReadTransaction(db ethdb.Reader, hash common.Hash) (*types.Transaction, com
 		// which are encoded as byte arrays, the preimage is the content of
 		// the byte array, so trim their prefix here.
 		txRLP := txnIterator.Value()
-		rlpKind, txHashPayload, _, err := rlp.Split(txRLP)
+		kind, txHashPayload, _, err := rlp.Split(txRLP)
 		if err != nil {
 			return nil, common.Hash{}, 0, 0
 		}
-		if rlpKind == rlp.List {
+		if kind == rlp.List {
 			txHashPayload = txRLP
 		}
 		if crypto.Keccak256Hash(txHashPayload) == hash {

--- a/core/rawdb/accessors_indexes.go
+++ b/core/rawdb/accessors_indexes.go
@@ -129,10 +129,10 @@ func DeleteAllTxLookupEntries(db ethdb.KeyValueStore, condition func(common.Hash
 	}
 }
 
-// traverseBlockBody traverses the given RLP-encoded block body, searching for
+// findTxInBlockBody traverses the given RLP-encoded block body, searching for
 // the transaction specified by its hash.
-func traverseBlockBody(data rlp.RawValue, target common.Hash) (*types.Transaction, uint64, error) {
-	txnListRLP, _, err := rlp.SplitList(data)
+func findTxInBlockBody(blockbody rlp.RawValue, target common.Hash) (*types.Transaction, uint64, error) {
+	txnListRLP, _, err := rlp.SplitList(blockbody)
 	if err != nil {
 		return nil, 0, err
 	}
@@ -185,7 +185,7 @@ func ReadTransaction(db ethdb.Reader, hash common.Hash) (*types.Transaction, com
 		log.Error("Transaction referenced missing", "number", *blockNumber, "hash", blockHash)
 		return nil, common.Hash{}, 0, 0
 	}
-	tx, txIndex, err := traverseBlockBody(bodyRLP, hash)
+	tx, txIndex, err := findTxInBlockBody(bodyRLP, hash)
 	if err != nil {
 		log.Error("Transaction not found", "number", *blockNumber, "hash", blockHash, "txhash", hash, "err", err)
 		return nil, common.Hash{}, 0, 0

--- a/core/rawdb/accessors_indexes.go
+++ b/core/rawdb/accessors_indexes.go
@@ -158,11 +158,14 @@ func ReadTransaction(db ethdb.Reader, hash common.Hash) (*types.Transaction, com
 	for txnIterator.Next() && txnIterator.Err() == nil {
 		txnRLP := txnIterator.Value()
 
-		// Figure out if this a legacy transaction or not
+		// Preimage for hash calculation of legacy transactions
+		// are just their RLP encoding, but for EIP-2728 transactions
+		// the prefix needs to be trimmed before hashing.
 		rlpKind, hashPreimage, _, err := rlp.Split(txnRLP)
 		if err != nil {
 			return nil, common.Hash{}, 0, 0
 		}
+		// Legacy transactions are encoded as rlp lists.
 		if rlpKind == rlp.List {
 			hashPreimage = txnRLP
 		}

--- a/core/rawdb/accessors_indexes_test.go
+++ b/core/rawdb/accessors_indexes_test.go
@@ -17,16 +17,16 @@
 package rawdb
 
 import (
-	"github.com/davecgh/go-spew/spew"
-	"github.com/holiman/uint256"
 	"math/big"
 	"testing"
 
+	"github.com/davecgh/go-spew/spew"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/ethdb"
 	"github.com/ethereum/go-ethereum/internal/blocktest"
 	"github.com/ethereum/go-ethereum/rlp"
+	"github.com/holiman/uint256"
 )
 
 var newTestHasher = blocktest.NewHasher

--- a/core/rawdb/accessors_indexes_test.go
+++ b/core/rawdb/accessors_indexes_test.go
@@ -72,7 +72,15 @@ func TestLookupStorage(t *testing.T) {
 			tx1 := types.NewTransaction(1, common.BytesToAddress([]byte{0x11}), big.NewInt(111), 1111, big.NewInt(11111), []byte{0x11, 0x11, 0x11})
 			tx2 := types.NewTransaction(2, common.BytesToAddress([]byte{0x22}), big.NewInt(222), 2222, big.NewInt(22222), []byte{0x22, 0x22, 0x22})
 			tx3 := types.NewTransaction(3, common.BytesToAddress([]byte{0x33}), big.NewInt(333), 3333, big.NewInt(33333), []byte{0x33, 0x33, 0x33})
-			txs := []*types.Transaction{tx1, tx2, tx3}
+			tx4 := types.NewTx(&types.DynamicFeeTx{
+				To:        new(common.Address),
+				Nonce:     5,
+				Value:     big.NewInt(5),
+				Gas:       5,
+				GasTipCap: big.NewInt(55),
+				GasFeeCap: big.NewInt(1055),
+			})
+			txs := []*types.Transaction{tx1, tx2, tx3, tx4}
 
 			block := types.NewBlock(&types.Header{Number: big.NewInt(314)}, &types.Body{Transactions: txs}, nil, newTestHasher())
 

--- a/core/rawdb/accessors_indexes_test.go
+++ b/core/rawdb/accessors_indexes_test.go
@@ -120,7 +120,7 @@ func TestLookupStorage(t *testing.T) {
 	}
 }
 
-func TestTraverseBlockBody(t *testing.T) {
+func TestFindTxInBlockBody(t *testing.T) {
 	tx1 := types.NewTx(&types.LegacyTx{
 		Nonce:    1,
 		GasPrice: big.NewInt(1),
@@ -205,7 +205,7 @@ func TestTraverseBlockBody(t *testing.T) {
 
 	rlp := ReadBodyRLP(db, block.Hash(), block.NumberU64())
 	for i := 0; i < len(txs); i++ {
-		tx, txIndex, err := traverseBlockBody(rlp, txs[i].Hash())
+		tx, txIndex, err := findTxInBlockBody(rlp, txs[i].Hash())
 		if err != nil {
 			t.Fatalf("Failed to retrieve tx, err: %v", err)
 		}


### PR DESCRIPTION
Reading a single transaction out of a block shouldn't need decoding the entire body