### PR TITLE
feat(filters): send correct log payload to notifier to avoid pointer aliasing

### DIFF
--- a/eth/filters/api.go
+++ b/eth/filters/api.go
@@ -284,7 +284,7 @@ func (api *FilterAPI) Logs(ctx context.Context, crit FilterCriteria) (*rpc.Subsc
 			select {
 			case logs := <-matchedLogs:
 				for _, log := range logs {
-					notifier.Notify(rpcSub.ID, &log)
+					notifier.Notify(rpcSub.ID, log)
 				}
 			case <-rpcSub.Err(): // client send an unsubscribe request
 				return


### PR DESCRIPTION
This change updates Logs subscription notifications to pass the actual types.Log value instead of a pointer to the loop variable (&log). It prevents sending types.Log and avoids aliasing issues when the notifier buffers payloads before activation. Aligns notification style with other subscriptions (e.g., newHeads).