### PR TITLE
eth: do not warn on switching from snap sync to full sync

### DIFF
--- a/eth/handler.go
+++ b/eth/handler.go
@@ -181,8 +181,7 @@ func newHandler(config *handlerConfig) (*handler, error) {
 	} else {
 		head := h.chain.CurrentBlock()
 		if head.Number.Uint64() > 0 && h.chain.HasState(head.Root) {
-			// Print warning log if database is not empty to run snap sync.
-			log.Warn("Switch sync mode from snap sync to full sync", "reason", "snap sync complete")
+			log.Info("Switch sync mode from snap sync to full sync", "reason", "snap sync complete")
 		} else {
 			// If snap sync was requested and our database is empty, grant it
 			h.snapSync.Store(true)


### PR DESCRIPTION
This happens normally after a restart, so it is better to use Info level here.