### PR TITLE
triedb/pathdb, core: keep root->id mappings after truncation

### DIFF
--- a/core/rawdb/accessors_state.go
+++ b/core/rawdb/accessors_state.go
@@ -119,13 +119,6 @@ func WriteStateID(db ethdb.KeyValueWriter, root common.Hash, id uint64) {
 	}
 }
 
-// DeleteStateID deletes the specified state lookup from the database.
-func DeleteStateID(db ethdb.KeyValueWriter, root common.Hash) {
-	if err := db.Delete(stateIDKey(root)); err != nil {
-		log.Crit("Failed to delete state ID", "err", err)
-	}
-}
-
 // ReadPersistentStateID retrieves the id of the persistent state from the database.
 func ReadPersistentStateID(db ethdb.KeyValueReader) uint64 {
 	data, _ := db.Get(persistentStateIDKey)

--- a/triedb/pathdb/disklayer.go
+++ b/triedb/pathdb/disklayer.go
@@ -378,7 +378,7 @@ func (dl *diskLayer) writeStateHistory(diff *diffLayer) (bool, error) {
 		log.Debug("Skip tail truncation", "persistentID", persistentID, "tailID", tail+1, "headID", diff.stateID(), "limit", limit)
 		return true, nil
 	}
-	pruned, err := truncateFromTail(dl.db.diskdb, dl.db.stateFreezer, newFirst-1)
+	pruned, err := truncateFromTail(dl.db.stateFreezer, newFirst-1)
 	if err != nil {
 		return false, err
 	}

--- a/triedb/pathdb/history.go
+++ b/triedb/pathdb/history.go
@@ -1,0 +1,87 @@
+// Copyright 2025 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/
+
+package pathdb
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/ethereum/go-ethereum/ethdb"
+	"github.com/ethereum/go-ethereum/log"
+)
+
+var (
+	errHeadTruncationOutOfRange = errors.New("history head truncation out of range")
+	errTailTruncationOutOfRange = errors.New("history tail truncation out of range")
+)
+
+// truncateFromHead removes excess elements from the head of the freezer based
+// on the given parameters. It returns the number of items that were removed.
+func truncateFromHead(store ethdb.AncientStore, nhead uint64) (int, error) {
+	ohead, err := store.Ancients()
+	if err != nil {
+		return 0, err
+	}
+	otail, err := store.Tail()
+	if err != nil {
+		return 0, err
+	}
+	log.Info("Truncating from head", "ohead", ohead, "tail", otail, "nhead", nhead)
+
+	// Ensure that the truncation target falls within the valid range.
+	if ohead < nhead || nhead < otail {
+		return 0, fmt.Errorf("%w, tail: %d, head: %d, target: %d", errHeadTruncationOutOfRange, otail, ohead, nhead)
+	}
+	// Short circuit if nothing to truncate.
+	if ohead == nhead {
+		return 0, nil
+	}
+	ohead, err = store.TruncateHead(nhead)
+	if err != nil {
+		return 0, err
+	}
+	// Associated root->id mappings are left in the database and wait
+	// for overwriting.
+	return int(ohead - nhead), nil
+}
+
+// truncateFromTail removes excess elements from the end of the freezer based
+// on the given parameters. It returns the number of items that were removed.
+func truncateFromTail(store ethdb.AncientStore, ntail uint64) (int, error) {
+	ohead, err := store.Ancients()
+	if err != nil {
+		return 0, err
+	}
+	otail, err := store.Tail()
+	if err != nil {
+		return 0, err
+	}
+	// Ensure that the truncation target falls within the valid range.
+	if otail > ntail || ntail > ohead {
+		return 0, fmt.Errorf("%w, tail: %d, head: %d, target: %d", errTailTruncationOutOfRange, otail, ohead, ntail)
+	}
+	// Short circuit if nothing to truncate.
+	if otail == ntail {
+		return 0, nil
+	}
+	otail, err = store.TruncateTail(ntail)
+	if err != nil {
+		return 0, err
+	}
+	// Associated root->id mappings are left in the database.
+	return int(ntail - otail), nil
+}

--- a/triedb/pathdb/history_reader.go
+++ b/triedb/pathdb/history_reader.go
@@ -320,11 +320,12 @@ func (r *historyReader) read(state stateIdentQuery, stateID uint64, lastID uint6
 	tail, err := r.freezer.Tail()
 	if err != nil {
 		return nil, err
-	}
-	// stateID == tail is allowed, as the first history object preserved
-	// is tail+1
+	} // firstID = tail+1
+
+	// stateID+1 == firstID is allowed, as all the subsequent state histories
+	// are present with no gap inside.
 	if stateID < tail {
-		return nil, errors.New("historical state has been pruned")
+		return nil, fmt.Errorf("historical state has been pruned, first: %d, state: %d", tail+1, stateID)
 	}
 
 	// To serve the request, all state histories from stateID+1 to lastID

--- a/triedb/pathdb/history_state_test.go
+++ b/triedb/pathdb/history_state_test.go
@@ -108,7 +108,7 @@ func testEncodeDecodeStateHistory(t *testing.T, rawStorageKey bool) {
 	}
 }
 
-func checkStateHistory(t *testing.T, db ethdb.KeyValueReader, freezer ethdb.AncientReader, id uint64, root common.Hash, exist bool) {
+func checkStateHistory(t *testing.T, freezer ethdb.AncientReader, id uint64, exist bool) {
 	blob := rawdb.ReadStateHistoryMeta(freezer, id)
 	if exist && len(blob) == 0 {
 		t.Fatalf("Failed to load trie history, %d", id)
@@ -116,25 +116,17 @@ func checkStateHistory(t *testing.T, db ethdb.KeyValueReader, freezer ethdb.Anci
 	if !exist && len(blob) != 0 {
 		t.Fatalf("Unexpected trie history, %d", id)
 	}
-	if exist && rawdb.ReadStateID(db, root) == nil {
-		t.Fatalf("Root->ID mapping is not found, %d", id)
-	}
-	if !exist && rawdb.ReadStateID(db, root) != nil {
-		t.Fatalf("Unexpected root->ID mapping, %d", id)
-	}
 }
 
-func checkHistoriesInRange(t *testing.T, db ethdb.KeyValueReader, freezer ethdb.AncientReader, from, to uint64, roots []common.Hash, exist bool) {
-	for i, j := from, 0; i <= to; i, j = i+1, j+1 {
-		checkStateHistory(t, db, freezer, i, roots[j], exist)
+func checkHistoriesInRange(t *testing.T, freezer ethdb.AncientReader, from, to uint64, exist bool) {
+	for i := from; i <= to; i = i + 1 {
+		checkStateHistory(t, freezer, i, exist)
 	}
 }
 
 func TestTruncateHeadStateHistory(t *testing.T) {
 	var (
-		roots      []common.Hash
 		hs         = makeStateHistories(10)
-		db         = rawdb.NewMemoryDatabase()
 		freezer, _ = rawdb.NewStateFreezer(t.TempDir(), false, false)
 	)
 	defer freezer.Close()
@@ -142,27 +134,23 @@ func TestTruncateHeadStateHistory(t *testing.T) {
 	for i := 0; i < len(hs); i++ {
 		accountData, storageData, accountIndex, storageIndex := hs[i].encode()
 		rawdb.WriteStateHistory(freezer, uint64(i+1), hs[i].meta.encode(), accountIndex, storageIndex, accountData, storageData)
-		rawdb.WriteStateID(db, hs[i].meta.root, uint64(i+1))
-		roots = append(roots, hs[i].meta.root)
 	}
 	for size := len(hs); size > 0; size-- {
-		pruned, err := truncateFromHead(db, freezer, uint64(size-1))
+		pruned, err := truncateFromHead(freezer, uint64(size-1))
 		if err != nil {
 			t.Fatalf("Failed to truncate from head %v", err)
 		}
 		if pruned != 1 {
 			t.Error("Unexpected pruned items", "want", 1, "got", pruned)
 		}
-		checkHistoriesInRange(t, db, freezer, uint64(size), uint64(10), roots[size-1:], false)
-		checkHistoriesInRange(t, db, freezer, uint64(1), uint64(size-1), roots[:size-1], true)
+		checkHistoriesInRange(t, freezer, uint64(size), uint64(10), false)
+		checkHistoriesInRange(t, freezer, uint64(1), uint64(size-1), true)
 	}
 }
 
 func TestTruncateTailStateHistory(t *testing.T) {
 	var (
-		roots      []common.Hash
 		hs         = makeStateHistories(10)
-		db         = rawdb.NewMemoryDatabase()
 		freezer, _ = rawdb.NewStateFreezer(t.TempDir(), false, false)
 	)
 	defer freezer.Close()
@@ -170,16 +158,14 @@ func TestTruncateTailStateHistory(t *testing.T) {
 	for i := 0; i < len(hs); i++ {
 		accountData, storageData, accountIndex, storageIndex := hs[i].encode()
 		rawdb.WriteStateHistory(freezer, uint64(i+1), hs[i].meta.encode(), accountIndex, storageIndex, accountData, storageData)
-		rawdb.WriteStateID(db, hs[i].meta.root, uint64(i+1))
-		roots = append(roots, hs[i].meta.root)
 	}
 	for newTail := 1; newTail < len(hs); newTail++ {
-		pruned, _ := truncateFromTail(db, freezer, uint64(newTail))
+		pruned, _ := truncateFromTail(freezer, uint64(newTail))
 		if pruned != 1 {
 			t.Error("Unexpected pruned items", "want", 1, "got", pruned)
 		}
-		checkHistoriesInRange(t, db, freezer, uint64(1), uint64(newTail), roots[:newTail], false)
-		checkHistoriesInRange(t, db, freezer, uint64(newTail+1), uint64(10), roots[newTail:], true)
+		checkHistoriesInRange(t, freezer, uint64(1), uint64(newTail), false)
+		checkHistoriesInRange(t, freezer, uint64(newTail+1), uint64(10), true)
 	}
 }
 
@@ -191,21 +177,29 @@ func TestTruncateTailStateHistories(t *testing.T) {
 		minUnpruned uint64
 		empty       bool
 	}{
+		// history: id [10]
 		{
-			1, 9, 9, 10, false,
+			limit:     1,
+			expPruned: 9,
+			maxPruned: 9, minUnpruned: 10, empty: false,
 		},
+		// history: none
 		{
-			0, 10, 10, 0 /* no meaning */, true,
+			limit:     0,
+			expPruned: 10,
+			empty:     true,
 		},
+		// history: id [1:10]
 		{
-			10, 0, 0, 1, false,
+			limit:       10,
+			expPruned:   0,
+			maxPruned:   0,
+			minUnpruned: 1,
 		},
 	}
 	for i, c := range cases {
 		var (
-			roots      []common.Hash
 			hs         = makeStateHistories(10)
-			db         = rawdb.NewMemoryDatabase()
 			freezer, _ = rawdb.NewStateFreezer(t.TempDir()+fmt.Sprintf("%d", i), false, false)
 		)
 		defer freezer.Close()
@@ -213,19 +207,16 @@ func TestTruncateTailStateHistories(t *testing.T) {
 		for i := 0; i < len(hs); i++ {
 			accountData, storageData, accountIndex, storageIndex := hs[i].encode()
 			rawdb.WriteStateHistory(freezer, uint64(i+1), hs[i].meta.encode(), accountIndex, storageIndex, accountData, storageData)
-			rawdb.WriteStateID(db, hs[i].meta.root, uint64(i+1))
-			roots = append(roots, hs[i].meta.root)
 		}
-		pruned, _ := truncateFromTail(db, freezer, uint64(10)-c.limit)
+		pruned, _ := truncateFromTail(freezer, uint64(10)-c.limit)
 		if pruned != c.expPruned {
 			t.Error("Unexpected pruned items", "want", c.expPruned, "got", pruned)
 		}
 		if c.empty {
-			checkHistoriesInRange(t, db, freezer, uint64(1), uint64(10), roots, false)
+			checkHistoriesInRange(t, freezer, uint64(1), uint64(10), false)
 		} else {
-			tail := 10 - int(c.limit)
-			checkHistoriesInRange(t, db, freezer, uint64(1), c.maxPruned, roots[:tail], false)
-			checkHistoriesInRange(t, db, freezer, c.minUnpruned, uint64(10), roots[tail:], true)
+			checkHistoriesInRange(t, freezer, uint64(1), c.maxPruned, false)
+			checkHistoriesInRange(t, freezer, c.minUnpruned, uint64(10), true)
 		}
 	}
 }
@@ -233,7 +224,6 @@ func TestTruncateTailStateHistories(t *testing.T) {
 func TestTruncateOutOfRange(t *testing.T) {
 	var (
 		hs         = makeStateHistories(10)
-		db         = rawdb.NewMemoryDatabase()
 		freezer, _ = rawdb.NewStateFreezer(t.TempDir(), false, false)
 	)
 	defer freezer.Close()
@@ -241,9 +231,8 @@ func TestTruncateOutOfRange(t *testing.T) {
 	for i := 0; i < len(hs); i++ {
 		accountData, storageData, accountIndex, storageIndex := hs[i].encode()
 		rawdb.WriteStateHistory(freezer, uint64(i+1), hs[i].meta.encode(), accountIndex, storageIndex, accountData, storageData)
-		rawdb.WriteStateID(db, hs[i].meta.root, uint64(i+1))
 	}
-	truncateFromTail(db, freezer, uint64(len(hs)/2))
+	truncateFromTail(freezer, uint64(len(hs)/2))
 
 	// Ensure of-out-range truncations are rejected correctly.
 	head, _ := freezer.Ancients()
@@ -264,9 +253,9 @@ func TestTruncateOutOfRange(t *testing.T) {
 	for _, c := range cases {
 		var gotErr error
 		if c.mode == 0 {
-			_, gotErr = truncateFromHead(db, freezer, c.target)
+			_, gotErr = truncateFromHead(freezer, c.target)
 		} else {
-			_, gotErr = truncateFromTail(db, freezer, c.target)
+			_, gotErr = truncateFromTail(freezer, c.target)
 		}
 		if !reflect.DeepEqual(gotErr, c.expErr) {
 			t.Errorf("Unexpected error, want: %v, got: %v", c.expErr, gotErr)

--- a/triedb/pathdb/history_state_test.go
+++ b/triedb/pathdb/history_state_test.go
@@ -18,6 +18,7 @@ package pathdb
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"reflect"
 	"testing"
@@ -244,11 +245,11 @@ func TestTruncateOutOfRange(t *testing.T) {
 		expErr error
 	}{
 		{0, head, nil}, // nothing to delete
-		{0, head + 1, fmt.Errorf("out of range, tail: %d, head: %d, target: %d", tail, head, head+1)},
-		{0, tail - 1, fmt.Errorf("out of range, tail: %d, head: %d, target: %d", tail, head, tail-1)},
+		{0, head + 1, errHeadTruncationOutOfRange},
+		{0, tail - 1, errHeadTruncationOutOfRange},
 		{1, tail, nil}, // nothing to delete
-		{1, head + 1, fmt.Errorf("out of range, tail: %d, head: %d, target: %d", tail, head, head+1)},
-		{1, tail - 1, fmt.Errorf("out of range, tail: %d, head: %d, target: %d", tail, head, tail-1)},
+		{1, head + 1, errTailTruncationOutOfRange},
+		{1, tail - 1, errTailTruncationOutOfRange},
 	}
 	for _, c := range cases {
 		var gotErr error
@@ -257,7 +258,7 @@ func TestTruncateOutOfRange(t *testing.T) {
 		} else {
 			_, gotErr = truncateFromTail(freezer, c.target)
 		}
-		if !reflect.DeepEqual(gotErr, c.expErr) {
+		if !errors.Is(gotErr, c.expErr) {
 			t.Errorf("Unexpected error, want: %v, got: %v", c.expErr, gotErr)
 		}
 	}

--- a/triedb/pathdb/reader.go
+++ b/triedb/pathdb/reader.go
@@ -224,11 +224,11 @@ func (db *Database) HistoricReader(root common.Hash) (*HistoricalStateReader, er
 	}
 	// Ensure the requested state is canonical, historical states on side chain
 	// are not accessible.
-	meta, err := readStateHistoryMeta(db.stateFreezer, *id)
+	meta, err := readStateHistoryMeta(db.stateFreezer, *id+1)
 	if err != nil {
 		return nil, err // e.g., the referred state history has been pruned
 	}
-	if meta.root != root {
+	if meta.parent != root {
 		return nil, fmt.Errorf("state %#x is not canonincal", root)
 	}
 	return &HistoricalStateReader{

--- a/triedb/pathdb/reader.go
+++ b/triedb/pathdb/reader.go
@@ -213,19 +213,23 @@ func (db *Database) HistoricReader(root common.Hash) (*HistoricalStateReader, er
 	if !db.stateIndexer.inited() {
 		return nil, errors.New("state histories haven't been fully indexed yet")
 	}
-	// States at the current disk layer or above are directly accessible via
-	// db.StateReader.
+	// - States at the current disk layer or above are directly accessible
+	//   via `db.StateReader`.
 	//
-	// States older than the current disk layer (including the disk layer
-	// itself) are available through historic state access.
-	//
-	// Note: the requested state may refer to a stale historic state that has
-	// already been pruned. This function does not validate availability, as
-	// underlying states may be pruned dynamically. Validity is checked during
-	// each actual state retrieval.
+	// - States older than the current disk layer (including the disk layer
+	//   itself) are available via `db.HistoricReader`.
 	id := rawdb.ReadStateID(db.diskdb, root)
 	if id == nil {
 		return nil, fmt.Errorf("state %#x is not available", root)
+	}
+	// Ensure the requested state is canonical, historical states on side chain
+	// are not accessible.
+	meta, err := readStateHistoryMeta(db.stateFreezer, *id)
+	if err != nil {
+		return nil, err // e.g., the referred state history has been pruned
+	}
+	if meta.root != root {
+		return nil, fmt.Errorf("state %#x is not canonincal", root)
 	}
 	return &HistoricalStateReader{
 		id:     *id,


### PR DESCRIPTION
This pull request preserves the root->ID mappings in the path database even 
after the associated state histories are truncated, regardless of whether the 
truncation occurs at the head or the tail.

The motivation is to support an additional history type, trienode history. Since 
the root->ID mappings are shared between two history instances, they must 
not be removed by either one.

As a consequence, the root->ID mappings remain in the database even after 
the corresponding histories are pruned. While these mappings may become 
dangling, it is safe and cheap to keep them.

Additionally, this pull request enhances validation during historical reader 
construction, ensuring that only canonical historical state will be served.