### PR TITLE
eth/syncer: fix bugs in sync package

### DIFF
--- a/eth/syncer/syncer.go
+++ b/eth/syncer/syncer.go
@@ -119,7 +119,7 @@ func (s *Syncer) run() {
 					retries++
 					continue
 				}
-				// If the remote number is equal or bigger to the target, we don't need to resync.
+				// If the target number is smaller than the remote number, we don't need to sync.
 				if target != nil && header.Number.Cmp(target.Number) <= 0 {
 					log.Info("Syncer already synced", "hash", req.hash, "target", target)
 					req.errc <- nil

--- a/eth/syncer/syncer.go
+++ b/eth/syncer/syncer.go
@@ -119,13 +119,10 @@ func (s *Syncer) run() {
 					retries++
 					continue
 				}
+				// If the remote number is equal or bigger to the target, we don't need to resync.
 				if target != nil && header.Number.Cmp(target.Number) <= 0 {
-					// If the remote number is equal to the target, we don't need to resync.
-					if header.Number == target.Number {
-						req.errc <- nil
-					} else {
-						req.errc <- fmt.Errorf("stale sync target, current: %d, received: %d", target.Number, header.Number)
-					}
+					log.Info("Syncer already synced", "hash", req.hash, "target", target)
+					req.errc <- nil
 					break
 				}
 				target = header


### PR DESCRIPTION
1. ~~When the target number is smaller than the remote number, maybe it doesn't belong to the error condition.~~
2. In `exitWhenSynced == true` condition, after finished syncing, we should stop the `Sync` itself but not the `stack`?
3. Avoid being called by `Node` again after finishing `exitWhenSynced == true` condition.