### PR TITLE
core: remove redundant isVerkle branch in getContractStoredBlockHash

### DIFF
--- a/core/verkle_witness_test.go
+++ b/core/verkle_witness_test.go
@@ -247,7 +247,7 @@ func TestProcessParentBlockHash(t *testing.T) {
 		}
 		// Read block hashes for block 0 .. num-1
 		for i := 0; i < num; i++ {
-			have, want := getContractStoredBlockHash(statedb, uint64(i), isVerkle), common.Hash{byte(i + 1)}
+			have, want := getContractStoredBlockHash(statedb, uint64(i)), common.Hash{byte(i + 1)}
 			if have != want {
 				t.Errorf("block %d, verkle=%v, have parent hash %v, want %v", i, isVerkle, have, want)
 			}
@@ -268,13 +268,10 @@ func TestProcessParentBlockHash(t *testing.T) {
 }
 
 // getContractStoredBlockHash is a utility method which reads the stored parent blockhash for block 'number'
-func getContractStoredBlockHash(statedb *state.StateDB, number uint64, isVerkle bool) common.Hash {
+func getContractStoredBlockHash(statedb *state.StateDB, number uint64) common.Hash {
 	ringIndex := number % params.HistoryServeWindow
 	var key common.Hash
 	binary.BigEndian.PutUint64(key[24:], ringIndex)
-	if isVerkle {
-		return statedb.GetState(params.HistoryStorageAddress, key)
-	}
 	return statedb.GetState(params.HistoryStorageAddress, key)
 }
 


### PR DESCRIPTION
- Remove the unused isVerkle parameter and redundant conditional from getContractStoredBlockHash in core/verkle_witness_test.go.
- Update the two call sites in TestProcessParentBlockHash accordingly.

Reason: StateDB.GetState abstracts over MPT vs Verkle; both modes read the same value for EIP-2935’s HistoryStorage contract. The extra branch adds noise without changing behavior.

Proof: I traced the data path in StateDB and the EIP-2935 system-call flow. ProcessParentBlockHash writes via a system call to HistoryStorageAddress, and subsequent reads use StateDB.GetState. The Reader/TrieDB internals handle the MPT/Verkle differences, so there’s no read-time divergence to account for here.