### PR TITLE
eth: handle TransactionToMessage error in stateAtTransaction

### DIFF
--- a/eth/state_accessor.go
+++ b/eth/state_accessor.go
@@ -261,7 +261,10 @@ func (eth *Ethereum) stateAtTransaction(ctx context.Context, block *types.Block,
 			return tx, context, statedb, release, nil
 		}
 		// Assemble the transaction call message and return if the requested offset
-		msg, _ := core.TransactionToMessage(tx, signer, block.BaseFee())
+		msg, err := core.TransactionToMessage(tx, signer, block.BaseFee())
+		if err != nil {
+			return nil, vm.BlockContext{}, nil, nil, fmt.Errorf("transaction %#x invalid: %w", tx.Hash(), err)
+		}
 
 		// Not yet the searched for transaction, execute on top of the current state
 		statedb.SetTxContext(tx.Hash(), idx)


### PR DESCRIPTION
Adds proper error handling for TransactionToMessage in eth/state_accessor.go. Previously the error was ignored, which could obscure precise failure reasons and diverge from the block processor’s behavior. This change aborts early with a clear error when message conversion fails, improving correctness and diagnostics while remaining a no-op for valid blocks.