### PR TITLE
fix: correct misleading fork state comments in forkid tests

### DIFF
--- a/core/forkid/forkid_test.go
+++ b/core/forkid/forkid_test.go
@@ -87,7 +87,7 @@ func TestCreation(t *testing.T) {
 			params.SepoliaChainConfig,
 			core.DefaultSepoliaGenesisBlock().ToBlock(),
 			[]testcase{
-				{0, 0, ID{Hash: checksumToBytes(0xfe3366e7), Next: 1735371}},                   // Unsynced, last Frontier, Homestead, Tangerine, Spurious, Byzantium, Constantinople, Petersburg, Istanbul, Berlin and first London block
+				{0, 0, ID{Hash: checksumToBytes(0xfe3366e7), Next: 1735371}},                   // Unsynced, last Frontier, Homestead, Tangerine, Spurious, Byzantium, Constantinople, Petersburg, Istanbul, Berlin and last London block
 				{1735370, 0, ID{Hash: checksumToBytes(0xfe3366e7), Next: 1735371}},             // Last London block
 				{1735371, 0, ID{Hash: checksumToBytes(0xb96cbd13), Next: 1677557088}},          // First MergeNetsplit block
 				{1735372, 1677557087, ID{Hash: checksumToBytes(0xb96cbd13), Next: 1677557088}}, // Last MergeNetsplit block
@@ -105,8 +105,8 @@ func TestCreation(t *testing.T) {
 			core.DefaultHoleskyGenesisBlock().ToBlock(),
 			[]testcase{
 				{0, 0, ID{Hash: checksumToBytes(0xc61a6098), Next: 1696000704}},            // Unsynced, last Frontier, Homestead, Tangerine, Spurious, Byzantium, Constantinople, Petersburg, Istanbul, Berlin, London, Paris block
-				{123, 0, ID{Hash: checksumToBytes(0xc61a6098), Next: 1696000704}},          // First MergeNetsplit block
-				{123, 1696000704, ID{Hash: checksumToBytes(0xfd4f016b), Next: 1707305664}}, // First Shanghai block
+				{123, 0, ID{Hash: checksumToBytes(0xc61a6098), Next: 1696000704}},          // Last Paris block
+				{123, 1696000704, ID{Hash: checksumToBytes(0xfd4f016b), Next: 1707305664}}, // Last Shanghai block
 				{123, 1707305663, ID{Hash: checksumToBytes(0xfd4f016b), Next: 1707305664}}, // Last Shanghai block
 				{123, 1707305664, ID{Hash: checksumToBytes(0x9b192ad0), Next: 1740434112}}, // First Cancun block
 				{123, 1740434111, ID{Hash: checksumToBytes(0x9b192ad0), Next: 1740434112}}, // Last Cancun block


### PR DESCRIPTION
Fix incorrect "First" vs "Last" fork state comments in forkid tests

The fork ID logic shows the current blockchain state, not the next fork.
These comments were misleading developers about when forks activate:

- Sepolia test: "first London block" → "last London block"
- Holesky test: "First MergeNetsplit block" → "Last Paris block"  
- Holesky test: "First Shanghai block" → "Last Shanghai block"

These corrections align with the established pattern in mainnet tests
and accurately reflect the fork activation logic (fork_time <= current_time).