### PR TITLE
core/vm: using testing.B.Loop

### DIFF
--- a/core/vm/analysis_legacy_test.go
+++ b/core/vm/analysis_legacy_test.go
@@ -65,21 +65,17 @@ func BenchmarkJumpdestAnalysis_1200k(bench *testing.B) {
 	// 1.4 ms
 	code := make([]byte, analysisCodeSize)
 	bench.SetBytes(analysisCodeSize)
-	bench.ResetTimer()
-	for i := 0; i < bench.N; i++ {
+	for bench.Loop() {
 		codeBitmap(code)
 	}
-	bench.StopTimer()
 }
 func BenchmarkJumpdestHashing_1200k(bench *testing.B) {
 	// 4 ms
 	code := make([]byte, analysisCodeSize)
 	bench.SetBytes(analysisCodeSize)
-	bench.ResetTimer()
-	for i := 0; i < bench.N; i++ {
+	for bench.Loop() {
 		crypto.Keccak256Hash(code)
 	}
-	bench.StopTimer()
 }
 
 func BenchmarkJumpdestOpAnalysis(bench *testing.B) {
@@ -91,8 +87,7 @@ func BenchmarkJumpdestOpAnalysis(bench *testing.B) {
 			code[i] = byte(op)
 		}
 		bits := make(BitVec, len(code)/8+1+4)
-		b.ResetTimer()
-		for i := 0; i < b.N; i++ {
+		for b.Loop() {
 			clear(bits)
 			codeBitmapInternal(code, bits)
 		}

--- a/core/vm/contracts_test.go
+++ b/core/vm/contracts_test.go
@@ -167,12 +167,10 @@ func benchmarkPrecompiled(addr string, test precompiledTest, bench *testing.B) {
 	bench.Run(fmt.Sprintf("%s-Gas=%d", test.Name, reqGas), func(bench *testing.B) {
 		bench.ReportAllocs()
 		start := time.Now()
-		bench.ResetTimer()
-		for i := 0; i < bench.N; i++ {
+		for bench.Loop() {
 			copy(data, in)
 			res, _, err = RunPrecompiledContract(p, data, reqGas, nil)
 		}
-		bench.StopTimer()
 		elapsed := uint64(time.Since(start))
 		if elapsed < 1 {
 			elapsed = 1

--- a/core/vm/instructions_test.go
+++ b/core/vm/instructions_test.go
@@ -291,8 +291,7 @@ func opBenchmark(bench *testing.B, op executionFunc, args ...string) {
 		intArgs[i] = new(uint256.Int).SetBytes(common.Hex2Bytes(arg))
 	}
 	pc := uint64(0)
-	bench.ResetTimer()
-	for i := 0; i < bench.N; i++ {
+	for bench.Loop() {
 		for _, arg := range intArgs {
 			stack.push(arg)
 		}
@@ -551,8 +550,7 @@ func BenchmarkOpMstore(bench *testing.B) {
 	memStart := new(uint256.Int)
 	value := new(uint256.Int).SetUint64(0x1337)
 
-	bench.ResetTimer()
-	for i := 0; i < bench.N; i++ {
+	for bench.Loop() {
 		stack.push(value)
 		stack.push(memStart)
 		opMstore(&pc, evm, &ScopeContext{mem, stack, nil})
@@ -609,8 +607,7 @@ func BenchmarkOpKeccak256(bench *testing.B) {
 	pc := uint64(0)
 	start := new(uint256.Int)
 
-	bench.ResetTimer()
-	for i := 0; i < bench.N; i++ {
+	for bench.Loop() {
 		stack.push(uint256.NewInt(32))
 		stack.push(start)
 		opKeccak256(&pc, evm, &ScopeContext{mem, stack, nil})

--- a/core/vm/instructions_test.go
+++ b/core/vm/instructions_test.go
@@ -298,7 +298,6 @@ func opBenchmark(bench *testing.B, op executionFunc, args ...string) {
 		op(&pc, evm, scope)
 		stack.pop()
 	}
-	bench.StopTimer()
 
 	for i, arg := range args {
 		want := new(uint256.Int).SetBytes(common.Hex2Bytes(arg))

--- a/core/vm/interpreter_test.go
+++ b/core/vm/interpreter_test.go
@@ -90,8 +90,7 @@ func BenchmarkInterpreter(b *testing.B) {
 	stack.push(uint256.NewInt(123))
 	stack.push(uint256.NewInt(123))
 	gasSStoreEIP3529 = makeGasSStoreFunc(params.SstoreClearsScheduleRefundEIP3529)
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		gasSStoreEIP3529(evm, contract, stack, mem, 1234)
 	}
 }

--- a/core/vm/runtime/runtime_test.go
+++ b/core/vm/runtime/runtime_test.go
@@ -150,8 +150,7 @@ func BenchmarkCall(b *testing.B) {
 		b.Fatal(err)
 	}
 
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		for j := 0; j < 400; j++ {
 			Execute(code, cpurchase, nil)
 			Execute(code, creceived, nil)
@@ -190,11 +189,9 @@ func benchmarkEVM_Create(bench *testing.B, code string) {
 		EVMConfig: vm.Config{},
 	}
 	// Warm up the intpools and stuff
-	bench.ResetTimer()
-	for i := 0; i < bench.N; i++ {
+	for bench.Loop() {
 		Call(receiver, []byte{}, &runtimeConfig)
 	}
-	bench.StopTimer()
 }
 
 func BenchmarkEVM_CREATE_500(bench *testing.B) {
@@ -233,8 +230,7 @@ func BenchmarkEVM_SWAP1(b *testing.B) {
 	b.Run("10k", func(b *testing.B) {
 		contractCode := swapContract(10_000)
 		state.SetCode(contractAddr, contractCode, tracing.CodeChangeUnspecified)
-
-		for i := 0; i < b.N; i++ {
+		for b.Loop() {
 			_, _, err := Call(contractAddr, []byte{}, &Config{State: state})
 			if err != nil {
 				b.Fatal(err)
@@ -264,8 +260,7 @@ func BenchmarkEVM_RETURN(b *testing.B) {
 
 			contractCode := returnContract(n)
 			state.SetCode(contractAddr, contractCode, tracing.CodeChangeUnspecified)
-
-			for i := 0; i < b.N; i++ {
+			for b.Loop() {
 				ret, _, err := Call(contractAddr, []byte{}, &Config{State: state})
 				if err != nil {
 					b.Fatal(err)
@@ -432,7 +427,7 @@ func benchmarkNonModifyingCode(gas uint64, code []byte, name string, tracerCode 
 
 	b.Run(name, func(b *testing.B) {
 		b.ReportAllocs()
-		for i := 0; i < b.N; i++ {
+		for b.Loop() {
 			Call(destination, nil, cfg)
 		}
 	})


### PR DESCRIPTION
before:
go test -run=^$ -bench=. ./core/vm/... -timeout=1h  1841.87s user 40.96s system 124% cpu 25:15.76 total
after:
go test -run=^$ -bench=. ./core/vm/... -timeout=1h  1588.65s user 33.79s system 123% cpu 21:53.25 total