### PR TITLE
core/vm/evm.go fix typo in comments

### DIFF
--- a/core/vm/evm.go
+++ b/core/vm/evm.go
@@ -186,7 +186,7 @@ func isSystemCall(caller common.Address) bool {
 }
 
 // Call executes the contract associated with the addr with the given input as
-// parameters. It also handles any necessary value transfer required and takse
+// parameters. It also handles any necessary value transfer required and takes 
 // the necessary steps to create accounts and reverses the state in case of an
 // execution error or failed value transfer.
 func (evm *EVM) Call(caller common.Address, addr common.Address, input []byte, gas uint64, value *uint256.Int) (ret []byte, leftOverGas uint64, err error) {


### PR DESCRIPTION
line:189 "transfer required ans takse"

"takse" -> "takes"