### PR TITLE
core/state: using testing.B.Loop

### DIFF
--- a/core/state/snapshot/difflayer_test.go
+++ b/core/state/snapshot/difflayer_test.go
@@ -229,8 +229,7 @@ func BenchmarkSearch(b *testing.B) {
 		layer = fill(layer)
 	}
 	key := crypto.Keccak256Hash([]byte{0x13, 0x38})
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		layer.AccountRLP(key)
 	}
 }
@@ -269,8 +268,7 @@ func BenchmarkSearchSlot(b *testing.B) {
 	for i := 0; i < 128; i++ {
 		layer = fill(layer)
 	}
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		layer.Storage(accountKey, storageKey)
 	}
 }
@@ -300,9 +298,7 @@ func BenchmarkFlatten(b *testing.B) {
 		}
 		return newDiffLayer(parent, common.Hash{}, accounts, storage)
 	}
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
-		b.StopTimer()
+	for b.Loop() {
 		var layer snapshot
 		layer = emptyLayer()
 		for i := 1; i < 128; i++ {
@@ -352,9 +348,7 @@ func BenchmarkJournal(b *testing.B) {
 	for i := 1; i < 128; i++ {
 		layer = fill(layer)
 	}
-	b.ResetTimer()
-
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		layer.Journal(new(bytes.Buffer))
 	}
 }

--- a/core/state/snapshot/iterator_test.go
+++ b/core/state/snapshot/iterator_test.go
@@ -928,7 +928,7 @@ func BenchmarkAccountIteratorTraversal(b *testing.B) {
 	head.(*diffLayer).newBinaryAccountIterator(common.Hash{})
 
 	b.Run("binary iterator keys", func(b *testing.B) {
-		for i := 0; i < b.N; i++ {
+		for b.Loop() {
 			got := 0
 			it := head.(*diffLayer).newBinaryAccountIterator(common.Hash{})
 			for it.Next() {
@@ -940,7 +940,7 @@ func BenchmarkAccountIteratorTraversal(b *testing.B) {
 		}
 	})
 	b.Run("binary iterator values", func(b *testing.B) {
-		for i := 0; i < b.N; i++ {
+		for b.Loop() {
 			got := 0
 			it := head.(*diffLayer).newBinaryAccountIterator(common.Hash{})
 			for it.Next() {
@@ -953,7 +953,7 @@ func BenchmarkAccountIteratorTraversal(b *testing.B) {
 		}
 	})
 	b.Run("fast iterator keys", func(b *testing.B) {
-		for i := 0; i < b.N; i++ {
+		for b.Loop() {
 			it, _ := snaps.AccountIterator(common.HexToHash("0x65"), common.Hash{})
 			defer it.Release()
 
@@ -967,7 +967,7 @@ func BenchmarkAccountIteratorTraversal(b *testing.B) {
 		}
 	})
 	b.Run("fast iterator values", func(b *testing.B) {
-		for i := 0; i < b.N; i++ {
+		for b.Loop() {
 			it, _ := snaps.AccountIterator(common.HexToHash("0x65"), common.Hash{})
 			defer it.Release()
 
@@ -1025,7 +1025,7 @@ func BenchmarkAccountIteratorLargeBaselayer(b *testing.B) {
 	head.(*diffLayer).newBinaryAccountIterator(common.Hash{})
 
 	b.Run("binary iterator (keys)", func(b *testing.B) {
-		for i := 0; i < b.N; i++ {
+		for b.Loop() {
 			got := 0
 			it := head.(*diffLayer).newBinaryAccountIterator(common.Hash{})
 			for it.Next() {
@@ -1037,7 +1037,7 @@ func BenchmarkAccountIteratorLargeBaselayer(b *testing.B) {
 		}
 	})
 	b.Run("binary iterator (values)", func(b *testing.B) {
-		for i := 0; i < b.N; i++ {
+		for b.Loop() {
 			got := 0
 			it := head.(*diffLayer).newBinaryAccountIterator(common.Hash{})
 			for it.Next() {
@@ -1051,7 +1051,7 @@ func BenchmarkAccountIteratorLargeBaselayer(b *testing.B) {
 		}
 	})
 	b.Run("fast iterator (keys)", func(b *testing.B) {
-		for i := 0; i < b.N; i++ {
+		for b.Loop() {
 			it, _ := snaps.AccountIterator(common.HexToHash("0x65"), common.Hash{})
 			defer it.Release()
 
@@ -1065,7 +1065,7 @@ func BenchmarkAccountIteratorLargeBaselayer(b *testing.B) {
 		}
 	})
 	b.Run("fast iterator (values)", func(b *testing.B) {
-		for i := 0; i < b.N; i++ {
+		for b.Loop() {
 			it, _ := snaps.AccountIterator(common.HexToHash("0x65"), common.Hash{})
 			defer it.Release()
 

--- a/core/state/state_object_test.go
+++ b/core/state/state_object_test.go
@@ -25,7 +25,7 @@ import (
 
 func BenchmarkCutOriginal(b *testing.B) {
 	value := common.HexToHash("0x01")
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		bytes.TrimLeft(value[:], "\x00")
 	}
 }
@@ -33,14 +33,14 @@ func BenchmarkCutOriginal(b *testing.B) {
 func BenchmarkCutsetterFn(b *testing.B) {
 	value := common.HexToHash("0x01")
 	cutSetFn := func(r rune) bool { return r == 0 }
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		bytes.TrimLeftFunc(value[:], cutSetFn)
 	}
 }
 
 func BenchmarkCutCustomTrim(b *testing.B) {
 	value := common.HexToHash("0x01")
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		common.TrimLeftZeroes(value[:])
 	}
 }


### PR DESCRIPTION
before:
go test -run=^$ -bench=. ./core/state/...  120.85s user 7.96s system 129% cpu 1:39.13 tota

after:
go test -run=^$ -bench=. ./core/state/...  21.32s user 2.12s system 97% cpu 24.006 total