### PR TITLE
accounts/keystore: update links to documenation

### DIFF
--- a/accounts/keystore/keystore.go
+++ b/accounts/keystore/keystore.go
@@ -17,7 +17,7 @@
 // Package keystore implements encrypted storage of secp256k1 private keys.
 //
 // Keys are stored as encrypted JSON files according to the Web3 Secret Storage specification.
-// See https://github.com/ethereum/wiki/wiki/Web3-Secret-Storage-Definition for more information.
+// See https://ethereum.org/en/developers/docs/data-structures-and-encoding/web3-secret-storage/ for more information.
 package keystore
 
 import (

--- a/accounts/keystore/passphrase.go
+++ b/accounts/keystore/passphrase.go
@@ -19,7 +19,7 @@
 This key store behaves as KeyStorePlain with the difference that
 the private key is encrypted and on disk uses another JSON encoding.
 
-The crypto is documented at https://github.com/ethereum/wiki/wiki/Web3-Secret-Storage-Definition
+The crypto is documented at https://ethereum.org/en/developers/docs/data-structures-and-encoding/web3-secret-storage/
 
 */
 


### PR DESCRIPTION


---


**Description:**  
- Replaced outdated GitHub wiki links with the official Ethereum documentation for Web3 Secret Storage.
- Updated references in `keystore.go` and `passphrase.go` for improved accuracy and reliability.


---