### PR TITLE
core/types: fix CellProofsAt method

### DIFF
--- a/core/types/tx_blob.go
+++ b/core/types/tx_blob.go
@@ -75,18 +75,14 @@ func (sc *BlobTxSidecar) BlobHashes() []common.Hash {
 }
 
 // CellProofsAt returns the cell proofs for blob with index idx.
+// This method is only valid for sidecars with version 1.
 func (sc *BlobTxSidecar) CellProofsAt(idx int) []kzg4844.Proof {
 	if sc.Version == 1 {
 		index := idx * kzg4844.CellProofsPerBlob
 		return sc.Proofs[index : index+kzg4844.CellProofsPerBlob]
 	}
-
-	cellProofs, err := kzg4844.ComputeCellProofs(&sc.Blobs[idx])
-	if err != nil {
-		log.Error("Failed to compute cell proofs for blob", "index", idx, "error", err)
-		return nil
-	}
-	return cellProofs
+	log.Error("cellProofsAt called with unsupported version", "version", sc.Version)
+	return nil
 }
 
 // encodedSize computes the RLP size of the sidecar elements. This does NOT return the

--- a/core/types/tx_blob.go
+++ b/core/types/tx_blob.go
@@ -77,6 +77,10 @@ func (sc *BlobTxSidecar) BlobHashes() []common.Hash {
 // CellProofsAt returns the cell proofs for blob with index idx.
 // This method is only valid for sidecars with version 1.
 func (sc *BlobTxSidecar) CellProofsAt(idx int) []kzg4844.Proof {
+	if idx < 0 || idx >= len(sc.Blobs) {
+		log.Error("cellProofsAt called with out of bounds index", "index", idx, "blobs", len(sc.Blobs))
+		return nil
+	}
 	if sc.Version == 1 {
 		index := idx * kzg4844.CellProofsPerBlob
 		return sc.Proofs[index : index+kzg4844.CellProofsPerBlob]

--- a/core/types/tx_blob.go
+++ b/core/types/tx_blob.go
@@ -76,7 +76,7 @@ func (sc *BlobTxSidecar) BlobHashes() []common.Hash {
 
 // CellProofsAt returns the cell proofs for blob with index idx.
 func (sc *BlobTxSidecar) CellProofsAt(idx int) []kzg4844.Proof {
-	if len(sc.Proofs) == len(sc.Blobs)*kzg4844.CellProofsPerBlob {
+	if sc.Version == 1 {
 		index := idx * kzg4844.CellProofsPerBlob
 		return sc.Proofs[index : index+kzg4844.CellProofsPerBlob]
 	}

--- a/eth/catalyst/api.go
+++ b/eth/catalyst/api.go
@@ -564,7 +564,12 @@ func (api *ConsensusAPI) GetBlobsV2(hashes []common.Hash) ([]*engine.BlobAndProo
 		blobHashes := sidecar.BlobHashes()
 		for bIdx, hash := range blobHashes {
 			if idxes, ok := index[hash]; ok {
-				proofs := sidecar.CellProofsAt(bIdx)
+				proofs, err := sidecar.CellProofsAt(bIdx)
+				if err != nil {
+					// TODO @rjl @marius we should return an error
+					log.Info("Failed to get cell proof", "err", err)
+					return nil, nil
+				}
 				var cellProofs []hexutil.Bytes
 				for _, proof := range proofs {
 					cellProofs = append(cellProofs, proof[:])


### PR DESCRIPTION
- In the `CellProofsAt` method, if the proofs are `kzg proof` and when the param `idx == 0`, then the method will return part of the blob proofs. It's not what we want.
- Add the missed `Version` field when copying blob tx.