### PR TITLE
.github: run tests with ci.go

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -55,4 +55,4 @@ jobs:
           cache: false
 
       - name: Run tests
-        run: go test ./...
+        run: go run build/ci.go test

--- a/cmd/geth/logging_test.go
+++ b/cmd/geth/logging_test.go
@@ -91,7 +91,7 @@ func testConsoleLogging(t *testing.T, format string, tStart, tEnd int) {
 		have = censor(have, tStart, tEnd)
 		want = censor(want, tStart, tEnd)
 		if have != want {
-			t.Logf(nicediff([]byte(have), []byte(want)))
+			t.Log(nicediff([]byte(have), []byte(want)))
 			t.Fatalf("format %v, line %d\nhave %v\nwant %v", format, i, have, want)
 		}
 	}
@@ -142,7 +142,7 @@ func TestJsonLogging(t *testing.T) {
 		}
 		if !bytes.Equal(have, want) {
 			// show an intelligent diff
-			t.Logf(nicediff(have, want))
+			t.Log(nicediff(have, want))
 			t.Errorf("file content wrong")
 		}
 	}
@@ -211,7 +211,7 @@ func TestFileOut(t *testing.T) {
 	}
 	if !bytes.Equal(have, want) {
 		// show an intelligent diff
-		t.Logf(nicediff(have, want))
+		t.Log(nicediff(have, want))
 		t.Errorf("file content wrong")
 	}
 }
@@ -231,7 +231,7 @@ func TestRotatingFileOut(t *testing.T) {
 	}
 	if !bytes.Equal(have, want) {
 		// show an intelligent diff
-		t.Logf(nicediff(have, want))
+		t.Log(nicediff(have, want))
 		t.Errorf("file content wrong")
 	}
 }


### PR DESCRIPTION
`ci.go` is the place to add custom build flags, build tags, etc. for the test run. So we should use it for CI.