### PR TITLE
all: replace the empty fmt.Errorf with errors.New

### DIFF
--- a/cmd/devp2p/internal/ethtest/conn.go
+++ b/cmd/devp2p/internal/ethtest/conn.go
@@ -129,7 +129,7 @@ func (c *Conn) Write(proto Proto, code uint64, msg any) error {
 	return err
 }
 
-var errDisc error = fmt.Errorf("disconnect")
+var errDisc error = errors.New("disconnect")
 
 // ReadEth reads an Eth sub-protocol wire message.
 func (c *Conn) ReadEth() (any, error) {

--- a/cmd/devp2p/internal/ethtest/suite.go
+++ b/cmd/devp2p/internal/ethtest/suite.go
@@ -19,6 +19,7 @@ package ethtest
 import (
 	"context"
 	"crypto/rand"
+	"errors"
 	"fmt"
 	"reflect"
 	"sync"
@@ -1092,7 +1093,7 @@ func (s *Suite) testBadBlobTx(t *utesting.T, tx *types.Transaction, badTx *types
 			return
 		}
 		if !readUntilDisconnect(conn) {
-			errc <- fmt.Errorf("expected bad peer to be disconnected")
+			errc <- errors.New("expected bad peer to be disconnected")
 			return
 		}
 		stage3.Done()
@@ -1139,7 +1140,7 @@ func (s *Suite) testBadBlobTx(t *utesting.T, tx *types.Transaction, badTx *types
 		}
 
 		if req.GetPooledTransactionsRequest[0] != tx.Hash() {
-			errc <- fmt.Errorf("requested unknown tx hash")
+			errc <- errors.New("requested unknown tx hash")
 			return
 		}
 
@@ -1149,7 +1150,7 @@ func (s *Suite) testBadBlobTx(t *utesting.T, tx *types.Transaction, badTx *types
 			return
 		}
 		if readUntilDisconnect(conn) {
-			errc <- fmt.Errorf("unexpected disconnect")
+			errc <- errors.New("unexpected disconnect")
 			return
 		}
 		close(errc)

--- a/cmd/geth/chaincmd.go
+++ b/cmd/geth/chaincmd.go
@@ -716,7 +716,7 @@ func downloadEra(ctx *cli.Context) error {
 		case ctx.IsSet(utils.SepoliaFlag.Name):
 			network = "sepolia"
 		default:
-			return fmt.Errorf("unsupported network, no known era1 checksums")
+			return errors.New("unsupported network, no known era1 checksums")
 		}
 	}
 

--- a/cmd/workload/testsuite.go
+++ b/cmd/workload/testsuite.go
@@ -18,7 +18,7 @@ package main
 
 import (
 	"embed"
-	"fmt"
+	"errors"
 	"io/fs"
 	"os"
 
@@ -97,7 +97,7 @@ type testConfig struct {
 	traceTestFile     string
 }
 
-var errPrunedHistory = fmt.Errorf("attempt to access pruned history")
+var errPrunedHistory = errors.New("attempt to access pruned history")
 
 // validateHistoryPruneErr checks whether the given error is caused by access
 // to history before the pruning threshold block (it is an rpc.Error with code 4444).
@@ -109,7 +109,7 @@ func validateHistoryPruneErr(err error, blockNum uint64, historyPruneBlock *uint
 	if err != nil {
 		if rpcErr, ok := err.(rpc.Error); ok && rpcErr.ErrorCode() == 4444 {
 			if historyPruneBlock != nil && blockNum > *historyPruneBlock {
-				return fmt.Errorf("pruned history error returned after pruning threshold")
+				return errors.New("pruned history error returned after pruning threshold")
 			}
 			return errPrunedHistory
 		}

--- a/core/state/snapshot/journal.go
+++ b/core/state/snapshot/journal.go
@@ -350,7 +350,7 @@ func iterateJournal(db ethdb.KeyValueReader, callback journalCallback) error {
 			}
 			if len(destructs) > 0 {
 				log.Warn("Incompatible legacy journal detected", "version", journalV0)
-				return fmt.Errorf("incompatible legacy journal detected")
+				return errors.New("incompatible legacy journal detected")
 			}
 		}
 		if err := r.Decode(&accounts); err != nil {

--- a/core/tracing/journal.go
+++ b/core/tracing/journal.go
@@ -17,7 +17,7 @@
 package tracing
 
 import (
-	"fmt"
+	"errors"
 	"math/big"
 
 	"github.com/ethereum/go-ethereum/common"
@@ -39,14 +39,14 @@ type entry interface {
 // WrapWithJournal wraps the given tracer with a journaling layer.
 func WrapWithJournal(hooks *Hooks) (*Hooks, error) {
 	if hooks == nil {
-		return nil, fmt.Errorf("wrapping nil tracer")
+		return nil, errors.New("wrapping nil tracer")
 	}
 	// No state change to journal, return the wrapped hooks as is
 	if hooks.OnBalanceChange == nil && hooks.OnNonceChange == nil && hooks.OnNonceChangeV2 == nil && hooks.OnCodeChange == nil && hooks.OnStorageChange == nil {
 		return hooks, nil
 	}
 	if hooks.OnNonceChange != nil && hooks.OnNonceChangeV2 != nil {
-		return nil, fmt.Errorf("cannot have both OnNonceChange and OnNonceChangeV2")
+		return nil, errors.New("cannot have both OnNonceChange and OnNonceChangeV2")
 	}
 
 	// Create a new Hooks instance and copy all hooks

--- a/core/txpool/validation.go
+++ b/core/txpool/validation.go
@@ -145,7 +145,7 @@ func ValidateTransaction(tx *types.Transaction, head *types.Header, signer types
 	}
 	if tx.Type() == types.SetCodeTxType {
 		if len(tx.SetCodeAuthorizations()) == 0 {
-			return fmt.Errorf("set code tx must have at least one authorization tuple")
+			return errors.New("set code tx must have at least one authorization tuple")
 		}
 	}
 	return nil

--- a/core/types/bal/bal_encoding.go
+++ b/core/types/bal/bal_encoding.go
@@ -169,7 +169,7 @@ func (e *AccountAccess) validate() error {
 	// Convert code change
 	if len(e.Code) == 1 {
 		if len(e.Code[0].Code) > params.MaxCodeSize {
-			return fmt.Errorf("code change contained oversized code")
+			return errors.New("code change contained oversized code")
 		}
 	}
 	return nil

--- a/eth/catalyst/api_test.go
+++ b/eth/catalyst/api_test.go
@@ -1497,7 +1497,7 @@ func checkEqualBody(a *types.Body, b *engine.ExecutionPayloadBody) error {
 		}
 	}
 	if !reflect.DeepEqual(a.Withdrawals, b.Withdrawals) {
-		return fmt.Errorf("withdrawals mismatch")
+		return errors.New("withdrawals mismatch")
 	}
 	return nil
 }

--- a/eth/ethconfig/config.go
+++ b/eth/ethconfig/config.go
@@ -18,7 +18,7 @@
 package ethconfig
 
 import (
-	"fmt"
+	"errors"
 	"time"
 
 	"github.com/ethereum/go-ethereum/common"
@@ -171,7 +171,7 @@ type Config struct {
 func CreateConsensusEngine(config *params.ChainConfig, db ethdb.Database) (consensus.Engine, error) {
 	if config.TerminalTotalDifficulty == nil {
 		log.Error("Geth only supports PoS networks. Please transition legacy networks using Geth v1.13.x.")
-		return nil, fmt.Errorf("'terminalTotalDifficulty' is not set in genesis block")
+		return nil, errors.New("'terminalTotalDifficulty' is not set in genesis block")
 	}
 	// Wrap previously supported consensus engines into their post-merge counterpart
 	if config.Clique != nil {

--- a/ethdb/leveldb/leveldb.go
+++ b/ethdb/leveldb/leveldb.go
@@ -22,6 +22,7 @@ package leveldb
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"sync"
 	"time"
@@ -31,7 +32,7 @@ import (
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/metrics"
 	"github.com/syndtr/goleveldb/leveldb"
-	"github.com/syndtr/goleveldb/leveldb/errors"
+	lerrors "github.com/syndtr/goleveldb/leveldb/errors"
 	"github.com/syndtr/goleveldb/leveldb/filter"
 	"github.com/syndtr/goleveldb/leveldb/opt"
 	"github.com/syndtr/goleveldb/leveldb/util"
@@ -120,7 +121,7 @@ func NewCustom(file string, namespace string, customize func(options *opt.Option
 
 	// Open the db and recover any potential corruptions
 	db, err := leveldb.OpenFile(file, options)
-	if _, corrupted := err.(*errors.ErrCorrupted); corrupted {
+	if _, corrupted := err.(*lerrors.ErrCorrupted); corrupted {
 		db, err = leveldb.RecoverFile(file, nil)
 	}
 	if err != nil {
@@ -548,7 +549,7 @@ func (r *replayer) DeleteRange(start, end []byte) {
 	if rangeDeleter, ok := r.writer.(ethdb.KeyValueRangeDeleter); ok {
 		r.failure = rangeDeleter.DeleteRange(start, end)
 	} else {
-		r.failure = fmt.Errorf("ethdb.KeyValueWriter does not implement DeleteRange")
+		r.failure = errors.New("ethdb.KeyValueWriter does not implement DeleteRange")
 	}
 }
 

--- a/ethdb/memorydb/memorydb.go
+++ b/ethdb/memorydb/memorydb.go
@@ -20,7 +20,6 @@ package memorydb
 import (
 	"bytes"
 	"errors"
-	"fmt"
 	"sort"
 	"strings"
 	"sync"
@@ -327,7 +326,7 @@ func (b *batch) Replay(w ethdb.KeyValueWriter) error {
 						return err
 					}
 				} else {
-					return fmt.Errorf("ethdb.KeyValueWriter does not implement DeleteRange")
+					return errors.New("ethdb.KeyValueWriter does not implement DeleteRange")
 				}
 			}
 			continue

--- a/ethdb/pebble/pebble.go
+++ b/ethdb/pebble/pebble.go
@@ -18,6 +18,7 @@
 package pebble
 
 import (
+	"errors"
 	"fmt"
 	"runtime"
 	"strings"
@@ -705,7 +706,7 @@ func (b *batch) Replay(w ethdb.KeyValueWriter) error {
 					return err
 				}
 			} else {
-				return fmt.Errorf("ethdb.KeyValueWriter does not implement DeleteRange")
+				return errors.New("ethdb.KeyValueWriter does not implement DeleteRange")
 			}
 		} else {
 			return fmt.Errorf("unhandled operation, keytype: %v", kind)

--- a/signer/core/apitypes/types.go
+++ b/signer/core/apitypes/types.go
@@ -151,7 +151,7 @@ func (args *SendTxArgs) ToTransaction() (*types.Transaction, error) {
 			al = *args.AccessList
 		}
 		if to == nil {
-			return nil, fmt.Errorf("transaction recipient must be set for blob transactions")
+			return nil, errors.New("transaction recipient must be set for blob transactions")
 		}
 		data = &types.BlobTx{
 			To:         *to,

--- a/tests/transaction_test_util.go
+++ b/tests/transaction_test_util.go
@@ -17,6 +17,7 @@
 package tests
 
 import (
+	"errors"
 	"fmt"
 	"math/big"
 
@@ -43,7 +44,7 @@ type ttFork struct {
 
 func (tt *TransactionTest) validate() error {
 	if tt.Txbytes == nil {
-		return fmt.Errorf("missing txbytes")
+		return errors.New("missing txbytes")
 	}
 	for name, fork := range tt.Result {
 		if err := tt.validateFork(fork); err != nil {
@@ -58,10 +59,10 @@ func (tt *TransactionTest) validateFork(fork *ttFork) error {
 		return nil
 	}
 	if fork.Hash == nil && fork.Exception == nil {
-		return fmt.Errorf("missing hash and exception")
+		return errors.New("missing hash and exception")
 	}
 	if fork.Hash != nil && fork.Sender == nil {
-		return fmt.Errorf("missing sender")
+		return errors.New("missing sender")
 	}
 	return nil
 }

--- a/triedb/pathdb/history_index.go
+++ b/triedb/pathdb/history_index.go
@@ -353,7 +353,7 @@ func (d *indexDeleter) empty() bool {
 // pop removes the last written element from the index writer.
 func (d *indexDeleter) pop(id uint64) error {
 	if id == 0 {
-		return fmt.Errorf("zero history ID is not valid")
+		return errors.New("zero history ID is not valid")
 	}
 	if id != d.lastID {
 		return fmt.Errorf("pop element out of order, last: %d, this: %d", d.lastID, id)


### PR DESCRIPTION
Following #32274. Replace most cases except for tests.

The errors.new function does not require string formatting, so its performance is better than that of fmt.Errorf.