### PR TITLE
core/tracing: remove unnecessary 'copy' field skip in TestAllHooksCalled

### DIFF
--- a/core/tracing/journal_test.go
+++ b/core/tracing/journal_test.go
@@ -280,10 +280,6 @@ func TestAllHooksCalled(t *testing.T) {
 		if field.Type.Kind() != reflect.Func {
 			continue
 		}
-		// Skip non-hooks, i.e. Copy
-		if field.Name == "copy" {
-			continue
-		}
 		// Skip if field is not set
 		if wrappedValue.Field(i).IsNil() {
 			continue


### PR DESCRIPTION
This test iterated over Hooks fields and skipped a field named copy. The Hooks struct has no such field, making the condition dead code.