### PR TITLE
core: reduce memory and cpu usage in state prefetching

### DIFF
--- a/core/state_prefetcher.go
+++ b/core/state_prefetcher.go
@@ -111,12 +111,9 @@ func (p *statePrefetcher) Prefetch(block *types.Block, statedb *state.StateDB, c
 				fails.Add(1)
 				return nil // Ugh, something went horribly wrong, bail out
 			}
-			// Pre-load trie nodes for the intermediate root.
-			//
-			// This operation incurs significant memory allocations due to
-			// trie hashing and node decoding. TODO(rjl493456442): investigate
-			// ways to mitigate this overhead.
-			stateCpy.IntermediateRoot(true)
+			// Pre-load trie nodes for cache warming without computing the actual
+			// intermediate root hash, reducing memory allocations and cpu cost from hashing.
+			stateCpy.IntermediateRootPrefetch(true)
 			return nil
 		})
 	}
@@ -124,5 +121,4 @@ func (p *statePrefetcher) Prefetch(block *types.Block, statedb *state.StateDB, c
 
 	blockPrefetchTxsValidMeter.Mark(int64(len(block.Transactions())) - fails.Load())
 	blockPrefetchTxsInvalidMeter.Mark(fails.Load())
-	return
 }


### PR DESCRIPTION
Skip the hashing in prefetch mode, as the prefetching is only used to cache nodes, no need to calculate the hash, the hash maybe also be recalculated again.