### PR TITLE
account/abi/bind/v2: fix TestDeploymentWithOverrides

### DIFF
--- a/accounts/abi/bind/v2/base.go
+++ b/accounts/abi/bind/v2/base.go
@@ -443,7 +443,6 @@ func (c *BoundContract) transact(opts *TransactOpts, contract *common.Address, i
 	if opts.NoSend {
 		return signedTx, nil
 	}
-	fmt.Println("nonce:", signedTx.Nonce())
 	if err := c.transactor.SendTransaction(ensureContext(opts.Context), signedTx); err != nil {
 		return nil, err
 	}

--- a/accounts/abi/bind/v2/base.go
+++ b/accounts/abi/bind/v2/base.go
@@ -443,6 +443,7 @@ func (c *BoundContract) transact(opts *TransactOpts, contract *common.Address, i
 	if opts.NoSend {
 		return signedTx, nil
 	}
+	fmt.Println("nonce:", signedTx.Nonce())
 	if err := c.transactor.SendTransaction(ensureContext(opts.Context), signedTx); err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
The root cause of the flaky test was a nonce conflict caused by async contract deployments.

This solution defines a custom deployer with automatic nonce management.