### PR TITLE
core: replace the empty fmt.Errorf with errors.New

### DIFF
--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -682,7 +682,7 @@ func (bc *BlockChain) initializeHistoryPruning(latest uint64) error {
 		predefinedPoint := history.PrunePoints[bc.genesisBlock.Hash()]
 		if predefinedPoint == nil || freezerTail != predefinedPoint.BlockNumber {
 			log.Error("Chain history database is pruned with unknown configuration", "tail", freezerTail)
-			return fmt.Errorf("unexpected database tail")
+			return errors.New("unexpected database tail")
 		}
 		bc.historyPrunePoint.Store(predefinedPoint)
 		return nil
@@ -695,15 +695,15 @@ func (bc *BlockChain) initializeHistoryPruning(latest uint64) error {
 			// action to happen. So just tell them how to do it.
 			log.Error(fmt.Sprintf("Chain history mode is configured as %q, but database is not pruned.", bc.cfg.ChainHistoryMode.String()))
 			log.Error(fmt.Sprintf("Run 'geth prune-history' to prune pre-merge history."))
-			return fmt.Errorf("history pruning requested via configuration")
+			return errors.New("history pruning requested via configuration")
 		}
 		predefinedPoint := history.PrunePoints[bc.genesisBlock.Hash()]
 		if predefinedPoint == nil {
 			log.Error("Chain history pruning is not supported for this network", "genesis", bc.genesisBlock.Hash())
-			return fmt.Errorf("history pruning requested for unknown network")
+			return errors.New("history pruning requested for unknown network")
 		} else if freezerTail > 0 && freezerTail != predefinedPoint.BlockNumber {
 			log.Error("Chain history database is pruned to unknown block", "tail", freezerTail)
-			return fmt.Errorf("unexpected database tail")
+			return errors.New("unexpected database tail")
 		}
 		bc.historyPrunePoint.Store(predefinedPoint)
 		return nil

--- a/core/vm/contracts.go
+++ b/core/vm/contracts.go
@@ -515,7 +515,7 @@ func (c *bigModExp) Run(input []byte) ([]byte, error) {
 	}
 	// enforce size cap for inputs
 	if c.eip7823 && max(baseLen, expLen, modLen) > 1024 {
-		return nil, fmt.Errorf("one or more of base/exponent/modulus length exceeded 1024 bytes")
+		return nil, errors.New("one or more of base/exponent/modulus length exceeded 1024 bytes")
 	}
 	// Retrieve the operands and execute the exponentiation
 	var (


### PR DESCRIPTION
The `errors.new` function does not require string formatting, so its performance is better than that of `fmt.Errorf`.