### PR TITLE
eth/downloader: fix downloader cancel

### DIFF
--- a/eth/downloader/downloader.go
+++ b/eth/downloader/downloader.go
@@ -630,15 +630,18 @@ func (d *Downloader) cancel() {
 // Cancel aborts all of the operations and waits for all download goroutines to
 // finish before returning.
 func (d *Downloader) Cancel() {
-	d.blockchain.InterruptInsert(true)
 	d.cancel()
 	d.cancelWg.Wait()
-	d.blockchain.InterruptInsert(false)
 }
 
 // Terminate interrupts the downloader, canceling all pending operations.
 // The downloader cannot be reused after calling Terminate.
 func (d *Downloader) Terminate() {
+	// Terminates chain insertion, which may result in an "aborted" error in
+	// the blockchain and ultimately lead to the corresponding peer being
+	// disconnected. This is acceptable behavior during Geth shutdown.
+	d.blockchain.InterruptInsert(true)
+
 	// Close the termination channel (make sure double close is allowed)
 	d.quitLock.Lock()
 	select {


### PR DESCRIPTION
This PR reverts the changes brought by https://github.com/ethereum/go-ethereum/pull/32067

Previously, the chain insertion will always be interrupted once the `downloader.Cancel` is called.
Unfortunately, the `aborted` error from Blockchain will be propagated and ultimately leading to
the corresponding peer serving this chain segment being dropped.

Therefore, this PR reverts the behavioral changes and only interrupt the chain insertion when
tearing down Geth. The `debug_setHead` needs to be improved with better solution.