### PR TITLE
miner: set sidecar version when recomputing proofs

### DIFF
--- a/miner/worker.go
+++ b/miner/worker.go
@@ -440,6 +440,7 @@ func (miner *Miner) commitTransactions(env *environment, plainTxs, blobTxs *tran
 						}
 						sidecar.Proofs = append(sidecar.Proofs, cellProofs...)
 					}
+					sidecar.Version = 1
 				}
 			}
 		}


### PR DESCRIPTION
- If the block number is `osaka` fork and needs to recompute some `blob proofs` to `cell proofs`, here also needs to set version to `1`.