### PR TITLE
core/types: opt or using bitutil

### DIFF
--- a/core/types/bloom9.go
+++ b/core/types/bloom9.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"math/big"
 
+	"github.com/ethereum/go-ethereum/common/bitutil"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/crypto"
 )
@@ -125,9 +126,7 @@ func MergeBloom(receipts Receipts) Bloom {
 	for _, receipt := range receipts {
 		if len(receipt.Logs) != 0 {
 			bl := receipt.Bloom.Bytes()
-			for i := range bin {
-				bin[i] |= bl[i]
-			}
+			bitutil.ORBytes(bin[:], bin[:], bl)
 		}
 	}
 	return bin


### PR DESCRIPTION
```
goos: darwin
goarch: amd64
pkg: github.com/ethereum/go-ethereum/core/types
cpu: VirtualApple @ 2.50GHz
                                 │   old.txt    │               new.txt               │
                                 │    sec/op    │   sec/op     vs base                │
CreateBloom/small-createbloom-10    1.676µ ± 4%   1.646µ ± 1%   -1.76% (p=0.000 n=10)
CreateBloom/large-createbloom-10    164.8µ ± 3%   164.3µ ± 0%        ~ (p=0.247 n=10)
CreateBloom/small-mergebloom-10    231.60n ± 0%   68.00n ± 0%  -70.64% (p=0.000 n=10)
CreateBloom/large-mergebloom-10    21.803µ ± 3%   5.107µ ± 1%  -76.58% (p=0.000 n=10)
geomean                             6.111µ        3.113µ       -49.06%

                                 │    old.txt     │                new.txt                │
                                 │      B/op      │     B/op      vs base                 │
CreateBloom/small-createbloom-10     112.0 ± 0%       112.0 ± 0%       ~ (p=1.000 n=10) ¹
CreateBloom/large-createbloom-10   10.94Ki ± 0%     10.94Ki ± 0%       ~ (p=0.474 n=10)
CreateBloom/small-mergebloom-10      0.000 ± 0%       0.000 ± 0%       ~ (p=1.000 n=10) ¹
CreateBloom/large-mergebloom-10      0.000 ± 0%       0.000 ± 0%       ~ (p=1.000 n=10) ¹
geomean                                         ²                 +0.00%                ²
¹ all samples are equal
² summaries must be >0 to compute geomean

                                 │   old.txt    │               new.txt               │
                                 │  allocs/op   │ allocs/op   vs base                 │
CreateBloom/small-createbloom-10   6.000 ± 0%     6.000 ± 0%       ~ (p=1.000 n=10) ¹
CreateBloom/large-createbloom-10   600.0 ± 0%     600.0 ± 0%       ~ (p=1.000 n=10) ¹
CreateBloom/small-mergebloom-10    0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
CreateBloom/large-mergebloom-10    0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
geomean                                       ²               +0.00%                ²
¹ all samples are equal
² summaries must be >0 to compute geomean
```