### PR TITLE
core/state: fix prefetch on single core CPU

### DIFF
--- a/core/state_prefetcher.go
+++ b/core/state_prefetcher.go
@@ -57,7 +57,7 @@ func (p *statePrefetcher) Prefetch(block *types.Block, statedb *state.StateDB, c
 		workers errgroup.Group
 		reader  = statedb.Reader()
 	)
-	workers.SetLimit(4 * runtime.NumCPU() / 5) // Aggressively run the prefetching
+	workers.SetLimit(max(1, 4*runtime.NumCPU()/5)) // Aggressively run the prefetching
 
 	// Iterate over and process the individual transactions
 	for i, tx := range block.Transactions() {


### PR DESCRIPTION
We need at least one prefetch goroutine. SetLimit(0) would block prefetch.