### PR TITLE
eth/protocols/eth: use BlockChain interface in Handshake

### DIFF
--- a/eth/protocols/eth/handshake.go
+++ b/eth/protocols/eth/handshake.go
@@ -22,7 +22,6 @@ import (
 	"time"
 
 	"github.com/ethereum/go-ethereum/common"
-	"github.com/ethereum/go-ethereum/core"
 	"github.com/ethereum/go-ethereum/core/forkid"
 	"github.com/ethereum/go-ethereum/metrics"
 	"github.com/ethereum/go-ethereum/p2p"
@@ -36,7 +35,7 @@ const (
 
 // Handshake executes the eth protocol handshake, negotiating version number,
 // network IDs, difficulties, head and genesis blocks.
-func (p *Peer) Handshake(networkID uint64, chain *core.BlockChain, rangeMsg BlockRangeUpdatePacket) error {
+func (p *Peer) Handshake(networkID uint64, chain forkid.Blockchain, rangeMsg BlockRangeUpdatePacket) error {
 	switch p.version {
 	case ETH69:
 		return p.handshake69(networkID, chain, rangeMsg)
@@ -47,10 +46,10 @@ func (p *Peer) Handshake(networkID uint64, chain *core.BlockChain, rangeMsg Bloc
 	}
 }
 
-func (p *Peer) handshake68(networkID uint64, chain *core.BlockChain) error {
+func (p *Peer) handshake68(networkID uint64, chain forkid.Blockchain) error {
 	var (
 		genesis    = chain.Genesis()
-		latest     = chain.CurrentBlock()
+		latest     = chain.CurrentHeader()
 		forkID     = forkid.NewID(chain.Config(), genesis, latest.Number.Uint64(), latest.Time)
 		forkFilter = forkid.NewFilter(chain)
 	)
@@ -92,10 +91,10 @@ func (p *Peer) readStatus68(networkID uint64, status *StatusPacket68, genesis co
 	return nil
 }
 
-func (p *Peer) handshake69(networkID uint64, chain *core.BlockChain, rangeMsg BlockRangeUpdatePacket) error {
+func (p *Peer) handshake69(networkID uint64, chain forkid.Blockchain, rangeMsg BlockRangeUpdatePacket) error {
 	var (
 		genesis    = chain.Genesis()
-		latest     = chain.CurrentBlock()
+		latest     = chain.CurrentHeader()
 		forkID     = forkid.NewID(chain.Config(), genesis, latest.Number.Uint64(), latest.Time)
 		forkFilter = forkid.NewFilter(chain)
 	)


### PR DESCRIPTION
Enforcing having to pass a whole `*core.BlockChain` instance for the Handshake makes it really hard to use outside of a full node. Using an interface with minimal methods is preferable.