### PR TITLE
downloader/queue_test: correct makeChain comment to match implementation

### DIFF
--- a/eth/downloader/queue_test.go
+++ b/eth/downloader/queue_test.go
@@ -36,13 +36,13 @@ import (
 )
 
 // makeChain creates a chain of n blocks starting at and including parent.
-// the returned hash chain is ordered head->parent. In addition, every 3rd block
-// contains a transaction and every 5th an uncle to allow testing correct block
-// reassembly.
+// The returned hash chain is ordered head->parent.
+// If empty is false, every second block (i%2==0) contains one transaction.
+// No uncles are added.
 func makeChain(n int, seed byte, parent *types.Block, empty bool) ([]*types.Block, []types.Receipts) {
 	blocks, receipts := core.GenerateChain(params.TestChainConfig, parent, ethash.NewFaker(), testDB, n, func(i int, block *core.BlockGen) {
 		block.SetCoinbase(common.Address{seed})
-		// Add one tx to every secondblock
+		// Add one tx to every second block
 		if !empty && i%2 == 0 {
 			signer := types.MakeSigner(params.TestChainConfig, block.Number(), block.Timestamp())
 			tx, err := types.SignTx(types.NewTransaction(block.TxNonce(testAddress), common.Address{seed}, big.NewInt(1000), params.TxGas, block.BaseFee(), nil), signer, testKey)


### PR DESCRIPTION
The previous comment stated that every 3rd block has a tx and every 5th has an uncle.
The implementation actually adds one transaction to every second block and does not add uncles.
Updated the comment to reflect the real behavior to avoid confusion when reading tests.