### PR TITLE
triedb/pathdb: fix journal resolution in pathdb

### DIFF
--- a/triedb/pathdb/states.go
+++ b/triedb/pathdb/states.go
@@ -387,13 +387,8 @@ func (s *stateSet) decode(r *rlp.Stream) error {
 	if err := r.Decode(&dec); err != nil {
 		return fmt.Errorf("load diff accounts: %v", err)
 	}
-	for i := 0; i < len(dec.AddrHashes); i++ {
-		if len(dec.Accounts[i]) > 0 {
-			accountSet[dec.AddrHashes[i]] = dec.Accounts[i]
-		} else {
-			// RLP loses nil-ness, but `[]byte{}` is not a valid item, so reinterpret that
-			accountSet[dec.AddrHashes[i]] = nil
-		}
+	for i := range dec.AddrHashes {
+		accountSet[dec.AddrHashes[i]] = empty2nil(dec.Accounts[i])
 	}
 	s.accountData = accountSet
 
@@ -412,13 +407,8 @@ func (s *stateSet) decode(r *rlp.Stream) error {
 	}
 	for _, entry := range storages {
 		storageSet[entry.AddrHash] = make(map[common.Hash][]byte, len(entry.Keys))
-		for i := 0; i < len(entry.Keys); i++ {
-			if len(entry.Vals[i]) > 0 {
-				storageSet[entry.AddrHash][entry.Keys[i]] = entry.Vals[i]
-			} else {
-				// RLP loses nil-ness, but `[]byte{}` is not a valid item, so reinterpret that
-				storageSet[entry.AddrHash][entry.Keys[i]] = nil
-			}
+		for i := range entry.Keys {
+			storageSet[entry.AddrHash][entry.Keys[i]] = empty2nil(entry.Vals[i])
 		}
 	}
 	s.storageData = storageSet
@@ -560,13 +550,8 @@ func (s *StateSetWithOrigin) decode(r *rlp.Stream) error {
 	if err := r.Decode(&accounts); err != nil {
 		return fmt.Errorf("load diff account origin set: %v", err)
 	}
-	for i := 0; i < len(accounts.Accounts); i++ {
-		if len(accounts.Accounts[i]) > 0 {
-			accountSet[accounts.Addresses[i]] = accounts.Accounts[i]
-		} else {
-			// RLP loses nil-ness, but `[]byte{}` is not a valid item, so reinterpret that
-			accountSet[accounts.Addresses[i]] = nil
-		}
+	for i := range accounts.Accounts {
+		accountSet[accounts.Addresses[i]] = empty2nil(accounts.Accounts[i])
 	}
 	s.accountOrigin = accountSet
 
@@ -585,15 +570,17 @@ func (s *StateSetWithOrigin) decode(r *rlp.Stream) error {
 	}
 	for _, storage := range storages {
 		storageSet[storage.Address] = make(map[common.Hash][]byte)
-		for i := 0; i < len(storage.Keys); i++ {
-			if len(storage.Vals[i]) > 0 {
-				storageSet[storage.Address][storage.Keys[i]] = storage.Vals[i]
-			} else {
-				// RLP loses nil-ness, but `[]byte{}` is not a valid item, so reinterpret that
-				storageSet[storage.Address][storage.Keys[i]] = nil
-			}
+		for i := range storage.Keys {
+			storageSet[storage.Address][storage.Keys[i]] = empty2nil(storage.Vals[i])
 		}
 	}
 	s.storageOrigin = storageSet
 	return nil
+}
+
+func empty2nil(b []byte) []byte {
+    if len(b) == 0 {
+	return nil
+    }
+    return b
 }

--- a/triedb/pathdb/states.go
+++ b/triedb/pathdb/states.go
@@ -579,8 +579,8 @@ func (s *StateSetWithOrigin) decode(r *rlp.Stream) error {
 }
 
 func empty2nil(b []byte) []byte {
-    if len(b) == 0 {
-	return nil
-    }
-    return b
+	if len(b) == 0 {
+		return nil
+	}
+	return b
 }

--- a/triedb/pathdb/states.go
+++ b/triedb/pathdb/states.go
@@ -388,7 +388,12 @@ func (s *stateSet) decode(r *rlp.Stream) error {
 		return fmt.Errorf("load diff accounts: %v", err)
 	}
 	for i := 0; i < len(dec.AddrHashes); i++ {
-		accountSet[dec.AddrHashes[i]] = dec.Accounts[i]
+		if len(dec.Accounts[i]) > 0 {
+			accountSet[dec.AddrHashes[i]] = dec.Accounts[i]
+		} else {
+			// RLP loses nil-ness, but `[]byte{}` is not a valid item, so reinterpret that
+			accountSet[dec.AddrHashes[i]] = nil
+		}
 	}
 	s.accountData = accountSet
 
@@ -408,7 +413,12 @@ func (s *stateSet) decode(r *rlp.Stream) error {
 	for _, entry := range storages {
 		storageSet[entry.AddrHash] = make(map[common.Hash][]byte, len(entry.Keys))
 		for i := 0; i < len(entry.Keys); i++ {
-			storageSet[entry.AddrHash][entry.Keys[i]] = entry.Vals[i]
+			if len(entry.Vals[i]) > 0 {
+				storageSet[entry.AddrHash][entry.Keys[i]] = entry.Vals[i]
+			} else {
+				// RLP loses nil-ness, but `[]byte{}` is not a valid item, so reinterpret that
+				storageSet[entry.AddrHash][entry.Keys[i]] = nil
+			}
 		}
 	}
 	s.storageData = storageSet
@@ -551,7 +561,12 @@ func (s *StateSetWithOrigin) decode(r *rlp.Stream) error {
 		return fmt.Errorf("load diff account origin set: %v", err)
 	}
 	for i := 0; i < len(accounts.Accounts); i++ {
-		accountSet[accounts.Addresses[i]] = accounts.Accounts[i]
+		if len(accounts.Accounts[i]) > 0 {
+			accountSet[accounts.Addresses[i]] = accounts.Accounts[i]
+		} else {
+			// RLP loses nil-ness, but `[]byte{}` is not a valid item, so reinterpret that
+			accountSet[accounts.Addresses[i]] = nil
+		}
 	}
 	s.accountOrigin = accountSet
 
@@ -571,7 +586,12 @@ func (s *StateSetWithOrigin) decode(r *rlp.Stream) error {
 	for _, storage := range storages {
 		storageSet[storage.Address] = make(map[common.Hash][]byte)
 		for i := 0; i < len(storage.Keys); i++ {
-			storageSet[storage.Address][storage.Keys[i]] = storage.Vals[i]
+			if len(storage.Vals[i]) > 0 {
+				storageSet[storage.Address][storage.Keys[i]] = storage.Vals[i]
+			} else {
+				// RLP loses nil-ness, but `[]byte{}` is not a valid item, so reinterpret that
+				storageSet[storage.Address][storage.Keys[i]] = nil
+			}
 		}
 	}
 	s.storageOrigin = storageSet


### PR DESCRIPTION
This pull request fixes a flaw in the PBSS state iterator, which could return empty 
account or storage data.

In PBSS, multiple in-memory diff layers and a write buffer are maintained. These 
layers are persisted to the database and reloaded after node restarts. However, 
since the state data is encoded using RLP, the distinction between nil and an empty 
byte slice is lost during the encode/decode process. As a result, invalid state values 
such as `[]byte{}` can appear in PBSS and ultimately be returned by the state iterator.

Checkout https://github.com/ethereum/go-ethereum/blob/master/triedb/pathdb/iterator_fast.go#L270
for more iterator details.

It's a long-term existent issue and now be activated since the snapshot integration.
The error `err="range contains deletion"` will occur when Geth tries to serve other
peers with SNAP protocol request.