### PR TITLE
common, eth: remove duplicate test cases

### DIFF
--- a/common/hexutil/json_test.go
+++ b/common/hexutil/json_test.go
@@ -408,7 +408,6 @@ func TestUnmarshalFixedUnprefixedText(t *testing.T) {
 		{input: "0x2", wantErr: ErrOddLength},
 		{input: "2", wantErr: ErrOddLength},
 		{input: "4444", wantErr: errors.New("hex string has length 4, want 8 for x")},
-		{input: "4444", wantErr: errors.New("hex string has length 4, want 8 for x")},
 		// check that output is not modified for partially correct input
 		{input: "444444gg", wantErr: ErrSyntax, want: []byte{0, 0, 0, 0}},
 		{input: "0x444444gg", wantErr: ErrSyntax, want: []byte{0, 0, 0, 0}},

--- a/eth/protocols/snap/gentrie_test.go
+++ b/eth/protocols/snap/gentrie_test.go
@@ -239,7 +239,6 @@ func TestPartialGentree(t *testing.T) {
 			{1, len(entries) - 1},                // no left
 			{2, len(entries) - 1},                // no left
 			{2, len(entries) - 2},                // no left and right
-			{2, len(entries) - 2},                // no left and right
 			{len(entries) / 2, len(entries) / 2}, // single
 			{0, 0},                               // single first
 			{len(entries) - 1, len(entries) - 1}, // single last
@@ -347,7 +346,6 @@ func TestGentreeDanglingClearing(t *testing.T) {
 			{0, len(entries) - 1},                // full
 			{1, len(entries) - 1},                // no left
 			{2, len(entries) - 1},                // no left
-			{2, len(entries) - 2},                // no left and right
 			{2, len(entries) - 2},                // no left and right
 			{len(entries) / 2, len(entries) / 2}, // single
 			{0, 0},                               // single first

--- a/eth/protocols/snap/sync_test.go
+++ b/eth/protocols/snap/sync_test.go
@@ -597,7 +597,6 @@ func testSyncBloatedProof(t *testing.T, scheme string) {
 		proof := trienode.NewProofSet()
 		if err := t.accountTrie.Prove(origin[:], proof); err != nil {
 			t.logger.Error("Could not prove origin", "origin", origin, "error", err)
-			t.logger.Error("Could not prove origin", "origin", origin, "error", err)
 		}
 		// The bloat: add proof of every single element
 		for _, entry := range t.accountValues {


### PR DESCRIPTION
Remove redundant duplicate test vectors. The two entries were identical and back-to-back, providing no additional coverage while adding noise. Keeping a single instance maintains test intent and clarity without altering behavior.