### PR TITLE
core/vm: fix typo in CLZ doc

### DIFF
--- a/core/vm/eips.go
+++ b/core/vm/eips.go
@@ -294,7 +294,7 @@ func opBlobBaseFee(pc *uint64, evm *EVM, scope *ScopeContext) ([]byte, error) {
 	return nil, nil
 }
 
-// opCLZ implements the CLZ opcode (count leading zero bytes)
+// opCLZ implements the CLZ opcode (count leading zero bits)
 func opCLZ(pc *uint64, evm *EVM, scope *ScopeContext) ([]byte, error) {
 	x := scope.Stack.peek()
 	x.SetUint64(256 - uint64(x.BitLen()))


### PR DESCRIPTION
Fix typo