### PR TITLE
core/rawdb: fix typo in TestWriteAncientHeaderChain

### DIFF
--- a/core/rawdb/accessors_chain_test.go
+++ b/core/rawdb/accessors_chain_test.go
@@ -511,7 +511,7 @@ func TestWriteAncientHeaderChain(t *testing.T) {
 			t.Fatalf("unexpected body returned")
 		}
 		if blob := ReadReceiptsRLP(db, header.Hash(), header.Number.Uint64()); len(blob) != 0 {
-			t.Fatalf("unexpected body returned")
+			t.Fatalf("unexpected receipts returned")
 		}
 	}
 }


### PR DESCRIPTION
Correct the failure messages to match what each assertion validates. The first assertion checks ReadBodyRLP and now reports “unexpected body returned”; the second checks ReadReceiptsRLP and reports “unexpected receipts returned”. This ensures test output accurately reflects the failing condition, avoiding confusion during debugging.