### PR TITLE
cmd/era: fix iterator error source handling in checkAccumulator

### DIFF
--- a/cmd/era/main.go
+++ b/cmd/era/main.go
@@ -273,8 +273,8 @@ func checkAccumulator(e *era.Era) error {
 	// accumulation across the entire set and are verified at the end.
 	for it.Next() {
 		// 1) next() walks the block index, so we're able to implicitly verify it.
-		if itErr := it.Error(); itErr != nil {
-			return fmt.Errorf("error reading block %d: %w", it.Number(), itErr)
+		if it.Error() != nil {
+			return fmt.Errorf("error reading block %d: %w", it.Number(), it.Error())
 		}
 		block, receipts, err := it.BlockAndReceipts()
 		if err != nil {
@@ -293,6 +293,9 @@ func checkAccumulator(e *era.Era) error {
 		hashes = append(hashes, block.Hash())
 		td.Add(td, block.Difficulty())
 		tds = append(tds, new(big.Int).Set(td))
+	}
+	if it.Error() != nil {
+		return fmt.Errorf("error reading block %d: %w", it.Number(), it.Error())
 	}
 	// 4+5) Verify accumulator and total difficulty.
 	got, err := era.ComputeAccumulator(hashes, tds)

--- a/cmd/era/main.go
+++ b/cmd/era/main.go
@@ -273,11 +273,11 @@ func checkAccumulator(e *era.Era) error {
 	// accumulation across the entire set and are verified at the end.
 	for it.Next() {
 		// 1) next() walks the block index, so we're able to implicitly verify it.
-		if it.Error() != nil {
-			return fmt.Errorf("error reading block %d: %w", it.Number(), err)
+		if itErr := it.Error(); itErr != nil {
+			return fmt.Errorf("error reading block %d: %w", it.Number(), itErr)
 		}
 		block, receipts, err := it.BlockAndReceipts()
-		if it.Error() != nil {
+		if err != nil {
 			return fmt.Errorf("error reading block %d: %w", it.Number(), err)
 		}
 		// 2) recompute tx root and verify against header.


### PR DESCRIPTION
This change replaces wrapping a stale outer err with the iterator’s own error after Next(), and switches the post-BlockAndReceipts() check to use the returned err. According to internal/era iterator contract, Error() should be consulted immediately after Next() to surface iteration errors, while decoding errors from Block/Receipts are returned directly. The previous code could hide the real failure (using nil or unrelated err), leading to misleading diagnostics and missed iteration errors.