### PR TITLE
triedb/pathdb: improve the performance of parse index block

### DIFF
--- a/triedb/pathdb/history_index_block_test.go
+++ b/triedb/pathdb/history_index_block_test.go
@@ -214,3 +214,21 @@ func TestCorruptedIndexBlock(t *testing.T) {
 		t.Fatal("Corrupted index block data is not detected")
 	}
 }
+
+// BenchmarkParseIndexBlock benchmarks the performance of parseIndexBlock.
+func BenchmarkParseIndexBlock(b *testing.B) {
+	// Generate a realistic index block blob
+	bw, _ := newBlockWriter(nil, newIndexBlockDesc(0))
+	for i := 0; i < 4096; i++ {
+		bw.append(uint64(i * 2))
+	}
+	blob := bw.finish()
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, _, err := parseIndexBlock(blob)
+		if err != nil {
+			b.Fatalf("parseIndexBlock failed: %v", err)
+		}
+	}
+}


### PR DESCRIPTION
The implementation of `parseIndexBlock` used a reverse loop with slice appends to build the restart points, which was less cache-friendly and involved unnecessary allocations and operations. In this PR we change the implementation to read and validate the restart points in one single forward loop. 

Here is the benchmark test:

```bash
go test -benchmem -bench=BenchmarkParseIndexBlock ./triedb/pathdb/
```

The result as below:

```
benchmark                      old ns/op     new ns/op     delta
BenchmarkParseIndexBlock-8     52.9          37.5          -29.05%
```

about 29% improvements 