### PR TITLE
core/state: remove unneeded trampoline funcs in hookedStateDB

### DIFF
--- a/core/state/statedb_hooked.go
+++ b/core/state/statedb_hooked.go
@@ -20,19 +20,16 @@ import (
 	"math/big"
 
 	"github.com/ethereum/go-ethereum/common"
-	"github.com/ethereum/go-ethereum/core/stateless"
 	"github.com/ethereum/go-ethereum/core/tracing"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/crypto"
-	"github.com/ethereum/go-ethereum/params"
-	"github.com/ethereum/go-ethereum/trie/utils"
 	"github.com/holiman/uint256"
 )
 
 // hookedStateDB represents a statedb which emits calls to tracing-hooks
 // on state operations.
 type hookedStateDB struct {
-	inner *StateDB
+	*StateDB
 	hooks *tracing.Hooks
 }
 
@@ -45,124 +42,8 @@ func NewHookedState(stateDb *StateDB, hooks *tracing.Hooks) *hookedStateDB {
 	return s
 }
 
-func (s *hookedStateDB) CreateAccount(addr common.Address) {
-	s.inner.CreateAccount(addr)
-}
-
-func (s *hookedStateDB) CreateContract(addr common.Address) {
-	s.inner.CreateContract(addr)
-}
-
-func (s *hookedStateDB) GetBalance(addr common.Address) *uint256.Int {
-	return s.inner.GetBalance(addr)
-}
-
-func (s *hookedStateDB) GetNonce(addr common.Address) uint64 {
-	return s.inner.GetNonce(addr)
-}
-
-func (s *hookedStateDB) GetCodeHash(addr common.Address) common.Hash {
-	return s.inner.GetCodeHash(addr)
-}
-
-func (s *hookedStateDB) GetCode(addr common.Address) []byte {
-	return s.inner.GetCode(addr)
-}
-
-func (s *hookedStateDB) GetCodeSize(addr common.Address) int {
-	return s.inner.GetCodeSize(addr)
-}
-
-func (s *hookedStateDB) AddRefund(u uint64) {
-	s.inner.AddRefund(u)
-}
-
-func (s *hookedStateDB) SubRefund(u uint64) {
-	s.inner.SubRefund(u)
-}
-
-func (s *hookedStateDB) GetRefund() uint64 {
-	return s.inner.GetRefund()
-}
-
-func (s *hookedStateDB) GetStateAndCommittedState(addr common.Address, hash common.Hash) (common.Hash, common.Hash) {
-	return s.inner.GetStateAndCommittedState(addr, hash)
-}
-
-func (s *hookedStateDB) GetState(addr common.Address, hash common.Hash) common.Hash {
-	return s.inner.GetState(addr, hash)
-}
-
-func (s *hookedStateDB) GetStorageRoot(addr common.Address) common.Hash {
-	return s.inner.GetStorageRoot(addr)
-}
-
-func (s *hookedStateDB) GetTransientState(addr common.Address, key common.Hash) common.Hash {
-	return s.inner.GetTransientState(addr, key)
-}
-
-func (s *hookedStateDB) SetTransientState(addr common.Address, key, value common.Hash) {
-	s.inner.SetTransientState(addr, key, value)
-}
-
-func (s *hookedStateDB) HasSelfDestructed(addr common.Address) bool {
-	return s.inner.HasSelfDestructed(addr)
-}
-
-func (s *hookedStateDB) Exist(addr common.Address) bool {
-	return s.inner.Exist(addr)
-}
-
-func (s *hookedStateDB) Empty(addr common.Address) bool {
-	return s.inner.Empty(addr)
-}
-
-func (s *hookedStateDB) AddressInAccessList(addr common.Address) bool {
-	return s.inner.AddressInAccessList(addr)
-}
-
-func (s *hookedStateDB) SlotInAccessList(addr common.Address, slot common.Hash) (addressOk bool, slotOk bool) {
-	return s.inner.SlotInAccessList(addr, slot)
-}
-
-func (s *hookedStateDB) AddAddressToAccessList(addr common.Address) {
-	s.inner.AddAddressToAccessList(addr)
-}
-
-func (s *hookedStateDB) AddSlotToAccessList(addr common.Address, slot common.Hash) {
-	s.inner.AddSlotToAccessList(addr, slot)
-}
-
-func (s *hookedStateDB) PointCache() *utils.PointCache {
-	return s.inner.PointCache()
-}
-
-func (s *hookedStateDB) Prepare(rules params.Rules, sender, coinbase common.Address, dest *common.Address, precompiles []common.Address, txAccesses types.AccessList) {
-	s.inner.Prepare(rules, sender, coinbase, dest, precompiles, txAccesses)
-}
-
-func (s *hookedStateDB) RevertToSnapshot(i int) {
-	s.inner.RevertToSnapshot(i)
-}
-
-func (s *hookedStateDB) Snapshot() int {
-	return s.inner.Snapshot()
-}
-
-func (s *hookedStateDB) AddPreimage(hash common.Hash, bytes []byte) {
-	s.inner.AddPreimage(hash, bytes)
-}
-
-func (s *hookedStateDB) Witness() *stateless.Witness {
-	return s.inner.Witness()
-}
-
-func (s *hookedStateDB) AccessEvents() *AccessEvents {
-	return s.inner.AccessEvents()
-}
-
 func (s *hookedStateDB) SubBalance(addr common.Address, amount *uint256.Int, reason tracing.BalanceChangeReason) uint256.Int {
-	prev := s.inner.SubBalance(addr, amount, reason)
+	prev := s.StateDB.SubBalance(addr, amount, reason)
 	if s.hooks.OnBalanceChange != nil && !amount.IsZero() {
 		newBalance := new(uint256.Int).Sub(&prev, amount)
 		s.hooks.OnBalanceChange(addr, prev.ToBig(), newBalance.ToBig(), reason)
@@ -171,7 +52,7 @@ func (s *hookedStateDB) SubBalance(addr common.Address, amount *uint256.Int, rea
 }
 
 func (s *hookedStateDB) AddBalance(addr common.Address, amount *uint256.Int, reason tracing.BalanceChangeReason) uint256.Int {
-	prev := s.inner.AddBalance(addr, amount, reason)
+	prev := s.StateDB.AddBalance(addr, amount, reason)
 	if s.hooks.OnBalanceChange != nil && !amount.IsZero() {
 		newBalance := new(uint256.Int).Add(&prev, amount)
 		s.hooks.OnBalanceChange(addr, prev.ToBig(), newBalance.ToBig(), reason)
@@ -180,8 +61,8 @@ func (s *hookedStateDB) AddBalance(addr common.Address, amount *uint256.Int, rea
 }
 
 func (s *hookedStateDB) SetNonce(address common.Address, nonce uint64, reason tracing.NonceChangeReason) {
-	prev := s.inner.GetNonce(address)
-	s.inner.SetNonce(address, nonce, reason)
+	prev := s.GetNonce(address)
+	s.StateDB.SetNonce(address, nonce, reason)
 	if s.hooks.OnNonceChangeV2 != nil {
 		s.hooks.OnNonceChangeV2(address, prev, nonce, reason)
 	} else if s.hooks.OnNonceChange != nil {
@@ -190,7 +71,7 @@ func (s *hookedStateDB) SetNonce(address common.Address, nonce uint64, reason tr
 }
 
 func (s *hookedStateDB) SetCode(address common.Address, code []byte) []byte {
-	prev := s.inner.SetCode(address, code)
+	prev := s.StateDB.SetCode(address, code)
 	if s.hooks.OnCodeChange != nil {
 		prevHash := types.EmptyCodeHash
 		if len(prev) != 0 {
@@ -202,7 +83,7 @@ func (s *hookedStateDB) SetCode(address common.Address, code []byte) []byte {
 }
 
 func (s *hookedStateDB) SetState(address common.Address, key common.Hash, value common.Hash) common.Hash {
-	prev := s.inner.SetState(address, key, value)
+	prev := s.StateDB.SetState(address, key, value)
 	if s.hooks.OnStorageChange != nil && prev != value {
 		s.hooks.OnStorageChange(address, key, prev, value)
 	}
@@ -214,11 +95,11 @@ func (s *hookedStateDB) SelfDestruct(address common.Address) uint256.Int {
 	var prevCodeHash common.Hash
 
 	if s.hooks.OnCodeChange != nil {
-		prevCode = s.inner.GetCode(address)
-		prevCodeHash = s.inner.GetCodeHash(address)
+		prevCode = s.GetCode(address)
+		prevCodeHash = s.GetCodeHash(address)
 	}
 
-	prev := s.inner.SelfDestruct(address)
+	prev := s.StateDB.SelfDestruct(address)
 
 	if s.hooks.OnBalanceChange != nil && !prev.IsZero() {
 		s.hooks.OnBalanceChange(address, prev.ToBig(), new(big.Int), tracing.BalanceDecreaseSelfdestruct)
@@ -236,11 +117,11 @@ func (s *hookedStateDB) SelfDestruct6780(address common.Address) (uint256.Int, b
 	var prevCodeHash common.Hash
 
 	if s.hooks.OnCodeChange != nil {
-		prevCodeHash = s.inner.GetCodeHash(address)
-		prevCode = s.inner.GetCode(address)
+		prevCodeHash = s.GetCodeHash(address)
+		prevCode = s.GetCode(address)
 	}
 
-	prev, changed := s.inner.SelfDestruct6780(address)
+	prev, changed := s.StateDB.SelfDestruct6780(address)
 
 	if s.hooks.OnBalanceChange != nil && changed && !prev.IsZero() {
 		s.hooks.OnBalanceChange(address, prev.ToBig(), new(big.Int), tracing.BalanceDecreaseSelfdestruct)
@@ -255,19 +136,19 @@ func (s *hookedStateDB) SelfDestruct6780(address common.Address) (uint256.Int, b
 
 func (s *hookedStateDB) AddLog(log *types.Log) {
 	// The inner will modify the log (add fields), so invoke that first
-	s.inner.AddLog(log)
+	s.StateDB.AddLog(log)
 	if s.hooks.OnLog != nil {
 		s.hooks.OnLog(log)
 	}
 }
 
 func (s *hookedStateDB) Finalise(deleteEmptyObjects bool) {
-	defer s.inner.Finalise(deleteEmptyObjects)
+	defer s.StateDB.Finalise(deleteEmptyObjects)
 	if s.hooks.OnBalanceChange == nil {
 		return
 	}
-	for addr := range s.inner.journal.dirties {
-		obj := s.inner.stateObjects[addr]
+	for addr := range s.StateDB.journal.dirties {
+		obj := s.StateDB.stateObjects[addr]
 		if obj != nil && obj.selfDestructed {
 			// If ether was sent to account post-selfdestruct it is burnt.
 			if bal := obj.Balance(); bal.Sign() != 0 {


### PR DESCRIPTION
they don't really hurt, but they are not really needed either. 