### PR TITLE
ethdb: using testing.B.Loop

### DIFF
--- a/ethdb/memorydb/memorydb_test.go
+++ b/ethdb/memorydb/memorydb_test.go
@@ -38,7 +38,7 @@ func BenchmarkBatchAllocs(b *testing.B) {
 	var key = make([]byte, 20)
 	var val = make([]byte, 100)
 	// 120 * 1_000 -> 120_000 == 120kB
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		batch := New().NewBatch()
 		for j := uint64(0); j < 1000; j++ {
 			binary.BigEndian.PutUint64(key, j)


### PR DESCRIPTION
<img width="821" height="398" alt="image" src="https://github.com/user-attachments/assets/38b94fc0-fd28-431c-8556-570e671d467c" />

before:

```shell
 go test -run=^$ -bench=. ./ethdb/memorydb -timeout=1h
goos: darwin
goarch: arm64
pkg: github.com/ethereum/go-ethereum/ethdb/memorydb
cpu: Apple M4
BenchmarkBatchAllocs-10    	   14352	     81703 ns/op	  563850 B/op	    2034 allocs/op
PASS
ok  	github.com/ethereum/go-ethereum/ethdb/memorydb	2.429s
```




after change:

 ```shell
go test -run=^$ -bench=. ./ethdb/memorydb -timeout=1h
goos: darwin
goarch: arm64
pkg: github.com/ethereum/go-ethereum/ethdb/memorydb
cpu: Apple M4
BenchmarkBatchAllocs-10    	   13500	     86406 ns/op	  563897 B/op	    2035 allocs/op
PASS
ok  	github.com/ethereum/go-ethereum/ethdb/memorydb	1.396s
```
