### PR TITLE
core/vm: opt using strconv.FormatInt instead of fmt.Sprintf

### DIFF
--- a/core/vm/eips.go
+++ b/core/vm/eips.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"math"
 	"sort"
+	"strconv"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/tracing"
@@ -63,7 +64,7 @@ func ValidEip(eipNum int) bool {
 func ActivateableEips() []string {
 	var nums []string
 	for k := range activators {
-		nums = append(nums, fmt.Sprintf("%d", k))
+		nums = append(nums, strconv.FormatInt(int64(k), 10))
 	}
 	sort.Strings(nums)
 	return nums


### PR DESCRIPTION
```
package main

import (
	"fmt"
	"strconv"
	"testing"
)

// 测试不同的整数值
var testValues = []int64{
	0,
	42,
	-42,
	1234567890,
	-1234567890,
	9223372036854775807,  // int64 最大值
	-9223372036854775808, // int64 最小值
}

func BenchmarkStrconvFormatInt(b *testing.B) {
	for i := 0; i < b.N; i++ {
		for _, v := range testValues {
			_ = strconv.FormatInt(v, 10)
		}
	}
}

func BenchmarkFmtSprintf(b *testing.B) {
	for i := 0; i < b.N; i++ {
		for _, v := range testValues {
			_ = fmt.Sprintf("%d", v)
		}
	}
}

```

```
goos: darwin
goarch: arm64
pkg: github.com/ethereum/go-ethereum/debug/to_string_bench
cpu: Apple M1 Pro
BenchmarkStrconvFormatInt
BenchmarkStrconvFormatInt-10    	 8849244	       128.2 ns/op
BenchmarkFmtSprintf
BenchmarkFmtSprintf-10          	 3072813	       384.6 ns/op
```