### PR TITLE
core/vm: opt opPushx

### DIFF
--- a/core/vm/instructions.go
+++ b/core/vm/instructions.go
@@ -990,12 +990,9 @@ func makePush(size uint64, pushByteSize int) executionFunc {
 			start   = min(codeLen, int(*pc+1))
 			end     = min(codeLen, start+pushByteSize)
 		)
-		a := new(uint256.Int).SetBytes(scope.Contract.Code[start:end])
-
-		// Missing bytes: pushByteSize - len(pushData)
-		if missing := pushByteSize - (end - start); missing > 0 {
-			a.Lsh(a, uint(8*missing))
-		}
+		var b [32]byte
+		copy(b[:], scope.Contract.Code[start:end])
+		a := new(uint256.Int).SetBytes(b[:pushByteSize])
 		scope.Stack.push(a)
 		*pc += size
 		return nil, nil

--- a/core/vm/instructions_test.go
+++ b/core/vm/instructions_test.go
@@ -973,6 +973,25 @@ func TestPush(t *testing.T) {
 	}
 }
 
+func BenchmarkPush(b *testing.B) {
+	code := common.FromHex("ff")
+
+	push32 := makePush(32, 32)
+
+	scope := &ScopeContext{
+		Memory: nil,
+		Stack:  newstack(),
+		Contract: &Contract{
+			Code: code,
+		},
+	}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		pc := new(uint64)
+		_, _ = push32(pc, nil, scope)
+	}
+}
+
 func TestOpCLZ(t *testing.T) {
 	evm := NewEVM(BlockContext{}, nil, params.TestChainConfig, Config{})
 


### PR DESCRIPTION
name     old time/op    new time/op    delta
Push-10    40.7ns ±41%    37.5ns ±32%  -8.01%  (p=0.030 n=50+46)

name     old alloc/op   new alloc/op   delta
Push-10      176B ±12%      183B ±10%  +4.02%  (p=0.002 n=50+50)

name     old allocs/op  new allocs/op  delta
Push-10      0.00           0.00         ~     (all equal)
