### PR TITLE
core/rawdb: change log level

### DIFF
--- a/core/rawdb/chain_freezer.go
+++ b/core/rawdb/chain_freezer.go
@@ -104,7 +104,7 @@ func (f *chainFreezer) Close() error {
 func (f *chainFreezer) readHeadNumber(db ethdb.KeyValueReader) uint64 {
 	hash := ReadHeadBlockHash(db)
 	if hash == (common.Hash{}) {
-		log.Error("Head block is not reachable")
+		log.Warn("Head block is not reachable")
 		return 0
 	}
 	number, ok := ReadHeaderNumber(db, hash)


### PR DESCRIPTION
When initializing the genesis state, the block number is set to 0, and the genesis hash is empty in the database. Since this is expected behavior, why not adjust the log level to 'warning' instead?