### PR TITLE
eth/catalyst: remove useless log on enabling Engine API

### DIFF
--- a/eth/catalyst/api.go
+++ b/eth/catalyst/api.go
@@ -47,7 +47,6 @@ import (
 
 // Register adds the engine API to the full node.
 func Register(stack *node.Node, backend *eth.Ethereum) error {
-	log.Info("Engine API enabled", "protocol", "eth")
 	stack.RegisterAPIs([]rpc.API{
 		{
 			Namespace:     "engine",


### PR DESCRIPTION
This is normal, nothing to warn about.