### PR TITLE
fix: skip storage entries with missing preimage keys

### DIFF
--- a/core/state/dump.go
+++ b/core/state/dump.go
@@ -182,7 +182,11 @@ func (s *StateDB) DumpToCollector(c DumpCollector, conf *DumpConfig) (nextKey []
 					log.Error("Failed to decode the value returned by iterator", "error", err)
 					continue
 				}
-				account.Storage[common.BytesToHash(s.trie.GetKey(storageIt.Key))] = common.Bytes2Hex(content)
+				key := s.trie.GetKey(storageIt.Key)
+				if key == nil {
+					continue
+				}
+				account.Storage[common.BytesToHash(key)] = common.Bytes2Hex(content)
 			}
 		}
 		c.OnAccount(address, account)


### PR DESCRIPTION
When `GetKey` (see https://github.com/ethereum/go-ethereum/blob/v1.15.11/trie/secure_trie.go#L235) is called, a missing preimage can cause the function to return a `nil` key. This, in turn, makes `account.Storage` persist an incorrect value.