### PR TITLE
eth/fetcher: using slices.SortFunc

### DIFF
--- a/eth/fetcher/tx_fetcher.go
+++ b/eth/fetcher/tx_fetcher.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"math"
 	mrand "math/rand"
+	"slices"
 	"sort"
 	"time"
 
@@ -1014,8 +1015,8 @@ func (f *TxFetcher) forEachAnnounce(announces map[common.Hash]*txMetadataWithSeq
 	for hash, entry := range announces {
 		list = append(list, announcement{hash: hash, meta: entry.txMetadata, seq: entry.seq})
 	}
-	sort.Slice(list, func(i, j int) bool {
-		return list[i].seq < list[j].seq
+	slices.SortFunc(list, func(a, b announcement) int {
+		return int(a.seq) - int(b.seq)
 	})
 	for i := range list {
 		if !do(list[i].hash, list[i].meta) {


### PR DESCRIPTION
package bench

import (
	"math/rand"
	"slices"
	"sort"
	"testing"
)

const N = 100_000

func randomInts(n int) []int {
	a := make([]int, n)
	for i := range a {
		a[i] = rand.Int()
	}
	return a
}

// sort.Slice
func BenchmarkSortSlice(b *testing.B) {
	data := randomInts(N)
	b.ResetTimer()
	for i := 0; i < b.N; i++ {
		arr := append([]int(nil), data...)
		sort.Slice(arr, func(i, j int) bool {
			return arr[i] < arr[j]
		})
	}
}

// slices.Sort
func BenchmarkSlicesSort(b *testing.B) {
	data := randomInts(N)
	b.ResetTimer()
	for i := 0; i < b.N; i++ {
		arr := append([]int(nil), data...)
		slices.Sort(arr)
	}
}

// slices.SortFunc
func BenchmarkSlicesSortFunc(b *testing.B) {
	data := randomInts(N)
	b.ResetTimer()
	for i := 0; i < b.N; i++ {
		arr := append([]int(nil), data...)
		slices.SortFunc(arr, func(a, b int) int {
			// 返回负数表示 a < b
			if a < b {
				return -1
			} else if a > b {
				return 1
			}
			return 0
		})
	}
}

```
GOROOT=/Volumes/Elements/code/go/goroot/go1.24.5/go #gosetup
GOPATH=/Users/xiecui/code/go/gopath #gosetup
/Volumes/Elements/code/go/goroot/go1.24.5/go/bin/go test -c -o /Users/xiecui/Library/Caches/JetBrains/GoLand2025.2/tmp/GoLand/___gobench_github_com_cuiweixie_mylabs_tests_bench_slice_sort_and_sort_slice.test github.com/cuiweixie/mylabs/tests/bench_slice_sort_and_sort_slice #gosetup
/Users/xiecui/Library/Caches/JetBrains/GoLand2025.2/tmp/GoLand/___gobench_github_com_cuiweixie_mylabs_tests_bench_slice_sort_and_sort_slice.test -test.v -test.paniconexit0 -test.bench . -test.run ^$ #gosetup
goos: darwin
goarch: arm64
pkg: github.com/cuiweixie/mylabs/tests/bench_slice_sort_and_sort_slice
cpu: Apple M1 Pro
BenchmarkSortSlice
BenchmarkSortSlice-10         	     120	  10047983 ns/op
BenchmarkSlicesSort
BenchmarkSlicesSort-10        	     207	   5888880 ns/op
BenchmarkSlicesSortFunc
BenchmarkSlicesSortFunc-10    	     140	   8415482 ns/op
PASS

Process finished with the exit code 0

```