### PR TITLE
crypto/bn256: switch to gnark again

### DIFF
--- a/crypto/bn256/bn256_fast.go
+++ b/crypto/bn256/bn256_fast.go
@@ -9,18 +9,18 @@
 package bn256
 
 import (
-	bn256cf "github.com/ethereum/go-ethereum/crypto/bn256/cloudflare"
+	gnark "github.com/ethereum/go-ethereum/crypto/bn256/gnark"
 )
 
 // G1 is an abstract cyclic group. The zero value is suitable for use as the
 // output of an operation, but cannot be used as an input.
-type G1 = bn256cf.G1
+type G1 = gnark.G1
 
 // G2 is an abstract cyclic group. The zero value is suitable for use as the
 // output of an operation, but cannot be used as an input.
-type G2 = bn256cf.G2
+type G2 = gnark.G2
 
 // PairingCheck calculates the Optimal Ate pairing for a set of points.
 func PairingCheck(a []*G1, b []*G2) bool {
-	return bn256cf.PairingCheck(a, b)
+	return gnark.PairingCheck(a, b)
 }


### PR DESCRIPTION
We recently update our default implementation to gnark in https://github.com/ethereum/go-ethereum/pull/32024
Then we found a consensus issue and reverted it in https://github.com/ethereum/go-ethereum/commit/65d77c51295c3b5c237a082af856a6926766a51c
We fixed the consensus issue and have been fuzzing it more since then in 
https://github.com/ethereum/go-ethereum/pull/32055/files
https://github.com/ethereum/go-ethereum/pull/32065
https://github.com/ethereum/go-ethereum/pull/32055/files

So I think now is the time to update it back to gnark