### PR TITLE
cmd/geth: snapshot traverse account trie

### DIFF
--- a/cmd/geth/snapshot.go
+++ b/cmd/geth/snapshot.go
@@ -612,7 +612,7 @@ func (ts *traverseSetup) traverseState(ctx context.Context, counters *traverseCo
 
 			if ts.config != nil {
 				// Skip branches that are entirely before startKey
-				if limitKey != nil && bytes.Compare(limitKey, ts.config.startKey) <= 0 {
+				if ts.config.startKey != nil && limitKey != nil && bytes.Compare(limitKey, ts.config.startKey) <= 0 {
 					return nil
 				}
 

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -994,6 +994,22 @@ var (
 		StateSchemeFlag,
 		HttpHeaderFlag,
 	}
+
+	// TraverseStateFlags is the flag group of all state traversal flags.
+	TraverseStateFlags = []cli.Flag{
+		&cli.StringFlag{
+			Name:  "account",
+			Usage: "Account address or hash to traverse storage for (enables account mode)",
+		},
+		&cli.StringFlag{
+			Name:  "start",
+			Usage: "Starting key (account key for state mode, storage key for account mode)",
+		},
+		&cli.StringFlag{
+			Name:  "limit",
+			Usage: "Ending key (account key for state mode, storage key for account mode)",
+		},
+	}
 )
 
 // default account to prefund when running Geth in dev mode


### PR DESCRIPTION
Extend the `snapshot traverse-{raw}state` to iterate with state trie or storage trie.

Full command as below:

```bash
geth snapshot traverse-state [--account <account>] [--start <key>] [--limit <key>] <state-root>
```

1. Traverse the whole state from the given state root:
- `--start`: starting account key (64/66 chars hex) [optional]
- `--limit`: ending account key (64/66 chars hex) [optional]

2. Traverse a specific account's storage:
- `--account`: account address (40/42 chars) or hash (64/66 chars) [required]
- `--start`: starting storage key (64/66 chars hex) [optional]
- `--limit`: ending storage key (64/66 chars hex) [optional]


