### PR TITLE
eth/catalyst: add BPOs to allowed forks for newpayload v4

### DIFF
--- a/eth/catalyst/api.go
+++ b/eth/catalyst/api.go
@@ -636,8 +636,8 @@ func (api *ConsensusAPI) NewPayloadV4(params engine.ExecutableData, versionedHas
 		return invalidStatus, paramsErr("nil beaconRoot post-cancun")
 	case executionRequests == nil:
 		return invalidStatus, paramsErr("nil executionRequests post-prague")
-	case !api.checkFork(params.Timestamp, forks.Prague, forks.Osaka):
-		return invalidStatus, unsupportedForkErr("newPayloadV4 must only be called for prague payloads")
+	case !api.checkFork(params.Timestamp, forks.Prague, forks.Osaka, forks.BPO1, forks.BPO2, forks.BPO3, forks.BPO4, forks.BPO5):
+		return invalidStatus, unsupportedForkErr("newPayloadV4 must only be called for Prague payloads")
 	}
 	requests := convertRequests(executionRequests)
 	if err := validateRequests(requests); err != nil {


### PR DESCRIPTION
Fixes an issue I accidentally introduced in #32579. Essentially, because we gate the engine methods based on particular forks and I did not add the BPOs as allowed forks to the method.