### PR TITLE
eth/catalyst:  abort dev mode block commit if shut down is triggered

### DIFF
--- a/eth/catalyst/simulated_beacon_api.go
+++ b/eth/catalyst/simulated_beacon_api.go
@@ -70,7 +70,12 @@ func (a *simulatedBeaconAPI) loop() {
 				if executable, _ := a.sim.eth.TxPool().Stats(); executable == 0 {
 					break
 				}
-				a.sim.Commit()
+				select {
+				case <-a.sim.shutdownCh:
+					return
+				default:
+					a.sim.Commit()
+				}
 			}
 		}
 	}()


### PR DESCRIPTION
alternate approach to https://github.com/ethereum/go-ethereum/pull/31328 suggested by @MariusVanDerWijden .  This prevents Geth from outputting a lot of logs when trying to commit on-demand dev mode blocks while the client is shutting down.

The issue is hard to reproduce, but I've seen it myself and it is annoying when it happens.  I think this is a reasonable simple solution, and we can revisit if we find that the output is still too large (i.e. there is a large delay  between initiating shut down and the simulated beacon receiving the signal, while in this loop).