### PR TITLE
build: faster gh actions workflow, no ubuntu on appveyor

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -55,4 +55,4 @@ jobs:
           cache: false
 
       - name: Run tests
-        run: go run build/ci.go test -p 4
+        run: go run build/ci.go test -p 8

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -55,4 +55,4 @@ jobs:
           cache: false
 
       - name: Run tests
-        run: go run build/ci.go test -p 8
+        run: go run build/ci.go test -p 4

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   lint:
     name: Lint
-    runs-on: self-hosted-ghr
+    runs-on: [self-hosted-ghr, size-s-x64]
     steps:
     - uses: actions/checkout@v4
       with:
@@ -37,7 +37,7 @@ jobs:
   test:
     name: Test
     needs: lint
-    runs-on: self-hosted-ghr
+    runs-on: [self-hosted-ghr, size-l-x64]
     strategy:
       matrix:
         go:
@@ -55,4 +55,4 @@ jobs:
           cache: false
 
       - name: Run tests
-        run: go run build/ci.go test
+        run: go run build/ci.go test -p 4

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,7 +2,6 @@ clone_depth: 5
 version: "{branch}.{build}"
 
 image:
-  - Ubuntu
   - Visual Studio 2019
 
 environment:
@@ -17,25 +16,6 @@ install:
   - go version
 
 for:
-  # Linux has its own script without -arch and -cc.
-  # The linux builder also runs lint.
-  - matrix:
-      only:
-        - image: Ubuntu
-    build_script:
-      - go run build/ci.go lint
-      - go run build/ci.go check_generate
-      - go run build/ci.go check_baddeps
-      - go run build/ci.go install -dlgo
-    test_script:
-      - go run build/ci.go test -dlgo -short
-
-  # linux/386 is disabled.
-  - matrix:
-      exclude:
-        - image: Ubuntu
-          GETH_ARCH: 386
-
   # Windows builds for amd64 + 386.
   - matrix:
       only:
@@ -56,4 +36,4 @@ for:
       - go run build/ci.go archive -arch %GETH_ARCH% -type zip -signer WINDOWS_SIGNING_KEY -upload gethstore/builds
       - go run build/ci.go nsis -arch %GETH_ARCH% -signer WINDOWS_SIGNING_KEY -upload gethstore/builds
     test_script:
-      - go run build/ci.go test -dlgo -arch %GETH_ARCH% -cc %GETH_CC% -short
+      - go run build/ci.go test -dlgo -arch %GETH_ARCH% -cc %GETH_CC% -short -skip-spectests

--- a/build/ci.go
+++ b/build/ci.go
@@ -293,9 +293,11 @@ func doTest(cmdline []string) {
 	)
 	flag.CommandLine.Parse(cmdline)
 
+	// Load checksums file (needed for both spec tests and dlgo)
+	csdb := download.MustLoadChecksums("build/checksums.txt")
+
 	// Get test fixtures.
 	if !*skipspectests {
-		csdb := download.MustLoadChecksums("build/checksums.txt")
 		downloadSpecTestFixtures(csdb, *cachedir)
 	}
 

--- a/build/ci.go
+++ b/build/ci.go
@@ -290,7 +290,7 @@ func doTest(cmdline []string) {
 		short         = flag.Bool("short", false, "Pass the 'short'-flag to go test")
 		cachedir      = flag.String("cachedir", "./build/cache", "directory for caching downloads")
 		skipspectests = flag.Bool("skip-spectests", false, "Skip downloading execution-spec-tests fixtures")
-		threads       = flag.Int("threads", 1, "Number of CPU threads to use for testing")
+		threads       = flag.Int("p", 1, "Number of CPU threads to use for testing")
 	)
 	flag.CommandLine.Parse(cmdline)
 

--- a/build/ci.go
+++ b/build/ci.go
@@ -321,7 +321,7 @@ func doTest(cmdline []string) {
 
 	// Test a single package at a time. CI builders are slow
 	// and some tests run into timeouts under load.
-	gotest.Args = append(gotest.Args, "-p", *threads)
+	gotest.Args = append(gotest.Args, "-p", fmt.Sprintf("%d", *threads))
 	if *coverage {
 		gotest.Args = append(gotest.Args, "-covermode=atomic", "-cover")
 	}

--- a/build/ci.go
+++ b/build/ci.go
@@ -281,20 +281,23 @@ func buildFlags(env build.Environment, staticLinking bool, buildTags []string) (
 
 func doTest(cmdline []string) {
 	var (
-		dlgo     = flag.Bool("dlgo", false, "Download Go and build with it")
-		arch     = flag.String("arch", "", "Run tests for given architecture")
-		cc       = flag.String("cc", "", "Sets C compiler binary")
-		coverage = flag.Bool("coverage", false, "Whether to record code coverage")
-		verbose  = flag.Bool("v", false, "Whether to log verbosely")
-		race     = flag.Bool("race", false, "Execute the race detector")
-		short    = flag.Bool("short", false, "Pass the 'short'-flag to go test")
-		cachedir = flag.String("cachedir", "./build/cache", "directory for caching downloads")
+		dlgo       = flag.Bool("dlgo", false, "Download Go and build with it")
+		arch       = flag.String("arch", "", "Run tests for given architecture")
+		cc         = flag.String("cc", "", "Sets C compiler binary")
+		coverage   = flag.Bool("coverage", false, "Whether to record code coverage")
+		verbose    = flag.Bool("v", false, "Whether to log verbosely")
+		race       = flag.Bool("race", false, "Execute the race detector")
+		short      = flag.Bool("short", false, "Pass the 'short'-flag to go test")
+		cachedir   = flag.String("cachedir", "./build/cache", "directory for caching downloads")
+		skipspectests = flag.Bool("skip-spectests", false, "Skip downloading execution-spec-tests fixtures")
 	)
 	flag.CommandLine.Parse(cmdline)
 
 	// Get test fixtures.
-	csdb := download.MustLoadChecksums("build/checksums.txt")
-	downloadSpecTestFixtures(csdb, *cachedir)
+	if !*skipspectests {
+		csdb := download.MustLoadChecksums("build/checksums.txt")
+		downloadSpecTestFixtures(csdb, *cachedir)
+	}
 
 	// Configure the toolchain.
 	tc := build.GoToolchain{GOARCH: *arch, CC: *cc}

--- a/build/ci.go
+++ b/build/ci.go
@@ -281,15 +281,16 @@ func buildFlags(env build.Environment, staticLinking bool, buildTags []string) (
 
 func doTest(cmdline []string) {
 	var (
-		dlgo       = flag.Bool("dlgo", false, "Download Go and build with it")
-		arch       = flag.String("arch", "", "Run tests for given architecture")
-		cc         = flag.String("cc", "", "Sets C compiler binary")
-		coverage   = flag.Bool("coverage", false, "Whether to record code coverage")
-		verbose    = flag.Bool("v", false, "Whether to log verbosely")
-		race       = flag.Bool("race", false, "Execute the race detector")
-		short      = flag.Bool("short", false, "Pass the 'short'-flag to go test")
-		cachedir   = flag.String("cachedir", "./build/cache", "directory for caching downloads")
+		dlgo          = flag.Bool("dlgo", false, "Download Go and build with it")
+		arch          = flag.String("arch", "", "Run tests for given architecture")
+		cc            = flag.String("cc", "", "Sets C compiler binary")
+		coverage      = flag.Bool("coverage", false, "Whether to record code coverage")
+		verbose       = flag.Bool("v", false, "Whether to log verbosely")
+		race          = flag.Bool("race", false, "Execute the race detector")
+		short         = flag.Bool("short", false, "Pass the 'short'-flag to go test")
+		cachedir      = flag.String("cachedir", "./build/cache", "directory for caching downloads")
 		skipspectests = flag.Bool("skip-spectests", false, "Skip downloading execution-spec-tests fixtures")
+		threads       = flag.Int("threads", 1, "Number of CPU threads to use for testing")
 	)
 	flag.CommandLine.Parse(cmdline)
 
@@ -320,7 +321,7 @@ func doTest(cmdline []string) {
 
 	// Test a single package at a time. CI builders are slow
 	// and some tests run into timeouts under load.
-	gotest.Args = append(gotest.Args, "-p", "1")
+	gotest.Args = append(gotest.Args, "-p", *threads)
 	if *coverage {
 		gotest.Args = append(gotest.Args, "-covermode=atomic", "-cover")
 	}


### PR DESCRIPTION
This PR does a few things:
- Sets the gh actions runner sizes for lint (s) and test (l) workflows
- Runs the tests on gh in parallel
- Skips fetching the spec tests when unnecessary (on windows in appveyor)
- Removes ubuntu appveyor runner since it's essentially duplicate of the gh action workflow now

The gh test seems to go down from ~35min to ~13min.