### PR TITLE
core/state: improve the prefetcher concurrency allowance

### DIFF
--- a/core/state_prefetcher.go
+++ b/core/state_prefetcher.go
@@ -57,7 +57,7 @@ func (p *statePrefetcher) Prefetch(block *types.Block, statedb *state.StateDB, c
 		workers errgroup.Group
 		reader  = statedb.Reader()
 	)
-	workers.SetLimit(runtime.NumCPU() / 2)
+	workers.SetLimit(4 * runtime.NumCPU() / 5) // Aggressively run the prefetching
 
 	// Iterate over and process the individual transactions
 	for i, tx := range block.Transactions() {


### PR DESCRIPTION
Improve the prefetcher concurrency allowance.

Moved to its own PR from #31998, which adds the statistics.

Author: @rjl493456442