### PR TITLE
cmd/utils: fix formatting for beacon flag errors to fit Fatalf form

### DIFF
--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -1891,11 +1891,11 @@ func MakeBeaconLightConfig(ctx *cli.Context) bparams.ClientConfig {
 		if c, err := hexutil.Decode(ctx.String(BeaconGenesisRootFlag.Name)); err == nil && len(c) <= 32 {
 			copy(config.GenesisValidatorsRoot[:len(c)], c)
 		} else {
-			Fatalf("Invalid hex string", "beacon.genesis.gvroot", ctx.String(BeaconGenesisRootFlag.Name), "error", err)
+			Fatalf("Could not parse --%s: %v", BeaconGenesisRootFlag.Name, err)
 		}
 		configFile := ctx.String(BeaconConfigFlag.Name)
 		if err := config.ChainConfig.LoadForks(configFile); err != nil {
-			Fatalf("Could not load beacon chain config", "file", configFile, "error", err)
+			Fatalf("Could not load beacon chain config '%s': %v", configFile, err)
 		}
 		log.Info("Using custom beacon chain config", "file", configFile)
 	} else {
@@ -1912,17 +1912,17 @@ func MakeBeaconLightConfig(ctx *cli.Context) bparams.ClientConfig {
 	// are saved to the specified file.
 	if ctx.IsSet(BeaconCheckpointFileFlag.Name) {
 		if _, err := config.SetCheckpointFile(ctx.String(BeaconCheckpointFileFlag.Name)); err != nil {
-			Fatalf("Could not load beacon checkpoint file", "beacon.checkpoint.file", ctx.String(BeaconCheckpointFileFlag.Name), "error", err)
+			Fatalf("Could not load beacon checkpoint file '%s': %v", ctx.String(BeaconCheckpointFileFlag.Name), err)
 		}
 	}
 	if ctx.IsSet(BeaconCheckpointFlag.Name) {
 		hex := ctx.String(BeaconCheckpointFlag.Name)
 		c, err := hexutil.Decode(hex)
 		if err != nil {
-			Fatalf("Invalid hex string", "beacon.checkpoint", hex, "error", err)
+			Fatalf("Could not parse --%s: %v", BeaconCheckpointFlag.Name, err)
 		}
 		if len(c) != 32 {
-			Fatalf("Invalid hex string length", "beacon.checkpoint", hex, "length", len(c))
+			Fatalf("Could not parse --%s: invalid length %d, want 32", BeaconCheckpointFlag.Name, len(c))
 		}
 		copy(config.Checkpoint[:len(c)], c)
 	}


### PR DESCRIPTION
Noticed that the errors for the blsync flags were not formatted correctly for `Fatalf(..)`.