### PR TITLE
common: using testing.B.Loop

### DIFF
--- a/common/bitutil/bitutil_test.go
+++ b/common/bitutil/bitutil_test.go
@@ -120,7 +120,7 @@ func BenchmarkFastXOR4KB(b *testing.B) { benchmarkFastXOR(b, 4096) }
 func benchmarkFastXOR(b *testing.B, size int) {
 	p, q := make([]byte, size), make([]byte, size)
 
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		XORBytes(p, p, q)
 	}
 }
@@ -133,7 +133,7 @@ func BenchmarkBaseXOR4KB(b *testing.B) { benchmarkBaseXOR(b, 4096) }
 func benchmarkBaseXOR(b *testing.B, size int) {
 	p, q := make([]byte, size), make([]byte, size)
 
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		safeXORBytes(p, p, q)
 	}
 }
@@ -146,7 +146,7 @@ func BenchmarkFastAND4KB(b *testing.B) { benchmarkFastAND(b, 4096) }
 func benchmarkFastAND(b *testing.B, size int) {
 	p, q := make([]byte, size), make([]byte, size)
 
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		ANDBytes(p, p, q)
 	}
 }
@@ -159,7 +159,7 @@ func BenchmarkBaseAND4KB(b *testing.B) { benchmarkBaseAND(b, 4096) }
 func benchmarkBaseAND(b *testing.B, size int) {
 	p, q := make([]byte, size), make([]byte, size)
 
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		safeANDBytes(p, p, q)
 	}
 }
@@ -172,7 +172,7 @@ func BenchmarkFastOR4KB(b *testing.B) { benchmarkFastOR(b, 4096) }
 func benchmarkFastOR(b *testing.B, size int) {
 	p, q := make([]byte, size), make([]byte, size)
 
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		ORBytes(p, p, q)
 	}
 }
@@ -185,7 +185,7 @@ func BenchmarkBaseOR4KB(b *testing.B) { benchmarkBaseOR(b, 4096) }
 func benchmarkBaseOR(b *testing.B, size int) {
 	p, q := make([]byte, size), make([]byte, size)
 
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		safeORBytes(p, p, q)
 	}
 }
@@ -200,7 +200,7 @@ func BenchmarkFastTest4KB(b *testing.B) { benchmarkFastTest(b, 4096) }
 func benchmarkFastTest(b *testing.B, size int) {
 	p := make([]byte, size)
 	a := false
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		a = a != TestBytes(p)
 	}
 	GloBool = a // Use of benchmark "result" to prevent total dead code elimination.
@@ -214,7 +214,7 @@ func BenchmarkBaseTest4KB(b *testing.B) { benchmarkBaseTest(b, 4096) }
 func benchmarkBaseTest(b *testing.B, size int) {
 	p := make([]byte, size)
 	a := false
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		a = a != safeTestBytes(p)
 	}
 	GloBool = a // Use of benchmark "result" to prevent total dead code elimination.

--- a/common/bitutil/compress_test.go
+++ b/common/bitutil/compress_test.go
@@ -178,9 +178,9 @@ func benchmarkEncoding(b *testing.B, bytes int, fill float64) {
 		data[idx] |= 1 << bit
 	}
 	// Reset the benchmark and measure encoding/decoding
-	b.ResetTimer()
+
 	b.ReportAllocs()
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		bitsetDecodeBytes(bitsetEncodeBytes(data), len(data))
 	}
 }

--- a/common/hexutil/hexutil_test.go
+++ b/common/hexutil/hexutil_test.go
@@ -207,7 +207,7 @@ func BenchmarkEncodeBig(b *testing.B) {
 		b.Run(bench.want, func(b *testing.B) {
 			b.ReportAllocs()
 			bigint := bench.input.(*big.Int)
-			for i := 0; i < b.N; i++ {
+			for b.Loop() {
 				EncodeBig(bigint)
 			}
 		})

--- a/common/hexutil/json_test.go
+++ b/common/hexutil/json_test.go
@@ -100,7 +100,7 @@ func TestUnmarshalBytes(t *testing.T) {
 
 func BenchmarkUnmarshalBytes(b *testing.B) {
 	input := []byte(`"0x123456789abcdef123456789abcdef"`)
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		var v Bytes
 		if err := v.UnmarshalJSON(input); err != nil {
 			b.Fatal(err)
@@ -239,7 +239,7 @@ func TestUnmarshalU256(t *testing.T) {
 
 func BenchmarkUnmarshalBig(b *testing.B) {
 	input := []byte(`"0x123456789abcdef123456789abcdef"`)
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		var v Big
 		if err := v.UnmarshalJSON(input); err != nil {
 			b.Fatal(err)
@@ -305,7 +305,7 @@ func TestUnmarshalUint64(t *testing.T) {
 
 func BenchmarkUnmarshalUint64(b *testing.B) {
 	input := []byte(`"0x123456789abcdf"`)
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		var v Uint64
 		v.UnmarshalJSON(input)
 	}

--- a/common/lru/basiclru_test.go
+++ b/common/lru/basiclru_test.go
@@ -206,7 +206,7 @@ func BenchmarkLRU(b *testing.B) {
 
 	b.Run("Add/BasicLRU", func(b *testing.B) {
 		cache := NewBasicLRU[int, int](capacity)
-		for i := 0; i < b.N; i++ {
+		for i := 0; b.Loop(); i++ {
 			cache.Add(i, i)
 		}
 	})
@@ -218,7 +218,7 @@ func BenchmarkLRU(b *testing.B) {
 		}
 
 		b.ResetTimer()
-		for i := 0; i < b.N; i++ {
+		for i := 0; b.Loop(); i++ {
 			k := keys[indexes[i%len(indexes)]]
 			v, ok := cache.Get(k)
 			if ok {

--- a/common/math/big_test.go
+++ b/common/math/big_test.go
@@ -88,28 +88,28 @@ func TestPaddedBigBytes(t *testing.T) {
 
 func BenchmarkPaddedBigBytesLargePadding(b *testing.B) {
 	bigint := MustParseBig256("123456789123456789123456789123456789")
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		PaddedBigBytes(bigint, 200)
 	}
 }
 
 func BenchmarkPaddedBigBytesSmallPadding(b *testing.B) {
 	bigint := MustParseBig256("0x18F8F8F1000111000110011100222004330052300000000000000000FEFCF3CC")
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		PaddedBigBytes(bigint, 5)
 	}
 }
 
 func BenchmarkPaddedBigBytesSmallOnePadding(b *testing.B) {
 	bigint := MustParseBig256("0x18F8F8F1000111000110011100222004330052300000000000000000FEFCF3CC")
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		PaddedBigBytes(bigint, 32)
 	}
 }
 
 func BenchmarkByteAtOld(b *testing.B) {
 	bigint := MustParseBig256("0x18F8F8F1000111000110011100222004330052300000000000000000FEFCF3CC")
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		PaddedBigBytes(bigint, 32)
 	}
 }

--- a/common/types_test.go
+++ b/common/types_test.go
@@ -151,7 +151,7 @@ func TestAddressHexChecksum(t *testing.T) {
 
 func BenchmarkAddressHex(b *testing.B) {
 	testAddr := HexToAddress("0x5aaeb6053f3e94c9b9a09f33669435e7ef1beaed")
-	for n := 0; n < b.N; n++ {
+	for b.Loop() {
 		testAddr.Hex()
 	}
 }
@@ -590,8 +590,8 @@ func BenchmarkPrettyDuration(b *testing.B) {
 	var x = PrettyDuration(time.Duration(int64(1203123912312)))
 	b.Logf("Pre %s", time.Duration(x).String())
 	var a string
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+
+	for b.Loop() {
 		a = x.String()
 	}
 	b.Logf("Post %s", a)


### PR DESCRIPTION
use b.Loop() to simplify the code and improve performance

before:

```shell
 go test -run=^$ -bench=. ./common -timeout=1h
goos: darwin
goarch: arm64
pkg: github.com/ethereum/go-ethereum/common
cpu: Apple M4
BenchmarkAddressHex-10        	 3927842	       289.0 ns/op
BenchmarkPrettyDuration-10    	 9909748	       122.9 ns/op
--- BENCH: BenchmarkPrettyDuration-10
    types_test.go:591: Pre 20m3.123912312s
    types_test.go:597: Post 20m3.123s
    types_test.go:591: Pre 20m3.123912312s
    types_test.go:597: Post 20m3.123s
    types_test.go:591: Pre 20m3.123912312s
    types_test.go:597: Post 20m3.123s
    types_test.go:591: Pre 20m3.123912312s
    types_test.go:597: Post 20m3.123s
    types_test.go:591: Pre 20m3.123912312s
    types_test.go:597: Post 20m3.123s
	... [output truncated]
PASS
ok  	github.com/ethereum/go-ethereum/common	3.200s
```


after:

```shell
 go test -run=^$ -bench=. ./common -timeout=1h
goos: darwin
goarch: arm64
pkg: github.com/ethereum/go-ethereum/common
cpu: Apple M4
BenchmarkAddressHex-10        	 3821083	       298.0 ns/op
BenchmarkPrettyDuration-10    	 9998107	       119.6 ns/op
--- BENCH: BenchmarkPrettyDuration-10
    types_test.go:591: Pre 20m3.123912312s
    types_test.go:597: Post 20m3.123s
PASS
ok  	github.com/ethereum/go-ethereum/common	2.567s
```