### PR TITLE
accounts/abi: remove duplicate types from varTypes array in abifuzzer_test.go

### DIFF
--- a/accounts/abi/abifuzzer_test.go
+++ b/accounts/abi/abifuzzer_test.go
@@ -48,7 +48,7 @@ var (
 	vNames   = []string{"a", "b", "c", "d", "e", "f", "g"}
 	varNames = append(vNames, names...)
 	varTypes = []string{"bool", "address", "bytes", "string",
-		"uint8", "int8", "uint8", "int8", "uint16", "int16",
+		"uint8", "int8", "uint16", "int16",
 		"uint24", "int24", "uint32", "int32", "uint40", "int40", "uint48", "int48", "uint56", "int56",
 		"uint64", "int64", "uint72", "int72", "uint80", "int80", "uint88", "int88", "uint96", "int96",
 		"uint104", "int104", "uint112", "int112", "uint120", "int120", "uint128", "int128", "uint136", "int136",


### PR DESCRIPTION

## Summary

Remove duplicate `"uint8"` and `"int8"` entries from the `varTypes` array in `abifuzzer_test.go` to eliminate redundant code and improve test consistency.

## Changes

- Removed duplicate `"uint8", "int8"` entries from the `varTypes` slice
- Maintains the same type coverage while ensuring each type appears only once

## Rationale

The duplicate entries in the `varTypes` array were causing the fuzzer to have an uneven distribution of type selection, with `uint8` and `int8` being twice as likely to be chosen compared to other types. This change:

- Eliminates redundant code
- Ensures consistent type distribution in fuzzing tests  
- Improves code clarity and maintainability

