### PR TITLE
eth/filters, cmd: add config of eth_getLogs address limit

### DIFF
--- a/cmd/geth/main.go
+++ b/cmd/geth/main.go
@@ -180,6 +180,7 @@ var (
 		utils.RPCGlobalGasCapFlag,
 		utils.RPCGlobalEVMTimeoutFlag,
 		utils.RPCGlobalTxFeeCapFlag,
+		utils.EthGetLogMaxAddressFlag,
 		utils.AllowUnprotectedTxs,
 		utils.BatchRequestLimit,
 		utils.BatchResponseMaxSize,

--- a/cmd/geth/main.go
+++ b/cmd/geth/main.go
@@ -180,7 +180,7 @@ var (
 		utils.RPCGlobalGasCapFlag,
 		utils.RPCGlobalEVMTimeoutFlag,
 		utils.RPCGlobalTxFeeCapFlag,
-		utils.EthGetLogMaxAddressFlag,
+		utils.RPCGlobalLogQueryLimit,
 		utils.AllowUnprotectedTxs,
 		utils.BatchRequestLimit,
 		utils.BatchResponseMaxSize,

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -1696,7 +1696,7 @@ func SetEthConfig(ctx *cli.Context, stack *node.Node, cfg *ethconfig.Config) {
 		cfg.FilterLogCacheSize = ctx.Int(CacheLogSizeFlag.Name)
 	}
 	if ctx.IsSet(EthGetLogMaxAddressFlag.Name) {
-		cfg.FilterMaxAddresses = int(ctx.Uint64(EthGetLogMaxAddressFlag.Name))
+		cfg.FilterMaxAddresses = ctx.Int(EthGetLogMaxAddressFlag.Name)
 	}
 	if !ctx.Bool(SnapshotFlag.Name) || cfg.SnapshotCache == 0 {
 		// If snap-sync is requested, this flag is also required

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -590,10 +590,10 @@ var (
 		Value:    ethconfig.Defaults.RPCTxFeeCap,
 		Category: flags.APICategory,
 	}
-	EthGetLogMaxAddressFlag = &cli.IntFlag{
-		Name:     "rpc.getlogmaxaddrs",
-		Usage:    "Maximum number of addresses allowed in eth_getLogs filter criteria",
-		Value:    ethconfig.Defaults.FilterMaxAddresses,
+	RPCGlobalLogQueryLimit = &cli.IntFlag{
+		Name:     "rpc.logquerylimit",
+		Usage:    "Maximum number of alternative addresses or topics allowed per search position in eth_getLogs filter criteria (0 = no cap)",
+		Value:    ethconfig.Defaults.LogQueryLimit,
 		Category: flags.APICategory,
 	}
 	// Authenticated RPC HTTP settings
@@ -1695,8 +1695,8 @@ func SetEthConfig(ctx *cli.Context, stack *node.Node, cfg *ethconfig.Config) {
 	if ctx.IsSet(CacheLogSizeFlag.Name) {
 		cfg.FilterLogCacheSize = ctx.Int(CacheLogSizeFlag.Name)
 	}
-	if ctx.IsSet(EthGetLogMaxAddressFlag.Name) {
-		cfg.FilterMaxAddresses = ctx.Int(EthGetLogMaxAddressFlag.Name)
+	if ctx.IsSet(RPCGlobalLogQueryLimit.Name) {
+		cfg.LogQueryLimit = ctx.Int(RPCGlobalLogQueryLimit.Name)
 	}
 	if !ctx.Bool(SnapshotFlag.Name) || cfg.SnapshotCache == 0 {
 		// If snap-sync is requested, this flag is also required
@@ -2007,7 +2007,7 @@ func RegisterGraphQLService(stack *node.Node, backend ethapi.Backend, filterSyst
 func RegisterFilterAPI(stack *node.Node, backend ethapi.Backend, ethcfg *ethconfig.Config) *filters.FilterSystem {
 	filterSystem := filters.NewFilterSystem(backend, filters.Config{
 		LogCacheSize: ethcfg.FilterLogCacheSize,
-		MaxAddresses: ethcfg.FilterMaxAddresses,
+		LogQueryLimit: ethcfg.LogQueryLimit,
 	})
 	stack.RegisterAPIs([]rpc.API{{
 		Namespace: "eth",

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -590,10 +590,10 @@ var (
 		Value:    ethconfig.Defaults.RPCTxFeeCap,
 		Category: flags.APICategory,
 	}
-	EthGetLogMaxAddressFlag = &cli.Uint64Flag{
+	EthGetLogMaxAddressFlag = &cli.IntFlag{
 		Name:     "rpc.getlogmaxaddrs",
 		Usage:    "Maximum number of addresses allowed in eth_getLogs filter criteria",
-		Value:    1000,
+		Value:    ethconfig.Defaults.FilterMaxAddresses,
 		Category: flags.APICategory,
 	}
 	// Authenticated RPC HTTP settings

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -2006,7 +2006,7 @@ func RegisterGraphQLService(stack *node.Node, backend ethapi.Backend, filterSyst
 // RegisterFilterAPI adds the eth log filtering RPC API to the node.
 func RegisterFilterAPI(stack *node.Node, backend ethapi.Backend, ethcfg *ethconfig.Config) *filters.FilterSystem {
 	filterSystem := filters.NewFilterSystem(backend, filters.Config{
-		LogCacheSize: ethcfg.FilterLogCacheSize,
+		LogCacheSize:  ethcfg.FilterLogCacheSize,
 		LogQueryLimit: ethcfg.LogQueryLimit,
 	})
 	stack.RegisterAPIs([]rpc.API{{

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -590,6 +590,12 @@ var (
 		Value:    ethconfig.Defaults.RPCTxFeeCap,
 		Category: flags.APICategory,
 	}
+	EthGetLogMaxAddressFlag = &cli.Uint64Flag{
+		Name:     "rpc.getlogmaxaddrs",
+		Usage:    "Maximum number of addresses allowed in eth_getLogs filter criteria",
+		Value:    1000,
+		Category: flags.APICategory,
+	}
 	// Authenticated RPC HTTP settings
 	AuthListenFlag = &cli.StringFlag{
 		Name:     "authrpc.addr",
@@ -1689,6 +1695,9 @@ func SetEthConfig(ctx *cli.Context, stack *node.Node, cfg *ethconfig.Config) {
 	if ctx.IsSet(CacheLogSizeFlag.Name) {
 		cfg.FilterLogCacheSize = ctx.Int(CacheLogSizeFlag.Name)
 	}
+	if ctx.IsSet(EthGetLogMaxAddressFlag.Name) {
+		cfg.FilterMaxAddresses = int(ctx.Uint64(EthGetLogMaxAddressFlag.Name))
+	}
 	if !ctx.Bool(SnapshotFlag.Name) || cfg.SnapshotCache == 0 {
 		// If snap-sync is requested, this flag is also required
 		if cfg.SyncMode == ethconfig.SnapSync {
@@ -1998,6 +2007,7 @@ func RegisterGraphQLService(stack *node.Node, backend ethapi.Backend, filterSyst
 func RegisterFilterAPI(stack *node.Node, backend ethapi.Backend, ethcfg *ethconfig.Config) *filters.FilterSystem {
 	filterSystem := filters.NewFilterSystem(backend, filters.Config{
 		LogCacheSize: ethcfg.FilterLogCacheSize,
+		MaxAddresses: ethcfg.FilterMaxAddresses,
 	})
 	stack.RegisterAPIs([]rpc.API{{
 		Namespace: "eth",

--- a/eth/ethconfig/config.go
+++ b/eth/ethconfig/config.go
@@ -62,7 +62,7 @@ var Defaults = Config{
 	TrieTimeout:        60 * time.Minute,
 	SnapshotCache:      102,
 	FilterLogCacheSize: 32,
-	FilterMaxAddresses: 1000,
+	LogQueryLimit:      1000,
 	Miner:              miner.DefaultConfig,
 	TxPool:             legacypool.DefaultConfig,
 	BlobPool:           blobpool.DefaultConfig,
@@ -133,7 +133,7 @@ type Config struct {
 	FilterLogCacheSize int
 
 	// This is the maximum number of addresses allowed in filter criteria for eth_getLogs.
-	FilterMaxAddresses int
+	LogQueryLimit int
 
 	// Mining options
 	Miner miner.Config

--- a/eth/ethconfig/config.go
+++ b/eth/ethconfig/config.go
@@ -132,7 +132,8 @@ type Config struct {
 	// This is the number of blocks for which logs will be cached in the filter system.
 	FilterLogCacheSize int
 
-	// This is the maximum number of addresses allowed in filter criteria for eth_getLogs.
+	// This is the maximum number of addresses or topics allowed in filter criteria
+	// for eth_getLogs.
 	LogQueryLimit int
 
 	// Mining options

--- a/eth/ethconfig/config.go
+++ b/eth/ethconfig/config.go
@@ -62,6 +62,7 @@ var Defaults = Config{
 	TrieTimeout:        60 * time.Minute,
 	SnapshotCache:      102,
 	FilterLogCacheSize: 32,
+	FilterMaxAddresses: 1000,
 	Miner:              miner.DefaultConfig,
 	TxPool:             legacypool.DefaultConfig,
 	BlobPool:           blobpool.DefaultConfig,
@@ -130,6 +131,9 @@ type Config struct {
 
 	// This is the number of blocks for which logs will be cached in the filter system.
 	FilterLogCacheSize int
+
+	// This is the maximum number of addresses allowed in filter criteria for eth_getLogs.
+	FilterMaxAddresses int
 
 	// Mining options
 	Miner miner.Config

--- a/eth/ethconfig/gen_config.go
+++ b/eth/ethconfig/gen_config.go
@@ -44,7 +44,7 @@ func (c Config) MarshalTOML() (interface{}, error) {
 		SnapshotCache           int
 		Preimages               bool
 		FilterLogCacheSize      int
-		FilterMaxAddresses      int
+		LogQueryLimit           int
 		Miner                   miner.Config
 		TxPool                  legacypool.Config
 		BlobPool                blobpool.Config
@@ -87,7 +87,7 @@ func (c Config) MarshalTOML() (interface{}, error) {
 	enc.SnapshotCache = c.SnapshotCache
 	enc.Preimages = c.Preimages
 	enc.FilterLogCacheSize = c.FilterLogCacheSize
-	enc.FilterMaxAddresses = c.FilterMaxAddresses
+	enc.LogQueryLimit = c.LogQueryLimit
 	enc.Miner = c.Miner
 	enc.TxPool = c.TxPool
 	enc.BlobPool = c.BlobPool
@@ -134,7 +134,7 @@ func (c *Config) UnmarshalTOML(unmarshal func(interface{}) error) error {
 		SnapshotCache           *int
 		Preimages               *bool
 		FilterLogCacheSize      *int
-		FilterMaxAddresses      *int
+		LogQueryLimit           *int
 		Miner                   *miner.Config
 		TxPool                  *legacypool.Config
 		BlobPool                *blobpool.Config
@@ -234,8 +234,8 @@ func (c *Config) UnmarshalTOML(unmarshal func(interface{}) error) error {
 	if dec.FilterLogCacheSize != nil {
 		c.FilterLogCacheSize = *dec.FilterLogCacheSize
 	}
-	if dec.FilterMaxAddresses != nil {
-		c.FilterMaxAddresses = *dec.FilterMaxAddresses
+	if dec.LogQueryLimit != nil {
+		c.LogQueryLimit = *dec.LogQueryLimit
 	}
 	if dec.Miner != nil {
 		c.Miner = *dec.Miner

--- a/eth/ethconfig/gen_config.go
+++ b/eth/ethconfig/gen_config.go
@@ -44,6 +44,7 @@ func (c Config) MarshalTOML() (interface{}, error) {
 		SnapshotCache           int
 		Preimages               bool
 		FilterLogCacheSize      int
+		FilterMaxAddresses      int
 		Miner                   miner.Config
 		TxPool                  legacypool.Config
 		BlobPool                blobpool.Config
@@ -86,6 +87,7 @@ func (c Config) MarshalTOML() (interface{}, error) {
 	enc.SnapshotCache = c.SnapshotCache
 	enc.Preimages = c.Preimages
 	enc.FilterLogCacheSize = c.FilterLogCacheSize
+	enc.FilterMaxAddresses = c.FilterMaxAddresses
 	enc.Miner = c.Miner
 	enc.TxPool = c.TxPool
 	enc.BlobPool = c.BlobPool
@@ -132,6 +134,7 @@ func (c *Config) UnmarshalTOML(unmarshal func(interface{}) error) error {
 		SnapshotCache           *int
 		Preimages               *bool
 		FilterLogCacheSize      *int
+		FilterMaxAddresses      *int
 		Miner                   *miner.Config
 		TxPool                  *legacypool.Config
 		BlobPool                *blobpool.Config
@@ -230,6 +233,9 @@ func (c *Config) UnmarshalTOML(unmarshal func(interface{}) error) error {
 	}
 	if dec.FilterLogCacheSize != nil {
 		c.FilterLogCacheSize = *dec.FilterLogCacheSize
+	}
+	if dec.FilterMaxAddresses != nil {
+		c.FilterMaxAddresses = *dec.FilterMaxAddresses
 	}
 	if dec.Miner != nil {
 		c.Miner = *dec.Miner

--- a/eth/filters/api.go
+++ b/eth/filters/api.go
@@ -347,8 +347,15 @@ func (api *FilterAPI) GetLogs(ctx context.Context, crit FilterCriteria) ([]*type
 	if len(crit.Topics) > maxTopics {
 		return nil, errExceedMaxTopics
 	}
-	if len(crit.Addresses) > api.logQueryLimit {
-		return nil, errExceedLogQueryLimit
+	if api.logQueryLimit != 0 {
+		if len(crit.Addresses) > api.logQueryLimit {
+			return nil, errExceedLogQueryLimit
+		}
+		for _, topics := range crit.Topics {
+			if len(topics) > api.logQueryLimit {
+				return nil, errExceedLogQueryLimit
+			}
+		}
 	}
 
 	var filter *Filter

--- a/eth/filters/api_test.go
+++ b/eth/filters/api_test.go
@@ -19,7 +19,6 @@ package filters
 import (
 	"encoding/json"
 	"fmt"
-	"strings"
 	"testing"
 
 	"github.com/ethereum/go-ethereum/common"
@@ -182,16 +181,5 @@ func TestUnmarshalJSONNewFilterArgs(t *testing.T) {
 	}
 	if len(test7.Topics[2]) != 0 {
 		t.Fatalf("expected 0 topics, got %d topics", len(test7.Topics[2]))
-	}
-
-	// multiple address exceeding max
-	var test8 FilterCriteria
-	addresses := make([]string, maxAddresses+1)
-	for i := 0; i < maxAddresses+1; i++ {
-		addresses[i] = fmt.Sprintf(`"%s"`, common.HexToAddress(fmt.Sprintf("0x%x", i)).Hex())
-	}
-	vector = fmt.Sprintf(`{"address": [%s]}`, strings.Join(addresses, ", "))
-	if err := json.Unmarshal([]byte(vector), &test8); err != errExceedMaxAddresses {
-		t.Fatal("expected errExceedMaxAddresses, got", err)
 	}
 }

--- a/eth/filters/filter_system.go
+++ b/eth/filters/filter_system.go
@@ -53,9 +53,6 @@ func (cfg Config) withDefaults() Config {
 	if cfg.LogCacheSize == 0 {
 		cfg.LogCacheSize = 32
 	}
-	if cfg.LogQueryLimit == 0 {
-		cfg.LogQueryLimit = 1000
-	}
 	return cfg
 }
 

--- a/eth/filters/filter_system.go
+++ b/eth/filters/filter_system.go
@@ -43,6 +43,7 @@ import (
 type Config struct {
 	LogCacheSize int           // maximum number of cached blocks (default: 32)
 	Timeout      time.Duration // how long filters stay active (default: 5min)
+	MaxAddresses int           // maximum number of addresses allowed in filter criteria (default: 1000)
 }
 
 func (cfg Config) withDefaults() Config {
@@ -51,6 +52,9 @@ func (cfg Config) withDefaults() Config {
 	}
 	if cfg.LogCacheSize == 0 {
 		cfg.LogCacheSize = 32
+	}
+	if cfg.MaxAddresses == 0 {
+		cfg.MaxAddresses = 1000
 	}
 	return cfg
 }
@@ -291,7 +295,7 @@ func (es *EventSystem) SubscribeLogs(crit ethereum.FilterQuery, logs chan []*typ
 	if len(crit.Topics) > maxTopics {
 		return nil, errExceedMaxTopics
 	}
-	if len(crit.Addresses) > maxAddresses {
+	if len(crit.Addresses) > es.sys.cfg.MaxAddresses {
 		return nil, errExceedMaxAddresses
 	}
 	var from, to rpc.BlockNumber

--- a/eth/filters/filter_system.go
+++ b/eth/filters/filter_system.go
@@ -295,8 +295,15 @@ func (es *EventSystem) SubscribeLogs(crit ethereum.FilterQuery, logs chan []*typ
 	if len(crit.Topics) > maxTopics {
 		return nil, errExceedMaxTopics
 	}
-	if len(crit.Addresses) > es.sys.cfg.LogQueryLimit {
-		return nil, errExceedLogQueryLimit
+	if es.sys.cfg.LogQueryLimit != 0 {
+		if len(crit.Addresses) > es.sys.cfg.LogQueryLimit {
+			return nil, errExceedLogQueryLimit
+		}
+		for _, topics := range crit.Topics {
+			if len(topics) > es.sys.cfg.LogQueryLimit {
+				return nil, errExceedLogQueryLimit
+			}
+		}
 	}
 	var from, to rpc.BlockNumber
 	if crit.FromBlock == nil {

--- a/eth/filters/filter_system.go
+++ b/eth/filters/filter_system.go
@@ -41,9 +41,9 @@ import (
 
 // Config represents the configuration of the filter system.
 type Config struct {
-	LogCacheSize int           // maximum number of cached blocks (default: 32)
-	Timeout      time.Duration // how long filters stay active (default: 5min)
-	MaxAddresses int           // maximum number of addresses allowed in filter criteria (default: 1000)
+	LogCacheSize  int           // maximum number of cached blocks (default: 32)
+	Timeout       time.Duration // how long filters stay active (default: 5min)
+	LogQueryLimit int           // maximum number of addresses allowed in filter criteria (default: 1000)
 }
 
 func (cfg Config) withDefaults() Config {
@@ -53,8 +53,8 @@ func (cfg Config) withDefaults() Config {
 	if cfg.LogCacheSize == 0 {
 		cfg.LogCacheSize = 32
 	}
-	if cfg.MaxAddresses == 0 {
-		cfg.MaxAddresses = 1000
+	if cfg.LogQueryLimit == 0 {
+		cfg.LogQueryLimit = 1000
 	}
 	return cfg
 }
@@ -295,8 +295,8 @@ func (es *EventSystem) SubscribeLogs(crit ethereum.FilterQuery, logs chan []*typ
 	if len(crit.Topics) > maxTopics {
 		return nil, errExceedMaxTopics
 	}
-	if len(crit.Addresses) > es.sys.cfg.MaxAddresses {
-		return nil, errExceedMaxAddresses
+	if len(crit.Addresses) > es.sys.cfg.LogQueryLimit {
+		return nil, errExceedLogQueryLimit
 	}
 	var from, to rpc.BlockNumber
 	if crit.FromBlock == nil {

--- a/eth/filters/filter_system_test.go
+++ b/eth/filters/filter_system_test.go
@@ -456,7 +456,7 @@ func TestInvalidGetLogsRequest(t *testing.T) {
 			BaseFee: big.NewInt(params.InitialBaseFee),
 		}
 		db, blocks, _    = core.GenerateChainWithGenesis(genesis, ethash.NewFaker(), 10, func(i int, gen *core.BlockGen) {})
-		_, sys           = newTestFilterSystem(db, Config{})
+		_, sys           = newTestFilterSystem(db, Config{LogQueryLimit: 10})
 		api              = NewFilterAPI(sys)
 		blockHash        = blocks[0].Hash()
 		unknownBlockHash = common.HexToHash("0x1111111111111111111111111111111111111111111111111111111111111111")

--- a/eth/filters/filter_system_test.go
+++ b/eth/filters/filter_system_test.go
@@ -435,7 +435,7 @@ func TestInvalidLogFilterCreation(t *testing.T) {
 		1: {FromBlock: big.NewInt(rpc.PendingBlockNumber.Int64()), ToBlock: big.NewInt(100)},
 		2: {FromBlock: big.NewInt(rpc.LatestBlockNumber.Int64()), ToBlock: big.NewInt(100)},
 		3: {Topics: [][]common.Hash{{}, {}, {}, {}, {}}},
-		4: {Addresses: make([]common.Address, api.maxAddresses+1)},
+		4: {Addresses: make([]common.Address, api.logQueryLimit+1)},
 	}
 
 	for i, test := range testCases {
@@ -532,10 +532,10 @@ func TestInvalidGetRangeLogsRequest(t *testing.T) {
 func TestInvalidAddressLengthRequest(t *testing.T) {
 	t.Parallel()
 
-	// Test with custom config (MaxAddresses = 5 for easier testing)
+	// Test with custom config (LogQueryLimit = 5 for easier testing)
 	var (
 		db     = rawdb.NewMemoryDatabase()
-		_, sys = newTestFilterSystem(db, Config{MaxAddresses: 5})
+		_, sys = newTestFilterSystem(db, Config{LogQueryLimit: 5})
 		api    = NewFilterAPI(sys)
 	)
 
@@ -550,14 +550,14 @@ func TestInvalidAddressLengthRequest(t *testing.T) {
 		FromBlock: big.NewInt(0),
 		ToBlock:   big.NewInt(100),
 		Addresses: invalidAddresses,
-	}); err != errExceedMaxAddresses {
-		t.Errorf("Expected GetLogs with 6 addresses to return errExceedMaxAddresses, but got: %v", err)
+	}); err != errExceedLogQueryLimit {
+		t.Errorf("Expected GetLogs with 6 addresses to return errExceedLogQueryLimit, but got: %v", err)
 	}
 
 	// Test with default config should reject 1001 addresses
 	var (
 		db2     = rawdb.NewMemoryDatabase()
-		_, sys2 = newTestFilterSystem(db2, Config{}) // Uses default MaxAddresses = 1000
+		_, sys2 = newTestFilterSystem(db2, Config{}) // Uses default LogQueryLimit = 1000
 		api2    = NewFilterAPI(sys2)
 	)
 
@@ -571,8 +571,8 @@ func TestInvalidAddressLengthRequest(t *testing.T) {
 		FromBlock: big.NewInt(0),
 		ToBlock:   big.NewInt(100),
 		Addresses: tooManyAddresses,
-	}); err != errExceedMaxAddresses {
-		t.Errorf("Expected GetLogs with 1001 addresses to return errExceedMaxAddresses, but got: %v", err)
+	}); err != errExceedLogQueryLimit {
+		t.Errorf("Expected GetLogs with 1001 addresses to return errExceedLogQueryLimit, but got: %v", err)
 	}
 }
 


### PR DESCRIPTION
Add cli configurable limit for the number of addresses allowed in eth_getLogs filter criteria: https://github.com/ethereum/go-ethereum/issues/32264
 
 Key changes:
  - Added --rpc.getlogmaxaddrs CLI flag (default: 1000) to configure the maximum number of addresses
  - Updated ethconfig.Config with FilterMaxAddresses field for configuration management
  - Modified filter system to use the configurable limit instead of the hardcoded maxAddresses constant
  - Enhanced test coverage with new test cases for address limit validation
  - Removed hardcoded validation from JSON unmarshaling, moving it to runtime validation

Please notice that I remove the check at FilterCriteria UnmarshalJSON because the runtime config can not pass into this validation. 

Please help review this change!