### PR TITLE
cmd/utils: show full deprecated flags

### DIFF
--- a/cmd/utils/flags_legacy.go
+++ b/cmd/utils/flags_legacy.go
@@ -44,6 +44,10 @@ var DeprecatedFlags = []cli.Flag{
 	MinerNewPayloadTimeoutFlag,
 	MinerEtherbaseFlag,
 	MiningEnabledFlag,
+	MetricsEnabledExpensiveFlag,
+	EnablePersonal,
+	UnlockedAccountFlag,
+	InsecureUnlockAllowedFlag,
 }
 
 var (
@@ -83,6 +87,7 @@ var (
 	// Deprecated August 2023
 	TxLookupLimitFlag = &cli.Uint64Flag{
 		Name:     "txlookuplimit",
+		Hidden:   true,
 		Usage:    "Number of recent blocks to maintain transactions index for (default = about one year, 0 = entire chain) (deprecated, use history.transactions instead)",
 		Value:    ethconfig.Defaults.TransactionHistory,
 		Category: flags.DeprecatedCategory,


### PR DESCRIPTION
This is a follow up PR after #32128 , Seems I've missed to add --txlookuplimit as hidden.
In hte meanwhile, I also add the other deprecated flags into the output of `show-deprecated-flags`