### PR TITLE
accounts/abi: shadow loop variables in TestPack to fix parallel subtest capture

### DIFF
--- a/accounts/abi/pack_test.go
+++ b/accounts/abi/pack_test.go
@@ -34,6 +34,7 @@ import (
 func TestPack(t *testing.T) {
 	t.Parallel()
 	for i, test := range packUnpackTests {
+		i, test := i, test
 		t.Run(strconv.Itoa(i), func(t *testing.T) {
 			t.Parallel()
 			encb, err := hex.DecodeString(test.packed)


### PR DESCRIPTION
Shadow loop variables i and test before t.Run in TestPack to prevent closure capture issues when running subtests with t.Parallel(). Without shadowing, all parallel subtests may read mutated loop variables, causing flaky and non-deterministic assertions. This change ensures each subtest operates on the correct iteration values. No functional logic changes; test stability only.