### PR TITLE
trie/bintrie: remove redundant pre-Hash call in ToDot

### DIFF
--- a/trie/bintrie/trie.go
+++ b/trie/bintrie/trie.go
@@ -47,7 +47,6 @@ type BinaryTrie struct {
 
 // ToDot converts the binary trie to a DOT language representation. Useful for debugging.
 func (t *BinaryTrie) ToDot() string {
-	t.root.Hash()
 	return ToDot(t.root)
 }
 


### PR DESCRIPTION
 The ToDot method called t.root.Hash() and ignored the result. Hash() in bintrie nodes (InternalNode/StemNode) is pure and has no side effects or caching, and ToDot does not depend on any prior hashing. Therefore, the call is dead code and unnecessary. Removing it simplifies the function with no behavioral change.