### PR TITLE
eth/downloader: fix ancient limit in snap sync

### DIFF
--- a/eth/downloader/downloader.go
+++ b/eth/downloader/downloader.go
@@ -535,9 +535,15 @@ func (d *Downloader) syncToHead() (err error) {
 
 		// If a part of blockchain data has already been written into active store,
 		// disable the ancient style insertion explicitly.
-		if origin >= frozen && frozen != 0 {
+		if origin >= frozen && origin != 0 {
 			d.ancientLimit = 0
-			log.Info("Disabling direct-ancient mode", "origin", origin, "ancient", frozen-1)
+			var ancient string
+			if frozen == 0 {
+				ancient = "null"
+			} else {
+				ancient = fmt.Sprintf("%d", frozen-1)
+			}
+			log.Info("Disabling direct-ancient mode", "origin", origin, "ancient", ancient)
 		} else if d.ancientLimit > 0 {
 			log.Debug("Enabling direct-ancient mode", "ancient", d.ancientLimit)
 		}


### PR DESCRIPTION
This pull request fixes an issue in disabling direct-ancient mode in snap sync.

Specifically, if `origin >= frozen && origin != 0`, it implies a part of chain data
has been written into the key-value store, all the following writes into ancient
store scheduled by downloader will be rejected with error 

`ERROR[07-10|03:46:57.924] Error importing chain data to ancients   err="can't add block 1166 hash: the append operation is out-order: have 1166 want 0"`.

This issue is detected by the https://github.com/ethpandaops/kurtosis-sync-test, which
initiates the first snap sync cycle without the finalized header and implicitly disables
the direct-ancient mode. A few seconds later the second snap sync cycle is initiated
with the finalized information and direct-ancient mode is enabled incorrectly.