### PR TITLE
node: fix vhosts for adminAPI

### DIFF
--- a/node/api.go
+++ b/node/api.go
@@ -191,7 +191,7 @@ func (api *adminAPI) StartHTTP(host *string, port *int, cors *string, apis *stri
 	}
 	if vhosts != nil {
 		config.Vhosts = nil
-		for _, vhost := range strings.Split(*host, ",") {
+		for _, vhost := range strings.Split(*vhosts, ",") {
 			config.Vhosts = append(config.Vhosts, strings.TrimSpace(vhost))
 		}
 	}


### PR DESCRIPTION
I guess it should be vhosts in this context. Otherwise, vhosts is not used at all in this function.