### PR TITLE
cmd/geth: log current key in expandVerkle instead of keylist[0]

### DIFF
--- a/cmd/geth/verkle.go
+++ b/cmd/geth/verkle.go
@@ -201,7 +201,7 @@ func expandVerkle(ctx *cli.Context) error {
 	}
 
 	for i, key := range keylist {
-		log.Info("Reading key", "index", i, "key", keylist[0])
+		log.Info("Reading key", "index", i, "key", key)
 		root.Get(key, chaindb.Get)
 	}
 


### PR DESCRIPTION
Fix logging in the verkle dump path to report the actual key being processed.
Previously, the loop always logged keylist[0], which misled users when
expanding multiple keys and made debugging harder. This change aligns the
log with the key passed to root.Get, improving traceability and diagnostics.