### PR TITLE
ci: bump actions/checkout to v5

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -12,7 +12,7 @@ jobs:
     name: Lint
     runs-on: self-hosted-ghr
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
       with:
         submodules: false
 
@@ -44,7 +44,7 @@ jobs:
           - '1.25'
           - '1.24'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           submodules: true
 


### PR DESCRIPTION
Ref: https://github.com/actions/checkout/releases/tag/v5.0.0