### PR TITLE
fix: remove duplicate test case in ABI reflect tests

### DIFF
--- a/accounts/abi/reflect_test.go
+++ b/accounts/abi/reflect_test.go
@@ -100,16 +100,6 @@ var reflectTests = []reflectTest{
 		},
 	},
 	{
-		name: "DifferentName",
-		args: []string{"fieldB"},
-		struc: struct {
-			FieldA int `abi:"fieldB"`
-		}{},
-		want: map[string]string{
-			"fieldB": "FieldA",
-		},
-	},
-	{
 		name: "MultipleFields",
 		args: []string{"fieldA", "fieldB"},
 		struc: struct {


### PR DESCRIPTION
Removed duplicate test case "DifferentName" from reflectTests slice. The test case was defined twice with identical parameters (args, struc, want), which could cause confusion during test execution and debugging