### PR TITLE
rlp: remove duplicate optionalAndTailField test case

### DIFF
--- a/rlp/encode_test.go
+++ b/rlp/encode_test.go
@@ -317,7 +317,6 @@ var encTests = []encTest{
 	{val: &optionalAndTailField{A: 1}, output: "C101"},
 	{val: &optionalAndTailField{A: 1, B: 2}, output: "C20102"},
 	{val: &optionalAndTailField{A: 1, Tail: []uint{5, 6}}, output: "C401800506"},
-	{val: &optionalAndTailField{A: 1, Tail: []uint{5, 6}}, output: "C401800506"},
 	{val: &optionalBigIntField{A: 1}, output: "C101"},
 	{val: &optionalPtrField{A: 1}, output: "C101"},
 	{val: &optionalPtrFieldNil{A: 1}, output: "C101"},


### PR DESCRIPTION
Remove a redundant duplicate test vector for optionalAndTailField{A: 1, Tail: []uint{5, 6}}. The two entries were identical and back-to-back, providing no additional coverage while adding noise. Keeping a single instance maintains test intent and clarity without altering behavior.