### PR TITLE
miner: default gaslimit 45M

### DIFF
--- a/miner/miner.go
+++ b/miner/miner.go
@@ -52,7 +52,7 @@ type Config struct {
 
 // DefaultConfig contains default settings for miner.
 var DefaultConfig = Config{
-	GasCeil:  36_000_000,
+	GasCeil:  45_000_000,
 	GasPrice: big.NewInt(params.GWei / 1000),
 
 	// The default recommit time is chosen as two seconds since


### PR DESCRIPTION
We believe it is safe to raise the gaslimit to 45M before the Fusaka fork. So this PR changes the default to 45M.