### PR TITLE
core: optimize SnapSyncCommitHead to accept block instead of hash

### DIFF
--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -1107,13 +1107,12 @@ func (bc *BlockChain) setHeadBeyondRoot(head uint64, time uint64, root common.Ha
 	return rootNumber, bc.loadLastState()
 }
 
-// SnapSyncCommitHead sets the current head block to the one defined by the hash
+// SnapSyncCommitHead sets the current head block to the one defined by the block
 // irrelevant what the chain contents were prior.
-func (bc *BlockChain) SnapSyncCommitHead(hash common.Hash) error {
+func (bc *BlockChain) SnapSyncCommitHead(block *types.Block) error {
 	// Make sure that both the block as well at its state trie exists
-	block := bc.GetBlockByHash(hash)
 	if block == nil {
-		return fmt.Errorf("non existent block [%x..]", hash[:4])
+		return fmt.Errorf("non existent block")
 	}
 	// Reset the trie database with the fresh snap synced state.
 	root := block.Root()
@@ -1138,7 +1137,7 @@ func (bc *BlockChain) SnapSyncCommitHead(hash common.Hash) error {
 	if bc.snaps != nil {
 		bc.snaps.Rebuild(root)
 	}
-	log.Info("Committed new head block", "number", block.Number(), "hash", hash)
+	log.Info("Committed new head block", "number", block.Number(), "hash", block.Hash())
 	return nil
 }
 

--- a/eth/downloader/downloader.go
+++ b/eth/downloader/downloader.go
@@ -190,7 +190,7 @@ type BlockChain interface {
 	CurrentSnapBlock() *types.Header
 
 	// SnapSyncCommitHead directly commits the head block to a certain entity.
-	SnapSyncCommitHead(common.Hash) error
+	SnapSyncCommitHead(block *types.Block) error
 
 	// InsertHeadersBeforeCutoff inserts a batch of headers before the configured
 	// chain cutoff into the ancient store.
@@ -1066,7 +1066,7 @@ func (d *Downloader) commitPivotBlock(result *fetchResult) error {
 	if _, err := d.blockchain.InsertReceiptChain([]*types.Block{block}, []rlp.RawValue{result.Receipts}, d.ancientLimit); err != nil {
 		return err
 	}
-	if err := d.blockchain.SnapSyncCommitHead(block.Hash()); err != nil {
+	if err := d.blockchain.SnapSyncCommitHead(block); err != nil {
 		return err
 	}
 	d.committed.Store(true)


### PR DESCRIPTION
This changes SnapSyncCommitHead to accept *types.Block directly instead of common.Hash, eliminating an unnecessary GetBlockByHash database lookup.               