### PR TITLE
cmd: hide the deprecated flags

### DIFF
--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -1379,13 +1379,13 @@ func SetNodeConfig(ctx *cli.Context, cfg *node.Config) {
 		cfg.UseLightweightKDF = ctx.Bool(LightKDFFlag.Name)
 	}
 	if ctx.IsSet(NoUSBFlag.Name) || cfg.NoUSB {
-		log.Warn("Option nousb is deprecated and USB is deactivated by default. Use --usb to enable")
+		log.Warn("Option --nousb is deprecated and USB is deactivated by default. Use --usb to enable")
 	}
 	if ctx.IsSet(USBFlag.Name) {
 		cfg.USB = ctx.Bool(USBFlag.Name)
 	}
 	if ctx.IsSet(InsecureUnlockAllowedFlag.Name) {
-		log.Warn(fmt.Sprintf("Option %q is deprecated and has no effect", InsecureUnlockAllowedFlag.Name))
+		log.Warn(fmt.Sprintf("Option --%s is deprecated and has no effect", InsecureUnlockAllowedFlag.Name))
 	}
 	if ctx.IsSet(DBEngineFlag.Name) {
 		dbEngine := ctx.String(DBEngineFlag.Name)
@@ -1397,10 +1397,10 @@ func SetNodeConfig(ctx *cli.Context, cfg *node.Config) {
 	}
 	// deprecation notice for log debug flags (TODO: find a more appropriate place to put these?)
 	if ctx.IsSet(LogBacktraceAtFlag.Name) {
-		log.Warn("log.backtrace flag is deprecated")
+		log.Warn("Option --log.backtrace flag is deprecated")
 	}
 	if ctx.IsSet(LogDebugFlag.Name) {
-		log.Warn("log.debug flag is deprecated")
+		log.Warn("Option --log.debug flag is deprecated")
 	}
 }
 

--- a/cmd/utils/flags_legacy.go
+++ b/cmd/utils/flags_legacy.go
@@ -50,28 +50,33 @@ var (
 	// Deprecated May 2020, shown in aliased flags section
 	NoUSBFlag = &cli.BoolFlag{
 		Name:     "nousb",
+		Hidden:   true,
 		Usage:    "Disables monitoring for and managing USB hardware wallets (deprecated)",
 		Category: flags.DeprecatedCategory,
 	}
 	// Deprecated March 2022
 	LegacyWhitelistFlag = &cli.StringFlag{
 		Name:     "whitelist",
+		Hidden:   true,
 		Usage:    "Comma separated block number-to-hash mappings to enforce (<number>=<hash>) (deprecated in favor of --eth.requiredblocks)",
 		Category: flags.DeprecatedCategory,
 	}
 	// Deprecated July 2023
 	CacheTrieJournalFlag = &cli.StringFlag{
 		Name:     "cache.trie.journal",
+		Hidden:   true,
 		Usage:    "Disk journal directory for trie cache to survive node restarts",
 		Category: flags.DeprecatedCategory,
 	}
 	CacheTrieRejournalFlag = &cli.DurationFlag{
 		Name:     "cache.trie.rejournal",
+		Hidden:   true,
 		Usage:    "Time interval to regenerate the trie cache journal",
 		Category: flags.DeprecatedCategory,
 	}
 	LegacyDiscoveryV5Flag = &cli.BoolFlag{
 		Name:     "v5disc",
+		Hidden:   true,
 		Usage:    "Enables the experimental RLPx V5 (Topic Discovery) mechanism (deprecated, use --discv5 instead)",
 		Category: flags.DeprecatedCategory,
 	}
@@ -85,51 +90,60 @@ var (
 	// Deprecated November 2023
 	LogBacktraceAtFlag = &cli.StringFlag{
 		Name:     "log.backtrace",
+		Hidden:   true,
 		Usage:    "Request a stack trace at a specific logging statement (deprecated)",
 		Value:    "",
 		Category: flags.DeprecatedCategory,
 	}
 	LogDebugFlag = &cli.BoolFlag{
 		Name:     "log.debug",
+		Hidden:   true,
 		Usage:    "Prepends log messages with call-site location (deprecated)",
 		Category: flags.DeprecatedCategory,
 	}
 	// Deprecated February 2024
 	MinerNewPayloadTimeoutFlag = &cli.DurationFlag{
 		Name:     "miner.newpayload-timeout",
+		Hidden:   true,
 		Usage:    "Specify the maximum time allowance for creating a new payload (deprecated)",
 		Value:    ethconfig.Defaults.Miner.Recommit,
 		Category: flags.DeprecatedCategory,
 	}
 	MinerEtherbaseFlag = &cli.StringFlag{
 		Name:     "miner.etherbase",
+		Hidden:   true,
 		Usage:    "0x prefixed public address for block mining rewards (deprecated)",
 		Category: flags.DeprecatedCategory,
 	}
 	MiningEnabledFlag = &cli.BoolFlag{
 		Name:     "mine",
+		Hidden:   true,
 		Usage:    "Enable mining (deprecated)",
 		Category: flags.DeprecatedCategory,
 	}
 	MetricsEnabledExpensiveFlag = &cli.BoolFlag{
 		Name:     "metrics.expensive",
+		Hidden:   true,
 		Usage:    "Enable expensive metrics collection and reporting (deprecated)",
 		Category: flags.DeprecatedCategory,
 	}
 	// Deprecated Oct 2024
 	EnablePersonal = &cli.BoolFlag{
 		Name:     "rpc.enabledeprecatedpersonal",
+		Hidden:   true,
 		Usage:    "This used to enable the 'personal' namespace.",
 		Category: flags.DeprecatedCategory,
 	}
 	UnlockedAccountFlag = &cli.StringFlag{
 		Name:     "unlock",
+		Hidden:   true,
 		Usage:    "Comma separated list of accounts to unlock (deprecated)",
 		Value:    "",
 		Category: flags.DeprecatedCategory,
 	}
 	InsecureUnlockAllowedFlag = &cli.BoolFlag{
 		Name:     "allow-insecure-unlock",
+		Hidden:   true,
 		Usage:    "Allow insecure account unlocking when account-related RPCs are exposed by http (deprecated)",
 		Category: flags.DeprecatedCategory,
 	}

--- a/internal/debug/flags.go
+++ b/internal/debug/flags.go
@@ -55,13 +55,13 @@ var (
 		Usage:    "Per-module verbosity: comma-separated list of <pattern>=<level> (e.g. eth/*=5,p2p=4)",
 		Value:    "",
 		Hidden:   true,
-		Category: flags.LoggingCategory,
+		Category: flags.DeprecatedCategory,
 	}
 	logjsonFlag = &cli.BoolFlag{
 		Name:     "log.json",
 		Usage:    "Format logs with JSON",
 		Hidden:   true,
-		Category: flags.LoggingCategory,
+		Category: flags.DeprecatedCategory,
 	}
 	logFormatFlag = &cli.StringFlag{
 		Name:     "log.format",


### PR DESCRIPTION
Some of the flags were deprecated, so try to hide them in the help message. And move the `--vmodule` and `--logjson` flags to the DeprecatedCategory.