### PR TITLE
rpc: fix flaky test TestServerWebsocketReadLimit

### DIFF
--- a/rpc/server_test.go
+++ b/rpc/server_test.go
@@ -273,7 +273,8 @@ func TestServerWebsocketReadLimit(t *testing.T) {
 					}
 				} else if !errors.Is(err, websocket.ErrReadLimit) &&
 					!strings.Contains(strings.ToLower(err.Error()), "1009") &&
-					!strings.Contains(strings.ToLower(err.Error()), "message too big") {
+					!strings.Contains(strings.ToLower(err.Error()), "message too big") &&
+					!strings.Contains(strings.ToLower(err.Error()), "connection reset by peer") {
 					// Not the error we expect from exceeding the message size limit.
 					t.Fatalf("unexpected error for read limit violation: %v", err)
 				}


### PR DESCRIPTION
### Fix: Tolerate "connection reset by peer" in TestServerWebsocketReadLimit

#### What does this PR do?

This PR updates the `TestServerWebsocketReadLimit` test to tolerate the `"connection reset by peer"` error as a valid outcome when the websocket read limit is exceeded.  
This error can occur due to a race condition where the TCP connection closes before the websocket close frame is sent, as discussed in [issue #32866](https://github.com/ethereum/go-ethereum/issues/32866).

#### Why is this needed?

Occasionally, in CI or some local environments, the test fails with:
```
unexpected error for read limit violation: write tcp ...: write: connection reset by peer
```
Previously, the test only accepted specific websocket errors (like CloseError code 1009, ErrReadLimit, or errors containing "1009"/"message too big").  
By allowing "connection reset by peer", the test becomes more robust against this race condition and prevents intermittent failures.

#### Reference

Fixes [#32866](https://github.com/ethereum/go-ethereum/issues/32866)

#### Checklist

- [x] Ran tests locally
- [x] Only test code changed

---

Let me know if you want to edit or clarify anything!