### PR TITLE
triedb: track and index the trienode in pathdb lookup

### DIFF
--- a/triedb/pathdb/layertree.go
+++ b/triedb/pathdb/layertree.go
@@ -340,6 +340,8 @@ func (tree *layerTree) lookupStorage(accountHash common.Hash, slotHash common.Ha
 	return l, nil
 }
 
+// lookupNode returns the layer that is guaranteed to contain the trie node
+// data corresponding to the specified state root being queried.
 func (tree *layerTree) lookupNode(accountHash common.Hash, path string, state common.Hash) (layer, error) {
 	// Hold the read lock to prevent the unexpected layer changes
 	tree.lock.RLock()

--- a/triedb/pathdb/layertree.go
+++ b/triedb/pathdb/layertree.go
@@ -339,3 +339,19 @@ func (tree *layerTree) lookupStorage(accountHash common.Hash, slotHash common.Ha
 	}
 	return l, nil
 }
+
+func (tree *layerTree) lookupNode(accountHash common.Hash, path string, state common.Hash) (layer, error) {
+	// Hold the read lock to prevent the unexpected layer changes
+	tree.lock.RLock()
+	defer tree.lock.RUnlock()
+
+	tip := tree.lookup.nodeTip(accountHash, path, state, tree.base.root)
+	if tip == (common.Hash{}) {
+		return nil, fmt.Errorf("[%#x] %w", state, errSnapshotStale)
+	}
+	l := tree.layers[tip]
+	if l == nil {
+		return nil, fmt.Errorf("triedb layer [%#x] missing", tip)
+	}
+	return l, nil
+}

--- a/triedb/pathdb/lookup_test.go
+++ b/triedb/pathdb/lookup_test.go
@@ -1,0 +1,123 @@
+package pathdb
+
+import (
+	"crypto/rand"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/trie/trienode"
+)
+
+// generateRandomAccountNodes creates a map of random trie nodes
+func generateRandomAccountNodes(count int) map[string]*trienode.Node {
+	nodes := make(map[string]*trienode.Node, count)
+
+	for i := 0; i < count; i++ {
+		path := make([]byte, 32)
+		rand.Read(path)
+
+		blob := make([]byte, 64)
+		rand.Read(blob)
+
+		var hash common.Hash
+		rand.Read(hash[:])
+
+		nodes[common.Bytes2Hex(path)] = &trienode.Node{Hash: hash, Blob: blob}
+	}
+
+	return nodes
+}
+
+// generateRandomStorageNodes creates a map of storage nodes organized by account
+func generateRandomStorageNodes(accountCount, nodesPerAccount int) map[common.Hash]map[string]*trienode.Node {
+	storageNodes := make(map[common.Hash]map[string]*trienode.Node, accountCount)
+
+	for i := 0; i < accountCount; i++ {
+		var hash common.Hash
+		rand.Read(hash[:])
+
+		storageNodes[hash] = generateRandomAccountNodes(nodesPerAccount)
+	}
+
+	return storageNodes
+}
+
+// addNodes is a helper method for testing that adds nodes to the lookup structure
+func (l *lookup) addNodes(stateHash common.Hash, accountNodes map[string]*trienode.Node, storageNodes map[common.Hash]map[string]*trienode.Node) {
+	// Add account nodes
+	for path := range accountNodes {
+		list, exists := l.accountNodes[path]
+		if !exists {
+			list = make([]common.Hash, 0, 16)
+		}
+		list = append(list, stateHash)
+		l.accountNodes[path] = list
+	}
+
+	// Add storage nodes
+	for accountHash, slots := range storageNodes {
+		for path := range slots {
+			key := accountHash.Hex() + path
+			list, exists := l.storageNodes[key]
+			if !exists {
+				list = make([]common.Hash, 0, 16)
+			}
+			list = append(list, stateHash)
+			l.storageNodes[key] = list
+		}
+	}
+}
+
+func BenchmarkAddNodes(b *testing.B) {
+	tests := []struct {
+		name                string
+		accountNodeCount    int
+		storageAccountCount int
+		nodesPerAccount     int
+	}{
+		{
+			name:                "Small-100-accounts-10-nodes",
+			accountNodeCount:    100,
+			storageAccountCount: 100,
+			nodesPerAccount:     10,
+		},
+		{
+			name:                "Medium-500-accounts-20-nodes",
+			accountNodeCount:    500,
+			storageAccountCount: 500,
+			nodesPerAccount:     20,
+		},
+		{
+			name:                "Large-2000-accounts-40-nodes",
+			accountNodeCount:    2000,
+			storageAccountCount: 2000,
+			nodesPerAccount:     40,
+		},
+	}
+
+	for _, tc := range tests {
+		b.Run(tc.name, func(b *testing.B) {
+			accountNodes := generateRandomAccountNodes(tc.accountNodeCount)
+			storageNodes := generateRandomStorageNodes(tc.storageAccountCount, tc.nodesPerAccount)
+
+			lookup := &lookup{
+				accountNodes: make(map[string][]common.Hash),
+				storageNodes: make(map[string][]common.Hash),
+			}
+
+			var stateHash common.Hash
+			rand.Read(stateHash[:])
+
+			b.ResetTimer()
+			b.ReportAllocs()
+
+			for i := 0; i < b.N; i++ {
+				// Clear the nodes maps for each iteration
+				lookup.accountNodes = make(map[string][]common.Hash)
+				lookup.storageNodes = make(map[string][]common.Hash)
+
+				lookup.addNodes(stateHash, accountNodes, storageNodes)
+			}
+		})
+	}
+}

--- a/triedb/pathdb/lookup_test.go
+++ b/triedb/pathdb/lookup_test.go
@@ -2,7 +2,6 @@ package pathdb
 
 import (
 	"crypto/rand"
-	"fmt"
 	"testing"
 
 	"github.com/ethereum/go-ethereum/common"
@@ -43,173 +42,56 @@ func generateRandomStorageNodes(accountCount, nodesPerAccount int) map[common.Ha
 	return storageNodes
 }
 
-// addNodes is a helper method for testing that adds nodes to the lookup structure
-func (l *lookup) addNodes(stateHash common.Hash, accountNodes map[string]*trienode.Node, storageNodes map[common.Hash]map[string]*trienode.Node) {
-	// Add account nodes
-	for path := range accountNodes {
-		list, exists := l.accountNodes[path]
-		if !exists {
-			list = make([]common.Hash, 0, 16)
-		}
-		list = append(list, stateHash)
-		l.accountNodes[path] = list
-	}
-
-	// Add storage nodes using single-level sharded structure
-	for accountHash, slots := range storageNodes {
-		accountHex := accountHash.Hex()
-
-		for path := range slots {
-			// Construct the combined key but use only path for shard calculation
-			key := accountHex + path
-			shardIndex := getStorageShardIndex(path) // Use only path for sharding
-			shardMap := l.storageNodes[shardIndex]
-
-			list, exists := shardMap[key]
-			if !exists {
-				list = make([]common.Hash, 0, 16)
-			}
-			list = append(list, stateHash)
-			shardMap[key] = list
-		}
-	}
-}
-
 func BenchmarkAddNodes(b *testing.B) {
 	tests := []struct {
-		name                string
-		accountNodeCount    int
-		storageAccountCount int
-		nodesPerAccount     int
+		name             string
+		accountNodeCount int
+		nodesPerAccount  int
 	}{
 		{
-			name:                "Small-100-accounts-10-nodes",
-			accountNodeCount:    100,
-			storageAccountCount: 100,
-			nodesPerAccount:     10,
+			name:             "Small-100-accounts-10-nodes",
+			accountNodeCount: 100,
+			nodesPerAccount:  10,
 		},
 		{
-			name:                "Medium-500-accounts-20-nodes",
-			accountNodeCount:    500,
-			storageAccountCount: 500,
-			nodesPerAccount:     20,
+			name:             "Medium-500-accounts-20-nodes",
+			accountNodeCount: 500,
+			nodesPerAccount:  20,
 		},
 		{
-			name:                "Large-2000-accounts-40-nodes",
-			accountNodeCount:    2000,
-			storageAccountCount: 2000,
-			nodesPerAccount:     40,
+			name:             "Large-2000-accounts-40-nodes",
+			accountNodeCount: 2000,
+			nodesPerAccount:  40,
 		},
 	}
 
 	for _, tc := range tests {
 		b.Run(tc.name, func(b *testing.B) {
-			accountNodes := generateRandomAccountNodes(tc.accountNodeCount)
-			storageNodes := generateRandomStorageNodes(tc.storageAccountCount, tc.nodesPerAccount)
+			storageNodes := generateRandomStorageNodes(tc.accountNodeCount, tc.nodesPerAccount)
 
 			lookup := &lookup{
 				accountNodes: make(map[string][]common.Hash),
 			}
+
 			// Initialize all 16 storage node shards
-			for i := 0; i < 16; i++ {
+			for i := 0; i < storageNodesShardCount; i++ {
 				lookup.storageNodes[i] = make(map[string][]common.Hash)
 			}
 
-			var stateHash common.Hash
-			rand.Read(stateHash[:])
+			var state common.Hash
+			rand.Read(state[:])
 
 			b.ResetTimer()
 			b.ReportAllocs()
 
 			for i := 0; i < b.N; i++ {
-				// Clear the nodes maps for each iteration
-				lookup.accountNodes = make(map[string][]common.Hash)
-				// Reinitialize all 16 storage node shards
-				for j := 0; j < 16; j++ {
+				// Reset the lookup instance for each benchmark iteration
+				for j := 0; j < storageNodesShardCount; j++ {
 					lookup.storageNodes[j] = make(map[string][]common.Hash)
 				}
 
-				lookup.addNodes(stateHash, accountNodes, storageNodes)
+				lookup.addStorageNodes(state, storageNodes)
 			}
 		})
-	}
-}
-
-func TestConcurrentStorageNodesUpdate(b *testing.T) {
-	// Create a lookup instance
-	lookup := &lookup{
-		accountNodes: make(map[string][]common.Hash),
-	}
-	// Initialize all storage node shards
-	for i := 0; i < storageNodesShardCount; i++ {
-		lookup.storageNodes[i] = make(map[string][]common.Hash)
-	}
-
-	// Create test data with known shard distribution
-	testData := map[common.Hash]map[string]*trienode.Node{}
-
-	// Create accounts that will distribute across different shards
-	for i := 0; i < 100; i++ {
-		var accountHash common.Hash
-		accountHash[0] = byte(i)
-
-		testData[accountHash] = make(map[string]*trienode.Node)
-
-		// Create paths that will hash to different shards
-		for j := 0; j < 10; j++ {
-			path := fmt.Sprintf("path_%d_%d", i, j)
-			var nodeHash common.Hash
-			nodeHash[0] = byte(j)
-
-			testData[accountHash][path] = &trienode.Node{Hash: nodeHash}
-		}
-	}
-
-	// Add nodes using the concurrent method
-	var stateHash common.Hash
-	stateHash[0] = 0x42
-	lookup.addNodes(stateHash, nil, testData)
-
-	// Verify that all nodes were added correctly
-	totalNodes := 0
-	for accountHash, slots := range testData {
-		accountHex := accountHash.Hex()
-		for path := range slots {
-			key := accountHex + path
-			shardIndex := getStorageShardIndex(path)
-
-			list, exists := lookup.storageNodes[shardIndex][key]
-			if !exists {
-				b.Errorf("Node not found: account=%x, path=%s, shard=%d", accountHash, path, shardIndex)
-				continue
-			}
-
-			if len(list) != 1 {
-				b.Errorf("Expected 1 state hash, got %d: account=%x, path=%s", len(list), accountHash, path)
-				continue
-			}
-
-			if list[0] != stateHash {
-				b.Errorf("Expected state hash %x, got %x: account=%x, path=%s", stateHash, list[0], accountHash, path)
-				continue
-			}
-
-			totalNodes++
-		}
-	}
-
-	expectedTotal := 100 * 10 // 100 accounts * 10 nodes each
-	if totalNodes != expectedTotal {
-		b.Errorf("Expected %d total nodes, got %d", expectedTotal, totalNodes)
-	}
-
-	// Verify shard distribution
-	for i := 0; i < storageNodesShardCount; i++ {
-		shardSize := len(lookup.storageNodes[i])
-		if shardSize == 0 {
-			b.Logf("Shard %d is empty", i)
-		} else {
-			b.Logf("Shard %d has %d entries", i, shardSize)
-		}
 	}
 }

--- a/triedb/pathdb/lookup_test.go
+++ b/triedb/pathdb/lookup_test.go
@@ -140,8 +140,8 @@ func TestConcurrentStorageNodesUpdate(b *testing.T) {
 	lookup := &lookup{
 		accountNodes: make(map[string][]common.Hash),
 	}
-	// Initialize all 16 storage node shards
-	for i := 0; i < 16; i++ {
+	// Initialize all storage node shards
+	for i := 0; i < storageNodesShardCount; i++ {
 		lookup.storageNodes[i] = make(map[string][]common.Hash)
 	}
 
@@ -204,53 +204,12 @@ func TestConcurrentStorageNodesUpdate(b *testing.T) {
 	}
 
 	// Verify shard distribution
-	for i := 0; i < 16; i++ {
+	for i := 0; i < storageNodesShardCount; i++ {
 		shardSize := len(lookup.storageNodes[i])
 		if shardSize == 0 {
 			b.Logf("Shard %d is empty", i)
 		} else {
 			b.Logf("Shard %d has %d entries", i, shardSize)
 		}
-	}
-}
-
-func TestShardDistribution(b *testing.T) {
-	// Test shard distribution with different path patterns
-	paths := []string{
-		"path_0_0", "path_0_1", "path_0_2", "path_0_3",
-		"path_1_0", "path_1_1", "path_1_2", "path_1_3",
-		"path_2_0", "path_2_1", "path_2_2", "path_2_3",
-		"path_3_0", "path_3_1", "path_3_2", "path_3_3",
-		"path_4_0", "path_4_1", "path_4_2", "path_4_3",
-		"path_5_0", "path_5_1", "path_5_2", "path_5_3",
-		"path_6_0", "path_6_1", "path_6_2", "path_6_3",
-		"path_7_0", "path_7_1", "path_7_2", "path_7_3",
-		"path_8_0", "path_8_1", "path_8_2", "path_8_3",
-		"path_9_0", "path_9_1", "path_9_2", "path_9_3",
-	}
-
-	shardCounts := make(map[int]int)
-	for _, path := range paths {
-		shardIndex := getStorageShardIndex(path)
-		shardCounts[shardIndex]++
-		b.Logf("Path: %s -> Shard: %d", path, shardIndex)
-	}
-
-	b.Logf("Shard distribution:")
-	for i := 0; i < 16; i++ {
-		count := shardCounts[i]
-		b.Logf("  Shard %d: %d paths", i, count)
-	}
-
-	// Check if we have a reasonable distribution
-	usedShards := 0
-	for _, count := range shardCounts {
-		if count > 0 {
-			usedShards++
-		}
-	}
-
-	if usedShards < 4 {
-		b.Logf("Warning: Only %d shards are being used out of 16", usedShards)
 	}
 }

--- a/triedb/pathdb/reader.go
+++ b/triedb/pathdb/reader.go
@@ -64,7 +64,14 @@ type reader struct {
 // node info. Don't modify the returned byte slice since it's not deep-copied
 // and still be referenced by database.
 func (r *reader) Node(owner common.Hash, path []byte, hash common.Hash) ([]byte, error) {
-	blob, got, loc, err := r.layer.node(owner, path, 0)
+	l, err := r.db.tree.lookupNode(owner, string(path), r.state)
+	if err != nil {
+		return nil, err
+	}
+	blob, got, loc, err := l.node(owner, path, 0)
+	if errors.Is(err, errSnapshotStale) {
+		blob, got, loc, err = r.layer.node(owner, path, 0)
+	}
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
> ref https://github.com/ethereum/go-ethereum/issues/32059


Here we use a [16]array of path map to store all the trienodes indexes, then we can split the large storage trienodes into 16 goroutines to do lock-free updates.


**The below charts are generated with geth on hoodi network with full sync**

> full sync block height

<img width="1870" alt="image" src="https://github.com/user-attachments/assets/36317f40-e981-4096-9776-f999a851f5e6" />

- green is master 
- yellow is this branch



> pathdb lookup latency

<img width="1871" alt="image" src="https://github.com/user-attachments/assets/115fa727-28a5-4553-8b0a-d9c5530ac1c1" />



Results:

1. The totally block inserting time is similar
2. The time of (un)indexing in this branch is 3 times more than the master branch.
