### PR TITLE
accounts/scwallet: remove selfDerive start from Initialize to avoid goroutine leak

### DIFF
--- a/accounts/scwallet/wallet.go
+++ b/accounts/scwallet/wallet.go
@@ -617,7 +617,6 @@ func (w *Wallet) Contains(account accounts.Account) bool {
 
 // Initialize installs a keypair generated from the provided key into the wallet.
 func (w *Wallet) Initialize(seed []byte) error {
-	go w.selfDerive()
 	// DO NOT lock at this stage, as the initialize
 	// function relies on Status()
 	return w.session.initialize(seed)


### PR DESCRIPTION
Remove the go w.selfDerive() invocation from Wallet.Initialize. Starting the self-derivation loop here launches a goroutine before w.deriveReq and w.deriveQuit are initialized, causing the loop to block forever on a select over nil channels. Later, Open correctly initializes the channels and starts another selfDerive, leaving the first goroutine stuck and unkillable. The self-derivation lifecycle should begin in Open only, after channels are set up. This change aligns with the USB wallet backend pattern and prevents leaked goroutines.