### PR TITLE
ethdb/leveldb: check iterator error in Database.DeleteRange

### DIFF
--- a/ethdb/leveldb/leveldb.go
+++ b/ethdb/leveldb/leveldb.go
@@ -233,6 +233,9 @@ func (db *Database) DeleteRange(start, end []byte) error {
 			return err
 		}
 	}
+	if err := it.Error(); err != nil {
+		return err
+	}
 	return batch.Write()
 }
 


### PR DESCRIPTION
Add missing it.Error() check after iteration in Database.DeleteRange to avoid silently 
ignoring iterator errors before writing the batch.

Aligns behavior with batch.DeleteRange, which already validates iterator errors.
No other functional changes; existing tests pass (TestLevelDB).