### PR TITLE
core/txpool/blobpool: remove unused `txValidationFn` from BlobPool

### DIFF
--- a/core/txpool/blobpool/blobpool.go
+++ b/core/txpool/blobpool/blobpool.go
@@ -326,10 +326,6 @@ type BlobPool struct {
 	discoverFeed event.Feed // Event feed to send out new tx events on pool discovery (reorg excluded)
 	insertFeed   event.Feed // Event feed to send out new tx events on pool inclusion (reorg included)
 
-	// txValidationFn defaults to txpool.ValidateTransaction, but can be
-	// overridden for testing purposes.
-	txValidationFn txpool.ValidationFunction
-
 	lock sync.RWMutex // Mutex protecting the pool during reorg handling
 }
 
@@ -348,7 +344,6 @@ func New(config Config, chain BlockChain, hasPendingAuth func(common.Address) bo
 		lookup:         newLookup(),
 		index:          make(map[common.Address][]*blobTxMeta),
 		spent:          make(map[common.Address]*uint256.Int),
-		txValidationFn: txpool.ValidateTransaction,
 	}
 }
 

--- a/core/txpool/blobpool/blobpool_test.go
+++ b/core/txpool/blobpool/blobpool_test.go
@@ -1724,12 +1724,6 @@ func benchmarkPoolPending(b *testing.B, datacap uint64) {
 	// Make the pool not use disk (just drop everything). This test never reads
 	// back the data, it just iterates over the pool in-memory items
 	pool.store = &fakeBilly{pool.store, 0}
-	// Avoid validation - verifying all blob proofs take significant time
-	// when the capacity is large. The purpose of this bench is to measure assembling
-	// the lazies, not the kzg verifications.
-	pool.txValidationFn = func(tx *types.Transaction, head *types.Header, signer types.Signer, opts *txpool.ValidationOptions) error {
-		return nil // accept all
-	}
 	// Fill the pool up with one random transaction from each account with the
 	// same price and everything to maximize the worst case scenario
 	for i := 0; i < int(capacity); i++ {


### PR DESCRIPTION
This PR removes the now‑unused `txValidationFn` field from BlobPool.
It became obsolete after a PR https://github.com/ethereum/go-ethereum/pull/31202 was merged

Resolves https://github.com/ethereum/go-ethereum/issues/32236