### PR TITLE
eth/tracers: apply block header overrides correctly

### DIFF
--- a/eth/tracers/api.go
+++ b/eth/tracers/api.go
@@ -954,48 +954,52 @@ func (api *API) TraceCall(ctx context.Context, args ethapi.TransactionArgs, bloc
 	defer release()
 
 	h := block.Header()
+	blockContext := core.NewEVMBlockContext(h, api.chainContext(ctx), nil)
 
-	if config != nil && config.BlockOverrides != nil {
-		if config.BlockOverrides.Number.ToInt().Uint64() == h.Number.Uint64()+1 {
-			h = config.BlockOverrides.MakeHeader(block.Header())
-			h.ParentHash = block.Hash()
-		}
-	}
-
-	vmctx := core.NewEVMBlockContext(h, api.chainContext(ctx), nil)
 	// Apply the customization rules if required.
 	if config != nil {
-		if overrideErr := config.BlockOverrides.Apply(&vmctx); overrideErr != nil {
-			return nil, overrideErr
+		if config.BlockOverrides != nil && config.BlockOverrides.Number.ToInt().Uint64() == h.Number.Uint64()+1 {
+			// Overriding the block number to n+1 is a common way for wallets to
+			// simulate transactions, however without the following fix, a contract
+			// can assert it is being simulated by checking if blockhash(n) == 0x0 and
+			// can behave differently during the simulation. (#32175 for more info)
+			// --
+			// Modify the parent hash and number so that downstream, blockContext's
+			// GetHash function can correctly return n.
+			h.ParentHash = h.Hash()
+			h.Number.Add(h.Number, big.NewInt(1))
 		}
-		rules := api.backend.ChainConfig().Rules(vmctx.BlockNumber, vmctx.Random != nil, vmctx.Time)
-
+		if err := config.BlockOverrides.Apply(&blockContext); err != nil {
+			return nil, err
+		}
+		rules := api.backend.ChainConfig().Rules(blockContext.BlockNumber, blockContext.Random != nil, blockContext.Time)
 		precompiles = vm.ActivePrecompiledContracts(rules)
 		if err := config.StateOverrides.Apply(statedb, precompiles); err != nil {
 			return nil, err
 		}
 	}
-	// Execute the trace
-	if err := args.CallDefaults(api.backend.RPCGasCap(), vmctx.BaseFee, api.backend.ChainConfig().ChainID); err != nil {
+
+	// Execute the trace.
+	if err := args.CallDefaults(api.backend.RPCGasCap(), blockContext.BaseFee, api.backend.ChainConfig().ChainID); err != nil {
 		return nil, err
 	}
 	var (
-		msg         = args.ToMessage(vmctx.BaseFee, true, true)
+		msg         = args.ToMessage(blockContext.BaseFee, true, true)
 		tx          = args.ToTransaction(types.LegacyTxType)
 		traceConfig *TraceConfig
 	)
 	// Lower the basefee to 0 to avoid breaking EVM
 	// invariants (basefee < feecap).
 	if msg.GasPrice.Sign() == 0 {
-		vmctx.BaseFee = new(big.Int)
+		blockContext.BaseFee = new(big.Int)
 	}
 	if msg.BlobGasFeeCap != nil && msg.BlobGasFeeCap.BitLen() == 0 {
-		vmctx.BlobBaseFee = new(big.Int)
+		blockContext.BlobBaseFee = new(big.Int)
 	}
 	if config != nil {
 		traceConfig = &config.TraceConfig
 	}
-	return api.traceTx(ctx, tx, msg, new(Context), vmctx, statedb, traceConfig, precompiles)
+	return api.traceTx(ctx, tx, msg, new(Context), blockContext, statedb, traceConfig, precompiles)
 }
 
 // traceTx configures a new tracer according to the provided configuration, and

--- a/eth/tracers/api.go
+++ b/eth/tracers/api.go
@@ -953,18 +953,16 @@ func (api *API) TraceCall(ctx context.Context, args ethapi.TransactionArgs, bloc
 	}
 	defer release()
 
-	h := *block.Header()
+	h := block.Header()
 
 	if config != nil && config.BlockOverrides != nil {
-		h = *config.BlockOverrides.MakeHeader(block.Header())
-		if h.Number.Uint64() == block.NumberU64()+1 {
+		if config.BlockOverrides.Number.ToInt().Uint64() == h.Number.Uint64()+1 {
+			h = config.BlockOverrides.MakeHeader(block.Header())
 			h.ParentHash = block.Hash()
-		} else if h.Number.Uint64() > block.NumberU64()+1 {
-			h.ParentHash = common.Hash{}
 		}
 	}
 
-	vmctx := core.NewEVMBlockContext(&h, api.chainContext(ctx), nil)
+	vmctx := core.NewEVMBlockContext(h, api.chainContext(ctx), nil)
 	// Apply the customization rules if required.
 	if config != nil {
 		if overrideErr := config.BlockOverrides.Apply(&vmctx); overrideErr != nil {

--- a/eth/tracers/api.go
+++ b/eth/tracers/api.go
@@ -953,7 +953,14 @@ func (api *API) TraceCall(ctx context.Context, args ethapi.TransactionArgs, bloc
 	}
 	defer release()
 
-	vmctx := core.NewEVMBlockContext(block.Header(), api.chainContext(ctx), nil)
+	hdr := *block.Header()
+	if config != nil {
+		if err := config.BlockOverrides.ApplyHeader(&hdr); err != nil {
+			return nil, err
+		}
+	}
+
+	vmctx := core.NewEVMBlockContext(&hdr, api.chainContext(ctx), nil)
 	// Apply the customization rules if required.
 	if config != nil {
 		if overrideErr := config.BlockOverrides.Apply(&vmctx); overrideErr != nil {

--- a/eth/tracers/api.go
+++ b/eth/tracers/api.go
@@ -955,9 +955,7 @@ func (api *API) TraceCall(ctx context.Context, args ethapi.TransactionArgs, bloc
 
 	hdr := *block.Header()
 	if config != nil {
-		if err := config.BlockOverrides.ApplyHeader(&hdr); err != nil {
-			return nil, err
-		}
+		hdr = *config.BlockOverrides.MakeHeader(block.Header())
 	}
 
 	vmctx := core.NewEVMBlockContext(&hdr, api.chainContext(ctx), nil)

--- a/eth/tracers/api_test.go
+++ b/eth/tracers/api_test.go
@@ -689,9 +689,6 @@ func TestTracingWithOverrides(t *testing.T) {
 		Failed      bool
 		ReturnValue string
 	}
-	overrideBlockNumber := genBlocks + 1
-	parentHash := backend.chain.GetHeaderByNumber(uint64(genBlocks)).Hash().Hex()[2:]
-	expectParent := fmt.Sprintf("0x%064s", parentHash)
 
 	var testSuite = []struct {
 		blockNumber rpc.BlockNumber
@@ -792,7 +789,7 @@ func TestTracingWithOverrides(t *testing.T) {
 			},
 			want: `{"gas":72666,"failed":false,"returnValue":"0x000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000"}`,
 		},
-		{ // Override blocknumber, and query a blockhash
+		{ // Override blocknumber with block n+1 and query a blockhash (resolves issue #32175)
 			blockNumber: rpc.LatestBlockNumber,
 			call: ethapi.TransactionArgs{
 				From: &accounts[0].addr,
@@ -807,9 +804,9 @@ func TestTracingWithOverrides(t *testing.T) {
 				}), // blocknumber
 			},
 			config: &TraceCallConfig{
-				BlockOverrides: &override.BlockOverrides{Number: (*hexutil.Big)(big.NewInt(int64(overrideBlockNumber)))},
+				BlockOverrides: &override.BlockOverrides{Number: (*hexutil.Big)(big.NewInt(int64(genBlocks + 1)))},
 			},
-			want: fmt.Sprintf(`{"gas":59590,"failed":false,"returnValue":"%s"}`, expectParent),
+			want: fmt.Sprintf(`{"gas":59590,"failed":false,"returnValue":"%s"}`, fmt.Sprintf("0x%064s", backend.chain.GetHeaderByNumber(uint64(genBlocks)).Hash().Hex()[2:])),
 		},
 		/*
 			pragma solidity =0.8.12;

--- a/eth/tracers/api_test.go
+++ b/eth/tracers/api_test.go
@@ -801,12 +801,12 @@ func TestTracingWithOverrides(t *testing.T) {
 					byte(vm.PUSH1), 0x20,
 					byte(vm.PUSH1), 0x00,
 					byte(vm.RETURN),
-				}), // blocknumber
+				}),
 			},
 			config: &TraceCallConfig{
 				BlockOverrides: &override.BlockOverrides{Number: (*hexutil.Big)(big.NewInt(int64(genBlocks + 1)))},
 			},
-			want: fmt.Sprintf(`{"gas":59590,"failed":false,"returnValue":"%s"}`, fmt.Sprintf("0x%064s", backend.chain.GetHeaderByNumber(uint64(genBlocks)).Hash().Hex()[2:])),
+			want: fmt.Sprintf(`{"gas":59590,"failed":false,"returnValue":"%s"}`, backend.chain.GetHeaderByNumber(uint64(genBlocks)).Hash().Hex()),
 		},
 		/*
 			pragma solidity =0.8.12;

--- a/eth/tracers/api_test.go
+++ b/eth/tracers/api_test.go
@@ -689,8 +689,6 @@ func TestTracingWithOverrides(t *testing.T) {
 		Failed      bool
 		ReturnValue string
 	}
-	parentHashHex := backend.chain.GetHeaderByNumber(uint64(genBlocks - 1)).Hash().Hex()[2:]
-	return96 := fmt.Sprintf("0x%064s%s%064s", "", parentHashHex, "")
 
 	var testSuite = []struct {
 		blockNumber rpc.BlockNumber
@@ -789,7 +787,7 @@ func TestTracingWithOverrides(t *testing.T) {
 			config: &TraceCallConfig{
 				BlockOverrides: &override.BlockOverrides{Number: (*hexutil.Big)(big.NewInt(0x1337))},
 			},
-			want: fmt.Sprintf(`{"gas":72666,"failed":false,"returnValue":"%s"}`, return96),
+			want: `{"gas":72666,"failed":false,"returnValue":"0x000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000"}`,
 		},
 		/*
 			pragma solidity =0.8.12;

--- a/eth/tracers/api_test.go
+++ b/eth/tracers/api_test.go
@@ -689,6 +689,9 @@ func TestTracingWithOverrides(t *testing.T) {
 		Failed      bool
 		ReturnValue string
 	}
+	parentHashHex := backend.chain.GetHeaderByNumber(uint64(genBlocks - 1)).Hash().Hex()[2:]
+	return96 := fmt.Sprintf("0x%064s%s%064s", "", parentHashHex, "")
+
 	var testSuite = []struct {
 		blockNumber rpc.BlockNumber
 		call        ethapi.TransactionArgs
@@ -786,7 +789,7 @@ func TestTracingWithOverrides(t *testing.T) {
 			config: &TraceCallConfig{
 				BlockOverrides: &override.BlockOverrides{Number: (*hexutil.Big)(big.NewInt(0x1337))},
 			},
-			want: `{"gas":72666,"failed":false,"returnValue":"0x000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000"}`,
+			want: fmt.Sprintf(`{"gas":72666,"failed":false,"returnValue":"%s"}`, return96),
 		},
 		/*
 			pragma solidity =0.8.12;

--- a/internal/ethapi/override/override.go
+++ b/internal/ethapi/override/override.go
@@ -171,6 +171,29 @@ func (o *BlockOverrides) Apply(blockCtx *vm.BlockContext) error {
 	return nil
 }
 
+func (o *BlockOverrides) ApplyHeader(h *types.Header) error {
+	if o == nil {
+		return nil
+	}
+	if o.Number != nil {
+		h.Number = o.Number.ToInt()
+	}
+	if o.Time != nil {
+		h.Time = uint64(*o.Time)
+	}
+	if o.GasLimit != nil {
+		h.GasLimit = uint64(*o.GasLimit)
+	}
+	if o.Difficulty != nil {
+		h.Difficulty = o.Difficulty.ToInt()
+	}
+	if o.BaseFeePerGas != nil {
+		h.BaseFee = o.BaseFeePerGas.ToInt()
+	}
+
+	return nil
+}
+
 // MakeHeader returns a new header object with the overridden
 // fields.
 // Note: MakeHeader ignores BlobBaseFee if set. That's because

--- a/internal/ethapi/override/override.go
+++ b/internal/ethapi/override/override.go
@@ -171,29 +171,6 @@ func (o *BlockOverrides) Apply(blockCtx *vm.BlockContext) error {
 	return nil
 }
 
-func (o *BlockOverrides) ApplyHeader(h *types.Header) error {
-	if o == nil {
-		return nil
-	}
-	if o.Number != nil {
-		h.Number = o.Number.ToInt()
-	}
-	if o.Time != nil {
-		h.Time = uint64(*o.Time)
-	}
-	if o.GasLimit != nil {
-		h.GasLimit = uint64(*o.GasLimit)
-	}
-	if o.Difficulty != nil {
-		h.Difficulty = o.Difficulty.ToInt()
-	}
-	if o.BaseFeePerGas != nil {
-		h.BaseFee = o.BaseFeePerGas.ToInt()
-	}
-
-	return nil
-}
-
 // MakeHeader returns a new header object with the overridden
 // fields.
 // Note: MakeHeader ignores BlobBaseFee if set. That's because


### PR DESCRIPTION
Fixes #32175.

This fixes the scenario where the blockhash opcode would return 0x0 during RPC simulations when using BlockOverrides with a future block number. The root cause was that BlockOverrides.Apply() only modified the vm.BlockContext, but GetHashFn() depends on the actual types.Header.Number to resolve valid historical block hashes. This caused a mismatch and resulted in incorrect behavior during trace and call simulations.

**Changes:**
Added a new ApplyHeader method to BlockOverrides, which mutates the *types.Header with overridden fields. Updated the RPC simulation/tracing paths to apply header overrides directly to the Header object before creating the EVM block context. This makes sure that there is consistency between BlockContext.BlockNumber and Header.Number to allow GetHashFn() to function correctly in simulations.

**Tests**
I reproduced the error in a dev chain on geth and ran the updated code against the issue to ensure correctness. 
<img width="860" height="154" alt="test" src="https://github.com/user-attachments/assets/9af8cadc-ea7c-42cb-a7f0-f791810e5c0f" />
<img width="408" height="278" alt="test2" src="https://github.com/user-attachments/assets/58fdf81c-4fbc-4fd3-9081-98332c35644d" />
<img width="165" height="50" alt="test3" src="https://github.com/user-attachments/assets/9ec61e11-98be-40dc-a41c-faf32402c228" />




