### PR TITLE
eth: Refactor updateFilterMapsHeads to Use Timer Instead of time.After

### DIFF
--- a/eth/backend.go
+++ b/eth/backend.go
@@ -502,14 +502,20 @@ func (s *Ethereum) updateFilterMapsHeads() {
 	}
 	setHead(s.blockchain.CurrentBlock())
 
+	timer := time.NewTimer(time.Second * 10)
+	defer timer.Stop()
+
 	for {
 		select {
 		case ev := <-headEventCh:
 			setHead(ev.Header)
+			timer.Reset(time.Second * 10)
 		case blockProc := <-blockProcCh:
 			s.filterMaps.SetBlockProcessing(blockProc)
-		case <-time.After(time.Second * 10):
+			timer.Reset(time.Second * 10)
+		case <-timer.C:
 			setHead(s.blockchain.CurrentBlock())
+			timer.Reset(time.Second * 10)
 		case ch := <-s.closeFilterMaps:
 			close(ch)
 			return


### PR DESCRIPTION
## Issue Description

The `updateFilterMapsHeads()` function at `eth/backend.go:511` uses `time.After()` inside a `for-select` loop. This creates a new timer object on every loop iteration. While Go 1.23+ can garbage collect these timers, this pattern is inefficient and goes against Go best practices for timer usage in loops.

**Affected Code:**
```go
// File: eth/backend.go
// Line: 505-517

for {
    select {
    case ev := <-headEventCh:
        setHead(ev.Header)
    case blockProc := <-blockProcCh:
        s.filterMaps.SetBlockProcessing(blockProc)
    case <-time.After(time.Second * 10):  // ⚠️ INEFFICIENT: Creates new timer on each iteration
        setHead(s.blockchain.CurrentBlock())
    case ch := <-s.closeFilterMaps:
        close(ch)
        return
    }
}
```
**Optimized code:**

```go
func (s *Ethereum) updateFilterMapsHeads() {
	// ... same setup ...

	// ✅ Refactor: Use timer with reset 
	timer := time.NewTimer(time.Second * 10)
	defer timer.Stop()

	for {
		select {
		case ev := <-headEventCh:
			setHead(ev.Header)
			timer.Reset(time.Second * 10)  // ✅ guarantees no stale values
			
		case blockProc := <-blockProcCh:
			s.filterMaps.SetBlockProcessing(blockProc)
			timer.Reset(time.Second * 10)  // ✅ guarantees no stale values
			
		case <-timer.C:
			setHead(s.blockchain.CurrentBlock())
			timer.Reset(time.Second * 10) // ✅ guarantees no stale values
			
		case ch := <-s.closeFilterMaps:
			close(ch)
			return
		}
	}
}
```