### PR TITLE
core/state: add missing address key in state_object log

### DIFF
--- a/core/state/state_object.go
+++ b/core/state/state_object.go
@@ -333,7 +333,7 @@ func (s *stateObject) updateTrie() (Trie, error) {
 			continue
 		}
 		if !exist {
-			log.Error("Storage slot is not found in pending area", s.address, "slot", key)
+			log.Error("Storage slot is not found in pending area", "address", s.address, "slot", key)
 			continue
 		}
 		if (value != common.Hash{}) {


### PR DESCRIPTION
Fix incorrect logging context in state_object: the address was passed without a key, producing an odd number of context args and treating the address as a key. Align with surrounding logs and the logging API by using a proper key/value pair: "address", s.address. This ensures structured logging works correctly and avoids normalization side effects.