### PR TITLE
triedb: truncate history states in a batch way

### DIFF
--- a/core/rawdb/chain_freezer.go
+++ b/core/rawdb/chain_freezer.go
@@ -415,6 +415,14 @@ func (f *chainFreezer) TruncateTail(items uint64) (uint64, error) {
 	return f.ancients.TruncateTail(items)
 }
 
+func (f *chainFreezer) SoftTruncateHead(items uint64) (uint64, error) {
+	return f.ancients.SoftTruncateHead(items)
+}
+
+func (f *chainFreezer) CommitTruncation() error {
+	return f.ancients.CommitTruncation()
+}
+
 func (f *chainFreezer) SyncAncient() error {
 	return f.ancients.SyncAncient()
 }

--- a/core/rawdb/database.go
+++ b/core/rawdb/database.go
@@ -130,6 +130,16 @@ func (db *nofreezedb) TruncateTail(items uint64) (uint64, error) {
 	return 0, errNotSupported
 }
 
+// SoftTruncateHead returns an error as we don't have a backing chain freezer.
+func (db *nofreezedb) SoftTruncateHead(items uint64) (uint64, error) {
+	return 0, errNotSupported
+}
+
+// CommitTruncation returns an error as we don't have a backing chain freezer.
+func (db *nofreezedb) CommitTruncation() error {
+	return errNotSupported
+}
+
 // SyncAncient returns an error as we don't have a backing chain freezer.
 func (db *nofreezedb) SyncAncient() error {
 	return errNotSupported

--- a/core/rawdb/freezer_resettable.go
+++ b/core/rawdb/freezer_resettable.go
@@ -185,6 +185,22 @@ func (f *resettableFreezer) TruncateTail(tail uint64) (uint64, error) {
 	return f.freezer.TruncateTail(tail)
 }
 
+// SoftTruncateHead marks items above threshold as logically deleted without physical truncation.
+func (f *resettableFreezer) SoftTruncateHead(items uint64) (uint64, error) {
+	f.lock.RLock()
+	defer f.lock.RUnlock()
+
+	return f.freezer.SoftTruncateHead(items)
+}
+
+// CommitTruncation performs the actual file truncation to match any soft truncations.
+func (f *resettableFreezer) CommitTruncation() error {
+	f.lock.RLock()
+	defer f.lock.RUnlock()
+
+	return f.freezer.CommitTruncation()
+}
+
 // SyncAncient flushes all data tables to disk.
 func (f *resettableFreezer) SyncAncient() error {
 	f.lock.RLock()

--- a/core/rawdb/table.go
+++ b/core/rawdb/table.go
@@ -101,6 +101,18 @@ func (t *table) TruncateTail(items uint64) (uint64, error) {
 	return t.db.TruncateTail(items)
 }
 
+// SoftTruncateHead is a noop passthrough that just forwards the request to the underlying
+// database.
+func (t *table) SoftTruncateHead(items uint64) (uint64, error) {
+	return t.db.SoftTruncateHead(items)
+}
+
+// CommitTruncation is a noop passthrough that just forwards the request to the underlying
+// database.
+func (t *table) CommitTruncation() error {
+	return t.db.CommitTruncation()
+}
+
 // SyncAncient is a noop passthrough that just forwards the request to the underlying
 // database.
 func (t *table) SyncAncient() error {

--- a/ethdb/database.go
+++ b/ethdb/database.go
@@ -163,6 +163,14 @@ type AncientWriter interface {
 	//
 	// Note that data marked as non-prunable will still be retained and remain accessible.
 	TruncateTail(n uint64) (uint64, error)
+
+	// SoftTruncateHead marks items above threshold as logically deleted without physical truncation.
+	// This is much faster than TruncateHead as it only updates a pointer.
+	SoftTruncateHead(n uint64) (uint64, error)
+
+	// CommitTruncation performs the actual file truncation to match any soft truncations.
+	// This should be called after all soft truncations are complete.
+	CommitTruncation() error
 }
 
 // AncientWriteOp is given to the function argument of ModifyAncients.

--- a/ethdb/remotedb/remotedb.go
+++ b/ethdb/remotedb/remotedb.go
@@ -140,6 +140,16 @@ func (db *Database) Close() error {
 	return nil
 }
 
+// SoftTruncateHead returns an error as we don't have a backing chain freezer.
+func (db *Database) SoftTruncateHead(items uint64) (uint64, error) {
+	panic("not supported")
+}
+
+// CommitTruncation returns an error as we don't have a backing chain freezer.
+func (db *Database) CommitTruncation() error {
+	panic("not supported")
+}
+
 func New(client *rpc.Client) ethdb.Database {
 	if client == nil {
 		return nil

--- a/triedb/database.go
+++ b/triedb/database.go
@@ -280,35 +280,15 @@ func (db *Database) Recover(target common.Hash) error {
 	return pdb.Recover(target)
 }
 
-// TruncateHead truncates all state histories in the freezer above the bottom state layer.
-// This operation is only supported by path-based database. It's typically used during
-// state recovery to align the state histories with the current state.
-func (db *Database) TruncateHead() error {
+// RecoverDone commits all pending soft truncations after a series of recovery operations.
+// This should be called after all recover operations are complete to finalize the state
+// freezer truncation in one efficient batch operation.
+func (db *Database) RecoverDone() error {
 	pdb, ok := db.backend.(*pathdb.Database)
 	if !ok {
 		return errors.New("not supported")
 	}
-	return pdb.TruncateHead()
-}
-
-// SoftTruncateHead marks state histories above the bottom state layer as logically deleted
-// without physical truncation. This is much faster than TruncateHead.
-func (db *Database) SoftTruncateHead() error {
-	pdb, ok := db.backend.(*pathdb.Database)
-	if !ok {
-		return errors.New("not supported")
-	}
-	return pdb.SoftTruncateHead()
-}
-
-// CommitTruncation performs the actual file truncation to match any soft truncations.
-// This should be called after all soft truncations are complete.
-func (db *Database) CommitTruncation() error {
-	pdb, ok := db.backend.(*pathdb.Database)
-	if !ok {
-		return errors.New("not supported")
-	}
-	return pdb.CommitTruncation()
+	return pdb.RecoverDone()
 }
 
 // Recoverable returns the indicator if the specified state is enabled to be

--- a/triedb/database.go
+++ b/triedb/database.go
@@ -280,6 +280,17 @@ func (db *Database) Recover(target common.Hash) error {
 	return pdb.Recover(target)
 }
 
+// TruncateHead truncates all state histories in the freezer above the bottom state layer.
+// This operation is only supported by path-based database It's typically used during
+// state recovery to align the state histories with the current state.
+func (db *Database) TruncateHead() error {
+	pdb, ok := db.backend.(*pathdb.Database)
+	if !ok {
+		return errors.New("not supported")
+	}
+	return pdb.TruncateHead()
+}
+
 // Recoverable returns the indicator if the specified state is enabled to be
 // recovered. It's only supported by path-based database and will return an
 // error for others.

--- a/triedb/database.go
+++ b/triedb/database.go
@@ -281,7 +281,7 @@ func (db *Database) Recover(target common.Hash) error {
 }
 
 // TruncateHead truncates all state histories in the freezer above the bottom state layer.
-// This operation is only supported by path-based database It's typically used during
+// This operation is only supported by path-based database. It's typically used during
 // state recovery to align the state histories with the current state.
 func (db *Database) TruncateHead() error {
 	pdb, ok := db.backend.(*pathdb.Database)

--- a/triedb/database.go
+++ b/triedb/database.go
@@ -291,6 +291,26 @@ func (db *Database) TruncateHead() error {
 	return pdb.TruncateHead()
 }
 
+// SoftTruncateHead marks state histories above the bottom state layer as logically deleted
+// without physical truncation. This is much faster than TruncateHead.
+func (db *Database) SoftTruncateHead() error {
+	pdb, ok := db.backend.(*pathdb.Database)
+	if !ok {
+		return errors.New("not supported")
+	}
+	return pdb.SoftTruncateHead()
+}
+
+// CommitTruncation performs the actual file truncation to match any soft truncations.
+// This should be called after all soft truncations are complete.
+func (db *Database) CommitTruncation() error {
+	pdb, ok := db.backend.(*pathdb.Database)
+	if !ok {
+		return errors.New("not supported")
+	}
+	return pdb.CommitTruncation()
+}
+
 // Recoverable returns the indicator if the specified state is enabled to be
 // recovered. It's only supported by path-based database and will return an
 // error for others.

--- a/triedb/pathdb/database.go
+++ b/triedb/pathdb/database.go
@@ -512,6 +512,19 @@ func (db *Database) TruncateHead() error {
 	return err
 }
 
+// SoftTruncateHead marks state histories above the bottom state layer as logically deleted
+// without physical truncation. This is much faster than TruncateHead.
+func (db *Database) SoftTruncateHead() error {
+	_, err := db.stateFreezer.SoftTruncateHead(db.tree.bottom().stateID())
+	return err
+}
+
+// CommitTruncation performs the actual file truncation to match any soft truncations.
+// This should be called after all soft truncations are complete.
+func (db *Database) CommitTruncation() error {
+	return db.stateFreezer.CommitTruncation()
+}
+
 // Recoverable returns the indicator if the specified state is recoverable.
 //
 // The supplied root must be a valid trie hash value.

--- a/triedb/pathdb/database.go
+++ b/triedb/pathdb/database.go
@@ -502,12 +502,14 @@ func (db *Database) Recover(root common.Hash) error {
 	if err := db.diskdb.SyncKeyValue(); err != nil {
 		return err
 	}
-	_, err := truncateFromHead(db.stateFreezer, dl.stateID())
-	if err != nil {
-		return err
-	}
 	log.Debug("Recovered state", "root", root, "elapsed", common.PrettyDuration(time.Since(start)))
 	return nil
+}
+
+// TruncateHead truncates all state histories in the freezer above the bottom state layer.
+func (db *Database) TruncateHead() error {
+	_, err := truncateFromHead(db.stateFreezer, db.tree.bottom().stateID())
+	return err
 }
 
 // Recoverable returns the indicator if the specified state is recoverable.

--- a/triedb/pathdb/database_test.go
+++ b/triedb/pathdb/database_test.go
@@ -600,17 +600,15 @@ func TestDatabaseRollback(t *testing.T) {
 		if err := tester.db.Recover(parent); err != nil {
 			t.Fatalf("Failed to revert db, err: %v", err)
 		}
-		if err := tester.db.SoftTruncateHead(); err != nil {
-			t.Fatalf("Failed to soft truncate head, err: %v", err)
-		}
-		if err := tester.db.CommitTruncation(); err != nil {
-			t.Fatalf("Failed to commit truncation, err: %v", err)
-		}
 		if i > 0 {
 			if err := tester.verifyState(parent); err != nil {
 				t.Fatalf("Failed to verify state, err: %v", err)
 			}
 		}
+	}
+	// Finalize all recovery operations
+	if err := tester.db.RecoverDone(); err != nil {
+		t.Fatalf("Failed to finalize recovery, err: %v", err)
 	}
 	if tester.db.tree.len() != 1 {
 		t.Fatal("Only disk layer is expected")

--- a/triedb/pathdb/database_test.go
+++ b/triedb/pathdb/database_test.go
@@ -600,6 +600,9 @@ func TestDatabaseRollback(t *testing.T) {
 		if err := tester.db.Recover(parent); err != nil {
 			t.Fatalf("Failed to revert db, err: %v", err)
 		}
+		if err := tester.db.TruncateHead(); err != nil {
+			t.Fatalf("Failed to truncate head, err: %v", err)
+		}
 		if i > 0 {
 			if err := tester.verifyState(parent); err != nil {
 				t.Fatalf("Failed to verify state, err: %v", err)

--- a/triedb/pathdb/database_test.go
+++ b/triedb/pathdb/database_test.go
@@ -600,8 +600,11 @@ func TestDatabaseRollback(t *testing.T) {
 		if err := tester.db.Recover(parent); err != nil {
 			t.Fatalf("Failed to revert db, err: %v", err)
 		}
-		if err := tester.db.TruncateHead(); err != nil {
-			t.Fatalf("Failed to truncate head, err: %v", err)
+		if err := tester.db.SoftTruncateHead(); err != nil {
+			t.Fatalf("Failed to soft truncate head, err: %v", err)
+		}
+		if err := tester.db.CommitTruncation(); err != nil {
+			t.Fatalf("Failed to commit truncation, err: %v", err)
 		}
 		if i > 0 {
 			if err := tester.verifyState(parent); err != nil {


### PR DESCRIPTION
closes https://github.com/ethereum/go-ethereum/issues/31829

I'm running the Hoodie testnet, and from some metrics of the rewinding procedure, I see that 14ms out of 20ms was used in the `truncateFromHead` operation. 
Therefore, I propose running the `truncateFromHead` operation periodically, instead of executing it for each block. 