### PR TITLE
internal/ethapi: remove redundant check in test

### DIFF
--- a/internal/ethapi/api_test.go
+++ b/internal/ethapi/api_test.go
@@ -3746,8 +3746,8 @@ func TestCreateAccessListWithStateOverrides(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to create access list: %v", err)
 	}
-	if err != nil || result == nil {
-		t.Fatalf("Failed to create access list: %v", err)
+	if result == nil {
+		t.Fatalf("Failed to create access list: result is nil")
 	}
 	require.NotNil(t, result.Accesslist)
 


### PR DESCRIPTION
The redundant `if err != nil || result == nil` check contained dead code because `t.Fatalf` in the previous block terminates test execution. Only the `result == nil` check is needed and meaningful.