### PR TITLE
tracers, era: show actual vs max in limit errors

### DIFF
--- a/eth/tracers/internal/util.go
+++ b/eth/tracers/internal/util.go
@@ -39,7 +39,7 @@ func GetMemoryCopyPadded(m []byte, offset, size int64) ([]byte, error) {
 	}
 	paddingNeeded := offset + size - length
 	if paddingNeeded > memoryPadLimit {
-		return nil, fmt.Errorf("reached limit for padding memory slice: %d", paddingNeeded)
+		return nil, fmt.Errorf("padding %d exceeds limit %d", paddingNeeded, memoryPadLimit)
 	}
 	cpy := make([]byte, size)
 	if overlap := length - offset; overlap > 0 {

--- a/internal/era/builder.go
+++ b/internal/era/builder.go
@@ -127,7 +127,7 @@ func (b *Builder) AddRLP(header, body, receipts []byte, number uint64, hash comm
 		b.written += n
 	}
 	if len(b.indexes) >= MaxEra1Size {
-		return fmt.Errorf("exceeds maximum batch size of %d", MaxEra1Size)
+		return fmt.Errorf("batch size %d exceeds maximum %d", len(b.indexes), MaxEra1Size)
 	}
 
 	b.indexes = append(b.indexes, uint64(b.written))


### PR DESCRIPTION
Make limit errors print both the attempted value and the cap (e.g., “padding X exceeds Y”).