### PR TITLE
cmd/devp2p/internal/ethtest: fix possible infinite wait

### DIFF
--- a/cmd/devp2p/internal/ethtest/suite.go
+++ b/cmd/devp2p/internal/ethtest/suite.go
@@ -1133,7 +1133,10 @@ func (s *Suite) testBadBlobTx(t *utesting.T, tx *types.Transaction, badTx *types
 		// transmit the same tx but with correct sidecar from the good peer.
 
 		var req *eth.GetPooledTransactionsPacket
-		req, err = readUntil[eth.GetPooledTransactionsPacket](context.Background(), conn)
+		ctx, cancel := context.WithTimeout(context.Background(), 12*time.Second)
+		defer cancel()
+
+		req, err = readUntil[eth.GetPooledTransactionsPacket](ctx, conn)
 		if err != nil {
 			errc <- fmt.Errorf("reading pooled tx request failed: %v", err)
 			return


### PR DESCRIPTION
TestBlobTxWithoutSidecar test could run infinitely in case of a client not requesting the good transaction. This adds a timeout to make the test fail in this case.

Fixes https://github.com/ethereum/go-ethereum/issues/32422