### PR TITLE
accounts/abi:  fix abigen v1 bindings for deployment of library dependencies

### DIFF
--- a/accounts/abi/abigen/source.go.tpl
+++ b/accounts/abi/abigen/source.go.tpl
@@ -4,8 +4,10 @@
 package {{.Package}}
 
 import (
+    "context"
 	"math/big"
 	"strings"
+	"time"
 	"errors"
 
 	ethereum "github.com/ethereum/go-ethereum"
@@ -27,6 +29,8 @@ var (
 	_ = types.BloomLookup
 	_ = event.NewSubscription
 	_ = abi.ConvertType
+	_ = time.Tick
+	_ = context.Background
 )
 
 {{$structs := .Structs}}
@@ -78,8 +82,9 @@ var (
 		  }
 		  {{range $pattern, $name := .Libraries}}
 			{{decapitalise $name}}Addr, tx, _, _ := Deploy{{capitalise $name}}(auth, backend)
-			if err := bind.WaitAccepted(context.Background(), backend, tx.Hash()); err != nil {
-			    return common.Address{}, nil, nil err
+			ctx, _ := context.WithTimeout(context.Background(), 5 * time.Second)
+			if err := bind.WaitAccepted(ctx, backend, tx); err != nil {
+			    return common.Address{}, nil, nil, err
 			}
 			{{$contract.Type}}Bin = strings.ReplaceAll({{$contract.Type}}Bin, "__${{$pattern}}$__", {{decapitalise $name}}Addr.String()[2:])
 		  {{end}}

--- a/accounts/abi/abigen/source.go.tpl
+++ b/accounts/abi/abigen/source.go.tpl
@@ -77,7 +77,10 @@ var (
 			return common.Address{}, nil, nil, errors.New("GetABI returned nil")
 		  }
 		  {{range $pattern, $name := .Libraries}}
-			{{decapitalise $name}}Addr, _, _, _ := Deploy{{capitalise $name}}(auth, backend)
+			{{decapitalise $name}}Addr, tx, _, _ := Deploy{{capitalise $name}}(auth, backend)
+			if err := bind.WaitAccepted(context.Background(), backend, tx.Hash()); err != nil {
+			    return common.Address{}, nil, nil err
+			}
 			{{$contract.Type}}Bin = strings.ReplaceAll({{$contract.Type}}Bin, "__${{$pattern}}$__", {{decapitalise $name}}Addr.String()[2:])
 		  {{end}}
 		  address, tx, contract, err := bind.DeployContract(auth, *parsed, common.FromHex({{.Type}}Bin), backend {{range .Constructor.Inputs}}, {{.Name}}{{end}})

--- a/accounts/abi/abigen/source.go.tpl
+++ b/accounts/abi/abigen/source.go.tpl
@@ -4,7 +4,7 @@
 package {{.Package}}
 
 import (
-    "context"
+	"context"
 	"math/big"
 	"strings"
 	"time"

--- a/accounts/abi/bind/old.go
+++ b/accounts/abi/bind/old.go
@@ -266,6 +266,12 @@ func (m *MetaData) GetAbi() (*abi.ABI, error) {
 
 // util.go
 
+// WaitAccepted waits for a tx to be accepted into the pool.
+// It stops waiting when the context is canceled.
+func WaitAccepted(ctx context.Context, b ContractBackend, tx *types.Transaction) error {
+	return bind2.WaitAccepted(ctx, b, tx.Hash())
+}
+
 // WaitMined waits for tx to be mined on the blockchain.
 // It stops waiting when the context is canceled.
 func WaitMined(ctx context.Context, b DeployBackend, tx *types.Transaction) (*types.Receipt, error) {

--- a/accounts/abi/bind/v2/backend.go
+++ b/accounts/abi/bind/v2/backend.go
@@ -103,13 +103,15 @@ type ContractTransactor interface {
 
 	// PendingNonceAt retrieves the current pending nonce associated with an account.
 	PendingNonceAt(ctx context.Context, account common.Address) (uint64, error)
+
+	// TransactionByHash retrieves the transaction associated with the hash, if it exists in the pool.
+	TransactionByHash(ctx context.Context, hash common.Hash) (tx *types.Transaction, isPending bool, err error)
 }
 
 // DeployBackend wraps the operations needed by WaitMined and WaitDeployed.
 type DeployBackend interface {
 	TransactionReceipt(ctx context.Context, txHash common.Hash) (*types.Receipt, error)
 	CodeAt(ctx context.Context, account common.Address, blockNumber *big.Int) ([]byte, error)
-	TransactionByHash(ctx context.Context, hash common.Hash) (tx *types.Transaction, isPending bool, err error)
 }
 
 // ContractFilterer defines the methods needed to access log events using one-off

--- a/accounts/abi/bind/v2/backend.go
+++ b/accounts/abi/bind/v2/backend.go
@@ -109,6 +109,7 @@ type ContractTransactor interface {
 type DeployBackend interface {
 	TransactionReceipt(ctx context.Context, txHash common.Hash) (*types.Receipt, error)
 	CodeAt(ctx context.Context, account common.Address, blockNumber *big.Int) ([]byte, error)
+	TransactionByHash(ctx context.Context, hash common.Hash) (tx *types.Transaction, isPending bool, err error)
 }
 
 // ContractFilterer defines the methods needed to access log events using one-off

--- a/accounts/abi/bind/v2/base.go
+++ b/accounts/abi/bind/v2/base.go
@@ -313,7 +313,7 @@ func (c *BoundContract) createDynamicTx(opts *TransactOpts, contract *common.Add
 		}
 	}
 	// create the transaction
-	nonce, err := c.getNonce(opts)
+	nonce, err := c.GetNonce(opts)
 	if err != nil {
 		return nil, err
 	}
@@ -358,7 +358,7 @@ func (c *BoundContract) createLegacyTx(opts *TransactOpts, contract *common.Addr
 		}
 	}
 	// create the transaction
-	nonce, err := c.getNonce(opts)
+	nonce, err := c.GetNonce(opts)
 	if err != nil {
 		return nil, err
 	}
@@ -395,7 +395,7 @@ func (c *BoundContract) estimateGasLimit(opts *TransactOpts, contract *common.Ad
 	return c.transactor.EstimateGas(ensureContext(opts.Context), msg)
 }
 
-func (c *BoundContract) getNonce(opts *TransactOpts) (uint64, error) {
+func (c *BoundContract) GetNonce(opts *TransactOpts) (uint64, error) {
 	if opts.Nonce == nil {
 		return c.transactor.PendingNonceAt(ensureContext(opts.Context), opts.From)
 	} else {

--- a/accounts/abi/bind/v2/base_test.go
+++ b/accounts/abi/bind/v2/base_test.go
@@ -75,6 +75,10 @@ func (mt *mockTransactor) SendTransaction(ctx context.Context, tx *types.Transac
 	return nil
 }
 
+func (mt *mockTransactor) TransactionByHash(ctx context.Context, hash common.Hash) (*types.Transaction, bool, error) {
+	return nil, false, nil
+}
+
 type mockCaller struct {
 	codeAtBlockNumber       *big.Int
 	callContractBlockNumber *big.Int

--- a/accounts/abi/bind/v2/util.go
+++ b/accounts/abi/bind/v2/util.go
@@ -75,3 +75,28 @@ func WaitDeployed(ctx context.Context, b DeployBackend, hash common.Hash) (commo
 	}
 	return receipt.ContractAddress, err
 }
+
+func WaitAccepted(ctx context.Context, d DeployBackend, txHash common.Hash) error {
+	queryTicker := time.NewTicker(time.Second)
+	defer queryTicker.Stop()
+	logger := log.New("hash", txHash)
+	for {
+		_, _, err := d.TransactionByHash(ctx, txHash)
+		if err == nil {
+			return nil
+		}
+
+		if errors.Is(err, ethereum.NotFound) { // TODO: check this is emitted
+			logger.Trace("Transaction not yet accepted")
+		} else {
+			logger.Trace("Transaction submission failed", "err", err)
+		}
+
+		// Wait for the next round.
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-queryTicker.C:
+		}
+	}
+}

--- a/accounts/abi/bind/v2/util.go
+++ b/accounts/abi/bind/v2/util.go
@@ -76,7 +76,7 @@ func WaitDeployed(ctx context.Context, b DeployBackend, hash common.Hash) (commo
 	return receipt.ContractAddress, err
 }
 
-func WaitAccepted(ctx context.Context, d DeployBackend, txHash common.Hash) error {
+func WaitAccepted(ctx context.Context, d ContractBackend, txHash common.Hash) error {
 	queryTicker := time.NewTicker(time.Second)
 	defer queryTicker.Stop()
 	logger := log.New("hash", txHash)


### PR DESCRIPTION
When we are deploying library dependencies, if the `TransactOpts` nonce is unset we will choose the nonce of the next deployment transaction based on the pending nonce of the sender.  If a previous library deployment transaction was made but not yet accepted into the pool, the pending nonce will not be updated for the the next deployment transaction.

This PR introduces a new method to the bind API `WaitAccepted` which poll until a submitted transaction hash is accepted into the pool or rejected.  The bindings for v1 are updated to invoke this method after deploying each library dependency.