### PR TITLE
core/vm: handle os.WriteFile error in TestWriteExpectedValues

### DIFF
--- a/core/vm/instructions_test.go
+++ b/core/vm/instructions_test.go
@@ -259,7 +259,7 @@ func TestWriteExpectedValues(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		_ = os.WriteFile(fmt.Sprintf("testdata/testcases_%v.json", name), data, 0644)
+		err = os.WriteFile(fmt.Sprintf("testdata/testcases_%v.json", name), data, 0644)
 		if err != nil {
 			t.Fatal(err)
 		}


### PR DESCRIPTION
Properly capture and check the return value from os.WriteFile in TestWriteExpectedValues. Previously, the code assigned the write error to the blank identifier and then mistakenly re-checked the earlier json.Marshal error, leaving any write failure undetected.
This change is necessary because when the test is enabled (t.Skip removed) it writes generated fixtures to testdata. os.WriteFile can fail in real scenarios (missing directory, read-only filesystem, insufficient permissions, module cache, CI environments, or concurrent access). Failing to surface that error makes debugging flaky or environment-specific failures difficult.