### PR TITLE
core/state: remove not used addr parameter

### DIFF
--- a/core/state/iterator.go
+++ b/core/state/iterator.go
@@ -144,7 +144,7 @@ func (it *nodeIterator) step() error {
 	}
 	if !bytes.Equal(account.CodeHash, types.EmptyCodeHash.Bytes()) {
 		it.codeHash = common.BytesToHash(account.CodeHash)
-		it.code, err = it.state.reader.Code(address, common.BytesToHash(account.CodeHash))
+		it.code, err = it.state.reader.Code(common.BytesToHash(account.CodeHash))
 		if err != nil {
 			return fmt.Errorf("code %x: %v", account.CodeHash, err)
 		}

--- a/core/state/reader.go
+++ b/core/state/reader.go
@@ -41,14 +41,14 @@ type ContractCodeReader interface {
 	// - Returns nil code along with nil error if the requested contract code
 	//   doesn't exist
 	// - Returns an error only if an unexpected issue occurs
-	Code(addr common.Address, codeHash common.Hash) ([]byte, error)
+	Code(codeHash common.Hash) ([]byte, error)
 
 	// CodeSize retrieves a particular contracts code's size.
 	//
 	// - Returns zero code size along with nil error if the requested contract code
 	//   doesn't exist
 	// - Returns an error only if an unexpected issue occurs
-	CodeSize(addr common.Address, codeHash common.Hash) (int, error)
+	CodeSize(codeHash common.Hash) (int, error)
 }
 
 // StateReader defines the interface for accessing accounts and storage slots
@@ -121,7 +121,7 @@ func newCachingCodeReader(db ethdb.KeyValueReader, codeCache *lru.SizeConstraine
 
 // Code implements ContractCodeReader, retrieving a particular contract's code.
 // If the contract code doesn't exist, no error will be returned.
-func (r *cachingCodeReader) Code(addr common.Address, codeHash common.Hash) ([]byte, error) {
+func (r *cachingCodeReader) Code(codeHash common.Hash) ([]byte, error) {
 	code, _ := r.codeCache.Get(codeHash)
 	if len(code) > 0 {
 		return code, nil
@@ -136,11 +136,11 @@ func (r *cachingCodeReader) Code(addr common.Address, codeHash common.Hash) ([]b
 
 // CodeSize implements ContractCodeReader, retrieving a particular contracts code's size.
 // If the contract code doesn't exist, no error will be returned.
-func (r *cachingCodeReader) CodeSize(addr common.Address, codeHash common.Hash) (int, error) {
+func (r *cachingCodeReader) CodeSize(codeHash common.Hash) (int, error) {
 	if cached, ok := r.codeSizeCache.Get(codeHash); ok {
 		return cached, nil
 	}
-	code, err := r.Code(addr, codeHash)
+	code, err := r.Code(codeHash)
 	if err != nil {
 		return 0, err
 	}

--- a/core/state/state_object.go
+++ b/core/state/state_object.go
@@ -517,7 +517,7 @@ func (s *stateObject) Code() []byte {
 	if bytes.Equal(s.CodeHash(), types.EmptyCodeHash.Bytes()) {
 		return nil
 	}
-	code, err := s.db.reader.Code(s.address, common.BytesToHash(s.CodeHash()))
+	code, err := s.db.reader.Code(common.BytesToHash(s.CodeHash()))
 	if err != nil {
 		s.db.setError(fmt.Errorf("can't load code hash %x: %v", s.CodeHash(), err))
 	}
@@ -538,7 +538,7 @@ func (s *stateObject) CodeSize() int {
 	if bytes.Equal(s.CodeHash(), types.EmptyCodeHash.Bytes()) {
 		return 0
 	}
-	size, err := s.db.reader.CodeSize(s.address, common.BytesToHash(s.CodeHash()))
+	size, err := s.db.reader.CodeSize(common.BytesToHash(s.CodeHash()))
 	if err != nil {
 		s.db.setError(fmt.Errorf("can't load code size %x: %v", s.CodeHash(), err))
 	}

--- a/core/state/statedb.go
+++ b/core/state/statedb.go
@@ -423,19 +423,12 @@ func (s *StateDB) HasSelfDestructed(addr common.Address) bool {
 
 // AddBalance adds amount to the account associated with addr.
 func (s *StateDB) AddBalance(addr common.Address, amount *uint256.Int, reason tracing.BalanceChangeReason) uint256.Int {
-	stateObject := s.getOrNewStateObject(addr)
-	if stateObject == nil {
-		return uint256.Int{}
-	}
-	return stateObject.AddBalance(amount)
+	return s.getOrNewStateObject(addr).AddBalance(amount)
 }
 
 // SubBalance subtracts amount from the account associated with addr.
 func (s *StateDB) SubBalance(addr common.Address, amount *uint256.Int, reason tracing.BalanceChangeReason) uint256.Int {
 	stateObject := s.getOrNewStateObject(addr)
-	if stateObject == nil {
-		return uint256.Int{}
-	}
 	if amount.IsZero() {
 		return *(stateObject.Balance())
 	}
@@ -443,32 +436,19 @@ func (s *StateDB) SubBalance(addr common.Address, amount *uint256.Int, reason tr
 }
 
 func (s *StateDB) SetBalance(addr common.Address, amount *uint256.Int, reason tracing.BalanceChangeReason) {
-	stateObject := s.getOrNewStateObject(addr)
-	if stateObject != nil {
-		stateObject.SetBalance(amount)
-	}
+	s.getOrNewStateObject(addr).SetBalance(amount)
 }
 
 func (s *StateDB) SetNonce(addr common.Address, nonce uint64, reason tracing.NonceChangeReason) {
-	stateObject := s.getOrNewStateObject(addr)
-	if stateObject != nil {
-		stateObject.SetNonce(nonce)
-	}
+	s.getOrNewStateObject(addr).SetNonce(nonce)
 }
 
 func (s *StateDB) SetCode(addr common.Address, code []byte) (prev []byte) {
-	stateObject := s.getOrNewStateObject(addr)
-	if stateObject != nil {
-		return stateObject.SetCode(crypto.Keccak256Hash(code), code)
-	}
-	return nil
+	return s.getOrNewStateObject(addr).SetCode(crypto.Keccak256Hash(code), code)
 }
 
 func (s *StateDB) SetState(addr common.Address, key, value common.Hash) common.Hash {
-	if stateObject := s.getOrNewStateObject(addr); stateObject != nil {
-		return stateObject.SetState(key, value)
-	}
-	return common.Hash{}
+	return s.getOrNewStateObject(addr).SetState(key, value)
 }
 
 // SetStorage replaces the entire storage for the specified account with given

--- a/core/state/sync_test.go
+++ b/core/state/sync_test.go
@@ -222,7 +222,7 @@ func testIterativeStateSync(t *testing.T, count int, commit bool, bypath bool, s
 			codeResults = make([]trie.CodeSyncResult, len(codeElements))
 		)
 		for i, element := range codeElements {
-			data, err := cReader.Code(common.Address{}, element.code)
+			data, err := cReader.Code(element.code)
 			if err != nil || len(data) == 0 {
 				t.Fatalf("failed to retrieve contract bytecode for hash %x", element.code)
 			}
@@ -346,7 +346,7 @@ func testIterativeDelayedStateSync(t *testing.T, scheme string) {
 		if len(codeElements) > 0 {
 			codeResults := make([]trie.CodeSyncResult, len(codeElements)/2+1)
 			for i, element := range codeElements[:len(codeResults)] {
-				data, err := cReader.Code(common.Address{}, element.code)
+				data, err := cReader.Code(element.code)
 				if err != nil || len(data) == 0 {
 					t.Fatalf("failed to retrieve contract bytecode for %x", element.code)
 				}
@@ -452,7 +452,7 @@ func testIterativeRandomStateSync(t *testing.T, count int, scheme string) {
 		if len(codeQueue) > 0 {
 			results := make([]trie.CodeSyncResult, 0, len(codeQueue))
 			for hash := range codeQueue {
-				data, err := cReader.Code(common.Address{}, hash)
+				data, err := cReader.Code(hash)
 				if err != nil || len(data) == 0 {
 					t.Fatalf("failed to retrieve node data for %x", hash)
 				}
@@ -551,7 +551,7 @@ func testIterativeRandomDelayedStateSync(t *testing.T, scheme string) {
 			for hash := range codeQueue {
 				delete(codeQueue, hash)
 
-				data, err := cReader.Code(common.Address{}, hash)
+				data, err := cReader.Code(hash)
 				if err != nil || len(data) == 0 {
 					t.Fatalf("failed to retrieve node data for %x", hash)
 				}
@@ -671,7 +671,7 @@ func testIncompleteStateSync(t *testing.T, scheme string) {
 		if len(codeQueue) > 0 {
 			results := make([]trie.CodeSyncResult, 0, len(codeQueue))
 			for hash := range codeQueue {
-				data, err := cReader.Code(common.Address{}, hash)
+				data, err := cReader.Code(hash)
 				if err != nil || len(data) == 0 {
 					t.Fatalf("failed to retrieve node data for %x", hash)
 				}

--- a/core/state_prefetcher.go
+++ b/core/state_prefetcher.go
@@ -80,7 +80,7 @@ func (p *statePrefetcher) Prefetch(block *types.Block, statedb *state.StateDB, c
 
 				// Preload the contract code if the destination has non-empty code
 				if account != nil && !bytes.Equal(account.CodeHash, types.EmptyCodeHash.Bytes()) {
-					reader.Code(*tx.To(), common.BytesToHash(account.CodeHash))
+					reader.Code(common.BytesToHash(account.CodeHash))
 				}
 			}
 			for _, list := range tx.AccessList() {


### PR DESCRIPTION
- Remove the unused `addr` parameter.
- `getOrNewStateObject` method returns a `not null` value, so don't need to check `stateObject != nil`.