### PR TITLE
fix: use correct EIP-2935 history serve window parameter

### DIFF
--- a/params/protocol_params.go
+++ b/params/protocol_params.go
@@ -174,7 +174,7 @@ const (
 	BlobTxMinBlobGasprice              = 1       // Minimum gas price for data blobs
 	BlobTxPointEvaluationPrecompileGas = 50000   // Gas price for the point evaluation precompile.
 
-	HistoryServeWindow = 8192 // Number of blocks to serve historical block hashes for, EIP-2935.
+	HistoryServeWindow = 8191 // Number of blocks to serve historical block hashes for, EIP-2935.
 )
 
 // Bls12381G1MultiExpDiscountTable is the gas discount table for BLS12-381 G1 multi exponentiation operation


### PR DESCRIPTION
[EIP-2935](https://eips.ethereum.org/EIPS/eip-2935) specifies `HISTORY_SERVE_WINDOW = 8191`. Geth currently uses `8192` This does not break consensus since the history storage system contract is updated via EVM execution. However, the test function `getContractStoredBlockHash` could return incorrect results.