### PR TITLE
fix: correct typos in comments and strings

### DIFF
--- a/accounts/scwallet/wallet.go
+++ b/accounts/scwallet/wallet.go
@@ -56,7 +56,7 @@ var ErrPINNeeded = errors.New("smartcard: pin needed")
 // ErrPINUnblockNeeded is returned if opening the smart card requires a PIN code,
 // but all PIN attempts have already been exhausted. In this case the calling
 // application should request user input for the PUK and a new PIN code to set
-// fo the card.
+// for the card.
 var ErrPINUnblockNeeded = errors.New("smartcard: pin unblock needed")
 
 // ErrAlreadyOpen is returned if the smart card is attempted to be opened, but

--- a/cmd/devp2p/internal/ethtest/suite.go
+++ b/cmd/devp2p/internal/ethtest/suite.go
@@ -175,7 +175,7 @@ to check if the node disconnects after receiving multiple invalid requests.`)
 		},
 	}
 
-	// Send request 10 times. Some clients are lient on the first few invalids.
+	// Send request 10 times. Some clients are lenient on the first few invalids.
 	for i := 0; i < 10; i++ {
 		badReq.RequestId = uint64(i)
 		if err := conn.Write(ethProto, eth.GetBlockHeadersMsg, badReq); err != nil {
@@ -542,7 +542,7 @@ func (s *Suite) TestBlockRangeUpdateInvalid(t *utesting.T) {
 
 func (s *Suite) TestBlockRangeUpdateFuture(t *utesting.T) {
 	t.Log(`This test sends a BlockRangeUpdate that is beyond the chain head.
-The node should accept the update and should not disonnect.`)
+The node should accept the update and should not disconnect.`)
 	conn, err := s.dialAndPeer(nil)
 	if err != nil {
 		t.Fatal(err)
@@ -578,7 +578,7 @@ The node should accept the update and should not disonnect.`)
 
 func (s *Suite) TestBlockRangeUpdateHistoryExp(t *utesting.T) {
 	t.Log(`This test sends a BlockRangeUpdate announcing incomplete (expired) history.
-The node should accept the update and should not disonnect.`)
+The node should accept the update and should not disconnect.`)
 	conn, err := s.dialAndPeer(nil)
 	if err != nil {
 		t.Fatal(err)

--- a/core/filtermaps/matcher.go
+++ b/core/filtermaps/matcher.go
@@ -445,7 +445,7 @@ func (m *singleMatcherInstance) cleanMapIndices() {
 	m.mapIndices = m.mapIndices[:j]
 }
 
-// matchAny combinines a set of matchers and returns a match for every position
+// matchAny combines a set of matchers and returns a match for every position
 // where any of the underlying matchers signaled a match. A zero-length matchAny
 // acts as a "wild card" that signals a potential match at every position.
 type matchAny []matcher
@@ -458,7 +458,7 @@ type matchAnyInstance struct {
 }
 
 // matchAnyResults is used by matchAnyInstance to collect results from all
-// child matchers for a specific map index. Once all results has been received
+// child matchers for a specific map index. Once all results have been received
 // a merged result is returned for the given map and this structure is discarded.
 type matchAnyResults struct {
 	matches  []potentialMatches

--- a/core/overlay/state_transition.go
+++ b/core/overlay/state_transition.go
@@ -29,7 +29,7 @@ import (
 // TransitionState is a structure that holds the progress markers of the
 // translation process.
 type TransitionState struct {
-	CurrentAccountAddress *common.Address // addresss of the last translated account
+	CurrentAccountAddress *common.Address // address of the last translated account
 	CurrentSlotHash       common.Hash     // hash of the last translated storage slot
 	CurrentPreimageOffset int64           // next byte to read from the preimage file
 	Started, Ended        bool

--- a/core/rawdb/accessors_indexes.go
+++ b/core/rawdb/accessors_indexes.go
@@ -563,7 +563,7 @@ func DeleteBlockLvPointers(db ethdb.KeyValueStore, blocks common.Range[uint64], 
 }
 
 // FilterMapsRange is a storage representation of the block range covered by the
-// filter maps structure and the corresponting log value index range.
+// filter maps structure and the corresponding log value index range.
 type FilterMapsRange struct {
 	Version                      uint32
 	HeadIndexed                  bool

--- a/core/rawdb/database.go
+++ b/core/rawdb/database.go
@@ -597,7 +597,7 @@ func InspectDatabase(db ethdb.Database, keyPrefix, keyStart []byte) error {
 	return nil
 }
 
-// This is the list of known 'metadata' keys stored in the databasse.
+// This is the list of known 'metadata' keys stored in the database.
 var knownMetadataKeys = [][]byte{
 	databaseVersionKey, headHeaderKey, headBlockKey, headFastBlockKey, headFinalizedBlockKey,
 	lastPivotKey, fastTrieProgressKey, snapshotDisabledKey, SnapshotRootKey, snapshotJournalKey,
@@ -659,7 +659,7 @@ func ReadChainMetadata(db ethdb.KeyValueStore) [][]string {
 // is periodically called and if it returns an error then SafeDeleteRange
 // stops and also returns that error. The callback is not called if native
 // range delete is used or there are a small number of keys only. The bool
-// argument passed to the callback is true if enrties have actually been
+// argument passed to the callback is true if entries have actually been
 // deleted already.
 func SafeDeleteRange(db ethdb.KeyValueStore, start, end []byte, hashScheme bool, stopCallback func(bool) bool) error {
 	if !hashScheme {

--- a/core/state_transition.go
+++ b/core/state_transition.go
@@ -585,7 +585,7 @@ func (st *stateTransition) validateAuthorization(auth *types.SetCodeAuthorizatio
 		return authority, fmt.Errorf("%w: %v", ErrAuthorizationInvalidSignature, err)
 	}
 	// Check the authority account
-	//  1) doesn't have code or has exisiting delegation
+	//  1) doesn't have code or has existing delegation
 	//  2) matches the auth's nonce
 	//
 	// Note it is added to the access list even if the authorization is invalid.

--- a/core/txpool/blobpool/blobpool_test.go
+++ b/core/txpool/blobpool/blobpool_test.go
@@ -217,7 +217,7 @@ func makeTx(nonce uint64, gasTipCap uint64, gasFeeCap uint64, blobFeeCap uint64,
 	return types.MustSignNewTx(key, types.LatestSigner(params.MainnetChainConfig), blobtx)
 }
 
-// makeMultiBlobTx is a utility method to construct a ramdom blob tx with
+// makeMultiBlobTx is a utility method to construct a random blob tx with
 // certain number of blobs in its sidecar.
 func makeMultiBlobTx(nonce uint64, gasTipCap uint64, gasFeeCap uint64, blobFeeCap uint64, blobCount int, blobOffset int, key *ecdsa.PrivateKey, version byte) *types.Transaction {
 	var (

--- a/core/txpool/blobpool/lookup.go
+++ b/core/txpool/blobpool/lookup.go
@@ -21,7 +21,7 @@ import (
 )
 
 type txMetadata struct {
-	id   uint64 // the billy id of transction
+	id   uint64 // the billy id of transaction
 	size uint64 // the RLP encoded size of transaction (blobs are included)
 }
 

--- a/eth/protocols/snap/sync.go
+++ b/eth/protocols/snap/sync.go
@@ -82,8 +82,8 @@ const (
 	minTrienodeHealThrottle = 1
 
 	// maxTrienodeHealThrottle is the maximum divisor for throttling trie node
-	// heal requests to avoid overloading the local node and exessively expanding
-	// the state trie bedth wise.
+	// heal requests to avoid overloading the local node and excessively expanding
+	// the state trie breadth wise.
 	maxTrienodeHealThrottle = maxTrieRequestCount
 
 	// trienodeHealThrottleIncrease is the multiplier for the throttle when the

--- a/internal/flags/flags.go
+++ b/internal/flags/flags.go
@@ -156,7 +156,7 @@ func (f *BigFlag) IsSet() bool     { return f.HasBeenSet }
 func (f *BigFlag) String() string  { return cli.FlagStringer(f) }
 
 func (f *BigFlag) Apply(set *flag.FlagSet) error {
-	// Set default value so that environment wont be able to overwrite it
+	// Set default value so that environment won't be able to overwrite it
 	if f.Value != nil {
 		f.defaultValue = new(big.Int).Set(f.Value)
 	}

--- a/node/api.go
+++ b/node/api.go
@@ -51,7 +51,7 @@ func (n *Node) apis() []rpc.API {
 }
 
 // adminAPI is the collection of administrative API methods exposed over
-// both secure and unsecure RPC channels.
+// both secure and insecure RPC channels.
 type adminAPI struct {
 	node *Node // Node interfaced by this API
 }

--- a/p2p/enode/iter.go
+++ b/p2p/enode/iter.go
@@ -207,7 +207,7 @@ func AsyncFilter(it Iterator, check AsyncFilterFunc, workers int) Iterator {
 					item := iteratorItem{nn, nodeSource}
 					select {
 					case f.passed <- item:
-					case <-ctx.Done(): // bale out if downstream is already closed and not calling Next
+					case <-ctx.Done(): // bail out if downstream is already closed and not calling Next
 					}
 				}
 				f.slots <- struct{}{}

--- a/tests/fuzzers/bn256/bn256_fuzz.go
+++ b/tests/fuzzers/bn256/bn256_fuzz.go
@@ -184,7 +184,7 @@ func fuzzUnmarshalG1(input []byte) int {
 		}
 		return 1
 	} else {
-		panic(fmt.Sprintf("error missmatch: cf: %v g: %v gn: %v", errC, errG, errS))
+		panic(fmt.Sprintf("error mismatch: cf: %v g: %v gn: %v", errC, errG, errS))
 	}
 }
 
@@ -211,7 +211,7 @@ func fuzzUnmarshalG2(input []byte) int {
 		}
 		return 1
 	} else {
-		panic(fmt.Sprintf("error missmatch: cf: %v g: %v gn: %v", errC, errG, errS))
+		panic(fmt.Sprintf("error mismatch: cf: %v g: %v gn: %v", errC, errG, errS))
 	}
 }
 


### PR DESCRIPTION
### Summary
Fixes typos and minor grammatical issues in comments, logs, and test messages. No functional behavior, public APIs/ABI, or data formats are affected.

### What changed
- Comments, user/test strings, and log messages only.
- Examples: `disonnect` → `disconnect`, `exisiting` → `existing`, `missmatch` → `mismatch`, `unsecure` → `insecure`, `bale out` → `bail out`, etc.

### Touched files
- `accounts/scwallet/wallet.go`
- `cmd/devp2p/internal/ethtest/suite.go`
- `core/filtermaps/matcher.go`
- `core/overlay/state_transition.go`
- `core/rawdb/accessors_indexes.go`
- `core/rawdb/database.go`
- `core/state_transition.go`
- `core/txpool/blobpool/blobpool_test.go`
- `core/txpool/blobpool/lookup.go`
- `eth/protocols/snap/sync.go`
- `internal/flags/flags.go`
- `node/api.go`
- `p2p/enode/iter.go`
- `tests/fuzzers/bn256/bn256_fuzz.go`

### Motivation
- Improve clarity and code quality in comments and messages.
- Reduce noise in reviews and repository search.

### Verification
- No functional changes; build unaffected.
- Linter reports clean for changed files.