### PR TITLE
eth/catalyst: remove unnecessary unused variable suppression

### DIFF
--- a/eth/catalyst/simulated_beacon_test.go
+++ b/eth/catalyst/simulated_beacon_test.go
@@ -88,7 +88,6 @@ func TestSimulatedBeaconSendWithdrawals(t *testing.T) {
 	var gasLimit uint64 = 10_000_000
 	genesis := core.DeveloperGenesisBlock(gasLimit, &testAddr)
 	node, ethService, mock := startSimulatedBeaconEthService(t, genesis, 1)
-	_ = mock
 	defer node.Close()
 
 	chainHeadCh := make(chan core.ChainHeadEvent, 10)


### PR DESCRIPTION
The `_ = mock` line in TestSimulatedBeaconSendWithdrawals was unnecessary
since the `mock` variable is actually used later in the test to call
`mock.withdrawals.add()`. This suppression was likely added by mistake
or by an overly aggressive linter/IDE auto-fix that didn't account for
the variable being used after the suppression line.

