### PR TITLE
Fix incorrect error formatting in downloader_test.go

### DIFF
--- a/eth/downloader/downloader_test.go
+++ b/eth/downloader/downloader_test.go
@@ -544,7 +544,7 @@ func testMultiProtoSync(t *testing.T, protocol uint, mode SyncMode) {
 	tester.newPeer("peer 68", eth.ETH68, chain.blocks[1:])
 
 	if err := tester.downloader.BeaconSync(mode, chain.blocks[len(chain.blocks)-1].Header(), nil); err != nil {
-		t.Fatalf("failed to start beacon sync: #{err}")
+		t.Fatalf("failed to start beacon sync: %v", err)
 	}
 	select {
 	case <-complete:


### PR DESCRIPTION
Replaced the incorrect string interpolation #{err} with the proper Go formatting verb %v in an error message within downloader_test.go. This ensures that error details are correctly displayed when a test fails, improving test output clarity and debugging experience. No other changes were made.