### PR TITLE
core: fix nonce overflow validation logic

### DIFF
--- a/core/state_transition.go
+++ b/core/state_transition.go
@@ -319,7 +319,7 @@ func (st *stateTransition) preCheck() error {
 		} else if stNonce > msgNonce {
 			return fmt.Errorf("%w: address %v, tx: %d state: %d", ErrNonceTooLow,
 				msg.From.Hex(), msgNonce, stNonce)
-		} else if stNonce+1 < stNonce {
+		} else if stNonce == math.MaxUint64 {
 			return fmt.Errorf("%w: address %v, nonce: %d", ErrNonceMax,
 				msg.From.Hex(), stNonce)
 		}


### PR DESCRIPTION
Fixed a sneaky bug in nonce validation that was working by pure luck.

The old code checked `stNonce+1 < stNonce` which only worked because of uint64 overflow wrapping MaxUint64+1 back to 0. This was confusing and fragile - if someone didn't know about overflow behavior, they'd be scratching their head wondering how this could ever be true.

Changed it to the obvious `stNonce == math.MaxUint64` check instead. 
Now it's crystal clear what we're doing and doesn't rely on overflow 
tricks.

Tested with existing EIP-2681 tests - everything still works as expected.