### PR TITLE
core: skip parsing L1MessageTxType

### DIFF
--- a/core/types/transaction.go
+++ b/core/types/transaction.go
@@ -31,15 +31,16 @@ import (
 )
 
 var (
-	ErrInvalidSig           = errors.New("invalid transaction v, r, s values")
-	ErrUnexpectedProtection = errors.New("transaction type does not supported EIP-155 protected signatures")
-	ErrInvalidTxType        = errors.New("transaction type not valid in this context")
-	ErrTxTypeNotSupported   = errors.New("transaction type not supported")
-	ErrGasFeeCapTooLow      = errors.New("fee cap less than base fee")
-	errShortTypedTx         = errors.New("typed transaction too short")
-	errInvalidYParity       = errors.New("'yParity' field must be 0 or 1")
-	errVYParityMismatch     = errors.New("'v' and 'yParity' fields do not match")
-	errVYParityMissing      = errors.New("missing 'yParity' or 'v' field in transaction")
+	ErrInvalidSig                  = errors.New("invalid transaction v, r, s values")
+	ErrUnexpectedProtection        = errors.New("transaction type does not supported EIP-155 protected signatures")
+	ErrInvalidTxType               = errors.New("transaction type not valid in this context")
+	ErrTxTypeNotSupported          = errors.New("transaction type not supported")
+	ErrL1MessageTxTypeNotSupported = errors.New("l1 message transaction type not supported")
+	ErrGasFeeCapTooLow             = errors.New("fee cap less than base fee")
+	errShortTypedTx                = errors.New("typed transaction too short")
+	errInvalidYParity              = errors.New("'yParity' field must be 0 or 1")
+	errVYParityMismatch            = errors.New("'v' and 'yParity' fields do not match")
+	errVYParityMissing             = errors.New("missing 'yParity' or 'v' field in transaction")
 )
 
 // Transaction types.

--- a/core/types/transaction.go
+++ b/core/types/transaction.go
@@ -49,6 +49,7 @@ const (
 	DynamicFeeTxType = 0x02
 	BlobTxType       = 0x03
 	SetCodeTxType    = 0x04
+	L1MessageTxType  = 0x7e
 )
 
 // Transaction is an Ethereum transaction.

--- a/core/types/transaction_marshalling.go
+++ b/core/types/transaction_marshalling.go
@@ -508,7 +508,7 @@ func (tx *Transaction) UnmarshalJSON(input []byte) error {
 		}
 
 	case L1MessageTxType:
-		return nil
+		return ErrL1MessageTxTypeNotSupported
 
 	default:
 		return ErrTxTypeNotSupported

--- a/core/types/transaction_marshalling.go
+++ b/core/types/transaction_marshalling.go
@@ -507,6 +507,9 @@ func (tx *Transaction) UnmarshalJSON(input []byte) error {
 			}
 		}
 
+	case L1MessageTxType:
+		return nil
+
 	default:
 		return ErrTxTypeNotSupported
 	}


### PR DESCRIPTION
fixes #32113 

This makes sure `BlockByNumber` works on any L2 network.