### PR TITLE
core/vm: opt opSwap*

### DIFF
--- a/core/vm/stack.go
+++ b/core/vm/stack.go
@@ -65,52 +65,68 @@ func (st *Stack) len() int {
 }
 
 func (st *Stack) swap1() {
-	st.data[st.len()-2], st.data[st.len()-1] = st.data[st.len()-1], st.data[st.len()-2]
+	length := st.len()
+	st.data[length-2], st.data[length-1] = st.data[length-1], st.data[length-2]
 }
 func (st *Stack) swap2() {
-	st.data[st.len()-3], st.data[st.len()-1] = st.data[st.len()-1], st.data[st.len()-3]
+	length := st.len()
+	st.data[length-3], st.data[length-1] = st.data[length-1], st.data[length-3]
 }
 func (st *Stack) swap3() {
-	st.data[st.len()-4], st.data[st.len()-1] = st.data[st.len()-1], st.data[st.len()-4]
+	length := st.len()
+	st.data[length-4], st.data[length-1] = st.data[length-1], st.data[length-4]
 }
 func (st *Stack) swap4() {
-	st.data[st.len()-5], st.data[st.len()-1] = st.data[st.len()-1], st.data[st.len()-5]
+	length := st.len()
+	st.data[length-5], st.data[length-1] = st.data[length-1], st.data[length-5]
 }
 func (st *Stack) swap5() {
-	st.data[st.len()-6], st.data[st.len()-1] = st.data[st.len()-1], st.data[st.len()-6]
+	length := st.len()
+	st.data[length-6], st.data[length-1] = st.data[length-1], st.data[length-6]
 }
 func (st *Stack) swap6() {
-	st.data[st.len()-7], st.data[st.len()-1] = st.data[st.len()-1], st.data[st.len()-7]
+	length := st.len()
+	st.data[length-7], st.data[length-1] = st.data[length-1], st.data[length-7]
 }
 func (st *Stack) swap7() {
-	st.data[st.len()-8], st.data[st.len()-1] = st.data[st.len()-1], st.data[st.len()-8]
+	length := st.len()
+	st.data[length-8], st.data[length-1] = st.data[length-1], st.data[length-8]
 }
 func (st *Stack) swap8() {
-	st.data[st.len()-9], st.data[st.len()-1] = st.data[st.len()-1], st.data[st.len()-9]
+	length := st.len()
+	st.data[length-9], st.data[length-1] = st.data[length-1], st.data[length-9]
 }
 func (st *Stack) swap9() {
-	st.data[st.len()-10], st.data[st.len()-1] = st.data[st.len()-1], st.data[st.len()-10]
+	length := st.len()
+	st.data[length-10], st.data[length-1] = st.data[length-1], st.data[length-10]
 }
 func (st *Stack) swap10() {
-	st.data[st.len()-11], st.data[st.len()-1] = st.data[st.len()-1], st.data[st.len()-11]
+	length := st.len()
+	st.data[length-11], st.data[length-1] = st.data[length-1], st.data[length-11]
 }
 func (st *Stack) swap11() {
-	st.data[st.len()-12], st.data[st.len()-1] = st.data[st.len()-1], st.data[st.len()-12]
+	length := st.len()
+	st.data[length-12], st.data[length-1] = st.data[length-1], st.data[length-12]
 }
 func (st *Stack) swap12() {
-	st.data[st.len()-13], st.data[st.len()-1] = st.data[st.len()-1], st.data[st.len()-13]
+	length := st.len()
+	st.data[length-13], st.data[length-1] = st.data[length-1], st.data[length-13]
 }
 func (st *Stack) swap13() {
-	st.data[st.len()-14], st.data[st.len()-1] = st.data[st.len()-1], st.data[st.len()-14]
+	length := st.len()
+	st.data[length-14], st.data[length-1] = st.data[length-1], st.data[length-14]
 }
 func (st *Stack) swap14() {
-	st.data[st.len()-15], st.data[st.len()-1] = st.data[st.len()-1], st.data[st.len()-15]
+	length := st.len()
+	st.data[length-15], st.data[length-1] = st.data[length-1], st.data[length-15]
 }
 func (st *Stack) swap15() {
-	st.data[st.len()-16], st.data[st.len()-1] = st.data[st.len()-1], st.data[st.len()-16]
+	length := st.len()
+	st.data[length-16], st.data[length-1] = st.data[length-1], st.data[length-16]
 }
 func (st *Stack) swap16() {
-	st.data[st.len()-17], st.data[st.len()-1] = st.data[st.len()-1], st.data[st.len()-17]
+	length := st.len()
+	st.data[length-17], st.data[length-1] = st.data[length-1], st.data[length-17]
 }
 
 func (st *Stack) dup(n int) {


### PR DESCRIPTION
```
package vm

import (
	"testing"

	"github.com/holiman/uint256"
)

func createTestStack(size int) *Stack {
	data := make([]uint256.Int, size)
	for i := 0; i < size; i++ {
		data[i] = *uint256.NewInt(uint64(i + 1))
	}
	return &Stack{data: data}
}

func BenchmarkSwap1(b *testing.B) {
	stack := createTestStack(20)
	b.ResetTimer()
	for i := 0; i < b.N; i++ {
		stack.swap1()
	}
}

func BenchmarkSwap2(b *testing.B) {
	stack := createTestStack(20)
	b.ResetTimer()
	for i := 0; i < b.N; i++ {
		stack.swap2()
	}
}

func BenchmarkSwap3(b *testing.B) {
	stack := createTestStack(20)
	b.ResetTimer()
	for i := 0; i < b.N; i++ {
		stack.swap3()
	}
}

func BenchmarkSwap4(b *testing.B) {
	stack := createTestStack(20)
	b.ResetTimer()
	for i := 0; i < b.N; i++ {
		stack.swap4()
	}
}

func BenchmarkSwap5(b *testing.B) {
	stack := createTestStack(20)
	b.ResetTimer()
	for i := 0; i < b.N; i++ {
		stack.swap5()
	}
}

func BenchmarkSwap6(b *testing.B) {
	stack := createTestStack(20)
	b.ResetTimer()
	for i := 0; i < b.N; i++ {
		stack.swap6()
	}
}

func BenchmarkSwap7(b *testing.B) {
	stack := createTestStack(20)
	b.ResetTimer()
	for i := 0; i < b.N; i++ {
		stack.swap7()
	}
}

func BenchmarkSwap8(b *testing.B) {
	stack := createTestStack(20)
	b.ResetTimer()
	for i := 0; i < b.N; i++ {
		stack.swap8()
	}
}

func BenchmarkSwap9(b *testing.B) {
	stack := createTestStack(20)
	b.ResetTimer()
	for i := 0; i < b.N; i++ {
		stack.swap9()
	}
}

func BenchmarkSwap10(b *testing.B) {
	stack := createTestStack(20)
	b.ResetTimer()
	for i := 0; i < b.N; i++ {
		stack.swap10()
	}
}

func BenchmarkSwap11(b *testing.B) {
	stack := createTestStack(20)
	b.ResetTimer()
	for i := 0; i < b.N; i++ {
		stack.swap11()
	}
}

func BenchmarkSwap12(b *testing.B) {
	stack := createTestStack(20)
	b.ResetTimer()
	for i := 0; i < b.N; i++ {
		stack.swap12()
	}
}

func BenchmarkSwap13(b *testing.B) {
	stack := createTestStack(20)
	b.ResetTimer()
	for i := 0; i < b.N; i++ {
		stack.swap13()
	}
}

func BenchmarkSwap14(b *testing.B) {
	stack := createTestStack(20)
	b.ResetTimer()
	for i := 0; i < b.N; i++ {
		stack.swap14()
	}
}

func BenchmarkSwap15(b *testing.B) {
	stack := createTestStack(20)
	b.ResetTimer()
	for i := 0; i < b.N; i++ {
		stack.swap15()
	}
}

func BenchmarkSwap16(b *testing.B) {
	stack := createTestStack(20)
	b.ResetTimer()
	for i := 0; i < b.N; i++ {
		stack.swap16()
	}
}

```
```
go test -run=^$ -bench="BenchmarkSwap[0-9]+$" -benchtime=1m -benchmem
```
before:
```
goos: darwin
goarch: arm64
pkg: github.com/ethereum/go-ethereum/core/vm
cpu: Apple M1 Pro
BenchmarkSwap1-10     	1000000000	         2.845 ns/op	       0 B/op	       0 allocs/op
BenchmarkSwap2-10     	1000000000	         2.887 ns/op	       0 B/op	       0 allocs/op
BenchmarkSwap3-10     	1000000000	         2.814 ns/op	       0 B/op	       0 allocs/op
BenchmarkSwap4-10     	1000000000	         2.841 ns/op	       0 B/op	       0 allocs/op
BenchmarkSwap5-10     	1000000000	         2.780 ns/op	       0 B/op	       0 allocs/op
BenchmarkSwap6-10     	1000000000	         2.789 ns/op	       0 B/op	       0 allocs/op
BenchmarkSwap7-10     	1000000000	         2.771 ns/op	       0 B/op	       0 allocs/op
BenchmarkSwap8-10     	1000000000	         2.937 ns/op	       0 B/op	       0 allocs/op
BenchmarkSwap9-10     	1000000000	         2.795 ns/op	       0 B/op	       0 allocs/op
BenchmarkSwap10-10    	1000000000	         2.788 ns/op	       0 B/op	       0 allocs/op
BenchmarkSwap11-10    	1000000000	         2.766 ns/op	       0 B/op	       0 allocs/op
BenchmarkSwap12-10    	1000000000	         2.784 ns/op	       0 B/op	       0 allocs/op
BenchmarkSwap13-10    	1000000000	         2.783 ns/op	       0 B/op	       0 allocs/op
BenchmarkSwap14-10    	1000000000	         2.788 ns/op	       0 B/op	       0 allocs/op
BenchmarkSwap15-10    	1000000000	         2.766 ns/op	       0 B/op	       0 allocs/op
BenchmarkSwap16-10    	1000000000	         2.923 ns/op	       0 B/op	       0 allocs/op
PASS
ok  	github.com/ethereum/go-ethereum/core/vm	49.677s

```
after:
```
goos: darwin
goarch: arm64
pkg: github.com/ethereum/go-ethereum/core/vm
cpu: Apple M1 Pro
BenchmarkSwap1-10     	1000000000	         2.815 ns/op	       0 B/op	       0 allocs/op
BenchmarkSwap2-10     	1000000000	         2.874 ns/op	       0 B/op	       0 allocs/op
BenchmarkSwap3-10     	1000000000	         2.962 ns/op	       0 B/op	       0 allocs/op
BenchmarkSwap4-10     	1000000000	         2.798 ns/op	       0 B/op	       0 allocs/op
BenchmarkSwap5-10     	1000000000	         2.807 ns/op	       0 B/op	       0 allocs/op
BenchmarkSwap6-10     	1000000000	         2.791 ns/op	       0 B/op	       0 allocs/op
BenchmarkSwap7-10     	1000000000	         2.780 ns/op	       0 B/op	       0 allocs/op
BenchmarkSwap8-10     	1000000000	         2.905 ns/op	       0 B/op	       0 allocs/op
BenchmarkSwap9-10     	1000000000	         2.804 ns/op	       0 B/op	       0 allocs/op
BenchmarkSwap10-10    	1000000000	         2.772 ns/op	       0 B/op	       0 allocs/op
BenchmarkSwap11-10    	1000000000	         2.807 ns/op	       0 B/op	       0 allocs/op
BenchmarkSwap12-10    	1000000000	         2.764 ns/op	       0 B/op	       0 allocs/op
BenchmarkSwap13-10    	1000000000	         2.799 ns/op	       0 B/op	       0 allocs/op
BenchmarkSwap14-10    	1000000000	         2.777 ns/op	       0 B/op	       0 allocs/op
BenchmarkSwap15-10    	1000000000	         2.786 ns/op	       0 B/op	       0 allocs/op
BenchmarkSwap16-10    	1000000000	         2.918 ns/op	       0 B/op	       0 allocs/op
PASS
ok  	github.com/ethereum/go-ethereum/core/vm	49.807s

```

It has tiny improvement.(^.^