### PR TITLE
triedb/pathdb: rm the useless accountList and storageList

### DIFF
--- a/triedb/pathdb/history_index_test.go
+++ b/triedb/pathdb/history_index_test.go
@@ -199,15 +199,18 @@ func TestBatchIndexerWrite(t *testing.T) {
 		storages = make(map[common.Hash]map[common.Hash][]uint64)
 	)
 	for i, h := range histories {
-		for _, addr := range h.accountList {
+		for addr := range h.accounts {
 			addrHash := crypto.Keccak256Hash(addr.Bytes())
 			accounts[addrHash] = append(accounts[addrHash], uint64(i+1))
 
 			if _, ok := storages[addrHash]; !ok {
 				storages[addrHash] = make(map[common.Hash][]uint64)
 			}
-			for _, slot := range h.storageList[addr] {
-				storages[addrHash][slot] = append(storages[addrHash][slot], uint64(i+1))
+			slots, ok := h.storages[addr]
+			if ok {
+				for slot := range slots {
+					storages[addrHash][slot] = append(storages[addrHash][slot], uint64(i+1))
+				}
 			}
 		}
 	}

--- a/triedb/pathdb/history_indexer.go
+++ b/triedb/pathdb/history_indexer.go
@@ -94,12 +94,12 @@ func newBatchIndexer(db ethdb.KeyValueStore, delete bool) *batchIndexer {
 // process iterates through the accounts and their associated storage slots in the
 // state history, tracking the mapping between state and history IDs.
 func (b *batchIndexer) process(h *history, historyID uint64) error {
-	for _, address := range h.accountList {
+	for address := range h.accounts {
 		addrHash := crypto.Keccak256Hash(address.Bytes())
 		b.counter += 1
 		b.accounts[addrHash] = append(b.accounts[addrHash], historyID)
 
-		for _, slotKey := range h.storageList[address] {
+		for slotKey := range h.storages[address] {
 			b.counter += 1
 			if _, ok := b.storages[addrHash]; !ok {
 				b.storages[addrHash] = make(map[common.Hash][]uint64)

--- a/triedb/pathdb/history_test.go
+++ b/triedb/pathdb/history_test.go
@@ -100,12 +100,6 @@ func testEncodeDecodeHistory(t *testing.T, rawStorageKey bool) {
 	if !compareStorages(dec.storages, obj.storages) {
 		t.Fatal("storage data is mismatched")
 	}
-	if !compareList(dec.accountList, obj.accountList) {
-		t.Fatal("account list is mismatched")
-	}
-	if !compareStorageList(dec.storageList, obj.storageList) {
-		t.Fatal("storage list is mismatched")
-	}
 }
 
 func checkHistory(t *testing.T, db ethdb.KeyValueReader, freezer ethdb.AncientReader, id uint64, root common.Hash, exist bool) {

--- a/triedb/pathdb/history_test.go
+++ b/triedb/pathdb/history_test.go
@@ -284,18 +284,6 @@ func compareSet[k comparable](a, b map[k][]byte) bool {
 	return true
 }
 
-func compareList[k comparable](a, b []k) bool {
-	if len(a) != len(b) {
-		return false
-	}
-	for i := 0; i < len(a); i++ {
-		if a[i] != b[i] {
-			return false
-		}
-	}
-	return true
-}
-
 func compareStorages(a, b map[common.Address]map[common.Hash][]byte) bool {
 	if len(a) != len(b) {
 		return false
@@ -306,22 +294,6 @@ func compareStorages(a, b map[common.Address]map[common.Hash][]byte) bool {
 			return false
 		}
 		if !compareSet(subA, subB) {
-			return false
-		}
-	}
-	return true
-}
-
-func compareStorageList(a, b map[common.Address][]common.Hash) bool {
-	if len(a) != len(b) {
-		return false
-	}
-	for h, la := range a {
-		lb, ok := b[h]
-		if !ok {
-			return false
-		}
-		if !compareList(la, lb) {
 			return false
 		}
 	}


### PR DESCRIPTION
Seems the `accountList` and `storageList` fields, which were only used internally for encoding and not required elsewhere, then we can move those fields from struct to local variables, so in the decoding phase, we can skip recovering these fields.