### PR TITLE
accounts/abi/bind/v2: add Address method to BoundContract

### DIFF
--- a/accounts/abi/bind/v2/base.go
+++ b/accounts/abi/bind/v2/base.go
@@ -150,6 +150,11 @@ func NewBoundContract(address common.Address, abi abi.ABI, caller ContractCaller
 	}
 }
 
+// Address returns the deployment address of the contract.
+func (c *BoundContract) Address() common.Address {
+	return c.address
+}
+
 // Call invokes the (constant) contract method with params as input values and
 // sets the output to result. The result type might be a single field for simple
 // returns, a slice of interfaces for anonymous returns and a struct for named


### PR DESCRIPTION
## Rationale

Since we're already storing the deployment address inside `BoundContract`, a simple reader method would be helpful to access the same without allocating new variables.

For example, here's the `PackConstructor` method for the OpenZeppelin Governance contract:

```go
func (myGovernor *MyGovernor) PackConstructor(_token common.Address, _timelock common.Address) []byte {
	enc, err := myGovernor.abi.Pack("", _token, _timelock)
	if err != nil {
		panic(err)
	}
	return enc
}
```

Since we've already deployed the token and timelock contracts and created instance wrappers for the same, simply calling `Address()` on those wrappers will be helpful here.