### PR TITLE
trie: reduce allocations in hashFullNodeChildren

### DIFF
--- a/trie/hasher.go
+++ b/trie/hasher.go
@@ -102,7 +102,7 @@ func (h *hasher) hashShortNodeChildren(n *shortNode) *shortNode {
 // hashFullNodeChildren returns a copy of the supplied fullNode, with its child
 // being replaced by either the hash or an embedded node if the child is small.
 func (h *hasher) hashFullNodeChildren(n *fullNode) *fullNode {
-	var children [17]node
+	fullNode := fullNode{flags: nodeFlag{}}
 	if h.parallel {
 		var wg sync.WaitGroup
 		wg.Add(16)
@@ -110,9 +110,9 @@ func (h *hasher) hashFullNodeChildren(n *fullNode) *fullNode {
 			go func(i int) {
 				hasher := newHasher(false)
 				if child := n.Children[i]; child != nil {
-					children[i] = hasher.hash(child, false)
+					fullNode.Children[i] = hasher.hash(child, false)
 				} else {
-					children[i] = nilValueNode
+					fullNode.Children[i] = nilValueNode
 				}
 				returnHasherToPool(hasher)
 				wg.Done()
@@ -122,16 +122,16 @@ func (h *hasher) hashFullNodeChildren(n *fullNode) *fullNode {
 	} else {
 		for i := 0; i < 16; i++ {
 			if child := n.Children[i]; child != nil {
-				children[i] = h.hash(child, false)
+				fullNode.Children[i] = h.hash(child, false)
 			} else {
-				children[i] = nilValueNode
+				fullNode.Children[i] = nilValueNode
 			}
 		}
 	}
 	if n.Children[16] != nil {
-		children[16] = n.Children[16]
+		fullNode.Children[16] = n.Children[16]
 	}
-	return &fullNode{flags: nodeFlag{}, Children: children}
+	return &fullNode
 }
 
 // shortNodeToHash computes the hash of the given shortNode. The shortNode must


### PR DESCRIPTION
temporary children array espaces to heap. Directly hash into a fullNode instead.


```
goos: linux
goarch: amd64
pkg: github.com/ethereum/go-ethereum/trie
cpu: AMD Ryzen 7 5700U with Radeon Graphics         
                      │ /tmp/old.txt │            /tmp/new.txt             │
                      │    sec/op    │   sec/op     vs base                │
HashFixedSize/10-16      22.74µ ± 0%   22.46µ ± 1%   -1.24% (p=0.000 n=10)
HashFixedSize/100-16     67.65µ ± 1%   66.15µ ± 1%   -2.21% (p=0.000 n=10)
HashFixedSize/1K-16      471.4µ ± 4%   517.5µ ± 1%   +9.77% (p=0.000 n=10)
HashFixedSize/10K-16     4.170m ± 1%   3.762m ± 1%   -9.78% (p=0.000 n=10)
HashFixedSize/100K-16    28.05m ± 3%   24.27m ± 2%  -13.48% (p=0.000 n=10)
geomean                  610.5µ        587.9µ        -3.72%

                      │ /tmp/old.txt │             /tmp/new.txt             │
                      │     B/op     │     B/op      vs base                │
HashFixedSize/10-16     7.852Ki ± 0%   5.880Ki ± 0%  -25.12% (p=0.000 n=10)
HashFixedSize/100-16    39.22Ki ± 0%   29.89Ki ± 0%  -23.78% (p=0.000 n=10)
HashFixedSize/1K-16     385.7Ki ± 0%   292.4Ki ± 0%  -24.21% (p=0.000 n=10)
HashFixedSize/10K-16    4.017Mi ± 0%   2.988Mi ± 0%  -25.62% (p=0.000 n=10)
HashFixedSize/100K-16   39.82Mi ± 0%   29.59Mi ± 0%  -25.67% (p=0.000 n=10)
geomean                 456.9Ki        343.2Ki       -24.88%

                      │ /tmp/old.txt │            /tmp/new.txt            │
                      │  allocs/op   │  allocs/op   vs base               │
HashFixedSize/10-16       108.0 ± 0%    101.0 ± 0%  -6.48% (p=0.000 n=10)
HashFixedSize/100-16      570.0 ± 0%    537.0 ± 0%  -5.79% (p=0.000 n=10)
HashFixedSize/1K-16      5.414k ± 0%   5.083k ± 0%  -6.11% (p=0.000 n=10)
HashFixedSize/10K-16     55.56k ± 0%   51.82k ± 0%  -6.73% (p=0.000 n=10)
HashFixedSize/100K-16    554.4k ± 0%   517.2k ± 0%  -6.71% (p=0.000 n=10)
geomean                  6.343k        5.939k       -6.37%
```