### PR TITLE
p2p/discover: wait for bootstrap to be done

### DIFF
--- a/p2p/discover/v4_udp_test.go
+++ b/p2p/discover/v4_udp_test.go
@@ -575,6 +575,13 @@ func startLocalhostV4(t *testing.T, cfg Config) *UDPv4 {
 	if err != nil {
 		t.Fatal(err)
 	}
+
+	// Wait for bootstrap to complete.
+	select {
+	case <-udp.tab.initDone:
+	case <-time.After(5 * time.Second):
+		t.Fatalf("timed out waiting for table initialization")
+	}
 	return udp
 }
 


### PR DESCRIPTION
close https://github.com/ethereum/go-ethereum/issues/32863 


_Found by Claude Code_

  - When a discovery table starts, it kicks off doRefresh in the background and keeps initDone open until that finishes.
  - While initDone is still open, handleAddNode rejects every inbound contact (p2p/discover/table.go:512-518) as a DoS safeguard. The rejection simply returns false, so the caller proceeds without the peer ever
  being inserted.
  - In the test we start node₀ and immediately spin up node₁…node₃. Their very first action is a PING to the bootnode. If node₀’s initDone hasn’t closed yet, those pings hit the guard above and are dropped. The
  routing table stays empty, so every goroutine running lookupIterator.Next() goes down the lookupFailed → waitForNodes path and blocks forever (exactly what you see in p2p-test-hang.log).
  - Once initDone eventually closes the guard stops firing, but it’s too late—the initial pings were lost; no node ever got added; the goroutines are already stuck waiting for a node count that never increases; the
  outer timeout kills the test after 45 minutes.

  So the “race” is about the relative timing between “table finishes bootstrapping” and “remote peers dial us the first time”. Waiting for initDone before returning from startLocalhostV4 removes that window and
  makes the test deterministic.
