### PR TITLE
cmd/devp2p/internal/ethtest: accept responses in any order 

### DIFF
--- a/cmd/devp2p/internal/ethtest/protocol.go
+++ b/cmd/devp2p/internal/ethtest/protocol.go
@@ -86,3 +86,9 @@ func protoOffset(proto Proto) uint64 {
 		panic("unhandled protocol")
 	}
 }
+
+// msgTypePtr is the constraint for protocol message types.
+type msgTypePtr[U any] interface {
+	*U
+	Kind() byte
+}


### PR DESCRIPTION
In both `TestSimultaneousRequests` and `TestSameRequestID`, we send two concurrent requests. The client under test is free to respond in either order, so we need to handle responses both ways.

Also fixes an issue where some generated blob transactions didn't have any blobs.

