### PR TITLE
cmd: opt with clear map

### DIFF
--- a/cmd/utils/cmd.go
+++ b/cmd/utils/cmd.go
@@ -526,7 +526,7 @@ func ImportPreimages(db ethdb.Database, fn string) error {
 		preimages[crypto.Keccak256Hash(blob)] = common.CopyBytes(blob)
 		if len(preimages) > 1024 {
 			rawdb.WritePreimages(db, preimages)
-			preimages = make(map[common.Hash][]byte)
+			clear(preimages)
 		}
 	}
 	// Flush the last batch preimage data


### PR DESCRIPTION
```
package main

import (
	"testing"
)

const N = 1024 // number of kv to insert

// Benchmark: clear map and then insert
func BenchmarkMapClear(b *testing.B) {
	m := make(map[int]int, N)
	for i := 0; i < b.N; i++ {
		for r := 0; r < 100; r++ {
			for j := 0; j < N; j++ {
				m[j] = j
			}
			// clear map
			clear(m)
		}
	}
}

// Benchmark: new mem and insert
func BenchmarkMapNew(b *testing.B) {
	for i := 0; i < b.N; i++ {
		for r := 0; r < 100; r++ {
			m := make(map[int]int, N)
			for j := 0; j < N; j++ {
				m[j] = j
			}
		}
	}
}
```

below is result:

```
goos: darwin
goarch: arm64
cpu: Apple M1 Pro
BenchmarkMapClear
BenchmarkMapClear-10    	    1207	    992326 ns/op	      30 B/op	       0 allocs/op
BenchmarkMapNew
BenchmarkMapNew-10      	    1168	   1100310 ns/op	 3694421 B/op	     500 allocs/op
PASS
```