### PR TITLE
eth: fix typos and outdated comments

### DIFF
--- a/eth/ethconfig/config.go
+++ b/eth/ethconfig/config.go
@@ -154,7 +154,7 @@ type Config struct {
 	// RPCEVMTimeout is the global timeout for eth-call.
 	RPCEVMTimeout time.Duration
 
-	// RPCTxFeeCap is the global transaction fee(price * gaslimit) cap for
+	// RPCTxFeeCap is the global transaction fee (price * gas limit) cap for
 	// send-transaction variants. The unit is ether.
 	RPCTxFeeCap float64
 

--- a/eth/filters/filter.go
+++ b/eth/filters/filter.go
@@ -456,7 +456,6 @@ func (f *Filter) blockLogs(ctx context.Context, header *types.Header) ([]*types.
 
 // checkMatches checks if the receipts belonging to the given header contain any log events that
 // match the filter criteria. This function is called when the bloom filter signals a potential match.
-// skipFilter signals all logs of the given block are requested.
 func (f *Filter) checkMatches(ctx context.Context, header *types.Header) ([]*types.Log, error) {
 	hash := header.Hash()
 	// Logs in cache are partially filled with context data

--- a/eth/filters/filter_system.go
+++ b/eth/filters/filter_system.go
@@ -207,7 +207,7 @@ type EventSystem struct {
 }
 
 // NewEventSystem creates a new manager that listens for event on the given mux,
-// parses and filters them. It uses the all map to retrieve filter changes. The
+// parses and filters them. It uses an internal map to retrieve filter changes. The
 // work loop holds its own index that is used to forward events to filters.
 //
 // The returned manager has a loop that needs to be stopped with the Stop function


### PR DESCRIPTION
ethconfig/config.go:
    *   Fixed a small typo and spacing issue in a comment to improve readability.

eth/filters/filter.go:
    *   Removed an outdated comment that was describing a feature that no longer exists in the code.

eth/filters/filter_system.go:
    *   Updated a comment that was referring to an old variable name.
