### PR TITLE
build/ci: update golangci-linter with --new-from-rev

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -15,6 +15,7 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: false
+        fetch-depth: 0
 
     # Cache build tools to avoid downloading them each time
     - uses: actions/cache@v4
@@ -27,6 +28,12 @@ jobs:
       with:
         go-version: 1.24
         cache: false
+
+    - name: Fetch base branch
+      run: |
+        if [ ! -z "$GITHUB_BASE_REF" ]; then
+          git fetch origin $GITHUB_BASE_REF:refs/remotes/origin/$GITHUB_BASE_REF
+        fi
 
     - name: Run linters
       run: |
@@ -56,3 +63,4 @@ jobs:
 
       - name: Run tests
         run: go test ./...
+

--- a/build/ci.go
+++ b/build/ci.go
@@ -433,7 +433,14 @@ func doLint(cmdline []string) {
 	}
 
 	linter := downloadLinter(*cachedir)
-	lflags := []string{"run", "--config", ".golangci.yml", "--new-from-rev=origin/master"}
+	baseRef := "master"
+	if ref := os.Getenv("GITHUB_BASE_REF"); ref != "" {
+		baseRef = ref
+	}
+
+	lflags := []string{"run", "--config", ".golangci.yml",
+		fmt.Sprintf("--new-from-rev=origin/%s", baseRef),
+	}
 	build.MustRunCommandWithOutput(linter, append(lflags, packages...)...)
 	fmt.Println("You have achieved perfection.")
 }
@@ -1172,3 +1179,4 @@ func doSanityCheck() {
 	csdb := download.MustLoadChecksums("build/checksums.txt")
 	csdb.DownloadAndVerifyAll()
 }
+

--- a/build/ci.go
+++ b/build/ci.go
@@ -433,7 +433,7 @@ func doLint(cmdline []string) {
 	}
 
 	linter := downloadLinter(*cachedir)
-	lflags := []string{"run", "--config", ".golangci.yml"}
+	lflags := []string{"run", "--config", ".golangci.yml", "--new-from-rev=origin/main"}
 	build.MustRunCommandWithOutput(linter, append(lflags, packages...)...)
 	fmt.Println("You have achieved perfection.")
 }

--- a/build/ci.go
+++ b/build/ci.go
@@ -433,7 +433,7 @@ func doLint(cmdline []string) {
 	}
 
 	linter := downloadLinter(*cachedir)
-	lflags := []string{"run", "--config", ".golangci.yml", "--new-from-rev=origin/main"}
+	lflags := []string{"run", "--config", ".golangci.yml", "--new-from-rev=origin/master"}
 	build.MustRunCommandWithOutput(linter, append(lflags, packages...)...)
 	fmt.Println("You have achieved perfection.")
 }


### PR DESCRIPTION
By using `--new-from-rev=origin/master` with golangci-lint, it only lint the files that have changed compared to `origin/master`, reducing the linting workload. 