### PR TITLE
Blob tx limit

### DIFF
--- a/core/block_validator.go
+++ b/core/block_validator.go
@@ -86,8 +86,13 @@ func (v *BlockValidator) ValidateBody(block *types.Block) error {
 	}
 
 	// Blob transactions may be present after the Cancun fork.
+	isOsaka := v.config.IsOsaka(block.Number(), block.Time())
 	var blobs int
 	for i, tx := range block.Transactions() {
+		if isOsaka && len(tx.BlobHashes()) > params.BlobTxMaxBlobs {
+			return ErrTooManyBlobs
+		}
+
 		// Count the number of blobs to validate against the header's blobGasUsed
 		blobs += len(tx.BlobHashes())
 

--- a/core/error.go
+++ b/core/error.go
@@ -118,6 +118,9 @@ var (
 	// ErrMissingBlobHashes is returned if a blob transaction has no blob hashes.
 	ErrMissingBlobHashes = errors.New("blob transaction missing blob hashes")
 
+	// ErrTooManyBlobs is returned if a blob transaction exceeds the maximum number of blobs.
+	ErrTooManyBlobs = errors.New("blob transaction has too many blobs")
+
 	// ErrBlobTxCreate is returned if a blob transaction has no explicit to field.
 	ErrBlobTxCreate = errors.New("blob transaction of type create")
 

--- a/core/txpool/blobpool/blobpool.go
+++ b/core/txpool/blobpool/blobpool.go
@@ -65,7 +65,7 @@ const (
 	// carry. We choose a smaller limit than the protocol-permitted MaxBlobsPerBlock
 	// in order to ensure network and txpool stability.
 	// Note: if you increase this, validation will fail on txMaxSize.
-	maxBlobsPerTx = 7
+	maxBlobsPerTx = params.BlobTxMaxBlobs
 
 	// maxTxsPerAccount is the maximum number of blob transactions admitted from
 	// a single account. The limit is enforced to minimize the DoS potential of

--- a/params/protocol_params.go
+++ b/params/protocol_params.go
@@ -177,6 +177,7 @@ const (
 	BlobTxBlobGasPerBlob               = 1 << 17 // Gas consumption of a single data blob (== blob byte size)
 	BlobTxMinBlobGasprice              = 1       // Minimum gas price for data blobs
 	BlobTxPointEvaluationPrecompileGas = 50000   // Gas price for the point evaluation precompile.
+	BlobTxMaxBlobs                     = 6
 	BlobBaseCost                       = 1 << 13 // Base execution gas cost for a blob.
 
 	HistoryServeWindow = 8192 // Number of blocks to serve historical block hashes for, EIP-2935.


### PR DESCRIPTION
[EIP-7594](https://eips.ethereum.org/EIPS/eip-7594) defines a limit of max 6 blobs per transaction. We need to enforce this limit during block processing.