### PR TITLE
core,triedb: fix two inaccurate comments

### DIFF
--- a/core/rawdb/schema.go
+++ b/core/rawdb/schema.go
@@ -125,8 +125,8 @@ var (
 	StateHistoryIndexPrefix           = []byte("m")   // The global prefix of state history index data
 	StateHistoryAccountMetadataPrefix = []byte("ma")  // StateHistoryAccountMetadataPrefix + account address hash => account metadata
 	StateHistoryStorageMetadataPrefix = []byte("ms")  // StateHistoryStorageMetadataPrefix + account address hash + storage slot hash => slot metadata
-	StateHistoryAccountBlockPrefix    = []byte("mba") // StateHistoryAccountBlockPrefix + account address hash + block_number => account block
-	StateHistoryStorageBlockPrefix    = []byte("mbs") // StateHistoryStorageBlockPrefix + account address hash + storage slot hash + block_number => slot block
+	StateHistoryAccountBlockPrefix    = []byte("mba") // StateHistoryAccountBlockPrefix + account address hash + blockID => account block
+	StateHistoryStorageBlockPrefix    = []byte("mbs") // StateHistoryStorageBlockPrefix + account address hash + storage slot hash + blockID => slot block
 
 	// VerklePrefix is the database prefix for Verkle trie data, which includes:
 	// (a) Trie nodes

--- a/triedb/pathdb/history_indexer.go
+++ b/triedb/pathdb/history_indexer.go
@@ -73,8 +73,8 @@ func storeIndexMetadata(db ethdb.KeyValueWriter, last uint64) {
 // batchIndexer is a structure designed to perform batch indexing or unindexing
 // of state histories atomically.
 type batchIndexer struct {
-	accounts map[common.Hash][]uint64                 // History ID list, Keyed by account address
-	storages map[common.Hash]map[common.Hash][]uint64 // History ID list, Keyed by account address and the hash of raw storage key
+	accounts map[common.Hash][]uint64                 // History ID list, Keyed by the hash of account address
+	storages map[common.Hash]map[common.Hash][]uint64 // History ID list, Keyed by the hash of account address and the hash of raw storage key
 	counter  int                                      // The counter of processed states
 	delete   bool                                     // Index or unindex mode
 	lastID   uint64                                   // The ID of latest processed history


### PR DESCRIPTION
1. the `block_number` in state history prefix is confusing, we should avoid it
2. use account hash instead of address as key