### PR TITLE
signer/core/apitypes: the to address shouldn't be null in blob tx

### DIFF
--- a/signer/core/apitypes/types.go
+++ b/signer/core/apitypes/types.go
@@ -151,7 +151,7 @@ func (args *SendTxArgs) ToTransaction() (*types.Transaction, error) {
 			al = *args.AccessList
 		}
 		if to == nil {
-			return nil, fmt.Errorf("the to address shouldn't be null in blob transaction")
+			return nil, fmt.Errorf("transaction recipient must be set for blob transactions")
 		}
 		data = &types.BlobTx{
 			To:         *to,


### PR DESCRIPTION
Check the `to` address before building the blob tx.