### PR TITLE
p2p/discover: fix timeout on refresh if no bootnodes

### DIFF
--- a/p2p/discover/table.go
+++ b/p2p/discover/table.go
@@ -428,6 +428,12 @@ func (tab *Table) doRefresh(done chan struct{}) {
 	// (hopefully) still alive.
 	tab.loadSeedNodes()
 
+	// If the table is empty, we cannot perform any lookups.
+	if tab.len() == 0 {
+		log.Debug("doRefresh called, but no nodes to start from")
+		return
+	}
+
 	// Run self lookup to discover new neighbor nodes.
 	tab.net.lookupSelf()
 


### PR DESCRIPTION
If we have no nodes to add in a refresh, and the table is empty, it is useless to do lookups.

This was triggering a 3 second wait for a timeout in the initialization code in some synthetic tests when no bootnodes were added, making some hive tests fail.
This fixes https://github.com/ethereum/hive/issues/1335