### PR TITLE
triedb/pathdb: improve state history indexing completion log

### DIFF
--- a/triedb/pathdb/history_indexer.go
+++ b/triedb/pathdb/history_indexer.go
@@ -560,7 +560,7 @@ func (i *indexIniter) index(done chan struct{}, interrupt *atomic.Int32, lastID 
 			storeIndexMetadata(i.disk, i.typ, 0)
 			i.log.Info("Initialized history indexing flag")
 		} else {
-			i.log.Debug("History is fully indexed", i.getHistoryRangeInfo(lastID))
+			i.log.Debug("History is fully indexed", i.getHistoryRangeInfo(lastID)...)
 		}
 		return
 	}


### PR DESCRIPTION
Try to fix https://github.com/ethereum/go-ethereum/issues/32825. While this may not be a bug, the previous log message "State histories have been fully indexed last=X" was misleading since it only displayed the stateID without reflecting the actual number of queryable history objects. This commit introduces a helper function getHistoryRangeInfo() to retrieve the indexed block range and provide clearer information to users.