### PR TITLE
cmd, eth/catalyst: exit geth only if exitWhenSynced is specified

### DIFF
--- a/cmd/geth/config.go
+++ b/cmd/geth/config.go
@@ -268,7 +268,7 @@ func makeFullNode(ctx *cli.Context) *node.Node {
 		if len(hex) != common.HashLength {
 			utils.Fatalf("invalid sync target length: have %d, want %d", len(hex), common.HashLength)
 		}
-		utils.RegisterFullSyncTester(stack, eth, common.BytesToHash(hex))
+		utils.RegisterFullSyncTester(stack, eth, common.BytesToHash(hex), ctx.Bool(utils.ExitWhenSyncedFlag.Name))
 	}
 
 	if ctx.IsSet(utils.DeveloperFlag.Name) {

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -1998,9 +1998,9 @@ func RegisterFilterAPI(stack *node.Node, backend ethapi.Backend, ethcfg *ethconf
 }
 
 // RegisterFullSyncTester adds the full-sync tester service into node.
-func RegisterFullSyncTester(stack *node.Node, eth *eth.Ethereum, target common.Hash) {
-	catalyst.RegisterFullSyncTester(stack, eth, target)
-	log.Info("Registered full-sync tester", "hash", target)
+func RegisterFullSyncTester(stack *node.Node, eth *eth.Ethereum, target common.Hash, exitWhenSynced bool) {
+	catalyst.RegisterFullSyncTester(stack, eth, target, exitWhenSynced)
+	log.Info("Registered full-sync tester", "hash", target, "exitWhenSynced", exitWhenSynced)
 }
 
 // SetupMetrics configures the metrics system.

--- a/eth/catalyst/tester.go
+++ b/eth/catalyst/tester.go
@@ -34,21 +34,23 @@ import (
 // This tester can be applied to different networks, no matter it's pre-merge or
 // post-merge, but only for full-sync.
 type FullSyncTester struct {
-	stack   *node.Node
-	backend *eth.Ethereum
-	target  common.Hash
-	closed  chan struct{}
-	wg      sync.WaitGroup
+	stack          *node.Node
+	backend        *eth.Ethereum
+	target         common.Hash
+	closed         chan struct{}
+	wg             sync.WaitGroup
+	exitWhenSynced bool
 }
 
 // RegisterFullSyncTester registers the full-sync tester service into the node
 // stack for launching and stopping the service controlled by node.
-func RegisterFullSyncTester(stack *node.Node, backend *eth.Ethereum, target common.Hash) (*FullSyncTester, error) {
+func RegisterFullSyncTester(stack *node.Node, backend *eth.Ethereum, target common.Hash, exitWhenSynced bool) (*FullSyncTester, error) {
 	cl := &FullSyncTester{
-		stack:   stack,
-		backend: backend,
-		target:  target,
-		closed:  make(chan struct{}),
+		stack:          stack,
+		backend:        backend,
+		target:         target,
+		closed:         make(chan struct{}),
+		exitWhenSynced: exitWhenSynced,
 	}
 	stack.RegisterLifecycle(cl)
 	return cl, nil
@@ -76,7 +78,10 @@ func (tester *FullSyncTester) Start() error {
 				// Stop in case the target block is already stored locally.
 				if block := tester.backend.BlockChain().GetBlockByHash(tester.target); block != nil {
 					log.Info("Full-sync target reached", "number", block.NumberU64(), "hash", block.Hash())
-					go tester.stack.Close() // async since we need to close ourselves
+
+					if tester.exitWhenSynced {
+						go tester.stack.Close() // async since we need to close ourselves
+					}
 					return
 				}
 

--- a/eth/catalyst/tester.go
+++ b/eth/catalyst/tester.go
@@ -81,6 +81,7 @@ func (tester *FullSyncTester) Start() error {
 
 					if tester.exitWhenSynced {
 						go tester.stack.Close() // async since we need to close ourselves
+						log.Info("Terminating the node")
 					}
 					return
 				}


### PR DESCRIPTION
This pull request modifies the behavior of `--synctarget` to terminate the node
only when `--exitWhenSynced` is explicitly specified.