### PR TITLE
crypto: using testing.B.Loop

### DIFF
--- a/crypto/blake2b/blake2b_test.go
+++ b/crypto/blake2b/blake2b_test.go
@@ -303,8 +303,7 @@ func benchmarkSum(b *testing.B, size int, sse4, avx, avx2 bool) {
 
 	data := make([]byte, size)
 	b.SetBytes(int64(size))
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		Sum512(data)
 	}
 }
@@ -319,8 +318,7 @@ func benchmarkWrite(b *testing.B, size int, sse4, avx, avx2 bool) {
 	data := make([]byte, size)
 	h, _ := New512(nil)
 	b.SetBytes(int64(size))
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		h.Write(data)
 	}
 }

--- a/crypto/crypto_test.go
+++ b/crypto/crypto_test.go
@@ -60,7 +60,7 @@ func TestToECDSAErrors(t *testing.T) {
 
 func BenchmarkSha3(b *testing.B) {
 	a := []byte("hello world")
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		Keccak256(a)
 	}
 }
@@ -310,7 +310,7 @@ func BenchmarkKeccak256Hash(b *testing.B) {
 	rand.Read(input[:])
 
 	b.ReportAllocs()
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		Keccak256Hash(input[:])
 	}
 }
@@ -329,7 +329,7 @@ func BenchmarkHashData(b *testing.B) {
 	rand.Read(input[:])
 
 	b.ReportAllocs()
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		HashData(buffer, input[:])
 	}
 }

--- a/crypto/ecies/ecies_test.go
+++ b/crypto/ecies/ecies_test.go
@@ -164,7 +164,7 @@ func TestTooBigSharedKey(t *testing.T) {
 
 // Benchmark the generation of P256 keys.
 func BenchmarkGenerateKeyP256(b *testing.B) {
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		if _, err := GenerateKey(rand.Reader, elliptic.P256(), nil); err != nil {
 			b.Fatal(err)
 		}
@@ -177,8 +177,7 @@ func BenchmarkGenSharedKeyP256(b *testing.B) {
 	if err != nil {
 		b.Fatal(err)
 	}
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		_, err := prv.GenerateShared(&prv.PublicKey, 16, 16)
 		if err != nil {
 			b.Fatal(err)
@@ -192,8 +191,7 @@ func BenchmarkGenSharedKeyS256(b *testing.B) {
 	if err != nil {
 		b.Fatal(err)
 	}
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		_, err := prv.GenerateShared(&prv.PublicKey, 16, 16)
 		if err != nil {
 			b.Fatal(err)

--- a/crypto/kzg4844/kzg4844_test.go
+++ b/crypto/kzg4844/kzg4844_test.go
@@ -105,8 +105,7 @@ func benchmarkBlobToCommitment(b *testing.B, ckzg bool) {
 
 	blob := randBlob()
 
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		BlobToCommitment(blob)
 	}
 }
@@ -125,8 +124,7 @@ func benchmarkComputeProof(b *testing.B, ckzg bool) {
 		point = randFieldElement()
 	)
 
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		ComputeProof(blob, point)
 	}
 }
@@ -147,8 +145,7 @@ func benchmarkVerifyProof(b *testing.B, ckzg bool) {
 		proof, claim, _ = ComputeProof(blob, point)
 	)
 
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		VerifyProof(commitment, point, claim, proof)
 	}
 }
@@ -167,8 +164,7 @@ func benchmarkComputeBlobProof(b *testing.B, ckzg bool) {
 		commitment, _ = BlobToCommitment(blob)
 	)
 
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		ComputeBlobProof(blob, commitment)
 	}
 }
@@ -188,8 +184,7 @@ func benchmarkVerifyBlobProof(b *testing.B, ckzg bool) {
 		proof, _      = ComputeBlobProof(blob, commitment)
 	)
 
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		VerifyBlobProof(blob, commitment, proof)
 	}
 }

--- a/crypto/secp256k1/secp256_test.go
+++ b/crypto/secp256k1/secp256_test.go
@@ -221,9 +221,7 @@ func TestRecoverSanity(t *testing.T) {
 func BenchmarkSign(b *testing.B) {
 	_, seckey := generateKeyPair()
 	msg := csprngEntropy(32)
-	b.ResetTimer()
-
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		Sign(msg, seckey)
 	}
 }
@@ -232,9 +230,7 @@ func BenchmarkRecover(b *testing.B) {
 	msg := csprngEntropy(32)
 	_, seckey := generateKeyPair()
 	sig, _ := Sign(msg, seckey)
-	b.ResetTimer()
-
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		RecoverPubkey(msg, sig)
 	}
 }

--- a/crypto/signature_test.go
+++ b/crypto/signature_test.go
@@ -135,7 +135,7 @@ func TestPubkeyRandom(t *testing.T) {
 }
 
 func BenchmarkEcrecoverSignature(b *testing.B) {
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		if _, err := Ecrecover(testmsg, testsig); err != nil {
 			b.Fatal("ecrecover error", err)
 		}
@@ -144,7 +144,7 @@ func BenchmarkEcrecoverSignature(b *testing.B) {
 
 func BenchmarkVerifySignature(b *testing.B) {
 	sig := testsig[:len(testsig)-1] // remove recovery id
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		if !VerifySignature(testpubkey, testmsg, sig) {
 			b.Fatal("verify error")
 		}
@@ -152,7 +152,7 @@ func BenchmarkVerifySignature(b *testing.B) {
 }
 
 func BenchmarkDecompressPubkey(b *testing.B) {
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		if _, err := DecompressPubkey(testpubkeyc); err != nil {
 			b.Fatal(err)
 		}


### PR DESCRIPTION
before:
go test -run=^$ -bench=. ./crypto/...  94.83s user 2.68s system 138% cpu 1:10.55 tota

after:
go test -run=^$ -bench=. ./crypto/...  75.43s user 2.58s system 123% cpu 1:03.01 total