### PR TITLE
common/prque: remove unreachable offset==blockSize branch in Push

### DIFF
--- a/common/prque/sstack.go
+++ b/common/prque/sstack.go
@@ -57,9 +57,6 @@ func (s *sstack[P, V]) Push(data any) {
 		s.blocks = append(s.blocks, s.active)
 		s.capacity += blockSize
 		s.offset = 0
-	} else if s.offset == blockSize {
-		s.active = s.blocks[s.size/blockSize]
-		s.offset = 0
 	}
 	if s.setIndex != nil {
 		s.setIndex(data.(*item[P, V]).value, s.size)


### PR DESCRIPTION
The else-if branch checking s.offset == blockSize in Push was never reachable.
At the start of each Push, offset is effectively size % blockSize, so it cannot equal blockSize. Block rollover is already handled when size == capacity, wherea new block is allocated and offset is reset to 0. Removing the dead branch simplifies the logic and reduces code noise without changing behavior.