### PR TITLE
accounts/keystore: use ticker to avoid timer allocations

### DIFF
--- a/accounts/keystore/keystore.go
+++ b/accounts/keystore/keystore.go
@@ -196,11 +196,14 @@ func (ks *KeyStore) Subscribe(sink chan<- accounts.WalletEvent) event.Subscripti
 // forces a manual refresh (only triggers for systems where the filesystem notifier
 // is not running).
 func (ks *KeyStore) updater() {
+	ticker := time.NewTicker(walletRefreshCycle)
+	defer ticker.Stop()
+
 	for {
 		// Wait for an account update or a refresh timeout
 		select {
 		case <-ks.changes:
-		case <-time.After(walletRefreshCycle):
+		case <-ticker.C:
 		}
 		// Run the wallet refresher
 		ks.refreshWallets()


### PR DESCRIPTION

### Description
- Replace time.After with a long‑lived time.Ticker in KeyStore.updater.
- Prevents per‑iteration timer allocations and potential timer buildup under frequent change events.
- Behavior unchanged: same refresh cadence and clean shutdown when no subscribers remain.

### Impact
- Lower GC pressure and fewer transient allocations in the wallet refresh loop.



