### PR TITLE
refactor: use the built-in max/min to simplify the code

### DIFF
--- a/common/bitutil/bitutil.go
+++ b/common/bitutil/bitutil.go
@@ -27,10 +27,7 @@ func XORBytes(dst, a, b []byte) int {
 // fastXORBytes xors in bulk. It only works on architectures that support
 // unaligned read/writes.
 func fastXORBytes(dst, a, b []byte) int {
-	n := len(a)
-	if len(b) < n {
-		n = len(b)
-	}
+	n := min(len(b), len(a))
 	w := n / wordSize
 	if w > 0 {
 		dw := *(*[]uintptr)(unsafe.Pointer(&dst))
@@ -49,10 +46,7 @@ func fastXORBytes(dst, a, b []byte) int {
 // safeXORBytes xors one by one. It works on all architectures, independent if
 // it supports unaligned read/writes or not.
 func safeXORBytes(dst, a, b []byte) int {
-	n := len(a)
-	if len(b) < n {
-		n = len(b)
-	}
+	n := min(len(b), len(a))
 	for i := 0; i < n; i++ {
 		dst[i] = a[i] ^ b[i]
 	}
@@ -71,10 +65,7 @@ func ANDBytes(dst, a, b []byte) int {
 // fastANDBytes ands in bulk. It only works on architectures that support
 // unaligned read/writes.
 func fastANDBytes(dst, a, b []byte) int {
-	n := len(a)
-	if len(b) < n {
-		n = len(b)
-	}
+	n := min(len(b), len(a))
 	w := n / wordSize
 	if w > 0 {
 		dw := *(*[]uintptr)(unsafe.Pointer(&dst))
@@ -93,10 +84,7 @@ func fastANDBytes(dst, a, b []byte) int {
 // safeANDBytes ands one by one. It works on all architectures, independent if
 // it supports unaligned read/writes or not.
 func safeANDBytes(dst, a, b []byte) int {
-	n := len(a)
-	if len(b) < n {
-		n = len(b)
-	}
+	n := min(len(b), len(a))
 	for i := 0; i < n; i++ {
 		dst[i] = a[i] & b[i]
 	}
@@ -115,10 +103,7 @@ func ORBytes(dst, a, b []byte) int {
 // fastORBytes ors in bulk. It only works on architectures that support
 // unaligned read/writes.
 func fastORBytes(dst, a, b []byte) int {
-	n := len(a)
-	if len(b) < n {
-		n = len(b)
-	}
+	n := min(len(b), len(a))
 	w := n / wordSize
 	if w > 0 {
 		dw := *(*[]uintptr)(unsafe.Pointer(&dst))
@@ -137,10 +122,7 @@ func fastORBytes(dst, a, b []byte) int {
 // safeORBytes ors one by one. It works on all architectures, independent if
 // it supports unaligned read/writes or not.
 func safeORBytes(dst, a, b []byte) int {
-	n := len(a)
-	if len(b) < n {
-		n = len(b)
-	}
+	n := min(len(b), len(a))
 	for i := 0; i < n; i++ {
 		dst[i] = a[i] | b[i]
 	}

--- a/common/fdlimit/fdlimit_darwin.go
+++ b/common/fdlimit/fdlimit_darwin.go
@@ -31,10 +31,7 @@ func Raise(max uint64) (uint64, error) {
 		return 0, err
 	}
 	// Try to update the limit to the max allowance
-	limit.Cur = limit.Max
-	if limit.Cur > max {
-		limit.Cur = max
-	}
+	limit.Cur = min(limit.Max, max)
 	if err := syscall.Setrlimit(syscall.RLIMIT_NOFILE, &limit); err != nil {
 		return 0, err
 	}

--- a/common/hexutil/hexutil.go
+++ b/common/hexutil/hexutil.go
@@ -146,10 +146,7 @@ func DecodeBig(input string) (*big.Int, error) {
 	words := make([]big.Word, len(raw)/bigWordNibbles+1)
 	end := len(raw)
 	for i := range words {
-		start := end - bigWordNibbles
-		if start < 0 {
-			start = 0
-		}
+		start := max(end-bigWordNibbles, 0)
 		for ri := start; ri < end; ri++ {
 			nib := decodeNibble(raw[ri])
 			if nib == badNibble {

--- a/common/hexutil/json.go
+++ b/common/hexutil/json.go
@@ -179,10 +179,7 @@ func (b *Big) UnmarshalText(input []byte) error {
 	words := make([]big.Word, len(raw)/bigWordNibbles+1)
 	end := len(raw)
 	for i := range words {
-		start := end - bigWordNibbles
-		if start < 0 {
-			start = 0
-		}
+		start := max(end-bigWordNibbles, 0)
 		for ri := start; ri < end; ri++ {
 			nib := decodeNibble(raw[ri])
 			if nib == badNibble {


### PR DESCRIPTION
In Go 1.21, the standard library includes built-in [max/min](https://pkg.go.dev/builtin@go1.21.0#max) function, which can greatly simplify the code.
