### PR TITLE
 ethclient/simulated: disable log indexing by default

### DIFF
--- a/ethclient/simulated/backend.go
+++ b/ethclient/simulated/backend.go
@@ -86,6 +86,8 @@ func NewBackend(alloc types.GenesisAlloc, options ...func(nodeConf *node.Config,
 	}
 	ethConf.SyncMode = ethconfig.FullSync
 	ethConf.TxPool.NoLocals = true
+	// Disable log indexing to force unindexed log search
+	ethConf.LogNoHistory = true
 
 	for _, option := range options {
 		option(&nodeConf, &ethConf)


### PR DESCRIPTION
This pr try to fix https://github.com/ethereum/go-ethereum/issues/32552. 
Root Cause Analysis:

 [This](https://gist.github.com/jb617-ux/e66ad8b9980506d9270112262518ac57)  gets stuck because of a performance bottleneck between block generation speed and log indexing speed. Here's what happens:

  1. Block Generation Rate: Blocks are committed every 2ms
  2. Log Query Rate: FilterLogs() runs every second
  3. Indexing Bottleneck: The log indexing system cannot keep up with this rapid block generation

  The Deadlock Scenario:

  When FilterLogs() is called, it tries to use the log index for efficient searching. However, if the index is still being built for recent blocks, the query hangs waiting for indexing to complete. This creates a deadlock-like
  situation:

  - New blocks generate faster than they can be indexed
  - Log queries wait indefinitely for the index to catch up
  - The indexing process gets blocked by pending queries

To fix this issue, we should disable the log index by default.