### PR TITLE
core,trie: fix typo in TransitionTrie

### DIFF
--- a/core/state/reader.go
+++ b/core/state/reader.go
@@ -253,7 +253,7 @@ func newTrieReader(root common.Hash, db *triedb.Database, cache *utils.PointCach
 			if err != nil {
 				return nil, err
 			}
-			tr = trie.NewTransitionTree(mpt, tr.(*trie.VerkleTrie), false)
+			tr = trie.NewTransitionTrie(mpt, tr.(*trie.VerkleTrie), false)
 		}
 	}
 	if err != nil {

--- a/trie/transition.go
+++ b/trie/transition.go
@@ -37,7 +37,7 @@ type TransitionTrie struct {
 }
 
 // NewTransitionTrie creates a new TransitionTrie.
-func NewTransitionTree(base *SecureTrie, overlay *VerkleTrie, st bool) *TransitionTrie {
+func NewTransitionTrie(base *SecureTrie, overlay *VerkleTrie, st bool) *TransitionTrie {
 	return &TransitionTrie{
 		overlay: overlay,
 		base:    base,


### PR DESCRIPTION
Change `NewTransitionTree` to the correct `NewTransitionTrie`.