### PR TITLE
core: fix fork readiness log

### DIFF
--- a/params/forks/forks.go
+++ b/params/forks/forks.go
@@ -77,4 +77,9 @@ var forkToString = map[Fork]string{
 	Cancun:           "Cancun",
 	Prague:           "Prague",
 	Osaka:            "Osaka",
+	BPO1:             "BPO1",
+	BPO2:             "BPO2",
+	BPO3:             "BPO3",
+	BPO4:             "BPO4",
+	BPO5:             "BPO5",
 }


### PR DESCRIPTION
When I implemented in #31340 I didn't expect multiple forks to be configured at once, but this is exactly how BPOs are defined. This updates the method to determine the next scheduled fork rather than the last fork.

Additionally I missed the fork<>string map when adding the BPOs, so adding those here too.