### PR TITLE
core/types: protect the integrity of proofs

### DIFF
--- a/core/types/tx_blob.go
+++ b/core/types/tx_blob.go
@@ -117,15 +117,16 @@ func (sc *BlobTxSidecar) ToV1() error {
 		return nil
 	}
 	if sc.Version == BlobSidecarVersion0 {
-		sc.Proofs = make([]kzg4844.Proof, 0, len(sc.Blobs)*kzg4844.CellProofsPerBlob)
+		proofs := make([]kzg4844.Proof, 0, len(sc.Blobs)*kzg4844.CellProofsPerBlob)
 		for _, blob := range sc.Blobs {
 			cellProofs, err := kzg4844.ComputeCellProofs(&blob)
 			if err != nil {
 				return err
 			}
-			sc.Proofs = append(sc.Proofs, cellProofs...)
+			proofs = append(proofs, cellProofs...)
 		}
 		sc.Version = BlobSidecarVersion1
+		sc.Proofs = proofs
 	}
 	return nil
 }


### PR DESCRIPTION
We know building the `cell proofs` will take several seconds, so `sc.Proofs = make(...)` at first can let the field be in an invalid intermediate state.