### PR TITLE
ethapi: reject oversize storage keys before hex decode

### DIFF
--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -446,11 +446,11 @@ func decodeHash(s string) (h common.Hash, inputLength int, err error) {
 	if strings.HasPrefix(s, "0x") || strings.HasPrefix(s, "0X") {
 		s = s[2:]
 	}
-	if len(s) > 64 { // 32 bytes
-		return common.Hash{}, len(s) / 2, errors.New("hex string too long, want at most 32 bytes")
-	}
 	if (len(s) & 1) > 0 {
 		s = "0" + s
+	}
+	if len(s) > 64 {
+		return common.Hash{}, len(s) / 2, errors.New("hex string too long, want at most 32 bytes")
 	}
 	b, err := hex.DecodeString(s)
 	if err != nil {

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -446,15 +446,15 @@ func decodeHash(s string) (h common.Hash, inputLength int, err error) {
 	if strings.HasPrefix(s, "0x") || strings.HasPrefix(s, "0X") {
 		s = s[2:]
 	}
+	if len(s) > 64 { // 32 bytes
+		return common.Hash{}, len(s) / 2, errors.New("hex string too long, want at most 32 bytes")
+	}
 	if (len(s) & 1) > 0 {
 		s = "0" + s
 	}
 	b, err := hex.DecodeString(s)
 	if err != nil {
 		return common.Hash{}, 0, errors.New("hex string invalid")
-	}
-	if len(b) > 32 {
-		return common.Hash{}, len(b), errors.New("hex string too long, want at most 32 bytes")
 	}
 	return common.BytesToHash(b), len(b), nil
 }


### PR DESCRIPTION
## Summary
  - bail out of decodeHash when the raw hex string is longer than 32 bytes
  - keep error semantics identical while avoiding unnecessary hex decoding work