### PR TITLE
triedb: using testing.B.Loop

### DIFF
--- a/triedb/pathdb/difflayer_test.go
+++ b/triedb/pathdb/difflayer_test.go
@@ -89,7 +89,7 @@ func benchmarkSearch(b *testing.B, depth int, total int) {
 		have []byte
 		err  error
 	)
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		have, _, _, err = layer.node(common.Hash{}, npath, 0)
 		if err != nil {
 			b.Fatal(err)
@@ -120,7 +120,7 @@ func BenchmarkPersist(b *testing.B) {
 		}
 		return newDiffLayer(parent, common.Hash{}, 0, 0, NewNodeSetWithOrigin(nodes, nil), NewStateSetWithOrigin(nil, nil, nil, nil, false))
 	}
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		b.StopTimer()
 		var layer layer
 		layer = emptyLayer()
@@ -165,7 +165,7 @@ func BenchmarkJournal(b *testing.B) {
 	}
 	b.ResetTimer()
 
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		layer.journal(new(bytes.Buffer))
 	}
 }

--- a/triedb/pathdb/history_index_block_test.go
+++ b/triedb/pathdb/history_index_block_test.go
@@ -225,7 +225,7 @@ func BenchmarkParseIndexBlock(b *testing.B) {
 	blob := bw.finish()
 
 	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		_, _, err := parseIndexBlock(blob)
 		if err != nil {
 			b.Fatalf("parseIndexBlock failed: %v", err)
@@ -241,7 +241,7 @@ func BenchmarkBlockWriterAppend(b *testing.B) {
 	desc := newIndexBlockDesc(0)
 	writer, _ := newBlockWriter(nil, desc)
 
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		if writer.full() {
 			desc = newIndexBlockDesc(0)
 			writer, _ = newBlockWriter(nil, desc)

--- a/triedb/pathdb/iterator_test.go
+++ b/triedb/pathdb/iterator_test.go
@@ -1051,7 +1051,7 @@ func BenchmarkAccountIteratorTraversal(b *testing.B) {
 	head.(*diffLayer).newBinaryAccountIterator(common.Hash{})
 
 	b.Run("binary iterator keys", func(b *testing.B) {
-		for i := 0; i < b.N; i++ {
+		for b.Loop() {
 			got := 0
 			it := head.(*diffLayer).newBinaryAccountIterator(common.Hash{})
 			for it.Next() {
@@ -1063,7 +1063,7 @@ func BenchmarkAccountIteratorTraversal(b *testing.B) {
 		}
 	})
 	b.Run("binary iterator values", func(b *testing.B) {
-		for i := 0; i < b.N; i++ {
+		for b.Loop() {
 			got := 0
 			it := head.(*diffLayer).newBinaryAccountIterator(common.Hash{})
 			for it.Next() {
@@ -1076,7 +1076,7 @@ func BenchmarkAccountIteratorTraversal(b *testing.B) {
 		}
 	})
 	b.Run("fast iterator keys", func(b *testing.B) {
-		for i := 0; i < b.N; i++ {
+		for b.Loop() {
 			it, _ := db.AccountIterator(common.HexToHash("0x65"), common.Hash{})
 			defer it.Release()
 
@@ -1090,7 +1090,7 @@ func BenchmarkAccountIteratorTraversal(b *testing.B) {
 		}
 	})
 	b.Run("fast iterator values", func(b *testing.B) {
-		for i := 0; i < b.N; i++ {
+		for b.Loop() {
 			it, _ := db.AccountIterator(common.HexToHash("0x65"), common.Hash{})
 			defer it.Release()
 
@@ -1142,7 +1142,7 @@ func BenchmarkAccountIteratorLargeBaselayer(b *testing.B) {
 	head.(*diffLayer).newBinaryAccountIterator(common.Hash{})
 
 	b.Run("binary iterator (keys)", func(b *testing.B) {
-		for i := 0; i < b.N; i++ {
+		for b.Loop() {
 			got := 0
 			it := head.(*diffLayer).newBinaryAccountIterator(common.Hash{})
 			for it.Next() {
@@ -1154,7 +1154,7 @@ func BenchmarkAccountIteratorLargeBaselayer(b *testing.B) {
 		}
 	})
 	b.Run("binary iterator (values)", func(b *testing.B) {
-		for i := 0; i < b.N; i++ {
+		for b.Loop() {
 			got := 0
 			it := head.(*diffLayer).newBinaryAccountIterator(common.Hash{})
 			for it.Next() {
@@ -1168,7 +1168,7 @@ func BenchmarkAccountIteratorLargeBaselayer(b *testing.B) {
 		}
 	})
 	b.Run("fast iterator (keys)", func(b *testing.B) {
-		for i := 0; i < b.N; i++ {
+		for b.Loop() {
 			it, _ := db.AccountIterator(common.HexToHash("0x65"), common.Hash{})
 			defer it.Release()
 
@@ -1182,7 +1182,7 @@ func BenchmarkAccountIteratorLargeBaselayer(b *testing.B) {
 		}
 	})
 	b.Run("fast iterator (values)", func(b *testing.B) {
-		for i := 0; i < b.N; i++ {
+		for b.Loop() {
 			it, _ := db.AccountIterator(common.HexToHash("0x65"), common.Hash{})
 			defer it.Release()
 


### PR DESCRIPTION
before 
`go test -run=^$ -bench=. ./triedb/... -timeout=1h  39.12s user 2.43s system 111% cpu 37.191 total
`
after 
`go test -run=^$ -bench=. ./triedb/... -timeout=1h  28.51s user 2.08s system 111% cpu 27.520 total
`