### PR TITLE
ethclient: Default fromBlock/toBlock to "latest" if nil (Fixes #32675)

### DIFF
--- a/ethclient/ethclient.go
+++ b/ethclient/ethclient.go
@@ -497,11 +497,7 @@ func toFilterArg(q ethereum.FilterQuery) (interface{}, error) {
 			return nil, errors.New("cannot specify both BlockHash and FromBlock/ToBlock")
 		}
 	} else {
-		if q.FromBlock == nil {
-			arg["fromBlock"] = "0x0"
-		} else {
-			arg["fromBlock"] = toBlockNumArg(q.FromBlock)
-		}
+		arg["fromBlock"] = toBlockNumArg(q.FromBlock)
 		arg["toBlock"] = toBlockNumArg(q.ToBlock)
 	}
 	return arg, nil

--- a/ethclient/types_test.go
+++ b/ethclient/types_test.go
@@ -65,7 +65,7 @@ func TestToFilterArg(t *testing.T) {
 			},
 			map[string]interface{}{
 				"address":   addresses,
-				"fromBlock": "0x0",
+				"fromBlock": "latest",
 				"toBlock":   "latest",
 				"topics":    [][]common.Hash{},
 			},


### PR DESCRIPTION
Simple fix: in `toFilterArg`, set `fromBlock` and `toBlock` to `"latest"` when nil.
Closes #32675.