### PR TITLE
trie: fix test message

### DIFF
--- a/trie/iterator_test.go
+++ b/trie/iterator_test.go
@@ -1005,9 +1005,9 @@ func TestPrefixIteratorEdgeCases(t *testing.T) {
 				count++
 			}
 		}
-		// Should find at least the allFF key itself
+		// Should find exactly the two keys with the all-0xff prefix
 		if count != 2 {
-			t.Errorf("Expected at least 1 result for all-0xff prefix, got %d", count)
+			t.Errorf("Expected 2 results for all-0xff prefix, got %d", count)
 		}
 	})
 


### PR DESCRIPTION
The AllFFPrefix subtest asserted an exact count of 2 results but used a comment and error message implying a lower bound (“at least 1”). This change updates the comment and error text to reflect the exact expectation (2 results), matching the iterator behavior for all-0xff prefixes where nextKey(nil) yields no upper bound, and only keys with that exact prefix are included.