### PR TITLE
build: use context.Background in Azure blob listing pager

### DIFF
--- a/internal/build/azure.go
+++ b/internal/build/azure.go
@@ -81,7 +81,7 @@ func AzureBlobstoreList(config AzureBlobstoreConfig) ([]*container.BlobItem, err
 
 	var blobs []*container.BlobItem
 	for pager.More() {
-		page, err := pager.NextPage(context.TODO())
+		page, err := pager.NextPage(context.Background())
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
- Replace context.TODO() with context.Background() in AzureBlobstoreList
- Aligns with existing usage in UploadFile/DeleteBlob in the same file
- Keeps utility package style (no context threading through callers)