### PR TITLE
build: update tests to fusaka-devnet-3

### DIFF
--- a/build/checksums.txt
+++ b/build/checksums.txt
@@ -1,9 +1,9 @@
 # This file contains sha256 checksums of optional build dependencies.
 
-# version:spec-tests v4.5.0
+# version:spec-tests fusaka-devnet-3%40v1.0.0
 # https://github.com/ethereum/execution-spec-tests/releases
-# https://github.com/ethereum/execution-spec-tests/releases/download/v4.5.0/
-58afb92a0075a2cb7c4dec1281f7cb88b21b02afbedad096b580f3f8cc14c54c  fixtures_develop.tar.gz
+# https://github.com/ethereum/execution-spec-tests/releases/download/fusaka-devnet-3%40v1.0.0
+576261e1280e5300c458aa9b05eccb2fec5ff80a0005940dc52fa03fdd907249  fixtures_fusaka-devnet-3.tar.gz
 
 # version:golang 1.24.4
 # https://go.dev/dl/

--- a/build/ci.go
+++ b/build/ci.go
@@ -332,7 +332,7 @@ func doTest(cmdline []string) {
 // downloadSpecTestFixtures downloads and extracts the execution-spec-tests fixtures.
 func downloadSpecTestFixtures(csdb *download.ChecksumDB, cachedir string) string {
 	ext := ".tar.gz"
-	base := "fixtures_develop"
+	base := "fixtures_fusaka-devnet-3"
 	archivePath := filepath.Join(cachedir, base+ext)
 	if err := csdb.DownloadFileFromKnownURL(archivePath); err != nil {
 		log.Fatal(err)


### PR DESCRIPTION
Here I am updating the tests to the latest release for Fusaka devnet 3. This is just to ensure we don't regress on Fusaka for future changes, since they are otherwise untested.