### PR TITLE
ethdb/pebble: set metric namespace correctly

### DIFF
--- a/ethdb/pebble/pebble.go
+++ b/ethdb/pebble/pebble.go
@@ -218,9 +218,9 @@ func New(file string, cache int, handles int, namespace string, readonly bool) (
 		memTableSize = maxMemTableSize - 1
 	}
 	db := &Database{
-		fn:       file,
-		log:      logger,
-		quitChan: make(chan chan error),
+		fn:        file,
+		log:       logger,
+		quitChan:  make(chan chan error),
 		namespace: namespace,
 
 		// Use asynchronous write mode by default. Otherwise, the overhead of frequent fsync


### PR DESCRIPTION
Ensure Database.namespace is initialized in pebble.New(...). Without this, the write-stall metrics registered in onWriteStallBegin/End are emitted without the intended namespace prefix, while other Pebble metrics use the provided constructor parameter. This aligns stall metrics with the rest of the Pebble metric set and fixes inconsistent metric naming.