### PR TITLE
trie: a small gc improvement

### DIFF
--- a/trie/encoding.go
+++ b/trie/encoding.go
@@ -108,7 +108,6 @@ func keybytesToHex(str []byte) []byte {
 // OBS! This method omits the termination flag.
 // OBS! The dst slice must be at least 2x as large as the key
 func writeHexKey(dst []byte, key []byte) []byte {
-	_ = dst[2*len(key)-1]
 	for i, b := range key {
 		dst[i*2] = b / 16
 		dst[i*2+1] = b % 16

--- a/trie/stacktrie.go
+++ b/trie/stacktrie.go
@@ -59,7 +59,7 @@ func NewStackTrie(onTrieNode OnTrieNode) *StackTrie {
 		root:       stPool.Get().(*stNode),
 		h:          newHasher(false),
 		onTrieNode: onTrieNode,
-		last:       make([]byte, 64),
+		last:       make([]byte, 0, 64),
 		kBuf:       make([]byte, 64),
 		pBuf:       make([]byte, 64),
 	}

--- a/trie/stacktrie.go
+++ b/trie/stacktrie.go
@@ -59,6 +59,7 @@ func NewStackTrie(onTrieNode OnTrieNode) *StackTrie {
 		root:       stPool.Get().(*stNode),
 		h:          newHasher(false),
 		onTrieNode: onTrieNode,
+		last:       make([]byte, 64),
 		kBuf:       make([]byte, 64),
 		pBuf:       make([]byte, 64),
 	}
@@ -83,11 +84,7 @@ func (t *StackTrie) Update(key, value []byte) error {
 	if bytes.Compare(t.last, k) >= 0 {
 		return errors.New("non-ascending key order")
 	}
-	if t.last == nil {
-		t.last = append([]byte{}, k...) // allocate key slice
-	} else {
-		t.last = append(t.last[:0], k...) // reuse key slice
-	}
+	t.last = append(t.last[:0], k...) // reuse key slice
 	t.insert(t.root, k, value, t.pBuf[:0])
 	return nil
 }
@@ -95,7 +92,7 @@ func (t *StackTrie) Update(key, value []byte) error {
 // Reset resets the stack trie object to empty state.
 func (t *StackTrie) Reset() {
 	t.root = stPool.Get().(*stNode)
-	t.last = nil
+	t.last = t.last[:0]
 }
 
 // TrieKey returns the internal key representation for the given user key.


### PR DESCRIPTION
A slight improvement in reducing GC about the `latest` field.

Still holds the `latest` content, never set to `null`, so that the slice won't be recycled by GC.