### PR TITLE
.gitea: switch release builds to static linking

### DIFF
--- a/.gitea/workflows/release.yml
+++ b/.gitea/workflows/release.yml
@@ -25,7 +25,7 @@ jobs:
 
     - name: Build (amd64)
       run: |
-        go run build/ci.go install -arch amd64 -dlgo
+        go run build/ci.go install -static -arch amd64 -dlgo
 
     - name: Create/upload archive (amd64)
       run: |
@@ -37,11 +37,11 @@ jobs:
 
     - name: Build (386)
       run: |
-        go run build/ci.go install -arch 386 -dlgo
+        go run build/ci.go install -static -arch 386 -dlgo
 
     - name: Create/upload archive (386)
       run: |
-        go run build/ci.go archive -arch 386 -type tar -signer LINUX_SIGNING_KEY -upload gethstore/builds
+        go run build/ci.go archive -static -arch 386 -type tar -signer LINUX_SIGNING_KEY -upload gethstore/builds
         rm -f build/bin/*
       env:
         LINUX_SIGNING_KEY: ${{ secrets.LINUX_SIGNING_KEY }}
@@ -67,7 +67,7 @@ jobs:
 
     - name: Build (arm64)
       run: |
-        go run build/ci.go install -dlgo -arch arm64 -cc aarch64-linux-gnu-gcc
+        go run build/ci.go install -static -dlgo -arch arm64 -cc aarch64-linux-gnu-gcc
 
     - name: Create/upload archive (arm64)
       run: |
@@ -79,7 +79,7 @@ jobs:
 
     - name: Run build (arm5)
       run: |
-        go run build/ci.go install -dlgo -arch arm -cc arm-linux-gnueabi-gcc
+        go run build/ci.go install -static -dlgo -arch arm -cc arm-linux-gnueabi-gcc
       env:
         GOARM: "5"
 
@@ -93,7 +93,7 @@ jobs:
 
     - name: Run build (arm6)
       run: |
-        go run build/ci.go install -dlgo -arch arm -cc arm-linux-gnueabi-gcc
+        go run build/ci.go install -static -dlgo -arch arm -cc arm-linux-gnueabi-gcc
       env:
         GOARM: "6"
 
@@ -108,7 +108,7 @@ jobs:
 
     - name: Run build (arm7)
       run: |
-        go run build/ci.go install -dlgo -arch arm -cc arm-linux-gnueabi-gcc
+        go run build/ci.go install -static -dlgo -arch arm -cc arm-linux-gnueabi-gcc
       env:
         GOARM: "7"
 


### PR DESCRIPTION
This is to avoid compatibility issues with mismatched glibc versions between the builder and deployment target.

Fixes #32102 