### PR TITLE
internal/ethapi: fix some issues in eth_config impl

### DIFF
--- a/core/vm/contracts.go
+++ b/core/vm/contracts.go
@@ -21,7 +21,6 @@ import (
 	"encoding/binary"
 	"errors"
 	"fmt"
-	"maps"
 	"math"
 	"math/big"
 	"math/bits"
@@ -211,7 +210,7 @@ func init() {
 	}
 }
 
-func activePrecompiledContracts(rules params.Rules) PrecompiledContracts {
+func ActivePrecompiledContracts(rules params.Rules) PrecompiledContracts {
 	switch {
 	case rules.IsVerkle:
 		return PrecompiledContractsVerkle
@@ -230,11 +229,6 @@ func activePrecompiledContracts(rules params.Rules) PrecompiledContracts {
 	default:
 		return PrecompiledContractsHomestead
 	}
-}
-
-// ActivePrecompiledContracts returns a copy of precompiled contracts enabled with the current configuration.
-func ActivePrecompiledContracts(rules params.Rules) PrecompiledContracts {
-	return maps.Clone(activePrecompiledContracts(rules))
 }
 
 // ActivePrecompiles returns the precompile addresses enabled with the current configuration.

--- a/core/vm/evm.go
+++ b/core/vm/evm.go
@@ -146,7 +146,7 @@ func NewEVM(blockCtx BlockContext, statedb StateDB, chainConfig *params.ChainCon
 		jumpDests:   newMapJumpDests(),
 		hasher:      crypto.NewKeccakState(),
 	}
-	evm.precompiles = activePrecompiledContracts(evm.chainRules)
+	evm.precompiles = ActivePrecompiledContracts(evm.chainRules)
 
 	switch {
 	case evm.chainRules.IsOsaka:

--- a/params/config.go
+++ b/params/config.go
@@ -598,9 +598,9 @@ func (c *ChainConfig) Description() string {
 
 // BlobConfig specifies the target and max blobs per block for the associated fork.
 type BlobConfig struct {
+	UpdateFraction uint64 `json:"baseFeeUpdateFraction"`
 	Target         int    `json:"target"`
 	Max            int    `json:"max"`
-	UpdateFraction uint64 `json:"baseFeeUpdateFraction"`
 }
 
 // BlobScheduleConfig determines target and max number of blobs allow per fork.


### PR DESCRIPTION
I was reviewing the implementation of `etc_config` among clients and noticed some stuff I fix/wanna discuss in this PR:

- Precompiles must be ordered according to the [EIP](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-7910.md#precompiles). It was not as it used `maps.Clone`, which does not preserve the order (as gaoling maps are unordered)
- Changed the order of `BlobConfig` to match the [EIP](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-7910.md#precompiles) and other clients
- There is an issue that may be related to BPO (I'm checking rn, but wanna flag it asap). When running kurtosis from genesis, geth returns a non-null `last` value, when it should be `null` by definition (there is no `last` fork before genesis). For repro, run a testnet with the next config (from Pari):

```yaml
participants:
  - cl_type: teku
    cl_image: consensys/teku:25.9.3
    el_type: geth
    el_image: ethereum/client-go:v1.16.4
    supernode: true

  - cl_type: teku
    cl_image: consensys/teku:25.9.3
    el_type: reth
    el_image: ghcr.io/paradigmxyz/reth:v1.8.1
    supernode: true

  - cl_type: teku
    cl_image: consensys/teku:25.9.3
    el_type: nethermind
    el_image: nethermindeth/nethermind:release-1.34.0
    supernode: true

  - cl_type: teku
    cl_image: consensys/teku:25.9.3
    el_type: besu
    el_image: hyperledger/besu:25.9.0
    supernode: true

  - cl_type: teku
    cl_image: consensys/teku:25.9.3
    el_type: erigon
    el_image: erigontech/erigon:v3.2.0-rc1
  
network_params:
  fulu_fork_epoch: 1
  bpo_1_epoch: 2
  bpo_1_max_blobs: 9
  bpo_1_target_blobs: 6
  bpo_2_epoch: 3
  bpo_2_max_blobs: 18
  bpo_2_target_blobs: 12
  bpo_3_epoch: 4
  bpo_3_max_blobs: 9
  bpo_3_target_blobs: 6
  bpo_4_epoch: 5
  bpo_4_max_blobs: 18
  bpo_4_target_blobs: 12
  bpo_5_epoch: 6
  bpo_5_max_blobs: 9
  bpo_5_target_blobs: 6
```

query geth rpc endpoint with

```bash
curl -X POST -H "Content-Type: application/json" --data '{"jsonrpc":"2.0","method":"eth_config","id":1}' http://localhost:$PORT | python3 -m json.tool
```

and you should get a response like (stripped for better readiness):

```json
{
    "jsonrpc": "2.0",
    "id": 1,
    "result": {
        "current": {
            "activationTime": 0,
            "blobSchedule": {
                "target": 6,
                "max": 9,
                "baseFeeUpdateFraction": 5007716
            },

            ...
        },
        "next": {
            "activationTime": 1758889461,
            "blobSchedule": {
                "target": 6,
                "max": 9,
                "baseFeeUpdateFraction": 5007716
            },

            ...
        },
        "last": {
            "activationTime": 1758891381,
            "blobSchedule": {
                "target": 6,
                "max": 9,
                "baseFeeUpdateFraction": 5007716
            },

            ...
        }
    }
}
```