### PR TITLE
core/vm: generic not-traced EVM implementation

### DIFF
--- a/core/vm/contract.go
+++ b/core/vm/contract.go
@@ -18,7 +18,6 @@ package vm
 
 import (
 	"github.com/ethereum/go-ethereum/common"
-	"github.com/ethereum/go-ethereum/core/tracing"
 	"github.com/holiman/uint256"
 )
 
@@ -123,29 +122,6 @@ func (c *Contract) GetOp(n uint64) OpCode {
 // call, including that of caller's caller.
 func (c *Contract) Caller() common.Address {
 	return c.caller
-}
-
-// UseGas attempts the use gas and subtracts it and returns true on success
-func (c *Contract) UseGas(gas uint64, logger *tracing.Hooks, reason tracing.GasChangeReason) (ok bool) {
-	if c.Gas < gas {
-		return false
-	}
-	if logger != nil && logger.OnGasChange != nil && reason != tracing.GasChangeIgnored {
-		logger.OnGasChange(c.Gas, c.Gas-gas, reason)
-	}
-	c.Gas -= gas
-	return true
-}
-
-// RefundGas refunds gas to the contract
-func (c *Contract) RefundGas(gas uint64, logger *tracing.Hooks, reason tracing.GasChangeReason) {
-	if gas == 0 {
-		return
-	}
-	if logger != nil && logger.OnGasChange != nil && reason != tracing.GasChangeIgnored {
-		logger.OnGasChange(c.Gas, c.Gas+gas, reason)
-	}
-	c.Gas += gas
 }
 
 // Address returns the contracts address

--- a/core/vm/contracts.go
+++ b/core/vm/contracts.go
@@ -257,12 +257,12 @@ func ActivePrecompiles(rules params.Rules) []common.Address {
 // - the returned bytes,
 // - the _remaining_ gas,
 // - any error that occurred
-func RunPrecompiledContract(p PrecompiledContract, input []byte, suppliedGas uint64, logger *tracing.Hooks) (ret []byte, remainingGas uint64, err error) {
+func RunPrecompiledContract[TS TracingSwitch](p PrecompiledContract, input []byte, suppliedGas uint64, logger *tracing.Hooks) (ret []byte, remainingGas uint64, err error) {
 	gasCost := p.RequiredGas(input)
 	if suppliedGas < gasCost {
 		return nil, 0, ErrOutOfGas
 	}
-	if logger != nil && logger.OnGasChange != nil {
+	if tracingIsEnabled[TS]() && logger.OnGasChange != nil {
 		logger.OnGasChange(suppliedGas, suppliedGas-gasCost, tracing.GasChangeCallPrecompiledContract)
 	}
 	suppliedGas -= gasCost

--- a/core/vm/contracts_fuzz_test.go
+++ b/core/vm/contracts_fuzz_test.go
@@ -36,7 +36,7 @@ func FuzzPrecompiledContracts(f *testing.F) {
 			return
 		}
 		inWant := string(input)
-		RunPrecompiledContract(p, input, gas, nil)
+		RunPrecompiledContract[TracingDisabled](p, input, gas, nil)
 		if inHave := string(input); inWant != inHave {
 			t.Errorf("Precompiled %v modified input data", a)
 		}

--- a/core/vm/contracts_test.go
+++ b/core/vm/contracts_test.go
@@ -99,7 +99,7 @@ func testPrecompiled(addr string, test precompiledTest, t *testing.T) {
 	in := common.Hex2Bytes(test.Input)
 	gas := p.RequiredGas(in)
 	t.Run(fmt.Sprintf("%s-Gas=%d", test.Name, gas), func(t *testing.T) {
-		if res, _, err := RunPrecompiledContract(p, in, gas, nil); err != nil {
+		if res, _, err := RunPrecompiledContract[TracingDisabled](p, in, gas, nil); err != nil {
 			t.Error(err)
 		} else if common.Bytes2Hex(res) != test.Expected {
 			t.Errorf("Expected %v, got %v", test.Expected, common.Bytes2Hex(res))
@@ -121,7 +121,7 @@ func testPrecompiledOOG(addr string, test precompiledTest, t *testing.T) {
 	gas := p.RequiredGas(in) - 1
 
 	t.Run(fmt.Sprintf("%s-Gas=%d", test.Name, gas), func(t *testing.T) {
-		_, _, err := RunPrecompiledContract(p, in, gas, nil)
+		_, _, err := RunPrecompiledContract[TracingDisabled](p, in, gas, nil)
 		if err.Error() != "out of gas" {
 			t.Errorf("Expected error [out of gas], got [%v]", err)
 		}
@@ -138,7 +138,7 @@ func testPrecompiledFailure(addr string, test precompiledFailureTest, t *testing
 	in := common.Hex2Bytes(test.Input)
 	gas := p.RequiredGas(in)
 	t.Run(test.Name, func(t *testing.T) {
-		_, _, err := RunPrecompiledContract(p, in, gas, nil)
+		_, _, err := RunPrecompiledContract[TracingDisabled](p, in, gas, nil)
 		if err.Error() != test.ExpectedError {
 			t.Errorf("Expected error [%v], got [%v]", test.ExpectedError, err)
 		}
@@ -170,7 +170,7 @@ func benchmarkPrecompiled(addr string, test precompiledTest, bench *testing.B) {
 		bench.ResetTimer()
 		for i := 0; i < bench.N; i++ {
 			copy(data, in)
-			res, _, err = RunPrecompiledContract(p, data, reqGas, nil)
+			res, _, err = RunPrecompiledContract[TracingDisabled](p, data, reqGas, nil)
 		}
 		bench.StopTimer()
 		elapsed := uint64(time.Since(start))

--- a/core/vm/jump_table.go
+++ b/core/vm/jump_table.go
@@ -48,21 +48,21 @@ type operation struct {
 }
 
 var (
-	frontierInstructionSet         = newFrontierInstructionSet()
-	homesteadInstructionSet        = newHomesteadInstructionSet()
-	tangerineWhistleInstructionSet = newTangerineWhistleInstructionSet()
-	spuriousDragonInstructionSet   = newSpuriousDragonInstructionSet()
-	byzantiumInstructionSet        = newByzantiumInstructionSet()
-	constantinopleInstructionSet   = newConstantinopleInstructionSet()
-	istanbulInstructionSet         = newIstanbulInstructionSet()
-	berlinInstructionSet           = newBerlinInstructionSet()
-	londonInstructionSet           = newLondonInstructionSet()
-	mergeInstructionSet            = newMergeInstructionSet()
-	shanghaiInstructionSet         = newShanghaiInstructionSet()
-	cancunInstructionSet           = newCancunInstructionSet()
-	verkleInstructionSet           = newVerkleInstructionSet()
-	pragueInstructionSet           = newPragueInstructionSet()
-	osakaInstructionSet            = newOsakaInstructionSet()
+	frontierInstructionSet, frontierInstructionSetNT                 = newFrontierInstructionSet[TracingEnabled](), newFrontierInstructionSet[TracingDisabled]()
+	homesteadInstructionSet, homesteadInstructionSetNT               = newHomesteadInstructionSet[TracingEnabled](), newHomesteadInstructionSet[TracingDisabled]()
+	tangerineWhistleInstructionSet, tangerineWhistleInstructionSetNT = newTangerineWhistleInstructionSet[TracingEnabled](), newTangerineWhistleInstructionSet[TracingDisabled]()
+	spuriousDragonInstructionSet, spuriousDragonInstructionSetNT     = newSpuriousDragonInstructionSet[TracingEnabled](), newSpuriousDragonInstructionSet[TracingDisabled]()
+	byzantiumInstructionSet, byzantiumInstructionSetNT               = newByzantiumInstructionSet[TracingEnabled](), newByzantiumInstructionSet[TracingDisabled]()
+	constantinopleInstructionSet, constantinopleInstructionSetNT     = newConstantinopleInstructionSet[TracingEnabled](), newConstantinopleInstructionSet[TracingDisabled]()
+	istanbulInstructionSet, istanbulInstructionSetNT                 = newIstanbulInstructionSet[TracingEnabled](), newIstanbulInstructionSet[TracingDisabled]()
+	berlinInstructionSet, berlinInstructionSetNT                     = newBerlinInstructionSet[TracingEnabled](), newBerlinInstructionSet[TracingDisabled]()
+	londonInstructionSet, londonInstructionSetNT                     = newLondonInstructionSet[TracingEnabled](), newLondonInstructionSet[TracingDisabled]()
+	mergeInstructionSet, mergeInstructionSetNT                       = newMergeInstructionSet[TracingEnabled](), newMergeInstructionSet[TracingDisabled]()
+	shanghaiInstructionSet, shanghaiInstructionSetNT                 = newShanghaiInstructionSet[TracingEnabled](), newShanghaiInstructionSet[TracingDisabled]()
+	cancunInstructionSet, cancunInstructionSetNT                     = newCancunInstructionSet[TracingEnabled](), newCancunInstructionSet[TracingDisabled]()
+	verkleInstructionSet, verkleInstructionSetNT                     = newVerkleInstructionSet[TracingEnabled](), newVerkleInstructionSet[TracingDisabled]()
+	pragueInstructionSet, pragueInstructionSetNT                     = newPragueInstructionSet[TracingEnabled](), newPragueInstructionSet[TracingDisabled]()
+	osakaInstructionSet, osakaInstructionSetNT                       = newOsakaInstructionSet[TracingEnabled](), newOsakaInstructionSet[TracingDisabled]()
 )
 
 // JumpTable contains the EVM opcodes supported at a given fork.
@@ -86,26 +86,26 @@ func validate(jt JumpTable) JumpTable {
 	return jt
 }
 
-func newVerkleInstructionSet() JumpTable {
-	instructionSet := newShanghaiInstructionSet()
-	enable4762(&instructionSet)
+func newVerkleInstructionSet[TS TracingSwitch]() JumpTable {
+	instructionSet := newShanghaiInstructionSet[TS]()
+	enable4762[TS](&instructionSet)
 	return validate(instructionSet)
 }
 
-func newOsakaInstructionSet() JumpTable {
-	instructionSet := newPragueInstructionSet()
+func newOsakaInstructionSet[TS TracingSwitch]() JumpTable {
+	instructionSet := newPragueInstructionSet[TS]()
 	enable7939(&instructionSet) // EIP-7939 (CLZ opcode)
 	return validate(instructionSet)
 }
 
-func newPragueInstructionSet() JumpTable {
-	instructionSet := newCancunInstructionSet()
-	enable7702(&instructionSet) // EIP-7702 Setcode transaction type
+func newPragueInstructionSet[TS TracingSwitch]() JumpTable {
+	instructionSet := newCancunInstructionSet[TS]()
+	enable7702[TS](&instructionSet) // EIP-7702 Setcode transaction type
 	return validate(instructionSet)
 }
 
-func newCancunInstructionSet() JumpTable {
-	instructionSet := newShanghaiInstructionSet()
+func newCancunInstructionSet[TS TracingSwitch]() JumpTable {
+	instructionSet := newShanghaiInstructionSet[TS]()
 	enable4844(&instructionSet) // EIP-4844 (BLOBHASH opcode)
 	enable7516(&instructionSet) // EIP-7516 (BLOBBASEFEE opcode)
 	enable1153(&instructionSet) // EIP-1153 "Transient Storage"
@@ -114,16 +114,16 @@ func newCancunInstructionSet() JumpTable {
 	return validate(instructionSet)
 }
 
-func newShanghaiInstructionSet() JumpTable {
-	instructionSet := newMergeInstructionSet()
+func newShanghaiInstructionSet[TS TracingSwitch]() JumpTable {
+	instructionSet := newMergeInstructionSet[TS]()
 	enable3855(&instructionSet) // PUSH0 instruction
 	enable3860(&instructionSet) // Limit and meter initcode
 
 	return validate(instructionSet)
 }
 
-func newMergeInstructionSet() JumpTable {
-	instructionSet := newLondonInstructionSet()
+func newMergeInstructionSet[TS TracingSwitch]() JumpTable {
+	instructionSet := newLondonInstructionSet[TS]()
 	instructionSet[PREVRANDAO] = &operation{
 		execute:     opRandom,
 		constantGas: GasQuickStep,
@@ -135,8 +135,8 @@ func newMergeInstructionSet() JumpTable {
 
 // newLondonInstructionSet returns the frontier, homestead, byzantium,
 // constantinople, istanbul, petersburg, berlin and london instructions.
-func newLondonInstructionSet() JumpTable {
-	instructionSet := newBerlinInstructionSet()
+func newLondonInstructionSet[TS TracingSwitch]() JumpTable {
+	instructionSet := newBerlinInstructionSet[TS]()
 	enable3529(&instructionSet) // EIP-3529: Reduction in refunds https://eips.ethereum.org/EIPS/eip-3529
 	enable3198(&instructionSet) // Base fee opcode https://eips.ethereum.org/EIPS/eip-3198
 	return validate(instructionSet)
@@ -144,16 +144,16 @@ func newLondonInstructionSet() JumpTable {
 
 // newBerlinInstructionSet returns the frontier, homestead, byzantium,
 // constantinople, istanbul, petersburg and berlin instructions.
-func newBerlinInstructionSet() JumpTable {
-	instructionSet := newIstanbulInstructionSet()
-	enable2929(&instructionSet) // Gas cost increases for state access opcodes https://eips.ethereum.org/EIPS/eip-2929
+func newBerlinInstructionSet[TS TracingSwitch]() JumpTable {
+	instructionSet := newIstanbulInstructionSet[TS]()
+	enable2929[TS](&instructionSet) // Gas cost increases for state access opcodes https://eips.ethereum.org/EIPS/eip-2929
 	return validate(instructionSet)
 }
 
 // newIstanbulInstructionSet returns the frontier, homestead, byzantium,
 // constantinople, istanbul and petersburg instructions.
-func newIstanbulInstructionSet() JumpTable {
-	instructionSet := newConstantinopleInstructionSet()
+func newIstanbulInstructionSet[TS TracingSwitch]() JumpTable {
+	instructionSet := newConstantinopleInstructionSet[TS]()
 
 	enable1344(&instructionSet) // ChainID opcode - https://eips.ethereum.org/EIPS/eip-1344
 	enable1884(&instructionSet) // Reprice reader opcodes - https://eips.ethereum.org/EIPS/eip-1884
@@ -164,8 +164,8 @@ func newIstanbulInstructionSet() JumpTable {
 
 // newConstantinopleInstructionSet returns the frontier, homestead,
 // byzantium and constantinople instructions.
-func newConstantinopleInstructionSet() JumpTable {
-	instructionSet := newByzantiumInstructionSet()
+func newConstantinopleInstructionSet[TS TracingSwitch]() JumpTable {
+	instructionSet := newByzantiumInstructionSet[TS]()
 	instructionSet[SHL] = &operation{
 		execute:     opSHL,
 		constantGas: GasFastestStep,
@@ -191,7 +191,7 @@ func newConstantinopleInstructionSet() JumpTable {
 		maxStack:    maxStack(1, 1),
 	}
 	instructionSet[CREATE2] = &operation{
-		execute:     opCreate2,
+		execute:     opCreate2[TS],
 		constantGas: params.Create2Gas,
 		dynamicGas:  gasCreate2,
 		minStack:    minStack(4, 1),
@@ -203,10 +203,10 @@ func newConstantinopleInstructionSet() JumpTable {
 
 // newByzantiumInstructionSet returns the frontier, homestead and
 // byzantium instructions.
-func newByzantiumInstructionSet() JumpTable {
-	instructionSet := newSpuriousDragonInstructionSet()
+func newByzantiumInstructionSet[TS TracingSwitch]() JumpTable {
+	instructionSet := newSpuriousDragonInstructionSet[TS]()
 	instructionSet[STATICCALL] = &operation{
-		execute:     opStaticCall,
+		execute:     opStaticCall[TS],
 		constantGas: params.CallGasEIP150,
 		dynamicGas:  gasStaticCall,
 		minStack:    minStack(6, 1),
@@ -238,15 +238,15 @@ func newByzantiumInstructionSet() JumpTable {
 }
 
 // EIP 158 a.k.a Spurious Dragon
-func newSpuriousDragonInstructionSet() JumpTable {
-	instructionSet := newTangerineWhistleInstructionSet()
+func newSpuriousDragonInstructionSet[TS TracingSwitch]() JumpTable {
+	instructionSet := newTangerineWhistleInstructionSet[TS]()
 	instructionSet[EXP].dynamicGas = gasExpEIP158
 	return validate(instructionSet)
 }
 
 // EIP 150 a.k.a Tangerine Whistle
-func newTangerineWhistleInstructionSet() JumpTable {
-	instructionSet := newHomesteadInstructionSet()
+func newTangerineWhistleInstructionSet[TS TracingSwitch]() JumpTable {
+	instructionSet := newHomesteadInstructionSet[TS]()
 	instructionSet[BALANCE].constantGas = params.BalanceGasEIP150
 	instructionSet[EXTCODESIZE].constantGas = params.ExtcodeSizeGasEIP150
 	instructionSet[SLOAD].constantGas = params.SloadGasEIP150
@@ -259,10 +259,10 @@ func newTangerineWhistleInstructionSet() JumpTable {
 
 // newHomesteadInstructionSet returns the frontier and homestead
 // instructions that can be executed during the homestead phase.
-func newHomesteadInstructionSet() JumpTable {
-	instructionSet := newFrontierInstructionSet()
+func newHomesteadInstructionSet[TS TracingSwitch]() JumpTable {
+	instructionSet := newFrontierInstructionSet[TS]()
 	instructionSet[DELEGATECALL] = &operation{
-		execute:     opDelegateCall,
+		execute:     opDelegateCall[TS],
 		dynamicGas:  gasDelegateCall,
 		constantGas: params.CallGasFrontier,
 		minStack:    minStack(6, 1),
@@ -274,7 +274,7 @@ func newHomesteadInstructionSet() JumpTable {
 
 // newFrontierInstructionSet returns the frontier instructions
 // that can be executed during the frontier phase.
-func newFrontierInstructionSet() JumpTable {
+func newFrontierInstructionSet[TS TracingSwitch]() JumpTable {
 	tbl := JumpTable{
 		STOP: {
 			execute:     opStop,
@@ -1040,7 +1040,7 @@ func newFrontierInstructionSet() JumpTable {
 			memorySize: memoryLog,
 		},
 		CREATE: {
-			execute:     opCreate,
+			execute:     opCreate[TS],
 			constantGas: params.CreateGas,
 			dynamicGas:  gasCreate,
 			minStack:    minStack(3, 1),
@@ -1048,7 +1048,7 @@ func newFrontierInstructionSet() JumpTable {
 			memorySize:  memoryCreate,
 		},
 		CALL: {
-			execute:     opCall,
+			execute:     opCall[TS],
 			constantGas: params.CallGasFrontier,
 			dynamicGas:  gasCall,
 			minStack:    minStack(7, 1),
@@ -1056,7 +1056,7 @@ func newFrontierInstructionSet() JumpTable {
 			memorySize:  memoryCall,
 		},
 		CALLCODE: {
-			execute:     opCallCode,
+			execute:     opCallCode[TS],
 			constantGas: params.CallGasFrontier,
 			dynamicGas:  gasCallCode,
 			minStack:    minStack(7, 1),

--- a/core/vm/jump_table_export.go
+++ b/core/vm/jump_table_export.go
@@ -24,38 +24,38 @@ import (
 
 // LookupInstructionSet returns the instruction set for the fork configured by
 // the rules.
-func LookupInstructionSet(rules params.Rules) (JumpTable, error) {
+func LookupInstructionSet[TS TracingSwitch](rules params.Rules) (JumpTable, error) {
 	switch {
 	case rules.IsVerkle:
-		return newCancunInstructionSet(), errors.New("verkle-fork not defined yet")
+		return newCancunInstructionSet[TS](), errors.New("verkle-fork not defined yet")
 	case rules.IsOsaka:
-		return newOsakaInstructionSet(), nil
+		return newOsakaInstructionSet[TS](), nil
 	case rules.IsPrague:
-		return newPragueInstructionSet(), nil
+		return newPragueInstructionSet[TS](), nil
 	case rules.IsCancun:
-		return newCancunInstructionSet(), nil
+		return newCancunInstructionSet[TS](), nil
 	case rules.IsShanghai:
-		return newShanghaiInstructionSet(), nil
+		return newShanghaiInstructionSet[TS](), nil
 	case rules.IsMerge:
-		return newMergeInstructionSet(), nil
+		return newMergeInstructionSet[TS](), nil
 	case rules.IsLondon:
-		return newLondonInstructionSet(), nil
+		return newLondonInstructionSet[TS](), nil
 	case rules.IsBerlin:
-		return newBerlinInstructionSet(), nil
+		return newBerlinInstructionSet[TS](), nil
 	case rules.IsIstanbul:
-		return newIstanbulInstructionSet(), nil
+		return newIstanbulInstructionSet[TS](), nil
 	case rules.IsConstantinople:
-		return newConstantinopleInstructionSet(), nil
+		return newConstantinopleInstructionSet[TS](), nil
 	case rules.IsByzantium:
-		return newByzantiumInstructionSet(), nil
+		return newByzantiumInstructionSet[TS](), nil
 	case rules.IsEIP158:
-		return newSpuriousDragonInstructionSet(), nil
+		return newSpuriousDragonInstructionSet[TS](), nil
 	case rules.IsEIP150:
-		return newTangerineWhistleInstructionSet(), nil
+		return newTangerineWhistleInstructionSet[TS](), nil
 	case rules.IsHomestead:
-		return newHomesteadInstructionSet(), nil
+		return newHomesteadInstructionSet[TS](), nil
 	}
-	return newFrontierInstructionSet(), nil
+	return newFrontierInstructionSet[TS](), nil
 }
 
 // Stack returns the minimum and maximum stack requirements.

--- a/core/vm/jump_table_test.go
+++ b/core/vm/jump_table_test.go
@@ -24,7 +24,7 @@ import (
 
 // TestJumpTableCopy tests that deep copy is necessary to prevent modify shared jump table
 func TestJumpTableCopy(t *testing.T) {
-	tbl := newMergeInstructionSet()
+	tbl := newMergeInstructionSet[TracingEnabled]()
 	require.Equal(t, uint64(0), tbl[SLOAD].constantGas)
 
 	// a deep copy won't modify the shared jump table

--- a/eth/tracers/js/tracer_test.go
+++ b/eth/tracers/js/tracer_test.go
@@ -65,7 +65,7 @@ func runTrace(tracer *tracers.Tracer, vmctx *vmContext, chaincfg *params.ChainCo
 
 	tracer.OnTxStart(evm.GetVMContext(), types.NewTx(&types.LegacyTx{Gas: gasLimit, GasPrice: vmctx.txCtx.GasPrice}), contract.Caller())
 	tracer.OnEnter(0, byte(vm.CALL), contract.Caller(), contract.Address(), []byte{}, startGas, value.ToBig())
-	ret, err := evm.Run(contract, []byte{}, false)
+	ret, err := vm.Run[vm.TracingEnabled](evm, contract, []byte{}, false)
 	tracer.OnExit(0, ret, startGas-contract.Gas, err, true)
 	// Rest gas assumes no refund
 	tracer.OnTxEnd(&types.Receipt{GasUsed: gasLimit - contract.Gas}, nil)

--- a/eth/tracers/logger/logger_test.go
+++ b/eth/tracers/logger/logger_test.go
@@ -52,7 +52,7 @@ func TestStoreCapture(t *testing.T) {
 	contract.Code = []byte{byte(vm.PUSH1), 0x1, byte(vm.PUSH1), 0x0, byte(vm.SSTORE)}
 	var index common.Hash
 	logger.OnTxStart(evm.GetVMContext(), nil, common.Address{})
-	_, err := evm.Run(contract, []byte{}, false)
+	_, err := vm.Run[vm.TracingEnabled](evm, contract, []byte{}, false)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
this allows the EVM to follow the not-traced codepaths when it is not configured for tracing and skip the runtime checks

This is a better alternative to #32273 imo. Mainly because the types can stay stable with this approach, which allows a smaller diff. 