### PR TITLE
core/rawdb: change the mechanism to schedule freezer sync

### DIFF
--- a/core/rawdb/freezer_batch.go
+++ b/core/rawdb/freezer_batch.go
@@ -216,9 +216,9 @@ func (batch *freezerTableBatch) commit() error {
 	batch.t.writeMeter.Mark(dataSize + indexSize)
 
 	// Periodically sync the table, todo (rjl493456442) make it configurable?
-	batch.t.uncommit += items
-	if batch.t.uncommit > freezerTableFlushThreshold && time.Since(batch.t.lastSync) > 30*time.Second {
-		batch.t.uncommit = 0
+	batch.t.uncommitted += items
+	if batch.t.uncommitted > freezerTableFlushThreshold && time.Since(batch.t.lastSync) > 30*time.Second {
+		batch.t.uncommitted = 0
 		batch.t.lastSync = time.Now()
 		return batch.t.Sync()
 	}

--- a/core/rawdb/freezer_table.go
+++ b/core/rawdb/freezer_table.go
@@ -112,9 +112,9 @@ type freezerTable struct {
 	headId uint32              // number of the currently active head file
 	tailId uint32              // number of the earliest file
 
-	metadata *freezerTableMeta // metadata of the table
-	uncommit uint64            // Count of items written without flushing to file
-	lastSync time.Time         // Timestamp when the last sync was performed
+	metadata    *freezerTableMeta // metadata of the table
+	uncommitted uint64            // Count of items written without flushing to file
+	lastSync    time.Time         // Timestamp when the last sync was performed
 
 	headBytes  int64          // Number of bytes written to the head file
 	readMeter  *metrics.Meter // Meter for measuring the effective amount of data read

--- a/core/rawdb/freezer_table.go
+++ b/core/rawdb/freezer_table.go
@@ -113,6 +113,7 @@ type freezerTable struct {
 	tailId uint32              // number of the earliest file
 
 	metadata *freezerTableMeta // metadata of the table
+	uncommit uint64            // Count of items written without flushing to file
 	lastSync time.Time         // Timestamp when the last sync was performed
 
 	headBytes  int64          // Number of bytes written to the head file


### PR DESCRIPTION
This pull request slightly improves the freezer fsync mechanism by scheduling the 
Sync operation based on the number of uncommitted items and original time interval.

Originally, freezer.Sync was triggered every 30 seconds, which worked well during 
active chain synchronization. However, once the initial state sync is complete, the 
fixed interval causes Sync to be scheduled too frequently.

To address this, the scheduling logic has been improved to consider both the time 
interval and the number of uncommitted items. This additional condition helps avoid 
unnecessary Sync operations when the chain is idle.