### PR TITLE
eth/gasestimator: check ErrGasLimitTooHigh conditions

### DIFF
--- a/eth/ethconfig/config.go
+++ b/eth/ethconfig/config.go
@@ -65,7 +65,7 @@ var Defaults = Config{
 	Miner:              miner.DefaultConfig,
 	TxPool:             legacypool.DefaultConfig,
 	BlobPool:           blobpool.DefaultConfig,
-	RPCGasCap:          params.MaxTxGas,
+	RPCGasCap:          50000000,
 	RPCEVMTimeout:      5 * time.Second,
 	GPO:                FullNodeGPO,
 	RPCTxFeeCap:        1, // 1 ether

--- a/eth/ethconfig/config.go
+++ b/eth/ethconfig/config.go
@@ -65,7 +65,7 @@ var Defaults = Config{
 	Miner:              miner.DefaultConfig,
 	TxPool:             legacypool.DefaultConfig,
 	BlobPool:           blobpool.DefaultConfig,
-	RPCGasCap:          30000000,
+	RPCGasCap:          params.MaxTxGas,
 	RPCEVMTimeout:      5 * time.Second,
 	GPO:                FullNodeGPO,
 	RPCTxFeeCap:        1, // 1 ether

--- a/eth/ethconfig/config.go
+++ b/eth/ethconfig/config.go
@@ -65,7 +65,7 @@ var Defaults = Config{
 	Miner:              miner.DefaultConfig,
 	TxPool:             legacypool.DefaultConfig,
 	BlobPool:           blobpool.DefaultConfig,
-	RPCGasCap:          50000000,
+	RPCGasCap:          30000000,
 	RPCEVMTimeout:      5 * time.Second,
 	GPO:                FullNodeGPO,
 	RPCTxFeeCap:        1, // 1 ether

--- a/eth/gasestimator/gasestimator.go
+++ b/eth/gasestimator/gasestimator.go
@@ -62,9 +62,23 @@ func Estimate(ctx context.Context, call *core.Message, opts *Options, gasCap uin
 	if call.GasLimit >= params.TxGas {
 		hi = call.GasLimit
 	}
-	if hi >= params.MaxTxGas {
-		hi = params.MaxTxGas
+
+	// Cap the maximum gas allowance according to EIP-7825 if the estimation targets Osaka
+	if hi > params.MaxTxGas {
+		blockNumber, blockTime := opts.Header.Number, opts.Header.Time
+		if opts.BlockOverrides != nil {
+			if opts.BlockOverrides.Number != nil {
+				blockNumber = opts.BlockOverrides.Number.ToInt()
+			}
+			if opts.BlockOverrides.Time != nil {
+				blockTime = uint64(*opts.BlockOverrides.Time)
+			}
+		}
+		if opts.Config.IsOsaka(blockNumber, blockTime) {
+			hi = params.MaxTxGas
+		}
 	}
+
 	// Normalize the max fee per gas the call is willing to spend.
 	var feeCap *big.Int
 	if call.GasFeeCap != nil {

--- a/eth/gasestimator/gasestimator.go
+++ b/eth/gasestimator/gasestimator.go
@@ -62,6 +62,9 @@ func Estimate(ctx context.Context, call *core.Message, opts *Options, gasCap uin
 	if call.GasLimit >= params.TxGas {
 		hi = call.GasLimit
 	}
+	if hi >= params.MaxTxGas {
+		hi = params.MaxTxGas
+	}
 	// Normalize the max fee per gas the call is willing to spend.
 	var feeCap *big.Int
 	if call.GasFeeCap != nil {
@@ -208,6 +211,9 @@ func execute(ctx context.Context, call *core.Message, opts *Options, gasLimit ui
 	if err != nil {
 		if errors.Is(err, core.ErrIntrinsicGas) {
 			return true, nil, nil // Special case, raise gas limit
+		}
+		if errors.Is(err, core.ErrGasLimitTooHigh) {
+			return true, nil, nil // Special case, lower gas limit
 		}
 		return true, nil, err // Bail out
 	}

--- a/internal/ethapi/override/override_test.go
+++ b/internal/ethapi/override/override_test.go
@@ -31,6 +31,10 @@ import (
 
 type precompileContract struct{}
 
+func (p *precompileContract) Name() string {
+	panic("implement me")
+}
+
 func (p *precompileContract) RequiredGas(input []byte) uint64 { return 0 }
 
 func (p *precompileContract) Run(input []byte) ([]byte, error) { return nil, nil }


### PR DESCRIPTION
This PR makes 2 changes to how [EIP-7825](https://github.com/ethereum/go-ethereum/pull/31824) behaves. 

When `eth_estimateGas` or `eth_createAccessList` is called without any gas limit in the payload, geth will choose the block's gas limit or the `RPCGasCap`, which can be larger than the `maxTxGas`. 

When this happens for `estimateGas`, the gas estimation just errors out and ends, when it should continue doing binary search to find the lowest possible gas limit. 

This PR will: 
- Add a check to see if `hi` is larger than `maxTxGas` and cap it to `maxTxGas` if it's larger. And add a special case handling for gas estimation execute when it errs with `ErrGasLimitTooHigh`

- Decrease the `RPCGasCap` to 30M (== maxTxGas) to make `createAccessList` choose 30M as the highest gas cap for the tx. This can also be fixed by adding a check like this to use `maxTxGas` when the specified `RPCGasCap` is larger than `maxTxGas`. I'd be glad to fix it either way!
```
gasCap :=b.RPCGasCap()  
if gasCap > params.MaxTxGas { 
    gasCap = params.MaxTxGas
}
```

> A duplicate of https://github.com/ethereum/go-ethereum/pull/32268