### PR TITLE
cmd/geth: update vcheck testdata, add docs on generating signatures

### DIFF
--- a/cmd/geth/testdata/vcheck/data.json
+++ b/cmd/geth/testdata/vcheck/data.json
@@ -6,7 +6,7 @@
     "description": "A mining flaw could cause miners to erroneously calculate PoW, due to an index overflow, if DAG size is exceeding the maximum 32 bit unsigned value.\n\nThis occurred on the ETC chain on 2020-11-06. This is likely to trigger for ETH mainnet around block `11550000`/epoch `385`, slated to occur early January 2021.\n\nThis issue is relevant only for miners, non-mining nodes are unaffected, since non-mining nodes use a smaller verification cache instead of a full DAG.",
     "links": [
       "https://github.com/ethereum/go-ethereum/pull/21793",
-      "https://blog.ethereum.org/2020/11/12/geth_security_release/",
+      "https://blog.ethereum.org/2020/11/12/geth-security-release",
       "https://github.com/ethereum/go-ethereum/commit/567d41d9363706b4b13ce0903804e8acf214af49"
     ],
     "introduced": "v1.6.0",
@@ -21,7 +21,7 @@
     "summary": "A denial-of-service issue can be used to crash Geth nodes during block processing, due to an underlying bug in Go (CVE-2020-28362) versions < `1.15.5`, or `<1.14.12`",
     "description": "The DoS issue can be used to crash all Geth nodes during block processing, the effects of which would be that a major part of the Ethereum network went offline.\n\nOutside of Go-Ethereum, the issue is most likely relevant for all forks of Geth (such as TurboGeth or ETC’s core-geth) which is built with versions of Go which contains the vulnerability.",
     "links": [
-      "https://blog.ethereum.org/2020/11/12/geth_security_release/",
+      "https://blog.ethereum.org/2020/11/12/geth-security-release",
       "https://groups.google.com/g/golang-announce/c/NpBGTTmKzpM",
       "https://github.com/golang/go/issues/42552"
     ],
@@ -36,7 +36,7 @@
     "summary": "A consensus flaw in Geth, related to `datacopy` precompile",
     "description": "Geth erroneously performed a 'shallow' copy when the precompiled `datacopy` (at `0x00...04`) was invoked. An attacker could deploy a contract that uses the shallow copy to corrupt the contents of the `RETURNDATA`, thus causing a consensus failure.",
     "links": [
-      "https://blog.ethereum.org/2020/11/12/geth_security_release/"
+      "https://blog.ethereum.org/2020/11/12/geth-security-release"
     ],
     "introduced": "v1.9.7",
     "fixed": "v1.9.17",
@@ -50,7 +50,7 @@
     "summary": "A denial-of-service issue can be used to crash Geth nodes during block processing",
     "description": "Full details to be disclosed at a later date",
     "links": [
-      "https://blog.ethereum.org/2020/11/12/geth_security_release/"
+      "https://blog.ethereum.org/2020/11/12/geth-security-release"
     ],
     "introduced": "v1.9.16",
     "fixed": "v1.9.18",

--- a/cmd/geth/testdata/vcheck/data.json
+++ b/cmd/geth/testdata/vcheck/data.json
@@ -7,27 +7,32 @@
     "links": [
       "https://github.com/ethereum/go-ethereum/pull/21793",
       "https://blog.ethereum.org/2020/11/12/geth-security-release",
-      "https://github.com/ethereum/go-ethereum/commit/567d41d9363706b4b13ce0903804e8acf214af49"
+      "https://github.com/ethereum/go-ethereum/commit/567d41d9363706b4b13ce0903804e8acf214af49",
+      "https://github.com/ethereum/go-ethereum/security/advisories/GHSA-v592-xf75-856p"
     ],
     "introduced": "v1.6.0",
     "fixed": "v1.9.24",
     "published": "2020-11-12",
     "severity": "Medium",
-    "check": "Geth\\/v1\\.(6|7|8)\\..*|Geth\\/v1\\.9\\.2(1|2|3)-.*"
+    "CVE": "CVE-2020-26240",
+    "check": "Geth\\/v1\\.(6|7|8)\\..*|Geth\\/v1\\.9\\.\\d-.*|Geth\\/v1\\.9\\.1.*|Geth\\/v1\\.9\\.2(0|1|2|3)-.*"
   },
   {
-    "name": "GoCrash",
+    "name": "Denial of service due to Go CVE-2020-28362",
     "uid": "GETH-2020-02",
     "summary": "A denial-of-service issue can be used to crash Geth nodes during block processing, due to an underlying bug in Go (CVE-2020-28362) versions < `1.15.5`, or `<1.14.12`",
     "description": "The DoS issue can be used to crash all Geth nodes during block processing, the effects of which would be that a major part of the Ethereum network went offline.\n\nOutside of Go-Ethereum, the issue is most likely relevant for all forks of Geth (such as TurboGeth or ETC’s core-geth) which is built with versions of Go which contains the vulnerability.",
     "links": [
       "https://blog.ethereum.org/2020/11/12/geth-security-release",
       "https://groups.google.com/g/golang-announce/c/NpBGTTmKzpM",
-      "https://github.com/golang/go/issues/42552"
+      "https://github.com/golang/go/issues/42552",
+      "https://github.com/ethereum/go-ethereum/security/advisories/GHSA-m6gx-rhvj-fh52"
     ],
+    "introduced": "v0.0.0",
     "fixed": "v1.9.24",
     "published": "2020-11-12",
     "severity": "Critical",
+    "CVE": "CVE-2020-28362",
     "check": "Geth.*\\/go1\\.(11(.*)|12(.*)|13(.*)|14|14\\.(\\d|10|11|)|15|15\\.[0-4])$"
   },
   {
@@ -36,26 +41,162 @@
     "summary": "A consensus flaw in Geth, related to `datacopy` precompile",
     "description": "Geth erroneously performed a 'shallow' copy when the precompiled `datacopy` (at `0x00...04`) was invoked. An attacker could deploy a contract that uses the shallow copy to corrupt the contents of the `RETURNDATA`, thus causing a consensus failure.",
     "links": [
-      "https://blog.ethereum.org/2020/11/12/geth-security-release"
+      "https://blog.ethereum.org/2020/11/12/geth-security-release",
+      "https://github.com/ethereum/go-ethereum/security/advisories/GHSA-69v6-xc2j-r2jf"
     ],
     "introduced": "v1.9.7",
     "fixed": "v1.9.17",
     "published": "2020-11-12",
     "severity": "Critical",
+    "CVE": "CVE-2020-26241",
     "check": "Geth\\/v1\\.9\\.(7|8|9|10|11|12|13|14|15|16).*$"
   },
   {
-    "name": "GethCrash",
+    "name": "Geth DoS via MULMOD",
     "uid": "GETH-2020-04",
     "summary": "A denial-of-service issue can be used to crash Geth nodes during block processing",
-    "description": "Full details to be disclosed at a later date",
+    "description": "Affected versions suffer from a vulnerability which can be exploited through the `MULMOD` operation, by specifying a modulo of `0`: `mulmod(a,b,0)`, causing a `panic` in the underlying library. \nThe crash was in the `uint256` library, where a buffer [underflowed](https://github.com/holiman/uint256/blob/4ce82e695c10ddad57215bdbeafb68b8c5df2c30/uint256.go#L442).\n\n\tif `d == 0`, `dLen` remains `0`\n\nand https://github.com/holiman/uint256/blob/4ce82e695c10ddad57215bdbeafb68b8c5df2c30/uint256.go#L451 will try to access index `[-1]`.\n\nThe `uint256` library was first merged in this [commit](https://github.com/ethereum/go-ethereum/commit/cf6674539c589f80031f3371a71c6a80addbe454), on 2020-06-08. \nExploiting this vulnerabilty would cause all vulnerable nodes to drop off the network. \n\nThe issue was brought to our attention through a [bug report](https://github.com/ethereum/go-ethereum/issues/21367), showing a `panic` occurring on sync from genesis on the Ropsten network.\n \nIt was estimated that the least obvious way to fix this would be to merge the fix into `uint256`, make a new release of that library and then update the geth-dependency.\n",
     "links": [
-      "https://blog.ethereum.org/2020/11/12/geth-security-release"
+      "https://blog.ethereum.org/2020/11/12/geth-security-release",
+      "https://github.com/ethereum/go-ethereum/security/advisories/GHSA-jm5c-rv3w-w83m",
+      "https://github.com/holiman/uint256/releases/tag/v1.1.1",
+      "https://github.com/holiman/uint256/pull/80",
+      "https://github.com/ethereum/go-ethereum/pull/21368"
     ],
     "introduced": "v1.9.16",
     "fixed": "v1.9.18",
     "published": "2020-11-12",
     "severity": "Critical",
+    "CVE": "CVE-2020-26242",
     "check": "Geth\\/v1\\.9.(16|17).*$"
+  },
+  {
+    "name": "LES Server DoS via GetProofsV2",
+    "uid": "GETH-2020-05",
+    "summary": "A DoS vulnerability can make a LES server crash.",
+    "description": "A DoS vulnerability can make a LES server crash via malicious GetProofsV2 request from a connected LES client.\n\nThe vulnerability was patched in #21896.\n\nThis vulnerability only concern users explicitly running geth as a light server",
+    "links": [
+      "https://github.com/ethereum/go-ethereum/security/advisories/GHSA-r33q-22hv-j29q",
+      "https://github.com/ethereum/go-ethereum/pull/21896"
+    ],
+    "introduced": "v1.8.0",
+    "fixed": "v1.9.25",
+    "published": "2020-12-10",
+    "severity": "Medium",
+    "CVE": "CVE-2020-26264",
+    "check": "(Geth\\/v1\\.8\\.*)|(Geth\\/v1\\.9\\.\\d-.*)|(Geth\\/v1\\.9\\.1\\d-.*)|(Geth\\/v1\\.9\\.(20|21|22|23|24)-.*)$"
+  },
+  {
+    "name": "SELFDESTRUCT-recreate consensus flaw",
+    "uid": "GETH-2020-06",
+    "introduced": "v1.9.4",
+    "fixed": "v1.9.20",
+    "summary": "A consensus-vulnerability in Geth could cause a chain split, where vulnerable versions refuse to accept the canonical chain.",
+    "description": "A flaw was repoted at 2020-08-11 by John Youngseok Yang (Software Platform Lab), where a particular sequence of transactions could cause a consensus failure.\n\n- Tx 1:\n - `sender` invokes `caller`.\n - `caller` invokes `0xaa`. `0xaa` has 3 wei, does a self-destruct-to-self\n - `caller` does a  `1 wei` -call to `0xaa`, who thereby has 1 wei (the code in `0xaa` still executed, since the tx is still ongoing, but doesn't redo the selfdestruct, it takes a different path if callvalue is non-zero)\n\n-Tx 2:\n - `sender` does a 5-wei call to 0xaa. No exec (since no code). \n\nIn geth, the result would be that `0xaa` had `6 wei`, whereas OE reported (correctly) `5` wei. Furthermore, in geth, if the second tx was not executed, the `0xaa` would be destructed, resulting in `0 wei`. Thus obviously wrong. \n\nIt was determined that the root cause was this [commit](https://github.com/ethereum/go-ethereum/commit/223b950944f494a5b4e0957fd9f92c48b09037ad) from [this PR](https://github.com/ethereum/go-ethereum/pull/19953). The semantics of `createObject` was subtly changd, into returning a non-nil object (with `deleted=true`) where it previously did not if the account had been destructed. This return value caused the new object to inherit the old `balance`.\n",
+    "links": [
+      "https://github.com/ethereum/go-ethereum/security/advisories/GHSA-xw37-57qp-9mm4"
+    ],
+    "published": "2020-12-10",
+    "severity": "High",
+    "CVE": "CVE-2020-26265",
+    "check": "(Geth\\/v1\\.9\\.(4|5|6|7|8|9)-.*)|(Geth\\/v1\\.9\\.1\\d-.*)$"
+  },
+  {
+    "name": "Not ready for London upgrade",
+    "uid": "GETH-2021-01",
+    "summary": "The client is not ready for the 'London' technical upgrade, and will deviate from the canonical chain when the London upgrade occurs (at block '12965000' around August 4, 2021.",
+    "description": "At (or around) August 4, Ethereum will undergo a technical upgrade called 'London'. Clients not upgraded will fail to progress on the canonical chain.",
+    "links": [
+      "https://github.com/ethereum/eth1.0-specs/blob/master/network-upgrades/mainnet-upgrades/london.md",
+      "https://notes.ethereum.org/@timbeiko/ropsten-postmortem"
+    ],
+    "introduced": "v1.10.1",
+    "fixed": "v1.10.6",
+    "published": "2021-07-22",
+    "severity": "High",
+    "check": "(Geth\\/v1\\.10\\.(1|2|3|4|5)-.*)$"
+  },
+  {
+    "name": "RETURNDATA corruption via datacopy",
+    "uid": "GETH-2021-02",
+    "summary": "A consensus-flaw in the Geth EVM could cause a node to deviate from the canonical chain.",
+    "description": "A memory-corruption bug within the EVM can cause a consensus error, where vulnerable nodes obtain a different `stateRoot` when processing a maliciously crafted transaction. This, in turn, would lead to the chain being split: mainnet splitting in two forks.\n\nAll Geth versions supporting the London hard fork are vulnerable (the bug is older than London), so all users should update.\n\nThis bug was exploited on Mainnet at block 13107518.\n\nCredits for the discovery go to @guidovranken (working for Sentnl during an audit of the Telos EVM) and reported via bounty@ethereum.org.",
+    "links": [
+      "https://github.com/ethereum/go-ethereum/blob/master/docs/postmortems/2021-08-22-split-postmortem.md",
+      "https://github.com/ethereum/go-ethereum/security/advisories/GHSA-9856-9gg9-qcmq",
+      "https://github.com/ethereum/go-ethereum/releases/tag/v1.10.8"
+    ],
+    "introduced": "v1.10.0",
+    "fixed": "v1.10.8",
+    "published": "2021-08-24",
+    "severity": "High",
+    "CVE": "CVE-2021-39137",
+    "check": "(Geth\\/v1\\.10\\.(0|1|2|3|4|5|6|7)-.*)$"
+  },
+  {
+    "name": "DoS via malicious `snap/1` request",
+    "uid": "GETH-2021-03",
+    "summary": "A vulnerable node is susceptible to crash when processing a maliciously crafted message from a peer, via the snap/1 protocol. The crash can be triggered by sending a malicious snap/1 GetTrieNodes package.",
+    "description": "The `snap/1` protocol handler contains two vulnerabilities related to the `GetTrieNodes` packet, which can be exploited to crash the node. Full details are available at the Github security [advisory](https://github.com/ethereum/go-ethereum/security/advisories/GHSA-59hh-656j-3p7v)",
+    "links": [
+      "https://github.com/ethereum/go-ethereum/security/advisories/GHSA-59hh-656j-3p7v",
+      "https://geth.ethereum.org/docs/vulnerabilities/vulnerabilities",
+      "https://github.com/ethereum/go-ethereum/pull/23657"
+    ],
+    "introduced": "v1.10.0",
+    "fixed": "v1.10.9",
+    "published": "2021-10-24",
+    "severity": "Medium",
+    "CVE": "CVE-2021-41173",
+    "check": "(Geth\\/v1\\.10\\.(0|1|2|3|4|5|6|7|8)-.*)$"
+  },
+  {
+    "name": "DoS via malicious p2p message",
+    "uid": "GETH-2022-01",
+    "summary": "A vulnerable node can crash via p2p messages sent from an attacker node, if running with non-default log options.",
+    "description": "A vulnerable node, if configured to use high verbosity logging, can be made to crash when handling specially crafted p2p messages sent from an attacker node. Full details are available at the Github security [advisory](https://github.com/ethereum/go-ethereum/security/advisories/GHSA-wjxw-gh3m-7pm5)",
+    "links": [
+      "https://github.com/ethereum/go-ethereum/security/advisories/GHSA-wjxw-gh3m-7pm5",
+      "https://geth.ethereum.org/docs/vulnerabilities/vulnerabilities",
+      "https://github.com/ethereum/go-ethereum/pull/24507"
+    ],
+    "introduced": "v1.10.0",
+    "fixed": "v1.10.17",
+    "published": "2022-05-11",
+    "severity": "Low",
+    "CVE": "CVE-2022-29177",
+    "check": "(Geth\\/v1\\.10\\.(0|1|2|3|4|5|6|7|8|9|10|11|12|13|14|15|16)-.*)$"
+  },
+  {
+    "name": "DoS via malicious p2p message",
+    "uid": "GETH-2023-01",
+    "summary": "A vulnerable node can be made to consume unbounded amounts of memory when handling specially crafted p2p messages sent from an attacker node.",
+    "description": "The p2p handler spawned a new goroutine to respond to ping requests. By flooding a node with ping requests, an unbounded number of goroutines can be created, leading to resource exhaustion and potentially crash due to OOM.",
+    "links": [
+      "https://github.com/ethereum/go-ethereum/security/advisories/GHSA-ppjg-v974-84cm",
+      "https://geth.ethereum.org/docs/vulnerabilities/vulnerabilities"
+    ],
+    "introduced": "v1.10.0",
+    "fixed": "v1.12.1",
+    "published": "2023-09-06",
+    "severity": "High",
+    "CVE": "CVE-2023-40591",
+    "check": "(Geth\\/v1\\.(10|11)\\..*)|(Geth\\/v1\\.12\\.0-.*)$"
+  },
+  {
+    "name": "DoS via malicious p2p message",
+    "uid": "GETH-2024-01",
+    "summary": "A vulnerable node can be made to consume very large amounts of memory when handling specially crafted p2p messages sent from an attacker node.",
+    "description": "A vulnerable node can be made to consume very large amounts of memory when handling specially crafted p2p messages sent from an attacker node. Full details will be available at the Github security [advisory](https://github.com/ethereum/go-ethereum/security/advisories/GHSA-4xc9-8hmq-j652)",
+    "links": [
+      "https://github.com/ethereum/go-ethereum/security/advisories/GHSA-4xc9-8hmq-j652",
+      "https://geth.ethereum.org/docs/vulnerabilities/vulnerabilities"
+    ],
+    "introduced": "v1.10.0",
+    "fixed": "v1.13.15",
+    "published": "2024-05-06",
+    "severity": "High",
+    "CVE": "CVE-2024-32972",
+    "check": "(Geth\\/v1\\.(10|11|12)\\..*)|(Geth\\/v1\\.13\\.\\d-.*)|(Geth\\/v1\\.13\\.1(0|1|2|3|4)-.*)$"
   }
 ]

--- a/cmd/geth/testdata/vcheck/minisig-sigs-new/data.json.minisig
+++ b/cmd/geth/testdata/vcheck/minisig-sigs-new/data.json.minisig
@@ -1,4 +1,4 @@
 untrusted comment: signature from minisign secret key
-RUQkliYstQBOKLK05Sy5f3bVRMBqJT26ABo6Vbp3BNJAVjejoqYCu4GWE/+7qcDfHBqYIniDCbFIUvYEnOHxV6vZ93wO1xJWDQw=
-trusted comment: timestamp:1693986492	file:data.json	hashed
-6Fdw2H+W1ZXK7QXSF77Z5AWC7+AEFAfDmTSxNGylU5HLT1AuSJQmxslj+VjtUBamYCvOuET7plbXza942AlWDw==
+RUQkliYstQBOKHklFEYCUjepz81dyUuDmIAxjAvXa+icjGuKcjtVfV06G7qfOMSpplS5EcntU12n+AnGNyuOM8zIctaIWcfG2w0=
+trusted comment: timestamp:1752094689	file:data.json	hashed
+u2e4wo4HBTU6viQTSY/NVBHoWoPFJnnTvLZS0FYl3JdvSOYi6+qpbEsDhAIFqq/n8VmlS/fPqqf7vKCNiAgjAA==

--- a/cmd/geth/testdata/vcheck/minisig-sigs/vulnerabilities.json.minisig.1
+++ b/cmd/geth/testdata/vcheck/minisig-sigs/vulnerabilities.json.minisig.1
@@ -1,4 +1,4 @@
 untrusted comment: signature from minisign secret key
-RWQkliYstQBOKFQFQTjmCd6TPw07VZyWFSB3v4+1BM1kv8eHLE5FDy2OkPEqtdaL53xftlrHoJQie0uCcovdlSV8kpyxiLrxEQ0=
-trusted comment: timestamp:1605618622	file:vulnerabilities.json
-osAPs4QPdDkmiWQxqeMIzYv/b+ZGxJ+19Sbrk1Cpq4t2gHBT+lqFtwL3OCzKWWyjGRTmHfsVGBYpzEdPRQ0/BQ==
+RWQkliYstQBOKNoyq2O98hPmeVJQ6ShQLM58+4n0gkY0y0trFMDAsHuN/l4IyHfh8dDQ1ry0+IuZVrf/i8M/P3YFzFfAymDYCQ0=
+trusted comment: timestamp:1752094703	file:data.json
+cNyq3ZGlqo785HtWODb9ejWqF0HhSeXuLGXzC7z1IhnDrBObWBJngYd3qBG1dQcYlHQ+bgB/On5mSyMFn4UoCQ==

--- a/cmd/geth/testdata/vcheck/minisig-sigs/vulnerabilities.json.minisig.2
+++ b/cmd/geth/testdata/vcheck/minisig-sigs/vulnerabilities.json.minisig.2
@@ -1,4 +1,4 @@
 untrusted comment: Here's a comment
-RWQkliYstQBOKFQFQTjmCd6TPw07VZyWFSB3v4+1BM1kv8eHLE5FDy2OkPEqtdaL53xftlrHoJQie0uCcovdlSV8kpyxiLrxEQ0=
+RWQkliYstQBOKNoyq2O98hPmeVJQ6ShQLM58+4n0gkY0y0trFMDAsHuN/l4IyHfh8dDQ1ry0+IuZVrf/i8M/P3YFzFfAymDYCQ0=
 trusted comment: Here's a trusted comment
-3CnkIuz9MEDa7uNyGZAbKZhuirwfiqm7E1uQHrd2SiO4Y8+Akw9vs052AyKw0s5nhbYHCZE2IMQdHNjKwxEGAQ==
+dL7lO8sqFFCOXJO/u8SgoDk2nlXGWPRDbOTJkChMbmtUp9PB7sG831basXkZ/0CQ/l/vG7AbPyMNEVZyJn5NCg==

--- a/cmd/geth/testdata/vcheck/minisig-sigs/vulnerabilities.json.minisig.3
+++ b/cmd/geth/testdata/vcheck/minisig-sigs/vulnerabilities.json.minisig.3
@@ -1,4 +1,4 @@
-untrusted comment: One more (untrusted) comment
-RWQkliYstQBOKFQFQTjmCd6TPw07VZyWFSB3v4+1BM1kv8eHLE5FDy2OkPEqtdaL53xftlrHoJQie0uCcovdlSV8kpyxiLrxEQ0=
+untrusted comment: One more (untrusted™) comment
+RWQkliYstQBOKNoyq2O98hPmeVJQ6ShQLM58+4n0gkY0y0trFMDAsHuN/l4IyHfh8dDQ1ry0+IuZVrf/i8M/P3YFzFfAymDYCQ0=
 trusted comment: Here's a trusted comment
-3CnkIuz9MEDa7uNyGZAbKZhuirwfiqm7E1uQHrd2SiO4Y8+Akw9vs052AyKw0s5nhbYHCZE2IMQdHNjKwxEGAQ==
+dL7lO8sqFFCOXJO/u8SgoDk2nlXGWPRDbOTJkChMbmtUp9PB7sG831basXkZ/0CQ/l/vG7AbPyMNEVZyJn5NCg==

--- a/cmd/geth/testdata/vcheck/signify-sigs/data.json.sig
+++ b/cmd/geth/testdata/vcheck/signify-sigs/data.json.sig
@@ -1,2 +1,2 @@
-untrusted comment: verify with ./signifykey.pub
-RWSKLNhZb0KdAbhRUhW2LQZXdnwttu2SYhM9EuC4mMgOJB85h7/YIPupf8/ldTs4N8e9Y/fhgdY40q5LQpt5IFC62fq0v8U1/w8=
+untrusted comment: verify with signifykey.pub
+RWSKLNhZb0KdARbMcGN40hbHzKQYZDgDOFhEUT1YpzMnqre/mbKJ8td/HVlG03Am1YCszATiI0DbnljjTy4iNHYwqBfzrFUqUg0=

--- a/cmd/geth/testdata/vcheck/sigs/vulnerabilities.json.minisig.1
+++ b/cmd/geth/testdata/vcheck/sigs/vulnerabilities.json.minisig.1
@@ -1,4 +1,0 @@
-untrusted comment: signature from minisign secret key
-RWQkliYstQBOKFQFQTjmCd6TPw07VZyWFSB3v4+1BM1kv8eHLE5FDy2OkPEqtdaL53xftlrHoJQie0uCcovdlSV8kpyxiLrxEQ0=
-trusted comment: timestamp:1605618622	file:vulnerabilities.json
-osAPs4QPdDkmiWQxqeMIzYv/b+ZGxJ+19Sbrk1Cpq4t2gHBT+lqFtwL3OCzKWWyjGRTmHfsVGBYpzEdPRQ0/BQ==

--- a/cmd/geth/testdata/vcheck/sigs/vulnerabilities.json.minisig.2
+++ b/cmd/geth/testdata/vcheck/sigs/vulnerabilities.json.minisig.2
@@ -1,4 +1,0 @@
-untrusted comment: Here's a comment
-RWQkliYstQBOKFQFQTjmCd6TPw07VZyWFSB3v4+1BM1kv8eHLE5FDy2OkPEqtdaL53xftlrHoJQie0uCcovdlSV8kpyxiLrxEQ0=
-trusted comment: Here's a trusted comment
-3CnkIuz9MEDa7uNyGZAbKZhuirwfiqm7E1uQHrd2SiO4Y8+Akw9vs052AyKw0s5nhbYHCZE2IMQdHNjKwxEGAQ==

--- a/cmd/geth/testdata/vcheck/sigs/vulnerabilities.json.minisig.3
+++ b/cmd/geth/testdata/vcheck/sigs/vulnerabilities.json.minisig.3
@@ -1,4 +1,0 @@
-untrusted comment: One more (untrusted) comment
-RWQkliYstQBOKFQFQTjmCd6TPw07VZyWFSB3v4+1BM1kv8eHLE5FDy2OkPEqtdaL53xftlrHoJQie0uCcovdlSV8kpyxiLrxEQ0=
-trusted comment: Here's a trusted comment
-3CnkIuz9MEDa7uNyGZAbKZhuirwfiqm7E1uQHrd2SiO4Y8+Akw9vs052AyKw0s5nhbYHCZE2IMQdHNjKwxEGAQ==

--- a/cmd/geth/testdata/vcheck/vulnerabilities.json
+++ b/cmd/geth/testdata/vcheck/vulnerabilities.json
@@ -6,7 +6,7 @@
     "description": "A mining flaw could cause miners to erroneously calculate PoW, due to an index overflow, if DAG size is exceeding the maximum 32 bit unsigned value.\n\nThis occurred on the ETC chain on 2020-11-06. This is likely to trigger for ETH mainnet around block `11550000`/epoch `385`, slated to occur early January 2021.\n\nThis issue is relevant only for miners, non-mining nodes are unaffected, since non-mining nodes use a smaller verification cache instead of a full DAG.",
     "links": [
       "https://github.com/ethereum/go-ethereum/pull/21793",
-      "https://blog.ethereum.org/2020/11/12/geth_security_release/",
+      "https://blog.ethereum.org/2020/11/12/geth-security-release",
       "https://github.com/ethereum/go-ethereum/commit/567d41d9363706b4b13ce0903804e8acf214af49",
       "https://github.com/ethereum/go-ethereum/security/advisories/GHSA-v592-xf75-856p"
     ],
@@ -23,7 +23,7 @@
     "summary": "A denial-of-service issue can be used to crash Geth nodes during block processing, due to an underlying bug in Go (CVE-2020-28362) versions < `1.15.5`, or `<1.14.12`",
     "description": "The DoS issue can be used to crash all Geth nodes during block processing, the effects of which would be that a major part of the Ethereum network went offline.\n\nOutside of Go-Ethereum, the issue is most likely relevant for all forks of Geth (such as TurboGeth or ETC’s core-geth) which is built with versions of Go which contains the vulnerability.",
     "links": [
-      "https://blog.ethereum.org/2020/11/12/geth_security_release/",
+      "https://blog.ethereum.org/2020/11/12/geth-security-release",
       "https://groups.google.com/g/golang-announce/c/NpBGTTmKzpM",
       "https://github.com/golang/go/issues/42552",
       "https://github.com/ethereum/go-ethereum/security/advisories/GHSA-m6gx-rhvj-fh52"
@@ -41,7 +41,7 @@
     "summary": "A consensus flaw in Geth, related to `datacopy` precompile",
     "description": "Geth erroneously performed a 'shallow' copy when the precompiled `datacopy` (at `0x00...04`) was invoked. An attacker could deploy a contract that uses the shallow copy to corrupt the contents of the `RETURNDATA`, thus causing a consensus failure.",
     "links": [
-      "https://blog.ethereum.org/2020/11/12/geth_security_release/",
+      "https://blog.ethereum.org/2020/11/12/geth-security-release",
       "https://github.com/ethereum/go-ethereum/security/advisories/GHSA-69v6-xc2j-r2jf"
     ],
     "introduced": "v1.9.7",
@@ -57,7 +57,7 @@
     "summary": "A denial-of-service issue can be used to crash Geth nodes during block processing",
     "description": "Affected versions suffer from a vulnerability which can be exploited through the `MULMOD` operation, by specifying a modulo of `0`: `mulmod(a,b,0)`, causing a `panic` in the underlying library. \nThe crash was in the `uint256` library, where a buffer [underflowed](https://github.com/holiman/uint256/blob/4ce82e695c10ddad57215bdbeafb68b8c5df2c30/uint256.go#L442).\n\n\tif `d == 0`, `dLen` remains `0`\n\nand https://github.com/holiman/uint256/blob/4ce82e695c10ddad57215bdbeafb68b8c5df2c30/uint256.go#L451 will try to access index `[-1]`.\n\nThe `uint256` library was first merged in this [commit](https://github.com/ethereum/go-ethereum/commit/cf6674539c589f80031f3371a71c6a80addbe454), on 2020-06-08. \nExploiting this vulnerabilty would cause all vulnerable nodes to drop off the network. \n\nThe issue was brought to our attention through a [bug report](https://github.com/ethereum/go-ethereum/issues/21367), showing a `panic` occurring on sync from genesis on the Ropsten network.\n \nIt was estimated that the least obvious way to fix this would be to merge the fix into `uint256`, make a new release of that library and then update the geth-dependency.\n",
     "links": [
-      "https://blog.ethereum.org/2020/11/12/geth_security_release/",
+      "https://blog.ethereum.org/2020/11/12/geth-security-release",
       "https://github.com/ethereum/go-ethereum/security/advisories/GHSA-jm5c-rv3w-w83m",
       "https://github.com/holiman/uint256/releases/tag/v1.1.1",
       "https://github.com/holiman/uint256/pull/80",

--- a/cmd/geth/version_check_test.go
+++ b/cmd/geth/version_check_test.go
@@ -36,6 +36,9 @@ func TestVerification(t *testing.T) {
 		t.Parallel()
 		// For this test, the pubkey is in testdata/vcheck/minisign.pub
 		// (the privkey is `minisign.sec`, if we want to expand this test. Password 'test' )
+		//	1. `minisign -S -l -s ./minisign.sec -m data.json -x ./minisig-sigs/vulnerabilities.json.minisig.1 -c "signature from minisign secret key"`
+		//	2. `minisign -S -l -s ./minisign.sec -m vulnerabilities.json -x ./minisig-sigs/vulnerabilities.json.minisig.2 -c "Here's a comment" -t "Here's a trusted comment"`
+		//	3.	minisign -S -l -s ./minisign.sec -m vulnerabilities.json -x ./minisig-sigs/vulnerabilities.json.minisig.3 -c "One more (untrusted™) comment" -t "Here's a trusted comment"
 		pub := "RWQkliYstQBOKOdtClfgC3IypIPX6TAmoEi7beZ4gyR3wsaezvqOMWsp"
 		testVerification(t, pub, "./testdata/vcheck/minisig-sigs/")
 	})

--- a/cmd/geth/version_check_test.go
+++ b/cmd/geth/version_check_test.go
@@ -46,7 +46,7 @@ func TestVerification(t *testing.T) {
 		t.Parallel()
 		// For this test, the pubkey is in testdata/vcheck/minisign.pub
 		// (the privkey is `minisign.sec`, if we want to expand this test. Password 'test' )
-		// `minisign -S -s ./minisign.sec  -m data.json  -x ./minisig-sigs-new/data.json.minisig`
+		// `minisign -S -s ./minisign.sec  -m data.json -x ./minisig-sigs-new/data.json.minisig`
 		pub := "RWQkliYstQBOKOdtClfgC3IypIPX6TAmoEi7beZ4gyR3wsaezvqOMWsp"
 		testVerification(t, pub, "./testdata/vcheck/minisig-sigs-new/")
 	})
@@ -56,6 +56,7 @@ func TestVerification(t *testing.T) {
 		t.Skip("This currently fails, minisign expects 4 lines of data, signify provides only 2")
 		// For this test, the pubkey is in testdata/vcheck/signifykey.pub
 		// (the privkey is `signifykey.sec`, if we want to expand this test. Password 'test' )
+		// `signify -S -s signifykey.sec -m data.json -x ./signify-sigs/data.json.sig`
 		pub := "RWSKLNhZb0KdATtRT7mZC/bybI3t3+Hv/O2i3ye04Dq9fnT9slpZ1a2/"
 		testVerification(t, pub, "./testdata/vcheck/signify-sigs/")
 	})


### PR DESCRIPTION
Fixed typo in security release URL by replacing:
Old: https://blog.ethereum.org/2020/11/12/geth_security_release/
New: https://blog.ethereum.org/2020/11/12/geth-security-release/