### PR TITLE
Update Safe API documentation links

### DIFF
--- a/cmd/clef/extapi_changelog.md
+++ b/cmd/clef/extapi_changelog.md
@@ -65,7 +65,7 @@ The API-method `account_signGnosisSafeTx` was added. This method takes two param
 ```
 
 Not all fields are required, though. This method is really just a UX helper, which massages the 
-input to conform to the `EIP-712` [specification](https://docs.gnosis.io/safe/docs/contracts_tx_execution/#transaction-hash) 
+input to conform to the `EIP-712` [specification](https://docs.safe.global/core-api/transaction-service-reference/gnosis) 
 for the Gnosis Safe, and making the output be directly importable to by a relay service. 
 
 


### PR DESCRIPTION


This PR updates the outdated documentation URL from docs.gnosis.io to the new official docs.safe.global domain. The change reflects the rebranding from Gnosis Safe to Safe and ensures that users are directed to the current API documentation for transaction service reference.

Changes:
- Replace old URL: https://docs.gnosis.io/safe/docs/contracts_tx_execution/#transaction-hash
- Add new URL: https://docs.safe.global/core-api/transaction-service-reference/gnosis