### PR TITLE
trie, core: rework tracer and track origin value of dirty nodes

### DIFF
--- a/core/state/statedb.go
+++ b/core/state/statedb.go
@@ -977,7 +977,7 @@ func (s *StateDB) fastDeleteStorage(snaps *snapshot.Tree, addrHash common.Hash, 
 		storageOrigins = make(map[common.Hash][]byte)  // the set for tracking the original value of slot
 	)
 	stack := trie.NewStackTrie(func(path []byte, hash common.Hash, blob []byte) {
-		nodes.AddNode(path, trienode.NewDeleted())
+		nodes.AddNode(path, trienode.NewDeletedWithPrev(blob))
 	})
 	for iter.Next() {
 		slot := common.CopyBytes(iter.Slot())
@@ -1028,7 +1028,7 @@ func (s *StateDB) slowDeleteStorage(addr common.Address, addrHash common.Hash, r
 		if it.Hash() == (common.Hash{}) {
 			continue
 		}
-		nodes.AddNode(it.Path(), trienode.NewDeleted())
+		nodes.AddNode(it.Path(), trienode.NewDeletedWithPrev(it.NodeBlob()))
 	}
 	if err := it.Error(); err != nil {
 		return nil, nil, nil, err
@@ -1160,7 +1160,7 @@ func (s *StateDB) commit(deleteEmptyObjects bool, noStorageWiping bool) (*stateU
 		//
 		// Given that some accounts may be destroyed and then recreated within
 		// the same block, it's possible that a node set with the same owner
-		// may already exists. In such cases, these two sets are combined, with
+		// may already exist. In such cases, these two sets are combined, with
 		// the later one overwriting the previous one if any nodes are modified
 		// or deleted in both sets.
 		//

--- a/trie/committer.go
+++ b/trie/committer.go
@@ -29,12 +29,12 @@ import (
 // insertion order.
 type committer struct {
 	nodes       *trienode.NodeSet
-	tracer      *tracer
+	tracer      *prevalueTracer
 	collectLeaf bool
 }
 
 // newCommitter creates a new committer or picks one from the pool.
-func newCommitter(nodeset *trienode.NodeSet, tracer *tracer, collectLeaf bool) *committer {
+func newCommitter(nodeset *trienode.NodeSet, tracer *prevalueTracer, collectLeaf bool) *committer {
 	return &committer{
 		nodes:       nodeset,
 		tracer:      tracer,
@@ -140,8 +140,7 @@ func (c *committer) store(path []byte, n node) node {
 		// The node is embedded in its parent, in other words, this node
 		// will not be stored in the database independently, mark it as
 		// deleted only if the node was existent in database before.
-		_, ok := c.tracer.accessList[string(path)]
-		if ok {
+		if c.tracer.has(path) {
 			c.nodes.AddNode(path, trienode.NewDeleted())
 		}
 		return n

--- a/trie/committer.go
+++ b/trie/committer.go
@@ -110,14 +110,16 @@ func (c *committer) commitChildren(path []byte, n *fullNode, parallel bool) {
 		} else {
 			wg.Add(1)
 			go func(index int) {
+				defer wg.Done()
+
 				p := append(path, byte(index))
 				childSet := trienode.NewNodeSet(c.nodes.Owner)
 				childCommitter := newCommitter(childSet, c.tracer, c.collectLeaf)
 				n.Children[index] = childCommitter.commit(p, child, false)
+
 				nodesMu.Lock()
-				c.nodes.MergeSet(childSet)
+				c.nodes.MergeDisjoint(childSet)
 				nodesMu.Unlock()
-				wg.Done()
 			}(i)
 		}
 	}
@@ -140,14 +142,15 @@ func (c *committer) store(path []byte, n node) node {
 		// The node is embedded in its parent, in other words, this node
 		// will not be stored in the database independently, mark it as
 		// deleted only if the node was existent in database before.
-		if c.tracer.has(path) {
-			c.nodes.AddNode(path, trienode.NewDeleted())
+		origin := c.tracer.get(path)
+		if len(origin) != 0 {
+			c.nodes.AddNode(path, trienode.NewDeletedWithPrev(origin))
 		}
 		return n
 	}
 	// Collect the dirty node to nodeset for return.
 	nhash := common.BytesToHash(hash)
-	c.nodes.AddNode(path, trienode.New(nhash, nodeToBytes(n)))
+	c.nodes.AddNode(path, trienode.NewNodeWithPrev(nhash, nodeToBytes(n), c.tracer.get(path)))
 
 	// Collect the corresponding leaf node if it's required. We don't check
 	// full node since it's impossible to store value in fullNode. The key

--- a/trie/proof.go
+++ b/trie/proof.go
@@ -573,7 +573,12 @@ func VerifyRangeProof(rootHash common.Hash, firstKey []byte, keys [][]byte, valu
 	}
 	// Rebuild the trie with the leaf stream, the shape of trie
 	// should be same with the original one.
-	tr := &Trie{root: root, reader: newEmptyReader(), tracer: newTracer()}
+	tr := &Trie{
+		root:           root,
+		reader:         newEmptyReader(),
+		opTracer:       newOpTracer(),
+		prevalueTracer: newPrevalueTracer(),
+	}
 	if empty {
 		tr.root = nil
 	}

--- a/trie/tracer.go
+++ b/trie/tracer.go
@@ -18,14 +18,14 @@ package trie
 
 import (
 	"maps"
-
-	"github.com/ethereum/go-ethereum/common"
+	"slices"
+	"sync"
 )
 
-// tracer tracks the changes of trie nodes. During the trie operations,
+// opTracer tracks the changes of trie nodes. During the trie operations,
 // some nodes can be deleted from the trie, while these deleted nodes
 // won't be captured by trie.Hasher or trie.Committer. Thus, these deleted
-// nodes won't be removed from the disk at all. Tracer is an auxiliary tool
+// nodes won't be removed from the disk at all. opTracer is an auxiliary tool
 // used to track all insert and delete operations of trie and capture all
 // deleted nodes eventually.
 //
@@ -35,38 +35,25 @@ import (
 // This tool can track all of them no matter the node is embedded in its
 // parent or not, but valueNode is never tracked.
 //
-// Besides, it's also used for recording the original value of the nodes
-// when they are resolved from the disk. The pre-value of the nodes will
-// be used to construct trie history in the future.
-//
-// Note tracer is not thread-safe, callers should be responsible for handling
+// Note opTracer is not thread-safe, callers should be responsible for handling
 // the concurrency issues by themselves.
-type tracer struct {
-	inserts    map[string]struct{}
-	deletes    map[string]struct{}
-	accessList map[string][]byte
+type opTracer struct {
+	inserts map[string]struct{}
+	deletes map[string]struct{}
 }
 
-// newTracer initializes the tracer for capturing trie changes.
-func newTracer() *tracer {
-	return &tracer{
-		inserts:    make(map[string]struct{}),
-		deletes:    make(map[string]struct{}),
-		accessList: make(map[string][]byte),
+// newOpTracer initializes the tracer for capturing trie changes.
+func newOpTracer() *opTracer {
+	return &opTracer{
+		inserts: make(map[string]struct{}),
+		deletes: make(map[string]struct{}),
 	}
-}
-
-// onRead tracks the newly loaded trie node and caches the rlp-encoded
-// blob internally. Don't change the value outside of function since
-// it's not deep-copied.
-func (t *tracer) onRead(path []byte, val []byte) {
-	t.accessList[string(path)] = val
 }
 
 // onInsert tracks the newly inserted trie node. If it's already
 // in the deletion set (resurrected node), then just wipe it from
 // the deletion set as it's "untouched".
-func (t *tracer) onInsert(path []byte) {
+func (t *opTracer) onInsert(path []byte) {
 	if _, present := t.deletes[string(path)]; present {
 		delete(t.deletes, string(path))
 		return
@@ -77,7 +64,7 @@ func (t *tracer) onInsert(path []byte) {
 // onDelete tracks the newly deleted trie node. If it's already
 // in the addition set, then just wipe it from the addition set
 // as it's untouched.
-func (t *tracer) onDelete(path []byte) {
+func (t *opTracer) onDelete(path []byte) {
 	if _, present := t.inserts[string(path)]; present {
 		delete(t.inserts, string(path))
 		return
@@ -86,37 +73,102 @@ func (t *tracer) onDelete(path []byte) {
 }
 
 // reset clears the content tracked by tracer.
-func (t *tracer) reset() {
-	t.inserts = make(map[string]struct{})
-	t.deletes = make(map[string]struct{})
-	t.accessList = make(map[string][]byte)
+func (t *opTracer) reset() {
+	clear(t.inserts)
+	clear(t.deletes)
 }
 
 // copy returns a deep copied tracer instance.
-func (t *tracer) copy() *tracer {
-	accessList := make(map[string][]byte, len(t.accessList))
-	for path, blob := range t.accessList {
-		accessList[path] = common.CopyBytes(blob)
-	}
-	return &tracer{
-		inserts:    maps.Clone(t.inserts),
-		deletes:    maps.Clone(t.deletes),
-		accessList: accessList,
+func (t *opTracer) copy() *opTracer {
+	return &opTracer{
+		inserts: maps.Clone(t.inserts),
+		deletes: maps.Clone(t.deletes),
 	}
 }
 
-// deletedNodes returns a list of node paths which are deleted from the trie.
-func (t *tracer) deletedNodes() []string {
-	var paths []string
+// deletedList returns a list of node paths which are deleted from the trie.
+func (t *opTracer) deletedList() [][]byte {
+	paths := make([][]byte, 0, len(t.deletes))
 	for path := range t.deletes {
-		// It's possible a few deleted nodes were embedded
-		// in their parent before, the deletions can be no
-		// effect by deleting nothing, filter them out.
-		_, ok := t.accessList[path]
-		if !ok {
-			continue
-		}
-		paths = append(paths, path)
+		paths = append(paths, []byte(path))
 	}
 	return paths
+}
+
+// prevalueTracer tracks the original values of resolved trie nodes. Cached trie
+// node values are expected to be immutable.
+//
+// prevalueTracer is protected by a lock to ensure concurrency safety, as
+// concurrent map writes may occur during concurrent trie read operations.
+type prevalueTracer struct {
+	data map[string][]byte
+	lock sync.RWMutex
+}
+
+// newPrevalueTracer initializes the tracer for capturing resolved trie nodes.
+func newPrevalueTracer() *prevalueTracer {
+	return &prevalueTracer{
+		data: make(map[string][]byte),
+	}
+}
+
+// put tracks the newly loaded trie node and caches its RLP-encoded
+// blob internally. Do not modify the value outside this function,
+// as it is not deep-copied.
+func (t *prevalueTracer) put(path []byte, val []byte) {
+	t.lock.Lock()
+	defer t.lock.Unlock()
+
+	t.data[string(path)] = val
+}
+
+// has returns a flag indicating whether the corresponding trie node specified
+// by the path exists in the trie.
+func (t *prevalueTracer) has(path []byte) bool {
+	t.lock.RLock()
+	defer t.lock.RUnlock()
+
+	_, ok := t.data[string(path)]
+	return ok
+}
+
+// hasList returns a list of flag indicating whether the corresponding trie nodes
+// specified by the path exists in the trie.
+func (t *prevalueTracer) hasList(list [][]byte) []bool {
+	t.lock.RLock()
+	defer t.lock.RUnlock()
+
+	exists := make([]bool, 0, len(list))
+	for _, path := range list {
+		_, ok := t.data[string(path)]
+		exists = append(exists, ok)
+	}
+	return exists
+}
+
+// values returns a list of values of the cached trie nodes.
+func (t *prevalueTracer) values() [][]byte {
+	t.lock.RLock()
+	defer t.lock.RUnlock()
+
+	return slices.Collect(maps.Values(t.data))
+}
+
+// reset resets the cached content in the prevalueTracer.
+func (t *prevalueTracer) reset() {
+	t.lock.Lock()
+	defer t.lock.Unlock()
+
+	clear(t.data)
+}
+
+// copy returns a copied prevalueTracer instance.
+func (t *prevalueTracer) copy() *prevalueTracer {
+	t.lock.RLock()
+	defer t.lock.RUnlock()
+
+	// Shadow clone is used, as the cached trie node values are immutable
+	return &prevalueTracer{
+		data: maps.Clone(t.data),
+	}
 }

--- a/trie/tracer_test.go
+++ b/trie/tracer_test.go
@@ -68,8 +68,8 @@ func testTrieTracer(t *testing.T, vals []struct{ k, v string }) {
 	for _, val := range vals {
 		trie.MustUpdate([]byte(val.k), []byte(val.v))
 	}
-	insertSet := copySet(trie.tracer.inserts) // copy before commit
-	deleteSet := copySet(trie.tracer.deletes) // copy before commit
+	insertSet := copySet(trie.opTracer.inserts) // copy before commit
+	deleteSet := copySet(trie.opTracer.deletes) // copy before commit
 	root, nodes := trie.Commit(false)
 	db.Update(root, types.EmptyRootHash, trienode.NewWithNodeSet(nodes))
 
@@ -86,7 +86,7 @@ func testTrieTracer(t *testing.T, vals []struct{ k, v string }) {
 	for _, val := range vals {
 		trie.MustDelete([]byte(val.k))
 	}
-	insertSet, deleteSet = copySet(trie.tracer.inserts), copySet(trie.tracer.deletes)
+	insertSet, deleteSet = copySet(trie.opTracer.inserts), copySet(trie.opTracer.deletes)
 	if !compareSet(insertSet, nil) {
 		t.Fatal("Unexpected insertion set")
 	}
@@ -112,10 +112,10 @@ func testTrieTracerNoop(t *testing.T, vals []struct{ k, v string }) {
 	for _, val := range vals {
 		trie.MustDelete([]byte(val.k))
 	}
-	if len(trie.tracer.inserts) != 0 {
+	if len(trie.opTracer.inserts) != 0 {
 		t.Fatal("Unexpected insertion set")
 	}
-	if len(trie.tracer.deletes) != 0 {
+	if len(trie.opTracer.deletes) != 0 {
 		t.Fatal("Unexpected deletion set")
 	}
 }
@@ -249,9 +249,9 @@ func TestAccessListLeak(t *testing.T) {
 	}
 	for _, c := range cases {
 		trie, _ = New(TrieID(root), db)
-		n1 := len(trie.tracer.accessList)
+		n1 := len(trie.prevalueTracer.data)
 		c.op(trie)
-		n2 := len(trie.tracer.accessList)
+		n2 := len(trie.prevalueTracer.data)
 
 		if n1 != n2 {
 			t.Fatalf("AccessList is leaked, prev %d after %d", n1, n2)

--- a/trie/tracer_test.go
+++ b/trie/tracer_test.go
@@ -52,15 +52,15 @@ var (
 	}
 )
 
-func TestTrieTracer(t *testing.T) {
-	testTrieTracer(t, tiny)
-	testTrieTracer(t, nonAligned)
-	testTrieTracer(t, standard)
+func TestTrieOpTracer(t *testing.T) {
+	testTrieOpTracer(t, tiny)
+	testTrieOpTracer(t, nonAligned)
+	testTrieOpTracer(t, standard)
 }
 
 // Tests if the trie diffs are tracked correctly. Tracer should capture
 // all non-leaf dirty nodes, no matter the node is embedded or not.
-func testTrieTracer(t *testing.T, vals []struct{ k, v string }) {
+func testTrieOpTracer(t *testing.T, vals []struct{ k, v string }) {
 	db := newTestDatabase(rawdb.NewMemoryDatabase(), rawdb.HashScheme)
 	trie := NewEmpty(db)
 
@@ -70,6 +70,7 @@ func testTrieTracer(t *testing.T, vals []struct{ k, v string }) {
 	}
 	insertSet := copySet(trie.opTracer.inserts) // copy before commit
 	deleteSet := copySet(trie.opTracer.deletes) // copy before commit
+
 	root, nodes := trie.Commit(false)
 	db.Update(root, types.EmptyRootHash, trienode.NewWithNodeSet(nodes))
 
@@ -97,13 +98,13 @@ func testTrieTracer(t *testing.T, vals []struct{ k, v string }) {
 
 // Test that after inserting a new batch of nodes and deleting them immediately,
 // the trie tracer should be cleared normally as no operation happened.
-func TestTrieTracerNoop(t *testing.T) {
-	testTrieTracerNoop(t, tiny)
-	testTrieTracerNoop(t, nonAligned)
-	testTrieTracerNoop(t, standard)
+func TestTrieOpTracerNoop(t *testing.T) {
+	testTrieOpTracerNoop(t, tiny)
+	testTrieOpTracerNoop(t, nonAligned)
+	testTrieOpTracerNoop(t, standard)
 }
 
-func testTrieTracerNoop(t *testing.T, vals []struct{ k, v string }) {
+func testTrieOpTracerNoop(t *testing.T, vals []struct{ k, v string }) {
 	db := newTestDatabase(rawdb.NewMemoryDatabase(), rawdb.HashScheme)
 	trie := NewEmpty(db)
 	for _, val := range vals {
@@ -120,14 +121,14 @@ func testTrieTracerNoop(t *testing.T, vals []struct{ k, v string }) {
 	}
 }
 
-// Tests if the accessList is correctly tracked.
-func TestAccessList(t *testing.T) {
-	testAccessList(t, tiny)
-	testAccessList(t, nonAligned)
-	testAccessList(t, standard)
+// Tests if the original value of trie nodes are correctly tracked.
+func TestPrevalueTracer(t *testing.T) {
+	testPrevalueTracer(t, tiny)
+	testPrevalueTracer(t, nonAligned)
+	testPrevalueTracer(t, standard)
 }
 
-func testAccessList(t *testing.T, vals []struct{ k, v string }) {
+func testPrevalueTracer(t *testing.T, vals []struct{ k, v string }) {
 	var (
 		db   = newTestDatabase(rawdb.NewMemoryDatabase(), rawdb.HashScheme)
 		trie = NewEmpty(db)
@@ -210,7 +211,7 @@ func testAccessList(t *testing.T, vals []struct{ k, v string }) {
 }
 
 // Tests origin values won't be tracked in Iterator or Prover
-func TestAccessListLeak(t *testing.T) {
+func TestPrevalueTracerLeak(t *testing.T) {
 	var (
 		db   = newTestDatabase(rawdb.NewMemoryDatabase(), rawdb.HashScheme)
 		trie = NewEmpty(db)

--- a/trie/trie_test.go
+++ b/trie/trie_test.go
@@ -595,18 +595,18 @@ func runRandTest(rt randTest) error {
 					deleteExp[path] = struct{}{}
 				}
 			}
-			if len(insertExp) != len(tr.tracer.inserts) {
+			if len(insertExp) != len(tr.opTracer.inserts) {
 				rt[i].err = errors.New("insert set mismatch")
 			}
-			if len(deleteExp) != len(tr.tracer.deletes) {
+			if len(deleteExp) != len(tr.opTracer.deletes) {
 				rt[i].err = errors.New("delete set mismatch")
 			}
-			for insert := range tr.tracer.inserts {
+			for insert := range tr.opTracer.inserts {
 				if _, present := insertExp[insert]; !present {
 					rt[i].err = errors.New("missing inserted node")
 				}
 			}
-			for del := range tr.tracer.deletes {
+			for del := range tr.opTracer.deletes {
 				if _, present := deleteExp[del]; !present {
 					rt[i].err = errors.New("missing deleted node")
 				}

--- a/trie/trie_test.go
+++ b/trie/trie_test.go
@@ -449,35 +449,35 @@ func verifyAccessList(old *Trie, new *Trie, set *trienode.NodeSet) error {
 		if !ok || n.IsDeleted() {
 			return errors.New("expect new node")
 		}
-		//if len(n.Prev) > 0 {
-		//	return errors.New("unexpected origin value")
-		//}
+		if len(set.Origins[path]) > 0 {
+			return errors.New("unexpected origin value")
+		}
 	}
 	// Check deletion set
-	for path := range deletes {
+	for path, blob := range deletes {
 		n, ok := set.Nodes[path]
 		if !ok || !n.IsDeleted() {
 			return errors.New("expect deleted node")
 		}
-		//if len(n.Prev) == 0 {
-		//	return errors.New("expect origin value")
-		//}
-		//if !bytes.Equal(n.Prev, blob) {
-		//	return errors.New("invalid origin value")
-		//}
+		if len(set.Origins[path]) == 0 {
+			return errors.New("expect origin value")
+		}
+		if !bytes.Equal(set.Origins[path], blob) {
+			return errors.New("invalid origin value")
+		}
 	}
 	// Check update set
-	for path := range updates {
+	for path, blob := range updates {
 		n, ok := set.Nodes[path]
 		if !ok || n.IsDeleted() {
 			return errors.New("expect updated node")
 		}
-		//if len(n.Prev) == 0 {
-		//	return errors.New("expect origin value")
-		//}
-		//if !bytes.Equal(n.Prev, blob) {
-		//	return errors.New("invalid origin value")
-		//}
+		if len(set.Origins[path]) == 0 {
+			return errors.New("expect origin value")
+		}
+		if !bytes.Equal(set.Origins[path], blob) {
+			return errors.New("invalid origin value")
+		}
 	}
 	return nil
 }

--- a/trie/trienode/node_test.go
+++ b/trie/trienode/node_test.go
@@ -17,12 +17,99 @@
 package trienode
 
 import (
+	"bytes"
 	"crypto/rand"
+	"maps"
+	"reflect"
+	"slices"
 	"testing"
 
+	"github.com/davecgh/go-spew/spew"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/ethereum/go-ethereum/internal/testrand"
 )
+
+func makeTestSet(owner common.Hash, n int, paths [][]byte) *NodeSet {
+	set := NewNodeSet(owner)
+	for i := 0; i < n*3/4; i++ {
+		path := testrand.Bytes(10)
+		blob := testrand.Bytes(100)
+		set.AddNode(path, NewNodeWithPrev(crypto.Keccak256Hash(blob), blob, testrand.Bytes(100)))
+	}
+	for i := 0; i < n/4; i++ {
+		path := testrand.Bytes(10)
+		set.AddNode(path, NewDeletedWithPrev(testrand.Bytes(100)))
+	}
+	for i := 0; i < len(paths); i++ {
+		if i%3 == 0 {
+			set.AddNode(paths[i], NewDeletedWithPrev(testrand.Bytes(100)))
+		} else {
+			blob := testrand.Bytes(100)
+			set.AddNode(paths[i], NewNodeWithPrev(crypto.Keccak256Hash(blob), blob, testrand.Bytes(100)))
+		}
+	}
+	return set
+}
+
+func copyNodeSet(set *NodeSet) *NodeSet {
+	cpy := &NodeSet{
+		Owner:   set.Owner,
+		Leaves:  slices.Clone(set.Leaves),
+		updates: set.updates,
+		deletes: set.deletes,
+		Nodes:   maps.Clone(set.Nodes),
+		Origins: maps.Clone(set.Origins),
+	}
+	return cpy
+}
+
+func TestNodeSetMerge(t *testing.T) {
+	var shared [][]byte
+	for i := 0; i < 2; i++ {
+		shared = append(shared, testrand.Bytes(10))
+	}
+	owner := testrand.Hash()
+	setA := makeTestSet(owner, 20, shared)
+	cpyA := copyNodeSet(setA)
+
+	setB := makeTestSet(owner, 20, shared)
+	setA.Merge(setB)
+
+	for path, node := range setA.Nodes {
+		nA, inA := cpyA.Nodes[path]
+		nB, inB := setB.Nodes[path]
+
+		switch {
+		case inA && inB:
+			origin := setA.Origins[path]
+			if !bytes.Equal(origin, cpyA.Origins[path]) {
+				t.Errorf("Unexpected origin, path %v: want: %v, got: %v", []byte(path), cpyA.Origins[path], origin)
+			}
+			if !reflect.DeepEqual(node, nB) {
+				t.Errorf("Unexpected node, path %v: want: %v, got: %v", []byte(path), spew.Sdump(nB), spew.Sdump(node))
+			}
+		case !inA && inB:
+			origin := setA.Origins[path]
+			if !bytes.Equal(origin, setB.Origins[path]) {
+				t.Errorf("Unexpected origin, path %v: want: %v, got: %v", []byte(path), setB.Origins[path], origin)
+			}
+			if !reflect.DeepEqual(node, nB) {
+				t.Errorf("Unexpected node, path %v: want: %v, got: %v", []byte(path), spew.Sdump(nB), spew.Sdump(node))
+			}
+		case inA && !inB:
+			origin := setA.Origins[path]
+			if !bytes.Equal(origin, cpyA.Origins[path]) {
+				t.Errorf("Unexpected origin, path %v: want: %v, got: %v", []byte(path), cpyA.Origins[path], origin)
+			}
+			if !reflect.DeepEqual(node, nA) {
+				t.Errorf("Unexpected node, path %v: want: %v, got: %v", []byte(path), spew.Sdump(nA), spew.Sdump(node))
+			}
+		default:
+			t.Errorf("Unexpected node, %v", []byte(path))
+		}
+	}
+}
 
 func BenchmarkMerge(b *testing.B) {
 	b.Run("1K", func(b *testing.B) {
@@ -42,7 +129,7 @@ func benchmarkMerge(b *testing.B, count int) {
 		blob := make([]byte, 32)
 		rand.Read(blob)
 		hash := crypto.Keccak256Hash(blob)
-		s.AddNode(path, New(hash, blob))
+		s.AddNode(path, NewNodeWithPrev(hash, blob, nil))
 	}
 	for i := 0; i < count; i++ {
 		// Random path of 4 nibbles
@@ -53,9 +140,9 @@ func benchmarkMerge(b *testing.B, count int) {
 	for i := 0; i < b.N; i++ {
 		// Store set x into a backup
 		z := NewNodeSet(common.Hash{})
-		z.Merge(common.Hash{}, x.Nodes)
+		z.Merge(x)
 		// Merge y into x
-		x.Merge(common.Hash{}, y.Nodes)
+		x.Merge(y)
 		x = z
 	}
 }


### PR DESCRIPTION
These changes made in the PR should be highlighted here

The trie tracer is split into two distinct structs: opTracer and prevalueTracer.
The former is specific to MPT, while the latter is generic and applicable to all 
trie implementations.

The original values of dirty nodes are tracked in a NodeSet. This serves as the 
foundation for both full archive node implementations and the state live tracer.


