### PR TITLE
cmd/keeper: disable GC for zkvm execution

### DIFF
--- a/cmd/keeper/main.go
+++ b/cmd/keeper/main.go
@@ -19,6 +19,7 @@ package main
 import (
 	"fmt"
 	"os"
+	"runtime/debug"
 
 	"github.com/ethereum/go-ethereum/core"
 	"github.com/ethereum/go-ethereum/core/stateless"
@@ -33,6 +34,10 @@ type Payload struct {
 	ChainID uint64
 	Block   *types.Block
 	Witness *stateless.Witness
+}
+
+func init() {
+	debug.SetGCPercent(-1) // Disable garbage collection
 }
 
 func main() {


### PR DESCRIPTION
ZKVMs are constrained environments that liberally allocate memory and never release it. In this context, using the GC is only going to cause issues down the road, and slow things down in any case.