### PR TITLE
Improve entropy in RPC subscription ID fallback generation

### DIFF
--- a/rpc/subscription.go
+++ b/rpc/subscription.go
@@ -64,7 +64,8 @@ func randomIDGenerator() func() ID {
 	if _, err := crand.Read(buf); err == nil {
 		seed = int64(binary.BigEndian.Uint64(buf))
 	} else {
-		seed = int64(time.Now().Nanosecond())
+		// Fallback: use UnixNano for higher entropy than Nanosecond-only value
+		seed = time.Now().UnixNano()
 	}
 
 	var (


### PR DESCRIPTION


## Description

Enhance the fallback seed generation in `randomIDGenerator()` to use `time.Now().UnixNano()` instead of `time.Now().Nanosecond()` when `crypto/rand` fails.

## Problem

When `crypto/rand` is unavailable, the current fallback uses `time.Now().Nanosecond()` which provides only ~30 bits of entropy and is predictable within the same second. This increases collision risk and makes subscription IDs potentially guessable.

## Solution

- Replace `Nanosecond()` with `UnixNano()` for higher entropy (~60+ bits)


