### PR TITLE
ci: allow - and () in PR title scope regex

### DIFF
--- a/.github/workflows/validate_pr.yml
+++ b/.github/workflows/validate_pr.yml
@@ -13,7 +13,7 @@ jobs:
         with:
           script: |
             const prTitle = context.payload.pull_request.title;
-            const titleRegex = /^([\w\s,{}/.]+): .+/;
+            const titleRegex = /^([A-Za-z0-9_\-\/\s,()\[\]{}.]+): .+/;
             
             if (!titleRegex.test(prTitle)) {
               core.setFailed(`PR title "${prTitle}" does not match required format: directory, ...: description`);


### PR DESCRIPTION
### Summary
Relax PR title scope regex to allow hyphen and parentheses in the scope portion of the title. The workflow still requires the colon separator and the general format `scope: description`.

### Rationale
Some components and modules include hyphens or parentheses in their names (for example `cmd/geth-android` or `accounts/hd (bip44)`) which the previous regex rejected. This change widens allowed characters in the scope so common repo naming is accepted without changing the required `scope: description` pattern.

### Examples
- Good: `cmd/geth: fix startup race`
- Good: `accounts/hd (bip44): add tests`
- Good: `rpc-client: add timeout`
- Bad: `invalidtitle` (no colon separator)

If maintainers prefer a stricter rule set, I can adjust the regex accordingly.
