### PR TITLE
Fix eth/filters: Unsubscription Missing at `filter` Api With Subscrip…

### DIFF
--- a/eth/filters/api.go
+++ b/eth/filters/api.go
@@ -152,6 +152,7 @@ func (api *FilterAPI) NewPendingTransactionFilter(fullTx *bool) rpc.ID {
 				api.filtersMu.Lock()
 				delete(api.filters, pendingTxSub.ID)
 				api.filtersMu.Unlock()
+				pendingTxSub.Unsubscribe()
 				return
 			}
 		}


### PR DESCRIPTION
#32793 
Fix issue https://github.com/ethereum/go-ethereum/issues/32793