### PR TITLE
eth,core: terminate the downloader immediately when shutdown signal is received

### DIFF
--- a/eth/downloader/downloader.go
+++ b/eth/downloader/downloader.go
@@ -199,6 +199,9 @@ type BlockChain interface {
 	// InsertChain inserts a batch of blocks into the local chain.
 	InsertChain(types.Blocks) (int, error)
 
+	// StopInsert interrupts the inserting process.
+	StopInsert()
+
 	// InsertReceiptChain inserts a batch of blocks along with their receipts
 	// into the local chain. Blocks older than the specified `ancientLimit`
 	// are stored directly in the ancient store, while newer blocks are stored
@@ -634,6 +637,9 @@ func (d *Downloader) Cancel() {
 // Terminate interrupts the downloader, canceling all pending operations.
 // The downloader cannot be reused after calling Terminate.
 func (d *Downloader) Terminate() {
+	// Signal to stop inserting in-flight blocks
+	d.blockchain.StopInsert()
+
 	// Close the termination channel (make sure double close is allowed)
 	d.quitLock.Lock()
 	select {


### PR DESCRIPTION
closes https://github.com/ethereum/go-ethereum/issues/32058


Test with the hoodi testnet in full-sync, the results as below

> master branch about 36seconds

```
INFO [06-18|15:08:01.553] Got interrupt, shutting down...
INFO [06-18|15:08:01.553] HTTP server stopped                      endpoint=[::]:4545
INFO [06-18|15:08:01.553] HTTP server stopped                      endpoint=[::]:4546
INFO [06-18|15:08:01.553] HTTP server stopped                      endpoint=[::]:8551
INFO [06-18|15:08:01.553] IPC endpoint closed                      url=/data/geth.ipc
... 
INFO [06-18|15:08:37.213] Blockchain stopped
```

> this branch about 5seconds

```
INFO [06-18|15:05:20.774] Got interrupt, shutting down...
INFO [06-18|15:05:20.774] HTTP server stopped                      endpoint=[::]:4545
INFO [06-18|15:05:20.774] HTTP server stopped                      endpoint=[::]:4546
INFO [06-18|15:05:20.774] HTTP server stopped                      endpoint=[::]:8551
INFO [06-18|15:05:20.774] IPC endpoint closed                      url=/data/geth.ipc
...
INFO [06-18|15:05:25.462] Blockchain stopped
```