### PR TITLE
ethclient/gethclient: use common.Hash to debug_traceTransaction

### DIFF
--- a/ethclient/gethclient/gethclient.go
+++ b/ethclient/gethclient/gethclient.go
@@ -209,7 +209,7 @@ func (ec *Client) SubscribePendingTransactions(ctx context.Context, ch chan<- co
 // and returns them as a JSON object.
 func (ec *Client) TraceTransaction(ctx context.Context, hash common.Hash, config *tracers.TraceConfig) (any, error) {
 	var result any
-	err := ec.c.CallContext(ctx, &result, "debug_traceTransaction", hash.Hex(), config)
+	err := ec.c.CallContext(ctx, &result, "debug_traceTransaction", hash, config)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION

- Unifies hash argument encoding: TraceTransaction now passes common.Hash directly, matching TraceBlock and other RPC calls.
- Leverages common.Hash JSON marshaling (0x‑prefixed hex via MarshalText); no functional change expected. 
- Aligns with RPC handler signature (tracers.API.TraceBlockByHash(ctx, hash common.Hash, ...)) and existing ethclient usage (e.g., eth_getBlockByHash, eth_getTransactionByHash). 
- Simplifies code by avoiding unnecessary Hex() conversion and improves consistency/readability.