### PR TITLE
Expose eth_simulateV1 RPC method via ethclient

### DIFF
--- a/ethclient/ethclient.go
+++ b/ethclient/ethclient.go
@@ -36,6 +36,13 @@ type Client struct {
 	c *rpc.Client
 }
 
+// SimulateV1 calls the eth_simulateV1 RPC method.
+func (ec *Client) SimulateV1(ctx context.Context, opts map[string]interface{}, blockParam string) (map[string]interface{}, error) {
+    var result map[string]interface{}
+    err := ec.c.CallContext(ctx, &result, "eth_simulateV1", opts, blockParam)
+    return result, err
+}
+
 // Dial connects a client to the given URL.
 func Dial(rawurl string) (*Client, error) {
 	return DialContext(context.Background(), rawurl)

--- a/ethclient/ethclient_test.go
+++ b/ethclient/ethclient_test.go
@@ -754,3 +754,28 @@ func ExampleRevertErrorData() {
 	// revert: 08c379a00000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000000a75736572206572726f72
 	// message: user error
 }
+
+// Test for SimulateV1
+func TestSimulateV1(t *testing.T) {
+    client := ethclient.NewClient(rpc.DialContext)
+    opts := map[string]interface{}{
+        "traceTransfers": true,
+        "validation":     true,
+        "blockStateCalls": []interface{}{
+            map[string]interface{}{
+                "calls": []interface{}{
+                    map[string]interface{}{
+                        "from": "0x...",
+                        "to":   "0x...",
+                        "data": "0x...",
+                    },
+                },
+            },
+        },
+    }
+    resp, err := client.SimulateV1(context.Background(), opts, "latest")
+    if err != nil {
+        t.Fatalf("SimulateV1 failed: %v", err)
+    }
+    t.Logf("Response: %+v", resp)
+}


### PR DESCRIPTION
### Summary
Expose the new `eth_simulateV1` RPC method via the `ethclient` package.

### Changes
- Adds `SimulateV1()` method to `ethclient.Client`
- Accepts flexible payload and returns raw response
- Enables developers to simulate blocks and transactions with overrides
- Includes basic test case

Closes #32852