### PR TITLE
core/overlay: fix incorrect debug log key/value in LoadTransitionState

### DIFF
--- a/core/overlay/state_transition.go
+++ b/core/overlay/state_transition.go
@@ -97,7 +97,7 @@ func LoadTransitionState(db ethdb.KeyValueReader, root common.Hash, isVerkle boo
 		// Initialize the first transition state, with the "ended"
 		// field set to true if the database was created
 		// as a verkle database.
-		log.Debug("no transition state found, starting fresh", "is verkle", db)
+    	log.Debug("no transition state found, starting fresh", "verkle", isVerkle)
 
 		// Start with a fresh state
 		ts = &TransitionState{Ended: isVerkle}


### PR DESCRIPTION
Replace logging of the database handle under the key "is verkle" with the actual boolean flag isVerkle and a space-free key "verkle". This aligns with project logging conventions and avoids misleading output where a DB object appeared under a boolean key, ensuring accurate diagnostics when no transition state is found.