### PR TITLE
eth/downloader: skip nil peer in GetHeader

### DIFF
--- a/eth/downloader/beacondevsync.go
+++ b/eth/downloader/beacondevsync.go
@@ -52,6 +52,7 @@ func (d *Downloader) GetHeader(hash common.Hash) (*types.Header, error) {
 
 	for _, peer := range d.peers.peers {
 		if peer == nil {
+			log.Warn("Encountered nil peer while retrieving sync target", "hash", hash)
 			continue
 		}
 		// Found a peer, attempt to retrieve the header whilst blocking and

--- a/eth/downloader/beacondevsync.go
+++ b/eth/downloader/beacondevsync.go
@@ -52,7 +52,7 @@ func (d *Downloader) GetHeader(hash common.Hash) (*types.Header, error) {
 
 	for _, peer := range d.peers.peers {
 		if peer == nil {
-			return nil, errors.New("could not find peer")
+			continue
 		}
 		// Found a peer, attempt to retrieve the header whilst blocking and
 		// retry if it fails for whatever reason


### PR DESCRIPTION
The GetHeader function was incorrectly returning an error when encountering
nil peers in the peers list, which contradicted the comment "keep retrying
if none are yet available". 

Changed the logic to skip nil peers with 'continue' instead of returning
an error, allowing the function to properly iterate through all available
peers and attempt to retrieve the target header from each valid peer.

This ensures the function behaves as intended - trying all available peers
before giving up, rather than failing on the first nil peer encountered.