### PR TITLE
node: fix error condition in gzipResponseWriter.init()

### DIFF
--- a/node/rpcstack.go
+++ b/node/rpcstack.go
@@ -500,7 +500,7 @@ func (w *gzipResponseWriter) init() {
 	hdr := w.resp.Header()
 	length := hdr.Get("content-length")
 	if len(length) > 0 {
-		if n, err := strconv.ParseUint(length, 10, 64); err != nil {
+		if n, err := strconv.ParseUint(length, 10, 64); err == nil {
 			w.hasLength = true
 			w.contentLength = n
 		}


### PR DESCRIPTION
## Summary

Fixed a logic error in `gzipResponseWriter.init()` where the error condition for parsing Content-Length header was inverted. The code was setting `hasLength=true` and `contentLength=n` when parsing **failed** instead of when it **succeeded**, causing the gzip stream to close prematurely when invalid Content-Length headers were received.

## Problem Description

### Current Behavior (Buggy)

```go
// Line 503 in node/rpcstack.go
if n, err := strconv.ParseUint(length, 10, 64); err != nil {  // ❌ Wrong condition
    w.hasLength = true
    w.contentLength = n  // n=0 when parsing fails
}
```

## Proposed Solution
### Code Fix

```go
// Line 503 in node/rpcstack.go
if n, err := strconv.ParseUint(length, 10, 64); err == nil {  // ✅ Fixed condition
    w.hasLength = true
    w.contentLength = n
}
```