### PR TITLE
accounts/abi/bind/v2: modify the default contract deployer to block until the tx is accepted/rejected from the pool

### DIFF
--- a/accounts/abi/bind/v2/backend.go
+++ b/accounts/abi/bind/v2/backend.go
@@ -103,6 +103,9 @@ type ContractTransactor interface {
 
 	// PendingNonceAt retrieves the current pending nonce associated with an account.
 	PendingNonceAt(ctx context.Context, account common.Address) (uint64, error)
+
+	// TransactionByHash retrieves the transaction corresponding to the given hash.
+	TransactionByHash(ctx context.Context, txHash common.Hash) (tx *types.Transaction, isPending bool, err error)
 }
 
 // DeployBackend wraps the operations needed by WaitMined and WaitDeployed.

--- a/accounts/abi/bind/v2/base_test.go
+++ b/accounts/abi/bind/v2/base_test.go
@@ -75,6 +75,10 @@ func (mt *mockTransactor) SendTransaction(ctx context.Context, tx *types.Transac
 	return nil
 }
 
+func (mt *mockTransactor) TransactionByHash(ctx context.Context, txHash common.Hash) (tx *types.Transaction, isPending bool, err error) {
+	return nil, false, nil
+}
+
 type mockCaller struct {
 	codeAtBlockNumber       *big.Int
 	callContractBlockNumber *big.Int

--- a/accounts/abi/bind/v2/lib.go
+++ b/accounts/abi/bind/v2/lib.go
@@ -29,6 +29,8 @@ package bind
 import (
 	"context"
 	"errors"
+	"time"
+
 	"github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/accounts/abi"
 	"github.com/ethereum/go-ethereum/common"
@@ -36,7 +38,6 @@ import (
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/event"
 	"github.com/ethereum/go-ethereum/log"
-	"time"
 )
 
 // ContractEvent is a type constraint for ABI event types.
@@ -268,7 +269,8 @@ func DefaultDeployer(opts *TransactOpts, backend ContractBackend) DeployFn {
 		if err != nil {
 			return common.Address{}, nil, err
 		}
-		ctx, _ := context.WithTimeout(context.Background(), 5*time.Second)
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
 		if err := waitAccepted(ctx, backend, tx.Hash()); err != nil {
 			return common.Address{}, nil, err
 		}

--- a/accounts/abi/bind/v2/lib.go
+++ b/accounts/abi/bind/v2/lib.go
@@ -27,14 +27,16 @@
 package bind
 
 import (
+	"context"
 	"errors"
-
 	"github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/accounts/abi"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/event"
+	"github.com/ethereum/go-ethereum/log"
+	"time"
 )
 
 // ContractEvent is a type constraint for ABI event types.
@@ -227,6 +229,34 @@ func DeployContract(opts *TransactOpts, bytecode []byte, backend ContractBackend
 	return crypto.CreateAddress(opts.From, tx.Nonce()), tx, nil
 }
 
+// waitAccepted polls the backend until the transaction is accepted or the
+// context is cancelled.  If the transaction was not accepted into the pool,
+// an error is returned.
+func waitAccepted(ctx context.Context, d ContractBackend, txHash common.Hash) error {
+	queryTicker := time.NewTicker(time.Second)
+	defer queryTicker.Stop()
+	logger := log.New("hash", txHash)
+	for {
+		_, _, err := d.TransactionByHash(ctx, txHash)
+		if err == nil {
+			return nil
+		}
+
+		if errors.Is(err, ethereum.NotFound) { // TODO: check this is emitted
+			logger.Trace("Transaction not yet accepted")
+		} else {
+			logger.Trace("Transaction submission failed", "err", err)
+		}
+
+		// Wait for the next round.
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-queryTicker.C:
+		}
+	}
+}
+
 // DefaultDeployer returns a DeployFn that signs and submits creation transactions
 // using the given signer.
 //
@@ -236,6 +266,10 @@ func DefaultDeployer(opts *TransactOpts, backend ContractBackend) DeployFn {
 	return func(input []byte, deployer []byte) (common.Address, *types.Transaction, error) {
 		addr, tx, err := DeployContract(opts, deployer, backend, input)
 		if err != nil {
+			return common.Address{}, nil, err
+		}
+		ctx, _ := context.WithTimeout(context.Background(), 5*time.Second)
+		if err := waitAccepted(ctx, backend, tx.Hash()); err != nil {
 			return common.Address{}, nil, err
 		}
 		return addr, tx, nil

--- a/accounts/abi/bind/v2/lib.go
+++ b/accounts/abi/bind/v2/lib.go
@@ -242,7 +242,7 @@ func waitAccepted(ctx context.Context, d ContractBackend, txHash common.Hash) er
 			return nil
 		}
 
-		if errors.Is(err, ethereum.NotFound) { // TODO: check this is emitted
+		if errors.Is(err, ethereum.NotFound) {
 			logger.Trace("Transaction not yet accepted")
 		} else {
 			logger.Trace("Transaction submission failed", "err", err)


### PR DESCRIPTION
This aims to fix some flaky tests in this package, and also fixes a valid issue that could affect users.

If the deploy invocation is part of a set of deployments and the nonce is `nil` in the `TransactOpts`, the tx nonce will be automatically determined by looking at the pending nonce in the txpool.

If there are subsequent dependent deployment transactions, we want to make sure that prior transactions had a chance to be accepted into the pool so that the nonces on all the transactions are set correctly.

TODO: Also, in the case of a multi-contract deployment where `TransactOpts` has non-nil nonce, we should not determine the txs' nonces based on the pending from the pool.  Instead, we should start incrementing from whatever was provided in the `TransactOpts`.