### PR TITLE
cmd/geth: db import with network flags

### DIFF
--- a/cmd/geth/chaincmd.go
+++ b/cmd/geth/chaincmd.go
@@ -116,7 +116,7 @@ if one is set.  Otherwise it prints the genesis from the datadir.`,
 			utils.LogNoHistoryFlag,
 			utils.LogExportCheckpointsFlag,
 			utils.StateHistoryFlag,
-		}, utils.DatabaseFlags, debug.Flags),
+		}, utils.DatabaseFlags, utils.NetworkFlags, debug.Flags),
 		Before: func(ctx *cli.Context) error {
 			flags.MigrateGlobalFlags(ctx)
 			return debug.Setup(ctx)


### PR DESCRIPTION
I'm trying to import the hoodi blocks with `geth import --hoodi`, but it failed with the error:

```
flag provided but not defined: -hoodi
```

then try to run without `--hoodi` flag, it also failed:

```
INFO [07-07|17:33:06.961] Loaded most recent local block           number=0 hash=d4e567..cb8fa3 age=56y3mo3w
INFO [07-07|17:33:06.963] Importing blockchain                     file=./geth.blocks.gz
WARN [07-07|17:33:07.094] Failed to load old bad blocks            error="pebble: not found"
ERROR[07-07|17:33:07.094]
########## BAD BLOCK #########
Block: 1 (0xc62962979a16131910a073095eadc7e458679bb9336299cd38a6e715c1c47996)
Error: unknown ancestor
Platform: geth v1.16.2-0.20250707080129-bdf47f4557bb+dirty go1.24.4 arm64 darwin
VCS: bdf47f45-20250707
Chain config: &params.ChainConfig{ChainID:1, HomesteadBlock:1150000, DAOForkBlock:1920000, DAOForkSupport:true, EIP150Block:2463000, EIP155Block:2675000, EIP158Block:2675000, ByzantiumBlock:4370000, ConstantinopleBlock:7280000, PetersburgBlock:7280000, IstanbulBlock:9069000, MuirGlacierBlock:9200000, BerlinBlock:12244000, LondonBlock:12965000, ArrowGlacierBlock:13773000, GrayGlacierBlock:15050000, MergeNetsplitBlock:<nil>, ShanghaiTime:(*uint64)(0x14000435ea8), CancunTime:(*uint64)(0x14000435eb0), PragueTime:(*uint64)(0x14000435eb8), OsakaTime:(*uint64)(nil), VerkleTime:(*uint64)(nil), TerminalTotalDifficulty:58750000000000000000000, DepositContractAddress:0x00000000219ab540356cBB839Cbe05303d7705Fa, EnableVerkleAtGenesis:false, Ethash:(*params.EthashConfig)(0x1059358e0), Clique:(*params.CliqueConfig)(nil), BlobScheduleConfig:(*params.BlobScheduleConfig)(0x1059021c0)}
Receipts:
##############################

ERROR[07-07|17:33:07.094] Import error                             err="invalid block 1: unknown ancestor"
```