### PR TITLE
rpc: fix TestHTTPResponseWithEmptyGet race problem

### DIFF
--- a/rpc/http_test.go
+++ b/rpc/http_test.go
@@ -111,7 +111,6 @@ func confirmHTTPRequestYieldsStatusCode(t *testing.T, method, contentType, body 
 }
 
 func TestHTTPResponseWithEmptyGet(t *testing.T) {
-	t.Parallel()
 
 	confirmHTTPRequestYieldsStatusCode(t, http.MethodGet, "", "", http.StatusOK)
 }


### PR DESCRIPTION
There is CloseIdleConnections called problem when running the TestHTTPResponseWithEmptyGet testcase. It may be caused by concurrent access to http.DefaultClient's connection pool. Removing t.Parallel() can work around the problem. See the issue here: https://github.com/ethereum/go-ethereum/actions/runs/18041757627/job/51346377003?pr=32756