### PR TITLE
docs(README): refine wording & style; standardize JSON-RPC, APIs, macOS, and bandwidth units

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ archives are published at https://geth.ethereum.org/downloads/.
 For prerequisites and detailed build instructions please read the [Installation Instructions](https://geth.ethereum.org/docs/getting-started/installing-geth).
 
 Building `geth` requires both a Go (version 1.23 or later) and a C compiler. You can install
-them using your favourite package manager. Once the dependencies are installed, run
+them using your favorite package manager. Once the dependencies are installed, run
 
 ```shell
 make geth
@@ -37,12 +37,12 @@ directory.
 
 |  Command   | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        |
 | :--------: | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **`geth`** | Our main Ethereum CLI client. It is the entry point into the Ethereum network (main-, test- or private net), capable of running as a full node (default), archive node (retaining all historical state) or a light node (retrieving data live). It can be used by other processes as a gateway into the Ethereum network via JSON RPC endpoints exposed on top of HTTP, WebSocket and/or IPC transports. `geth --help` and the [CLI page](https://geth.ethereum.org/docs/fundamentals/command-line-options) for command line options. |
+| **`geth`** | Our main Ethereum CLI client. It is the entry point into the Ethereum network (main-, test- or private net), capable of running as a full node (default), archive node (retaining all historical state) or a light node (retrieving data live). It can be used by other processes as a gateway into the Ethereum network via **JSON-RPC** endpoints exposed on top of HTTP, WebSocket and/or IPC transports. `geth --help` and the [CLI page](https://geth.ethereum.org/docs/fundamentals/command-line-options) for command line options. |
 |   `clef`   | Stand-alone signing tool, which can be used as a backend signer for `geth`.                                                                                                                                                                                                                                                                                                                                                                                                                                                        |
 |  `devp2p`  | Utilities to interact with nodes on the networking layer, without running a full blockchain.                                                                                                                                                                                                                                                                                                                                                                                                                                       |
 |  `abigen`  | Source code generator to convert Ethereum contract definitions into easy-to-use, compile-time type-safe Go packages. It operates on plain [Ethereum contract ABIs](https://docs.soliditylang.org/en/develop/abi-spec.html) with expanded functionality if the contract bytecode is also available. However, it also accepts Solidity source files, making development much more streamlined. Please see our [Native DApps](https://geth.ethereum.org/docs/developers/dapp-developer/native-bindings) page for details.                                  |
 |   `evm`    | Developer utility version of the EVM (Ethereum Virtual Machine) that is capable of running bytecode snippets within a configurable environment and execution mode. Its purpose is to allow isolated, fine-grained debugging of EVM opcodes (e.g. `evm --code 60ff60ff --debug run`).                                                                                                                                                                                                                                               |
-| `rlpdump`  | Developer utility tool to convert binary RLP ([Recursive Length Prefix](https://ethereum.org/en/developers/docs/data-structures-and-encoding/rlp)) dumps (data encoding used by the Ethereum protocol both network as well as consensus wise) to user-friendlier hierarchical representation (e.g. `rlpdump --hex CE0183FFFFFFC4C304050583616263`).                                                                                                                                                                                |
+| `rlpdump`  | Developer utility tool to convert binary RLP ([Recursive Length Prefix](https://ethereum.org/en/developers/docs/data-structures-and-encoding/rlp)) dumps (data encoding used by the Ethereum protocol **both network- and consensus-wise**) to user-friendlier hierarchical representation (e.g. `rlpdump --hex CE0183FFFFFFC4C304050583616263`).                                                                                                                                                                                |
 
 ## Running `geth`
 
@@ -58,14 +58,14 @@ Minimum:
 * CPU with 4+ cores
 * 8GB RAM
 * 1TB free storage space to sync the Mainnet
-* 8 MBit/sec download Internet service
+* **8 Mbit/s download speed**
 
 Recommended:
 
 * Fast CPU with 8+ cores
 * 16GB+ RAM
 * High-performance SSD with at least 1TB of free space
-* 25+ MBit/sec download Internet service
+* **25+ Mbit/s download speed**
 
 ### Full node on the main Ethereum network
 
@@ -111,7 +111,7 @@ Specifying the `--holesky` flag, however, will reconfigure your `geth` instance 
    states.
  * Instead of using the default data directory (`~/.ethereum` on Linux for example), `geth`
    will nest itself one level deeper into a `holesky` subfolder (`~/.ethereum/holesky` on
-   Linux). Note, on OSX and Linux this also means that attaching to a running testnet node
+   Linux). Note, on **macOS** and Linux this also means that attaching to a running testnet node
    requires the use of a custom endpoint since `geth attach` will try to attach to a
    production node endpoint by default, e.g.,
    `geth attach <datadir>/holesky/geth.ipc`. Windows users are not affected by
@@ -136,7 +136,7 @@ To get an idea of how the file should look like you can use the `dumpconfig` sub
 export your existing configuration:
 
 ```shell
-$ geth --your-favourite-flags dumpconfig
+$ geth --your-favorite-flags dumpconfig
 ```
 
 #### Docker quick start
@@ -145,9 +145,7 @@ One of the quickest ways to get Ethereum up and running on your machine is by us
 Docker:
 
 ```shell
-docker run -d --name ethereum-node -v /Users/alice/ethereum:/root \
-           -p 8545:8545 -p 30303:30303 \
-           ethereum/client-go
+docker run -d --name ethereum-node -v /Users/alice/ethereum:/root            -p 8545:8545 -p 30303:30303            ethereum/client-go
 ```
 
 This will start `geth` in snap-sync mode with a DB memory allowance of 1GB, as the
@@ -159,11 +157,11 @@ Do not forget `--http.addr 0.0.0.0`, if you want to access RPC from other contai
 and/or hosts. By default, `geth` binds to the local interface and RPC endpoints are not
 accessible from the outside.
 
-### Programmatically interfacing `geth` nodes
+### Programmatically interfacing with `geth` nodes
 
 As a developer, sooner rather than later you'll want to start interacting with `geth` and the
 Ethereum network via your own programs and not manually through the console. To aid
-this, `geth` has built-in support for a JSON-RPC based APIs ([standard APIs](https://ethereum.org/en/developers/docs/apis/json-rpc/)
+this, `geth` has built-in support for **JSON-RPC-based APIs** ([standard APIs](https://ethereum.org/en/developers/docs/apis/json-rpc/)
 and [`geth` specific APIs](https://geth.ethereum.org/docs/interacting-with-geth/rpc)).
 These can be exposed via HTTP, WebSockets and IPC (UNIX sockets on UNIX based
 platforms, and named pipes on Windows).
@@ -178,12 +176,12 @@ HTTP based JSON-RPC API options:
   * `--http` Enable the HTTP-RPC server
   * `--http.addr` HTTP-RPC server listening interface (default: `localhost`)
   * `--http.port` HTTP-RPC server listening port (default: `8545`)
-  * `--http.api` API's offered over the HTTP-RPC interface (default: `eth,net,web3`)
+  * `--http.api` **APIs** offered over the HTTP-RPC interface (default: `eth,net,web3`)
   * `--http.corsdomain` Comma separated list of domains from which to accept cross-origin requests (browser enforced)
   * `--ws` Enable the WS-RPC server
   * `--ws.addr` WS-RPC server listening interface (default: `localhost`)
   * `--ws.port` WS-RPC server listening port (default: `8546`)
-  * `--ws.api` API's offered over the WS-RPC interface (default: `eth,net,web3`)
+  * `--ws.api` **APIs** offered over the WS-RPC interface (default: `eth,net,web3`)
   * `--ws.origins` Origins from which to accept WebSocket requests
   * `--ipcdisable` Disable the IPC-RPC server
   * `--ipcpath` Filename for IPC socket/pipe within the datadir (explicit paths escape it)
@@ -241,7 +239,7 @@ testing procedures.
 
 ### Contributing to geth.ethereum.org
 
-For contributions to the [go-ethereum website](https://geth.ethereum.org), please checkout and raise pull requests against the `website` branch.
+For contributions to the [go-ethereum website](https://geth.ethereum.org), please **check out** and raise pull requests against the `website` branch.
 For more detailed instructions please see the `website` branch [README](https://github.com/ethereum/go-ethereum/tree/website#readme) or the 
 [contributing](https://geth.ethereum.org/docs/developers/geth-developer/contributing) page of the website.
 


### PR DESCRIPTION
- Replace “API's” → “APIs” (HTTP/WS options).
- “JSON RPC” → “JSON-RPC”; “JSON-RPC based” → “JSON-RPC-based”.
- “OSX” → “macOS”.
- “MBit/sec” → “Mbit/s”; “download Internet service” → “download speed”.
- Section title: “Programmatically interfacing geth nodes” → “Programmatically interfacing with geth nodes”.
- Phrase: “both network as well as consensus wise” → “both network- and consensus-wise”.
- “your-favourite-flags” → “your-favorite-flags”.
- “please checkout” → “please check out”.

Editorial changes only; no semantics altered.