### PR TITLE
core/rawdb: fix bad blocks sorted failure message to map index→number correctly

### DIFF
--- a/core/rawdb/accessors_chain_test.go
+++ b/core/rawdb/accessors_chain_test.go
@@ -246,7 +246,7 @@ func TestBadBlockStorage(t *testing.T) {
 	}
 	for i := 0; i < len(badBlocks)-1; i++ {
 		if badBlocks[i].NumberU64() < badBlocks[i+1].NumberU64() {
-			t.Fatalf("The bad blocks are not sorted #[%d](%d) < #[%d](%d)", i, i+1, badBlocks[i].NumberU64(), badBlocks[i+1].NumberU64())
+			t.Fatalf("The bad blocks are not sorted #[%d](%d) < #[%d](%d)", i, badBlocks[i].NumberU64(), i+1, badBlocks[i+1].NumberU64())
 		}
 	}
 


### PR DESCRIPTION
Fix the t.Fatalf format arguments in TestBadBlockStorage to match the intended #index output. Previously, the left number used i+1 and the right index used the block number, producing misleading diagnostics. Correct mapping improves test failure clarity and debuggability.