### PR TITLE
rlp: Fix the AppendToBytes method

### DIFF
--- a/rlp/encbuffer.go
+++ b/rlp/encbuffer.go
@@ -359,11 +359,16 @@ func (w *EncoderBuffer) ToBytes() []byte {
 }
 
 // AppendToBytes appends the encoded bytes to dst.
-func (w *EncoderBuffer) AppendToBytes(dst []byte) []byte {
+func (w *EncoderBuffer) AppendToBytes(dst *[]byte) {
 	size := w.buf.size()
-	out := append(dst, make([]byte, size)...)
-	w.buf.copyTo(out[len(dst):])
-	return out
+	tmp, length := *dst, len(*dst)
+	if cap(tmp) >= size+length {
+		tmp = tmp[:size+length]
+	} else {
+		tmp = append(tmp, make([]byte, size)...)
+	}
+	*dst = tmp
+	w.buf.copyTo(tmp[length:])
 }
 
 // Write appends b directly to the encoder output.

--- a/rlp/encode_test.go
+++ b/rlp/encode_test.go
@@ -435,7 +435,7 @@ func TestEncodeToBytes(t *testing.T) {
 }
 
 func TestEncodeAppendToBytes(t *testing.T) {
-	buffer := make([]byte, 20)
+	buffer := make([]byte, 3)
 	runEncTests(t, func(val interface{}) ([]byte, error) {
 		w := NewEncoderBuffer(nil)
 		defer w.Flush()
@@ -444,8 +444,9 @@ func TestEncodeAppendToBytes(t *testing.T) {
 		if err != nil {
 			return nil, err
 		}
-		output := w.AppendToBytes(buffer[:0])
-		return output, nil
+		buffer = buffer[:0]
+		w.AppendToBytes(&buffer)
+		return buffer, nil
 	})
 }
 

--- a/rlp/encode_test.go
+++ b/rlp/encode_test.go
@@ -435,7 +435,7 @@ func TestEncodeToBytes(t *testing.T) {
 }
 
 func TestEncodeAppendToBytes(t *testing.T) {
-	buffer := make([]byte, 3)
+	buffer := make([]byte, 20)
 	runEncTests(t, func(val interface{}) ([]byte, error) {
 		w := NewEncoderBuffer(nil)
 		defer w.Flush()

--- a/trie/hasher.go
+++ b/trie/hasher.go
@@ -181,7 +181,8 @@ func (h *hasher) encodeFullNode(n *fullNode) []byte {
 // This convention exists because node.encode can only be inlined/escape-analyzed when
 // called on a concrete receiver type.
 func (h *hasher) encodedBytes() []byte {
-	h.tmp = h.encbuf.AppendToBytes(h.tmp[:0])
+	h.tmp = h.tmp[:0]
+	h.encbuf.AppendToBytes(&h.tmp)
 	h.encbuf.Reset(nil)
 	return h.tmp
 }


### PR DESCRIPTION
When the remaining capacity of dst meets the size requirement, there is no need to create an additional slice, which allows reusing dst.
In the original code, regardless of whether the remaining capacity of dst meets the size requirement, a new slice will always be created and the old slice will be overwritten by return a new one.