### PR TITLE
accounts: using testing.B.Loop

### DIFF
--- a/accounts/abi/unpack_test.go
+++ b/accounts/abi/unpack_test.go
@@ -63,7 +63,7 @@ func BenchmarkUnpack(b *testing.B) {
 			b.ResetTimer()
 
 			var result any
-			for range b.N {
+			for b.Loop() {
 				result, _ = abi.Unpack("method", encb)
 			}
 			_ = result


### PR DESCRIPTION
use b.Loop() to simplify the code and improve performance

before:

```shell
go test -run=^$ -bench=. ./accounts -timeout=1h
PASS
ok  	github.com/ethereum/go-ethereum/accounts	0.334s
```

after:
```
go test -run=^$ -bench=. ./accounts -timeout=1h
PASS
ok  	github.com/ethereum/go-ethereum/accounts	0.155s
```