### PR TITLE
core/types: fix LatestSignerForChainID panic with chainID 0

### DIFF
--- a/core/types/transaction_signing.go
+++ b/core/types/transaction_signing.go
@@ -92,14 +92,14 @@ func LatestSigner(config *params.ChainConfig) Signer {
 
 // LatestSignerForChainID returns the 'most permissive' Signer available. Specifically,
 // this enables support for EIP-155 replay protection and all implemented EIP-2718
-// transaction types if chainID is non-nil.
+// transaction types if chainID is non-nil and greater than zero.
 //
 // Use this in transaction-handling code where the current block number and fork
 // configuration are unknown. If you have a ChainConfig, use LatestSigner instead.
 // If you have a ChainConfig and know the current block number, use MakeSigner instead.
 func LatestSignerForChainID(chainID *big.Int) Signer {
 	var signer Signer
-	if chainID != nil {
+	if chainID != nil && chainID.Sign() > 0 {
 		signer = NewPragueSigner(chainID)
 	} else {
 		signer = HomesteadSigner{}


### PR DESCRIPTION
LatestSignerForChainID was panicking when called with chainID 0 because it tried to create a modern signer which requires chainID > 0. Legacy transactions with chainID 0 should use HomesteadSigner instead.

Fixes panic when trying to get the signer of legacy transactions [#32582](https://github.com/ethereum/go-ethereum/issues/32582)