### PR TITLE
triedb/pathdb:  use binary.append to eliminate the tmp scratch slice

### DIFF
--- a/triedb/pathdb/history_index_block.go
+++ b/triedb/pathdb/history_index_block.go
@@ -381,8 +381,17 @@ func (b *blockWriter) full() bool {
 // This function is safe to be called multiple times.
 func (b *blockWriter) finish() []byte {
 	restartsLen := len(b.restarts)
-	buf := make([]byte, len(b.data)+restartsLen*2+1)
-	copy(buf, b.data)
+	extra := restartsLen*2 + 1
+	var buf []byte
+
+	if cap(b.data)-len(b.data) >= extra {
+		// Enough capacity, just reslice; data is already in place.
+		buf = b.data[:len(b.data)+extra]
+	} else {
+		// Not enough capacity, allocate and copy.
+		buf = make([]byte, len(b.data)+extra)
+		copy(buf, b.data)
+	}
 
 	restartsOffset := len(b.data)
 	for i, restart := range b.restarts {

--- a/triedb/pathdb/history_index_block.go
+++ b/triedb/pathdb/history_index_block.go
@@ -380,9 +380,12 @@ func (b *blockWriter) full() bool {
 //
 // This function is safe to be called multiple times.
 func (b *blockWriter) finish() []byte {
-	restartsLen := len(b.restarts)
-	extra := restartsLen*2 + 1
-	var buf []byte
+	var (
+		restartsLen = len(b.restarts)
+		restartsOff = len(b.data)
+		extra       = restartsLen*2 + 1
+		buf         []byte
+	)
 
 	if cap(b.data)-len(b.data) >= extra {
 		// Enough capacity, just reslice; data is already in place.
@@ -393,9 +396,8 @@ func (b *blockWriter) finish() []byte {
 		copy(buf, b.data)
 	}
 
-	restartsOffset := len(b.data)
 	for i, restart := range b.restarts {
-		binary.BigEndian.PutUint16(buf[restartsOffset+2*i:], restart)
+		binary.BigEndian.PutUint16(buf[restartsOff+2*i:], restart)
 	}
 	buf[len(buf)-1] = byte(restartsLen)
 	return buf

--- a/triedb/pathdb/history_index_block.go
+++ b/triedb/pathdb/history_index_block.go
@@ -272,11 +272,6 @@ func (b *blockWriter) append(id uint64) error {
 		b.data = binary.AppendUvarint(b.data, id-b.desc.max)
 	}
 	b.desc.entries++
-
-	// The state history ID must be greater than 0.
-	//if b.desc.min == 0 {
-	//	b.desc.min = id
-	//}
 	b.desc.max = id
 	return nil
 }

--- a/triedb/pathdb/history_index_block.go
+++ b/triedb/pathdb/history_index_block.go
@@ -380,25 +380,10 @@ func (b *blockWriter) full() bool {
 //
 // This function is safe to be called multiple times.
 func (b *blockWriter) finish() []byte {
-	var (
-		restartsLen = len(b.restarts)
-		restartsOff = len(b.data)
-		extra       = restartsLen*2 + 1
-		buf         []byte
-	)
-
-	if cap(b.data)-len(b.data) >= extra {
-		// Enough capacity, just reslice; data is already in place.
-		buf = b.data[:len(b.data)+extra]
-	} else {
-		// Not enough capacity, allocate and copy.
-		buf = make([]byte, len(b.data)+extra)
-		copy(buf, b.data)
-	}
-
+	buf := make([]byte, len(b.restarts)*2+1)
 	for i, restart := range b.restarts {
-		binary.BigEndian.PutUint16(buf[restartsOff+2*i:], restart)
+		binary.BigEndian.PutUint16(buf[2*i:], restart)
 	}
-	buf[len(buf)-1] = byte(restartsLen)
-	return buf
+	buf[len(buf)-1] = byte(len(b.restarts))
+	return append(b.data, buf...)
 }

--- a/triedb/pathdb/history_index_block_test.go
+++ b/triedb/pathdb/history_index_block_test.go
@@ -232,3 +232,22 @@ func BenchmarkParseIndexBlock(b *testing.B) {
 		}
 	}
 }
+
+// BenchmarkBlockWriterAppend benchmarks the performance of indexblock.writer
+func BenchmarkBlockWriterAppend(b *testing.B) {
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	desc := newIndexBlockDesc(0)
+	writer, _ := newBlockWriter(nil, desc)
+
+	for i := 0; i < b.N; i++ {
+		if writer.full() {
+			desc = newIndexBlockDesc(0)
+			writer, _ = newBlockWriter(nil, desc)
+		}
+		if err := writer.append(writer.desc.max + 1); err != nil {
+			b.Error(err)
+		}
+	}
+}


### PR DESCRIPTION
`binary.AppendUvarint` offers better performance than using append directly, because it avoids unnecessary memory allocation and copying. 

In our case, it can increase the performance by +35.8% for the `blockWriter.append` function:

```
benchmark                        old ns/op     new ns/op     delta
BenchmarkBlockWriterAppend-8     5.97          3.83          -35.80%
```