### PR TITLE
core/vm, et/tracers: move dynamic gas and memory handling to opcode handlers

### DIFF
--- a/cmd/evm/internal/t8ntool/file_tracer.go
+++ b/cmd/evm/internal/t8ntool/file_tracer.go
@@ -148,5 +148,10 @@ func (l *fileWritingTracer) hooks() *tracing.Hooks {
 				l.inner.OnSystemCallEnd()
 			}
 		},
+		OnGasChange: func(old, new uint64, reason tracing.GasChangeReason) {
+			if l.inner != nil && l.inner.OnGasChange != nil {
+				l.inner.OnGasChange(old, new, reason)
+			}
+		},
 	}
 }

--- a/cmd/evm/testdata/32/trace-0-0x47806361c0fa084be3caa18afe8c48156747c01dbdfc1ee11b5aecdbe4fcf23e.jsonl
+++ b/cmd/evm/testdata/32/trace-0-0x47806361c0fa084be3caa18afe8c48156747c01dbdfc1ee11b5aecdbe4fcf23e.jsonl
@@ -44,8 +44,7 @@
 {"pc":38,"op":82,"gas":"0x65ee4","gasCost":"0x6","memSize":0,"stack":["0x10","0x0"],"depth":2,"refund":0,"opName":"MSTORE"}
 {"pc":39,"op":96,"gas":"0x65ede","gasCost":"0x3","memSize":32,"stack":[],"depth":2,"refund":0,"opName":"PUSH1"}
 {"pc":41,"op":96,"gas":"0x65edb","gasCost":"0x3","memSize":32,"stack":["0x20"],"depth":2,"refund":0,"opName":"PUSH1"}
-{"pc":43,"op":253,"gas":"0x65ed8","gasCost":"0x0","memSize":32,"stack":["0x20","0x0"],"depth":2,"refund":0,"opName":"REVERT"}
-{"pc":43,"op":253,"gas":"0x65ed8","gasCost":"0x0","memSize":32,"stack":[],"depth":2,"refund":0,"opName":"REVERT","error":"execution reverted"}
+{"pc":43,"op":253,"gas":"0x65ed8","gasCost":"0x0","memSize":32,"stack":["0x20","0x0"],"depth":2,"refund":0,"opName":"REVERT","error":"execution reverted"}
 {"output":"0000000000000000000000000000000000000000000000000000000000000010","gasUsed":"0x2e44","error":"execution reverted"}
 {"pc":69,"op":96,"gas":"0x67976","gasCost":"0x3","memSize":0,"stack":["0x0"],"depth":1,"refund":0,"opName":"PUSH1"}
 {"pc":71,"op":85,"gas":"0x67973","gasCost":"0x1388","memSize":0,"stack":["0x0","0x2"],"depth":1,"refund":4800,"opName":"SSTORE"}

--- a/cmd/evm/testdata/evmrun/7.out.2.txt
+++ b/cmd/evm/testdata/evmrun/7.out.2.txt
@@ -910,7 +910,7 @@ Pre-execution info:
 |   20  |      PUSH1  |    3 |     19900 |[0x0,0x0,0x0,0x0,0x0] |
 |   22  |        GAS  |    2 |     19900 |[0x0,0x0,0x0,0x0,0x0,0xf9] |
 |   23  |   CALLCODE  |  100 |     19900 |[0x0,0x0,0x0,0x0,0x0,0xf9,0x885] |
-Error: out of gas: out of gas
+Error: at pc=23, op=242: out of gas: out of gas
 | 1786  |        POP  |    2 |         0 |[0x94a843a7335fc63be036fbdecc40b1365f3c5f26,0x0] |
 | 1787  |        POP  |    2 |         0 |[0x94a843a7335fc63be036fbdecc40b1365f3c5f26] |
 | 1788  |       STOP  |    0 |         0 |        [] |

--- a/core/tracing/gen_gas_change_reason_stringer.go
+++ b/core/tracing/gen_gas_change_reason_stringer.go
@@ -28,21 +28,22 @@ func _() {
 	_ = x[GasChangeWitnessCodeChunk-17]
 	_ = x[GasChangeWitnessContractCollisionCheck-18]
 	_ = x[GasChangeTxDataFloor-19]
+	_ = x[GasChangeCallOpCodeDynamic-20]
 	_ = x[GasChangeIgnored-255]
 }
 
 const (
-	_GasChangeReason_name_0 = "UnspecifiedTxInitialBalanceTxIntrinsicGasTxRefundsTxLeftOverReturnedCallInitialBalanceCallLeftOverReturnedCallLeftOverRefundedCallContractCreationCallContractCreation2CallCodeStorageCallOpCodeCallPrecompiledContractCallStorageColdAccessCallFailedExecutionWitnessContractInitWitnessContractCreationWitnessCodeChunkWitnessContractCollisionCheckTxDataFloor"
+	_GasChangeReason_name_0 = "UnspecifiedTxInitialBalanceTxIntrinsicGasTxRefundsTxLeftOverReturnedCallInitialBalanceCallLeftOverReturnedCallLeftOverRefundedCallContractCreationCallContractCreation2CallCodeStorageCallOpCodeCallPrecompiledContractCallStorageColdAccessCallFailedExecutionWitnessContractInitWitnessContractCreationWitnessCodeChunkWitnessContractCollisionCheckTxDataFloorCallOpCodeDynamic"
 	_GasChangeReason_name_1 = "Ignored"
 )
 
 var (
-	_GasChangeReason_index_0 = [...]uint16{0, 11, 27, 41, 50, 68, 86, 106, 126, 146, 167, 182, 192, 215, 236, 255, 274, 297, 313, 342, 353}
+	_GasChangeReason_index_0 = [...]uint16{0, 11, 27, 41, 50, 68, 86, 106, 126, 146, 167, 182, 192, 215, 236, 255, 274, 297, 313, 342, 353, 370}
 )
 
 func (i GasChangeReason) String() string {
 	switch {
-	case i <= 19:
+	case i <= 20:
 		return _GasChangeReason_name_0[_GasChangeReason_index_0[i]:_GasChangeReason_index_0[i+1]]
 	case i == 255:
 		return _GasChangeReason_name_1

--- a/core/tracing/hooks.go
+++ b/core/tracing/hooks.go
@@ -217,6 +217,14 @@ type Hooks struct {
 	OnBlockHashRead BlockHashReadHook
 }
 
+// GasChangeHook returns the OnGasChange hook if it exists
+func (h *Hooks) GasChangeHook() GasChangeHook {
+	if h != nil {
+		return h.OnGasChange
+	}
+	return nil
+}
+
 // BalanceChangeReason is used to indicate the reason for a balance change, useful
 // for tracing and reporting.
 type BalanceChangeReason byte
@@ -339,6 +347,9 @@ const (
 	// GasChangeTxDataFloor is the amount of extra gas the transaction has to pay to reach the minimum gas requirement for the
 	// transaction data. This change will always be a negative change.
 	GasChangeTxDataFloor GasChangeReason = 19
+	// GasChangeCallOpCodeDynamic is the amount of dynamic gas that will be charged for an opcode executed by the EVM.
+	// It will be emitted after the `OnOpcode` callback. So the cost should be attributed to the last instance of `OnOpcode`.
+	GasChangeCallOpCodeDynamic GasChangeReason = 20
 
 	// GasChangeIgnored is a special value that can be used to indicate that the gas change should be ignored as
 	// it will be "manually" tracked by a direct emit of the gas change event.

--- a/core/vm/contract.go
+++ b/core/vm/contract.go
@@ -126,12 +126,12 @@ func (c *Contract) Caller() common.Address {
 }
 
 // UseGas attempts the use gas and subtracts it and returns true on success
-func (c *Contract) UseGas(gas uint64, logger *tracing.Hooks, reason tracing.GasChangeReason) (ok bool) {
+func (c *Contract) UseGas(gas uint64, OnGasChange tracing.GasChangeHook, reason tracing.GasChangeReason) (ok bool) {
 	if c.Gas < gas {
 		return false
 	}
-	if logger != nil && logger.OnGasChange != nil && reason != tracing.GasChangeIgnored {
-		logger.OnGasChange(c.Gas, c.Gas-gas, reason)
+	if OnGasChange != nil && reason != tracing.GasChangeIgnored {
+		OnGasChange(c.Gas, c.Gas-gas, reason)
 	}
 	c.Gas -= gas
 	return true

--- a/core/vm/eips.go
+++ b/core/vm/eips.go
@@ -117,45 +117,45 @@ func opChainID(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([]
 // enable2200 applies EIP-2200 (Rebalance net-metered SSTORE)
 func enable2200(jt *JumpTable) {
 	jt[SLOAD].constantGas = params.SloadGasEIP2200
-	jt[SSTORE].dynamicGas = gasSStoreEIP2200
+	jt[SSTORE].execute = opSstoreEIP2200
 }
 
 // enable2929 enables "EIP-2929: Gas cost increases for state access opcodes"
 // https://eips.ethereum.org/EIPS/eip-2929
 func enable2929(jt *JumpTable) {
-	jt[SSTORE].dynamicGas = gasSStoreEIP2929
+	jt[SSTORE].execute = opSstoreEIP2929
 
 	jt[SLOAD].constantGas = 0
-	jt[SLOAD].dynamicGas = gasSLoadEIP2929
+	jt[SLOAD].execute = opSLoadEIP2929
 
 	jt[EXTCODECOPY].constantGas = params.WarmStorageReadCostEIP2929
-	jt[EXTCODECOPY].dynamicGas = gasExtCodeCopyEIP2929
+	jt[EXTCODECOPY].execute = opExtCodeCopyEIP2929
 
 	jt[EXTCODESIZE].constantGas = params.WarmStorageReadCostEIP2929
-	jt[EXTCODESIZE].dynamicGas = gasEip2929AccountCheck
+	jt[EXTCODESIZE].execute = opExtCodeSizeEIP2929
 
 	jt[EXTCODEHASH].constantGas = params.WarmStorageReadCostEIP2929
-	jt[EXTCODEHASH].dynamicGas = gasEip2929AccountCheck
+	jt[EXTCODEHASH].execute = opExtCodeHashEIP2929
 
 	jt[BALANCE].constantGas = params.WarmStorageReadCostEIP2929
-	jt[BALANCE].dynamicGas = gasEip2929AccountCheck
+	jt[BALANCE].execute = opBalanceEIP2929
 
 	jt[CALL].constantGas = params.WarmStorageReadCostEIP2929
-	jt[CALL].dynamicGas = gasCallEIP2929
+	jt[CALL].execute = opCallEIP2929
 
 	jt[CALLCODE].constantGas = params.WarmStorageReadCostEIP2929
-	jt[CALLCODE].dynamicGas = gasCallCodeEIP2929
+	jt[CALLCODE].execute = opCallCodeEIP2929
 
 	jt[STATICCALL].constantGas = params.WarmStorageReadCostEIP2929
-	jt[STATICCALL].dynamicGas = gasStaticCallEIP2929
+	jt[STATICCALL].execute = opStaticCallEIP2929
 
 	jt[DELEGATECALL].constantGas = params.WarmStorageReadCostEIP2929
-	jt[DELEGATECALL].dynamicGas = gasDelegateCallEIP2929
+	jt[DELEGATECALL].execute = opDelegateCallEIP2929
 
 	// This was previously part of the dynamic cost, but we're using it as a constantGas
 	// factor here
 	jt[SELFDESTRUCT].constantGas = params.SelfdestructGasEIP150
-	jt[SELFDESTRUCT].dynamicGas = gasSelfdestructEIP2929
+	jt[SELFDESTRUCT].execute = opSelfdestructEIP2929
 }
 
 // enable3529 enabled "EIP-3529: Reduction in refunds":
@@ -163,8 +163,8 @@ func enable2929(jt *JumpTable) {
 // - Reduces refunds for SSTORE
 // - Reduces max refunds to 20% gas
 func enable3529(jt *JumpTable) {
-	jt[SSTORE].dynamicGas = gasSStoreEIP3529
-	jt[SELFDESTRUCT].dynamicGas = gasSelfdestructEIP3529
+	jt[SSTORE].execute = opSstoreEIP3529
+	jt[SELFDESTRUCT].execute = opSelfdestructEIP3529
 }
 
 // enable3198 applies EIP-3198 (BASEFEE Opcode)
@@ -245,8 +245,8 @@ func opPush0(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([]by
 // enable3860 enables "EIP-3860: Limit and meter initcode"
 // https://eips.ethereum.org/EIPS/eip-3860
 func enable3860(jt *JumpTable) {
-	jt[CREATE].dynamicGas = gasCreateEip3860
-	jt[CREATE2].dynamicGas = gasCreate2Eip3860
+	jt[CREATE].execute = opCreateEIP3860
+	jt[CREATE2].execute = opCreate2EIP3860
 }
 
 // enable5656 enables EIP-5656 (MCOPY opcode)
@@ -255,15 +255,26 @@ func enable5656(jt *JumpTable) {
 	jt[MCOPY] = &operation{
 		execute:     opMcopy,
 		constantGas: GasFastestStep,
-		dynamicGas:  gasMcopy,
 		minStack:    minStack(3, 0),
 		maxStack:    maxStack(3, 0),
-		memorySize:  memoryMcopy,
 	}
 }
 
 // opMcopy implements the MCOPY opcode (https://eips.ethereum.org/EIPS/eip-5656)
 func opMcopy(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([]byte, error) {
+	memorySize, err := calculateMemorySize(memoryMcopy, scope.Stack, scope.Memory)
+	if err != nil {
+		return nil, err
+	}
+	dynamicCost, err := gasMcopy(interpreter.evm, scope.Contract, scope.Stack, scope.Memory, memorySize)
+	if err != nil {
+		return nil, fmt.Errorf("%w: %v", ErrOutOfGas, err)
+	}
+	if !scope.Contract.UseGas(dynamicCost, interpreter.evm.Config.Tracer.GasChangeHook(), tracing.GasChangeCallOpCodeDynamic) {
+		return nil, ErrOutOfGas
+	}
+	scope.Memory.Resize(memorySize)
+
 	var (
 		dst    = scope.Stack.pop()
 		src    = scope.Stack.pop()
@@ -333,8 +344,7 @@ func enable7516(jt *JumpTable) {
 // enable6780 applies EIP-6780 (deactivate SELFDESTRUCT)
 func enable6780(jt *JumpTable) {
 	jt[SELFDESTRUCT] = &operation{
-		execute:     opSelfdestruct6780,
-		dynamicGas:  gasSelfdestructEIP3529,
+		execute:     opSelfdestructEIP6780,
 		constantGas: params.SelfdestructGasEIP150,
 		minStack:    minStack(1, 0),
 		maxStack:    maxStack(1, 0),
@@ -342,6 +352,19 @@ func enable6780(jt *JumpTable) {
 }
 
 func opExtCodeCopyEIP4762(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([]byte, error) {
+	memorySize, err := calculateMemorySize(memoryExtCodeCopy, scope.Stack, scope.Memory)
+	if err != nil {
+		return nil, err
+	}
+	dynamicCost, err := gasExtCodeCopyEIP4762(interpreter.evm, scope.Contract, scope.Stack, scope.Memory, memorySize)
+	if err != nil {
+		return nil, fmt.Errorf("%w: %v", ErrOutOfGas, err)
+	}
+	if !scope.Contract.UseGas(dynamicCost, interpreter.evm.Config.Tracer.GasChangeHook(), tracing.GasChangeCallOpCodeDynamic) {
+		return nil, ErrOutOfGas
+	}
+	scope.Memory.Resize(memorySize)
+
 	var (
 		stack      = scope.Stack
 		a          = stack.pop()
@@ -357,7 +380,7 @@ func opExtCodeCopyEIP4762(pc *uint64, interpreter *EVMInterpreter, scope *ScopeC
 	code := interpreter.evm.StateDB.GetCode(addr)
 	paddedCodeCopy, copyOffset, nonPaddedCopyLength := getDataAndAdjustedBounds(code, uint64CodeOffset, length.Uint64())
 	consumed, wanted := interpreter.evm.AccessEvents.CodeChunksRangeGas(addr, copyOffset, nonPaddedCopyLength, uint64(len(code)), false, scope.Contract.Gas)
-	scope.Contract.UseGas(consumed, interpreter.evm.Config.Tracer, tracing.GasChangeUnspecified)
+	scope.Contract.UseGas(consumed, interpreter.evm.Config.Tracer.GasChangeHook(), tracing.GasChangeUnspecified)
 	if consumed < wanted {
 		return nil, ErrOutOfGas
 	}
@@ -383,7 +406,7 @@ func opPush1EIP4762(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext
 			// advanced past this boundary.
 			contractAddr := scope.Contract.Address()
 			consumed, wanted := interpreter.evm.AccessEvents.CodeChunksRangeGas(contractAddr, *pc+1, uint64(1), uint64(len(scope.Contract.Code)), false, scope.Contract.Gas)
-			scope.Contract.UseGas(wanted, interpreter.evm.Config.Tracer, tracing.GasChangeUnspecified)
+			scope.Contract.UseGas(wanted, interpreter.evm.Config.Tracer.GasChangeHook(), tracing.GasChangeUnspecified)
 			if consumed < wanted {
 				return nil, ErrOutOfGas
 			}
@@ -411,7 +434,7 @@ func makePushEIP4762(size uint64, pushByteSize int) executionFunc {
 		if !scope.Contract.IsDeployment && !scope.Contract.IsSystemCall {
 			contractAddr := scope.Contract.Address()
 			consumed, wanted := interpreter.evm.AccessEvents.CodeChunksRangeGas(contractAddr, uint64(start), uint64(pushByteSize), uint64(len(scope.Contract.Code)), false, scope.Contract.Gas)
-			scope.Contract.UseGas(consumed, interpreter.evm.Config.Tracer, tracing.GasChangeUnspecified)
+			scope.Contract.UseGas(consumed, interpreter.evm.Config.Tracer.GasChangeHook(), tracing.GasChangeUnspecified)
 			if consumed < wanted {
 				return nil, ErrOutOfGas
 			}
@@ -424,112 +447,90 @@ func makePushEIP4762(size uint64, pushByteSize int) executionFunc {
 
 func enable4762(jt *JumpTable) {
 	jt[SSTORE] = &operation{
-		dynamicGas: gasSStore4762,
-		execute:    opSstore,
-		minStack:   minStack(2, 0),
-		maxStack:   maxStack(2, 0),
+		execute:  opSstoreEIP4762,
+		minStack: minStack(2, 0),
+		maxStack: maxStack(2, 0),
 	}
 	jt[SLOAD] = &operation{
-		dynamicGas: gasSLoad4762,
-		execute:    opSload,
-		minStack:   minStack(1, 1),
-		maxStack:   maxStack(1, 1),
+		execute:  opSLoadEIP4762,
+		minStack: minStack(1, 1),
+		maxStack: maxStack(1, 1),
 	}
 
 	jt[BALANCE] = &operation{
-		execute:    opBalance,
-		dynamicGas: gasBalance4762,
-		minStack:   minStack(1, 1),
-		maxStack:   maxStack(1, 1),
+		execute:  opBalanceEIP4762,
+		minStack: minStack(1, 1),
+		maxStack: maxStack(1, 1),
 	}
 
 	jt[EXTCODESIZE] = &operation{
-		execute:    opExtCodeSize,
-		dynamicGas: gasExtCodeSize4762,
-		minStack:   minStack(1, 1),
-		maxStack:   maxStack(1, 1),
+		execute:  opExtCodeSizeEIP4762,
+		minStack: minStack(1, 1),
+		maxStack: maxStack(1, 1),
 	}
 
 	jt[EXTCODEHASH] = &operation{
-		execute:    opExtCodeHash,
-		dynamicGas: gasExtCodeHash4762,
-		minStack:   minStack(1, 1),
-		maxStack:   maxStack(1, 1),
+		execute:  opExtCodeHashEIP4762,
+		minStack: minStack(1, 1),
+		maxStack: maxStack(1, 1),
 	}
 
 	jt[EXTCODECOPY] = &operation{
-		execute:    opExtCodeCopyEIP4762,
-		dynamicGas: gasExtCodeCopyEIP4762,
-		minStack:   minStack(4, 0),
-		maxStack:   maxStack(4, 0),
-		memorySize: memoryExtCodeCopy,
+		execute:  opExtCodeCopyEIP4762,
+		minStack: minStack(4, 0),
+		maxStack: maxStack(4, 0),
 	}
 
 	jt[CODECOPY] = &operation{
-		execute:     opCodeCopy,
+		execute:     opCodeCopyEIP4762,
 		constantGas: GasFastestStep,
-		dynamicGas:  gasCodeCopyEip4762,
 		minStack:    minStack(3, 0),
 		maxStack:    maxStack(3, 0),
-		memorySize:  memoryCodeCopy,
 	}
 
 	jt[SELFDESTRUCT] = &operation{
-		execute:     opSelfdestruct6780,
-		dynamicGas:  gasSelfdestructEIP4762,
+		execute:     opSelfdestructEIP4762,
 		constantGas: params.SelfdestructGasEIP150,
 		minStack:    minStack(1, 0),
 		maxStack:    maxStack(1, 0),
 	}
 
 	jt[CREATE] = &operation{
-		execute:     opCreate,
+		execute:     opCreateEIP3860,
 		constantGas: params.CreateNGasEip4762,
-		dynamicGas:  gasCreateEip3860,
 		minStack:    minStack(3, 1),
 		maxStack:    maxStack(3, 1),
-		memorySize:  memoryCreate,
 	}
 
 	jt[CREATE2] = &operation{
-		execute:     opCreate2,
+		execute:     opCreate2EIP3860,
 		constantGas: params.CreateNGasEip4762,
-		dynamicGas:  gasCreate2Eip3860,
 		minStack:    minStack(4, 1),
 		maxStack:    maxStack(4, 1),
-		memorySize:  memoryCreate2,
 	}
 
 	jt[CALL] = &operation{
-		execute:    opCall,
-		dynamicGas: gasCallEIP4762,
-		minStack:   minStack(7, 1),
-		maxStack:   maxStack(7, 1),
-		memorySize: memoryCall,
+		execute:  opCallEIP4762,
+		minStack: minStack(7, 1),
+		maxStack: maxStack(7, 1),
 	}
 
 	jt[CALLCODE] = &operation{
-		execute:    opCallCode,
-		dynamicGas: gasCallCodeEIP4762,
-		minStack:   minStack(7, 1),
-		maxStack:   maxStack(7, 1),
-		memorySize: memoryCall,
+		execute:  opCallCodeEIP4762,
+		minStack: minStack(7, 1),
+		maxStack: maxStack(7, 1),
 	}
 
 	jt[STATICCALL] = &operation{
-		execute:    opStaticCall,
-		dynamicGas: gasStaticCallEIP4762,
-		minStack:   minStack(6, 1),
-		maxStack:   maxStack(6, 1),
-		memorySize: memoryStaticCall,
+		execute:  opStaticCallEIP4762,
+		minStack: minStack(6, 1),
+		maxStack: maxStack(6, 1),
 	}
 
 	jt[DELEGATECALL] = &operation{
-		execute:    opDelegateCall,
-		dynamicGas: gasDelegateCallEIP4762,
-		minStack:   minStack(6, 1),
-		maxStack:   maxStack(6, 1),
-		memorySize: memoryDelegateCall,
+		execute:  opDelegateCallEIP4762,
+		minStack: minStack(6, 1),
+		maxStack: maxStack(6, 1),
 	}
 
 	jt[PUSH1] = &operation{
@@ -550,8 +551,8 @@ func enable4762(jt *JumpTable) {
 
 // enable7702 the EIP-7702 changes to support delegation designators.
 func enable7702(jt *JumpTable) {
-	jt[CALL].dynamicGas = gasCallEIP7702
-	jt[CALLCODE].dynamicGas = gasCallCodeEIP7702
-	jt[STATICCALL].dynamicGas = gasStaticCallEIP7702
-	jt[DELEGATECALL].dynamicGas = gasDelegateCallEIP7702
+	jt[CALL].execute = opCallEIP7702
+	jt[CALLCODE].execute = opCallCodeEIP7702
+	jt[STATICCALL].execute = opStaticCallEIP7702
+	jt[DELEGATECALL].execute = opDelegateCallEIP7702
 }

--- a/core/vm/evm.go
+++ b/core/vm/evm.go
@@ -511,7 +511,7 @@ func (evm *EVM) create(caller common.Address, code []byte, gas uint64, value *ui
 	if err != nil && (evm.chainRules.IsHomestead || err != ErrCodeStoreOutOfGas) {
 		evm.StateDB.RevertToSnapshot(snapshot)
 		if err != ErrExecutionReverted {
-			contract.UseGas(contract.Gas, evm.Config.Tracer, tracing.GasChangeCallFailedExecution)
+			contract.UseGas(contract.Gas, evm.Config.Tracer.GasChangeHook(), tracing.GasChangeCallFailedExecution)
 		}
 	}
 	return ret, address, contract.Gas, err
@@ -537,12 +537,12 @@ func (evm *EVM) initNewContract(contract *Contract, address common.Address) ([]b
 
 	if !evm.chainRules.IsEIP4762 {
 		createDataGas := uint64(len(ret)) * params.CreateDataGas
-		if !contract.UseGas(createDataGas, evm.Config.Tracer, tracing.GasChangeCallCodeStorage) {
+		if !contract.UseGas(createDataGas, evm.Config.Tracer.GasChangeHook(), tracing.GasChangeCallCodeStorage) {
 			return ret, ErrCodeStoreOutOfGas
 		}
 	} else {
 		consumed, wanted := evm.AccessEvents.CodeChunksRangeGas(address, 0, uint64(len(ret)), uint64(len(ret)), true, contract.Gas)
-		contract.UseGas(consumed, evm.Config.Tracer, tracing.GasChangeWitnessCodeChunk)
+		contract.UseGas(consumed, evm.Config.Tracer.GasChangeHook(), tracing.GasChangeWitnessCodeChunk)
 		if len(ret) > 0 && (consumed < wanted) {
 			return ret, ErrCodeStoreOutOfGas
 		}

--- a/core/vm/instructions.go
+++ b/core/vm/instructions.go
@@ -17,6 +17,7 @@
 package vm
 
 import (
+	"fmt"
 	"math"
 
 	"github.com/ethereum/go-ethereum/common"
@@ -25,6 +26,19 @@ import (
 	"github.com/ethereum/go-ethereum/params"
 	"github.com/holiman/uint256"
 )
+
+// calculateMemorySize calculates the required memory size
+// it is important that this function is inlinable
+func calculateMemorySize(memF memorySizeFunc, stack *Stack, mem *Memory) (uint64, error) {
+	memSize, overflow := memF(stack)
+	// memory is expanded in words of 32 bytes. Gas
+	// is also calculated in words.
+	if overflow || memSize > math.MaxUint64-31 {
+		return 0, ErrGasUintOverflow
+	}
+	memorySize := ((memSize + 31) / 32) * 32
+	return memorySize, nil
+}
 
 func opAdd(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([]byte, error) {
 	x, y := scope.Stack.pop(), scope.Stack.peek()
@@ -66,6 +80,30 @@ func opSmod(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([]byt
 	x, y := scope.Stack.pop(), scope.Stack.peek()
 	y.SMod(&x, y)
 	return nil, nil
+}
+
+func opExpEIP158(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([]byte, error) {
+	dynamicCost, err := gasExpEIP158(interpreter.evm, scope.Contract, scope.Stack, scope.Memory, 0)
+	if err != nil {
+		return nil, fmt.Errorf("%w: %v", ErrOutOfGas, err)
+	}
+	if !scope.Contract.UseGas(dynamicCost, interpreter.evm.Config.Tracer.GasChangeHook(), tracing.GasChangeCallOpCodeDynamic) {
+		return nil, ErrOutOfGas
+	}
+
+	return opExp(pc, interpreter, scope)
+}
+
+func opExpFrontier(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([]byte, error) {
+	dynamicCost, err := gasExpFrontier(interpreter.evm, scope.Contract, scope.Stack, scope.Memory, 0)
+	if err != nil {
+		return nil, fmt.Errorf("%w: %v", ErrOutOfGas, err)
+	}
+	if !scope.Contract.UseGas(dynamicCost, interpreter.evm.Config.Tracer.GasChangeHook(), tracing.GasChangeCallOpCodeDynamic) {
+		return nil, ErrOutOfGas
+	}
+
+	return opExp(pc, interpreter, scope)
 }
 
 func opExp(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([]byte, error) {
@@ -230,6 +268,19 @@ func opSAR(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([]byte
 }
 
 func opKeccak256(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([]byte, error) {
+	memorySize, err := calculateMemorySize(memoryKeccak256, scope.Stack, scope.Memory)
+	if err != nil {
+		return nil, err
+	}
+	dynamicCost, err := gasKeccak256(interpreter.evm, scope.Contract, scope.Stack, scope.Memory, memorySize)
+	if err != nil {
+		return nil, fmt.Errorf("%w: %v", ErrOutOfGas, err)
+	}
+	if !scope.Contract.UseGas(dynamicCost, interpreter.evm.Config.Tracer.GasChangeHook(), tracing.GasChangeCallOpCodeDynamic) {
+		return nil, ErrOutOfGas
+	}
+	scope.Memory.Resize(memorySize)
+
 	offset, size := scope.Stack.pop(), scope.Stack.peek()
 	data := scope.Memory.GetPtr(offset.Uint64(), size.Uint64())
 
@@ -248,6 +299,30 @@ func opKeccak256(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) (
 func opAddress(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([]byte, error) {
 	scope.Stack.push(new(uint256.Int).SetBytes(scope.Contract.Address().Bytes()))
 	return nil, nil
+}
+
+func opBalanceEIP4762(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([]byte, error) {
+	dynamicCost, err := gasBalance4762(interpreter.evm, scope.Contract, scope.Stack, scope.Memory, 0)
+	if err != nil {
+		return nil, fmt.Errorf("%w: %v", ErrOutOfGas, err)
+	}
+	if !scope.Contract.UseGas(dynamicCost, interpreter.evm.Config.Tracer.GasChangeHook(), tracing.GasChangeCallOpCodeDynamic) {
+		return nil, ErrOutOfGas
+	}
+
+	return opBalance(pc, interpreter, scope)
+}
+
+func opBalanceEIP2929(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([]byte, error) {
+	dynamicCost, err := gasEip2929AccountCheck(interpreter.evm, scope.Contract, scope.Stack, scope.Memory, 0)
+	if err != nil {
+		return nil, fmt.Errorf("%w: %v", ErrOutOfGas, err)
+	}
+	if !scope.Contract.UseGas(dynamicCost, interpreter.evm.Config.Tracer.GasChangeHook(), tracing.GasChangeCallOpCodeDynamic) {
+		return nil, ErrOutOfGas
+	}
+
+	return opBalance(pc, interpreter, scope)
 }
 
 func opBalance(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([]byte, error) {
@@ -289,6 +364,19 @@ func opCallDataSize(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext
 }
 
 func opCallDataCopy(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([]byte, error) {
+	memorySize, err := calculateMemorySize(memoryCallDataCopy, scope.Stack, scope.Memory)
+	if err != nil {
+		return nil, err
+	}
+	dynamicCost, err := gasCallDataCopy(interpreter.evm, scope.Contract, scope.Stack, scope.Memory, memorySize)
+	if err != nil {
+		return nil, fmt.Errorf("%w: %v", ErrOutOfGas, err)
+	}
+	if !scope.Contract.UseGas(dynamicCost, interpreter.evm.Config.Tracer.GasChangeHook(), tracing.GasChangeCallOpCodeDynamic) {
+		return nil, ErrOutOfGas
+	}
+	scope.Memory.Resize(memorySize)
+
 	var (
 		memOffset  = scope.Stack.pop()
 		dataOffset = scope.Stack.pop()
@@ -312,6 +400,19 @@ func opReturnDataSize(pc *uint64, interpreter *EVMInterpreter, scope *ScopeConte
 }
 
 func opReturnDataCopy(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([]byte, error) {
+	memorySize, err := calculateMemorySize(memoryReturnDataCopy, scope.Stack, scope.Memory)
+	if err != nil {
+		return nil, err
+	}
+	dynamicCost, err := gasReturnDataCopy(interpreter.evm, scope.Contract, scope.Stack, scope.Memory, memorySize)
+	if err != nil {
+		return nil, fmt.Errorf("%w: %v", ErrOutOfGas, err)
+	}
+	if !scope.Contract.UseGas(dynamicCost, interpreter.evm.Config.Tracer.GasChangeHook(), tracing.GasChangeCallOpCodeDynamic) {
+		return nil, ErrOutOfGas
+	}
+	scope.Memory.Resize(memorySize)
+
 	var (
 		memOffset  = scope.Stack.pop()
 		dataOffset = scope.Stack.pop()
@@ -333,6 +434,28 @@ func opReturnDataCopy(pc *uint64, interpreter *EVMInterpreter, scope *ScopeConte
 	return nil, nil
 }
 
+func opExtCodeSizeEIP4762(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([]byte, error) {
+	dynamicCost, err := gasExtCodeSize4762(interpreter.evm, scope.Contract, scope.Stack, scope.Memory, 0)
+	if err != nil {
+		return nil, fmt.Errorf("%w: %v", ErrOutOfGas, err)
+	}
+	if !scope.Contract.UseGas(dynamicCost, interpreter.evm.Config.Tracer.GasChangeHook(), tracing.GasChangeCallOpCodeDynamic) {
+		return nil, ErrOutOfGas
+	}
+	return opExtCodeSize(pc, interpreter, scope)
+}
+
+func opExtCodeSizeEIP2929(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([]byte, error) {
+	dynamicCost, err := gasEip2929AccountCheck(interpreter.evm, scope.Contract, scope.Stack, scope.Memory, 0)
+	if err != nil {
+		return nil, fmt.Errorf("%w: %v", ErrOutOfGas, err)
+	}
+	if !scope.Contract.UseGas(dynamicCost, interpreter.evm.Config.Tracer.GasChangeHook(), tracing.GasChangeCallOpCodeDynamic) {
+		return nil, ErrOutOfGas
+	}
+	return opExtCodeSize(pc, interpreter, scope)
+}
+
 func opExtCodeSize(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([]byte, error) {
 	slot := scope.Stack.peek()
 	slot.SetUint64(uint64(interpreter.evm.StateDB.GetCodeSize(slot.Bytes20())))
@@ -342,6 +465,38 @@ func opExtCodeSize(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext)
 func opCodeSize(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([]byte, error) {
 	scope.Stack.push(new(uint256.Int).SetUint64(uint64(len(scope.Contract.Code))))
 	return nil, nil
+}
+
+func opCodeCopyEIP4762(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([]byte, error) {
+	memorySize, err := calculateMemorySize(memoryCodeCopy, scope.Stack, scope.Memory)
+	if err != nil {
+		return nil, err
+	}
+	dynamicCost, err := gasCodeCopyEip4762(interpreter.evm, scope.Contract, scope.Stack, scope.Memory, memorySize)
+	if err != nil {
+		return nil, fmt.Errorf("%w: %v", ErrOutOfGas, err)
+	}
+	if !scope.Contract.UseGas(dynamicCost, interpreter.evm.Config.Tracer.GasChangeHook(), tracing.GasChangeCallOpCodeDynamic) {
+		return nil, ErrOutOfGas
+	}
+	scope.Memory.Resize(memorySize)
+	return opCodeCopy(pc, interpreter, scope)
+}
+
+func opCodeCopyFrontier(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([]byte, error) {
+	memorySize, err := calculateMemorySize(memoryCodeCopy, scope.Stack, scope.Memory)
+	if err != nil {
+		return nil, err
+	}
+	dynamicCost, err := gasCodeCopy(interpreter.evm, scope.Contract, scope.Stack, scope.Memory, memorySize)
+	if err != nil {
+		return nil, fmt.Errorf("%w: %v", ErrOutOfGas, err)
+	}
+	if !scope.Contract.UseGas(dynamicCost, interpreter.evm.Config.Tracer.GasChangeHook(), tracing.GasChangeCallOpCodeDynamic) {
+		return nil, ErrOutOfGas
+	}
+	scope.Memory.Resize(memorySize)
+	return opCodeCopy(pc, interpreter, scope)
 }
 
 func opCodeCopy(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([]byte, error) {
@@ -358,6 +513,38 @@ func opCodeCopy(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([
 	codeCopy := getData(scope.Contract.Code, uint64CodeOffset, length.Uint64())
 	scope.Memory.Set(memOffset.Uint64(), length.Uint64(), codeCopy)
 	return nil, nil
+}
+
+func opExtCodeCopyEIP2929(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([]byte, error) {
+	memorySize, err := calculateMemorySize(memoryExtCodeCopy, scope.Stack, scope.Memory)
+	if err != nil {
+		return nil, err
+	}
+	dynamicCost, err := gasExtCodeCopyEIP2929(interpreter.evm, scope.Contract, scope.Stack, scope.Memory, memorySize)
+	if err != nil {
+		return nil, fmt.Errorf("%w: %v", ErrOutOfGas, err)
+	}
+	if !scope.Contract.UseGas(dynamicCost, interpreter.evm.Config.Tracer.GasChangeHook(), tracing.GasChangeCallOpCodeDynamic) {
+		return nil, ErrOutOfGas
+	}
+	scope.Memory.Resize(memorySize)
+	return opExtCodeCopy(pc, interpreter, scope)
+}
+
+func opExtCodeCopyFrontier(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([]byte, error) {
+	memorySize, err := calculateMemorySize(memoryExtCodeCopy, scope.Stack, scope.Memory)
+	if err != nil {
+		return nil, err
+	}
+	dynamicCost, err := gasExtCodeCopy(interpreter.evm, scope.Contract, scope.Stack, scope.Memory, memorySize)
+	if err != nil {
+		return nil, fmt.Errorf("%w: %v", ErrOutOfGas, err)
+	}
+	if !scope.Contract.UseGas(dynamicCost, interpreter.evm.Config.Tracer.GasChangeHook(), tracing.GasChangeCallOpCodeDynamic) {
+		return nil, ErrOutOfGas
+	}
+	scope.Memory.Resize(memorySize)
+	return opExtCodeCopy(pc, interpreter, scope)
 }
 
 func opExtCodeCopy(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([]byte, error) {
@@ -378,6 +565,28 @@ func opExtCodeCopy(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext)
 	scope.Memory.Set(memOffset.Uint64(), length.Uint64(), codeCopy)
 
 	return nil, nil
+}
+
+func opExtCodeHashEIP4762(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([]byte, error) {
+	dynamicCost, err := gasExtCodeHash4762(interpreter.evm, scope.Contract, scope.Stack, scope.Memory, 0)
+	if err != nil {
+		return nil, fmt.Errorf("%w: %v", ErrOutOfGas, err)
+	}
+	if !scope.Contract.UseGas(dynamicCost, interpreter.evm.Config.Tracer.GasChangeHook(), tracing.GasChangeCallOpCodeDynamic) {
+		return nil, ErrOutOfGas
+	}
+	return opExtCodeHash(pc, interpreter, scope)
+}
+
+func opExtCodeHashEIP2929(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([]byte, error) {
+	dynamicCost, err := gasEip2929AccountCheck(interpreter.evm, scope.Contract, scope.Stack, scope.Memory, 0)
+	if err != nil {
+		return nil, fmt.Errorf("%w: %v", ErrOutOfGas, err)
+	}
+	if !scope.Contract.UseGas(dynamicCost, interpreter.evm.Config.Tracer.GasChangeHook(), tracing.GasChangeCallOpCodeDynamic) {
+		return nil, ErrOutOfGas
+	}
+	return opExtCodeHash(pc, interpreter, scope)
 }
 
 // opExtCodeHash returns the code hash of a specified account.
@@ -492,6 +701,19 @@ func opPop(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([]byte
 }
 
 func opMload(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([]byte, error) {
+	memorySize, err := calculateMemorySize(memoryMLoad, scope.Stack, scope.Memory)
+	if err != nil {
+		return nil, err
+	}
+	dynamicCost, err := gasMLoad(interpreter.evm, scope.Contract, scope.Stack, scope.Memory, memorySize)
+	if err != nil {
+		return nil, fmt.Errorf("%w: %v", ErrOutOfGas, err)
+	}
+	if !scope.Contract.UseGas(dynamicCost, interpreter.evm.Config.Tracer.GasChangeHook(), tracing.GasChangeCallOpCodeDynamic) {
+		return nil, ErrOutOfGas
+	}
+	scope.Memory.Resize(memorySize)
+
 	v := scope.Stack.peek()
 	offset := v.Uint64()
 	v.SetBytes(scope.Memory.GetPtr(offset, 32))
@@ -499,15 +721,63 @@ func opMload(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([]by
 }
 
 func opMstore(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([]byte, error) {
+	memorySize, err := calculateMemorySize(memoryMStore, scope.Stack, scope.Memory)
+	if err != nil {
+		return nil, err
+	}
+	dynamicCost, err := gasMStore(interpreter.evm, scope.Contract, scope.Stack, scope.Memory, memorySize)
+	if err != nil {
+		return nil, fmt.Errorf("%w: %v", ErrOutOfGas, err)
+	}
+	if !scope.Contract.UseGas(dynamicCost, interpreter.evm.Config.Tracer.GasChangeHook(), tracing.GasChangeCallOpCodeDynamic) {
+		return nil, ErrOutOfGas
+	}
+	scope.Memory.Resize(memorySize)
+
 	mStart, val := scope.Stack.pop(), scope.Stack.pop()
 	scope.Memory.Set32(mStart.Uint64(), &val)
 	return nil, nil
 }
 
 func opMstore8(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([]byte, error) {
+	memorySize, err := calculateMemorySize(memoryMStore8, scope.Stack, scope.Memory)
+	if err != nil {
+		return nil, err
+	}
+	dynamicCost, err := gasMStore8(interpreter.evm, scope.Contract, scope.Stack, scope.Memory, memorySize)
+	if err != nil {
+		return nil, fmt.Errorf("%w: %v", ErrOutOfGas, err)
+	}
+	if !scope.Contract.UseGas(dynamicCost, interpreter.evm.Config.Tracer.GasChangeHook(), tracing.GasChangeCallOpCodeDynamic) {
+		return nil, ErrOutOfGas
+	}
+	scope.Memory.Resize(memorySize)
+
 	off, val := scope.Stack.pop(), scope.Stack.pop()
 	scope.Memory.store[off.Uint64()] = byte(val.Uint64())
 	return nil, nil
+}
+
+func opSLoadEIP4762(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([]byte, error) {
+	dynamicCost, err := gasSLoad4762(interpreter.evm, scope.Contract, scope.Stack, scope.Memory, 0)
+	if err != nil {
+		return nil, fmt.Errorf("%w: %v", ErrOutOfGas, err)
+	}
+	if !scope.Contract.UseGas(dynamicCost, interpreter.evm.Config.Tracer.GasChangeHook(), tracing.GasChangeCallOpCodeDynamic) {
+		return nil, ErrOutOfGas
+	}
+	return opSload(pc, interpreter, scope)
+}
+
+func opSLoadEIP2929(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([]byte, error) {
+	dynamicCost, err := gasSLoadEIP2929(interpreter.evm, scope.Contract, scope.Stack, scope.Memory, 0)
+	if err != nil {
+		return nil, fmt.Errorf("%w: %v", ErrOutOfGas, err)
+	}
+	if !scope.Contract.UseGas(dynamicCost, interpreter.evm.Config.Tracer.GasChangeHook(), tracing.GasChangeCallOpCodeDynamic) {
+		return nil, ErrOutOfGas
+	}
+	return opSload(pc, interpreter, scope)
 }
 
 func opSload(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([]byte, error) {
@@ -516,6 +786,66 @@ func opSload(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([]by
 	val := interpreter.evm.StateDB.GetState(scope.Contract.Address(), hash)
 	loc.SetBytes(val.Bytes())
 	return nil, nil
+}
+
+func opSstoreEIP4762(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([]byte, error) {
+	dynamicCost, err := gasSStore4762(interpreter.evm, scope.Contract, scope.Stack, scope.Memory, 0)
+	if err != nil {
+		return nil, fmt.Errorf("%w: %v", ErrOutOfGas, err)
+	}
+	if !scope.Contract.UseGas(dynamicCost, interpreter.evm.Config.Tracer.GasChangeHook(), tracing.GasChangeCallOpCodeDynamic) {
+		return nil, ErrOutOfGas
+	}
+
+	return opSstore(pc, interpreter, scope)
+}
+
+func opSstoreEIP3529(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([]byte, error) {
+	dynamicCost, err := gasSStoreEIP3529(interpreter.evm, scope.Contract, scope.Stack, scope.Memory, 0)
+	if err != nil {
+		return nil, fmt.Errorf("%w: %v", ErrOutOfGas, err)
+	}
+	if !scope.Contract.UseGas(dynamicCost, interpreter.evm.Config.Tracer.GasChangeHook(), tracing.GasChangeCallOpCodeDynamic) {
+		return nil, ErrOutOfGas
+	}
+
+	return opSstore(pc, interpreter, scope)
+}
+
+func opSstoreEIP2200(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([]byte, error) {
+	dynamicCost, err := gasSStoreEIP2200(interpreter.evm, scope.Contract, scope.Stack, scope.Memory, 0)
+	if err != nil {
+		return nil, fmt.Errorf("%w: %v", ErrOutOfGas, err)
+	}
+	if !scope.Contract.UseGas(dynamicCost, interpreter.evm.Config.Tracer.GasChangeHook(), tracing.GasChangeCallOpCodeDynamic) {
+		return nil, ErrOutOfGas
+	}
+
+	return opSstore(pc, interpreter, scope)
+}
+
+func opSstoreEIP2929(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([]byte, error) {
+	dynamicCost, err := gasSStoreEIP2929(interpreter.evm, scope.Contract, scope.Stack, scope.Memory, 0)
+	if err != nil {
+		return nil, fmt.Errorf("%w: %v", ErrOutOfGas, err)
+	}
+	if !scope.Contract.UseGas(dynamicCost, interpreter.evm.Config.Tracer.GasChangeHook(), tracing.GasChangeCallOpCodeDynamic) {
+		return nil, ErrOutOfGas
+	}
+
+	return opSstore(pc, interpreter, scope)
+}
+
+func opSstoreFrontier(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([]byte, error) {
+	dynamicCost, err := gasSStore(interpreter.evm, scope.Contract, scope.Stack, scope.Memory, 0)
+	if err != nil {
+		return nil, fmt.Errorf("%w: %v", ErrOutOfGas, err)
+	}
+	if !scope.Contract.UseGas(dynamicCost, interpreter.evm.Config.Tracer.GasChangeHook(), tracing.GasChangeCallOpCodeDynamic) {
+		return nil, ErrOutOfGas
+	}
+
+	return opSstore(pc, interpreter, scope)
 }
 
 func opSstore(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([]byte, error) {
@@ -653,10 +983,45 @@ func opSwap16(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([]b
 	return nil, nil
 }
 
+func opCreateEIP3860(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([]byte, error) {
+	memorySize, err := calculateMemorySize(memoryCreate, scope.Stack, scope.Memory)
+	if err != nil {
+		return nil, err
+	}
+	dynamicCost, err := gasCreateEip3860(interpreter.evm, scope.Contract, scope.Stack, scope.Memory, memorySize)
+	if err != nil {
+		return nil, fmt.Errorf("%w: %v", ErrOutOfGas, err)
+	}
+	if !scope.Contract.UseGas(dynamicCost, interpreter.evm.Config.Tracer.GasChangeHook(), tracing.GasChangeCallOpCodeDynamic) {
+		return nil, ErrOutOfGas
+	}
+	scope.Memory.Resize(memorySize)
+
+	return opCreate(pc, interpreter, scope)
+}
+
+func opCreateFrontier(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([]byte, error) {
+	memorySize, err := calculateMemorySize(memoryCreate, scope.Stack, scope.Memory)
+	if err != nil {
+		return nil, err
+	}
+	dynamicCost, err := gasCreate(interpreter.evm, scope.Contract, scope.Stack, scope.Memory, memorySize)
+	if err != nil {
+		return nil, fmt.Errorf("%w: %v", ErrOutOfGas, err)
+	}
+	if !scope.Contract.UseGas(dynamicCost, interpreter.evm.Config.Tracer.GasChangeHook(), tracing.GasChangeCallOpCodeDynamic) {
+		return nil, ErrOutOfGas
+	}
+	scope.Memory.Resize(memorySize)
+
+	return opCreate(pc, interpreter, scope)
+}
+
 func opCreate(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([]byte, error) {
 	if interpreter.readOnly {
 		return nil, ErrWriteProtection
 	}
+
 	var (
 		value        = scope.Stack.pop()
 		offset, size = scope.Stack.pop(), scope.Stack.pop()
@@ -670,7 +1035,7 @@ func opCreate(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([]b
 	// reuse size int for stackvalue
 	stackvalue := size
 
-	scope.Contract.UseGas(gas, interpreter.evm.Config.Tracer, tracing.GasChangeCallContractCreation)
+	scope.Contract.UseGas(gas, interpreter.evm.Config.Tracer.GasChangeHook(), tracing.GasChangeCallContractCreation)
 
 	res, addr, returnGas, suberr := interpreter.evm.Create(scope.Contract.Address(), input, gas, &value)
 	// Push item on the stack based on the returned error. If the ruleset is
@@ -696,6 +1061,40 @@ func opCreate(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([]b
 	return nil, nil
 }
 
+func opCreate2EIP3860(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([]byte, error) {
+	memorySize, err := calculateMemorySize(memoryCreate2, scope.Stack, scope.Memory)
+	if err != nil {
+		return nil, err
+	}
+	dynamicCost, err := gasCreate2Eip3860(interpreter.evm, scope.Contract, scope.Stack, scope.Memory, memorySize)
+	if err != nil {
+		return nil, fmt.Errorf("%w: %v", ErrOutOfGas, err)
+	}
+	if !scope.Contract.UseGas(dynamicCost, interpreter.evm.Config.Tracer.GasChangeHook(), tracing.GasChangeCallOpCodeDynamic) {
+		return nil, ErrOutOfGas
+	}
+	scope.Memory.Resize(memorySize)
+
+	return opCreate2(pc, interpreter, scope)
+}
+
+func opCreate2Constantinople(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([]byte, error) {
+	memorySize, err := calculateMemorySize(memoryCreate2, scope.Stack, scope.Memory)
+	if err != nil {
+		return nil, err
+	}
+	dynamicCost, err := gasCreate2(interpreter.evm, scope.Contract, scope.Stack, scope.Memory, memorySize)
+	if err != nil {
+		return nil, fmt.Errorf("%w: %v", ErrOutOfGas, err)
+	}
+	if !scope.Contract.UseGas(dynamicCost, interpreter.evm.Config.Tracer.GasChangeHook(), tracing.GasChangeCallOpCodeDynamic) {
+		return nil, ErrOutOfGas
+	}
+	scope.Memory.Resize(memorySize)
+
+	return opCreate2(pc, interpreter, scope)
+}
+
 func opCreate2(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([]byte, error) {
 	if interpreter.readOnly {
 		return nil, ErrWriteProtection
@@ -710,7 +1109,7 @@ func opCreate2(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([]
 
 	// Apply EIP150
 	gas -= gas / 64
-	scope.Contract.UseGas(gas, interpreter.evm.Config.Tracer, tracing.GasChangeCallContractCreation2)
+	scope.Contract.UseGas(gas, interpreter.evm.Config.Tracer.GasChangeHook(), tracing.GasChangeCallContractCreation2)
 	// reuse size int for stackvalue
 	stackvalue := size
 	res, addr, returnGas, suberr := interpreter.evm.Create2(scope.Contract.Address(), input, gas,
@@ -730,6 +1129,74 @@ func opCreate2(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([]
 	}
 	interpreter.returnData = nil // clear dirty return data buffer
 	return nil, nil
+}
+
+func opCallEIP4762(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([]byte, error) {
+	memorySize, err := calculateMemorySize(memoryCall, scope.Stack, scope.Memory)
+	if err != nil {
+		return nil, err
+	}
+	dynamicCost, err := gasCallEIP4762(interpreter.evm, scope.Contract, scope.Stack, scope.Memory, memorySize)
+	if err != nil {
+		return nil, fmt.Errorf("%w: %v", ErrOutOfGas, err)
+	}
+	if !scope.Contract.UseGas(dynamicCost, interpreter.evm.Config.Tracer.GasChangeHook(), tracing.GasChangeCallOpCodeDynamic) {
+		return nil, ErrOutOfGas
+	}
+	scope.Memory.Resize(memorySize)
+
+	return opCall(pc, interpreter, scope)
+}
+
+func opCallEIP7702(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([]byte, error) {
+	memorySize, err := calculateMemorySize(memoryCall, scope.Stack, scope.Memory)
+	if err != nil {
+		return nil, err
+	}
+	dynamicCost, err := gasCallEIP7702(interpreter.evm, scope.Contract, scope.Stack, scope.Memory, memorySize)
+	if err != nil {
+		return nil, fmt.Errorf("%w: %v", ErrOutOfGas, err)
+	}
+	if !scope.Contract.UseGas(dynamicCost, interpreter.evm.Config.Tracer.GasChangeHook(), tracing.GasChangeCallOpCodeDynamic) {
+		return nil, ErrOutOfGas
+	}
+	scope.Memory.Resize(memorySize)
+
+	return opCall(pc, interpreter, scope)
+}
+
+func opCallEIP2929(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([]byte, error) {
+	memorySize, err := calculateMemorySize(memoryCall, scope.Stack, scope.Memory)
+	if err != nil {
+		return nil, err
+	}
+	dynamicCost, err := gasCallEIP2929(interpreter.evm, scope.Contract, scope.Stack, scope.Memory, memorySize)
+	if err != nil {
+		return nil, fmt.Errorf("%w: %v", ErrOutOfGas, err)
+	}
+	if !scope.Contract.UseGas(dynamicCost, interpreter.evm.Config.Tracer.GasChangeHook(), tracing.GasChangeCallOpCodeDynamic) {
+		return nil, ErrOutOfGas
+	}
+	scope.Memory.Resize(memorySize)
+
+	return opCall(pc, interpreter, scope)
+}
+
+func opCallFrontier(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([]byte, error) {
+	memorySize, err := calculateMemorySize(memoryCall, scope.Stack, scope.Memory)
+	if err != nil {
+		return nil, err
+	}
+	dynamicCost, err := gasCall(interpreter.evm, scope.Contract, scope.Stack, scope.Memory, memorySize)
+	if err != nil {
+		return nil, fmt.Errorf("%w: %v", ErrOutOfGas, err)
+	}
+	if !scope.Contract.UseGas(dynamicCost, interpreter.evm.Config.Tracer.GasChangeHook(), tracing.GasChangeCallOpCodeDynamic) {
+		return nil, ErrOutOfGas
+	}
+	scope.Memory.Resize(memorySize)
+
+	return opCall(pc, interpreter, scope)
 }
 
 func opCall(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([]byte, error) {
@@ -768,6 +1235,74 @@ func opCall(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([]byt
 	return ret, nil
 }
 
+func opCallCodeEIP4762(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([]byte, error) {
+	memorySize, err := calculateMemorySize(memoryCall, scope.Stack, scope.Memory)
+	if err != nil {
+		return nil, err
+	}
+	dynamicCost, err := gasCallCodeEIP4762(interpreter.evm, scope.Contract, scope.Stack, scope.Memory, memorySize)
+	if err != nil {
+		return nil, fmt.Errorf("%w: %v", ErrOutOfGas, err)
+	}
+	if !scope.Contract.UseGas(dynamicCost, interpreter.evm.Config.Tracer.GasChangeHook(), tracing.GasChangeCallOpCodeDynamic) {
+		return nil, ErrOutOfGas
+	}
+	scope.Memory.Resize(memorySize)
+
+	return opCallCode(pc, interpreter, scope)
+}
+
+func opCallCodeEIP7702(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([]byte, error) {
+	memorySize, err := calculateMemorySize(memoryCall, scope.Stack, scope.Memory)
+	if err != nil {
+		return nil, err
+	}
+	dynamicCost, err := gasCallCodeEIP7702(interpreter.evm, scope.Contract, scope.Stack, scope.Memory, memorySize)
+	if err != nil {
+		return nil, fmt.Errorf("%w: %v", ErrOutOfGas, err)
+	}
+	if !scope.Contract.UseGas(dynamicCost, interpreter.evm.Config.Tracer.GasChangeHook(), tracing.GasChangeCallOpCodeDynamic) {
+		return nil, ErrOutOfGas
+	}
+	scope.Memory.Resize(memorySize)
+
+	return opCallCode(pc, interpreter, scope)
+}
+
+func opCallCodeEIP2929(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([]byte, error) {
+	memorySize, err := calculateMemorySize(memoryCall, scope.Stack, scope.Memory)
+	if err != nil {
+		return nil, err
+	}
+	dynamicCost, err := gasCallCodeEIP2929(interpreter.evm, scope.Contract, scope.Stack, scope.Memory, memorySize)
+	if err != nil {
+		return nil, fmt.Errorf("%w: %v", ErrOutOfGas, err)
+	}
+	if !scope.Contract.UseGas(dynamicCost, interpreter.evm.Config.Tracer.GasChangeHook(), tracing.GasChangeCallOpCodeDynamic) {
+		return nil, ErrOutOfGas
+	}
+	scope.Memory.Resize(memorySize)
+
+	return opCallCode(pc, interpreter, scope)
+}
+
+func opCallCodeFrontier(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([]byte, error) {
+	memorySize, err := calculateMemorySize(memoryCall, scope.Stack, scope.Memory)
+	if err != nil {
+		return nil, err
+	}
+	dynamicCost, err := gasCallCode(interpreter.evm, scope.Contract, scope.Stack, scope.Memory, memorySize)
+	if err != nil {
+		return nil, fmt.Errorf("%w: %v", ErrOutOfGas, err)
+	}
+	if !scope.Contract.UseGas(dynamicCost, interpreter.evm.Config.Tracer.GasChangeHook(), tracing.GasChangeCallOpCodeDynamic) {
+		return nil, ErrOutOfGas
+	}
+	scope.Memory.Resize(memorySize)
+
+	return opCallCode(pc, interpreter, scope)
+}
+
 func opCallCode(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([]byte, error) {
 	// Pop gas. The actual gas is in interpreter.evm.callGasTemp.
 	stack := scope.Stack
@@ -801,6 +1336,57 @@ func opCallCode(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([
 	return ret, nil
 }
 
+func opDelegateCallEIP7702(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([]byte, error) {
+	memorySize, err := calculateMemorySize(memoryDelegateCall, scope.Stack, scope.Memory)
+	if err != nil {
+		return nil, err
+	}
+	dynamicCost, err := gasDelegateCallEIP7702(interpreter.evm, scope.Contract, scope.Stack, scope.Memory, memorySize)
+	if err != nil {
+		return nil, fmt.Errorf("%w: %v", ErrOutOfGas, err)
+	}
+	if !scope.Contract.UseGas(dynamicCost, interpreter.evm.Config.Tracer.GasChangeHook(), tracing.GasChangeCallOpCodeDynamic) {
+		return nil, ErrOutOfGas
+	}
+	scope.Memory.Resize(memorySize)
+
+	return opDelegateCall(pc, interpreter, scope)
+}
+
+func opDelegateCallEIP2929(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([]byte, error) {
+	memorySize, err := calculateMemorySize(memoryDelegateCall, scope.Stack, scope.Memory)
+	if err != nil {
+		return nil, err
+	}
+	dynamicCost, err := gasDelegateCallEIP2929(interpreter.evm, scope.Contract, scope.Stack, scope.Memory, memorySize)
+	if err != nil {
+		return nil, fmt.Errorf("%w: %v", ErrOutOfGas, err)
+	}
+	if !scope.Contract.UseGas(dynamicCost, interpreter.evm.Config.Tracer.GasChangeHook(), tracing.GasChangeCallOpCodeDynamic) {
+		return nil, ErrOutOfGas
+	}
+	scope.Memory.Resize(memorySize)
+
+	return opDelegateCall(pc, interpreter, scope)
+}
+
+func opDelegateCallEIP4762(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([]byte, error) {
+	memorySize, err := calculateMemorySize(memoryDelegateCall, scope.Stack, scope.Memory)
+	if err != nil {
+		return nil, err
+	}
+	dynamicCost, err := gasDelegateCallEIP4762(interpreter.evm, scope.Contract, scope.Stack, scope.Memory, memorySize)
+	if err != nil {
+		return nil, fmt.Errorf("%w: %v", ErrOutOfGas, err)
+	}
+	if !scope.Contract.UseGas(dynamicCost, interpreter.evm.Config.Tracer.GasChangeHook(), tracing.GasChangeCallOpCodeDynamic) {
+		return nil, ErrOutOfGas
+	}
+	scope.Memory.Resize(memorySize)
+
+	return opDelegateCall(pc, interpreter, scope)
+}
+
 func opDelegateCall(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([]byte, error) {
 	stack := scope.Stack
 	// Pop gas. The actual gas is in interpreter.evm.callGasTemp.
@@ -828,6 +1414,91 @@ func opDelegateCall(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext
 
 	interpreter.returnData = ret
 	return ret, nil
+}
+
+func opDelegateCallHomestead(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([]byte, error) {
+	memorySize, err := calculateMemorySize(memoryDelegateCall, scope.Stack, scope.Memory)
+	if err != nil {
+		return nil, err
+	}
+	dynamicCost, err := gasDelegateCall(interpreter.evm, scope.Contract, scope.Stack, scope.Memory, memorySize)
+	if err != nil {
+		return nil, fmt.Errorf("%w: %v", ErrOutOfGas, err)
+	}
+	if !scope.Contract.UseGas(dynamicCost, interpreter.evm.Config.Tracer.GasChangeHook(), tracing.GasChangeCallOpCodeDynamic) {
+		return nil, ErrOutOfGas
+	}
+	scope.Memory.Resize(memorySize)
+
+	return opDelegateCall(pc, interpreter, scope)
+}
+
+func opStaticCallEIP7702(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([]byte, error) {
+	memorySize, err := calculateMemorySize(memoryStaticCall, scope.Stack, scope.Memory)
+	if err != nil {
+		return nil, err
+	}
+	dynamicCost, err := gasStaticCallEIP7702(interpreter.evm, scope.Contract, scope.Stack, scope.Memory, memorySize)
+	if err != nil {
+		return nil, fmt.Errorf("%w: %v", ErrOutOfGas, err)
+	}
+	if !scope.Contract.UseGas(dynamicCost, interpreter.evm.Config.Tracer.GasChangeHook(), tracing.GasChangeCallOpCodeDynamic) {
+		return nil, ErrOutOfGas
+	}
+	scope.Memory.Resize(memorySize)
+
+	return opStaticCall(pc, interpreter, scope)
+}
+
+func opStaticCallByzantium(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([]byte, error) {
+	memorySize, err := calculateMemorySize(memoryStaticCall, scope.Stack, scope.Memory)
+	if err != nil {
+		return nil, err
+	}
+	dynamicCost, err := gasStaticCall(interpreter.evm, scope.Contract, scope.Stack, scope.Memory, memorySize)
+	if err != nil {
+		return nil, fmt.Errorf("%w: %v", ErrOutOfGas, err)
+	}
+	if !scope.Contract.UseGas(dynamicCost, interpreter.evm.Config.Tracer.GasChangeHook(), tracing.GasChangeCallOpCodeDynamic) {
+		return nil, ErrOutOfGas
+	}
+	scope.Memory.Resize(memorySize)
+
+	return opStaticCall(pc, interpreter, scope)
+}
+
+func opStaticCallEIP2929(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([]byte, error) {
+	memorySize, err := calculateMemorySize(memoryStaticCall, scope.Stack, scope.Memory)
+	if err != nil {
+		return nil, err
+	}
+	dynamicCost, err := gasStaticCallEIP2929(interpreter.evm, scope.Contract, scope.Stack, scope.Memory, memorySize)
+	if err != nil {
+		return nil, fmt.Errorf("%w: %v", ErrOutOfGas, err)
+	}
+	if !scope.Contract.UseGas(dynamicCost, interpreter.evm.Config.Tracer.GasChangeHook(), tracing.GasChangeCallOpCodeDynamic) {
+		return nil, ErrOutOfGas
+	}
+	scope.Memory.Resize(memorySize)
+
+	return opStaticCall(pc, interpreter, scope)
+}
+
+func opStaticCallEIP4762(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([]byte, error) {
+	memorySize, err := calculateMemorySize(memoryStaticCall, scope.Stack, scope.Memory)
+	if err != nil {
+		return nil, err
+	}
+	dynamicCost, err := gasStaticCallEIP4762(interpreter.evm, scope.Contract, scope.Stack, scope.Memory, memorySize)
+	if err != nil {
+		return nil, fmt.Errorf("%w: %v", ErrOutOfGas, err)
+	}
+	if !scope.Contract.UseGas(dynamicCost, interpreter.evm.Config.Tracer.GasChangeHook(), tracing.GasChangeCallOpCodeDynamic) {
+		return nil, ErrOutOfGas
+	}
+	scope.Memory.Resize(memorySize)
+
+	return opStaticCall(pc, interpreter, scope)
 }
 
 func opStaticCall(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([]byte, error) {
@@ -860,6 +1531,19 @@ func opStaticCall(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) 
 }
 
 func opReturn(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([]byte, error) {
+	memorySize, err := calculateMemorySize(memoryReturn, scope.Stack, scope.Memory)
+	if err != nil {
+		return nil, err
+	}
+	dynamicCost, err := gasReturn(interpreter.evm, scope.Contract, scope.Stack, scope.Memory, memorySize)
+	if err != nil {
+		return nil, fmt.Errorf("%w: %v", ErrOutOfGas, err)
+	}
+	if !scope.Contract.UseGas(dynamicCost, interpreter.evm.Config.Tracer.GasChangeHook(), tracing.GasChangeCallOpCodeDynamic) {
+		return nil, ErrOutOfGas
+	}
+	scope.Memory.Resize(memorySize)
+
 	offset, size := scope.Stack.pop(), scope.Stack.pop()
 	ret := scope.Memory.GetCopy(offset.Uint64(), size.Uint64())
 
@@ -867,6 +1551,19 @@ func opReturn(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([]b
 }
 
 func opRevert(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([]byte, error) {
+	memorySize, err := calculateMemorySize(memoryRevert, scope.Stack, scope.Memory)
+	if err != nil {
+		return nil, err
+	}
+	dynamicCost, err := gasRevert(interpreter.evm, scope.Contract, scope.Stack, scope.Memory, memorySize)
+	if err != nil {
+		return nil, fmt.Errorf("%w: %v", ErrOutOfGas, err)
+	}
+	if !scope.Contract.UseGas(dynamicCost, interpreter.evm.Config.Tracer.GasChangeHook(), tracing.GasChangeCallOpCodeDynamic) {
+		return nil, ErrOutOfGas
+	}
+	scope.Memory.Resize(memorySize)
+
 	offset, size := scope.Stack.pop(), scope.Stack.pop()
 	ret := scope.Memory.GetCopy(offset.Uint64(), size.Uint64())
 
@@ -882,10 +1579,59 @@ func opStop(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([]byt
 	return nil, errStopToken
 }
 
+func opSelfdestructEIP6780(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([]byte, error) {
+	dynamicCost, err := gasSelfdestructEIP3529(interpreter.evm, scope.Contract, scope.Stack, scope.Memory, 0)
+	if err != nil {
+		return nil, fmt.Errorf("%w: %v", ErrOutOfGas, err)
+	}
+	if !scope.Contract.UseGas(dynamicCost, interpreter.evm.Config.Tracer.GasChangeHook(), tracing.GasChangeCallOpCodeDynamic) {
+		return nil, ErrOutOfGas
+	}
+
+	return opSelfdestruct6780(pc, interpreter, scope)
+}
+
+func opSelfdestructEIP3529(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([]byte, error) {
+	dynamicCost, err := gasSelfdestructEIP3529(interpreter.evm, scope.Contract, scope.Stack, scope.Memory, 0)
+	if err != nil {
+		return nil, fmt.Errorf("%w: %v", ErrOutOfGas, err)
+	}
+	if !scope.Contract.UseGas(dynamicCost, interpreter.evm.Config.Tracer.GasChangeHook(), tracing.GasChangeCallOpCodeDynamic) {
+		return nil, ErrOutOfGas
+	}
+
+	return opSelfdestruct(pc, interpreter, scope)
+}
+
+func opSelfdestructEIP2929(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([]byte, error) {
+	dynamicCost, err := gasSelfdestructEIP2929(interpreter.evm, scope.Contract, scope.Stack, scope.Memory, 0)
+	if err != nil {
+		return nil, fmt.Errorf("%w: %v", ErrOutOfGas, err)
+	}
+	if !scope.Contract.UseGas(dynamicCost, interpreter.evm.Config.Tracer.GasChangeHook(), tracing.GasChangeCallOpCodeDynamic) {
+		return nil, ErrOutOfGas
+	}
+
+	return opSelfdestruct(pc, interpreter, scope)
+}
+
+func opSelfdestructFrontier(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([]byte, error) {
+	dynamicCost, err := gasSelfdestruct(interpreter.evm, scope.Contract, scope.Stack, scope.Memory, 0)
+	if err != nil {
+		return nil, fmt.Errorf("%w: %v", ErrOutOfGas, err)
+	}
+	if !scope.Contract.UseGas(dynamicCost, interpreter.evm.Config.Tracer.GasChangeHook(), tracing.GasChangeCallOpCodeDynamic) {
+		return nil, ErrOutOfGas
+	}
+
+	return opSelfdestruct(pc, interpreter, scope)
+}
+
 func opSelfdestruct(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([]byte, error) {
 	if interpreter.readOnly {
 		return nil, ErrWriteProtection
 	}
+
 	beneficiary := scope.Stack.pop()
 	balance := interpreter.evm.StateDB.GetBalance(scope.Contract.Address())
 	interpreter.evm.StateDB.AddBalance(beneficiary.Bytes20(), balance, tracing.BalanceIncreaseSelfdestruct)
@@ -899,6 +1645,18 @@ func opSelfdestruct(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext
 		}
 	}
 	return nil, errStopToken
+}
+
+func opSelfdestructEIP4762(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([]byte, error) {
+	dynamicCost, err := gasSelfdestructEIP4762(interpreter.evm, scope.Contract, scope.Stack, scope.Memory, 0)
+	if err != nil {
+		return nil, fmt.Errorf("%w: %v", ErrOutOfGas, err)
+	}
+	if !scope.Contract.UseGas(dynamicCost, interpreter.evm.Config.Tracer.GasChangeHook(), tracing.GasChangeCallOpCodeDynamic) {
+		return nil, ErrOutOfGas
+	}
+
+	return opSelfdestruct6780(pc, interpreter, scope)
 }
 
 func opSelfdestruct6780(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([]byte, error) {
@@ -925,10 +1683,24 @@ func opSelfdestruct6780(pc *uint64, interpreter *EVMInterpreter, scope *ScopeCon
 
 // make log instruction function
 func makeLog(size int) executionFunc {
+	logGas := makeGasLog(uint64(size))
 	return func(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([]byte, error) {
 		if interpreter.readOnly {
 			return nil, ErrWriteProtection
 		}
+		memorySize, err := calculateMemorySize(memoryLog, scope.Stack, scope.Memory)
+		if err != nil {
+			return nil, err
+		}
+		dynamicCost, err := logGas(interpreter.evm, scope.Contract, scope.Stack, scope.Memory, memorySize)
+		if err != nil {
+			return nil, fmt.Errorf("%w: %v", ErrOutOfGas, err)
+		}
+		if !scope.Contract.UseGas(dynamicCost, interpreter.evm.Config.Tracer.GasChangeHook(), tracing.GasChangeCallOpCodeDynamic) {
+			return nil, ErrOutOfGas
+		}
+		scope.Memory.Resize(memorySize)
+
 		topics := make([]common.Hash, size)
 		stack := scope.Stack
 		mStart, mSize := stack.pop(), stack.pop()

--- a/core/vm/interpreter.go
+++ b/core/vm/interpreter.go
@@ -17,10 +17,7 @@
 package vm
 
 import (
-	"fmt"
-
 	"github.com/ethereum/go-ethereum/common"
-	"github.com/ethereum/go-ethereum/common/math"
 	"github.com/ethereum/go-ethereum/core/tracing"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/log"
@@ -139,7 +136,7 @@ func NewEVMInterpreter(evm *EVM) *EVMInterpreter {
 		table = &frontierInstructionSet
 	}
 	var extraEips []int
-	if len(evm.Config.ExtraEips) > 0 {
+	if len(evm.Config.ExtraEips) > 0 || evm.Config.Tracer != nil {
 		// Deep-copy jumptable to prevent modification of opcodes in other tables
 		table = copyJumpTable(table)
 	}
@@ -151,8 +148,39 @@ func NewEVMInterpreter(evm *EVM) *EVMInterpreter {
 			extraEips = append(extraEips, eip)
 		}
 	}
+	if evm.Config.Tracer != nil {
+		for _, op := range table {
+			op.execute = executeWithTracer(evm.Config.Tracer, op.execute)
+		}
+	}
+
 	evm.Config.ExtraEips = extraEips
 	return &EVMInterpreter{evm: evm, table: table, hasher: crypto.NewKeccakState()}
+}
+
+// executeWithTracer is a wrapper that enables tracing the given executionFunc
+func executeWithTracer(tracer *tracing.Hooks, execF executionFunc) executionFunc {
+	return func(pc *uint64, interpreter *EVMInterpreter, callContext *ScopeContext) ([]byte, error) {
+		pcCopy := *pc
+		op := callContext.Contract.GetOp(pcCopy)
+		operation := interpreter.table[op]
+		cost := operation.constantGas
+		gasCopy := callContext.Contract.Gas + cost
+
+		if tracer.OnGasChange != nil {
+			tracer.OnGasChange(gasCopy, gasCopy-cost, tracing.GasChangeCallOpCode)
+		}
+		if tracer.OnOpcode != nil {
+			tracer.OnOpcode(pcCopy, byte(op), gasCopy, cost, callContext, interpreter.returnData,
+				interpreter.evm.depth, nil)
+		}
+
+		ret, err := execF(pc, interpreter, callContext)
+		if err != nil && err != errStopToken && tracer.OnFault != nil {
+			tracer.OnFault(pcCopy, byte(op), gasCopy, gasCopy-callContext.Contract.Gas, callContext, interpreter.evm.depth, VMErrorFromErr(err))
+		}
+		return ret, err
+	}
 }
 
 // Run loops and evaluates the contract's code with the given input data and returns
@@ -197,12 +225,7 @@ func (in *EVMInterpreter) Run(contract *Contract, input []byte, readOnly bool) (
 		// to be uint256. Practically much less so feasible.
 		pc   = uint64(0) // program counter
 		cost uint64
-		// copies used by tracer
-		pcCopy  uint64 // needed for the deferred EVMLogger
-		gasCopy uint64 // for EVMLogger to log gas remaining before execution
-		logged  bool   // deferred EVMLogger should ignore already logged steps
-		res     []byte // result of the opcode execution function
-		debug   = in.evm.Config.Tracer != nil
+		res  []byte // result of the opcode execution function
 	)
 	// Don't move this deferred function, it's placed before the OnOpcode-deferred method,
 	// so that it gets executed _after_: the OnOpcode needs the stacks before
@@ -213,38 +236,28 @@ func (in *EVMInterpreter) Run(contract *Contract, input []byte, readOnly bool) (
 	}()
 	contract.Input = input
 
-	if debug {
-		defer func() { // this deferred method handles exit-with-error
-			if err == nil {
-				return
-			}
-			if !logged && in.evm.Config.Tracer.OnOpcode != nil {
-				in.evm.Config.Tracer.OnOpcode(pcCopy, byte(op), gasCopy, cost, callContext, in.returnData, in.evm.depth, VMErrorFromErr(err))
-			}
-			if logged && in.evm.Config.Tracer.OnFault != nil {
-				in.evm.Config.Tracer.OnFault(pcCopy, byte(op), gasCopy, cost, callContext, in.evm.depth, VMErrorFromErr(err))
-			}
-		}()
+	// This is just temporary until we move everything that can error in to the execution function
+	traceAndReturnError := func(err error) error {
+		if in.evm.Config.Tracer != nil && in.evm.Config.Tracer.OnFault != nil {
+			in.evm.Config.Tracer.OnFault(pc, byte(op), contract.Gas, cost, callContext, in.evm.depth, VMErrorFromErr(err))
+		}
+		return err
 	}
+
 	// The Interpreter main run loop (contextual). This loop runs until either an
 	// explicit STOP, RETURN or SELFDESTRUCT is executed, an error occurred during
 	// the execution of one of the operations or until the done flag is set by the
 	// parent context.
 	_ = jumpTable[0] // nil-check the jumpTable out of the loop
 	for {
-		if debug {
-			// Capture pre-execution values for tracing.
-			logged, pcCopy, gasCopy = false, pc, contract.Gas
-		}
-
 		if in.evm.chainRules.IsEIP4762 && !contract.IsDeployment && !contract.IsSystemCall {
 			// if the PC ends up in a new "chunk" of verkleized code, charge the
 			// associated costs.
 			contractAddr := contract.Address()
 			consumed, wanted := in.evm.TxContext.AccessEvents.CodeChunksRangeGas(contractAddr, pc, 1, uint64(len(contract.Code)), false, contract.Gas)
-			contract.UseGas(consumed, in.evm.Config.Tracer, tracing.GasChangeWitnessCodeChunk)
+			contract.UseGas(consumed, in.evm.Config.Tracer.GasChangeHook(), tracing.GasChangeWitnessCodeChunk)
 			if consumed < wanted {
-				return nil, ErrOutOfGas
+				return nil, traceAndReturnError(ErrOutOfGas)
 			}
 		}
 
@@ -255,63 +268,15 @@ func (in *EVMInterpreter) Run(contract *Contract, input []byte, readOnly bool) (
 		cost = operation.constantGas // For tracing
 		// Validate stack
 		if sLen := stack.len(); sLen < operation.minStack {
-			return nil, &ErrStackUnderflow{stackLen: sLen, required: operation.minStack}
+			return nil, traceAndReturnError(&ErrStackUnderflow{stackLen: sLen, required: operation.minStack})
 		} else if sLen > operation.maxStack {
-			return nil, &ErrStackOverflow{stackLen: sLen, limit: operation.maxStack}
+			return nil, traceAndReturnError(&ErrStackOverflow{stackLen: sLen, limit: operation.maxStack})
 		}
-		// for tracing: this gas consumption event is emitted below in the debug section.
+		// for tracing: this gas consumption event is emitted in the executeWithTracer wrapper.
 		if contract.Gas < cost {
-			return nil, ErrOutOfGas
+			return nil, traceAndReturnError(ErrOutOfGas)
 		} else {
 			contract.Gas -= cost
-		}
-
-		// All ops with a dynamic memory usage also has a dynamic gas cost.
-		var memorySize uint64
-		if operation.dynamicGas != nil {
-			// calculate the new memory size and expand the memory to fit
-			// the operation
-			// Memory check needs to be done prior to evaluating the dynamic gas portion,
-			// to detect calculation overflows
-			if operation.memorySize != nil {
-				memSize, overflow := operation.memorySize(stack)
-				if overflow {
-					return nil, ErrGasUintOverflow
-				}
-				// memory is expanded in words of 32 bytes. Gas
-				// is also calculated in words.
-				if memorySize, overflow = math.SafeMul(toWordSize(memSize), 32); overflow {
-					return nil, ErrGasUintOverflow
-				}
-			}
-			// Consume the gas and return an error if not enough gas is available.
-			// cost is explicitly set so that the capture state defer method can get the proper cost
-			var dynamicCost uint64
-			dynamicCost, err = operation.dynamicGas(in.evm, contract, stack, mem, memorySize)
-			cost += dynamicCost // for tracing
-			if err != nil {
-				return nil, fmt.Errorf("%w: %v", ErrOutOfGas, err)
-			}
-			// for tracing: this gas consumption event is emitted below in the debug section.
-			if contract.Gas < dynamicCost {
-				return nil, ErrOutOfGas
-			} else {
-				contract.Gas -= dynamicCost
-			}
-		}
-
-		// Do tracing before potential memory expansion
-		if debug {
-			if in.evm.Config.Tracer.OnGasChange != nil {
-				in.evm.Config.Tracer.OnGasChange(gasCopy, gasCopy-cost, tracing.GasChangeCallOpCode)
-			}
-			if in.evm.Config.Tracer.OnOpcode != nil {
-				in.evm.Config.Tracer.OnOpcode(pc, byte(op), gasCopy, cost, callContext, in.returnData, in.evm.depth, VMErrorFromErr(err))
-				logged = true
-			}
-		}
-		if memorySize > 0 {
-			mem.Resize(memorySize)
 		}
 
 		// execute the operation

--- a/core/vm/jump_table_export.go
+++ b/core/vm/jump_table_export.go
@@ -62,17 +62,3 @@ func LookupInstructionSet(rules params.Rules) (JumpTable, error) {
 func (op *operation) Stack() (int, int) {
 	return op.minStack, op.maxStack
 }
-
-// HasCost returns true if the opcode has a cost. Opcodes which do _not_ have
-// a cost assigned are one of two things:
-// - undefined, a.k.a invalid opcodes,
-// - the STOP opcode.
-// This method can thus be used to check if an opcode is "Invalid (or STOP)".
-func (op *operation) HasCost() bool {
-	// Ideally, we'd check this:
-	//	return op.execute == opUndefined
-	// However, go-lang does now allow that. So we'll just check some other
-	// 'indicators' that this is an invalid op. Alas, STOP is impossible to
-	// filter out
-	return op.dynamicGas != nil || op.constantGas != 0
-}

--- a/core/vm/operations_acl.go
+++ b/core/vm/operations_acl.go
@@ -164,7 +164,7 @@ func makeCallVariantGasCallEIP2929(oldCalculator gasFunc, addressPosition int) g
 			evm.StateDB.AddAddressToAccessList(addr)
 			// Charge the remaining difference here already, to correctly calculate available
 			// gas for call
-			if !contract.UseGas(coldCost, evm.Config.Tracer, tracing.GasChangeCallStorageColdAccess) {
+			if !contract.UseGas(coldCost, evm.Config.Tracer.GasChangeHook(), tracing.GasChangeCallStorageColdAccess) {
 				return 0, ErrOutOfGas
 			}
 		}
@@ -265,7 +265,7 @@ func makeCallVariantGasCallEIP7702(oldCalculator gasFunc) gasFunc {
 			coldCost := params.ColdAccountAccessCostEIP2929 - params.WarmStorageReadCostEIP2929
 			// Charge the remaining difference here already, to correctly calculate available
 			// gas for call
-			if !contract.UseGas(coldCost, evm.Config.Tracer, tracing.GasChangeCallStorageColdAccess) {
+			if !contract.UseGas(coldCost, evm.Config.Tracer.GasChangeHook(), tracing.GasChangeCallStorageColdAccess) {
 				return 0, ErrOutOfGas
 			}
 			total += coldCost
@@ -280,7 +280,7 @@ func makeCallVariantGasCallEIP7702(oldCalculator gasFunc) gasFunc {
 				evm.StateDB.AddAddressToAccessList(target)
 				cost = params.ColdAccountAccessCostEIP2929
 			}
-			if !contract.UseGas(cost, evm.Config.Tracer, tracing.GasChangeCallStorageColdAccess) {
+			if !contract.UseGas(cost, evm.Config.Tracer.GasChangeHook(), tracing.GasChangeCallStorageColdAccess) {
 				return 0, ErrOutOfGas
 			}
 			total += cost

--- a/core/vm/runtime/runtime_test.go
+++ b/core/vm/runtime/runtime_test.go
@@ -667,6 +667,11 @@ func TestColdAccountAccessCost(t *testing.T) {
 		Execute(tc.code, nil, &Config{
 			EVMConfig: vm.Config{
 				Tracer: &tracing.Hooks{
+					OnGasChange: func(old, new uint64, reason tracing.GasChangeReason) {
+						if step-1 == tc.step && reason == tracing.GasChangeCallOpCodeDynamic {
+							have += old - new
+						}
+					},
 					OnOpcode: func(pc uint64, op byte, gas, cost uint64, scope tracing.OpContext, rData []byte, depth int, err error) {
 						// Uncomment to investigate failures:
 						//t.Logf("%d: %v %d", step, vm.OpCode(op).String(), cost)
@@ -700,10 +705,15 @@ func TestRuntimeJSTracer(t *testing.T) {
 		this.exits++;
 		this.gasUsed = res.getGasUsed();
 	}}`,
-		`{enters: 0, exits: 0, enterGas: 0, gasUsed: 0, steps:0,
+		`{enters: 0, exits: 0, enterGas: 0, gasUsed: 0, steps:0, dynamicGas:0,
 	fault: function() {},
 	result: function() {
-		return [this.enters, this.exits,this.enterGas,this.gasUsed, this.steps].join(",")
+		return [this.enters, this.exits,this.enterGas,this.gasUsed, this.steps, this.dynamicGas].join(",")
+	},
+	gas: function(change) {
+		if (change.getReason() == "CallOpCodeDynamic") {
+			this.dynamicGas += change.getOld() - change.getNew();
+		}
 	},
 	enter: function(frame) {
 		this.enters++;
@@ -726,7 +736,7 @@ func TestRuntimeJSTracer(t *testing.T) {
 				Push(0).                  // value
 				Op(vm.CREATE).
 				Op(vm.POP).Bytes(),
-			results: []string{`"1,1,952853,6,12"`, `"1,1,952853,6,0"`},
+			results: []string{`"1,1,952853,6,12"`, `"1,1,952853,6,0,5"`},
 		},
 		{ // CREATE2
 			code: program.New().MstoreSmall(initcode, 0).
@@ -736,27 +746,27 @@ func TestRuntimeJSTracer(t *testing.T) {
 				Push(0).                  // value
 				Op(vm.CREATE2).
 				Op(vm.POP).Bytes(),
-			results: []string{`"1,1,952844,6,13"`, `"1,1,952844,6,0"`},
+			results: []string{`"1,1,952844,6,13"`, `"1,1,952844,6,0,11"`},
 		},
 		{ // CALL
 			code:    program.New().Call(nil, 0xbb, 0, 0, 0, 0, 0).Op(vm.POP).Bytes(),
-			results: []string{`"1,1,981796,6,13"`, `"1,1,981796,6,0"`},
+			results: []string{`"1,1,981796,6,13"`, `"1,1,981796,6,0,984296"`},
 		},
 		{ // CALLCODE
 			code:    program.New().CallCode(nil, 0xcc, 0, 0, 0, 0, 0).Op(vm.POP).Bytes(),
-			results: []string{`"1,1,981796,6,13"`, `"1,1,981796,6,0"`},
+			results: []string{`"1,1,981796,6,13"`, `"1,1,981796,6,0,984296"`},
 		},
 		{ // STATICCALL
 			code:    program.New().StaticCall(nil, 0xdd, 0, 0, 0, 0).Op(vm.POP).Bytes(),
-			results: []string{`"1,1,981799,6,12"`, `"1,1,981799,6,0"`},
+			results: []string{`"1,1,981799,6,12"`, `"1,1,981799,6,0,984299"`},
 		},
 		{ // DELEGATECALL
 			code:    program.New().DelegateCall(nil, 0xee, 0, 0, 0, 0).Op(vm.POP).Bytes(),
-			results: []string{`"1,1,981799,6,12"`, `"1,1,981799,6,0"`},
+			results: []string{`"1,1,981799,6,12"`, `"1,1,981799,6,0,984299"`},
 		},
 		{ // CALL self-destructing contract
 			code:    program.New().Call(nil, 0xff, 0, 0, 0, 0, 0).Op(vm.POP).Bytes(),
-			results: []string{`"2,2,0,5003,12"`, `"2,2,0,5003,0"`},
+			results: []string{`"2,2,0,5003,12"`, `"2,2,0,5003,0,984296"`},
 		},
 	}
 	calleeCode := []byte{
@@ -921,6 +931,11 @@ func TestDelegatedAccountAccessCost(t *testing.T) {
 			State:       statedb,
 			EVMConfig: vm.Config{
 				Tracer: &tracing.Hooks{
+					OnGasChange: func(old, new uint64, reason tracing.GasChangeReason) {
+						if step-1 == tc.step && reason == tracing.GasChangeCallOpCodeDynamic {
+							have += old - new
+						}
+					},
 					OnOpcode: func(pc uint64, op byte, gas, cost uint64, scope tracing.OpContext, rData []byte, depth int, err error) {
 						// Uncomment to investigate failures:
 						t.Logf("%d: %v %d", step, vm.OpCode(op).String(), cost)

--- a/eth/tracers/logger/logger.go
+++ b/eth/tracers/logger/logger.go
@@ -17,6 +17,7 @@
 package logger
 
 import (
+	"bytes"
 	"encoding/hex"
 	"encoding/json"
 	"errors"
@@ -96,12 +97,19 @@ func (s *StructLog) ErrorString() string {
 
 // WriteTo writes the human-readable log data into the supplied writer.
 func (s *StructLog) WriteTo(writer io.Writer) {
+	s.writeHeaderTo(writer)
+	s.writeVmStateTo(writer)
+}
+
+func (s *StructLog) writeHeaderTo(writer io.Writer) {
 	fmt.Fprintf(writer, "%-16spc=%08d gas=%v cost=%v", s.Op, s.Pc, s.Gas, s.GasCost)
 	if s.Err != nil {
 		fmt.Fprintf(writer, " ERROR: %v", s.Err)
 	}
 	fmt.Fprintln(writer)
+}
 
+func (s *StructLog) writeVmStateTo(writer io.Writer) {
 	if len(s.Stack) > 0 {
 		fmt.Fprintln(writer, "Stack:")
 		for i := len(s.Stack) - 1; i >= 0; i-- {
@@ -157,7 +165,7 @@ type structLogLegacy struct {
 }
 
 // toLegacyJSON converts the structLog to legacy json-encoded legacy form.
-func (s *StructLog) toLegacyJSON() json.RawMessage {
+func (s *StructLog) toLegacyJSON() structLogLegacy {
 	msg := structLogLegacy{
 		Pc:            s.Pc,
 		Op:            s.Op.String(),
@@ -195,8 +203,8 @@ func (s *StructLog) toLegacyJSON() json.RawMessage {
 		}
 		msg.Storage = &storage
 	}
-	element, _ := json.Marshal(msg)
-	return element
+
+	return msg
 }
 
 // StructLogger is an EVM state logger and implements EVMLogger.
@@ -223,6 +231,11 @@ type StructLogger struct {
 	interrupt atomic.Bool // Atomic flag to signal execution interruption
 	reason    error       // Textual reason for the interruption
 	skip      bool        // skip processing hooks.
+
+	// stitching context
+	stitchingBuffer   bytes.Buffer
+	inflightLog       StructLog
+	legacyInflightLog structLogLegacy
 }
 
 // NewStreamingStructLogger returns a new streaming logger.
@@ -252,6 +265,24 @@ func (l *StructLogger) Hooks() *tracing.Hooks {
 		OnSystemCallEnd:     l.OnSystemCallEnd,
 		OnExit:              l.OnExit,
 		OnOpcode:            l.OnOpcode,
+		OnGasChange:         l.OnGasChange,
+	}
+}
+
+// OnFault logs failing opcodes
+func (l *StructLogger) OnFault(pc uint64, op byte, gas, cost uint64, scope tracing.OpContext, depth int, err error) {
+	if l.skip {
+		return
+	}
+	l.inflightLog.Err = err
+	l.flushInflightLog()
+}
+
+// OnGasChange logs the dynamic and refunded gas amounts
+func (l *StructLogger) OnGasChange(old, new uint64, reason tracing.GasChangeReason) {
+	if reason == tracing.GasChangeCallOpCodeDynamic {
+		l.inflightLog.GasCost += old - new
+		l.inflightLog.RefundCounter = l.env.StateDB.GetRefund()
 	}
 }
 
@@ -263,6 +294,7 @@ func (l *StructLogger) OnOpcode(pc uint64, opcode byte, gas, cost uint64, scope 
 	if l.interrupt.Load() {
 		return
 	}
+	l.flushInflightLog()
 	// Processing a system call.
 	if l.skip {
 		return
@@ -279,6 +311,7 @@ func (l *StructLogger) OnOpcode(pc uint64, opcode byte, gas, cost uint64, scope 
 		stackLen     = len(stack)
 	)
 	log := StructLog{pc, op, gas, cost, nil, len(memory), nil, nil, nil, depth, l.env.StateDB.GetRefund(), err}
+	l.inflightLog = log
 	if l.cfg.EnableMemory {
 		log.Memory = memory
 	}
@@ -319,12 +352,31 @@ func (l *StructLogger) OnOpcode(pc uint64, opcode byte, gas, cost uint64, scope 
 
 	// create a log
 	if l.writer == nil {
-		entry := log.toLegacyJSON()
+		l.legacyInflightLog = log.toLegacyJSON()
+	} else {
+		log.writeVmStateTo(&l.stitchingBuffer)
+	}
+	if opcode == byte(vm.STOP) {
+		l.flushInflightLog()
+	}
+}
+
+func (l *StructLogger) flushInflightLog() {
+	// emptyLegacy is used as a sentinel value
+	var emptyLegacy structLogLegacy
+	if l.writer == nil && l.legacyInflightLog != emptyLegacy {
+		l.legacyInflightLog.GasCost = l.inflightLog.GasCost
+		l.legacyInflightLog.Error = l.inflightLog.ErrorString()
+		l.legacyInflightLog.RefundCounter = l.inflightLog.RefundCounter
+		entry, _ := json.Marshal(l.legacyInflightLog)
 		l.resultSize += len(entry)
 		l.logs = append(l.logs, entry)
-		return
+		l.legacyInflightLog = emptyLegacy
+	} else if l.stitchingBuffer.Len() > 0 {
+		l.inflightLog.writeHeaderTo(l.writer)
+		l.writer.Write(l.stitchingBuffer.Bytes())
 	}
-	log.WriteTo(l.writer)
+	l.stitchingBuffer.Reset()
 }
 
 // OnExit is called a call frame finishes processing.
@@ -414,6 +466,11 @@ type mdLogger struct {
 	cfg  *Config
 	env  *tracing.VMContext
 	skip bool
+
+	// stitching context
+	stitchingBuffer bytes.Buffer
+	cost            uint64
+	refund          uint64
 }
 
 // NewMarkdownLogger creates a logger which outputs information in a format adapted
@@ -435,6 +492,7 @@ func (t *mdLogger) Hooks() *tracing.Hooks {
 		OnExit:              t.OnExit,
 		OnOpcode:            t.OnOpcode,
 		OnFault:             t.OnFault,
+		OnGasChange:         t.OnGasChange,
 	}
 }
 
@@ -493,14 +551,26 @@ func (t *mdLogger) OnExit(depth int, output []byte, gasUsed uint64, err error, r
 	}
 }
 
+// OnGasChange tracks the dynamic gas and refund amounts
+func (t *mdLogger) OnGasChange(old, new uint64, reason tracing.GasChangeReason) {
+	if reason == tracing.GasChangeCallOpCodeDynamic {
+		t.cost += old - new
+		t.refund = t.env.StateDB.GetRefund()
+	}
+}
+
 // OnOpcode also tracks SLOAD/SSTORE ops to track storage change.
 func (t *mdLogger) OnOpcode(pc uint64, op byte, gas, cost uint64, scope tracing.OpContext, rData []byte, depth int, err error) {
+	t.flushInflightLog()
+
 	if t.skip {
 		return
 	}
 	stack := scope.StackData()
-	fmt.Fprintf(t.out, "| %4d  | %10v  |  %3d |%10v |", pc, vm.OpCode(op).String(),
-		cost, t.env.StateDB.GetRefund())
+	t.cost = cost
+	t.refund = t.env.StateDB.GetRefund()
+	fmt.Fprintf(&t.stitchingBuffer, "| %4d  | %10v  |  %s |%s |", pc, vm.OpCode(op).String(),
+		/* placeholders */ "%3d", "%10v")
 
 	if !t.cfg.DisableStack {
 		// format stack
@@ -509,11 +579,14 @@ func (t *mdLogger) OnOpcode(pc uint64, op byte, gas, cost uint64, scope tracing.
 			a = append(a, elem.Hex())
 		}
 		b := fmt.Sprintf("[%v]", strings.Join(a, ","))
-		fmt.Fprintf(t.out, "%10v |", b)
+		fmt.Fprintf(&t.stitchingBuffer, "%10v |", b)
 	}
-	fmt.Fprintln(t.out, "")
+	fmt.Fprintln(&t.stitchingBuffer, "")
 	if err != nil {
-		fmt.Fprintf(t.out, "Error: %v\n", err)
+		fmt.Fprintf(&t.stitchingBuffer, "Error: %v\n", err)
+	}
+	if op == byte(vm.STOP) {
+		t.flushInflightLog()
 	}
 }
 
@@ -521,7 +594,15 @@ func (t *mdLogger) OnFault(pc uint64, op byte, gas, cost uint64, scope tracing.O
 	if t.skip {
 		return
 	}
-	fmt.Fprintf(t.out, "\nError: at pc=%d, op=%v: %v\n", pc, op, err)
+	t.flushInflightLog()
+	fmt.Fprintf(t.out, "Error: at pc=%d, op=%v: %v\n", pc, op, err)
+}
+
+func (t *mdLogger) flushInflightLog() {
+	if t.stitchingBuffer.Len() > 0 {
+		fmt.Fprintf(t.out, t.stitchingBuffer.String(), t.cost, t.refund)
+		t.stitchingBuffer.Reset()
+	}
 }
 
 // ExecutionResult groups all structured logs emitted by the EVM


### PR DESCRIPTION
Closes https://github.com/ethereum/go-ethereum/issues/32082

This PR mainly moves all the dynamic gas and memory handling to opcode handlers to simplify the interpreter loop and reduce the number of unpredictable branches on the hot path. 

To do that, I also had to refactor some of the tracing code as well. Mainly, I had to move dynamic gas tracing from OnOpcode callback to OnGasChange and add some stitching code to preserve the existing output.

Compared to master, this is how it performs.

```
goos: linux
goarch: amd64
pkg: github.com/ethereum/go-ethereum/core/vm/runtime
cpu: AMD Ryzen 7 5700U with Radeon Graphics         
                                       │   old.txt   │               new.txt               │
                                       │   sec/op    │   sec/op     vs base                │
SimpleLoop/staticcall-identity-100M-16   262.5m ± 0%   260.2m ± 0%   -0.87% (p=0.000 n=20)
SimpleLoop/call-identity-100M-16         326.7m ± 0%   301.8m ± 0%   -7.62% (p=0.000 n=20)
SimpleLoop/loop-100M-16                  284.6m ± 1%   202.2m ± 1%  -28.95% (p=0.000 n=20)
SimpleLoop/loop2-100M-16                 285.6m ± 1%   234.4m ± 2%  -17.93% (p=0.000 n=20)
SimpleLoop/call-nonexist-100M-16         651.4m ± 0%   618.7m ± 0%   -5.03% (p=0.000 n=20)
SimpleLoop/call-EOA-100M-16              266.8m ± 0%   235.2m ± 0%  -11.85% (p=0.000 n=20)
SimpleLoop/call-reverting-100M-16        537.2m ± 1%   479.5m ± 1%  -10.74% (p=0.000 n=20)
geomean                                  350.6m        307.5m       -12.30%

                                       │   old.txt    │               new.txt                │
                                       │     B/op     │     B/op      vs base                │
SimpleLoop/staticcall-identity-100M-16   67.95Mi ± 0%   67.95Mi ± 0%        ~ (p=0.405 n=20)
SimpleLoop/call-identity-100M-16         66.58Mi ± 0%   66.58Mi ± 0%        ~ (p=0.382 n=20)
SimpleLoop/loop-100M-16                  5.273Ki ± 4%   4.641Ki ± 0%  -12.00% (p=0.000 n=20)
SimpleLoop/loop2-100M-16                 5.273Ki ± 4%   4.894Ki ± 3%   -7.20% (p=0.000 n=20)
SimpleLoop/call-nonexist-100M-16         119.6Mi ± 0%   119.6Mi ± 0%        ~ (p=0.066 n=20)
SimpleLoop/call-EOA-100M-16              22.79Mi ± 0%   22.78Mi ± 0%   -0.00% (p=0.000 n=20)
SimpleLoop/call-reverting-100M-16        163.8Mi ± 0%   163.8Mi ± 0%   -0.00% (p=0.000 n=20)
geomean                                  4.737Mi        4.602Mi        -2.85%

                                       │   old.txt   │              new.txt               │
                                       │  allocs/op  │  allocs/op   vs base               │
SimpleLoop/staticcall-identity-100M-16   2.740M ± 0%   2.740M ± 0%       ~ (p=0.296 n=20)
SimpleLoop/call-identity-100M-16         2.685M ± 0%   2.685M ± 0%       ~ (p=0.748 n=20)
SimpleLoop/loop-100M-16                   41.00 ± 2%    40.00 ± 0%  -2.44% (p=0.000 n=20)
SimpleLoop/loop2-100M-16                  41.00 ± 2%    41.00 ± 2%       ~ (p=0.741 n=20)
SimpleLoop/call-nonexist-100M-16         2.985M ± 0%   2.985M ± 0%       ~ (p=0.112 n=20)
SimpleLoop/call-EOA-100M-16              746.3k ± 0%   746.3k ± 0%       ~ (p=0.730 n=20)
SimpleLoop/call-reverting-100M-16        2.858M ± 0%   2.858M ± 0%       ~ (p=0.079 n=20)
geomean                                  96.64k        96.30k       -0.35%
```