### PR TITLE
cmd/evm: use PathScheme in blockrunner

### DIFF
--- a/cmd/evm/blockrunner.go
+++ b/cmd/evm/blockrunner.go
@@ -89,7 +89,7 @@ func runBlockTest(ctx *cli.Context, fname string) ([]testResult, error) {
 			continue
 		}
 		result := &testResult{Name: name, Pass: true}
-		if err := tests[name].Run(false, rawdb.HashScheme, ctx.Bool(WitnessCrossCheckFlag.Name), tracer, func(res error, chain *core.BlockChain) {
+		if err := tests[name].Run(false, rawdb.PathScheme, ctx.Bool(WitnessCrossCheckFlag.Name), tracer, func(res error, chain *core.BlockChain) {
 			if ctx.Bool(DumpFlag.Name) {
 				if s, _ := chain.State(); s != nil {
 					result.State = dump(s)


### PR DESCRIPTION
This is a preparatory change for Verkle/binary trees, since they don't support the hash-based database scheme. This has no impact on the MPT.