### PR TITLE
core/txpool/blobpool: introduce sidecar conversion for legacy blob transactions

### DIFF
--- a/core/txpool/blobpool/blobpool.go
+++ b/core/txpool/blobpool/blobpool.go
@@ -1481,7 +1481,7 @@ func (p *BlobPool) preCheck(txs []*types.Transaction) ([]*types.Transaction, []e
 			errs = append(errs, nil)
 			continue
 		}
-		if time.Now().After(deadline) {
+		if head.Time > uint64(deadline.Unix()) {
 			errs = append(errs, errors.New("legacy blob tx is not supported"))
 			continue
 		}

--- a/core/txpool/blobpool/blobpool_test.go
+++ b/core/txpool/blobpool/blobpool_test.go
@@ -1810,9 +1810,14 @@ func TestAdd(t *testing.T) {
 	}
 }
 
-// Tests adding transactions with legacy sidecars are correctly rejected
-// after the conversion window has passed.
+// Tests that transactions with legacy sidecars are accepted within the
+// conversion window but rejected after it has passed.
 func TestAddLegacyBlobTx(t *testing.T) {
+	testAddLegacyBlobTx(t, true)  // conversion window has not yet passed
+	testAddLegacyBlobTx(t, false) // conversion window passed
+}
+
+func testAddLegacyBlobTx(t *testing.T, accept bool) {
 	var (
 		key1, _ = crypto.GenerateKey()
 		key2, _ = crypto.GenerateKey()
@@ -1832,7 +1837,13 @@ func TestAddLegacyBlobTx(t *testing.T) {
 		blobfee: uint256.NewInt(105),
 		statedb: statedb,
 	}
-	time := *params.MergedTestChainConfig.OsakaTime + uint64(conversionTimeWindow.Seconds()) + 1
+	var timeDiff uint64
+	if accept {
+		timeDiff = uint64(conversionTimeWindow.Seconds()) - 1
+	} else {
+		timeDiff = uint64(conversionTimeWindow.Seconds()) + 1
+	}
+	time := *params.MergedTestChainConfig.OsakaTime + timeDiff
 	chain.setHeadTime(time)
 
 	pool := New(Config{Datadir: t.TempDir()}, chain, nil)
@@ -1844,12 +1855,15 @@ func TestAddLegacyBlobTx(t *testing.T) {
 	var (
 		tx1 = makeMultiBlobTx(0, 1, 1000, 100, 6, 0, key1, types.BlobSidecarVersion0)
 		tx2 = makeMultiBlobTx(0, 1, 800, 70, 6, 6, key2, types.BlobSidecarVersion0)
-		tx3 = makeMultiBlobTx(1, 1, 800, 70, 6, 12, key2, types.BlobSidecarVersion1)
+		txs = []*types.Transaction{tx1, tx2}
 	)
-	errs := pool.Add([]*types.Transaction{tx1, tx2, tx3}, true)
+	errs := pool.Add(txs, true)
 	for _, err := range errs {
-		if err == nil {
-			t.Fatalf("expected tx add to fail")
+		if accept && err != nil {
+			t.Fatalf("expected tx add to succeed, %v", err)
+		}
+		if !accept && err == nil {
+			t.Fatal("expected tx add to fail")
 		}
 	}
 	verifyPoolInternals(t, pool)

--- a/core/txpool/blobpool/blobpool_test.go
+++ b/core/txpool/blobpool/blobpool_test.go
@@ -1752,8 +1752,8 @@ func TestAdd(t *testing.T) {
 		// Add each transaction one by one, verifying the pool internals in between
 		for j, add := range tt.adds {
 			signed, _ := types.SignNewTx(keys[add.from], types.LatestSigner(params.MainnetChainConfig), add.tx)
-			if err := pool.add(signed); !errors.Is(err, add.err) {
-				t.Errorf("test %d, tx %d: adding transaction error mismatch: have %v, want %v", i, j, err, add.err)
+			if errs := pool.Add([]*types.Transaction{signed}, true); !errors.Is(errs[0], add.err) {
+				t.Errorf("test %d, tx %d: adding transaction error mismatch: have %v, want %v", i, j, errs[0], add.err)
 			}
 			if add.err == nil {
 				size, exist := pool.lookup.sizeOfTx(signed.Hash())

--- a/core/txpool/blobpool/conversion.go
+++ b/core/txpool/blobpool/conversion.go
@@ -90,8 +90,8 @@ func (q *conversionQueue) run(tasks []*cTask, done chan struct{}, interrupt *ato
 
 	for _, t := range tasks {
 		if interrupt != nil && interrupt.Load() != 0 {
-			log.Info("Legacy blob tx conversion is interrupted")
-			return
+			t.done <- errors.New("conversion is interrupted")
+			continue
 		}
 		sidecar := t.tx.BlobTxSidecar()
 		if sidecar == nil {

--- a/core/txpool/blobpool/conversion.go
+++ b/core/txpool/blobpool/conversion.go
@@ -1,0 +1,116 @@
+// Copyright 2025 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+
+package blobpool
+
+import (
+	"errors"
+
+	"github.com/ethereum/go-ethereum/core/types"
+)
+
+// cTask represents a conversion task with an attached result channel.
+type cTask struct {
+	tx   *types.Transaction // Blob transaction, sidecar is expected
+	done chan error         // Channel for signaling back if the conversion succeeds
+}
+
+// conversionQueue is a dedicated queue for converting legacy blob transactions
+// received from the network after the Osaka fork. Since conversion is expensive,
+// it is performed in the background by a single thread, ensuring the main Geth
+// process is not overloaded.
+type conversionQueue struct {
+	tasks  chan *cTask
+	quit   chan struct{}
+	closed chan struct{}
+}
+
+// newConversionQueue constructs the conversion queue.
+func newConversionQueue() *conversionQueue {
+	q := &conversionQueue{
+		tasks:  make(chan *cTask),
+		quit:   make(chan struct{}),
+		closed: make(chan struct{}),
+	}
+	go q.loop()
+	return q
+}
+
+// convert accepts a legacy blob transaction with version-0 blobs and queues it
+// for conversion.
+//
+// This function may block for a long time until the transaction is processed.
+func (q *conversionQueue) convert(tx *types.Transaction) error {
+	done := make(chan error, 1)
+	select {
+	case q.tasks <- &cTask{tx: tx, done: done}:
+		return <-done
+	case <-q.closed:
+		return errors.New("conversion queue closed")
+	}
+}
+
+// close terminates the conversion queue.
+func (q *conversionQueue) close() {
+	select {
+	case <-q.closed:
+		return
+	default:
+		close(q.quit)
+		<-q.closed
+	}
+}
+
+func (q *conversionQueue) run(tasks []*cTask, done chan struct{}) {
+	defer close(done)
+
+	for _, t := range tasks {
+		sidecar := t.tx.BlobTxSidecar()
+		if sidecar == nil {
+			t.done <- errors.New("tx without sidecar")
+			continue
+		}
+		// Run the conversion, the original sidecar will be mutated in place
+		t.done <- sidecar.ToV1()
+	}
+}
+
+func (q *conversionQueue) loop() {
+	defer close(q.closed)
+
+	var (
+		done   = make(chan struct{})
+		cTasks []*cTask
+	)
+	for {
+		select {
+		case t := <-q.tasks:
+			cTasks = append(cTasks, t)
+			if done == nil {
+				done = make(chan struct{})
+
+				tasks := cTasks
+				cTasks = cTasks[:0]
+				go q.run(tasks, done)
+			}
+		case <-done:
+			done = nil
+
+		case <-q.quit:
+			return
+		}
+	}
+}

--- a/core/txpool/blobpool/conversion.go
+++ b/core/txpool/blobpool/conversion.go
@@ -18,6 +18,7 @@ package blobpool
 
 import (
 	"errors"
+	"slices"
 	"sync/atomic"
 	"time"
 
@@ -130,10 +131,11 @@ func (q *conversionQueue) loop() {
 			if done == nil {
 				done, interrupt = make(chan struct{}), new(atomic.Int32)
 
-				tasks := cTasks
+				tasks := slices.Clone(cTasks)
 				cTasks = cTasks[:0]
 				go q.run(tasks, done, interrupt)
 			}
+
 		case <-done:
 			done, interrupt = nil, nil
 
@@ -142,7 +144,7 @@ func (q *conversionQueue) loop() {
 				return
 			}
 			interrupt.Store(1)
-			log.Info("Waiting background converter to exit")
+			log.Debug("Waiting for blob proof conversion to exit")
 			<-done
 			return
 		}

--- a/core/txpool/blobpool/conversion_test.go
+++ b/core/txpool/blobpool/conversion_test.go
@@ -1,0 +1,101 @@
+// Copyright 2025 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+
+package blobpool
+
+import (
+	"crypto/ecdsa"
+	"crypto/sha256"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/ethereum/go-ethereum/crypto/kzg4844"
+	"github.com/ethereum/go-ethereum/params"
+	"github.com/holiman/uint256"
+)
+
+// createV1BlobTx creates a blob transaction with version 1 sidecar for testing.
+func createV1BlobTx(nonce uint64, key *ecdsa.PrivateKey) *types.Transaction {
+	blob := &kzg4844.Blob{byte(nonce)}
+	commitment, _ := kzg4844.BlobToCommitment(blob)
+	cellProofs, _ := kzg4844.ComputeCellProofs(blob)
+
+	blobtx := &types.BlobTx{
+		ChainID:    uint256.MustFromBig(params.MainnetChainConfig.ChainID),
+		Nonce:      nonce,
+		GasTipCap:  uint256.NewInt(1),
+		GasFeeCap:  uint256.NewInt(1000),
+		Gas:        21000,
+		BlobFeeCap: uint256.NewInt(100),
+		BlobHashes: []common.Hash{kzg4844.CalcBlobHashV1(sha256.New(), &commitment)},
+		Value:      uint256.NewInt(100),
+		Sidecar:    types.NewBlobTxSidecar(types.BlobSidecarVersion1, []kzg4844.Blob{*blob}, []kzg4844.Commitment{commitment}, cellProofs),
+	}
+	return types.MustSignNewTx(key, types.LatestSigner(params.MainnetChainConfig), blobtx)
+}
+
+func TestConversionQueueBasic(t *testing.T) {
+	queue := newConversionQueue()
+	defer queue.close()
+
+	key, _ := crypto.GenerateKey()
+	tx := makeTx(0, 1, 1, 1, key)
+	if err := queue.convert(tx); err != nil {
+		t.Fatalf("Expected successful conversion, got error: %v", err)
+	}
+	if tx.BlobTxSidecar().Version != types.BlobSidecarVersion1 {
+		t.Errorf("Expected sidecar version to be %d, got %d", types.BlobSidecarVersion1, tx.BlobTxSidecar().Version)
+	}
+}
+
+func TestConversionQueueV1BlobTx(t *testing.T) {
+	queue := newConversionQueue()
+	defer queue.close()
+
+	key, _ := crypto.GenerateKey()
+	tx := createV1BlobTx(0, key)
+	version := tx.BlobTxSidecar().Version
+
+	err := queue.convert(tx)
+	if err != nil {
+		t.Fatalf("Expected successful conversion, got error: %v", err)
+	}
+	if tx.BlobTxSidecar().Version != version {
+		t.Errorf("Expected sidecar version to remain %d, got %d", version, tx.BlobTxSidecar().Version)
+	}
+}
+
+func TestConversionQueueClosed(t *testing.T) {
+	queue := newConversionQueue()
+
+	// Close the queue first
+	queue.close()
+	key, _ := crypto.GenerateKey()
+	tx := makeTx(0, 1, 1, 1, key)
+
+	err := queue.convert(tx)
+	if err == nil {
+		t.Fatal("Expected error when converting on closed queue, got nil")
+	}
+}
+
+func TestConversionQueueDoubleClose(t *testing.T) {
+	queue := newConversionQueue()
+	queue.close()
+	queue.close() // Should not panic
+}

--- a/core/txpool/validation.go
+++ b/core/txpool/validation.go
@@ -176,16 +176,14 @@ func validateBlobTx(tx *types.Transaction, head *types.Header, opts *ValidationO
 		return err
 	}
 	// Fork-specific sidecar checks, including proof verification.
-	if opts.Config.IsOsaka(head.Number, head.Time) {
+	if sidecar.Version == types.BlobSidecarVersion1 {
 		return validateBlobSidecarOsaka(sidecar, hashes)
+	} else {
+		return validateBlobSidecarLegacy(sidecar, hashes)
 	}
-	return validateBlobSidecarLegacy(sidecar, hashes)
 }
 
 func validateBlobSidecarLegacy(sidecar *types.BlobTxSidecar, hashes []common.Hash) error {
-	if sidecar.Version != types.BlobSidecarVersion0 {
-		return fmt.Errorf("invalid sidecar version pre-osaka: %v", sidecar.Version)
-	}
 	if len(sidecar.Proofs) != len(hashes) {
 		return fmt.Errorf("invalid number of %d blob proofs expected %d", len(sidecar.Proofs), len(hashes))
 	}
@@ -198,9 +196,6 @@ func validateBlobSidecarLegacy(sidecar *types.BlobTxSidecar, hashes []common.Has
 }
 
 func validateBlobSidecarOsaka(sidecar *types.BlobTxSidecar, hashes []common.Hash) error {
-	if sidecar.Version != types.BlobSidecarVersion1 {
-		return fmt.Errorf("invalid sidecar version post-osaka: %v", sidecar.Version)
-	}
 	if len(sidecar.Proofs) != len(hashes)*kzg4844.CellProofsPerBlob {
 		return fmt.Errorf("invalid number of %d blob proofs expected %d", len(sidecar.Proofs), len(hashes)*kzg4844.CellProofsPerBlob)
 	}


### PR DESCRIPTION
This pull request introduces a queue for legacy sidecar conversion to handle 
transactions that persist after the Osaka fork. Simply dropping these transactions 
would significantly harm the user experience.

To balance usability with system complexity, we have introduced a conversion 
time window of two hours post Osaka fork. During this period, the system will 
accept legacy blob transactions and convert them in a background process. 
After the window, all legacy transactions will be rejected. Notably, all the blob
transactions will be validated statically before the conversion, and also all 
conversion are performed in a single thread, minimize the risk of being DoS.

We believe this two hour window provides sufficient time to process in-flight 
legacy transactions and allows submitters to migrate to the new format.