### PR TITLE
core/state: fix incorrect comment for stateBloomFileSuffix in pruner.go

### DIFF
--- a/core/state/pruner/pruner.go
+++ b/core/state/pruner/pruner.go
@@ -42,7 +42,7 @@ const (
 	// stateBloomFilePrefix is the filename prefix of state bloom filter.
 	stateBloomFilePrefix = "statebloom"
 
-	// stateBloomFilePrefix is the filename suffix of state bloom filter.
+	// stateBloomFileSuffix is the filename suffix of state bloom filter.
 	stateBloomFileSuffix = "bf.gz"
 
 	// stateBloomFileTempSuffix is the filename suffix of state bloom filter


### PR DESCRIPTION
Correct an inconsistance in the constant comment where the suffix constant was mistakenly documented as the prefix. No functional changes; comment-only fix.