### PR TITLE
triedb/database: improve memory safety documentation for Node and Storage methods

### DIFF
--- a/triedb/database/database.go
+++ b/triedb/database/database.go
@@ -27,10 +27,13 @@ type NodeReader interface {
 	// node path and the corresponding node hash. No error will be returned
 	// if the node is not found.
 	//
-	// The returned node content won't be changed after the call.
+	// IMPORTANT: The returned byte slice is a direct reference to internal
+	// database storage and MUST NOT be modified. Any modification will
+	// corrupt the database state and cause undefined behavior. The slice
+	// is safe to read from but must be treated as read-only.
 	//
-	// Don't modify the returned byte slice since it's not deep-copied and
-	// still be referenced by database.
+	// For performance reasons, the data is not deep-copied. If you need
+	// to modify the data, create a copy using common.CopyBytes().
 	Node(owner common.Hash, path []byte, hash common.Hash) ([]byte, error)
 }
 
@@ -56,8 +59,15 @@ type StateReader interface {
 	// within a particular account. An error will be returned if the read operation
 	// exits abnormally.
 	//
+	// IMPORTANT: The returned byte slice is a direct reference to internal
+	// database storage and MUST NOT be modified. Any modification will
+	// corrupt the database state and cause undefined behavior. The slice
+	// is safe to read from but must be treated as read-only.
+	//
+	// For performance reasons, the data is not deep-copied. If you need
+	// to modify the data, create a copy using common.CopyBytes().
+	//
 	// Note:
-	// - the returned storage data is not a copy, please don't modify it
 	// - no error will be returned if the requested slot is not found in database
 	Storage(accountHash, storageHash common.Hash) ([]byte, error)
 }


### PR DESCRIPTION
Enhanced documentation for NodeReader.Node() and StateReader.Storage() methods to clearly communicate memory safety requirements and prevent potential data corruption.

### Changes:
- Added explicit warnings about read-only nature of returned byte slices
- Clarified that modifications will corrupt database state
- Explained performance rationale for not deep-copying data
- Provided guidance on using common.CopyBytes() when modifications are needed

### Why these changes are necessary:
The previous documentation was ambiguous about memory safety, potentially leading  developers to accidentally modify shared database storage. The returned byte slices are direct references to internal database structures that must remain immutable for data integrity. Any modification would corrupt the database state and cause undefined behavior across the entire Ethereum node. These changes ensure developers understand the critical importance of treating returned data as read-only while maintaining the performance benefits of zero-copy access patterns.