### PR TITLE
all: update dead wiki links

### DIFF
--- a/rpc/doc.go
+++ b/rpc/doc.go
@@ -98,7 +98,7 @@ Subscriptions are deleted when the user sends an unsubscribe request or when the
 connection which was used to create the subscription is closed. This can be initiated by
 the client and server. The server will close the connection for any write error.
 
-For more information about subscriptions, see https://github.com/ethereum/go-ethereum/wiki/RPC-PUB-SUB.
+For more information about subscriptions, see https://geth.ethereum.org/docs/interacting-with-geth/rpc/pubsub
 
 # Reverse Calls
 

--- a/tests/block_test_util.go
+++ b/tests/block_test_util.go
@@ -222,7 +222,7 @@ func (t *BlockTest) genesis(config *params.ChainConfig) *core.Genesis {
 }
 
 /*
-See https://github.com/ethereum/tests/wiki/Blockchain-Tests-II
+See https://ethereum-tests.readthedocs.io/en/latest/blockchain-ref.html
 
 	Whether a block is valid or not is a bit subtle, it's defined by presence of
 	blockHeader, transactions and uncleHeaders fields. If they are missing, the block is


### PR DESCRIPTION


---


**Description:**  
- Replaced outdated GitHub wiki links with current, official documentation URLs.
- Removed links that redirect or are no longer relevant.
- Ensured all references point to up-to-date and reliable sources.


---