### PR TITLE
core/vm: fix comment and remove unused divisor in osakaModexpGas

### DIFF
--- a/core/vm/contracts.go
+++ b/core/vm/contracts.go
@@ -531,7 +531,6 @@ func berlinModexpGas(baseLen, expLen, modLen uint64, expHead uint256.Int) uint64
 func osakaModexpGas(baseLen, expLen, modLen uint64, expHead uint256.Int) uint64 {
 	const (
 		multiplier = 16
-		divisor    = 3
 		minGas     = 500
 	)
 
@@ -542,7 +541,7 @@ func osakaModexpGas(baseLen, expLen, modLen uint64, expHead uint256.Int) uint64 
 	}
 	iterationCount := modexpIterationCount(expLen, expHead, multiplier)
 
-	// Calculate gas: (multComplexity * iterationCount) / osakaDivisor
+	// Calculate gas: multComplexity * iterationCount
 	carry, gas := bits.Mul64(iterationCount, multComplexity)
 	if carry != 0 {
 		return math.MaxUint64


### PR DESCRIPTION
The `divisor` const is not needed in the gas cost calculation in `osakaModexpGas`.

From [EIP-7883](https://eips.ethereum.org/EIPS/eip-7883):
The gas cost calculation is modified from:
`    return max(200, math.floor(multiplication_complexity * iteration_count / 3))`
to:
`    return max(500, math.floor(multiplication_complexity * iteration_count))`
This change increases the minimum gas cost from 200 to 500 and triples the general cost by removing the division by 3.