### PR TITLE
core/rawdb: update comments

### DIFF
--- a/core/rawdb/freezer.go
+++ b/core/rawdb/freezer.go
@@ -76,8 +76,9 @@ type Freezer struct {
 // NewFreezer creates a freezer instance for maintaining immutable ordered
 // data according to the given parameters.
 //
-// The 'tables' argument defines the data tables. If the value of a map
-// entry is true, snappy compression is disabled for the table.
+// The 'tables' argument defines the freezer tables and their configuration.
+// Each value is a freezerTableConfig specifying whether snappy compression is
+// disabled (noSnappy) and whether the table is prunable (prunable).
 func NewFreezer(datadir string, namespace string, readonly bool, maxTableSize uint32, tables map[string]freezerTableConfig) (*Freezer, error) {
 	// Create the initial freezer object
 	var (

--- a/core/rawdb/freezer_table.go
+++ b/core/rawdb/freezer_table.go
@@ -100,7 +100,7 @@ type freezerTable struct {
 	// should never be lower than itemOffset.
 	itemHidden atomic.Uint64
 
-    config      freezerTableConfig // table configuration (compression, prunability). Note: compression flag does not apply retroactively to existing files
+	config      freezerTableConfig // table configuration (compression, prunability). Note: compression flag does not apply retroactively to existing files
 	readonly    bool
 	maxFileSize uint32 // Max file size for data-files
 	name        string

--- a/core/rawdb/freezer_table.go
+++ b/core/rawdb/freezer_table.go
@@ -100,7 +100,7 @@ type freezerTable struct {
 	// should never be lower than itemOffset.
 	itemHidden atomic.Uint64
 
-	config      freezerTableConfig // if true, disables snappy compression. Note: does not work retroactively
+    config      freezerTableConfig // table configuration (compression, prunability). Note: compression flag does not apply retroactively to existing files
 	readonly    bool
 	maxFileSize uint32 // Max file size for data-files
 	name        string


### PR DESCRIPTION
- Replace outdated NewFreezer doc that referenced map[string]bool/snappy toggle with accurate description of -map[string]freezerTableConfig (noSnappy, prunable).
- Fix misleading field comment on freezerTable.config that spoke as if it were a boolean (“if true”), clarifying it’s a struct and noting compression is non-retroactive.