### PR TITLE
eth: add debug_syncTarget API

### DIFF
--- a/internal/web3ext/web3ext.go
+++ b/internal/web3ext/web3ext.go
@@ -218,6 +218,11 @@ web3._extend({
 			params: 1
 		}),
 		new web3._extend.Method({
+			name: 'syncTarget',
+			call: 'debug_syncTarget',
+			params: 1
+		}),
+		new web3._extend.Method({
 			name: 'seedHash',
 			call: 'debug_seedHash',
 			params: 1


### PR DESCRIPTION
closes https://github.com/ethereum/go-ethereum/issues/31375

Usage:

```
# set to an old target
> debug.syncTarget(eth.getBlockByNumber('latest').hash)
Error: sync target is already known in the chain
        at web3.js:6352:9(39)
        at send (web3.js:5116:62(29))
        at <eval>:1:17(7)


# success set a sync target
> debug.syncTarget( '0xb08a431304065baacc343026263f3ad5c7cdfafe05bdc1b8cec2be923951f8f0' )
null

# with a non-exist target
> debug.syncTarget( '0xb08a431304065baacc343026263f3ad5c7cdfafe05bdc1b8cec2be923951f8f1' )
Error: failed to retrieve header for target 0xb08a431304065baacc343026263f3ad5c7cdfafe05bdc1b8cec2be923951f8f1: failed to fetch sync target
        at web3.js:6352:9(39)
        at send (web3.js:5116:62(29))
        at <eval>:1:17(3)
```