### PR TITLE
ethdb/pebble: check error from db.Apply in TestPebbleLogData

### DIFF
--- a/ethdb/pebble/pebble_test.go
+++ b/ethdb/pebble/pebble_test.go
@@ -71,7 +71,9 @@ func TestPebbleLogData(t *testing.T) {
 
 	b := db.NewBatch()
 	b.LogData(nil, nil)
-	db.Apply(b, pebble.Sync)
+	if err := db.Apply(b, pebble.Sync); err != nil {
+		t.Fatal(err)
+	}
 
 	_, _, err = db.Get(nil)
 	if !errors.Is(err, pebble.ErrNotFound) {


### PR DESCRIPTION
- Ensure DB.Apply error is not ignored in TestPebbleLogData.
- Pebble’s Apply can fail (e.g., closed DB, IO issues). The production wrapper (Database.SyncKeyValue) returns this error; tests should mirror that behavior to avoid masking failures and to keep consistency with error-handling practices in the codebase.