### PR TITLE
consensus: make basefee 0 always reachable for `CalcBaseFee`

### DIFF
--- a/consensus/misc/eip1559/eip1559.go
+++ b/consensus/misc/eip1559/eip1559.go
@@ -89,7 +89,13 @@ func CalcBaseFee(config *params.ChainConfig, parent *types.Header) *big.Int {
 		num.Div(num, denom.SetUint64(parentGasTarget))
 		num.Div(num, denom.SetUint64(config.BaseFeeChangeDenominator()))
 
-		baseFee := num.Sub(parent.BaseFee, num)
+		var baseFee *big.Int
+		if num.Cmp(common.Big1) < 0 {
+			baseFee = num.Sub(parent.BaseFee, common.Big1)
+		} else {
+			baseFee = num.Sub(parent.BaseFee, num)
+		}
+		
 		if baseFee.Cmp(common.Big0) < 0 {
 			baseFee = common.Big0
 		}


### PR DESCRIPTION
Currently the processing in `CalcBaseFee` is not symmetrical in that if `parent.GasUsed > parentGasTarget`, increment is at least 1; but when `parent.GasUsed < parentGasTarget`, there's no such logic, leading to baseFee stuck at a value higher than 0.

This PR makes basefee 0 always reachable for those chains with low traffic, but it needs to be protected by some feature gate, so it's in draft status.