### PR TITLE
p2p: remove todo comment, as it's unnecessary

### DIFF
--- a/p2p/peer.go
+++ b/p2p/peer.go
@@ -173,7 +173,6 @@ func (p *Peer) Fullname() string {
 
 // Caps returns the capabilities (supported subprotocols) of the remote peer.
 func (p *Peer) Caps() []Cap {
-	// TODO: maybe return copy
 	return p.rw.caps
 }
 


### PR DESCRIPTION
as metioned in https://github.com/ethereum/go-ethereum/pull/32351,  I think this comment is unnecessary.