### PR TITLE
p2p/discover: remove delay from discv5 RandomNodes

### DIFF
--- a/p2p/discover/v5_udp.go
+++ b/p2p/discover/v5_udp.go
@@ -328,12 +328,6 @@ func (t *UDPv5) TalkRequestToID(id enode.ID, addr netip.AddrPort, protocol strin
 
 // RandomNodes returns an iterator that finds random nodes in the DHT.
 func (t *UDPv5) RandomNodes() enode.Iterator {
-	if t.tab.len() == 0 {
-		// All nodes were dropped, refresh. The very first query will hit this
-		// case and run the bootstrapping logic.
-		<-t.tab.refresh()
-	}
-
 	return newLookupIterator(t.closeCtx, t.newRandomLookup)
 }
 


### PR DESCRIPTION
Refresh is doing some lookups and thus it could block for some time. We do not want the initializer of an iterator to block. If there is something blocking, it should happen when calling Next.

Here, next will start a lookup, which will wait if needed (no nodes), making sure the iterator's Next is not creating a busy loop.