### PR TITLE
trie: fix TestOneElementProof expected value message

### DIFF
--- a/trie/proof_test.go
+++ b/trie/proof_test.go
@@ -109,7 +109,7 @@ func TestOneElementProof(t *testing.T) {
 			t.Fatalf("prover %d: failed to verify proof: %v\nraw proof: %x", i, err, proof)
 		}
 		if !bytes.Equal(val, []byte("v")) {
-			t.Fatalf("prover %d: verified value mismatch: have %x, want 'k'", i, val)
+			t.Fatalf("prover %d: verified value mismatch: have %x, want 'v'", i, val)
 		}
 	}
 }


### PR DESCRIPTION
- Correct the error message in TestOneElementProof to expect 'v' instead of 'k'.
- The trie is updated with key "k" and value "v"; on mismatch the expected value must be 'v'.
- Aligns the message with the actual test logic and other similar checks in this file, reducing confusion during test failures. No behavioral changes.