### PR TITLE
fix: add nil pointer protection in CanTransfer and Transfer functions

### DIFF
--- a/core/evm.go
+++ b/core/evm.go
@@ -136,11 +136,17 @@ func GetHashFn(ref *types.Header, chain ChainContext) func(n uint64) common.Hash
 // CanTransfer checks whether there are enough funds in the address' account to make a transfer.
 // This does not take the necessary gas in to account to make the transfer valid.
 func CanTransfer(db vm.StateDB, addr common.Address, amount *uint256.Int) bool {
+	if amount == nil {
+		return false
+	}
 	return db.GetBalance(addr).Cmp(amount) >= 0
 }
 
 // Transfer subtracts amount from sender and adds amount to recipient using the given Db
 func Transfer(db vm.StateDB, sender, recipient common.Address, amount *uint256.Int) {
+	if amount == nil {
+		return
+	}
 	db.SubBalance(sender, amount, tracing.BalanceChangeTransfer)
 	db.AddBalance(recipient, amount, tracing.BalanceChangeTransfer)
 }


### PR DESCRIPTION
- Return false early in CanTransfer for nil amount
- Return early in Transfer for nil amount
- Prevents potential crashes in EVM execution