### PR TITLE
rlp: using testing.B.Loop

### DIFF
--- a/rlp/decode_test.go
+++ b/rlp/decode_test.go
@@ -1180,9 +1180,8 @@ func BenchmarkDecodeUints(b *testing.B) {
 	enc := encodeTestSlice(90000)
 	b.SetBytes(int64(len(enc)))
 	b.ReportAllocs()
-	b.ResetTimer()
 
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		var s []uint
 		r := bytes.NewReader(enc)
 		if err := Decode(r, &s); err != nil {
@@ -1195,10 +1194,9 @@ func BenchmarkDecodeUintsReused(b *testing.B) {
 	enc := encodeTestSlice(100000)
 	b.SetBytes(int64(len(enc)))
 	b.ReportAllocs()
-	b.ResetTimer()
 
 	var s []uint
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		r := bytes.NewReader(enc)
 		if err := Decode(r, &s); err != nil {
 			b.Fatalf("Decode error: %v", err)
@@ -1213,10 +1211,9 @@ func BenchmarkDecodeByteArrayStruct(b *testing.B) {
 	}
 	b.SetBytes(int64(len(enc)))
 	b.ReportAllocs()
-	b.ResetTimer()
 
 	var out byteArrayStruct
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		if err := DecodeBytes(enc, &out); err != nil {
 			b.Fatal(err)
 		}
@@ -1234,10 +1231,9 @@ func BenchmarkDecodeBigInts(b *testing.B) {
 	}
 	b.SetBytes(int64(len(enc)))
 	b.ReportAllocs()
-	b.ResetTimer()
 
 	var out []*big.Int
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		if err := DecodeBytes(enc, &out); err != nil {
 			b.Fatal(err)
 		}
@@ -1255,10 +1251,9 @@ func BenchmarkDecodeU256Ints(b *testing.B) {
 	}
 	b.SetBytes(int64(len(enc)))
 	b.ReportAllocs()
-	b.ResetTimer()
 
 	var out []*uint256.Int
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		if err := DecodeBytes(enc, &out); err != nil {
 			b.Fatal(err)
 		}


### PR DESCRIPTION
before:

```shell
go test -run=^$ -bench=. ./rlp -timeout=1h
goos: darwin
goarch: arm64
pkg: github.com/ethereum/go-ethereum/rlp
cpu: Apple M4
BenchmarkDecodeUints-10                  	     674	   1591787 ns/op	 184.75 MB/s	 2259253 B/op	      56 allocs/op
BenchmarkDecodeUintsReused-10            	     727	   1650144 ns/op	 202.46 MB/s	    4690 B/op	       1 allocs/op
BenchmarkDecodeByteArrayStruct-10        	12303822	        97.51 ns/op	 912.77 MB/s	      24 B/op	       1 allocs/op
BenchmarkDecodeBigInts-10                	  260590	      4510 ns/op	 619.93 MB/s	      24 B/op	       1 allocs/op
BenchmarkDecodeU256Ints-10               	  312771	      3833 ns/op	 729.38 MB/s	      24 B/op	       1 allocs/op
BenchmarkIntsize-10                      	1000000000	         1.038 ns/op
BenchmarkPutint-10                       	94918566	        12.53 ns/op
BenchmarkEncodeBigInts-10                	  378451	      3240 ns/op	      24 B/op	       1 allocs/op
BenchmarkEncodeU256Ints-10               	  638024	      1809 ns/op	      24 B/op	       1 allocs/op
BenchmarkEncodeConcurrentInterface-10    	 1963641	       607.3 ns/op
BenchmarkEncodeByteArrayStruct-10        	19184511	        62.84 ns/op	       0 B/op	       0 allocs/op
BenchmarkEncodeStructPtrSlice-10         	 6489890	       184.7 ns/op	       0 B/op	       0 allocs/op
PASS
ok  	github.com/ethereum/go-ethereum/rlp	16.035s

```

after:


```shell
 go test -run=^$ -bench=. ./rlp -timeout=1h
goos: darwin
goarch: arm64
pkg: github.com/ethereum/go-ethereum/rlp
cpu: Apple M4
BenchmarkDecodeUints-10                  	     637	   1697648 ns/op	 173.23 MB/s	 2259260 B/op	      56 allocs/op
BenchmarkDecodeUintsReused-10            	     727	   1643762 ns/op	 203.24 MB/s	    4690 B/op	       1 allocs/op
BenchmarkDecodeByteArrayStruct-10        	12133304	        98.87 ns/op	 900.21 MB/s	      24 B/op	       1 allocs/op
BenchmarkDecodeBigInts-10                	  254995	      4432 ns/op	 630.84 MB/s	      24 B/op	       1 allocs/op
BenchmarkDecodeU256Ints-10               	  308304	      3840 ns/op	 728.07 MB/s	      24 B/op	       1 allocs/op
BenchmarkIntsize-10                      	1000000000	         1.047 ns/op
BenchmarkPutint-10                       	92690338	        12.82 ns/op
BenchmarkEncodeBigInts-10                	  364500	      3229 ns/op	      24 B/op	       1 allocs/op
BenchmarkEncodeU256Ints-10               	  664855	      1800 ns/op	      24 B/op	       1 allocs/op
BenchmarkEncodeConcurrentInterface-10    	 2134790	       562.9 ns/op
BenchmarkEncodeByteArrayStruct-10        	17753557	        63.88 ns/op	       0 B/op	       0 allocs/op
BenchmarkEncodeStructPtrSlice-10         	 6426432	       186.6 ns/op	       0 B/op	       0 allocs/op
PASS
ok  	github.com/ethereum/go-ethereum/rlp	15.317s

```