### PR TITLE
core/txpool: remove unused signer field from TxPool

### DIFF
--- a/core/txpool/txpool.go
+++ b/core/txpool/txpool.go
@@ -65,7 +65,6 @@ type BlockChain interface {
 type TxPool struct {
 	subpools []SubPool // List of subpools for specialized transaction handling
 	chain    BlockChain
-	signer   types.Signer
 
 	stateLock sync.RWMutex   // The lock for protecting state instance
 	state     *state.StateDB // Current state at the blockchain head
@@ -98,7 +97,6 @@ func New(gasTip uint64, chain BlockChain, subpools []SubPool) (*TxPool, error) {
 	pool := &TxPool{
 		subpools: subpools,
 		chain:    chain,
-		signer:   types.LatestSigner(chain.Config()),
 		state:    statedb,
 		quit:     make(chan chan error),
 		term:     make(chan struct{}),


### PR DESCRIPTION
The TxPool.signer field was never read and each subpool (legacy/blob) maintains its own signer instance. This field remained after txpool refactoring into subpools and is dead code. Removing it reduces confusion and simplifies the constructor.