### PR TITLE
cmd/evm/internal/t8ntool: panic on database corruption

### DIFF
--- a/cmd/evm/internal/t8ntool/execution.go
+++ b/cmd/evm/internal/t8ntool/execution.go
@@ -387,8 +387,14 @@ func MakePreState(db ethdb.Database, accounts types.GenesisAlloc) *state.StateDB
 		}
 	}
 	// Commit and re-open to start with a clean state.
-	root, _ := statedb.Commit(0, false, false)
-	statedb, _ = state.New(root, sdb)
+	root, err := statedb.Commit(0, false, false)
+	if err != nil {
+		panic(fmt.Errorf("failed to commit initial state: %v", err))
+	}
+	statedb, err = state.New(root, sdb)
+	if err != nil {
+		panic(fmt.Errorf("failed to reopen state after commit: %v", err))
+	}
 	return statedb
 }
 


### PR DESCRIPTION
These functions were previously ignoring the error returned by both `statedb.Commit()` and the subsequent `state.New()`,
which could silently fail and cause panics later when the `statedb` is used.
This change adds proper error checking and panics with a descriptive error
message if state creation fails.

While unlikely in normal operation, this can occur if there are database
corruption issues or if invalid root hashes are provided, making debugging
significantly easier when such issues do occur.

This issue was encountered and fixed in https://github.com/gballet/go-ethereum/pull/552
where the error handling proved essential for debugging

cc: @gballet as this was discussed in a call already.