### PR TITLE
core/types: update address of log comment for EIP-7702 compatibility

### DIFF
--- a/core/types/log.go
+++ b/core/types/log.go
@@ -29,6 +29,9 @@ import (
 type Log struct {
 	// Consensus fields:
 	// address of the contract that generated the event
+	//
+	// After Prague upgrade (EIP-7702), this can also be an EOA
+	// with delegated code that generated the event
 	Address common.Address `json:"address" gencodec:"required"`
 	// list of topics provided by the contract.
 	Topics []common.Hash `json:"topics" gencodec:"required"`


### PR DESCRIPTION
Updates the comment for Log.Address field to clarify that after the Prague upgrade (EIP-7702), logs can also be generated by EOAs (Externally Owned Accounts) with delegated code.