### PR TITLE
metrics: add chain/gas for cumulative gas usage

### DIFF
--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -67,6 +67,7 @@ var (
 
 	chainInfoGauge   = metrics.NewRegisteredGaugeInfo("chain/info", nil)
 	chainMgaspsMeter = metrics.NewRegisteredResettingTimer("chain/mgasps", nil)
+	chainGasCounter  = metrics.NewRegisteredCounter("chain/gas/total", nil)
 
 	accountReadTimer   = metrics.NewRegisteredResettingTimer("chain/account/reads", nil)
 	accountHashTimer   = metrics.NewRegisteredResettingTimer("chain/account/hashes", nil)
@@ -1888,6 +1889,7 @@ func (bc *BlockChain) insertChain(chain types.Blocks, setHead bool, makeWitness 
 		// Report the import stats before returning the various results
 		stats.processed++
 		stats.usedGas += res.usedGas
+		chainGasCounter.Inc(int64(res.usedGas))
 		witness = res.witness
 
 		var snapDiffItems, snapBufItems common.StorageSize


### PR DESCRIPTION
This redoes #32004 where the new metric I wanted to add was dropped in later revisions.

The reasoning is the same as before: a gauge is only useful at the moment you observe it, but most of us will have metric systems that collect and record the data periodically out of sync with gauge updates. A total value allows us to derive accurate Mgas/s metrics over long periods.