### PR TITLE
core: rename SkipNonceChecks to SkipFromNonceCheck for clarity

### DIFF
--- a/core/state_prefetcher.go
+++ b/core/state_prefetcher.go
@@ -101,7 +101,7 @@ func (p *statePrefetcher) Prefetch(block *types.Block, statedb *state.StateDB, c
 				return nil // Also invalid block, bail out
 			}
 			// Disable the nonce check
-			msg.SkipNonceChecks = true
+			msg.SkipFromNonceCheck = true
 
 			stateCpy.SetTxContext(tx.Hash(), i)
 

--- a/core/state_transition.go
+++ b/core/state_transition.go
@@ -157,12 +157,12 @@ type Message struct {
 	BlobHashes            []common.Hash
 	SetCodeAuthorizations []types.SetCodeAuthorization
 
-	// When SkipNonceChecks is true, the message nonce is not checked against the
-	// account nonce in state.
+	// When SkipFromNonceCheck is true, the message nonce is not checked
+	// against the account nonce in state.
 	//
 	// This field will be set to true for operations like RPC eth_call
 	// or the state prefetching.
-	SkipNonceChecks bool
+	SkipFromNonceCheck bool
 
 	// When SkipFromEOACheck is true, the message sender is not checked to be an EOA.
 	SkipFromEOACheck bool
@@ -181,7 +181,7 @@ func TransactionToMessage(tx *types.Transaction, s types.Signer, baseFee *big.In
 		Data:                  tx.Data(),
 		AccessList:            tx.AccessList(),
 		SetCodeAuthorizations: tx.SetCodeAuthorizations(),
-		SkipNonceChecks:       false,
+		SkipFromNonceCheck:    false,
 		SkipFromEOACheck:      false,
 		BlobHashes:            tx.BlobHashes(),
 		BlobGasFeeCap:         tx.BlobGasFeeCap(),
@@ -306,7 +306,7 @@ func (st *stateTransition) buyGas() error {
 func (st *stateTransition) preCheck() error {
 	// Only check transactions that are not fake
 	msg := st.msg
-	if !msg.SkipNonceChecks {
+	if !msg.SkipFromNonceCheck {
 		// Make sure this transaction's nonce is correct.
 		stNonce := st.state.GetNonce(msg.From)
 		if msgNonce := msg.Nonce; stNonce < msgNonce {

--- a/internal/ethapi/transaction_args.go
+++ b/internal/ethapi/transaction_args.go
@@ -461,7 +461,7 @@ func (args *TransactionArgs) ToMessage(baseFee *big.Int, skipNonceCheck, skipEoA
 		BlobGasFeeCap:         (*big.Int)(args.BlobFeeCap),
 		BlobHashes:            args.BlobHashes,
 		SetCodeAuthorizations: args.AuthorizationList,
-		SkipNonceChecks:       skipNonceCheck,
+		SkipFromNonceCheck:    skipNonceCheck,
 		SkipFromEOACheck:      skipEoACheck,
 	}
 }


### PR DESCRIPTION
We already has a field `SkipFromEOACheck`, so rename `SkipNonceChecks` to `SkipFromNonceCheck` for more clarity and consistency