### PR TITLE
core/txpool/blobpool: Do not use blobs with wrong sidecar version while building block after Osaka

### DIFF
--- a/core/txpool/blobpool/blobpool.go
+++ b/core/txpool/blobpool/blobpool.go
@@ -1667,7 +1667,7 @@ func (p *BlobPool) drop() {
 func (p *BlobPool) Pending(filter txpool.PendingFilter) map[common.Address][]*txpool.LazyTransaction {
 	// If only plain transactions are requested, this pool is unsuitable as it
 	// contains none, don't even bother.
-	if filter.OnlyPlainTxs {
+	if !filter.BlobTxs {
 		return nil
 	}
 	// Track the amount of time waiting to retrieve the list of pending blob txs
@@ -1688,12 +1688,8 @@ func (p *BlobPool) Pending(filter txpool.PendingFilter) map[common.Address][]*tx
 	for addr, txs := range p.index {
 		lazies := make([]*txpool.LazyTransaction, 0, len(txs))
 		for _, tx := range txs {
-
-			// Skip v0 or v1 blob transactions if not requested
-			if filter.OnlyBlobV0Txs && tx.version != types.BlobSidecarVersion0 {
-				break // skip the rest because of nonce ordering
-			}
-			if filter.OnlyBlobV1Txs && tx.version != types.BlobSidecarVersion1 {
+			// Skip v0 or v1 blob transactions depending on the filter
+			if tx.version != filter.BlobVersion {
 				break // skip the rest because of nonce ordering
 			}
 

--- a/core/txpool/blobpool/blobpool.go
+++ b/core/txpool/blobpool/blobpool.go
@@ -1691,10 +1691,10 @@ func (p *BlobPool) Pending(filter txpool.PendingFilter) map[common.Address][]*tx
 
 			// Skip v0 or v1 blob transactions if not requested
 			if filter.OnlyBlobV0Txs && tx.version != types.BlobSidecarVersion0 {
-				continue
+				break // skip the rest because of nonce ordering
 			}
 			if filter.OnlyBlobV1Txs && tx.version != types.BlobSidecarVersion1 {
-				continue
+				break // skip the rest because of nonce ordering
 			}
 
 			// If transaction filtering was requested, discard badly priced ones

--- a/core/txpool/blobpool/blobpool.go
+++ b/core/txpool/blobpool/blobpool.go
@@ -1688,6 +1688,15 @@ func (p *BlobPool) Pending(filter txpool.PendingFilter) map[common.Address][]*tx
 	for addr, txs := range p.index {
 		lazies := make([]*txpool.LazyTransaction, 0, len(txs))
 		for _, tx := range txs {
+
+			// Skip v0 or v1 blob transactions if not requested
+			if filter.OnlyBlobV0Txs && tx.version != types.BlobSidecarVersion0 {
+				continue
+			}
+			if filter.OnlyBlobV1Txs && tx.version != types.BlobSidecarVersion1 {
+				continue
+			}
+
 			// If transaction filtering was requested, discard badly priced ones
 			if filter.MinTip != nil && filter.BaseFee != nil {
 				if tx.execFeeCap.Lt(filter.BaseFee) {

--- a/core/txpool/legacypool/legacypool.go
+++ b/core/txpool/legacypool/legacypool.go
@@ -508,7 +508,7 @@ func (pool *LegacyPool) ContentFrom(addr common.Address) ([]*types.Transaction, 
 func (pool *LegacyPool) Pending(filter txpool.PendingFilter) map[common.Address][]*txpool.LazyTransaction {
 	// If only blob transactions are requested, this pool is unsuitable as it
 	// contains none, don't even bother.
-	if filter.OnlyBlobV0Txs || filter.OnlyBlobV1Txs {
+	if filter.BlobTxs {
 		return nil
 	}
 	pool.mu.Lock()

--- a/core/txpool/legacypool/legacypool.go
+++ b/core/txpool/legacypool/legacypool.go
@@ -508,7 +508,7 @@ func (pool *LegacyPool) ContentFrom(addr common.Address) ([]*types.Transaction, 
 func (pool *LegacyPool) Pending(filter txpool.PendingFilter) map[common.Address][]*txpool.LazyTransaction {
 	// If only blob transactions are requested, this pool is unsuitable as it
 	// contains none, don't even bother.
-	if filter.OnlyBlobTxs {
+	if filter.OnlyBlobV0Txs || filter.OnlyBlobV1Txs {
 		return nil
 	}
 	pool.mu.Lock()

--- a/core/txpool/subpool.go
+++ b/core/txpool/subpool.go
@@ -78,8 +78,9 @@ type PendingFilter struct {
 	BlobFee     *uint256.Int // Minimum 4844 blobfee needed to include a blob transaction
 	GasLimitCap uint64       // Maximum gas can be used for a single transaction execution (0 means no limit)
 
-	OnlyPlainTxs bool // Return only plain EVM transactions (peer-join announces, block space filling)
-	OnlyBlobTxs  bool // Return only blob transactions (block blob-space filling)
+	OnlyPlainTxs  bool // Return only plain EVM transactions (peer-join announces, block space filling)
+	OnlyBlobV0Txs bool // Return only V0 encoded blob transactions (block blob-space filling)
+	OnlyBlobV1Txs bool // Return only V1 encoded blob transactions (block blob-space filling)
 }
 
 // TxMetadata denotes the metadata of a transaction.

--- a/core/txpool/subpool.go
+++ b/core/txpool/subpool.go
@@ -78,9 +78,10 @@ type PendingFilter struct {
 	BlobFee     *uint256.Int // Minimum 4844 blobfee needed to include a blob transaction
 	GasLimitCap uint64       // Maximum gas can be used for a single transaction execution (0 means no limit)
 
-	OnlyPlainTxs  bool // Return only plain EVM transactions (peer-join announces, block space filling)
-	OnlyBlobV0Txs bool // Return only V0 encoded blob transactions (block blob-space filling)
-	OnlyBlobV1Txs bool // Return only V1 encoded blob transactions (block blob-space filling)
+	// When BlobTxs true, return only blob transactions (block blob-space filling)
+	// when false, return only non-blob txs (peer-join announces, block space filling)
+	BlobTxs     bool
+	BlobVersion byte // Blob tx version to include. 0 means pre-Osaka, 1 means Osaka and later
 }
 
 // TxMetadata denotes the metadata of a transaction.

--- a/eth/sync.go
+++ b/eth/sync.go
@@ -25,7 +25,7 @@ import (
 // syncTransactions starts sending all currently pending transactions to the given peer.
 func (h *handler) syncTransactions(p *eth.Peer) {
 	var hashes []common.Hash
-	for _, batch := range h.txpool.Pending(txpool.PendingFilter{OnlyPlainTxs: true}) {
+	for _, batch := range h.txpool.Pending(txpool.PendingFilter{BlobTxs: false}) {
 		for _, tx := range batch {
 			hashes = append(hashes, tx.Hash)
 		}

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -481,13 +481,14 @@ func (miner *Miner) fillTransactions(interrupt *atomic.Int32, env *environment) 
 	if miner.chainConfig.IsOsaka(env.header.Number, env.header.Time) {
 		filter.GasLimitCap = params.MaxTxGas
 	}
-	filter.OnlyPlainTxs, filter.OnlyBlobV0Txs, filter.OnlyBlobV1Txs = true, false, false
+	filter.BlobTxs = false
 	pendingPlainTxs := miner.txpool.Pending(filter)
 
+	filter.BlobTxs = true
 	if miner.chainConfig.IsOsaka(env.header.Number, env.header.Time) {
-		filter.OnlyPlainTxs, filter.OnlyBlobV0Txs, filter.OnlyBlobV1Txs = false, false, true
+		filter.BlobVersion = types.BlobSidecarVersion1
 	} else {
-		filter.OnlyPlainTxs, filter.OnlyBlobV0Txs, filter.OnlyBlobV1Txs = false, true, false
+		filter.BlobVersion = types.BlobSidecarVersion0
 	}
 	pendingBlobTxs := miner.txpool.Pending(filter)
 

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -481,10 +481,14 @@ func (miner *Miner) fillTransactions(interrupt *atomic.Int32, env *environment) 
 	if miner.chainConfig.IsOsaka(env.header.Number, env.header.Time) {
 		filter.GasLimitCap = params.MaxTxGas
 	}
-	filter.OnlyPlainTxs, filter.OnlyBlobTxs = true, false
+	filter.OnlyPlainTxs, filter.OnlyBlobV0Txs, filter.OnlyBlobV1Txs = true, false, false
 	pendingPlainTxs := miner.txpool.Pending(filter)
 
-	filter.OnlyPlainTxs, filter.OnlyBlobTxs = false, true
+	if miner.chainConfig.IsOsaka(env.header.Number, env.header.Time) {
+		filter.OnlyPlainTxs, filter.OnlyBlobV0Txs, filter.OnlyBlobV1Txs = false, false, true
+	} else {
+		filter.OnlyPlainTxs, filter.OnlyBlobV0Txs, filter.OnlyBlobV1Txs = false, true, false
+	}
 	pendingBlobTxs := miner.txpool.Pending(filter)
 
 	// Split the pending transactions into locals and remotes.


### PR DESCRIPTION
As a consequence of moving blob sidecar version migration code around, we ended up building blocks
with a mix of v0 and v1  blob transactions (different proof encoding in the sidecar).

This PR makes sure we are not building illegal blocks after Osaka. Blob migration is left for another PR.

Related issues and PRs:
- https://github.com/ethereum/go-ethereum/pull/31791
- https://github.com/ethereum/go-ethereum/pull/32347
- https://github.com/ethereum/go-ethereum/pull/31966
- https://github.com/ethereum/go-ethereum/issues/32235