### PR TITLE
trie: fix error message in test

### DIFF
--- a/trie/trie_test.go
+++ b/trie/trie_test.go
@@ -326,7 +326,7 @@ func TestReplication(t *testing.T) {
 		updateString(trie2, val.k, val.v)
 	}
 	if trie2.Hash() != hash {
-		t.Errorf("root failure. expected %x got %x", hash, hash)
+		t.Errorf("root failure. expected %x got %x", hash, trie2.Hash())
 	}
 }
 


### PR DESCRIPTION
The error message in TestReplication printed the expected hash twice:
"root failure. expected %x got %x", hash, hash.
This made failures misleading and harder to diagnose. The second argument is now the actual value (trie2.Hash()), ensuring the message correctly reports expected vs. got.