### PR TITLE
eth: using testing.B.Loop

### DIFF
--- a/eth/filters/filter_test.go
+++ b/eth/filters/filter_test.go
@@ -109,11 +109,8 @@ func benchmarkFilters(b *testing.B, history uint64, noHistory bool) {
 	backend.startFilterMaps(history, noHistory, filtermaps.DefaultParams)
 	defer backend.stopFilterMaps()
 
-	b.ResetTimer()
-
 	filter := sys.NewRangeFilter(0, int64(rpc.LatestBlockNumber), []common.Address{addr1, addr2, addr3, addr4}, nil)
-
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		filter.begin = 0
 		logs, _ := filter.Logs(context.Background())
 		if len(logs) != 4 {

--- a/eth/protocols/snap/sync_test.go
+++ b/eth/protocols/snap/sync_test.go
@@ -106,13 +106,13 @@ func BenchmarkHashing(b *testing.B) {
 	}
 	b.Run("old", func(b *testing.B) {
 		b.ReportAllocs()
-		for i := 0; i < b.N; i++ {
+		for b.Loop() {
 			old()
 		}
 	})
 	b.Run("new", func(b *testing.B) {
 		b.ReportAllocs()
-		for i := 0; i < b.N; i++ {
+		for b.Loop() {
 			new()
 		}
 	})

--- a/eth/tracers/internal/tracetest/calltrace_test.go
+++ b/eth/tracers/internal/tracetest/calltrace_test.go
@@ -211,11 +211,9 @@ func benchTracer(tracerName string, test *callTracerTest, b *testing.B) {
 	defer state.Close()
 
 	b.ReportAllocs()
-	b.ResetTimer()
 
 	evm := vm.NewEVM(context, state.StateDB, test.Genesis.Config, vm.Config{})
-
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		snap := state.StateDB.Snapshot()
 		tracer, err := tracers.DefaultDirectory.New(tracerName, new(tracers.Context), nil, test.Genesis.Config)
 		if err != nil {

--- a/eth/tracers/internal/tracetest/flat_calltrace_test.go
+++ b/eth/tracers/internal/tracetest/flat_calltrace_test.go
@@ -201,7 +201,7 @@ func BenchmarkFlatCallTracer(b *testing.B) {
 	for _, file := range files {
 		filename := strings.TrimPrefix(file, "testdata/call_tracer_flat/")
 		b.Run(camel(strings.TrimSuffix(filename, ".json")), func(b *testing.B) {
-			for n := 0; n < b.N; n++ {
+			for b.Loop() {
 				err := flatCallTracerTestRunner("flatCallTracer", filename, "call_tracer_flat", b)
 				if err != nil {
 					b.Fatal(err)

--- a/eth/tracers/tracers_test.go
+++ b/eth/tracers/tracers_test.go
@@ -84,10 +84,8 @@ func BenchmarkTransactionTraceV2(b *testing.B) {
 	if err != nil {
 		b.Fatalf("failed to prepare transaction for tracing: %v", err)
 	}
-	b.ResetTimer()
 	b.ReportAllocs()
-
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		tracer := logger.NewStructLogger(&logger.Config{}).Hooks()
 		tracer.OnTxStart(evm.GetVMContext(), tx, msg.From)
 		evm.Config.Tracer = tracer


### PR DESCRIPTION
before:
go test -run=^$ -bench=. ./eth/...  827.57s user 23.80s system 361% cpu 3:55.49 total

after:
go test -run=^$ -bench=. ./eth/...  281.62s user 13.62s system 245% cpu 2:00.49 total