### PR TITLE
eth/syncer: stop ticker to prevent resource leak

### DIFF
--- a/eth/syncer/syncer.go
+++ b/eth/syncer/syncer.go
@@ -89,6 +89,7 @@ func (s *Syncer) run() {
 		target *types.Header
 		ticker = time.NewTicker(time.Second * 5)
 	)
+	defer ticker.Stop()
 	for {
 		select {
 		case req := <-s.request:


### PR DESCRIPTION
- Add defer ticker.Stop() after time.NewTicker in Syncer.run.
- Aligns with project pattern in other long-running loops.
- Prevents potential goroutine/resource leak when the service stops.