### PR TITLE
params: use spaces instead of tabs in config description

### DIFF
--- a/params/config.go
+++ b/params/config.go
@@ -531,25 +531,25 @@ func (c *ChainConfig) Description() string {
 		banner += fmt.Sprintf(" - Prague:                      @%-10v\n", *c.PragueTime)
 	}
 	if c.OsakaTime != nil {
-		banner += fmt.Sprintf(" - Osaka:                      @%-10v\n", *c.OsakaTime)
+		banner += fmt.Sprintf(" - Osaka:                       @%-10v\n", *c.OsakaTime)
 	}
 	if c.VerkleTime != nil {
 		banner += fmt.Sprintf(" - Verkle:                      @%-10v\n", *c.VerkleTime)
 	}
 	if c.BPO1Time != nil {
-		banner += fmt.Sprintf(" - BPO1:                      @%-10v\n", *c.BPO1Time)
+		banner += fmt.Sprintf(" - BPO1:                        @%-10v\n", *c.BPO1Time)
 	}
 	if c.BPO2Time != nil {
-		banner += fmt.Sprintf(" - BPO2:                      @%-10v\n", *c.BPO2Time)
+		banner += fmt.Sprintf(" - BPO2:                        @%-10v\n", *c.BPO2Time)
 	}
 	if c.BPO3Time != nil {
-		banner += fmt.Sprintf(" - BPO3:                      @%-10v\n", *c.BPO3Time)
+		banner += fmt.Sprintf(" - BPO3:                        @%-10v\n", *c.BPO3Time)
 	}
 	if c.BPO4Time != nil {
-		banner += fmt.Sprintf(" - BPO4:                      @%-10v\n", *c.BPO4Time)
+		banner += fmt.Sprintf(" - BPO4:                        @%-10v\n", *c.BPO4Time)
 	}
 	if c.BPO5Time != nil {
-		banner += fmt.Sprintf(" - BPO5:                      @%-10v\n", *c.BPO5Time)
+		banner += fmt.Sprintf(" - BPO5:                        @%-10v\n", *c.BPO5Time)
 	}
 	return banner
 }


### PR DESCRIPTION
The tabs aren't consistently spaced with the other items in the description. This fixes it.

Before:
<img width="358" height="130" alt="Screenshot 2025-09-09 at 06 43 22" src="https://github.com/user-attachments/assets/bdbad009-9867-4918-8115-1e58770f2706" />

After:
<img width="356" height="130" alt="Screenshot 2025-09-09 at 06 42 33" src="https://github.com/user-attachments/assets/70c8fb0b-2de0-4703-9fe7-041a0eff449c" />
