### PR TITLE
core/txpool/blobpool: upgrade blobpool

### DIFF
--- a/core/txpool/blobpool/blobpool_test.go
+++ b/core/txpool/blobpool/blobpool_test.go
@@ -283,10 +283,10 @@ func verifyPoolInternals(t *testing.T, pool *BlobPool) {
 	seen := make(map[common.Hash]struct{})
 	for addr, txs := range pool.index {
 		for _, tx := range txs {
-			if _, ok := seen[tx.hash]; ok {
-				t.Errorf("duplicate hash #%x in transaction index: address %s, nonce %d", tx.hash, addr, tx.nonce)
+			if _, ok := seen[tx.TxHash]; ok {
+				t.Errorf("duplicate hash #%x in transaction index: address %s, nonce %d", tx.TxHash, addr, tx.Nonce)
 			}
-			seen[tx.hash] = struct{}{}
+			seen[tx.TxHash] = struct{}{}
 		}
 	}
 	for hash, id := range pool.lookup.txIndex {
@@ -302,11 +302,11 @@ func verifyPoolInternals(t *testing.T, pool *BlobPool) {
 	blobs := make(map[common.Hash]map[common.Hash]struct{})
 	for _, txs := range pool.index {
 		for _, tx := range txs {
-			for _, vhash := range tx.vhashes {
+			for _, vhash := range tx.VHashes {
 				if blobs[vhash] == nil {
 					blobs[vhash] = make(map[common.Hash]struct{})
 				}
-				blobs[vhash][tx.hash] = struct{}{}
+				blobs[vhash][tx.TxHash] = struct{}{}
 			}
 		}
 	}
@@ -328,18 +328,18 @@ func verifyPoolInternals(t *testing.T, pool *BlobPool) {
 	// and that the first nonce is the next expected one based on the state.
 	for addr, txs := range pool.index {
 		for i := 1; i < len(txs); i++ {
-			if txs[i].nonce != txs[i-1].nonce+1 {
-				t.Errorf("addr %v, tx %d nonce mismatch: have %d, want %d", addr, i, txs[i].nonce, txs[i-1].nonce+1)
+			if txs[i].Nonce != txs[i-1].Nonce+1 {
+				t.Errorf("addr %v, tx %d nonce mismatch: have %d, want %d", addr, i, txs[i].Nonce, txs[i-1].Nonce+1)
 			}
 		}
-		if txs[0].nonce != pool.state.GetNonce(addr) {
-			t.Errorf("addr %v, first tx nonce mismatch: have %d, want %d", addr, txs[0].nonce, pool.state.GetNonce(addr))
+		if txs[0].Nonce != pool.state.GetNonce(addr) {
+			t.Errorf("addr %v, first tx nonce mismatch: have %d, want %d", addr, txs[0].Nonce, pool.state.GetNonce(addr))
 		}
 	}
 	// Verify that calculated evacuation thresholds are correct
 	for addr, txs := range pool.index {
-		if !txs[0].evictionExecTip.Eq(txs[0].execTipCap) {
-			t.Errorf("addr %v, tx %d eviction execution tip mismatch: have %d, want %d", addr, 0, txs[0].evictionExecTip, txs[0].execTipCap)
+		if !txs[0].evictionExecTip.Eq(txs[0].ExecTipCap) {
+			t.Errorf("addr %v, tx %d eviction execution tip mismatch: have %d, want %d", addr, 0, txs[0].evictionExecTip, txs[0].ExecTipCap)
 		}
 		if math.Abs(txs[0].evictionExecFeeJumps-txs[0].basefeeJumps) > 0.001 {
 			t.Errorf("addr %v, tx %d eviction execution fee jumps mismatch: have %f, want %f", addr, 0, txs[0].evictionExecFeeJumps, txs[0].basefeeJumps)
@@ -349,8 +349,8 @@ func verifyPoolInternals(t *testing.T, pool *BlobPool) {
 		}
 		for i := 1; i < len(txs); i++ {
 			wantExecTip := txs[i-1].evictionExecTip
-			if wantExecTip.Gt(txs[i].execTipCap) {
-				wantExecTip = txs[i].execTipCap
+			if wantExecTip.Gt(txs[i].ExecTipCap) {
+				wantExecTip = txs[i].ExecTipCap
 			}
 			if !txs[i].evictionExecTip.Eq(wantExecTip) {
 				t.Errorf("addr %v, tx %d eviction execution tip mismatch: have %d, want %d", addr, i, txs[i].evictionExecTip, wantExecTip)
@@ -377,7 +377,7 @@ func verifyPoolInternals(t *testing.T, pool *BlobPool) {
 	for addr, txs := range pool.index {
 		spent := new(uint256.Int)
 		for _, tx := range txs {
-			spent.Add(spent, tx.costCap)
+			spent.Add(spent, tx.CostCap)
 		}
 		if !pool.spent[addr].Eq(spent) {
 			t.Errorf("addr %v expenditure mismatch: have %d, want %d", addr, pool.spent[addr], spent)
@@ -387,7 +387,7 @@ func verifyPoolInternals(t *testing.T, pool *BlobPool) {
 	var stored uint64
 	for _, txs := range pool.index {
 		for _, tx := range txs {
-			stored += uint64(tx.storageSize)
+			stored += uint64(tx.StorageSize)
 		}
 	}
 	if pool.stored != stored {
@@ -407,7 +407,7 @@ func verifyBlobRetrievals(t *testing.T, pool *BlobPool) {
 	known := make(map[common.Hash]struct{})
 	for _, txs := range pool.index {
 		for _, tx := range txs {
-			for _, vhash := range tx.vhashes {
+			for _, vhash := range tx.VHashes {
 				known[vhash] = struct{}{}
 			}
 		}
@@ -736,36 +736,36 @@ func TestOpenDrops(t *testing.T) {
 	alive := make(map[uint64]struct{})
 	for _, txs := range pool.index {
 		for _, tx := range txs {
-			switch tx.id {
+			switch tx.Id {
 			case malformed:
 				t.Errorf("malformed RLP transaction remained in storage")
 			case badsig:
 				t.Errorf("invalidly signed transaction remained in storage")
 			default:
-				if _, ok := dangling[tx.id]; ok {
-					t.Errorf("dangling transaction remained in storage: %d", tx.id)
-				} else if _, ok := filled[tx.id]; ok {
-					t.Errorf("filled transaction remained in storage: %d", tx.id)
-				} else if _, ok := overlapped[tx.id]; ok {
-					t.Errorf("overlapped transaction remained in storage: %d", tx.id)
-				} else if _, ok := gapped[tx.id]; ok {
-					t.Errorf("gapped transaction remained in storage: %d", tx.id)
-				} else if _, ok := underpaid[tx.id]; ok {
-					t.Errorf("underpaid transaction remained in storage: %d", tx.id)
-				} else if _, ok := outpriced[tx.id]; ok {
-					t.Errorf("outpriced transaction remained in storage: %d", tx.id)
-				} else if _, ok := exceeded[tx.id]; ok {
-					t.Errorf("fully overdrafted transaction remained in storage: %d", tx.id)
-				} else if _, ok := overdrafted[tx.id]; ok {
-					t.Errorf("partially overdrafted transaction remained in storage: %d", tx.id)
-				} else if _, ok := overcapped[tx.id]; ok {
-					t.Errorf("overcapped transaction remained in storage: %d", tx.id)
-				} else if _, ok := duplicated[tx.id]; ok {
-					t.Errorf("duplicated transaction remained in storage: %d", tx.id)
-				} else if _, ok := repeated[tx.id]; ok {
-					t.Errorf("repeated nonce transaction remained in storage: %d", tx.id)
+				if _, ok := dangling[tx.Id]; ok {
+					t.Errorf("dangling transaction remained in storage: %d", tx.Id)
+				} else if _, ok := filled[tx.Id]; ok {
+					t.Errorf("filled transaction remained in storage: %d", tx.Id)
+				} else if _, ok := overlapped[tx.Id]; ok {
+					t.Errorf("overlapped transaction remained in storage: %d", tx.Id)
+				} else if _, ok := gapped[tx.Id]; ok {
+					t.Errorf("gapped transaction remained in storage: %d", tx.Id)
+				} else if _, ok := underpaid[tx.Id]; ok {
+					t.Errorf("underpaid transaction remained in storage: %d", tx.Id)
+				} else if _, ok := outpriced[tx.Id]; ok {
+					t.Errorf("outpriced transaction remained in storage: %d", tx.Id)
+				} else if _, ok := exceeded[tx.Id]; ok {
+					t.Errorf("fully overdrafted transaction remained in storage: %d", tx.Id)
+				} else if _, ok := overdrafted[tx.Id]; ok {
+					t.Errorf("partially overdrafted transaction remained in storage: %d", tx.Id)
+				} else if _, ok := overcapped[tx.Id]; ok {
+					t.Errorf("overcapped transaction remained in storage: %d", tx.Id)
+				} else if _, ok := duplicated[tx.Id]; ok {
+					t.Errorf("duplicated transaction remained in storage: %d", tx.Id)
+				} else if _, ok := repeated[tx.Id]; ok {
+					t.Errorf("repeated Nonce transaction remained in storage: %d", tx.Id)
 				} else {
-					alive[tx.id] = struct{}{}
+					alive[tx.Id] = struct{}{}
 				}
 			}
 		}
@@ -851,8 +851,8 @@ func TestOpenIndex(t *testing.T) {
 
 	// Verify that the transactions have been sorted by nonce (case 1)
 	for i := 0; i < len(pool.index[addr]); i++ {
-		if pool.index[addr][i].nonce != uint64(i) {
-			t.Errorf("tx %d nonce mismatch: have %d, want %d", i, pool.index[addr][i].nonce, uint64(i))
+		if pool.index[addr][i].Nonce != uint64(i) {
+			t.Errorf("tx %d nonce mismatch: have %d, want %d", i, pool.index[addr][i].Nonce, uint64(i))
 		}
 	}
 	// Verify that the cumulative fee minimums have been correctly calculated (case 2)

--- a/core/txpool/blobpool/evictheap_test.go
+++ b/core/txpool/blobpool/evictheap_test.go
@@ -145,12 +145,12 @@ func TestPriceHeapSorting(t *testing.T) {
 				blobfeeJumps = dynamicFeeJumps(blobFee)
 			)
 			index[addr] = []*blobTxMeta{{
-				id:                   uint64(j),
-				storageSize:          128 * 1024,
-				nonce:                0,
-				execTipCap:           execTip,
-				execFeeCap:           execFee,
-				blobFeeCap:           blobFee,
+				Id:                   uint64(j),
+				StorageSize:          128 * 1024,
+				Nonce:                0,
+				ExecTipCap:           execTip,
+				ExecFeeCap:           execFee,
+				BlobFeeCap:           blobFee,
 				basefeeJumps:         basefeeJumps,
 				blobfeeJumps:         blobfeeJumps,
 				evictionExecTip:      execTip,
@@ -204,12 +204,12 @@ func benchmarkPriceHeapReinit(b *testing.B, datacap uint64) {
 			blobfeeJumps = dynamicFeeJumps(blobFee)
 		)
 		index[addr] = []*blobTxMeta{{
-			id:                   uint64(i),
-			storageSize:          128 * 1024,
-			nonce:                0,
-			execTipCap:           execTip,
-			execFeeCap:           execFee,
-			blobFeeCap:           blobFee,
+			Id:                   uint64(i),
+			StorageSize:          128 * 1024,
+			Nonce:                0,
+			ExecTipCap:           execTip,
+			ExecFeeCap:           execFee,
+			BlobFeeCap:           blobFee,
 			basefeeJumps:         basefeeJumps,
 			blobfeeJumps:         blobfeeJumps,
 			evictionExecTip:      execTip,
@@ -280,12 +280,12 @@ func benchmarkPriceHeapOverflow(b *testing.B, datacap uint64) {
 			blobfeeJumps = dynamicFeeJumps(blobFee)
 		)
 		index[addr] = []*blobTxMeta{{
-			id:                   uint64(i),
-			storageSize:          128 * 1024,
-			nonce:                0,
-			execTipCap:           execTip,
-			execFeeCap:           execFee,
-			blobFeeCap:           blobFee,
+			Id:                   uint64(i),
+			StorageSize:          128 * 1024,
+			Nonce:                0,
+			ExecTipCap:           execTip,
+			ExecFeeCap:           execFee,
+			BlobFeeCap:           blobFee,
 			basefeeJumps:         basefeeJumps,
 			blobfeeJumps:         blobfeeJumps,
 			evictionExecTip:      execTip,
@@ -311,12 +311,12 @@ func benchmarkPriceHeapOverflow(b *testing.B, datacap uint64) {
 			blobfeeJumps = dynamicFeeJumps(blobFee)
 		)
 		metas[i] = &blobTxMeta{
-			id:                   uint64(int(blobs) + i),
-			storageSize:          128 * 1024,
-			nonce:                0,
-			execTipCap:           execTip,
-			execFeeCap:           execFee,
-			blobFeeCap:           blobFee,
+			Id:                   uint64(int(blobs) + i),
+			StorageSize:          128 * 1024,
+			Nonce:                0,
+			ExecTipCap:           execTip,
+			ExecFeeCap:           execFee,
+			BlobFeeCap:           blobFee,
 			basefeeJumps:         basefeeJumps,
 			blobfeeJumps:         blobfeeJumps,
 			evictionExecTip:      execTip,

--- a/core/txpool/blobpool/lookup.go
+++ b/core/txpool/blobpool/lookup.go
@@ -83,16 +83,16 @@ func (l *lookup) sizeOfTx(txhash common.Hash) (uint64, bool) {
 // hashes; and from transaction hashes to datastore storage item ids.
 func (l *lookup) track(tx *blobTxMeta) {
 	// Map all the blobs to the transaction hash
-	for _, vhash := range tx.vhashes {
+	for _, vhash := range tx.VHashes {
 		if _, ok := l.blobIndex[vhash]; !ok {
 			l.blobIndex[vhash] = make(map[common.Hash]struct{})
 		}
-		l.blobIndex[vhash][tx.hash] = struct{}{} // may be double mapped if a tx contains the same blob twice
+		l.blobIndex[vhash][tx.TxHash] = struct{}{} // may be double mapped if a tx contains the same blob twice
 	}
 	// Map the transaction hash to the datastore id and RLP-encoded transaction size
-	l.txIndex[tx.hash] = &txMetadata{
-		id:   tx.id,
-		size: tx.size,
+	l.txIndex[tx.TxHash] = &txMetadata{
+		id:   tx.Id,
+		size: tx.Size,
 	}
 }
 
@@ -100,11 +100,11 @@ func (l *lookup) track(tx *blobTxMeta) {
 // hashes from the blob index.
 func (l *lookup) untrack(tx *blobTxMeta) {
 	// Unmap the transaction hash from the datastore id
-	delete(l.txIndex, tx.hash)
+	delete(l.txIndex, tx.TxHash)
 
 	// Unmap all the blobs from the transaction hash
-	for _, vhash := range tx.vhashes {
-		delete(l.blobIndex[vhash], tx.hash) // may be double deleted if a tx contains the same blob twice
+	for _, vhash := range tx.VHashes {
+		delete(l.blobIndex[vhash], tx.TxHash) // may be double deleted if a tx contains the same blob twice
 		if len(l.blobIndex[vhash]) == 0 {
 			delete(l.blobIndex, vhash)
 		}


### PR DESCRIPTION
Due to the large size of blob transactions, the goal of this PR is to reduce unnecessary repeated operations of extracting, storing, and retrieving blob transactions. As a result, only the transaction metadata is stored in `limbo`.
In the event of a reorganization, transactions will not be deleted from `blobpool.store`. Instead, their metadata will be transferred to `limbo` storage. When the finalization occurs, `blobpool.store` will be triggered to delete these transactions.