### PR TITLE
eth/downloader: fix incomplete code comment 

### DIFF
--- a/eth/downloader/api.go
+++ b/eth/downloader/api.go
@@ -200,7 +200,7 @@ func (s *SyncStatusSubscription) Unsubscribe() {
 }
 
 // SubscribeSyncStatus creates a subscription that will broadcast new synchronisation updates.
-// The given channel must receive interface values, the result can either.
+// The given channel must receive interface values, the result can either be a SyncingResult or false.
 func (api *DownloaderAPI) SubscribeSyncStatus(status chan interface{}) *SyncStatusSubscription {
 	api.installSyncSubscription <- status
 	return &SyncStatusSubscription{api: api, c: status}


### PR DESCRIPTION
Fix incomplete comment in SubscribeSyncStatus function

The comment on line 203 was cut off mid-sentence. Completed the comment
to properly describe that the function can return either a SyncingResult
or false depending on the synchronization status.

- Line 205: "the result can either" -> "the result can either be a SyncingResult or false"