### PR TITLE
Reset testTxHashes before generating new test chain to ensure test isolation

### DIFF
--- a/ethclient/gethclient/gethclient_test.go
+++ b/ethclient/gethclient/gethclient_test.go
@@ -86,6 +86,7 @@ func newTestBackend(t *testing.T) (*node.Node, []*types.Block) {
 }
 
 func generateTestChain() (*core.Genesis, []*types.Block) {
+	testTxHashes = nil // reset before generating a new chain
 	genesis := &core.Genesis{
 		Config: params.AllEthashProtocolChanges,
 		Alloc: types.GenesisAlloc{


### PR DESCRIPTION
The global variable testTxHashes was not being reset between test runs, causing transaction hashes to accumulate across tests. This could lead to unexpected behavior or test failures when running tests multiple times or in parallel. Resetting testTxHashes at the start of generateTestChain ensures each test run starts with a clean state, improving test reliability and isolation.