### PR TITLE
cmd/utils: don't alter the txlookup limit in archive node

### DIFF
--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -1634,9 +1634,11 @@ func SetEthConfig(ctx *cli.Context, stack *node.Node, cfg *ethconfig.Config) {
 	}
 	// Read the value from the flag no matter if it's set or not.
 	cfg.Preimages = ctx.Bool(CachePreimagesFlag.Name)
-	if cfg.NoPruning && !cfg.Preimages {
+	// Only check the user's input for hash mode here; path is the default scheme,
+	// so we don't need to check the actual database scheme.
+	if cfg.NoPruning && !cfg.Preimages && ctx.String(StateSchemeFlag.Name) == rawdb.HashScheme {
 		cfg.Preimages = true
-		log.Info("Enabling recording of key preimages since archive mode is used")
+		log.Info("Enabling recording of key preimages: required for archive mode with hash state scheme")
 	}
 	if ctx.IsSet(StateHistoryFlag.Name) {
 		cfg.StateHistory = ctx.Uint64(StateHistoryFlag.Name)

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -1656,18 +1656,11 @@ func SetEthConfig(ctx *cli.Context, stack *node.Node, cfg *ethconfig.Config) {
 		log.Warn("The flag --txlookuplimit is deprecated and will be removed, please use --history.transactions")
 		cfg.TransactionHistory = ctx.Uint64(TxLookupLimitFlag.Name)
 	}
-
-	if ctx.String(GCModeFlag.Name) == "archive" && cfg.TransactionHistory != 0 && ctx.IsSet(DataDirFlag.Name) {
-		chaindb := tryMakeReadOnlyDatabase(ctx, stack)
-		scheme, err := rawdb.ParseStateScheme(cfg.StateScheme, chaindb)
-		if err != nil {
-			Fatalf("%v", err)
-		}
-		if scheme == rawdb.HashScheme {
+	if ctx.String(GCModeFlag.Name) == "archive" {
+		if cfg.TransactionHistory != 0 {
 			cfg.TransactionHistory = 0
-			log.Warn("Disabled transaction unindexing for archive node with hash state scheme")
+			log.Warn("Disabled transaction unindexing for archive node")
 		}
-		chaindb.Close()
 	}
 	if ctx.IsSet(LogHistoryFlag.Name) {
 		cfg.LogHistory = ctx.Uint64(LogHistoryFlag.Name)

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -1634,11 +1634,9 @@ func SetEthConfig(ctx *cli.Context, stack *node.Node, cfg *ethconfig.Config) {
 	}
 	// Read the value from the flag no matter if it's set or not.
 	cfg.Preimages = ctx.Bool(CachePreimagesFlag.Name)
-	// Only check the user's input for hash mode here; path is the default scheme,
-	// so we don't need to check the actual database scheme.
-	if cfg.NoPruning && !cfg.Preimages && ctx.String(StateSchemeFlag.Name) == rawdb.HashScheme {
+	if cfg.NoPruning && !cfg.Preimages {
 		cfg.Preimages = true
-		log.Info("Enabling recording of key preimages: required for archive mode with hash state scheme")
+		log.Info("Enabling recording of key preimages since archive mode is used")
 	}
 	if ctx.IsSet(StateHistoryFlag.Name) {
 		cfg.StateHistory = ctx.Uint64(StateHistoryFlag.Name)

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -1656,12 +1656,6 @@ func SetEthConfig(ctx *cli.Context, stack *node.Node, cfg *ethconfig.Config) {
 		log.Warn("The flag --txlookuplimit is deprecated and will be removed, please use --history.transactions")
 		cfg.TransactionHistory = ctx.Uint64(TxLookupLimitFlag.Name)
 	}
-	if ctx.String(GCModeFlag.Name) == "archive" {
-		if cfg.TransactionHistory != 0 {
-			cfg.TransactionHistory = 0
-			log.Warn("Disabled transaction unindexing for archive node")
-		}
-	}
 	if ctx.IsSet(LogHistoryFlag.Name) {
 		cfg.LogHistory = ctx.Uint64(LogHistoryFlag.Name)
 	}

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -1656,11 +1656,18 @@ func SetEthConfig(ctx *cli.Context, stack *node.Node, cfg *ethconfig.Config) {
 		log.Warn("The flag --txlookuplimit is deprecated and will be removed, please use --history.transactions")
 		cfg.TransactionHistory = ctx.Uint64(TxLookupLimitFlag.Name)
 	}
-	if ctx.String(GCModeFlag.Name) == "archive" {
-		if cfg.TransactionHistory != 0 {
-			cfg.TransactionHistory = 0
-			log.Warn("Disabled transaction unindexing for archive node")
+
+	if ctx.String(GCModeFlag.Name) == "archive" && cfg.TransactionHistory != 0 && ctx.IsSet(DataDirFlag.Name) {
+		chaindb := tryMakeReadOnlyDatabase(ctx, stack)
+		scheme, err := rawdb.ParseStateScheme(cfg.StateScheme, chaindb)
+		if err != nil {
+			Fatalf("%v", err)
 		}
+		if scheme == rawdb.HashScheme {
+			cfg.TransactionHistory = 0
+			log.Warn("Disabled transaction unindexing for archive node with hash state scheme")
+		}
+		chaindb.Close()
 	}
 	if ctx.IsSet(LogHistoryFlag.Name) {
 		cfg.LogHistory = ctx.Uint64(LogHistoryFlag.Name)

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -1632,6 +1632,15 @@ func SetEthConfig(ctx *cli.Context, stack *node.Node, cfg *ethconfig.Config) {
 	if ctx.IsSet(CacheNoPrefetchFlag.Name) {
 		cfg.NoPrefetch = ctx.Bool(CacheNoPrefetchFlag.Name)
 	}
+	if ctx.IsSet(DataDirFlag.Name) {
+		chaindb := tryMakeReadOnlyDatabase(ctx, stack)
+		scheme, err := rawdb.ParseStateScheme(ctx.String(StateSchemeFlag.Name), chaindb)
+		if err != nil {
+			Fatalf("%v", err)
+		}
+		cfg.StateScheme = scheme
+		chaindb.Close()
+	}
 	// Read the value from the flag no matter if it's set or not.
 	cfg.Preimages = ctx.Bool(CachePreimagesFlag.Name)
 	if cfg.NoPruning && !cfg.Preimages {
@@ -1640,9 +1649,6 @@ func SetEthConfig(ctx *cli.Context, stack *node.Node, cfg *ethconfig.Config) {
 	}
 	if ctx.IsSet(StateHistoryFlag.Name) {
 		cfg.StateHistory = ctx.Uint64(StateHistoryFlag.Name)
-	}
-	if ctx.IsSet(StateSchemeFlag.Name) {
-		cfg.StateScheme = ctx.String(StateSchemeFlag.Name)
 	}
 	// Parse transaction history flag, if user is still using legacy config
 	// file with 'TxLookupLimit' configured, copy the value to 'TransactionHistory'.
@@ -1657,17 +1663,9 @@ func SetEthConfig(ctx *cli.Context, stack *node.Node, cfg *ethconfig.Config) {
 		cfg.TransactionHistory = ctx.Uint64(TxLookupLimitFlag.Name)
 	}
 
-	if ctx.String(GCModeFlag.Name) == "archive" && cfg.TransactionHistory != 0 && ctx.IsSet(DataDirFlag.Name) {
-		chaindb := tryMakeReadOnlyDatabase(ctx, stack)
-		scheme, err := rawdb.ParseStateScheme(cfg.StateScheme, chaindb)
-		if err != nil {
-			Fatalf("%v", err)
-		}
-		if scheme == rawdb.HashScheme {
-			cfg.TransactionHistory = 0
-			log.Warn("Disabled transaction unindexing for archive node with hash state scheme")
-		}
-		chaindb.Close()
+	if ctx.String(GCModeFlag.Name) == "archive" && cfg.TransactionHistory != 0 && cfg.StateScheme == rawdb.HashScheme {
+		cfg.TransactionHistory = 0
+		log.Warn("Disabled transaction unindexing for archive node with hash state scheme")
 	}
 	if ctx.IsSet(LogHistoryFlag.Name) {
 		cfg.LogHistory = ctx.Uint64(LogHistoryFlag.Name)
@@ -2206,9 +2204,9 @@ func MakeChain(ctx *cli.Context, stack *node.Node, readonly bool) (*core.BlockCh
 		// Disable transaction indexing/unindexing.
 		TxLookupLimit: -1,
 	}
-	if options.ArchiveMode && !options.Preimages {
+	if options.ArchiveMode && !options.Preimages && scheme == rawdb.HashScheme {
 		options.Preimages = true
-		log.Info("Enabling recording of key preimages since archive mode is used")
+		log.Info("Enabling recording of key preimages since archive mode is used in hash state scheme")
 	}
 	if !ctx.Bool(SnapshotFlag.Name) {
 		options.SnapshotLimit = 0 // Disabled


### PR DESCRIPTION
I'm running with pbss archive node, from the logs I see the preimage and full tx indexing is enabled:

```
INFO [06-27|01:08:48.495] Using pebble as db engine
INFO [06-27|01:08:48.508] Enabling recording of key preimages since archive mode is used
WARN [06-27|01:08:48.509] Disabled transaction unindexing for archive node
```


As pbss archive node is based on `history.state`, no need to run full indexing in archive mode