### PR TITLE
eth: fix negative eta in snap sync state progress logging

### DIFF
--- a/eth/protocols/snap/sync.go
+++ b/eth/protocols/snap/sync.go
@@ -3108,7 +3108,7 @@ func (s *Syncer) reportSyncProgress(force bool) {
 		accountFills,
 	).Uint64())
 	// Don't report anything until we have a meaningful progress
-	if estBytes < 1.0 {
+	if estBytes < 1.0 || float64(synced) > estBytes {
 		return
 	}
 	elapsed := time.Since(s.startTime)


### PR DESCRIPTION
I'm curious about the below log in the logging file, seems the estimated bytes was not correctly calculated, so add a guard to skip logging

```
Syncing: state download in progress      synced=17.90% state=33.33GiB       accounts=12,117,586@2.35GiB slots=130,573,559@26.98GiB codes=1,183,540@3.99GiB eta=-16.344s
```