### PR TITLE
core/vm: modexp fix for 7823

### DIFF
--- a/core/vm/contracts.go
+++ b/core/vm/contracts.go
@@ -500,22 +500,30 @@ func (c *bigModExp) RequiredGas(input []byte) uint64 {
 
 func (c *bigModExp) Run(input []byte) ([]byte, error) {
 	var (
-		baseLen = new(big.Int).SetBytes(getData(input, 0, 32)).Uint64()
-		expLen  = new(big.Int).SetBytes(getData(input, 32, 32)).Uint64()
-		modLen  = new(big.Int).SetBytes(getData(input, 64, 32)).Uint64()
+		baseLenBig = new(big.Int).SetBytes(getData(input, 0, 32))
+		expLenBig  = new(big.Int).SetBytes(getData(input, 32, 32))
+		modLenBig  = new(big.Int).SetBytes(getData(input, 64, 32))
+		baseLen    = baseLenBig.Uint64()
+		expLen     = expLenBig.Uint64()
+		modLen     = modLenBig.Uint64()
 	)
 	if len(input) > 96 {
 		input = input[96:]
 	} else {
 		input = input[:0]
 	}
+
+	inputLensHighBitsSet := baseLenBig.Rsh(baseLenBig, 64).Cmp(common.Big0) != 0 ||
+		expLenBig.Rsh(expLenBig, 64).Cmp(common.Big0) != 0 ||
+		modLenBig.Rsh(modLenBig, 64).Cmp(common.Big0) != 0
+
+	// enforce size cap for inputs
+	if c.eip7823 && (max(baseLen, expLen, modLen) > 1024 || inputLensHighBitsSet) {
+		return nil, errors.New("one or more of base/exponent/modulus length exceeded 1024 bytes")
+	}
 	// Handle a special case when both the base and mod length is zero
 	if baseLen == 0 && modLen == 0 {
 		return []byte{}, nil
-	}
-	// enforce size cap for inputs
-	if c.eip7823 && max(baseLen, expLen, modLen) > 1024 {
-		return nil, errors.New("one or more of base/exponent/modulus length exceeded 1024 bytes")
 	}
 	// Retrieve the operands and execute the exponentiation
 	var (


### PR DESCRIPTION
The order of the checks was wrong which would have allowed a call to modexp with `baseLen == 0 && modLen == 0` post fusaka.

Also handles an edge case where base/mod/exp length >= 2**64