### PR TITLE
trie: using testing.B.Loop

### DIFF
--- a/trie/encoding_test.go
+++ b/trie/encoding_test.go
@@ -112,35 +112,35 @@ func TestHexToCompactInPlaceRandom(t *testing.T) {
 
 func BenchmarkHexToCompact(b *testing.B) {
 	testBytes := []byte{0, 15, 1, 12, 11, 8, 16 /*term*/}
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		hexToCompact(testBytes)
 	}
 }
 
 func BenchmarkHexToCompactInPlace(b *testing.B) {
 	testBytes := []byte{0, 15, 1, 12, 11, 8, 16 /*term*/}
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		hexToCompactInPlace(testBytes)
 	}
 }
 
 func BenchmarkCompactToHex(b *testing.B) {
 	testBytes := []byte{0, 15, 1, 12, 11, 8, 16 /*term*/}
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		compactToHex(testBytes)
 	}
 }
 
 func BenchmarkKeybytesToHex(b *testing.B) {
 	testBytes := []byte{7, 6, 6, 5, 7, 2, 6, 2, 16}
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		keybytesToHex(testBytes)
 	}
 }
 
 func BenchmarkHexToKeybytes(b *testing.B) {
 	testBytes := []byte{7, 6, 6, 5, 7, 2, 6, 2, 16}
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		hexToKeybytes(testBytes)
 	}
 }

--- a/trie/iterator_test.go
+++ b/trie/iterator_test.go
@@ -1164,8 +1164,8 @@ func BenchmarkIterator(b *testing.B) {
 	diskDb, srcDb, tr, _ := makeTestTrie(rawdb.HashScheme)
 	root := tr.Hash()
 	b.ReportAllocs()
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+
+	for b.Loop() {
 		if err := checkTrieConsistency(diskDb, srcDb.Scheme(), root, false); err != nil {
 			b.Fatal(err)
 		}

--- a/trie/node_test.go
+++ b/trie/node_test.go
@@ -104,10 +104,10 @@ func BenchmarkEncodeShortNode(b *testing.B) {
 		Key: []byte{0x1, 0x2},
 		Val: hashNode(randBytes(32)),
 	}
-	b.ResetTimer()
+
 	b.ReportAllocs()
 
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		nodeToBytes(node)
 	}
 }
@@ -122,10 +122,10 @@ func BenchmarkEncodeFullNode(b *testing.B) {
 	for i := 0; i < 16; i++ {
 		node.Children[i] = hashNode(randBytes(32))
 	}
-	b.ResetTimer()
+
 	b.ReportAllocs()
 
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		nodeToBytes(node)
 	}
 }
@@ -143,10 +143,9 @@ func BenchmarkDecodeShortNode(b *testing.B) {
 	blob := nodeToBytes(node)
 	hash := crypto.Keccak256(blob)
 
-	b.ResetTimer()
 	b.ReportAllocs()
 
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		mustDecodeNode(hash, blob)
 	}
 }
@@ -164,10 +163,9 @@ func BenchmarkDecodeShortNodeUnsafe(b *testing.B) {
 	blob := nodeToBytes(node)
 	hash := crypto.Keccak256(blob)
 
-	b.ResetTimer()
 	b.ReportAllocs()
 
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		mustDecodeNodeUnsafe(hash, blob)
 	}
 }
@@ -185,10 +183,9 @@ func BenchmarkDecodeFullNode(b *testing.B) {
 	blob := nodeToBytes(node)
 	hash := crypto.Keccak256(blob)
 
-	b.ResetTimer()
 	b.ReportAllocs()
 
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		mustDecodeNode(hash, blob)
 	}
 }
@@ -206,10 +203,9 @@ func BenchmarkDecodeFullNodeUnsafe(b *testing.B) {
 	blob := nodeToBytes(node)
 	hash := crypto.Keccak256(blob)
 
-	b.ResetTimer()
 	b.ReportAllocs()
 
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		mustDecodeNodeUnsafe(hash, blob)
 	}
 }

--- a/trie/proof_test.go
+++ b/trie/proof_test.go
@@ -837,8 +837,7 @@ func BenchmarkProve(b *testing.B) {
 		keys = append(keys, k)
 	}
 
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for i := 0; b.Loop(); i++ {
 		kv := vals[keys[i%len(keys)]]
 		proofs := memorydb.New()
 		if trie.Prove(kv.k, proofs); proofs.Len() == 0 {
@@ -859,8 +858,7 @@ func BenchmarkVerifyProof(b *testing.B) {
 		proofs = append(proofs, proof)
 	}
 
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for i := 0; b.Loop(); i++ {
 		im := i % len(keys)
 		if _, err := VerifyProof(root, []byte(keys[im]), proofs[im]); err != nil {
 			b.Fatalf("key %x: %v", keys[im], err)
@@ -897,8 +895,7 @@ func benchmarkVerifyRangeProof(b *testing.B, size int) {
 		values = append(values, entries[i].v)
 	}
 
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for i := 0; b.Loop(); i++ {
 		_, err := VerifyRangeProof(trie.Hash(), keys[0], keys, values, proof)
 		if err != nil {
 			b.Fatalf("Case %d(%d->%d) expect no error, got %v", i, start, end-1, err)
@@ -924,8 +921,8 @@ func benchmarkVerifyRangeNoProof(b *testing.B, size int) {
 		keys = append(keys, entry.k)
 		values = append(values, entry.v)
 	}
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+
+	for b.Loop() {
 		_, err := VerifyRangeProof(trie.Hash(), keys[0], keys, values, nil)
 		if err != nil {
 			b.Fatalf("Expected no error, got %v", err)

--- a/trie/stacktrie_test.go
+++ b/trie/stacktrie_test.go
@@ -406,7 +406,7 @@ func BenchmarkInsert100K(b *testing.B) {
 	var val = make([]byte, 20)
 	var hash common.Hash
 	b.ReportAllocs()
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		s := NewStackTrie(nil)
 		var k uint64
 		for j := 0; j < num; j++ {

--- a/trie/trienode/node_test.go
+++ b/trie/trienode/node_test.go
@@ -136,8 +136,8 @@ func benchmarkMerge(b *testing.B, count int) {
 		addNode(x)
 		addNode(y)
 	}
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+
+	for b.Loop() {
 		// Store set x into a backup
 		z := NewNodeSet(common.Hash{})
 		z.Merge(x)

--- a/trie/utils/verkle_test.go
+++ b/trie/utils/verkle_test.go
@@ -64,9 +64,8 @@ func BenchmarkTreeKey(b *testing.B) {
 	verkle.GetConfig()
 
 	b.ReportAllocs()
-	b.ResetTimer()
 
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		BasicDataKey([]byte{0x01})
 	}
 }
@@ -85,8 +84,8 @@ func BenchmarkTreeKeyWithEvaluation(b *testing.B) {
 	eval := evaluateAddressPoint(addr)
 
 	b.ReportAllocs()
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+
+	for b.Loop() {
 		BasicDataKeyWithEvaluatedAddress(eval)
 	}
 }
@@ -102,9 +101,8 @@ func BenchmarkStorageKey(b *testing.B) {
 	verkle.GetConfig()
 
 	b.ReportAllocs()
-	b.ResetTimer()
 
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		StorageSlotKey([]byte{0x01}, bytes.Repeat([]byte{0xff}, 32))
 	}
 }
@@ -123,8 +121,8 @@ func BenchmarkStorageKeyWithEvaluation(b *testing.B) {
 	eval := evaluateAddressPoint(addr)
 
 	b.ReportAllocs()
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+
+	for b.Loop() {
 		StorageSlotKeyWithEvaluatedAddress(eval, bytes.Repeat([]byte{0xff}, 32))
 	}
 }


### PR DESCRIPTION

before:
go test -run=^$ -bench=. ./trie -timeout=1h 

```shell
Seed: 1cffe1772ed25ca4
goos: darwin
goarch: arm64
pkg: github.com/ethereum/go-ethereum/trie
cpu: Apple M4
BenchmarkHexToCompact-10                	139583215	         8.310 ns/op
BenchmarkHexToCompactInPlace-10         	446106673	         2.927 ns/op
BenchmarkCompactToHex-10                	100000000	        10.54 ns/op
BenchmarkKeybytesToHex-10               	91084759	        13.16 ns/op
BenchmarkHexToKeybytes-10               	144926617	         8.289 ns/op
BenchmarkIterator-10                    	    1116	   1070545 ns/op	 1668235 B/op	   29819 allocs/op
BenchmarkEncodeShortNode-10             	31957779	        37.47 ns/op	      48 B/op	       1 allocs/op
BenchmarkEncodeFullNode-10              	 7349817	       163.9 ns/op	     576 B/op	       1 allocs/op
BenchmarkDecodeShortNode-10             	17979580	        67.04 ns/op	     157 B/op	       4 allocs/op
BenchmarkDecodeShortNodeUnsafe-10       	20857987	        57.84 ns/op	     109 B/op	       3 allocs/op
BenchmarkDecodeFullNode-10              	 3332338	       359.6 ns/op	    1280 B/op	      18 allocs/op
BenchmarkDecodeFullNodeUnsafe-10        	 3787225	       320.1 ns/op	     704 B/op	      17 allocs/op
BenchmarkProve-10                       	  349172	      3413 ns/op
BenchmarkVerifyProof-10                 	  683511	      1728 ns/op
BenchmarkVerifyRangeProof10-10          	   98401	     12176 ns/op
BenchmarkVerifyRangeProof100-10         	   24099	     49688 ns/op
BenchmarkVerifyRangeProof1000-10        	    2312	    512210 ns/op
BenchmarkVerifyRangeProof5000-10        	     644	   1851649 ns/op
BenchmarkVerifyRangeNoProof10-10        	   17532	     68413 ns/op
BenchmarkVerifyRangeNoProof500-10       	    4237	    284530 ns/op
BenchmarkVerifyRangeNoProof1000-10      	    2166	    549854 ns/op
BenchmarkInsert100K-10                  	      58	  20296243 ns/op	    3151 B/op	      21 allocs/op
BenchmarkGet-10                         	20892001	        56.72 ns/op
BenchmarkUpdateBE-10                    	 3367831	       371.0 ns/op	     457 B/op	       7 allocs/op
BenchmarkUpdateLE-10                    	 3475134	       386.5 ns/op	     411 B/op	       6 allocs/op
BenchmarkHash-10                        	 5635941	      5016 ns/op	      95 B/op	       3 allocs/op
BenchmarkCommitAfterHash/no-onleaf-10   	 1000000	      1007 ns/op	    1020 B/op	       8 allocs/op
BenchmarkCommitAfterHash/with-onleaf-10 	 1469107	       889.6 ns/op	    1393 B/op	       9 allocs/op
BenchmarkHashFixedSize/10-10            	   91090	     13295 ns/op	    1529 B/op	      47 allocs/op
BenchmarkHashFixedSize/100-10           	   32478	     37363 ns/op	    8685 B/op	     269 allocs/op
BenchmarkHashFixedSize/1K-10            	    5998	    195640 ns/op	   78478 B/op	    2396 allocs/op
BenchmarkHashFixedSize/10K-10           	     782	   1569121 ns/op	  787571 B/op	   24097 allocs/op
BenchmarkHashFixedSize/100K-10          	      79	  16029630 ns/op	 7669767 B/op	  240054 allocs/op
BenchmarkCommitAfterHashFixedSize/10-10 	  147780	      8955 ns/op	   12155 B/op	     185 allocs/op
BenchmarkCommitAfterHashFixedSize/100-10         	   28700	     41832 ns/op	   74177 B/op	     866 allocs/op
BenchmarkCommitAfterHashFixedSize/1K-10          	    2004	    596690 ns/op	  982880 B/op	    8908 allocs/op
BenchmarkCommitAfterHashFixedSize/10K-10         	     321	   3720137 ns/op	 9939952 B/op	   87997 allocs/op
BenchmarkCommitAfterHashFixedSize/100K-10        	      31	  38488910 ns/op	118081066 B/op	  873769 allocs/op
BenchmarkCommit/commit-100nodes-sequential-10    	   30018	     39942 ns/op	   76511 B/op	     966 allocs/op
BenchmarkCommit/commit-100nodes-parallel-10      	   31039	     40685 ns/op	   76511 B/op	     966 allocs/op
BenchmarkCommit/commit-500nodes-sequential-10    	    5793	    204002 ns/op	  357959 B/op	    4909 allocs/op
BenchmarkCommit/commit-500nodes-parallel-10      	    8533	    145985 ns/op	  517693 B/op	    5360 allocs/op
BenchmarkCommit/commit-2000nodes-sequential-10   	    1479	    804152 ns/op	 1436668 B/op	   18661 allocs/op
BenchmarkCommit/commit-2000nodes-parallel-10     	    2034	    513625 ns/op	 2046623 B/op	   19259 allocs/op
BenchmarkCommit/commit-5000nodes-sequential-10   	     552	   2178746 ns/op	 3493502 B/op	   48180 allocs/op
BenchmarkCommit/commit-5000nodes-parallel-10     	     886	   1323806 ns/op	 5022400 B/op	   48886 allocs/op
BenchmarkTriePrefetch-10                         	   10000	    101281 ns/op
BenchmarkTrieSeqPrefetch-10                      	   16358	     72621 ns/op
PASS
ok  	github.com/ethereum/go-ethereum/trie	199.086s
```



after:
go test -run=^$ -bench=. ./trie -timeout=1h 

```shell
Seed: a3427b5d4bf6978f
goos: darwin
goarch: arm64
pkg: github.com/ethereum/go-ethereum/trie
cpu: Apple M4
BenchmarkHexToCompact-10                	147981626	         7.987 ns/op
BenchmarkHexToCompactInPlace-10         	451655104	         2.630 ns/op
BenchmarkCompactToHex-10                	100000000	        10.19 ns/op
BenchmarkKeybytesToHex-10               	513547764	         2.460 ns/op
BenchmarkHexToKeybytes-10               	158706733	         7.973 ns/op
BenchmarkIterator-10                    	    1129	   1065128 ns/op	 1668457 B/op	   29819 allocs/op
BenchmarkEncodeShortNode-10             	31370942	        38.04 ns/op	      48 B/op	       1 allocs/op
BenchmarkEncodeFullNode-10              	 7428176	       161.3 ns/op	     576 B/op	       1 allocs/op
BenchmarkDecodeShortNode-10             	17791900	        66.90 ns/op	     157 B/op	       4 allocs/op
BenchmarkDecodeShortNodeUnsafe-10       	20896291	        56.86 ns/op	     109 B/op	       3 allocs/op
BenchmarkDecodeFullNode-10              	 3352069	       357.0 ns/op	    1280 B/op	      18 allocs/op
BenchmarkDecodeFullNodeUnsafe-10        	 3799257	       315.0 ns/op	     704 B/op	      17 allocs/op
BenchmarkProve-10                       	  315142	      3504 ns/op
BenchmarkVerifyProof-10                 	  699159	      1767 ns/op
BenchmarkVerifyRangeProof10-10          	   95912	     11041 ns/op
BenchmarkVerifyRangeProof100-10         	   23242	     51491 ns/op
BenchmarkVerifyRangeProof1000-10        	    2323	    511138 ns/op
BenchmarkVerifyRangeProof5000-10        	     644	   1845489 ns/op
BenchmarkVerifyRangeNoProof10-10        	   17767	     68954 ns/op
BenchmarkVerifyRangeNoProof500-10       	    4188	    284862 ns/op
BenchmarkVerifyRangeNoProof1000-10      	    2150	    548632 ns/op
BenchmarkInsert100K-10                  	      58	  20434888 ns/op	    3061 B/op	      20 allocs/op
BenchmarkGet-10                         	20865936	        55.57 ns/op
BenchmarkUpdateBE-10                    	 3472222	       382.5 ns/op	     476 B/op	       7 allocs/op
BenchmarkUpdateLE-10                    	 3383004	       380.6 ns/op	     401 B/op	       6 allocs/op
BenchmarkHash-10                        	 5228299	      2190 ns/op	      95 B/op	       2 allocs/op
BenchmarkCommitAfterHash/no-onleaf-10   	 1788013	       761.8 ns/op	    1101 B/op	       8 allocs/op
BenchmarkCommitAfterHash/with-onleaf-10 	 1887049	       768.9 ns/op	    1206 B/op	       9 allocs/op
BenchmarkHashFixedSize/10-10            	   90512	     13178 ns/op	    1528 B/op	      47 allocs/op
BenchmarkHashFixedSize/100-10           	   32226	     38315 ns/op	    8679 B/op	     269 allocs/op
BenchmarkHashFixedSize/1K-10            	    6386	    193476 ns/op	   78416 B/op	    2396 allocs/op
BenchmarkHashFixedSize/10K-10           	     792	   1540411 ns/op	  786950 B/op	   24094 allocs/op
BenchmarkHashFixedSize/100K-10          	      78	  15892735 ns/op	 7666206 B/op	  240042 allocs/op
BenchmarkCommitAfterHashFixedSize/10-10 	  133327	      8932 ns/op	   12156 B/op	     185 allocs/op
BenchmarkCommitAfterHashFixedSize/100-10         	   28744	     41882 ns/op	   74167 B/op	     866 allocs/op
BenchmarkCommitAfterHashFixedSize/1K-10          	    2083	    592358 ns/op	  982891 B/op	    8908 allocs/op
BenchmarkCommitAfterHashFixedSize/10K-10         	     322	   3714973 ns/op	 9935227 B/op	   87998 allocs/op
BenchmarkCommitAfterHashFixedSize/100K-10        	      32	  38224414 ns/op	118082321 B/op	  873774 allocs/op
BenchmarkCommit/commit-100nodes-sequential-10    	   30302	     40673 ns/op	   76505 B/op	     966 allocs/op
BenchmarkCommit/commit-100nodes-parallel-10      	   31509	     40610 ns/op	   76505 B/op	     966 allocs/op
BenchmarkCommit/commit-500nodes-sequential-10    	    5224	    197783 ns/op	  357967 B/op	    4909 allocs/op
BenchmarkCommit/commit-500nodes-parallel-10      	    8190	    143364 ns/op	  517840 B/op	    5360 allocs/op
BenchmarkCommit/commit-2000nodes-sequential-10   	    1526	    791222 ns/op	 1436536 B/op	   18656 allocs/op
BenchmarkCommit/commit-2000nodes-parallel-10     	    2424	    508456 ns/op	 2046856 B/op	   19263 allocs/op
BenchmarkCommit/commit-5000nodes-sequential-10   	     570	   2057646 ns/op	 3495032 B/op	   48178 allocs/op
BenchmarkCommit/commit-5000nodes-parallel-10     	     837	   1341158 ns/op	 5018787 B/op	   48885 allocs/op
BenchmarkTriePrefetch-10                         	   12151	     98640 ns/op
BenchmarkTrieSeqPrefetch-10                      	   16714	     72052 ns/op
PASS
ok  	github.com/ethereum/go-ethereum/trie	173.577s
```


