### PR TITLE
eth, triedb/pathdb: permit write buffer allowance in PBSS archive mode

### DIFF
--- a/eth/backend.go
+++ b/eth/backend.go
@@ -140,7 +140,7 @@ func New(stack *node.Node, config *ethconfig.Config) (*Ethereum, error) {
 		log.Warn("Sanitizing invalid miner gas price", "provided", config.Miner.GasPrice, "updated", ethconfig.Defaults.Miner.GasPrice)
 		config.Miner.GasPrice = new(big.Int).Set(ethconfig.Defaults.Miner.GasPrice)
 	}
-	if config.NoPruning && config.TrieDirtyCache > 0 {
+	if config.NoPruning && config.TrieDirtyCache > 0 && config.StateScheme == rawdb.HashScheme {
 		if config.SnapshotCache > 0 {
 			config.TrieCleanCache += config.TrieDirtyCache * 3 / 5
 			config.SnapshotCache += config.TrieDirtyCache * 2 / 5

--- a/triedb/pathdb/history_indexer.go
+++ b/triedb/pathdb/history_indexer.go
@@ -224,9 +224,10 @@ func (b *batchIndexer) finish(force bool) error {
 
 // indexSingle processes the state history with the specified ID for indexing.
 func indexSingle(historyID uint64, db ethdb.KeyValueStore, freezer ethdb.AncientReader) error {
-	defer func(start time.Time) {
+	start := time.Now()
+	defer func() {
 		indexHistoryTimer.UpdateSince(start)
-	}(time.Now())
+	}()
 
 	metadata := loadIndexMetadata(db)
 	if metadata == nil || metadata.Last+1 != historyID {
@@ -247,15 +248,16 @@ func indexSingle(historyID uint64, db ethdb.KeyValueStore, freezer ethdb.Ancient
 	if err := b.finish(true); err != nil {
 		return err
 	}
-	log.Debug("Indexed state history", "id", historyID)
+	log.Info("Indexed state history", "id", historyID, "elapsed", common.PrettyDuration(time.Since(start)))
 	return nil
 }
 
 // unindexSingle processes the state history with the specified ID for unindexing.
 func unindexSingle(historyID uint64, db ethdb.KeyValueStore, freezer ethdb.AncientReader) error {
-	defer func(start time.Time) {
+	start := time.Now()
+	defer func() {
 		unindexHistoryTimer.UpdateSince(start)
-	}(time.Now())
+	}()
 
 	metadata := loadIndexMetadata(db)
 	if metadata == nil || metadata.Last != historyID {
@@ -276,7 +278,7 @@ func unindexSingle(historyID uint64, db ethdb.KeyValueStore, freezer ethdb.Ancie
 	if err := b.finish(true); err != nil {
 		return err
 	}
-	log.Debug("Unindexed state history", "id", historyID)
+	log.Debug("Unindexed state history", "id", historyID, "elapsed", common.PrettyDuration(time.Since(start)))
 	return nil
 }
 


### PR DESCRIPTION
This pull request fixes a flaw in PBSS archive mode that significantly degrades performance
when the mode is enabled.

Originally, in hash mode, the dirty trie cache is completely disabled when archive mode is 
active, in order to disable the in-memory garbage collection mechanism. However, the internal 
logic in path mode differs significantly, and the dirty trie node cache is essential for maintaining 
chain insertion performance. Therefore, the cache is now retained in path mode.