### PR TITLE
all: remove osaka and bpo override flags

### DIFF
--- a/cmd/geth/chaincmd.go
+++ b/cmd/geth/chaincmd.go
@@ -58,9 +58,6 @@ var (
 		ArgsUsage: "<genesisPath>",
 		Flags: slices.Concat([]cli.Flag{
 			utils.CachePreimagesFlag,
-			utils.OverrideOsaka,
-			utils.OverrideBPO1,
-			utils.OverrideBPO2,
 			utils.OverrideVerkle,
 		}, utils.DatabaseFlags),
 		Description: `
@@ -272,18 +269,6 @@ func initGenesis(ctx *cli.Context) error {
 	defer stack.Close()
 
 	var overrides core.ChainOverrides
-	if ctx.IsSet(utils.OverrideOsaka.Name) {
-		v := ctx.Uint64(utils.OverrideOsaka.Name)
-		overrides.OverrideOsaka = &v
-	}
-	if ctx.IsSet(utils.OverrideBPO1.Name) {
-		v := ctx.Uint64(utils.OverrideBPO1.Name)
-		overrides.OverrideBPO1 = &v
-	}
-	if ctx.IsSet(utils.OverrideBPO2.Name) {
-		v := ctx.Uint64(utils.OverrideBPO2.Name)
-		overrides.OverrideBPO2 = &v
-	}
 	if ctx.IsSet(utils.OverrideVerkle.Name) {
 		v := ctx.Uint64(utils.OverrideVerkle.Name)
 		overrides.OverrideVerkle = &v

--- a/cmd/geth/config.go
+++ b/cmd/geth/config.go
@@ -223,18 +223,6 @@ func constructDevModeBanner(ctx *cli.Context, cfg gethConfig) string {
 // makeFullNode loads geth configuration and creates the Ethereum backend.
 func makeFullNode(ctx *cli.Context) *node.Node {
 	stack, cfg := makeConfigNode(ctx)
-	if ctx.IsSet(utils.OverrideOsaka.Name) {
-		v := ctx.Uint64(utils.OverrideOsaka.Name)
-		cfg.Eth.OverrideOsaka = &v
-	}
-	if ctx.IsSet(utils.OverrideBPO1.Name) {
-		v := ctx.Uint64(utils.OverrideBPO1.Name)
-		cfg.Eth.OverrideBPO1 = &v
-	}
-	if ctx.IsSet(utils.OverrideBPO2.Name) {
-		v := ctx.Uint64(utils.OverrideBPO2.Name)
-		cfg.Eth.OverrideBPO2 = &v
-	}
 	if ctx.IsSet(utils.OverrideVerkle.Name) {
 		v := ctx.Uint64(utils.OverrideVerkle.Name)
 		cfg.Eth.OverrideVerkle = &v

--- a/cmd/geth/main.go
+++ b/cmd/geth/main.go
@@ -62,9 +62,6 @@ var (
 		utils.NoUSBFlag, // deprecated
 		utils.USBFlag,
 		utils.SmartCardDaemonPathFlag,
-		utils.OverrideOsaka,
-		utils.OverrideBPO1,
-		utils.OverrideBPO2,
 		utils.OverrideVerkle,
 		utils.EnablePersonal, // deprecated
 		utils.TxPoolLocalsFlag,

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -242,21 +242,6 @@ var (
 		Value:    2048,
 		Category: flags.EthCategory,
 	}
-	OverrideOsaka = &cli.Uint64Flag{
-		Name:     "override.osaka",
-		Usage:    "Manually specify the Osaka fork timestamp, overriding the bundled setting",
-		Category: flags.EthCategory,
-	}
-	OverrideBPO1 = &cli.Uint64Flag{
-		Name:     "override.bpo1",
-		Usage:    "Manually specify the bpo1 fork timestamp, overriding the bundled setting",
-		Category: flags.EthCategory,
-	}
-	OverrideBPO2 = &cli.Uint64Flag{
-		Name:     "override.bpo2",
-		Usage:    "Manually specify the bpo2 fork timestamp, overriding the bundled setting",
-		Category: flags.EthCategory,
-	}
 	OverrideVerkle = &cli.Uint64Flag{
 		Name:     "override.verkle",
 		Usage:    "Manually specify the Verkle fork timestamp, overriding the bundled setting",

--- a/core/genesis.go
+++ b/core/genesis.go
@@ -258,9 +258,6 @@ func (e *GenesisMismatchError) Error() string {
 
 // ChainOverrides contains the changes to chain config.
 type ChainOverrides struct {
-	OverrideOsaka  *uint64
-	OverrideBPO1   *uint64
-	OverrideBPO2   *uint64
 	OverrideVerkle *uint64
 }
 
@@ -268,15 +265,6 @@ type ChainOverrides struct {
 func (o *ChainOverrides) apply(cfg *params.ChainConfig) error {
 	if o == nil || cfg == nil {
 		return nil
-	}
-	if o.OverrideOsaka != nil {
-		cfg.OsakaTime = o.OverrideOsaka
-	}
-	if o.OverrideBPO1 != nil {
-		cfg.BPO1Time = o.OverrideBPO1
-	}
-	if o.OverrideBPO2 != nil {
-		cfg.BPO2Time = o.OverrideBPO2
 	}
 	if o.OverrideVerkle != nil {
 		cfg.VerkleTime = o.OverrideVerkle

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -259,15 +259,6 @@ func New(stack *node.Node, config *ethconfig.Config) (*Ethereum, error) {
 	}
 	// Override the chain config with provided settings.
 	var overrides core.ChainOverrides
-	if config.OverrideOsaka != nil {
-		overrides.OverrideOsaka = config.OverrideOsaka
-	}
-	if config.OverrideBPO1 != nil {
-		overrides.OverrideBPO1 = config.OverrideBPO1
-	}
-	if config.OverrideBPO2 != nil {
-		overrides.OverrideBPO2 = config.OverrideBPO2
-	}
 	if config.OverrideVerkle != nil {
 		overrides.OverrideVerkle = config.OverrideVerkle
 	}

--- a/eth/ethconfig/config.go
+++ b/eth/ethconfig/config.go
@@ -172,15 +172,6 @@ type Config struct {
 	// send-transaction variants. The unit is ether.
 	RPCTxFeeCap float64
 
-	// OverrideOsaka (TODO: remove after the fork)
-	OverrideOsaka *uint64 `toml:",omitempty"`
-
-	// OverrideBPO1 (TODO: remove after the fork)
-	OverrideBPO1 *uint64 `toml:",omitempty"`
-
-	// OverrideBPO2 (TODO: remove after the fork)
-	OverrideBPO2 *uint64 `toml:",omitempty"`
-
 	// OverrideVerkle (TODO: remove after the fork)
 	OverrideVerkle *uint64 `toml:",omitempty"`
 }

--- a/eth/ethconfig/gen_config.go
+++ b/eth/ethconfig/gen_config.go
@@ -58,10 +58,6 @@ func (c Config) MarshalTOML() (interface{}, error) {
 		RPCGasCap               uint64
 		RPCEVMTimeout           time.Duration
 		RPCTxFeeCap             float64
-		OverrideOsaka           *uint64 `toml:",omitempty"`
-		OverrideBPO1            *uint64 `toml:",omitempty"`
-		OverrideBPO2            *uint64 `toml:",omitempty"`
-		OverrideVerkle          *uint64 `toml:",omitempty"`
 	}
 	var enc Config
 	enc.Genesis = c.Genesis
@@ -105,10 +101,6 @@ func (c Config) MarshalTOML() (interface{}, error) {
 	enc.RPCGasCap = c.RPCGasCap
 	enc.RPCEVMTimeout = c.RPCEVMTimeout
 	enc.RPCTxFeeCap = c.RPCTxFeeCap
-	enc.OverrideOsaka = c.OverrideOsaka
-	enc.OverrideBPO1 = c.OverrideBPO1
-	enc.OverrideBPO2 = c.OverrideBPO2
-	enc.OverrideVerkle = c.OverrideVerkle
 	return &enc, nil
 }
 
@@ -156,10 +148,6 @@ func (c *Config) UnmarshalTOML(unmarshal func(interface{}) error) error {
 		RPCGasCap               *uint64
 		RPCEVMTimeout           *time.Duration
 		RPCTxFeeCap             *float64
-		OverrideOsaka           *uint64 `toml:",omitempty"`
-		OverrideBPO1            *uint64 `toml:",omitempty"`
-		OverrideBPO2            *uint64 `toml:",omitempty"`
-		OverrideVerkle          *uint64 `toml:",omitempty"`
 	}
 	var dec Config
 	if err := unmarshal(&dec); err != nil {
@@ -287,18 +275,6 @@ func (c *Config) UnmarshalTOML(unmarshal func(interface{}) error) error {
 	}
 	if dec.RPCTxFeeCap != nil {
 		c.RPCTxFeeCap = *dec.RPCTxFeeCap
-	}
-	if dec.OverrideOsaka != nil {
-		c.OverrideOsaka = dec.OverrideOsaka
-	}
-	if dec.OverrideBPO1 != nil {
-		c.OverrideBPO1 = dec.OverrideBPO1
-	}
-	if dec.OverrideBPO2 != nil {
-		c.OverrideBPO2 = dec.OverrideBPO2
-	}
-	if dec.OverrideVerkle != nil {
-		c.OverrideVerkle = dec.OverrideVerkle
 	}
 	return nil
 }


### PR DESCRIPTION
Currently `--override.osaka` doesn't work because it only overrides with the provided time, but does not provide a blob schedule. Since the blob schedule isn't provided on any network yet, it will fail to start. Even after we add the Osaka blob schedule to the default networks, it usefulness is very limited since 1) it alone cannot change the max or target for the fork and 2) there are several BPOs scheduled alongside Osaka with their own max and targets - none of which can be overridden yet.

For those reasons, I propose removing the `OverrideOsaka` flag and pursue a complete / future-proof solution such as #32556.