### PR TITLE
triedb: opt storageKey

### DIFF
--- a/triedb/pathdb/lookup.go
+++ b/triedb/pathdb/lookup.go
@@ -28,8 +28,8 @@ import (
 // storageKey returns a key for uniquely identifying the storage slot.
 func storageKey(accountHash common.Hash, slotHash common.Hash) [64]byte {
 	var key [64]byte
-	*(*[32]byte)(key[32:]) = slotHash
 	*(*[32]byte)(key[:32]) = accountHash
+	*(*[32]byte)(key[32:]) = slotHash
 	return key
 }
 

--- a/triedb/pathdb/lookup.go
+++ b/triedb/pathdb/lookup.go
@@ -28,8 +28,8 @@ import (
 // storageKey returns a key for uniquely identifying the storage slot.
 func storageKey(accountHash common.Hash, slotHash common.Hash) [64]byte {
 	var key [64]byte
-	copy(key[:32], accountHash[:])
-	copy(key[32:], slotHash[:])
+	*(*[32]byte)(key[32:]) = slotHash
+	*(*[32]byte)(key[:32]) = accountHash
 	return key
 }
 


### PR DESCRIPTION
benchmark code:
```
package main

import (
	"testing"

	"github.com/ethereum/go-ethereum/common"
)

func storageKeyCopy(accountHash, slotHash common.Hash) [64]byte {
	var key [64]byte
	copy(key[:32], accountHash[:])
	copy(key[32:], slotHash[:])
	return key
}

func storageKeyPointer(accountHash, slotHash common.Hash) [64]byte {
	var key [64]byte
	*(*[32]byte)(key[:32]) = accountHash
	*(*[32]byte)(key[32:]) = slotHash
	return key
}

func BenchmarkStorageKeyCopy(b *testing.B) {
	var a, s common.Hash
	for i := 0; i < b.N; i++ {
		_ = storageKeyCopy(a, s)
	}
}

func BenchmarkStorageKeyPointer(b *testing.B) {
	var a, s common.Hash
	for i := 0; i < b.N; i++ {
		_ = storageKeyPointer(a, s)
	}
}
···
the result is:
···
goos: darwin
goarch: arm64
pkg: github.com/cuiweixie/mylabs/tests
cpu: Apple M1 Pro
BenchmarkStorageKeyCopy
BenchmarkStorageKeyCopy-10       	415266823	         2.987 ns/op
BenchmarkStorageKeyPointer
BenchmarkStorageKeyPointer-10    	1000000000	         0.7977 ns/op
PASS

Process finished with the exit code 0

···