### PR TITLE
core/rawdb: report truncateErr in concurrent truncate failure

### DIFF
--- a/core/rawdb/freezer_test.go
+++ b/core/rawdb/freezer_test.go
@@ -239,7 +239,7 @@ func TestFreezerConcurrentModifyTruncate(t *testing.T) {
 		// fails, otherwise it succeeds. In either case, the freezer should be positioned
 		// at 10 after both operations are done.
 		if truncateErr != nil {
-			t.Fatal("concurrent truncate failed:", err)
+			t.Fatal("concurrent truncate failed:", truncateErr)
 		}
 		if !(errors.Is(modifyErr, nil) || errors.Is(modifyErr, errOutOrderInsertion)) {
 			t.Fatal("wrong error from concurrent modify:", modifyErr)


### PR DESCRIPTION
Replace incorrect use of outer-scoped err with truncateErr in TestFreezerConcurrentModifyTruncate.
This ensures failure output reflects the actual error from the truncate goroutine, avoiding misleading diagnostics during concurrent test failures.