### PR TITLE
accounts/abi/bind/v2: fix the transact method

### DIFF
--- a/accounts/abi/bind/v2/base.go
+++ b/accounts/abi/bind/v2/base.go
@@ -416,8 +416,6 @@ func (c *BoundContract) transact(opts *TransactOpts, contract *common.Address, i
 	)
 	if opts.GasPrice != nil {
 		rawTx, err = c.createLegacyTx(opts, contract, input)
-	} else if opts.GasFeeCap != nil && opts.GasTipCap != nil {
-		rawTx, err = c.createDynamicTx(opts, contract, input, nil)
 	} else {
 		// Only query for basefee if gasPrice not specified
 		if head, errHead := c.transactor.HeaderByNumber(ensureContext(opts.Context), nil); errHead != nil {


### PR DESCRIPTION
The `createDynamicTx` method requires `head != nil && head.BaseFee != nil` otherwise can only use `createLegacyTx`, then follow the logic is same as the following `else` condition.

Using the empty value of `head` can trigger panic in the `createDynamicTx` method.