### PR TITLE
tests: using testing.B.Loop

### DIFF
--- a/tests/state_test.go
+++ b/tests/state_test.go
@@ -309,7 +309,7 @@ func runBenchmark(b *testing.B, t *StateTest) {
 				refund  uint64
 			)
 			b.ResetTimer()
-			for n := 0; n < b.N; n++ {
+			for b.Loop() {
 				snapshot := state.StateDB.Snapshot()
 				state.StateDB.Prepare(rules, msg.From, context.Coinbase, msg.To, vm.ActivePrecompiles(rules), msg.AccessList)
 				b.StartTimer()


### PR DESCRIPTION
before:

```shell
 go test -run=^$ -bench=. ./tests -timeout=1h
can't find test files in evm-benchmarks/benchmarks, did you clone the evm-benchmarks submodule?
PASS
ok  	github.com/ethereum/go-ethereum/tests	0.438s

```


after change:

```shell
 go test -run=^$ -bench=. ./tests -timeout=1h
can't find test files in evm-benchmarks/benchmarks, did you clone the evm-benchmarks submodule?
PASS
ok  	github.com/ethereum/go-ethereum/tests	0.246s
```