### PR TITLE
core/types: using testing.B.Loop

### DIFF
--- a/core/types/block_test.go
+++ b/core/types/block_test.go
@@ -263,9 +263,8 @@ var benchBuffer = bytes.NewBuffer(make([]byte, 0, 32000))
 
 func BenchmarkEncodeBlock(b *testing.B) {
 	block := makeBenchBlock()
-	b.ResetTimer()
 
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		benchBuffer.Reset()
 		if err := rlp.Encode(benchBuffer, block); err != nil {
 			b.Fatal(err)

--- a/core/types/bloom9_test.go
+++ b/core/types/bloom9_test.go
@@ -78,7 +78,7 @@ func TestBloomExtensively(t *testing.T) {
 
 func BenchmarkBloom9(b *testing.B) {
 	test := []byte("testestestest")
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		Bloom9(test)
 	}
 }
@@ -86,7 +86,7 @@ func BenchmarkBloom9(b *testing.B) {
 func BenchmarkBloom9Lookup(b *testing.B) {
 	toTest := []byte("testtest")
 	bloom := new(Bloom)
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		bloom.Test(toTest)
 	}
 }
@@ -128,7 +128,7 @@ func BenchmarkCreateBloom(b *testing.B) {
 	}
 	b.Run("small-createbloom", func(b *testing.B) {
 		b.ReportAllocs()
-		for i := 0; i < b.N; i++ {
+		for b.Loop() {
 			for _, receipt := range rSmall {
 				receipt.Bloom = CreateBloom(receipt)
 			}
@@ -144,7 +144,7 @@ func BenchmarkCreateBloom(b *testing.B) {
 	})
 	b.Run("large-createbloom", func(b *testing.B) {
 		b.ReportAllocs()
-		for i := 0; i < b.N; i++ {
+		for b.Loop() {
 			for _, receipt := range rLarge {
 				receipt.Bloom = CreateBloom(receipt)
 			}
@@ -163,13 +163,11 @@ func BenchmarkCreateBloom(b *testing.B) {
 			receipt.Bloom = CreateBloom(receipt)
 		}
 		b.ReportAllocs()
-		b.ResetTimer()
 
 		var bl Bloom
-		for i := 0; i < b.N; i++ {
+		for b.Loop() {
 			bl = MergeBloom(rSmall)
 		}
-		b.StopTimer()
 
 		var exp = common.HexToHash("c384c56ece49458a427c67b90fefe979ebf7104795be65dc398b280f24104949")
 		got := crypto.Keccak256Hash(bl.Bytes())
@@ -182,13 +180,11 @@ func BenchmarkCreateBloom(b *testing.B) {
 			receipt.Bloom = CreateBloom(receipt)
 		}
 		b.ReportAllocs()
-		b.ResetTimer()
 
 		var bl Bloom
-		for i := 0; i < b.N; i++ {
+		for b.Loop() {
 			bl = MergeBloom(rLarge)
 		}
-		b.StopTimer()
 
 		var exp = common.HexToHash("c384c56ece49458a427c67b90fefe979ebf7104795be65dc398b280f24104949")
 		got := crypto.Keccak256Hash(bl.Bytes())

--- a/core/types/hashing_test.go
+++ b/core/types/hashing_test.go
@@ -84,9 +84,8 @@ func BenchmarkDeriveSha200(b *testing.B) {
 	var exp common.Hash
 	var got common.Hash
 	b.Run("std_trie", func(b *testing.B) {
-		b.ResetTimer()
 		b.ReportAllocs()
-		for i := 0; i < b.N; i++ {
+		for b.Loop() {
 			exp = types.DeriveSha(txs, trie.NewEmpty(triedb.NewDatabase(rawdb.NewMemoryDatabase(), nil)))
 		}
 	})
@@ -94,7 +93,7 @@ func BenchmarkDeriveSha200(b *testing.B) {
 	b.Run("stack_trie", func(b *testing.B) {
 		b.ResetTimer()
 		b.ReportAllocs()
-		for i := 0; i < b.N; i++ {
+		for b.Loop() {
 			got = types.DeriveSha(txs, trie.NewStackTrie(nil))
 		}
 	})

--- a/core/types/transaction_test.go
+++ b/core/types/transaction_test.go
@@ -591,7 +591,7 @@ func BenchmarkHash(b *testing.B) {
 		GasTipCap: big.NewInt(500),
 		GasFeeCap: big.NewInt(500),
 	})
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		signer.Hash(tx)
 	}
 }
@@ -614,7 +614,7 @@ func BenchmarkEffectiveGasTip(b *testing.B) {
 
 	b.Run("Original", func(b *testing.B) {
 		b.ReportAllocs()
-		for i := 0; i < b.N; i++ {
+		for b.Loop() {
 			_, err := tx.EffectiveGasTip(baseFee.ToBig())
 			if err != nil {
 				b.Fatal(err)
@@ -625,7 +625,7 @@ func BenchmarkEffectiveGasTip(b *testing.B) {
 	b.Run("IntoMethod", func(b *testing.B) {
 		b.ReportAllocs()
 		dst := new(uint256.Int)
-		for i := 0; i < b.N; i++ {
+		for b.Loop() {
 			err := tx.calcEffectiveGasTip(dst, baseFee)
 			if err != nil {
 				b.Fatal(err)
@@ -729,7 +729,7 @@ func BenchmarkEffectiveGasTipCmp(b *testing.B) {
 
 	b.Run("Original", func(b *testing.B) {
 		b.ReportAllocs()
-		for i := 0; i < b.N; i++ {
+		for b.Loop() {
 			tx.EffectiveGasTipCmp(other, baseFee)
 		}
 	})

--- a/core/types/types_test.go
+++ b/core/types/types_test.go
@@ -126,7 +126,7 @@ func benchRLP(b *testing.B, encode bool) {
 			b.Run(tc.name, func(b *testing.B) {
 				b.ReportAllocs()
 				var null = &devnull{}
-				for i := 0; i < b.N; i++ {
+				for b.Loop() {
 					rlp.Encode(null, tc.obj)
 				}
 				b.SetBytes(int64(null.len / b.N))
@@ -136,7 +136,7 @@ func benchRLP(b *testing.B, encode bool) {
 			// Test decoding
 			b.Run(tc.name, func(b *testing.B) {
 				b.ReportAllocs()
-				for i := 0; i < b.N; i++ {
+				for b.Loop() {
 					if err := rlp.DecodeBytes(data, tc.obj); err != nil {
 						b.Fatal(err)
 					}


### PR DESCRIPTION
before:
go test -run=^$ -bench=. ./core/types  47.80s user 2.18s system 102% cpu 48.936 tota

after:
go test -run=^$ -bench=. ./core/types  42.42s user 2.27s system 112% cpu 39.593 total