### PR TITLE
chore: Fix various typos and grammatical errors

### DIFF
--- a/ethdb/database.go
+++ b/ethdb/database.go
@@ -152,7 +152,7 @@ type AncientWriter interface {
 	SyncAncient() error
 
 	// TruncateHead discards all but the first n ancient data from the ancient store.
-	// After the truncation, the latest item can be accessed it item_n-1(start from 0).
+	// After the truncation, the latest item can be accessed at item_n-1(start from 0).
 	TruncateHead(n uint64) (uint64, error)
 
 	// TruncateTail discards the first n ancient data from the ancient store. The already

--- a/ethdb/remotedb/remotedb.go
+++ b/ethdb/remotedb/remotedb.go
@@ -17,7 +17,7 @@
 // Package remotedb implements the key-value database layer based on a remote geth
 // node. Under the hood, it utilises the `debug_dbGet` method to implement a
 // read-only database.
-// There really are no guarantees in this database, since the local geth does not
+// There really are no guarantees in this database, since the local geth does not have
 // exclusive access, but it can be used for basic diagnostics of a remote node.
 package remotedb
 

--- a/event/multisub_test.go
+++ b/event/multisub_test.go
@@ -77,7 +77,7 @@ func TestMultisub(t *testing.T) {
 	}
 }
 
-func TestMutisubPartialUnsubscribe(t *testing.T) {
+func TestMultisubPartialUnsubscribe(t *testing.T) {
 	// Create a double subscription but terminate one half, ensuring no error
 	// is propagated yet up to the outer subscription
 	var (

--- a/miner/payload_building.go
+++ b/miner/payload_building.go
@@ -228,7 +228,7 @@ func (miner *Miner) buildPayload(args *BuildPayloadArgs, witness bool) (*Payload
 	payload := newPayload(empty.block, empty.requests, empty.witness, args.Id())
 
 	// Spin up a routine for updating the payload in background. This strategy
-	// can maximum the revenue for including transactions with highest fee.
+	// can maximize the revenue for including transactions with highest fee.
 	go func() {
 		// Setup the timer for re-building the payload. The initial clock is kept
 		// for triggering process immediately.

--- a/miner/payload_building.go
+++ b/miner/payload_building.go
@@ -65,7 +65,7 @@ func (args *BuildPayloadArgs) Id() engine.PayloadID {
 
 // Payload wraps the built payload(block waiting for sealing). According to the
 // engine-api specification, EL should build the initial version of the payload
-// which has an empty transaction set and then keep update it in order to maximize
+// which has an empty transaction set and then keep updating it in order to maximize
 // the revenue. Therefore, the empty-block here is always available and full-block
 // will be set/updated afterwards.
 type Payload struct {

--- a/node/config.go
+++ b/node/config.go
@@ -107,7 +107,7 @@ type Config struct {
 	HTTPHost string
 
 	// HTTPPort is the TCP port number on which to start the HTTP RPC server. The
-	// default zero value is/ valid and will pick a port number randomly (useful
+	// default zero value is valid and will pick a port number randomly (useful
 	// for ephemeral nodes).
 	HTTPPort int `toml:",omitempty"`
 
@@ -152,7 +152,7 @@ type Config struct {
 	WSHost string
 
 	// WSPort is the TCP port number on which to start the websocket RPC server. The
-	// default zero value is/ valid and will pick a port number randomly (useful for
+	// default zero value is valid and will pick a port number randomly (useful for
 	// ephemeral nodes).
 	WSPort int `toml:",omitempty"`
 

--- a/node/doc.go
+++ b/node/doc.go
@@ -19,7 +19,7 @@ Package node sets up multi-protocol Ethereum nodes.
 
 In the model exposed by this package, a node is a collection of services which use shared
 resources to provide RPC APIs. Services can also offer devp2p protocols, which are wired
-up to the devp2p network when the node instance is started.
+up the devp2p network when the node instance is started.
 
 # Node Lifecycle
 
@@ -62,7 +62,7 @@ data directory. The location of each resource can be overridden through addition
 configuration. The data directory is optional. If it is not set and the location of a
 resource is otherwise unspecified, package node will create the resource in memory.
 
-To access to the devp2p network, Node configures and starts p2p.Server. Each host on the
+To access the devp2p network, Node configures and starts p2p.Server. Each host on the
 devp2p network has a unique identifier, the node key. The Node instance persists this key
 across restarts. Node also loads static and trusted node lists and ensures that knowledge
 about other hosts is persisted.

--- a/node/doc.go
+++ b/node/doc.go
@@ -19,7 +19,7 @@ Package node sets up multi-protocol Ethereum nodes.
 
 In the model exposed by this package, a node is a collection of services which use shared
 resources to provide RPC APIs. Services can also offer devp2p protocols, which are wired
-up the devp2p network when the node instance is started.
+up to the devp2p network when the node instance is started.
 
 # Node Lifecycle
 


### PR DESCRIPTION
ethdb/remotedb/remotedb.go: 
`does not` -> `does not have`


ethdb/database.go: 
`it` -> `at`


event/multisub_test.go: 
`TestMutisub...` -> `TestMultisub...`


miner/payload_building.go: 
`keep update` -> `keep updating` and `maximum` -> `maximize`


node/doc.go: 
`To access to` -> `To access`


node/config.go: 
`is/ valid` -> `is valid`

