### PR TITLE
node: do not double-wrap KV stores

### DIFF
--- a/node/database.go
+++ b/node/database.go
@@ -109,7 +109,7 @@ func newLevelDBDatabase(file string, cache int, handles int, namespace string, r
 		return nil, err
 	}
 	log.Info("Using LevelDB as the backing database")
-	return rawdb.NewDatabase(db), nil
+	return db, nil
 }
 
 // newPebbleDBDatabase creates a persistent key-value database without a freezer
@@ -119,5 +119,5 @@ func newPebbleDBDatabase(file string, cache int, handles int, namespace string, 
 	if err != nil {
 		return nil, err
 	}
-	return rawdb.NewDatabase(db), nil
+	return db, nil
 }


### PR DESCRIPTION
For no apparent reason, KV stores were getting wrapped in `nofreezedb` first and then in `freezerdb`.