### PR TITLE
core/filtermaps: clean up log format of unindexing message

### DIFF
--- a/core/filtermaps/filtermaps.go
+++ b/core/filtermaps/filtermaps.go
@@ -268,9 +268,9 @@ func NewFilterMaps(db ethdb.KeyValueStore, initView *ChainView, historyCutoff, f
 
 	if f.indexedRange.hasIndexedBlocks() {
 		log.Info("Initialized log indexer",
-			"first block", f.indexedRange.blocks.First(), "last block", f.indexedRange.blocks.Last(),
-			"first map", f.indexedRange.maps.First(), "last map", f.indexedRange.maps.Last(),
-			"head indexed", f.indexedRange.headIndexed)
+			"firstblock", f.indexedRange.blocks.First(), "lastblock", f.indexedRange.blocks.Last(),
+			"firstmap", f.indexedRange.maps.First(), "lastmap", f.indexedRange.maps.Last(),
+			"headindexed", f.indexedRange.headIndexed)
 	}
 	return f
 }

--- a/core/filtermaps/indexer.go
+++ b/core/filtermaps/indexer.go
@@ -380,9 +380,9 @@ func (f *FilterMaps) tryUnindexTail() (bool, error) {
 	}
 	if f.startedTailUnindex && f.indexedRange.hasIndexedBlocks() {
 		log.Info("Log index tail unindexing finished",
-			"first block", f.indexedRange.blocks.First(), "last block", f.indexedRange.blocks.Last(),
-			"removed maps", f.indexedRange.maps.First()-f.ptrTailUnindexMap,
-			"removed blocks", f.indexedRange.blocks.First()-f.tailPartialBlocks()-f.ptrTailUnindexBlock,
+			"firstblock", f.indexedRange.blocks.First(), "lastblock", f.indexedRange.blocks.Last(),
+			"removedmaps", f.indexedRange.maps.First()-f.ptrTailUnindexMap,
+			"removedblocks", f.indexedRange.blocks.First()-f.tailPartialBlocks()-f.ptrTailUnindexBlock,
 			"elapsed", common.PrettyDuration(time.Since(f.startedTailUnindexAt)))
 		f.startedTailUnindex = false
 	}


### PR DESCRIPTION
Sorry for not fully fixed in https://github.com/ethereum/go-ethereum/pull/31761, now the log format of unindexing message is cleaned up, to make it consistent with the indexing message.