### PR TITLE
core/stateless, eth: add debug_executionWitnessByHash

### DIFF
--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -1903,6 +1903,10 @@ type blockProcessingResult struct {
 	witness  *stateless.Witness
 }
 
+func (bpr *blockProcessingResult) Witness() *stateless.Witness {
+	return bpr.witness
+}
+
 // ProcessBlock executes and validates the given block. If there was no error
 // it writes the block and associated state to database.
 func (bc *BlockChain) ProcessBlock(parentRoot common.Hash, block *types.Block, setHead bool, makeWitness bool) (_ *blockProcessingResult, blockEndErr error) {

--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -1837,7 +1837,7 @@ func (bc *BlockChain) insertChain(chain types.Blocks, setHead bool, makeWitness 
 		}
 		// The traced section of block import.
 		start := time.Now()
-		res, err := bc.processBlock(parent.Root, block, setHead, makeWitness && len(chain) == 1)
+		res, err := bc.ProcessBlock(parent.Root, block, setHead, makeWitness && len(chain) == 1)
 		if err != nil {
 			return nil, it.index, err
 		}
@@ -1903,9 +1903,9 @@ type blockProcessingResult struct {
 	witness  *stateless.Witness
 }
 
-// processBlock executes and validates the given block. If there was no error
+// ProcessBlock executes and validates the given block. If there was no error
 // it writes the block and associated state to database.
-func (bc *BlockChain) processBlock(parentRoot common.Hash, block *types.Block, setHead bool, makeWitness bool) (_ *blockProcessingResult, blockEndErr error) {
+func (bc *BlockChain) ProcessBlock(parentRoot common.Hash, block *types.Block, setHead bool, makeWitness bool) (_ *blockProcessingResult, blockEndErr error) {
 	var (
 		err       error
 		startTime = time.Now()

--- a/core/stateless/encoding.go
+++ b/core/stateless/encoding.go
@@ -20,6 +20,7 @@ import (
 	"io"
 
 	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/rlp"
 )
 
@@ -28,11 +29,11 @@ func (w *Witness) ToExtWitness() *ExtWitness {
 	ext := &ExtWitness{
 		Headers: w.Headers,
 	}
-	ext.Codes = make([][]byte, 0, len(w.Codes))
+	ext.Codes = make([]hexutil.Bytes, 0, len(w.Codes))
 	for code := range w.Codes {
 		ext.Codes = append(ext.Codes, []byte(code))
 	}
-	ext.State = make([][]byte, 0, len(w.State))
+	ext.State = make([]hexutil.Bytes, 0, len(w.State))
 	for node := range w.State {
 		ext.State = append(ext.State, []byte(node))
 	}
@@ -70,8 +71,8 @@ func (w *Witness) DecodeRLP(s *rlp.Stream) error {
 
 // ExtWitness is a witness RLP encoding for transferring across clients.
 type ExtWitness struct {
-	Headers []*types.Header
-	Codes   [][]byte
-	State   [][]byte
-	Keys    [][]byte
+	Headers []*types.Header `json:"headers"`
+	Codes   []hexutil.Bytes `json:"codes"`
+	State   []hexutil.Bytes `json:"state"`
+	Keys    []hexutil.Bytes `json:"keys"`
 }

--- a/core/stateless/encoding.go
+++ b/core/stateless/encoding.go
@@ -23,9 +23,9 @@ import (
 	"github.com/ethereum/go-ethereum/rlp"
 )
 
-// toExtWitness converts our internal witness representation to the consensus one.
-func (w *Witness) toExtWitness() *extWitness {
-	ext := &extWitness{
+// ToExtWitness converts our internal witness representation to the consensus one.
+func (w *Witness) ToExtWitness() *ExtWitness {
+	ext := &ExtWitness{
 		Headers: w.Headers,
 	}
 	ext.Codes = make([][]byte, 0, len(w.Codes))
@@ -40,7 +40,7 @@ func (w *Witness) toExtWitness() *extWitness {
 }
 
 // fromExtWitness converts the consensus witness format into our internal one.
-func (w *Witness) fromExtWitness(ext *extWitness) error {
+func (w *Witness) fromExtWitness(ext *ExtWitness) error {
 	w.Headers = ext.Headers
 
 	w.Codes = make(map[string]struct{}, len(ext.Codes))
@@ -56,21 +56,22 @@ func (w *Witness) fromExtWitness(ext *extWitness) error {
 
 // EncodeRLP serializes a witness as RLP.
 func (w *Witness) EncodeRLP(wr io.Writer) error {
-	return rlp.Encode(wr, w.toExtWitness())
+	return rlp.Encode(wr, w.ToExtWitness())
 }
 
 // DecodeRLP decodes a witness from RLP.
 func (w *Witness) DecodeRLP(s *rlp.Stream) error {
-	var ext extWitness
+	var ext ExtWitness
 	if err := s.Decode(&ext); err != nil {
 		return err
 	}
 	return w.fromExtWitness(&ext)
 }
 
-// extWitness is a witness RLP encoding for transferring across clients.
-type extWitness struct {
+// ExtWitness is a witness RLP encoding for transferring across clients.
+type ExtWitness struct {
 	Headers []*types.Header
 	Codes   [][]byte
 	State   [][]byte
+	Keys    [][]byte
 }

--- a/core/stateless/witness.go
+++ b/core/stateless/witness.go
@@ -98,6 +98,10 @@ func (w *Witness) AddState(nodes map[string]struct{}) {
 	maps.Copy(w.State, nodes)
 }
 
+func (w *Witness) AddKey() {
+	panic("not yet implemented")
+}
+
 // Copy deep-copies the witness object.  Witness.Block isn't deep-copied as it
 // is never mutated by Witness
 func (w *Witness) Copy() *Witness {

--- a/eth/api_debug.go
+++ b/eth/api_debug.go
@@ -26,6 +26,7 @@ import (
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/core/rawdb"
 	"github.com/ethereum/go-ethereum/core/state"
+	"github.com/ethereum/go-ethereum/core/stateless"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/internal/ethapi"
@@ -442,4 +443,20 @@ func (api *DebugAPI) GetTrieFlushInterval() (string, error) {
 		return "", errors.New("trie flush interval is undefined for path-based scheme")
 	}
 	return api.eth.blockchain.GetTrieFlushInterval().String(), nil
+}
+
+func (api *DebugAPI) ExecuteWitnessByHash(hash common.Hash) (*stateless.ExtWitness, error) {
+	bc := api.eth.blockchain
+	block := bc.GetBlockByHash(hash)
+	if block != nil {
+		return &stateless.ExtWitness{}, fmt.Errorf("block hash %x not found", hash)
+	}
+	statedb, err := bc.StateAt(block.Header().Root)
+	if err != nil {
+		return &stateless.ExtWitness{}, err
+	}
+	parent := bc.GetHeader(block.ParentHash(), block.NumberU64()-1)
+	bc.ProcessBlock(parent.Root, block, false, true)
+
+	return statedb.Witness().ToExtWitness(), nil
 }

--- a/eth/api_debug.go
+++ b/eth/api_debug.go
@@ -448,15 +448,14 @@ func (api *DebugAPI) GetTrieFlushInterval() (string, error) {
 func (api *DebugAPI) ExecuteWitnessByHash(hash common.Hash) (*stateless.ExtWitness, error) {
 	bc := api.eth.blockchain
 	block := bc.GetBlockByHash(hash)
-	if block != nil {
+	if block == nil {
 		return &stateless.ExtWitness{}, fmt.Errorf("block hash %x not found", hash)
 	}
-	statedb, err := bc.StateAt(block.Header().Root)
-	if err != nil {
-		return &stateless.ExtWitness{}, err
-	}
 	parent := bc.GetHeader(block.ParentHash(), block.NumberU64()-1)
-	bc.ProcessBlock(parent.Root, block, false, true)
+	result, err := bc.ProcessBlock(parent.Root, block, false, true)
+	if err != nil {
+		return nil, err
+	}
 
-	return statedb.Witness().ToExtWitness(), nil
+	return result.Witness().ToExtWitness(), nil
 }


### PR DESCRIPTION
This is a request by @kevaundray.

This PR adds a new system call, which re-executes a block with stateless mode activated, so that the witness data are collected and returned.

This has some differences with the reth equivalent (list will likely :

 1. The returned block header is json-encoded and not rlp-encoded
 2. `nil` codes aren't added
 3. the `keys` field is present but is always empty - this is an agreement with Kev, that will be done in a later PR. The role of this PR is to find the disagreements with reth.
 
 Note that, besides these issues, I still do find some differences with what reth returns, which is why this PR is in Draft mode.