### PR TITLE
triedb/pathdb: add cache for history index and block

### DIFF
--- a/triedb/pathdb/database.go
+++ b/triedb/pathdb/database.go
@@ -61,8 +61,12 @@ var (
 	// maxDiffLayers is the maximum diff layers allowed in the layer tree.
 	maxDiffLayers = 128
 
-	// historyCacheSize is the maximum size of history cache.
-	historyCacheSize = 4096
+	// historyIndexCacheSize is the maximum count of history index cache.
+	// Each indexBlockDesc is 14bytes, assume each account has 10 descriptors,
+	// then the total memory usage is ~54MB.
+	historyIndexCacheSize = 409600
+	// historyBlockCacheSize is the maximum count of history block cache.
+	historyBlockCacheSize = 4096
 )
 
 // layer is the interface implemented by all state layers which includes some
@@ -246,7 +250,7 @@ func New(diskdb ethdb.Database, config *Config, isVerkle bool) *Database {
 		config:   config,
 		diskdb:   diskdb,
 		hasher:   merkleNodeHasher,
-		cacher:   newHistoryCacher(historyCacheSize),
+		cacher:   newHistoryCacher(historyIndexCacheSize, historyBlockCacheSize),
 	}
 	// Establish a dedicated database namespace tailored for verkle-specific
 	// data, ensuring the isolation of both verkle and merkle tree data. It's

--- a/triedb/pathdb/history_index.go
+++ b/triedb/pathdb/history_index.go
@@ -300,10 +300,14 @@ func (w *indexWriter) finish(batch ethdb.Batch) {
 		return // nothing to commit
 	}
 	for _, bw := range writers {
+		buf := bw.finish()
+		if key := fmt.Sprintf("%s:%d", w.state.String(), bw.desc.id); historyBlockCache.Contains(key) {
+			historyBlockCache.Add(key, buf)
+		}
 		if w.state.account {
-			rawdb.WriteAccountHistoryIndexBlock(batch, w.state.addressHash, bw.desc.id, bw.finish())
+			rawdb.WriteAccountHistoryIndexBlock(batch, w.state.addressHash, bw.desc.id, buf)
 		} else {
-			rawdb.WriteStorageHistoryIndexBlock(batch, w.state.addressHash, w.state.storageHash, bw.desc.id, bw.finish())
+			rawdb.WriteStorageHistoryIndexBlock(batch, w.state.addressHash, w.state.storageHash, bw.desc.id, buf)
 		}
 	}
 	w.frozen = nil // release all the frozen writers

--- a/triedb/pathdb/history_index.go
+++ b/triedb/pathdb/history_index.go
@@ -304,6 +304,9 @@ func (w *indexWriter) finish(batch ethdb.Batch) {
 	for _, desc := range descList {
 		buf = append(buf, desc.encode()...)
 	}
+	if key := w.state.String(); historyIndexCache.Contains(key) {
+		historyIndexCache.Add(key, buf)
+	}
 	if w.state.account {
 		rawdb.WriteAccountHistoryIndex(batch, w.state.addressHash, buf)
 	} else {
@@ -420,6 +423,9 @@ func (d *indexDeleter) pop(id uint64) error {
 //
 // This function is safe to be called multiple times.
 func (d *indexDeleter) finish(batch ethdb.Batch) {
+	if key := d.state.String(); historyIndexCache.Contains(key) {
+		historyIndexCache.Remove(key)
+	}
 	for _, id := range d.dropped {
 		if d.state.account {
 			rawdb.DeleteAccountHistoryIndexBlock(batch, d.state.addressHash, id)

--- a/triedb/pathdb/history_index_test.go
+++ b/triedb/pathdb/history_index_test.go
@@ -33,7 +33,7 @@ func TestIndexReaderBasic(t *testing.T) {
 		1, 5, 10, 11, 20,
 	}
 	db := rawdb.NewMemoryDatabase()
-	bw, _ := newIndexWriter(db, newAccountIdent(common.Hash{0xa}))
+	bw, _ := newIndexWriter(db, newAccountIdent(common.Hash{0xa}), nil)
 	for i := 0; i < len(elements); i++ {
 		bw.append(elements[i])
 	}
@@ -41,7 +41,7 @@ func TestIndexReaderBasic(t *testing.T) {
 	bw.finish(batch)
 	batch.Write()
 
-	br, err := newIndexReader(db, newAccountIdent(common.Hash{0xa}))
+	br, err := newIndexReader(db, newAccountIdent(common.Hash{0xa}), nil)
 	if err != nil {
 		t.Fatalf("Failed to construct the index reader, %v", err)
 	}
@@ -75,7 +75,7 @@ func TestIndexReaderLarge(t *testing.T) {
 	slices.Sort(elements)
 
 	db := rawdb.NewMemoryDatabase()
-	bw, _ := newIndexWriter(db, newAccountIdent(common.Hash{0xa}))
+	bw, _ := newIndexWriter(db, newAccountIdent(common.Hash{0xa}), nil)
 	for i := 0; i < len(elements); i++ {
 		bw.append(elements[i])
 	}
@@ -83,7 +83,7 @@ func TestIndexReaderLarge(t *testing.T) {
 	bw.finish(batch)
 	batch.Write()
 
-	br, err := newIndexReader(db, newAccountIdent(common.Hash{0xa}))
+	br, err := newIndexReader(db, newAccountIdent(common.Hash{0xa}), nil)
 	if err != nil {
 		t.Fatalf("Failed to construct the index reader, %v", err)
 	}
@@ -107,7 +107,7 @@ func TestIndexReaderLarge(t *testing.T) {
 }
 
 func TestEmptyIndexReader(t *testing.T) {
-	br, err := newIndexReader(rawdb.NewMemoryDatabase(), newAccountIdent(common.Hash{0xa}))
+	br, err := newIndexReader(rawdb.NewMemoryDatabase(), newAccountIdent(common.Hash{0xa}), nil)
 	if err != nil {
 		t.Fatalf("Failed to construct the index reader, %v", err)
 	}
@@ -122,7 +122,7 @@ func TestEmptyIndexReader(t *testing.T) {
 
 func TestIndexWriterBasic(t *testing.T) {
 	db := rawdb.NewMemoryDatabase()
-	iw, _ := newIndexWriter(db, newAccountIdent(common.Hash{0xa}))
+	iw, _ := newIndexWriter(db, newAccountIdent(common.Hash{0xa}), nil)
 	iw.append(2)
 	if err := iw.append(1); err == nil {
 		t.Fatal("out-of-order insertion is not expected")
@@ -134,7 +134,7 @@ func TestIndexWriterBasic(t *testing.T) {
 	iw.finish(batch)
 	batch.Write()
 
-	iw, err := newIndexWriter(db, newAccountIdent(common.Hash{0xa}))
+	iw, err := newIndexWriter(db, newAccountIdent(common.Hash{0xa}), nil)
 	if err != nil {
 		t.Fatalf("Failed to construct the block writer, %v", err)
 	}
@@ -148,7 +148,7 @@ func TestIndexWriterBasic(t *testing.T) {
 
 func TestIndexWriterDelete(t *testing.T) {
 	db := rawdb.NewMemoryDatabase()
-	iw, _ := newIndexWriter(db, newAccountIdent(common.Hash{0xa}))
+	iw, _ := newIndexWriter(db, newAccountIdent(common.Hash{0xa}), nil)
 	for i := 0; i < indexBlockEntriesCap*4; i++ {
 		iw.append(uint64(i + 1))
 	}
@@ -157,7 +157,7 @@ func TestIndexWriterDelete(t *testing.T) {
 	batch.Write()
 
 	// Delete unknown id, the request should be rejected
-	id, _ := newIndexDeleter(db, newAccountIdent(common.Hash{0xa}))
+	id, _ := newIndexDeleter(db, newAccountIdent(common.Hash{0xa}), nil)
 	if err := id.pop(indexBlockEntriesCap * 5); err == nil {
 		t.Fatal("Expect error to occur for unknown id")
 	}
@@ -179,7 +179,7 @@ func TestIndexWriterDelete(t *testing.T) {
 func TestBatchIndexerWrite(t *testing.T) {
 	var (
 		db        = rawdb.NewMemoryDatabase()
-		batch     = newBatchIndexer(db, false)
+		batch     = newBatchIndexer(db, nil, false)
 		histories = makeHistories(10)
 	)
 	for i, h := range histories {
@@ -212,7 +212,7 @@ func TestBatchIndexerWrite(t *testing.T) {
 		}
 	}
 	for addrHash, indexes := range accounts {
-		ir, _ := newIndexReader(db, newAccountIdent(addrHash))
+		ir, _ := newIndexReader(db, newAccountIdent(addrHash), nil)
 		for i := 0; i < len(indexes)-1; i++ {
 			n, err := ir.readGreaterThan(indexes[i])
 			if err != nil {
@@ -232,7 +232,7 @@ func TestBatchIndexerWrite(t *testing.T) {
 	}
 	for addrHash, slots := range storages {
 		for slotHash, indexes := range slots {
-			ir, _ := newIndexReader(db, newStorageIdent(addrHash, slotHash))
+			ir, _ := newIndexReader(db, newStorageIdent(addrHash, slotHash), nil)
 			for i := 0; i < len(indexes)-1; i++ {
 				n, err := ir.readGreaterThan(indexes[i])
 				if err != nil {
@@ -256,7 +256,7 @@ func TestBatchIndexerWrite(t *testing.T) {
 func TestBatchIndexerDelete(t *testing.T) {
 	var (
 		db        = rawdb.NewMemoryDatabase()
-		bw        = newBatchIndexer(db, false)
+		bw        = newBatchIndexer(db, nil, false)
 		histories = makeHistories(10)
 	)
 	// Index histories
@@ -270,7 +270,7 @@ func TestBatchIndexerDelete(t *testing.T) {
 	}
 
 	// Unindex histories
-	bd := newBatchIndexer(db, true)
+	bd := newBatchIndexer(db, nil, true)
 	for i := len(histories) - 1; i >= 0; i-- {
 		if err := bd.process(histories[i], uint64(i+1)); err != nil {
 			t.Fatalf("Failed to process history, %v", err)

--- a/triedb/pathdb/history_indexer.go
+++ b/triedb/pathdb/history_indexer.go
@@ -208,7 +208,6 @@ func (b *batchIndexer) finish(force bool) error {
 	if err := eg.Wait(); err != nil {
 		return err
 	}
-	mtime := time.Now()
 
 	// Update the position of last indexed state history
 	if !b.delete {
@@ -220,14 +219,10 @@ func (b *batchIndexer) finish(force bool) error {
 			storeIndexMetadata(batch, b.lastID-1)
 		}
 	}
-	wtime := time.Now()
 	if err := batch.Write(); err != nil {
 		return err
 	}
-	log.Debug("Committed batch indexer", "accounts", len(b.accounts), "storages", storages, "records", b.counter, "elapsed", common.PrettyDuration(time.Since(start)),
-		"mtime", common.PrettyDuration(mtime.Sub(start)),
-		"utime", common.PrettyDuration(wtime.Sub(mtime)),
-		"wtime", common.PrettyDuration(time.Since(wtime)))
+	log.Debug("Committed batch indexer", "accounts", len(b.accounts), "storages", storages, "records", b.counter, "elapsed", common.PrettyDuration(time.Since(start)))
 	b.counter = 0
 	b.accounts = make(map[common.Hash][]uint64)
 	b.storages = make(map[common.Hash]map[common.Hash][]uint64)

--- a/triedb/pathdb/history_indexer.go
+++ b/triedb/pathdb/history_indexer.go
@@ -208,6 +208,8 @@ func (b *batchIndexer) finish(force bool) error {
 	if err := eg.Wait(); err != nil {
 		return err
 	}
+	mtime := time.Now()
+
 	// Update the position of last indexed state history
 	if !b.delete {
 		storeIndexMetadata(batch, b.lastID)
@@ -218,10 +220,14 @@ func (b *batchIndexer) finish(force bool) error {
 			storeIndexMetadata(batch, b.lastID-1)
 		}
 	}
+	wtime := time.Now()
 	if err := batch.Write(); err != nil {
 		return err
 	}
-	log.Debug("Committed batch indexer", "accounts", len(b.accounts), "storages", storages, "records", b.counter, "elapsed", common.PrettyDuration(time.Since(start)))
+	log.Debug("Committed batch indexer", "accounts", len(b.accounts), "storages", storages, "records", b.counter, "elapsed", common.PrettyDuration(time.Since(start)),
+		"mtime", common.PrettyDuration(mtime.Sub(start)),
+		"utime", common.PrettyDuration(wtime.Sub(mtime)),
+		"wtime", common.PrettyDuration(time.Since(wtime)))
 	b.counter = 0
 	b.accounts = make(map[common.Hash][]uint64)
 	b.storages = make(map[common.Hash]map[common.Hash][]uint64)

--- a/triedb/pathdb/history_reader.go
+++ b/triedb/pathdb/history_reader.go
@@ -28,6 +28,7 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/lru"
 	"github.com/ethereum/go-ethereum/core/rawdb"
+	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/ethdb"
 	"github.com/ethereum/go-ethereum/log"
 )
@@ -59,6 +60,14 @@ func (ident stateIdent) String() string {
 		return ident.addressHash.Hex()
 	}
 	return ident.addressHash.Hex() + ident.storageHash.Hex()
+}
+
+// CacheKey returns the cache key for the state identifier.
+func (ident stateIdent) CacheKey() string {
+	if ident.account {
+		return ident.addressHash.Hex()
+	}
+	return crypto.Keccak256Hash(ident.addressHash.Bytes(), ident.storageHash.Bytes()).Hex()
 }
 
 // newAccountIdent constructs a state identifier for an account.

--- a/triedb/pathdb/history_reader.go
+++ b/triedb/pathdb/history_reader.go
@@ -34,6 +34,7 @@ import (
 
 var (
 	historyIndexCache = lru.NewCache[string, []byte](10000)
+	historyBlockCache = lru.NewCache[string, []byte](10000)
 )
 
 // stateIdent represents the identifier of a state element, which can be

--- a/triedb/pathdb/history_reader.go
+++ b/triedb/pathdb/history_reader.go
@@ -198,10 +198,10 @@ type historyCacher struct {
 }
 
 // newHistoryCacher creates a new historyCacher instance.
-func newHistoryCacher(size int) *historyCacher {
+func newHistoryCacher(indexSize, blockSize int) *historyCacher {
 	return &historyCacher{
-		index: lru.NewCache[string, []byte](size),
-		block: lru.NewCache[string, []byte](size),
+		index: lru.NewCache[string, []byte](indexSize),
+		block: lru.NewCache[string, []byte](blockSize),
 	}
 }
 

--- a/triedb/pathdb/history_reader.go
+++ b/triedb/pathdb/history_reader.go
@@ -26,9 +26,14 @@ import (
 	"time"
 
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/lru"
 	"github.com/ethereum/go-ethereum/core/rawdb"
 	"github.com/ethereum/go-ethereum/ethdb"
 	"github.com/ethereum/go-ethereum/log"
+)
+
+var (
+	historyIndexCache = lru.NewCache[string, []byte](10000)
 )
 
 // stateIdent represents the identifier of a state element, which can be

--- a/triedb/pathdb/history_reader.go
+++ b/triedb/pathdb/history_reader.go
@@ -23,10 +23,12 @@ import (
 	"fmt"
 	"math"
 	"sort"
+	"time"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/rawdb"
 	"github.com/ethereum/go-ethereum/ethdb"
+	"github.com/ethereum/go-ethereum/log"
 )
 
 // stateIdent represents the identifier of a state element, which can be
@@ -122,8 +124,9 @@ type indexReaderWithLimitTag struct {
 }
 
 // newIndexReaderWithLimitTag constructs a index reader with indexing position.
-func newIndexReaderWithLimitTag(db ethdb.KeyValueReader, state stateIdent, limit uint64) (*indexReaderWithLimitTag, error) {
-	r, err := newIndexReader(db, state)
+// Add timings parameter to pass through
+func newIndexReaderWithLimitTag(db ethdb.KeyValueReader, state stateIdent, limit uint64, timings *readTimings) (*indexReaderWithLimitTag, error) {
+	r, err := newIndexReaderWithTimings(db, state, timings)
 	if err != nil {
 		return nil, err
 	}
@@ -197,10 +200,24 @@ func newHistoryReader(disk ethdb.KeyValueReader, freezer ethdb.AncientReader) *h
 	}
 }
 
+// Struct to collect timing info for account or storage read
+type readTimings struct {
+	kvdbMeta    time.Duration
+	kvdbIndex   time.Duration
+	kvdbBlock   time.Duration
+	frdbIndex   time.Duration
+	frdbHistory time.Duration
+	frdbMeta    time.Duration
+}
+
 // readAccountMetadata resolves the account metadata within the specified
 // state history.
-func (r *historyReader) readAccountMetadata(address common.Address, historyID uint64) ([]byte, error) {
+func (r *historyReader) readAccountMetadata(address common.Address, historyID uint64, timings *readTimings) ([]byte, error) {
+	start := time.Now()
 	blob := rawdb.ReadStateAccountIndex(r.freezer, historyID)
+	if timings != nil {
+		timings.frdbIndex = time.Since(start)
+	}
 	if len(blob) == 0 {
 		return nil, fmt.Errorf("account index is truncated, historyID: %d", historyID)
 	}
@@ -225,9 +242,13 @@ func (r *historyReader) readAccountMetadata(address common.Address, historyID ui
 
 // readStorageMetadata resolves the storage slot metadata within the specified
 // state history.
-func (r *historyReader) readStorageMetadata(storageKey common.Hash, storageHash common.Hash, historyID uint64, slotOffset, slotNumber int) ([]byte, error) {
+func (r *historyReader) readStorageMetadata(storageKey common.Hash, storageHash common.Hash, historyID uint64, slotOffset, slotNumber int, timings *readTimings) ([]byte, error) {
 	// TODO(rj493456442) optimize it with partial read
+	start := time.Now()
 	blob := rawdb.ReadStateStorageIndex(r.freezer, historyID)
+	if timings != nil {
+		timings.frdbIndex = time.Since(start)
+	}
 	if len(blob) == 0 {
 		return nil, fmt.Errorf("storage index is truncated, historyID: %d", historyID)
 	}
@@ -244,7 +265,11 @@ func (r *historyReader) readStorageMetadata(storageKey common.Hash, storageHash 
 		m      meta
 		target common.Hash
 	)
+	startMeta := time.Now()
 	blob = rawdb.ReadStateHistoryMeta(r.freezer, historyID)
+	if timings != nil {
+		timings.frdbMeta = time.Since(startMeta)
+	}
 	if err := m.decode(blob); err != nil {
 		return nil, err
 	}
@@ -268,8 +293,8 @@ func (r *historyReader) readStorageMetadata(storageKey common.Hash, storageHash 
 }
 
 // readAccount retrieves the account data from the specified state history.
-func (r *historyReader) readAccount(address common.Address, historyID uint64) ([]byte, error) {
-	metadata, err := r.readAccountMetadata(address, historyID)
+func (r *historyReader) readAccount(address common.Address, historyID uint64, timings *readTimings) ([]byte, error) {
+	metadata, err := r.readAccountMetadata(address, historyID, timings)
 	if err != nil {
 		return nil, err
 	}
@@ -277,7 +302,11 @@ func (r *historyReader) readAccount(address common.Address, historyID uint64) ([
 	offset := int(binary.BigEndian.Uint32(metadata[common.AddressLength+1 : common.AddressLength+5])) // four bytes for the account data offset
 
 	// TODO(rj493456442) optimize it with partial read
+	start := time.Now()
 	data := rawdb.ReadStateAccountHistory(r.freezer, historyID)
+	if timings != nil {
+		timings.frdbHistory = time.Since(start)
+	}
 	if len(data) < length+offset {
 		return nil, fmt.Errorf("account data is truncated, address: %#x, historyID: %d, size: %d, offset: %d, len: %d", address, historyID, len(data), offset, length)
 	}
@@ -285,8 +314,8 @@ func (r *historyReader) readAccount(address common.Address, historyID uint64) ([
 }
 
 // readStorage retrieves the storage slot data from the specified state history.
-func (r *historyReader) readStorage(address common.Address, storageKey common.Hash, storageHash common.Hash, historyID uint64) ([]byte, error) {
-	metadata, err := r.readAccountMetadata(address, historyID)
+func (r *historyReader) readStorage(address common.Address, storageKey common.Hash, storageHash common.Hash, historyID uint64, timings *readTimings) ([]byte, error) {
+	metadata, err := r.readAccountMetadata(address, historyID, nil) // No timings for account metadata in storage read
 	if err != nil {
 		return nil, err
 	}
@@ -297,7 +326,7 @@ func (r *historyReader) readStorage(address common.Address, storageKey common.Ha
 	slotIndexOffset := int(binary.BigEndian.Uint32(metadata[common.AddressLength+5 : common.AddressLength+9]))
 	slotIndexNumber := int(binary.BigEndian.Uint32(metadata[common.AddressLength+9 : common.AddressLength+13]))
 
-	slotMetadata, err := r.readStorageMetadata(storageKey, storageHash, historyID, slotIndexOffset, slotIndexNumber)
+	slotMetadata, err := r.readStorageMetadata(storageKey, storageHash, historyID, slotIndexOffset, slotIndexNumber, timings)
 	if err != nil {
 		return nil, err
 	}
@@ -305,7 +334,11 @@ func (r *historyReader) readStorage(address common.Address, storageKey common.Ha
 	offset := int(binary.BigEndian.Uint32(slotMetadata[common.HashLength+1 : common.HashLength+5])) // four bytes for slot data offset
 
 	// TODO(rj493456442) optimize it with partial read
+	start := time.Now()
 	data := rawdb.ReadStateStorageHistory(r.freezer, historyID)
+	if timings != nil {
+		timings.frdbHistory = time.Since(start)
+	}
 	if len(data) < offset+length {
 		return nil, fmt.Errorf("storage data is truncated, address: %#x, key: %#x, historyID: %d, size: %d, offset: %d, len: %d", address, storageKey, historyID, len(data), offset, length)
 	}
@@ -317,6 +350,8 @@ func (r *historyReader) readStorage(address common.Address, storageKey common.Ha
 // lastID: represents the ID of the latest/newest state history;
 // latestValue: represents the state value at the current disk layer with ID == lastID;
 func (r *historyReader) read(state stateIdentQuery, stateID uint64, lastID uint64, latestValue []byte) ([]byte, error) {
+	origin := time.Now()
+	timings := &readTimings{}
 	tail, err := r.freezer.Tail()
 	if err != nil {
 		return nil, err
@@ -330,7 +365,9 @@ func (r *historyReader) read(state stateIdentQuery, stateID uint64, lastID uint6
 	// To serve the request, all state histories from stateID+1 to lastID
 	// must be indexed. It's not supposed to happen unless system is very
 	// wrong.
+	start := time.Now()
 	metadata := loadIndexMetadata(r.disk)
+	timings.kvdbMeta = time.Since(start)
 	if metadata == nil || metadata.Last < lastID {
 		indexed := "null"
 		if metadata != nil {
@@ -343,12 +380,13 @@ func (r *historyReader) read(state stateIdentQuery, stateID uint64, lastID uint6
 	// state retrieval
 	ir, ok := r.readers[state.String()]
 	if !ok {
-		ir, err = newIndexReaderWithLimitTag(r.disk, state.stateIdent, metadata.Last)
+		ir, err = newIndexReaderWithLimitTag(r.disk, state.stateIdent, metadata.Last, timings)
 		if err != nil {
 			return nil, err
 		}
 		r.readers[state.String()] = ir
 	}
+	ir.reader.timings = timings
 	historyID, err := ir.readGreaterThan(stateID, lastID)
 	if err != nil {
 		return nil, err
@@ -363,8 +401,18 @@ func (r *historyReader) read(state stateIdentQuery, stateID uint64, lastID uint6
 	// that the associated state histories are no longer available due to a rollback.
 	// Such truncation should be captured by the state resolver below, rather than returning
 	// invalid data.
+	var result []byte
+	var item string
 	if state.account {
-		return r.readAccount(state.address, historyID)
+		item = "account"
+		result, err = r.readAccount(state.address, historyID, timings)
+	} else {
+		item = "storage"
+		result, err = r.readStorage(state.address, state.storageKey, state.storageHash, historyID, timings)
 	}
-	return r.readStorage(state.address, state.storageKey, state.storageHash, historyID)
+	log.Info("HistoryRead", "item", item, "elapsed", time.Since(origin),
+		"kvdbMeta", timings.kvdbMeta, "kvdbIndex", timings.kvdbIndex, "kvdbBlock", timings.kvdbBlock,
+		"frdbIndex", timings.frdbIndex, "frdbHistory", timings.frdbHistory, "frdbMeta", timings.frdbMeta,
+	)
+	return result, err
 }

--- a/triedb/pathdb/history_reader_test.go
+++ b/triedb/pathdb/history_reader_test.go
@@ -133,7 +133,7 @@ func testHistoryReader(t *testing.T, historyLimit uint64) {
 	var (
 		roots = env.roots
 		dRoot = env.db.tree.bottom().rootHash()
-		hr    = newHistoryReader(env.db.diskdb, env.db.freezer)
+		hr    = newHistoryReader(env.db.diskdb, env.db.freezer, env.db.cacher)
 	)
 	for _, root := range roots {
 		if root == dRoot {

--- a/triedb/pathdb/reader.go
+++ b/triedb/pathdb/reader.go
@@ -230,7 +230,7 @@ func (db *Database) HistoricReader(root common.Hash) (*HistoricalStateReader, er
 	return &HistoricalStateReader{
 		id:     *id,
 		db:     db,
-		reader: newHistoryReader(db.diskdb, db.freezer),
+		reader: newHistoryReader(db.diskdb, db.freezer, db.cacher),
 	}, nil
 }
 


### PR DESCRIPTION
Add an lru cache for the history index descriptor and block, reduce the db read time