### PR TITLE
p2p/discover: remove unused var seedMinTableTime

### DIFF
--- a/p2p/discover/table.go
+++ b/p2p/discover/table.go
@@ -54,9 +54,8 @@ const (
 	bucketIPLimit, bucketSubnet = 2, 24 // at most 2 addresses from the same /24
 	tableIPLimit, tableSubnet   = 10, 24
 
-	seedMinTableTime = 5 * time.Minute
-	seedCount        = 30
-	seedMaxAge       = 5 * 24 * time.Hour
+	seedCount  = 30
+	seedMaxAge = 5 * 24 * time.Hour
 )
 
 // Table is the 'node table', a Kademlia-like index of neighbor nodes. The table keeps


### PR DESCRIPTION
`seedMinTableTime` is not used anymore, remove it.