### PR TITLE
eth/catalyst: check osaka in engine_getBlobsV1

### DIFF
--- a/eth/catalyst/api.go
+++ b/eth/catalyst/api.go
@@ -494,9 +494,9 @@ func (api *ConsensusAPI) getPayload(payloadID engine.PayloadID, full bool) (*eng
 func (api *ConsensusAPI) GetBlobsV1(hashes []common.Hash) ([]*engine.BlobAndProofV1, error) {
 	// Reject the request if Osaka has been activated.
 	// follow https://github.com/ethereum/execution-apis/blob/main/src/engine/osaka.md#cancun-api
-	header := api.eth.BlockChain().CurrentHeader()
-	if api.config().IsOsaka(header.Number, header.Time) {
-		return nil, unsupportedForkErr("engine_getBlobsV1 is not supported after Osaka fork")
+	head := api.eth.BlockChain().CurrentHeader()
+	if !api.checkFork(head.Time, forks.Cancun, forks.Prague) {
+		return nil, unsupportedForkErr("engine_getBlobsV1 is only available at Cancun/Prague fork")
 	}
 	if len(hashes) > 128 {
 		return nil, engine.TooLargeRequest.With(fmt.Errorf("requested blob count too large: %v", len(hashes)))
@@ -538,9 +538,6 @@ func (api *ConsensusAPI) GetBlobsV1(hashes []common.Hash) ([]*engine.BlobAndProo
 //   - if the request is [A_versioned_hash_for_blob_with_blob_proof], the response
 //     MUST be null as well.
 //
-//     Note, geth internally make the conversion from old version to new one, so the
-//     data will be returned normally.
-//
 // Client software MUST support request sizes of at least 128 blob versioned
 // hashes. The client MUST return -38004: Too large request error if the number
 // of requested blobs is too large.
@@ -548,6 +545,10 @@ func (api *ConsensusAPI) GetBlobsV1(hashes []common.Hash) ([]*engine.BlobAndProo
 // Client software MUST return null if syncing or otherwise unable to serve
 // blob pool data.
 func (api *ConsensusAPI) GetBlobsV2(hashes []common.Hash) ([]*engine.BlobAndProofV2, error) {
+	head := api.eth.BlockChain().CurrentHeader()
+	if !api.checkFork(head.Time, forks.Osaka) {
+		return nil, unsupportedForkErr("engine_getBlobsV2 is only available at Osaka fork")
+	}
 	if len(hashes) > 128 {
 		return nil, engine.TooLargeRequest.With(fmt.Errorf("requested blob count too large: %v", len(hashes)))
 	}

--- a/eth/catalyst/api.go
+++ b/eth/catalyst/api.go
@@ -492,12 +492,12 @@ func (api *ConsensusAPI) getPayload(payloadID engine.PayloadID, full bool) (*eng
 // Client software MAY return an array of all null entries if syncing or otherwise
 // unable to serve blob pool data.
 func (api *ConsensusAPI) GetBlobsV1(hashes []common.Hash) ([]*engine.BlobAndProofV1, error) {
-	// Check if Osaka fork is active
+	// Reject the request if Osaka has been activated.
 	// follow https://github.com/ethereum/execution-apis/blob/main/src/engine/osaka.md#cancun-api
-	if header := api.eth.BlockChain().CurrentHeader(); api.config().IsOsaka(header.Number, header.Time) {
+	header := api.eth.BlockChain().CurrentHeader()
+	if api.config().IsOsaka(header.Number, header.Time) {
 		return nil, unsupportedForkErr("engine_getBlobsV1 is not supported after Osaka fork")
 	}
-
 	if len(hashes) > 128 {
 		return nil, engine.TooLargeRequest.With(fmt.Errorf("requested blob count too large: %v", len(hashes)))
 	}

--- a/eth/catalyst/api.go
+++ b/eth/catalyst/api.go
@@ -495,7 +495,7 @@ func (api *ConsensusAPI) GetBlobsV1(hashes []common.Hash) ([]*engine.BlobAndProo
 	// Check if Osaka fork is active
 	// follow https://github.com/ethereum/execution-apis/blob/main/src/engine/osaka.md#cancun-api
 	if header := api.eth.BlockChain().CurrentHeader(); api.config().IsOsaka(header.Number, header.Time) {
-		return nil, engine.UnsupportedFork.With(fmt.Errorf("engine_getBlobsV1 is not supported after Osaka fork activation"))
+		return nil, unsupportedForkErr("engine_getBlobsV1 is not supported after Osaka fork")
 	}
 
 	if len(hashes) > 128 {

--- a/eth/catalyst/api.go
+++ b/eth/catalyst/api.go
@@ -546,8 +546,8 @@ func (api *ConsensusAPI) GetBlobsV1(hashes []common.Hash) ([]*engine.BlobAndProo
 // blob pool data.
 func (api *ConsensusAPI) GetBlobsV2(hashes []common.Hash) ([]*engine.BlobAndProofV2, error) {
 	head := api.eth.BlockChain().CurrentHeader()
-	if !api.checkFork(head.Time, forks.Osaka) {
-		return nil, unsupportedForkErr("engine_getBlobsV2 is only available at Osaka fork")
+	if api.config().LatestFork(head.Time) < forks.Osaka {
+		return nil, unsupportedForkErr("engine_getBlobsV2 is not available before Osaka fork")
 	}
 	if len(hashes) > 128 {
 		return nil, engine.TooLargeRequest.With(fmt.Errorf("requested blob count too large: %v", len(hashes)))

--- a/eth/catalyst/api.go
+++ b/eth/catalyst/api.go
@@ -492,6 +492,12 @@ func (api *ConsensusAPI) getPayload(payloadID engine.PayloadID, full bool) (*eng
 // Client software MAY return an array of all null entries if syncing or otherwise
 // unable to serve blob pool data.
 func (api *ConsensusAPI) GetBlobsV1(hashes []common.Hash) ([]*engine.BlobAndProofV1, error) {
+	// Check if Osaka fork is active
+	// follow https://github.com/ethereum/execution-apis/blob/main/src/engine/osaka.md#cancun-api
+	if header := api.eth.BlockChain().CurrentHeader(); api.config().IsOsaka(header.Number, header.Time) {
+		return nil, engine.UnsupportedFork.With(fmt.Errorf("engine_getBlobsV1 is not supported after Osaka fork activation"))
+	}
+
 	if len(hashes) > 128 {
 		return nil, engine.TooLargeRequest.With(fmt.Errorf("requested blob count too large: %v", len(hashes)))
 	}

--- a/eth/catalyst/api_test.go
+++ b/eth/catalyst/api_test.go
@@ -1991,53 +1991,28 @@ func TestGetBlobsV1(t *testing.T) {
 	}
 }
 
-func TestGetBlobsV1OsakaFork(t *testing.T) {
-	config := *params.AllEthashProtocolChanges
-	time := new(uint64)
-	config.ShanghaiTime = time
-	config.CancunTime = time
-	config.PragueTime = time
-	config.OsakaTime = time
-
-	// Add blob schedule configuration
-	config.BlobScheduleConfig = &params.BlobScheduleConfig{
-		Cancun: params.DefaultCancunBlobConfig,
-		Prague: params.DefaultPragueBlobConfig,
-		Osaka:  params.DefaultOsakaBlobConfig,
-	}
-
+func TestGetBlobsV1AfterOsakaFork(t *testing.T) {
 	genesis := &core.Genesis{
-		Config:     &config,
+		Config:     params.MergedTestChainConfig,
 		Alloc:      types.GenesisAlloc{testAddr: {Balance: testBalance}},
 		Difficulty: common.Big0,
 		Timestamp:  1, // Timestamp > 0 to ensure Osaka fork is active
 	}
-
 	n, ethServ := startEthService(t, genesis, nil)
 	defer n.Close()
 
+	var engineErr *engine.EngineAPIError
 	api := newConsensusAPIWithoutHeartbeat(ethServ)
-
-	vhashes := []common.Hash{testrand.Hash(), testrand.Hash()}
-	result, err := api.GetBlobsV1(vhashes)
-
-	if err == nil {
-		t.Fatal("Expected UnsupportedFork error when Osaka fork is active")
-	}
-
-	if engineErr, ok := err.(*engine.EngineAPIError); ok {
+	_, err := api.GetBlobsV1([]common.Hash{testrand.Hash()})
+	if !errors.As(err, &engineErr) {
+		t.Fatalf("Unexpected error: %T", err)
+	} else {
 		if engineErr.ErrorCode() != -38005 {
 			t.Fatalf("Expected error code -38005, got %d", engineErr.ErrorCode())
 		}
 		if engineErr.Error() != "Unsupported fork" {
 			t.Fatalf("Expected error message 'Unsupported fork', got '%s'", engineErr.Error())
 		}
-	} else {
-		t.Fatalf("Expected EngineAPIError, got %T", err)
-	}
-
-	if result != nil {
-		t.Fatal("Expected nil result when Osaka fork is active")
 	}
 }
 


### PR DESCRIPTION
ref https://github.com/ethereum/execution-apis/blob/main/src/engine/osaka.md#cancun-api

> Client software MUST return -38005: Unsupported fork error if the Osaka fork has been activated.

