### PR TITLE
consensus: using testing.B.Loop

### DIFF
--- a/consensus/ethash/consensus_test.go
+++ b/consensus/ethash/consensus_test.go
@@ -151,37 +151,37 @@ func BenchmarkDifficultyCalculator(b *testing.B) {
 	}
 	b.Run("big-frontier", func(b *testing.B) {
 		b.ReportAllocs()
-		for i := 0; i < b.N; i++ {
+		for b.Loop() {
 			calcDifficultyFrontier(1000014, h)
 		}
 	})
 	b.Run("u256-frontier", func(b *testing.B) {
 		b.ReportAllocs()
-		for i := 0; i < b.N; i++ {
+		for b.Loop() {
 			CalcDifficultyFrontierU256(1000014, h)
 		}
 	})
 	b.Run("big-homestead", func(b *testing.B) {
 		b.ReportAllocs()
-		for i := 0; i < b.N; i++ {
+		for b.Loop() {
 			calcDifficultyHomestead(1000014, h)
 		}
 	})
 	b.Run("u256-homestead", func(b *testing.B) {
 		b.ReportAllocs()
-		for i := 0; i < b.N; i++ {
+		for b.Loop() {
 			CalcDifficultyHomesteadU256(1000014, h)
 		}
 	})
 	b.Run("big-generic", func(b *testing.B) {
 		b.ReportAllocs()
-		for i := 0; i < b.N; i++ {
+		for b.Loop() {
 			x1(1000014, h)
 		}
 	})
 	b.Run("u256-generic", func(b *testing.B) {
 		b.ReportAllocs()
-		for i := 0; i < b.N; i++ {
+		for b.Loop() {
 			x2(1000014, h)
 		}
 	})


### PR DESCRIPTION
<img width="937" height="482" alt="image" src="https://github.com/user-attachments/assets/496c65b9-535a-4055-b833-49f23cbb94e7" />

before:

```shell
go test -run=^$ -bench=. ./consensus/ethash -timeout=1h
goos: darwin
goarch: arm64
pkg: github.com/ethereum/go-ethereum/consensus/ethash
cpu: Apple M4
BenchmarkDifficultyCalculator/big-frontier-10         	 6580833	       167.2 ns/op	     280 B/op	      12 allocs/op
BenchmarkDifficultyCalculator/u256-frontier-10        	41094423	        29.05 ns/op	      64 B/op	       2 allocs/op
BenchmarkDifficultyCalculator/big-homestead-10        	 6205758	       193.4 ns/op	     288 B/op	      13 allocs/op
BenchmarkDifficultyCalculator/u256-homestead-10       	40294260	        29.78 ns/op	      64 B/op	       2 allocs/op
BenchmarkDifficultyCalculator/big-generic-10          	12661504	        94.71 ns/op	      80 B/op	       7 allocs/op
BenchmarkDifficultyCalculator/u256-generic-10         	28973143	        41.12 ns/op	      96 B/op	       3 allocs/op
PASS
ok  	github.com/ethereum/go-ethereum/consensus/ethash	8.096s
```



after change:

```shell
 go test -run=^$ -bench=. ./consensus/ethash -timeout=1h
goos: darwin
goarch: arm64
pkg: github.com/ethereum/go-ethereum/consensus/ethash
cpu: Apple M4
BenchmarkDifficultyCalculator/big-frontier-10         	 6370836	       172.9 ns/op	     280 B/op	      12 allocs/op
BenchmarkDifficultyCalculator/u256-frontier-10        	39630554	        30.23 ns/op	      64 B/op	       2 allocs/op
BenchmarkDifficultyCalculator/big-homestead-10        	 5978432	       197.1 ns/op	     288 B/op	      13 allocs/op
BenchmarkDifficultyCalculator/u256-homestead-10       	37902266	        31.55 ns/op	      64 B/op	       2 allocs/op
BenchmarkDifficultyCalculator/big-generic-10          	12579560	        95.38 ns/op	      80 B/op	       7 allocs/op
BenchmarkDifficultyCalculator/u256-generic-10         	28032170	        42.63 ns/op	      96 B/op	       3 allocs/op
PASS
ok  	github.com/ethereum/go-ethereum/consensus/ethash	7.312s
```

