### PR TITLE
rpc: fix example comment and handle Dial error

### DIFF
--- a/rpc/client_example_test.go
+++ b/rpc/client_example_test.go
@@ -28,7 +28,7 @@ import (
 // In this example, our client wishes to track the latest 'block number'
 // known to the server. The server supports two methods:
 //
-// eth_getBlockByNumber("latest", {})
+// eth_getBlockByNumber("latest", false)
 //    returns the latest block object.
 //
 // eth_subscribe("newHeads")
@@ -40,7 +40,11 @@ type Block struct {
 
 func ExampleClientSubscription() {
 	// Connect the client.
-	client, _ := rpc.Dial("ws://127.0.0.1:8545")
+	client, err := rpc.Dial("ws://127.0.0.1:8545")
+	if err != nil {
+		fmt.Println("dial error:", err)
+		return
+	}
 	subch := make(chan Block)
 
 	// Ensure that subch receives the latest block.


### PR DESCRIPTION
1) Correct the eth_getBlockByNumber example comment to use a boolean for the second parameter ("false") instead of an object ("{}"), aligning with the JSON-RPC spec and the actual call below.
2) Handle the error returned by rpc.Dial rather than ignoring it. Without this check, a failed connection would leave client nil and subsequent method calls could panic. The example now reports the dial error and exits early, making it safe and consistent with error handling elsewhere in the codebase.