### PR TITLE
fix: correct typo in TestMustParseUint64Panic error message

### DIFF
--- a/common/math/integer_test.go
+++ b/common/math/integer_test.go
@@ -110,7 +110,7 @@ func TestMustParseUint64(t *testing.T) {
 func TestMustParseUint64Panic(t *testing.T) {
 	defer func() {
 		if recover() == nil {
-			t.Error("MustParseBig should've panicked")
+			t.Error("MustParseUint64 should've panicked")
 		}
 	}()
 	MustParseUint64("ggg")


### PR DESCRIPTION
Fix typo in test error message where "MustParseBig" was incorrectly 
used instead of "MustParseUint64" in the TestMustParseUint64Panic 
function. 

The test still functions correctly, but now the error message 
accurately reflects the function being tested.