### PR TITLE
build: remove end of life support of Ubuntu 24.10

### DIFF
--- a/build/ci.go
+++ b/build/ci.go
@@ -123,7 +123,6 @@ var (
 		"focal",    // 20.04, EOL: 04/2030
 		"jammy",    // 22.04, EOL: 04/2032
 		"noble",    // 24.04, EOL: 04/2034
-		"oracular", // 24.10, EOL: 07/2025
 	}
 
 	// This is where the tests should be unpacked.


### PR DESCRIPTION
Ubuntu 24.10 became end of life in 2025-07-10, removing it now. https://wiki.ubuntu.com/Releases

If non-LTS versions are no longer supported, then I would close #31666.