### PR TITLE
eth/tracers: add missing teardown in TestTraceChain

### DIFF
--- a/eth/tracers/api_test.go
+++ b/eth/tracers/api_test.go
@@ -527,7 +527,7 @@ func TestTraceTransaction(t *testing.T) {
 		b.AddTx(tx)
 		target = tx.Hash()
 	})
-	defer backend.chain.Stop()
+	defer backend.teardown()
 	api := NewAPI(backend)
 	result, err := api.TraceTransaction(context.Background(), target, nil)
 	if err != nil {
@@ -584,7 +584,7 @@ func TestTraceBlock(t *testing.T) {
 		b.AddTx(tx)
 		txHash = tx.Hash()
 	})
-	defer backend.chain.Stop()
+	defer backend.teardown()
 	api := NewAPI(backend)
 
 	var testSuite = []struct {
@@ -681,7 +681,7 @@ func TestTracingWithOverrides(t *testing.T) {
 			signer, accounts[0].key)
 		b.AddTx(tx)
 	})
-	defer backend.chain.Stop()
+	defer backend.teardown()
 	api := NewAPI(backend)
 	randomAccounts := newAccounts(3)
 	type res struct {
@@ -1213,7 +1213,7 @@ func TestTraceBlockWithBasefee(t *testing.T) {
 		txHash = tx.Hash()
 		baseFee.Set(b.BaseFee())
 	})
-	defer backend.chain.Stop()
+	defer backend.teardown()
 	api := NewAPI(backend)
 
 	var testSuite = []struct {
@@ -1299,7 +1299,7 @@ func TestStandardTraceBlockToFile(t *testing.T) {
 		b.AddTx(tx)
 		txHashs = append(txHashs, tx.Hash())
 	})
-	defer backend.chain.Stop()
+	defer backend.teardown()
 
 	var testSuite = []struct {
 		blockNumber rpc.BlockNumber


### PR DESCRIPTION
The TestTraceChain function was missing a defer backend.teardown() call,
which is required to properly release blockchain resources after test completion.

According to the newTestBackend comment: "After test is done, teardown must be
invoked in order to release associated resources." This was causing potential
resource leaks as the blockchain chain was not being stopped.

All other tests in the file properly use either defer backend.teardown() or
defer backend.chain.Stop(), so this fix aligns TestTraceChain with the
established pattern and prevents resource accumulation during test runs.