### PR TITLE
cmd/devp2p: prealloc capacity for keys

### DIFF
--- a/cmd/devp2p/nodesetcmd.go
+++ b/cmd/devp2p/nodesetcmd.go
@@ -82,7 +82,7 @@ func showAttributeCounts(ns nodeSet) {
 		}
 	}
 
-	var keys []string
+	keys := make([]string, 0, len(attrcount))
 	var maxlength int
 	for key := range attrcount {
 		keys = append(keys, key)

--- a/cmd/devp2p/nodesetcmd.go
+++ b/cmd/devp2p/nodesetcmd.go
@@ -82,8 +82,7 @@ func showAttributeCounts(ns nodeSet) {
 		}
 	}
 
-	// keys := make([]string, 0, len(attrcount))
-	var keys []string
+	keys := make([]string, 0, len(attrcount))
 	var maxlength int
 	for key := range attrcount {
 		keys = append(keys, key)

--- a/cmd/devp2p/nodesetcmd.go
+++ b/cmd/devp2p/nodesetcmd.go
@@ -82,7 +82,8 @@ func showAttributeCounts(ns nodeSet) {
 		}
 	}
 
-	keys := make([]string, 0, len(attrcount))
+	// keys := make([]string, 0, len(attrcount))
+	var keys []string
 	var maxlength int
 	for key := range attrcount {
 		keys = append(keys, key)


### PR DESCRIPTION
Improvement: prealloc capacity for `keys` to avoid realloc