### PR TITLE
triedb: reset state indexer after snap synced

### DIFF
--- a/triedb/pathdb/database.go
+++ b/triedb/pathdb/database.go
@@ -512,6 +512,8 @@ func (db *Database) Enable(root common.Hash) error {
 		if err := db.freezer.Reset(); err != nil {
 			return err
 		}
+		// Reset the state history indexer
+		storeIndexMetadata(db.diskdb, 0)
 	}
 	// Re-enable the database as the final step.
 	db.waitSync = false

--- a/triedb/pathdb/database.go
+++ b/triedb/pathdb/database.go
@@ -512,8 +512,6 @@ func (db *Database) Enable(root common.Hash) error {
 		if err := db.freezer.Reset(); err != nil {
 			return err
 		}
-		// Reset the state history indexer
-		storeIndexMetadata(db.diskdb, 0)
 	}
 	// Re-enable the database as the final step.
 	db.waitSync = false

--- a/triedb/pathdb/database.go
+++ b/triedb/pathdb/database.go
@@ -520,6 +520,17 @@ func (db *Database) Enable(root common.Hash) error {
 	// Re-construct a new disk layer backed by persistent state
 	// and schedule the state snapshot generation if it's permitted.
 	db.tree.init(generateSnapshot(db, root, db.isVerkle || db.config.SnapshotNoBuild))
+
+	// After snap sync, the state of the database may have changed completely.
+	// To ensure the history indexer always matches the current state, we must:
+	//   1. Close any existing indexer
+	//   2. Re-initialize the indexer so it starts indexing from the new state root.
+	if db.indexer != nil && db.freezer != nil && db.config.EnableStateIndexing {
+		db.indexer.close()
+		db.indexer = newHistoryIndexer(db.diskdb, db.freezer, db.tree.bottom().stateID())
+		log.Info("Enabled state history indexing (after snap sync)")
+	}
+
 	log.Info("Rebuilt trie database", "root", root)
 	return nil
 }

--- a/triedb/pathdb/database.go
+++ b/triedb/pathdb/database.go
@@ -528,9 +528,8 @@ func (db *Database) Enable(root common.Hash) error {
 	if db.indexer != nil && db.freezer != nil && db.config.EnableStateIndexing {
 		db.indexer.close()
 		db.indexer = newHistoryIndexer(db.diskdb, db.freezer, db.tree.bottom().stateID())
-		log.Info("Enabled state history indexing (after snap sync)")
+		log.Info("Re-enabled state history indexing")
 	}
-
 	log.Info("Rebuilt trie database", "root", root)
 	return nil
 }

--- a/triedb/pathdb/history_indexer.go
+++ b/triedb/pathdb/history_indexer.go
@@ -494,7 +494,18 @@ func (i *indexIniter) index(done chan struct{}, interrupt *atomic.Int32, lastID 
 	// when the state is reverted manually (chain.SetHead) or the deep reorg is
 	// encountered. In such cases, no indexing should be scheduled.
 	if beginID > lastID {
-		log.Debug("State history is fully indexed", "last", lastID)
+		if lastID == 0 && beginID == 1 {
+			// Initialize the indexing flag if the state history is empty by
+			// using zero as the disk layer ID. This is a common case that
+			// can occur after snap sync.
+			//
+			// This step is essential to avoid spinning up indexing thread
+			// endlessly until a history object is produced.
+			storeIndexMetadata(i.disk, 0)
+			log.Info("Initialized history indexing flag")
+		} else {
+			log.Debug("State history is fully indexed", "last", lastID)
+		}
 		return
 	}
 	log.Info("Start history indexing", "beginID", beginID, "lastID", lastID)

--- a/triedb/pathdb/history_indexer.go
+++ b/triedb/pathdb/history_indexer.go
@@ -49,10 +49,7 @@ type indexMetadata struct {
 func loadIndexMetadata(db ethdb.KeyValueReader) *indexMetadata {
 	blob := rawdb.ReadStateHistoryIndexMetadata(db)
 	if len(blob) == 0 {
-		return &indexMetadata{
-			Version: stateIndexVersion,
-			Last:    0,
-		}
+		return nil
 	}
 	var m indexMetadata
 	if err := rlp.DecodeBytes(blob, &m); err != nil {

--- a/triedb/pathdb/history_indexer.go
+++ b/triedb/pathdb/history_indexer.go
@@ -49,7 +49,10 @@ type indexMetadata struct {
 func loadIndexMetadata(db ethdb.KeyValueReader) *indexMetadata {
 	blob := rawdb.ReadStateHistoryIndexMetadata(db)
 	if len(blob) == 0 {
-		return nil
+		return &indexMetadata{
+			Version: stateIndexVersion,
+			Last:    0,
+		}
 	}
 	var m indexMetadata
 	if err := rlp.DecodeBytes(blob, &m); err != nil {


### PR DESCRIPTION
Running geth on hoodi network with path archive node, with the below command:

```bash
--hoodi
--gcmode=archive
--db.engine=pebble
--datadir=/data
--port=30303
--http
--http.addr=0.0.0.0
--http.port=8545
--http.vhosts=*
--http.corsdomain=*
--http.api=engine,web3,eth,net,miner,txpool,debug,admin
--authrpc.addr=0.0.0.0
--authrpc.port=8551
--authrpc.vhosts=*
--authrpc.jwtsecret=/jwt/jwt.hex
```

This datadir was copied from another instance, only the chaindb/ancient directory was retained, and the data of other kvdb was deleted, so geth will download the statedb data again, and after downloading and repairing the snapshot, the following problem occurred:

```
NewPayload: inserting block failed       error="history indexing is out of order, last: null, requested: 1"
```

Not sure if we have saved the `last: 0` state index into db or not, so here we return the default value if not found.