### PR TITLE
node: optimize port formatting using strconv.Itoa

### DIFF
--- a/node/config.go
+++ b/node/config.go
@@ -23,6 +23,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"strconv"
 	"strings"
 
 	"github.com/ethereum/go-ethereum/common"
@@ -264,7 +265,7 @@ func (c *Config) HTTPEndpoint() string {
 	if c.HTTPHost == "" {
 		return ""
 	}
-	return net.JoinHostPort(c.HTTPHost, fmt.Sprintf("%d", c.HTTPPort))
+	return net.JoinHostPort(c.HTTPHost, strconv.Itoa(c.HTTPPort))
 }
 
 // DefaultHTTPEndpoint returns the HTTP endpoint used by default.
@@ -279,7 +280,7 @@ func (c *Config) WSEndpoint() string {
 	if c.WSHost == "" {
 		return ""
 	}
-	return net.JoinHostPort(c.WSHost, fmt.Sprintf("%d", c.WSPort))
+	return net.JoinHostPort(c.WSHost, strconv.Itoa(c.WSPort))
 }
 
 // DefaultWSEndpoint returns the websocket endpoint used by default.


### PR DESCRIPTION
Replace fmt.Sprintf("%d", port) with strconv.Itoa(port) in HTTPEndpoint() and WSEndpoint() methods for better performance.

strconv.Itoa is specifically optimized for integer-to-string conversion and is 2-3x faster than fmt.Sprintf with no memory allocation overhead for string formatting.

