### PR TITLE
core/vm: introduce a tracer wrapper

### DIFF
--- a/core/vm/contract.go
+++ b/core/vm/contract.go
@@ -18,7 +18,6 @@ package vm
 
 import (
 	"github.com/ethereum/go-ethereum/common"
-	"github.com/ethereum/go-ethereum/core/tracing"
 	"github.com/holiman/uint256"
 )
 
@@ -123,29 +122,6 @@ func (c *Contract) GetOp(n uint64) OpCode {
 // call, including that of caller's caller.
 func (c *Contract) Caller() common.Address {
 	return c.caller
-}
-
-// UseGas attempts the use gas and subtracts it and returns true on success
-func (c *Contract) UseGas(gas uint64, logger *tracing.Hooks, reason tracing.GasChangeReason) (ok bool) {
-	if c.Gas < gas {
-		return false
-	}
-	if logger != nil && logger.OnGasChange != nil && reason != tracing.GasChangeIgnored {
-		logger.OnGasChange(c.Gas, c.Gas-gas, reason)
-	}
-	c.Gas -= gas
-	return true
-}
-
-// RefundGas refunds gas to the contract
-func (c *Contract) RefundGas(gas uint64, logger *tracing.Hooks, reason tracing.GasChangeReason) {
-	if gas == 0 {
-		return
-	}
-	if logger != nil && logger.OnGasChange != nil && reason != tracing.GasChangeIgnored {
-		logger.OnGasChange(c.Gas, c.Gas+gas, reason)
-	}
-	c.Gas += gas
 }
 
 // Address returns the contracts address

--- a/core/vm/contracts.go
+++ b/core/vm/contracts.go
@@ -257,14 +257,12 @@ func ActivePrecompiles(rules params.Rules) []common.Address {
 // - the returned bytes,
 // - the _remaining_ gas,
 // - any error that occurred
-func RunPrecompiledContract(p PrecompiledContract, input []byte, suppliedGas uint64, logger *tracing.Hooks) (ret []byte, remainingGas uint64, err error) {
+func RunPrecompiledContract[TS TracingSwitch](p PrecompiledContract, input []byte, suppliedGas uint64, tracer tracer[TS]) (ret []byte, remainingGas uint64, err error) {
 	gasCost := p.RequiredGas(input)
 	if suppliedGas < gasCost {
 		return nil, 0, ErrOutOfGas
 	}
-	if logger != nil && logger.OnGasChange != nil {
-		logger.OnGasChange(suppliedGas, suppliedGas-gasCost, tracing.GasChangeCallPrecompiledContract)
-	}
+	tracer.OnGasChange(suppliedGas, suppliedGas-gasCost, tracing.GasChangeCallPrecompiledContract)
 	suppliedGas -= gasCost
 	output, err := p.Run(input)
 	return output, suppliedGas, err

--- a/core/vm/contracts_fuzz_test.go
+++ b/core/vm/contracts_fuzz_test.go
@@ -36,7 +36,7 @@ func FuzzPrecompiledContracts(f *testing.F) {
 			return
 		}
 		inWant := string(input)
-		RunPrecompiledContract(p, input, gas, nil)
+		RunPrecompiledContract(p, input, gas, NewTracer[TracingDisabled](nil))
 		if inHave := string(input); inWant != inHave {
 			t.Errorf("Precompiled %v modified input data", a)
 		}

--- a/core/vm/contracts_test.go
+++ b/core/vm/contracts_test.go
@@ -99,7 +99,7 @@ func testPrecompiled(addr string, test precompiledTest, t *testing.T) {
 	in := common.Hex2Bytes(test.Input)
 	gas := p.RequiredGas(in)
 	t.Run(fmt.Sprintf("%s-Gas=%d", test.Name, gas), func(t *testing.T) {
-		if res, _, err := RunPrecompiledContract(p, in, gas, nil); err != nil {
+		if res, _, err := RunPrecompiledContract(p, in, gas, NewTracer[TracingDisabled](nil)); err != nil {
 			t.Error(err)
 		} else if common.Bytes2Hex(res) != test.Expected {
 			t.Errorf("Expected %v, got %v", test.Expected, common.Bytes2Hex(res))
@@ -121,7 +121,7 @@ func testPrecompiledOOG(addr string, test precompiledTest, t *testing.T) {
 	gas := p.RequiredGas(in) - 1
 
 	t.Run(fmt.Sprintf("%s-Gas=%d", test.Name, gas), func(t *testing.T) {
-		_, _, err := RunPrecompiledContract(p, in, gas, nil)
+		_, _, err := RunPrecompiledContract(p, in, gas, NewTracer[TracingDisabled](nil))
 		if err.Error() != "out of gas" {
 			t.Errorf("Expected error [out of gas], got [%v]", err)
 		}
@@ -138,7 +138,7 @@ func testPrecompiledFailure(addr string, test precompiledFailureTest, t *testing
 	in := common.Hex2Bytes(test.Input)
 	gas := p.RequiredGas(in)
 	t.Run(test.Name, func(t *testing.T) {
-		_, _, err := RunPrecompiledContract(p, in, gas, nil)
+		_, _, err := RunPrecompiledContract(p, in, gas, NewTracer[TracingDisabled](nil))
 		if err.Error() != test.ExpectedError {
 			t.Errorf("Expected error [%v], got [%v]", test.ExpectedError, err)
 		}
@@ -170,7 +170,7 @@ func benchmarkPrecompiled(addr string, test precompiledTest, bench *testing.B) {
 		bench.ResetTimer()
 		for i := 0; i < bench.N; i++ {
 			copy(data, in)
-			res, _, err = RunPrecompiledContract(p, data, reqGas, nil)
+			res, _, err = RunPrecompiledContract(p, data, reqGas, NewTracer[TracingDisabled](nil))
 		}
 		bench.StopTimer()
 		elapsed := uint64(time.Since(start))

--- a/core/vm/eips.go
+++ b/core/vm/eips.go
@@ -358,7 +358,7 @@ func opExtCodeCopyEIP4762(pc *uint64, evm *EVM, scope *ScopeContext) ([]byte, er
 	code := evm.StateDB.GetCode(addr)
 	paddedCodeCopy, copyOffset, nonPaddedCopyLength := getDataAndAdjustedBounds(code, uint64CodeOffset, length.Uint64())
 	consumed, wanted := evm.AccessEvents.CodeChunksRangeGas(addr, copyOffset, nonPaddedCopyLength, uint64(len(code)), false, scope.Contract.Gas)
-	scope.Contract.UseGas(consumed, evm.Config.Tracer, tracing.GasChangeUnspecified)
+	evm.UseGas(scope.Contract, consumed, tracing.GasChangeUnspecified)
 	if consumed < wanted {
 		return nil, ErrOutOfGas
 	}
@@ -384,7 +384,7 @@ func opPush1EIP4762(pc *uint64, evm *EVM, scope *ScopeContext) ([]byte, error) {
 			// advanced past this boundary.
 			contractAddr := scope.Contract.Address()
 			consumed, wanted := evm.AccessEvents.CodeChunksRangeGas(contractAddr, *pc+1, uint64(1), uint64(len(scope.Contract.Code)), false, scope.Contract.Gas)
-			scope.Contract.UseGas(wanted, evm.Config.Tracer, tracing.GasChangeUnspecified)
+			evm.UseGas(scope.Contract, wanted, tracing.GasChangeUnspecified)
 			if consumed < wanted {
 				return nil, ErrOutOfGas
 			}
@@ -412,7 +412,7 @@ func makePushEIP4762(size uint64, pushByteSize int) executionFunc {
 		if !scope.Contract.IsDeployment && !scope.Contract.IsSystemCall {
 			contractAddr := scope.Contract.Address()
 			consumed, wanted := evm.AccessEvents.CodeChunksRangeGas(contractAddr, uint64(start), uint64(pushByteSize), uint64(len(scope.Contract.Code)), false, scope.Contract.Gas)
-			scope.Contract.UseGas(consumed, evm.Config.Tracer, tracing.GasChangeUnspecified)
+			evm.UseGas(scope.Contract, consumed, tracing.GasChangeUnspecified)
 			if consumed < wanted {
 				return nil, ErrOutOfGas
 			}

--- a/core/vm/operations_acl.go
+++ b/core/vm/operations_acl.go
@@ -164,7 +164,7 @@ func makeCallVariantGasCallEIP2929(oldCalculator gasFunc, addressPosition int) g
 			evm.StateDB.AddAddressToAccessList(addr)
 			// Charge the remaining difference here already, to correctly calculate available
 			// gas for call
-			if !contract.UseGas(coldCost, evm.Config.Tracer, tracing.GasChangeCallStorageColdAccess) {
+			if !evm.UseGas(contract, coldCost, tracing.GasChangeCallStorageColdAccess) {
 				return 0, ErrOutOfGas
 			}
 		}
@@ -265,7 +265,7 @@ func makeCallVariantGasCallEIP7702(oldCalculator gasFunc) gasFunc {
 			coldCost := params.ColdAccountAccessCostEIP2929 - params.WarmStorageReadCostEIP2929
 			// Charge the remaining difference here already, to correctly calculate available
 			// gas for call
-			if !contract.UseGas(coldCost, evm.Config.Tracer, tracing.GasChangeCallStorageColdAccess) {
+			if !evm.UseGas(contract, coldCost, tracing.GasChangeCallStorageColdAccess) {
 				return 0, ErrOutOfGas
 			}
 			total += coldCost
@@ -280,7 +280,7 @@ func makeCallVariantGasCallEIP7702(oldCalculator gasFunc) gasFunc {
 				evm.StateDB.AddAddressToAccessList(target)
 				cost = params.ColdAccountAccessCostEIP2929
 			}
-			if !contract.UseGas(cost, evm.Config.Tracer, tracing.GasChangeCallStorageColdAccess) {
+			if !evm.UseGas(contract, cost, tracing.GasChangeCallStorageColdAccess) {
 				return 0, ErrOutOfGas
 			}
 			total += cost

--- a/core/vm/tracer.go
+++ b/core/vm/tracer.go
@@ -1,0 +1,188 @@
+// Copyright 2025 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+
+package vm
+
+import (
+	"math/big"
+	"unsafe"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/tracing"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/params"
+)
+
+const tracingEnabledSize = 1
+
+type TracingEnabled byte
+type TracingDisabled uint16
+
+type TracingSwitch interface {
+	TracingEnabled | TracingDisabled
+}
+
+// tracer is a wrapper that gives nil-safe access to a tracing.Hooks
+// and also enables VM tracing to be disabled at compile time
+type tracer[TS TracingSwitch] struct {
+	hooks tracing.Hooks
+}
+
+func NewTracer[TS TracingSwitch](hooks *tracing.Hooks) tracer[TS] {
+	var t tracer[TS]
+	if hooks != nil {
+		t.hooks = *hooks
+	}
+	return t
+}
+
+func (t *tracer[TS]) OnTxStart(vm *tracing.VMContext, tx *types.Transaction, from common.Address) {
+	if unsafe.Sizeof(*new(TS)) == tracingEnabledSize && t.hooks.OnTxStart != nil {
+		t.hooks.OnTxStart(vm, tx, from)
+	}
+}
+
+func (t *tracer[TS]) OnTxEnd(receipt *types.Receipt, err error) {
+	if unsafe.Sizeof(*new(TS)) == tracingEnabledSize && t.hooks.OnTxEnd != nil {
+		t.hooks.OnTxEnd(receipt, err)
+	}
+}
+
+func (t *tracer[TS]) OnEnter(depth int, typ byte, from common.Address, to common.Address, input []byte, gas uint64, value *big.Int) {
+	if unsafe.Sizeof(*new(TS)) == tracingEnabledSize && t.hooks.OnEnter != nil {
+		t.hooks.OnEnter(depth, typ, from, to, input, gas, value)
+	}
+}
+
+func (t *tracer[TS]) OnExit(depth int, output []byte, gasUsed uint64, err error, reverted bool) {
+	if unsafe.Sizeof(*new(TS)) == tracingEnabledSize && t.hooks.OnExit != nil {
+		t.hooks.OnExit(depth, output, gasUsed, err, reverted)
+	}
+}
+
+func (t *tracer[TS]) OnOpcode(pc uint64, op byte, gas, cost uint64, scope tracing.OpContext, rData []byte, depth int, err error) {
+	if unsafe.Sizeof(*new(TS)) == tracingEnabledSize && t.hooks.OnOpcode != nil {
+		t.hooks.OnOpcode(pc, op, gas, cost, scope, rData, depth, err)
+	}
+}
+
+func (t *tracer[TS]) OnFault(pc uint64, op byte, gas, cost uint64, scope tracing.OpContext, depth int, err error) {
+	if unsafe.Sizeof(*new(TS)) == tracingEnabledSize && t.hooks.OnFault != nil {
+		t.hooks.OnFault(pc, op, gas, cost, scope, depth, err)
+	}
+}
+
+func (t *tracer[TS]) OnGasChange(oldGas, newGas uint64, reason tracing.GasChangeReason) {
+	if unsafe.Sizeof(*new(TS)) == tracingEnabledSize && t.hooks.OnGasChange != nil {
+		t.hooks.OnGasChange(oldGas, newGas, reason)
+	}
+}
+
+func (t *tracer[TS]) OnBlockchainInit(chainConfig *params.ChainConfig) {
+	if unsafe.Sizeof(*new(TS)) == tracingEnabledSize && t.hooks.OnBlockchainInit != nil {
+		t.hooks.OnBlockchainInit(chainConfig)
+	}
+}
+
+func (t *tracer[TS]) OnClose() {
+	if unsafe.Sizeof(*new(TS)) == tracingEnabledSize && t.hooks.OnClose != nil {
+		t.hooks.OnClose()
+	}
+}
+
+func (t *tracer[TS]) OnBlockStart(event tracing.BlockEvent) {
+	if unsafe.Sizeof(*new(TS)) == tracingEnabledSize && t.hooks.OnBlockStart != nil {
+		t.hooks.OnBlockStart(event)
+	}
+}
+
+func (t *tracer[TS]) OnBlockEnd(err error) {
+	if unsafe.Sizeof(*new(TS)) == tracingEnabledSize && t.hooks.OnBlockEnd != nil {
+		t.hooks.OnBlockEnd(err)
+	}
+}
+
+func (t *tracer[TS]) OnSkippedBlock(event tracing.BlockEvent) {
+	if unsafe.Sizeof(*new(TS)) == tracingEnabledSize && t.hooks.OnSkippedBlock != nil {
+		t.hooks.OnSkippedBlock(event)
+	}
+}
+
+func (t *tracer[TS]) OnGenesisBlock(genesis *types.Block, alloc types.GenesisAlloc) {
+	if unsafe.Sizeof(*new(TS)) == tracingEnabledSize && t.hooks.OnGenesisBlock != nil {
+		t.hooks.OnGenesisBlock(genesis, alloc)
+	}
+}
+
+func (t *tracer[TS]) OnSystemCallStart() {
+	if unsafe.Sizeof(*new(TS)) == tracingEnabledSize && t.hooks.OnSystemCallStart != nil {
+		t.hooks.OnSystemCallStart()
+	}
+}
+
+func (t *tracer[TS]) OnSystemCallStartV2(vm *tracing.VMContext) {
+	if unsafe.Sizeof(*new(TS)) == tracingEnabledSize && t.hooks.OnSystemCallStartV2 != nil {
+		t.hooks.OnSystemCallStartV2(vm)
+	}
+}
+
+func (t *tracer[TS]) OnSystemCallEnd() {
+	if unsafe.Sizeof(*new(TS)) == tracingEnabledSize && t.hooks.OnSystemCallEnd != nil {
+		t.hooks.OnSystemCallEnd()
+	}
+}
+
+func (t *tracer[TS]) OnBalanceChange(addr common.Address, prevBalance, newBalance *big.Int, reason tracing.BalanceChangeReason) {
+	if unsafe.Sizeof(*new(TS)) == tracingEnabledSize && t.hooks.OnBalanceChange != nil {
+		t.hooks.OnBalanceChange(addr, prevBalance, newBalance, reason)
+	}
+}
+
+func (t *tracer[TS]) OnNonceChange(addr common.Address, prevNonce, newNonce uint64) {
+	if unsafe.Sizeof(*new(TS)) == tracingEnabledSize && t.hooks.OnNonceChange != nil {
+		t.hooks.OnNonceChange(addr, prevNonce, newNonce)
+	}
+}
+
+func (t *tracer[TS]) OnNonceChangeV2(addr common.Address, prevNonce, newNonce uint64, reason tracing.NonceChangeReason) {
+	if unsafe.Sizeof(*new(TS)) == tracingEnabledSize && t.hooks.OnNonceChangeV2 != nil {
+		t.hooks.OnNonceChangeV2(addr, prevNonce, newNonce, reason)
+	}
+}
+
+func (t *tracer[TS]) OnCodeChange(addr common.Address, prevCodeHash common.Hash, prevCode []byte, codeHash common.Hash, code []byte) {
+	if unsafe.Sizeof(*new(TS)) == tracingEnabledSize && t.hooks.OnCodeChange != nil {
+		t.hooks.OnCodeChange(addr, prevCodeHash, prevCode, codeHash, code)
+	}
+}
+
+func (t *tracer[TS]) OnStorageChange(addr common.Address, slot common.Hash, prevValue, newValue common.Hash) {
+	if unsafe.Sizeof(*new(TS)) == tracingEnabledSize && t.hooks.OnStorageChange != nil {
+		t.hooks.OnStorageChange(addr, slot, prevValue, newValue)
+	}
+}
+
+func (t *tracer[TS]) OnLog(log *types.Log) {
+	if unsafe.Sizeof(*new(TS)) == tracingEnabledSize && t.hooks.OnLog != nil {
+		t.hooks.OnLog(log)
+	}
+}
+
+func (t *tracer[TS]) OnBlockHashRead(blockNumber uint64, hash common.Hash) {
+	if unsafe.Sizeof(*new(TS)) == tracingEnabledSize && t.hooks.OnBlockHashRead != nil {
+		t.hooks.OnBlockHashRead(blockNumber, hash)
+	}
+}


### PR DESCRIPTION
to clean up the callsites a little and allow compile time disabling of tracing. The generic can be bubbled up to the `vm.EVM` and `vm.EVMInterpreter` to allow traced and not-traced versions of them.