### PR TITLE
trie, core/state: introduce Touch operation in trie to fasten preload

### DIFF
--- a/core/state/database.go
+++ b/core/state/database.go
@@ -80,10 +80,18 @@ type Trie interface {
 	// be returned.
 	GetAccount(address common.Address) (*types.StateAccount, error)
 
+	// PrefetchAccount attempts to resolve specific accounts from the database
+	// to accelerate subsequent trie operations.
+	PrefetchAccount([]common.Address) error
+
 	// GetStorage returns the value for key stored in the trie. The value bytes
 	// must not be modified by the caller. If a node was not found in the database,
 	// a trie.MissingNodeError is returned.
 	GetStorage(addr common.Address, key []byte) ([]byte, error)
+
+	// PrefetchStorage attempts to resolve specific storage slots from the database
+	// to accelerate subsequent trie operations.
+	PrefetchStorage(addr common.Address, keys [][]byte) error
 
 	// UpdateAccount abstracts an account write to the trie. It encodes the
 	// provided account object with associated algorithm and then updates it

--- a/core/state/trie_prefetcher.go
+++ b/core/state/trie_prefetcher.go
@@ -388,6 +388,10 @@ func (sf *subfetcher) loop() {
 			sf.tasks = nil
 			sf.lock.Unlock()
 
+			var (
+				addresses []common.Address
+				slots     [][]byte
+			)
 			for _, task := range tasks {
 				if task.addr != nil {
 					key := *task.addr
@@ -400,6 +404,7 @@ func (sf *subfetcher) loop() {
 							sf.dupsCross++
 							continue
 						}
+						sf.seenReadAddr[key] = struct{}{}
 					} else {
 						if _, ok := sf.seenReadAddr[key]; ok {
 							sf.dupsCross++
@@ -409,7 +414,9 @@ func (sf *subfetcher) loop() {
 							sf.dupsWrite++
 							continue
 						}
+						sf.seenWriteAddr[key] = struct{}{}
 					}
+					addresses = append(addresses, *task.addr)
 				} else {
 					key := *task.slot
 					if task.read {
@@ -421,6 +428,7 @@ func (sf *subfetcher) loop() {
 							sf.dupsCross++
 							continue
 						}
+						sf.seenReadSlot[key] = struct{}{}
 					} else {
 						if _, ok := sf.seenReadSlot[key]; ok {
 							sf.dupsCross++
@@ -430,25 +438,19 @@ func (sf *subfetcher) loop() {
 							sf.dupsWrite++
 							continue
 						}
+						sf.seenWriteSlot[key] = struct{}{}
 					}
+					slots = append(slots, key.Bytes())
 				}
-				if task.addr != nil {
-					sf.trie.GetAccount(*task.addr)
-				} else {
-					sf.trie.GetStorage(sf.addr, (*task.slot)[:])
+			}
+			if len(addresses) != 0 {
+				if err := sf.trie.PrefetchAccount(addresses); err != nil {
+					log.Error("Failed to prefetch accounts", "err", err)
 				}
-				if task.read {
-					if task.addr != nil {
-						sf.seenReadAddr[*task.addr] = struct{}{}
-					} else {
-						sf.seenReadSlot[*task.slot] = struct{}{}
-					}
-				} else {
-					if task.addr != nil {
-						sf.seenWriteAddr[*task.addr] = struct{}{}
-					} else {
-						sf.seenWriteSlot[*task.slot] = struct{}{}
-					}
+			}
+			if len(slots) != 0 {
+				if err := sf.trie.PrefetchStorage(common.Address{}, slots); err != nil {
+					log.Error("Failed to prefetch storage", "err", err)
 				}
 			}
 

--- a/core/state_prefetcher.go
+++ b/core/state_prefetcher.go
@@ -111,12 +111,6 @@ func (p *statePrefetcher) Prefetch(block *types.Block, statedb *state.StateDB, c
 				fails.Add(1)
 				return nil // Ugh, something went horribly wrong, bail out
 			}
-			// Pre-load trie nodes for the intermediate root.
-			//
-			// This operation incurs significant memory allocations due to
-			// trie hashing and node decoding. TODO(rjl493456442): investigate
-			// ways to mitigate this overhead.
-			stateCpy.IntermediateRoot(true)
 			return nil
 		})
 	}

--- a/trie/committer.go
+++ b/trie/committer.go
@@ -29,12 +29,12 @@ import (
 // insertion order.
 type committer struct {
 	nodes       *trienode.NodeSet
-	tracer      *tracer
+	tracer      *prevalueTracer
 	collectLeaf bool
 }
 
 // newCommitter creates a new committer or picks one from the pool.
-func newCommitter(nodeset *trienode.NodeSet, tracer *tracer, collectLeaf bool) *committer {
+func newCommitter(nodeset *trienode.NodeSet, tracer *prevalueTracer, collectLeaf bool) *committer {
 	return &committer{
 		nodes:       nodeset,
 		tracer:      tracer,
@@ -140,8 +140,8 @@ func (c *committer) store(path []byte, n node) node {
 		// The node is embedded in its parent, in other words, this node
 		// will not be stored in the database independently, mark it as
 		// deleted only if the node was existent in database before.
-		_, ok := c.tracer.accessList[string(path)]
-		if ok {
+		exists := c.tracer.has([][]byte{path})[0]
+		if exists {
 			c.nodes.AddNode(path, trienode.NewDeleted())
 		}
 		return n

--- a/trie/proof.go
+++ b/trie/proof.go
@@ -573,7 +573,12 @@ func VerifyRangeProof(rootHash common.Hash, firstKey []byte, keys [][]byte, valu
 	}
 	// Rebuild the trie with the leaf stream, the shape of trie
 	// should be same with the original one.
-	tr := &Trie{root: root, reader: newEmptyReader(), tracer: newTracer()}
+	tr := &Trie{
+		root:           root,
+		reader:         newEmptyReader(),
+		opTracer:       newOpTracer(),
+		prevalueTracer: newPrevalueTracer(),
+	}
 	if empty {
 		tr.root = nil
 	}

--- a/trie/secure_trie.go
+++ b/trie/secure_trie.go
@@ -105,19 +105,6 @@ func (t *StateTrie) MustGet(key []byte) []byte {
 	return t.trie.MustGet(crypto.Keccak256(key))
 }
 
-// GetStorage attempts to retrieve a storage slot with provided account address
-// and slot key. The value bytes must not be modified by the caller.
-// If the specified storage slot is not in the trie, nil will be returned.
-// If a trie node is not found in the database, a MissingNodeError is returned.
-func (t *StateTrie) GetStorage(_ common.Address, key []byte) ([]byte, error) {
-	enc, err := t.trie.Get(crypto.Keccak256(key))
-	if err != nil || len(enc) == 0 {
-		return nil, err
-	}
-	_, content, _, err := rlp.Split(enc)
-	return content, err
-}
-
 // GetAccount attempts to retrieve an account with provided account address.
 // If the specified account is not in the trie, nil will be returned.
 // If a trie node is not found in the database, a MissingNodeError is returned.
@@ -142,6 +129,39 @@ func (t *StateTrie) GetAccountByHash(addrHash common.Hash) (*types.StateAccount,
 	ret := new(types.StateAccount)
 	err = rlp.DecodeBytes(res, ret)
 	return ret, err
+}
+
+// PrefetchAccount attempts to resolve specific accounts from the database
+// to accelerate subsequent trie operations.
+func (t *StateTrie) PrefetchAccount(addresses []common.Address) error {
+	var keys [][]byte
+	for _, addr := range addresses {
+		keys = append(keys, crypto.Keccak256(addr.Bytes()))
+	}
+	return t.trie.Touch(keys)
+}
+
+// GetStorage attempts to retrieve a storage slot with provided account address
+// and slot key. The value bytes must not be modified by the caller.
+// If the specified storage slot is not in the trie, nil will be returned.
+// If a trie node is not found in the database, a MissingNodeError is returned.
+func (t *StateTrie) GetStorage(_ common.Address, key []byte) ([]byte, error) {
+	enc, err := t.trie.Get(crypto.Keccak256(key))
+	if err != nil || len(enc) == 0 {
+		return nil, err
+	}
+	_, content, _, err := rlp.Split(enc)
+	return content, err
+}
+
+// PrefetchStorage attempts to resolve specific storage slots from the database
+// to accelerate subsequent trie operations.
+func (t *StateTrie) PrefetchStorage(_ common.Address, keys [][]byte) error {
+	var keylist [][]byte
+	for _, key := range keys {
+		keylist = append(keylist, crypto.Keccak256(key))
+	}
+	return t.trie.Touch(keylist)
 }
 
 // GetNode attempts to retrieve a trie node by compact-encoded path. It is not

--- a/trie/tracer.go
+++ b/trie/tracer.go
@@ -18,11 +18,10 @@ package trie
 
 import (
 	"maps"
-
-	"github.com/ethereum/go-ethereum/common"
+	"sync"
 )
 
-// tracer tracks the changes of trie nodes. During the trie operations,
+// opTracer tracks the changes of trie nodes. During the trie operations,
 // some nodes can be deleted from the trie, while these deleted nodes
 // won't be captured by trie.Hasher or trie.Committer. Thus, these deleted
 // nodes won't be removed from the disk at all. Tracer is an auxiliary tool
@@ -35,38 +34,25 @@ import (
 // This tool can track all of them no matter the node is embedded in its
 // parent or not, but valueNode is never tracked.
 //
-// Besides, it's also used for recording the original value of the nodes
-// when they are resolved from the disk. The pre-value of the nodes will
-// be used to construct trie history in the future.
-//
-// Note tracer is not thread-safe, callers should be responsible for handling
+// Note opTracer is not thread-safe, callers should be responsible for handling
 // the concurrency issues by themselves.
-type tracer struct {
-	inserts    map[string]struct{}
-	deletes    map[string]struct{}
-	accessList map[string][]byte
+type opTracer struct {
+	inserts map[string]struct{}
+	deletes map[string]struct{}
 }
 
-// newTracer initializes the tracer for capturing trie changes.
-func newTracer() *tracer {
-	return &tracer{
-		inserts:    make(map[string]struct{}),
-		deletes:    make(map[string]struct{}),
-		accessList: make(map[string][]byte),
+// newOpTracer initializes the tracer for capturing trie changes.
+func newOpTracer() *opTracer {
+	return &opTracer{
+		inserts: make(map[string]struct{}),
+		deletes: make(map[string]struct{}),
 	}
-}
-
-// onRead tracks the newly loaded trie node and caches the rlp-encoded
-// blob internally. Don't change the value outside of function since
-// it's not deep-copied.
-func (t *tracer) onRead(path []byte, val []byte) {
-	t.accessList[string(path)] = val
 }
 
 // onInsert tracks the newly inserted trie node. If it's already
 // in the deletion set (resurrected node), then just wipe it from
 // the deletion set as it's "untouched".
-func (t *tracer) onInsert(path []byte) {
+func (t *opTracer) onInsert(path []byte) {
 	if _, present := t.deletes[string(path)]; present {
 		delete(t.deletes, string(path))
 		return
@@ -77,7 +63,7 @@ func (t *tracer) onInsert(path []byte) {
 // onDelete tracks the newly deleted trie node. If it's already
 // in the addition set, then just wipe it from the addition set
 // as it's untouched.
-func (t *tracer) onDelete(path []byte) {
+func (t *opTracer) onDelete(path []byte) {
 	if _, present := t.inserts[string(path)]; present {
 		delete(t.inserts, string(path))
 		return
@@ -86,37 +72,95 @@ func (t *tracer) onDelete(path []byte) {
 }
 
 // reset clears the content tracked by tracer.
-func (t *tracer) reset() {
+func (t *opTracer) reset() {
 	t.inserts = make(map[string]struct{})
 	t.deletes = make(map[string]struct{})
-	t.accessList = make(map[string][]byte)
 }
 
 // copy returns a deep copied tracer instance.
-func (t *tracer) copy() *tracer {
-	accessList := make(map[string][]byte, len(t.accessList))
-	for path, blob := range t.accessList {
-		accessList[path] = common.CopyBytes(blob)
-	}
-	return &tracer{
-		inserts:    maps.Clone(t.inserts),
-		deletes:    maps.Clone(t.deletes),
-		accessList: accessList,
+func (t *opTracer) copy() *opTracer {
+	return &opTracer{
+		inserts: maps.Clone(t.inserts),
+		deletes: maps.Clone(t.deletes),
 	}
 }
 
-// deletedNodes returns a list of node paths which are deleted from the trie.
-func (t *tracer) deletedNodes() []string {
-	var paths []string
+// deletedList returns a list of node paths which are deleted from the trie.
+func (t *opTracer) deletedList() [][]byte {
+	paths := make([][]byte, 0, len(t.deletes))
 	for path := range t.deletes {
-		// It's possible a few deleted nodes were embedded
-		// in their parent before, the deletions can be no
-		// effect by deleting nothing, filter them out.
-		_, ok := t.accessList[path]
-		if !ok {
-			continue
-		}
-		paths = append(paths, path)
+		paths = append(paths, []byte(path))
 	}
 	return paths
+}
+
+// prevalueTracer tracks the original values of resolved trie nodes.
+// Cached trie node values are expected to be immutable.
+//
+// prevalueTracer is protected by a lock to ensure concurrency safety,
+// as concurrent map writes may occur during trie.Touch operations.
+type prevalueTracer struct {
+	data map[string][]byte
+	lock sync.RWMutex
+}
+
+// newPrevalueTracer initializes the tracer for capturing resolved trie nodes.
+func newPrevalueTracer() *prevalueTracer {
+	return &prevalueTracer{
+		data: make(map[string][]byte),
+	}
+}
+
+// put tracks the newly loaded trie node and caches its RLP-encoded
+// blob internally. Do not modify the value outside this function,
+// as it is not deep-copied.
+func (t *prevalueTracer) put(path []byte, val []byte) {
+	t.lock.Lock()
+	defer t.lock.Unlock()
+
+	t.data[string(path)] = val
+}
+
+// has returns a list of flag indicating whether the corresponding trie nodes
+// specified by the path exists in the trie.
+func (t *prevalueTracer) has(list [][]byte) []bool {
+	t.lock.RLock()
+	defer t.lock.RUnlock()
+
+	exists := make([]bool, 0, len(list))
+	for _, path := range list {
+		_, ok := t.data[string(path)]
+		exists = append(exists, ok)
+	}
+	return exists
+}
+
+// values returns a list of values of the cached trie nodes.
+func (t *prevalueTracer) values() [][]byte {
+	t.lock.RLock()
+	defer t.lock.RUnlock()
+
+	values := make([][]byte, 0, len(t.data))
+	for _, v := range t.data {
+		values = append(values, v)
+	}
+	return values
+}
+
+// reset resets the cached content in the prevalueTracer.
+func (t *prevalueTracer) reset() {
+	t.lock.Lock()
+	defer t.lock.Unlock()
+
+	clear(t.data)
+}
+
+// copy returns a copied prevalueTracer instance.
+func (t *prevalueTracer) copy() *prevalueTracer {
+	t.lock.RLock()
+	defer t.lock.RUnlock()
+
+	return &prevalueTracer{
+		data: maps.Clone(t.data),
+	}
 }

--- a/trie/tracer_test.go
+++ b/trie/tracer_test.go
@@ -68,8 +68,8 @@ func testTrieTracer(t *testing.T, vals []struct{ k, v string }) {
 	for _, val := range vals {
 		trie.MustUpdate([]byte(val.k), []byte(val.v))
 	}
-	insertSet := copySet(trie.tracer.inserts) // copy before commit
-	deleteSet := copySet(trie.tracer.deletes) // copy before commit
+	insertSet := copySet(trie.opTracer.inserts) // copy before commit
+	deleteSet := copySet(trie.opTracer.deletes) // copy before commit
 	root, nodes := trie.Commit(false)
 	db.Update(root, types.EmptyRootHash, trienode.NewWithNodeSet(nodes))
 
@@ -86,7 +86,7 @@ func testTrieTracer(t *testing.T, vals []struct{ k, v string }) {
 	for _, val := range vals {
 		trie.MustDelete([]byte(val.k))
 	}
-	insertSet, deleteSet = copySet(trie.tracer.inserts), copySet(trie.tracer.deletes)
+	insertSet, deleteSet = copySet(trie.opTracer.inserts), copySet(trie.opTracer.deletes)
 	if !compareSet(insertSet, nil) {
 		t.Fatal("Unexpected insertion set")
 	}
@@ -112,10 +112,10 @@ func testTrieTracerNoop(t *testing.T, vals []struct{ k, v string }) {
 	for _, val := range vals {
 		trie.MustDelete([]byte(val.k))
 	}
-	if len(trie.tracer.inserts) != 0 {
+	if len(trie.opTracer.inserts) != 0 {
 		t.Fatal("Unexpected insertion set")
 	}
-	if len(trie.tracer.deletes) != 0 {
+	if len(trie.opTracer.deletes) != 0 {
 		t.Fatal("Unexpected deletion set")
 	}
 }
@@ -249,9 +249,9 @@ func TestAccessListLeak(t *testing.T) {
 	}
 	for _, c := range cases {
 		trie, _ = New(TrieID(root), db)
-		n1 := len(trie.tracer.accessList)
+		n1 := len(trie.prevalueTracer.data)
 		c.op(trie)
-		n2 := len(trie.tracer.accessList)
+		n2 := len(trie.prevalueTracer.data)
 
 		if n1 != n2 {
 			t.Fatalf("AccessList is leaked, prev %d after %d", n1, n2)

--- a/trie/trie.go
+++ b/trie/trie.go
@@ -27,6 +27,7 @@ import (
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/trie/trienode"
 	"github.com/ethereum/go-ethereum/triedb/database"
+	"golang.org/x/sync/errgroup"
 )
 
 // Trie represents a Merkle Patricia Trie. Use New to create a trie that operates
@@ -55,8 +56,9 @@ type Trie struct {
 	// reader is the handler trie can retrieve nodes from.
 	reader *trieReader
 
-	// tracer is the tool to track the trie changes.
-	tracer *tracer
+	// Various tracers for capturing the modification to trie
+	opTracer       *opTracer
+	prevalueTracer *prevalueTracer
 }
 
 // newFlag returns the cache flag value for a newly created node.
@@ -67,13 +69,14 @@ func (t *Trie) newFlag() nodeFlag {
 // Copy returns a copy of Trie.
 func (t *Trie) Copy() *Trie {
 	return &Trie{
-		root:        copyNode(t.root),
-		owner:       t.owner,
-		committed:   t.committed,
-		unhashed:    t.unhashed,
-		uncommitted: t.uncommitted,
-		reader:      t.reader,
-		tracer:      t.tracer.copy(),
+		root:           copyNode(t.root),
+		owner:          t.owner,
+		committed:      t.committed,
+		unhashed:       t.unhashed,
+		uncommitted:    t.uncommitted,
+		reader:         t.reader,
+		opTracer:       t.opTracer.copy(),
+		prevalueTracer: t.prevalueTracer.copy(),
 	}
 }
 
@@ -89,9 +92,10 @@ func New(id *ID, db database.NodeDatabase) (*Trie, error) {
 		return nil, err
 	}
 	trie := &Trie{
-		owner:  id.Owner,
-		reader: reader,
-		tracer: newTracer(),
+		owner:          id.Owner,
+		reader:         reader,
+		opTracer:       newOpTracer(),
+		prevalueTracer: newPrevalueTracer(),
 	}
 	if id.Root != (common.Hash{}) && id.Root != types.EmptyRootHash {
 		rootnode, err := trie.resolveAndTrack(id.Root[:], nil)
@@ -188,6 +192,51 @@ func (t *Trie) get(origNode node, key []byte, pos int) (value []byte, newnode no
 	default:
 		panic(fmt.Sprintf("%T: invalid node: %v", origNode, origNode))
 	}
+}
+
+// Touch attempts to resolve the leaves and intermediate trie nodes
+// specified by the key list in parallel. The results are silently
+// discarded to simplify the function.
+func (t *Trie) Touch(keylist [][]byte) error {
+	// Short circuit if the trie is already committed and not usable.
+	if t.committed {
+		return ErrCommitted
+	}
+	// Resolve the trie nodes sequentially if there are not too many
+	// trie nodes in the trie.
+	fn, ok := t.root.(*fullNode)
+	if !ok || len(keylist) < 4 {
+		for _, key := range keylist {
+			_, err := t.Get(key)
+			if err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+	var (
+		keys = make(map[byte][][]byte)
+		eg   errgroup.Group
+	)
+	for _, key := range keylist {
+		hkey := keybytesToHex(key)
+		keys[hkey[0]] = append(keys[hkey[0]], hkey)
+	}
+	for pos, ks := range keys {
+		eg.Go(func() error {
+			for _, k := range ks {
+				_, newnode, didResolve, err := t.get(fn.Children[pos], k, 1)
+				if err == nil && didResolve {
+					fn.Children[pos] = newnode
+				}
+				if err != nil {
+					return err
+				}
+			}
+			return nil
+		})
+	}
+	return eg.Wait()
 }
 
 // MustGetNode is a wrapper of GetNode and will omit any encountered error but
@@ -361,7 +410,7 @@ func (t *Trie) insert(n node, prefix, key []byte, value node) (bool, node, error
 		// New branch node is created as a child of the original short node.
 		// Track the newly inserted node in the tracer. The node identifier
 		// passed is the path from the root node.
-		t.tracer.onInsert(append(prefix, key[:matchlen]...))
+		t.opTracer.onInsert(append(prefix, key[:matchlen]...))
 
 		// Replace it with a short node leading up to the branch.
 		return true, &shortNode{key[:matchlen], branch, t.newFlag()}, nil
@@ -379,7 +428,7 @@ func (t *Trie) insert(n node, prefix, key []byte, value node) (bool, node, error
 		// New short node is created and track it in the tracer. The node identifier
 		// passed is the path from the root node. Note the valueNode won't be tracked
 		// since it's always embedded in its parent.
-		t.tracer.onInsert(prefix)
+		t.opTracer.onInsert(prefix)
 
 		return true, &shortNode{key, value, t.newFlag()}, nil
 
@@ -444,7 +493,7 @@ func (t *Trie) delete(n node, prefix, key []byte) (bool, node, error) {
 			// The matched short node is deleted entirely and track
 			// it in the deletion set. The same the valueNode doesn't
 			// need to be tracked at all since it's always embedded.
-			t.tracer.onDelete(prefix)
+			t.opTracer.onDelete(prefix)
 
 			return true, nil, nil // remove n entirely for whole matches
 		}
@@ -460,7 +509,7 @@ func (t *Trie) delete(n node, prefix, key []byte) (bool, node, error) {
 		case *shortNode:
 			// The child shortNode is merged into its parent, track
 			// is deleted as well.
-			t.tracer.onDelete(append(prefix, n.Key...))
+			t.opTracer.onDelete(append(prefix, n.Key...))
 
 			// Deleting from the subtrie reduced it to another
 			// short node. Merge the nodes to avoid creating a
@@ -525,7 +574,7 @@ func (t *Trie) delete(n node, prefix, key []byte) (bool, node, error) {
 					// Replace the entire full node with the short node.
 					// Mark the original short node as deleted since the
 					// value is embedded into the parent now.
-					t.tracer.onDelete(append(prefix, byte(pos)))
+					t.opTracer.onDelete(append(prefix, byte(pos)))
 
 					k := append([]byte{byte(pos)}, cnode.Key...)
 					return true, &shortNode{k, cnode.Val, t.newFlag()}, nil
@@ -616,11 +665,31 @@ func (t *Trie) resolveAndTrack(n hashNode, prefix []byte) (node, error) {
 	if err != nil {
 		return nil, err
 	}
-	t.tracer.onRead(prefix, blob)
+	t.prevalueTracer.put(prefix, blob)
 
 	// The returned node blob won't be changed afterward. No need to
 	// deep-copy the slice.
 	return decodeNodeUnsafe(n, blob)
+}
+
+// deletedNodes returns a list of node paths, referring the nodes being deleted
+// from the trie.
+func (t *Trie) deletedNodes() [][]byte {
+	list := t.opTracer.deletedList()
+
+	// It's possible a few deleted nodes were embedded in their parent before,
+	// the deletions can be no effect by deleting nothing, filter them out.
+	var (
+		pos   int
+		flags = t.prevalueTracer.has(list)
+	)
+	for i := 0; i < len(list); i++ {
+		if flags[i] { // exist, keep it
+			list[pos] = list[i]
+			pos++
+		}
+	}
+	return list[:pos] // Trim to the new length
 }
 
 // Hash returns the root hash of the trie. It does not write to the
@@ -644,13 +713,13 @@ func (t *Trie) Commit(collectLeaf bool) (common.Hash, *trienode.NodeSet) {
 	// (b) The trie was non-empty and all nodes are dropped => return
 	//     the node set includes all deleted nodes
 	if t.root == nil {
-		paths := t.tracer.deletedNodes()
+		paths := t.deletedNodes()
 		if len(paths) == 0 {
 			return types.EmptyRootHash, nil // case (a)
 		}
 		nodes := trienode.NewNodeSet(t.owner)
 		for _, path := range paths {
-			nodes.AddNode([]byte(path), trienode.NewDeleted())
+			nodes.AddNode(path, trienode.NewDeleted())
 		}
 		return types.EmptyRootHash, nodes // case (b)
 	}
@@ -667,11 +736,11 @@ func (t *Trie) Commit(collectLeaf bool) (common.Hash, *trienode.NodeSet) {
 		return rootHash, nil
 	}
 	nodes := trienode.NewNodeSet(t.owner)
-	for _, path := range t.tracer.deletedNodes() {
-		nodes.AddNode([]byte(path), trienode.NewDeleted())
+	for _, path := range t.deletedNodes() {
+		nodes.AddNode(path, trienode.NewDeleted())
 	}
 	// If the number of changes is below 100, we let one thread handle it
-	t.root = newCommitter(nodes, t.tracer, collectLeaf).Commit(t.root, t.uncommitted > 100)
+	t.root = newCommitter(nodes, t.prevalueTracer, collectLeaf).Commit(t.root, t.uncommitted > 100)
 	t.uncommitted = 0
 	return rootHash, nodes
 }
@@ -692,12 +761,13 @@ func (t *Trie) hashRoot() node {
 
 // Witness returns a set containing all trie nodes that have been accessed.
 func (t *Trie) Witness() map[string]struct{} {
-	if len(t.tracer.accessList) == 0 {
+	values := t.prevalueTracer.values()
+	if len(values) == 0 {
 		return nil
 	}
-	witness := make(map[string]struct{}, len(t.tracer.accessList))
-	for _, node := range t.tracer.accessList {
-		witness[string(node)] = struct{}{}
+	witness := make(map[string]struct{}, len(values))
+	for _, val := range values {
+		witness[string(val)] = struct{}{}
 	}
 	return witness
 }
@@ -708,6 +778,7 @@ func (t *Trie) Reset() {
 	t.owner = common.Hash{}
 	t.unhashed = 0
 	t.uncommitted = 0
-	t.tracer.reset()
+	t.opTracer.reset()
+	t.prevalueTracer.reset()
 	t.committed = false
 }

--- a/trie/trie_test.go
+++ b/trie/trie_test.go
@@ -595,18 +595,18 @@ func runRandTest(rt randTest) error {
 					deleteExp[path] = struct{}{}
 				}
 			}
-			if len(insertExp) != len(tr.tracer.inserts) {
+			if len(insertExp) != len(tr.opTracer.inserts) {
 				rt[i].err = errors.New("insert set mismatch")
 			}
-			if len(deleteExp) != len(tr.tracer.deletes) {
+			if len(deleteExp) != len(tr.opTracer.deletes) {
 				rt[i].err = errors.New("delete set mismatch")
 			}
-			for insert := range tr.tracer.inserts {
+			for insert := range tr.opTracer.inserts {
 				if _, present := insertExp[insert]; !present {
 					rt[i].err = errors.New("missing inserted node")
 				}
 			}
-			for del := range tr.tracer.deletes {
+			for del := range tr.opTracer.deletes {
 				if _, present := deleteExp[del]; !present {
 					rt[i].err = errors.New("missing deleted node")
 				}
@@ -1498,5 +1498,85 @@ func testTrieCopyNewTrie(t *testing.T, entries []kv) {
 	}
 	if trCpy.Hash() != hash {
 		t.Errorf("Hash mismatch: old %v, new %v", hash, tr.Hash())
+	}
+}
+
+// goos: darwin
+// goarch: arm64
+// pkg: github.com/ethereum/go-ethereum/trie
+// cpu: Apple M1 Pro
+// BenchmarkTrieTouch
+// BenchmarkTrieTouch-8   	    9961	    100706 ns/op
+func BenchmarkTrieTouch(b *testing.B) {
+	db := newTestDatabase(rawdb.NewMemoryDatabase(), rawdb.HashScheme)
+	tr := NewEmpty(db)
+	vals := make(map[string]*kv)
+	for i := 0; i < 3000; i++ {
+		value := &kv{
+			k: randBytes(32),
+			v: randBytes(20),
+			t: false,
+		}
+		tr.MustUpdate(value.k, value.v)
+		vals[string(value.k)] = value
+	}
+	root, nodes := tr.Commit(false)
+	db.Update(root, types.EmptyRootHash, trienode.NewWithNodeSet(nodes))
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		tr, err := New(TrieID(root), db)
+		if err != nil {
+			b.Fatalf("Failed to open the trie")
+		}
+		var keys [][]byte
+		for k := range vals {
+			keys = append(keys, []byte(k))
+			if len(keys) > 64 {
+				break
+			}
+		}
+		tr.Touch(keys)
+	}
+}
+
+// goos: darwin
+// goarch: arm64
+// pkg: github.com/ethereum/go-ethereum/trie
+// cpu: Apple M1 Pro
+// BenchmarkTrieSeqTouch
+// BenchmarkTrieSeqTouch-8   	   12879	     96710 ns/op
+func BenchmarkTrieSeqTouch(b *testing.B) {
+	db := newTestDatabase(rawdb.NewMemoryDatabase(), rawdb.HashScheme)
+	tr := NewEmpty(db)
+	vals := make(map[string]*kv)
+	for i := 0; i < 3000; i++ {
+		value := &kv{
+			k: randBytes(32),
+			v: randBytes(20),
+			t: false,
+		}
+		tr.MustUpdate(value.k, value.v)
+		vals[string(value.k)] = value
+	}
+	root, nodes := tr.Commit(false)
+	db.Update(root, types.EmptyRootHash, trienode.NewWithNodeSet(nodes))
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		tr, err := New(TrieID(root), db)
+		if err != nil {
+			b.Fatalf("Failed to open the trie")
+		}
+		var keys [][]byte
+		for k := range vals {
+			keys = append(keys, []byte(k))
+			if len(keys) > 64 {
+				break
+			}
+		}
+		for _, k := range keys {
+			tr.Get(k)
+		}
 	}
 }

--- a/trie/verkle.go
+++ b/trie/verkle.go
@@ -109,6 +109,19 @@ func (t *VerkleTrie) GetAccount(addr common.Address) (*types.StateAccount, error
 	return acc, nil
 }
 
+// PrefetchAccount attempts to resolve specific accounts from the database
+// to accelerate subsequent trie operations.
+//
+// TODO(rjl493456442) it can be optimized by GetStem.
+func (t *VerkleTrie) PrefetchAccount(addresses []common.Address) error {
+	for _, addr := range addresses {
+		if _, err := t.GetAccount(addr); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 // GetStorage implements state.Trie, retrieving the storage slot with the specified
 // account address and storage key. If the specified slot is not in the verkle tree,
 // nil will be returned. If the tree is corrupted, an error will be returned.
@@ -119,6 +132,19 @@ func (t *VerkleTrie) GetStorage(addr common.Address, key []byte) ([]byte, error)
 		return nil, err
 	}
 	return common.TrimLeftZeroes(val), nil
+}
+
+// PrefetchStorage attempts to resolve specific storage slots from the database
+// to accelerate subsequent trie operations.
+//
+// TODO(rjl493456442) it can be optimized by GetStem.
+func (t *VerkleTrie) PrefetchStorage(addr common.Address, keys [][]byte) error {
+	for _, key := range keys {
+		if _, err := t.GetStorage(addr, key); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 // UpdateAccount implements state.Trie, writing the provided account into the tree.


### PR DESCRIPTION
This pull introduces a `Touch` operation in the trie to prefetch trie nodes in parallel.
It is used by the `triePrefetcher` to accelerate state loading and improve overall 
chain processing performance.