### PR TITLE
fix: correct error message

### DIFF
--- a/consensus/misc/gaslimit.go
+++ b/consensus/misc/gaslimit.go
@@ -32,7 +32,7 @@ func VerifyGaslimit(parentGasLimit, headerGasLimit uint64) error {
 	}
 	limit := parentGasLimit / params.GasLimitBoundDivisor
 	if uint64(diff) >= limit {
-		return fmt.Errorf("invalid gas limit: have %d, want %d +-= %d", headerGasLimit, parentGasLimit, limit-1)
+		return fmt.Errorf("invalid gas limit: have %d, want %d +/- %d", headerGasLimit, parentGasLimit, limit-1)
 	}
 	if headerGasLimit < params.MinGasLimit {
 		return fmt.Errorf("invalid gas limit below %d", params.MinGasLimit)


### PR DESCRIPTION
## Description

Correct symmetric tolerance in gas limit validation:
Replace ambiguous "+-=" with standard "+/-" in the error message.
Logic rejects when |header − parent| ≥ limit, so allowed range is |Δ| ≤ limit − 1.

No logic or functionality has been modified.