### PR TITLE
Fix: dead links in bn256 crypto package comments

### DIFF
--- a/crypto/bn256/cloudflare/bn256.go
+++ b/crypto/bn256/cloudflare/bn256.go
@@ -9,7 +9,7 @@
 //
 // This package specifically implements the Optimal Ate pairing over a 256-bit
 // Barreto-Naehrig curve as described in
-// http://cryptojedi.org/papers/dclxvi-20100714.pdf. Its output is not
+// <https://cryptojedi.org/papers/dclxvi-20100714.pdf>. Its output is not
 // compatible with the implementation described in that paper, as different
 // parameters are chosen.
 //

--- a/crypto/bn256/cloudflare/optate.go
+++ b/crypto/bn256/cloudflare/optate.go
@@ -2,7 +2,7 @@ package bn256
 
 func lineFunctionAdd(r, p *twistPoint, q *curvePoint, r2 *gfP2) (a, b, c *gfP2, rOut *twistPoint) {
 	// See the mixed addition algorithm from "Faster Computation of the
-	// Tate Pairing", http://arxiv.org/pdf/0904.0854v3.pdf
+	// Tate Pairing", <https://arxiv.org/pdf/0904.0854v3.pdf>.
 	B := (&gfP2{}).Mul(&p.x, &r.t)
 
 	D := (&gfP2{}).Add(&p.y, &r.z)

--- a/crypto/bn256/google/bn256.go
+++ b/crypto/bn256/google/bn256.go
@@ -12,7 +12,7 @@
 //
 // This package specifically implements the Optimal Ate pairing over a 256-bit
 // Barreto-Naehrig curve as described in
-// http://cryptojedi.org/papers/dclxvi-20100714.pdf. Its output is not
+// <https://cryptojedi.org/papers/dclxvi-20100714.pdf> Its output is not
 // compatible with the implementation described in that paper, as different
 // parameters are chosen.
 //

--- a/crypto/bn256/google/optate.go
+++ b/crypto/bn256/google/optate.go
@@ -6,7 +6,7 @@ package bn256
 
 func lineFunctionAdd(r, p *twistPoint, q *curvePoint, r2 *gfP2, pool *bnPool) (a, b, c *gfP2, rOut *twistPoint) {
 	// See the mixed addition algorithm from "Faster Computation of the
-	// Tate Pairing", http://arxiv.org/pdf/0904.0854v3.pdf
+	// Tate Pairing", <https://arxiv.org/pdf/0904.0854v3.pdf>.
 
 	B := newGFp2(pool).Mul(p.x, r.t, pool)
 


### PR DESCRIPTION


## Description
Updates external URLs in crypto/bn256 package comments to resolve 404 errors and improve link reliability:

All URLs now use `<https://...>` format to prevent punctuation capture and ensure proper rendering in GoDoc/pkg.go.dev.

