### PR TITLE
metrics: replace time.Tick with time.NewTicker to avoid leaked timers

### DIFF
--- a/metrics/opentsdb.go
+++ b/metrics/opentsdb.go
@@ -39,7 +39,9 @@ func OpenTSDB(r Registry, d time.Duration, prefix string, addr *net.TCPAddr) {
 // OpenTSDBWithConfig is a blocking exporter function just like OpenTSDB,
 // but it takes a OpenTSDBConfig instead.
 func OpenTSDBWithConfig(c OpenTSDBConfig) {
-	for range time.Tick(c.FlushInterval) {
+	ticker := time.NewTicker(c.FlushInterval)
+	defer ticker.Stop() // Use NewTicker to allow explicit stop and avoid leaked timers.
+	for range ticker.C {
 		if err := openTSDB(&c); nil != err {
 			log.Println(err)
 		}


### PR DESCRIPTION

## Summary
Replace `time.Tick` with `time.NewTicker` in the OpenTSDB exporter to enable explicit stop and prevent leaked timers.

## Rationale
`time.Tick` cannot be stopped and may leak timers/goroutines over time. `time.NewTicker` allows proper lifecycle management and graceful shutdown.

## Changes
- metrics/opentsdb.go: use `time.NewTicker(c.FlushInterval)` with `defer ticker.Stop()`.

## Impact
- Improves resource management and shutdown behavior.

