### PR TITLE
ethclient: fix flaky pending tx test

### DIFF
--- a/ethclient/ethclient_test.go
+++ b/ethclient/ethclient_test.go
@@ -110,6 +110,12 @@ func newTestBackend(config *node.Config) (*node.Node, []*types.Block, error) {
 	if err != nil {
 		return nil, nil, fmt.Errorf("can't create new ethereum service: %v", err)
 	}
+	// Ensure tx pool starts the background operation
+	txPool := ethservice.TxPool()
+	if err = txPool.Sync(); err != nil {
+		return nil, nil, fmt.Errorf("can't sync transaction pool: %v", err)
+	}
+
 	// Import the test chain.
 	if err := n.Start(); err != nil {
 		return nil, nil, fmt.Errorf("can't start test node: %v", err)
@@ -506,8 +512,9 @@ func testAtFunctions(t *testing.T, client *rpc.Client) {
 	}
 
 	// send a transaction for some interesting pending status
-	// and wait for the transaction to be included in the pending block
-	sendTransaction(ec)
+	if err := sendTransaction(ec); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
 
 	// wait for the transaction to be included in the pending block
 	for {


### PR DESCRIPTION
Fixes: https://github.com/ethereum/go-ethereum/issues/32252

This PR fixes an issue where testAtFunctions fails because of timeout.

## Cause
The issue caused by infinite loop in the test here: https://github.com/ethereum/go-ethereum/blob/c3ef6c77c24956ebe1156205869259ffb8892486/ethclient/ethclient_test.go#L513-L523

Although the transaction is sent to the backend, it sometimes keeps returning a pending transaction count of `0`, never reaching the break condition. I was able to reproduce this failure locally, albeit rarely—about 1 in every 1000 test runs.

In the successful cases, `pendingNonceAt` returns `2`, which is consistent with inserting a block containing two transactions via `InsertChain` when initializing the test backend. However, in the failing cases, `pendingNonceAt` returns `0`.

## Root Cause

The issue is caused by a race condition between invoking `InsertChain` and  the startup of the txpool's background process that updates subpool `pendingNonces` when initializing test backend.

The failure occurs because the `pendingNonces` inside the `txPool`'s `subpools` does not have the correct nonce information. This is due to the fact that when the blocks are inserted via `InsertChain`, the [txpool.loop()](https://github.com/ethereum/go-ethereum/blob/c3ef6c77c24956ebe1156205869259ffb8892486/core/txpool/txpool.go#L148)  has not yet started running, so the background processing that updates the state does not occur.

In the regular cases, `txpool.loop` receives the updated head when the blocks are inserted, triggering `subpool.Reset(oldHead, newHead)`. Then, inside `LegacyPool.runReorg`, `pendingNonces` is properly updated.
In the failure pattern, however, blocks are ALWAYS inserted before `txpool.loop()` has started, so `pendingNonces` is never updated.

## Reproduction

The issue can be reliably reproduced by adding `time.Sleep(1 * time.Second)` at the beginning of `txpool.loop`. This delay causes the test to consistently fail, confirming the presence of a race condition.

## Solution

I found that we already have a handy function `txpool.Sync()` to wait for txpool starting its background loop. We can use it and fix the flakyness.