### PR TITLE
core/txpool/blobpool: validate the blob tx at first to avoid unnecessary conversion

### DIFF
--- a/core/txpool/blobpool/blobpool.go
+++ b/core/txpool/blobpool/blobpool.go
@@ -1406,12 +1406,14 @@ func (p *BlobPool) convertSidecar(txs []*types.Transaction) ([]*types.Transactio
 	}
 	var errs []error
 	for _, tx := range txs {
-		sidecar := tx.BlobTxSidecar()
-		if sidecar == nil {
-			errs = append(errs, errors.New("missing sidecar in blob transaction"))
+		// Validate the transaction at first to avoid unnecessary conversion.
+		if err := p.validateTx(tx); err != nil {
+			errs = append(errs, err)
 			continue
 		}
-		if sidecar.Version == types.BlobSidecarVersion0 {
+
+		sidecar := tx.BlobTxSidecar()
+		if tx.BlobTxSidecar().Version == types.BlobSidecarVersion0 {
 			if err := sidecar.ToV1(); err != nil {
 				errs = append(errs, err)
 				continue


### PR DESCRIPTION
This PR aims to avoid being attached by illegal blob txs.