### PR TITLE
core/state: correct expected value in TestMessageCallGas

### DIFF
--- a/core/state/access_events_test.go
+++ b/core/state/access_events_test.go
@@ -131,7 +131,7 @@ func TestMessageCallGas(t *testing.T) {
 	}
 	gas = ae.CodeHashGas(testAddr, false, math.MaxUint64, false)
 	if gas != params.WitnessChunkReadCost {
-		t.Fatalf("incorrect gas computed, got %d, want %d", gas, 0)
+		t.Fatalf("incorrect gas computed, got %d, want %d", gas, params.WitnessChunkReadCost)
 	}
 
 	// Check warm read cost


### PR DESCRIPTION
Fix misleading failure message in TestMessageCallGas by printing params.WitnessChunkReadCost instead of 0 when CodeHashGas should only incur a chunk read cost. This aligns the error message with the actual expectation and avoids confusion during test failures.