### PR TITLE
trie: avoid spawning goroutines for empty children

### DIFF
--- a/trie/hasher.go
+++ b/trie/hasher.go
@@ -105,18 +105,18 @@ func (h *hasher) hashFullNodeChildren(n *fullNode) *fullNode {
 	var children [17]node
 	if h.parallel {
 		var wg sync.WaitGroup
-		wg.Add(16)
 		for i := 0; i < 16; i++ {
-			go func(i int) {
-				hasher := newHasher(false)
-				if child := n.Children[i]; child != nil {
+			if child := n.Children[i]; child != nil {
+				wg.Add(1)
+				go func(i int) {
+					hasher := newHasher(false)
 					children[i] = hasher.hash(child, false)
-				} else {
-					children[i] = nilValueNode
-				}
-				returnHasherToPool(hasher)
-				wg.Done()
-			}(i)
+					returnHasherToPool(hasher)
+					wg.Done()
+				}(i)
+			} else {
+				children[i] = nilValueNode
+			}
 		}
 		wg.Wait()
 	} else {


### PR DESCRIPTION
I don't know how often a fullnode has empty children, but seemed like a nobrainer.