### PR TITLE
docs: fix typos

### DIFF
--- a/accounts/abi/bind/v2/dep_tree_test.go
+++ b/accounts/abi/bind/v2/dep_tree_test.go
@@ -329,7 +329,7 @@ func TestContractLinking(t *testing.T) {
 			map[rune]struct{}{},
 		},
 		// two contracts ('a' and 'f') share some dependencies.  contract 'a' is marked as an override.  expect that any of
-		// its depdencies that aren't shared with 'f' are not deployed.
+		// its dependencies that aren't shared with 'f' are not deployed.
 		linkTestCaseInput{map[rune][]rune{
 			'a': {'b', 'c', 'd', 'e'},
 			'f': {'g', 'c', 'd', 'h'}},

--- a/core/txpool/legacypool/legacypool_test.go
+++ b/core/txpool/legacypool/legacypool_test.go
@@ -2419,7 +2419,7 @@ func TestSetCodeTransactions(t *testing.T) {
 				if err := pool.addRemoteSync(pricedSetCodeTx(0, 250000, uint256.NewInt(3000), uint256.NewInt(300), keyA, []unsignedAuth{{0, keyC}})); err != nil {
 					t.Fatalf("%s: failed to add with remote setcode transaction: %v", name, err)
 				}
-				// B should not be considred as having an in-flight delegation, so
+				// B should not be considered as having an in-flight delegation, so
 				// should allow more than one pooled transaction.
 				if err := pool.addRemoteSync(pricedTransaction(0, 100000, big.NewInt(10), keyB)); err != nil {
 					t.Fatalf("%s: failed to replace with remote transaction: %v", name, err)

--- a/eth/protocols/snap/sync.go
+++ b/eth/protocols/snap/sync.go
@@ -82,7 +82,7 @@ const (
 	minTrienodeHealThrottle = 1
 
 	// maxTrienodeHealThrottle is the maximum divisor for throttling trie node
-	// heal requests to avoid overloading the local node and exessively expanding
+	// heal requests to avoid overloading the local node and excessively expanding
 	// the state trie bedth wise.
 	maxTrienodeHealThrottle = maxTrieRequestCount
 

--- a/triedb/pathdb/history_index_block_test.go
+++ b/triedb/pathdb/history_index_block_test.go
@@ -138,7 +138,7 @@ func TestBlockWriterDelete(t *testing.T) {
 		}
 		newMax := uint64(i - 1)
 		if bw.desc.max != newMax {
-			t.Fatalf("Maxmium element is not matched, want: %d, got: %d", newMax, bw.desc.max)
+			t.Fatalf("Maximum element is not matched, want: %d, got: %d", newMax, bw.desc.max)
 		}
 	}
 }


### PR DESCRIPTION

This PR fixes minor spelling errors across the codebase:

- **accounts/abi/bind/v2/dep_tree_test.go**: fixed `depdencies` → `dependencies`
- **core/txpool/legacypool/legacypool_test.go**: fixed `considred` → `considered`
- **eth/protocols/snap/sync.go**: fixed `exessively` → `excessively`
- **triedb/pathdb/history_index_block_test.go**: fixed `Maxmium` → `Maxmium`