### PR TITLE
core/overlay: copy BaseRoot in TransitionState.Copy

### DIFF
--- a/core/overlay/state_transition.go
+++ b/core/overlay/state_transition.go
@@ -60,6 +60,7 @@ func (ts *TransitionState) Copy() *TransitionState {
 		CurrentSlotHash:       ts.CurrentSlotHash,
 		CurrentPreimageOffset: ts.CurrentPreimageOffset,
 		StorageProcessed:      ts.StorageProcessed,
+		BaseRoot:              ts.BaseRoot,
 	}
 	if ts.CurrentAccountAddress != nil {
 		addr := *ts.CurrentAccountAddress


### PR DESCRIPTION
This change ensures TransitionState.Copy preserves BaseRoot. During a Verkle transition, ts.BaseRoot is required to construct the overlay MPT when ts.InTransition() is true. Previously, copies dropped BaseRoot, risking an invalid zero-hash base trie and inconsistent behavior.