### PR TITLE
rlp: fix typo in decode test message

### DIFF
--- a/rlp/decode_test.go
+++ b/rlp/decode_test.go
@@ -350,7 +350,7 @@ func TestDecodeErrors(t *testing.T) {
 	}
 
 	if err := Decode(r, new(uint)); err != io.EOF {
-		t.Errorf("Decode(r, new(int)) error mismatch, got %q, want %q", err, io.EOF)
+		t.Errorf("Decode(r, new(uint)) error mismatch, got %q, want %q", err, io.EOF)
 	}
 }
 


### PR DESCRIPTION
The test invokes Decode with new(uint) but the failure message referenced new(int), which is misleading during failures. This change corrects the message to new(uint) for accuracy and consistency with the actual call.