### PR TITLE
core/rawdb: fix misleading comment in HasTrieNode

### DIFF
--- a/core/rawdb/accessors_trie.go
+++ b/core/rawdb/accessors_trie.go
@@ -150,7 +150,7 @@ func HasTrieNode(db ethdb.KeyValueReader, owner common.Hash, path []byte, hash c
 		if len(blob) == 0 {
 			return false
 		}
-		return crypto.Keccak256Hash(blob) == hash // exists and match
+		return crypto.Keccak256Hash(blob) == hash // exist and match
 	default:
 		panic(fmt.Sprintf("Unknown scheme %v", scheme))
 	}
@@ -173,7 +173,7 @@ func ReadTrieNode(db ethdb.KeyValueReader, owner common.Hash, path []byte, hash 
 			return nil
 		}
 		if crypto.Keccak256Hash(blob) != hash {
-			return nil // exists but not match
+			return nil // exist but not match
 		}
 		return blob
 	default:

--- a/core/rawdb/accessors_trie.go
+++ b/core/rawdb/accessors_trie.go
@@ -150,7 +150,7 @@ func HasTrieNode(db ethdb.KeyValueReader, owner common.Hash, path []byte, hash c
 		if len(blob) == 0 {
 			return false
 		}
-		return crypto.Keccak256Hash(blob) == hash // exists but not match
+		return crypto.Keccak256Hash(blob) == hash // exists and match
 	default:
 		panic(fmt.Sprintf("Unknown scheme %v", scheme))
 	}


### PR DESCRIPTION
Correct the inline comment in HasTrieNode for the path-based scheme. The code returns true only when the node exists and its Keccak256 matches the expected hash, but the comment incorrectly said “exists but not match”. This change aligns the comment with actual behavior and with ReadTrieNode and trie/sync.go semantics, avoiding confusion for maintainers and users.