### PR TITLE
triedb/pathdb: fix max buffer size

### DIFF
--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -465,7 +465,7 @@ var (
 	CacheFlag = &cli.IntFlag{
 		Name:     "cache",
 		Usage:    "Megabytes of memory allocated to internal caching (default = 4096 mainnet full node, 128 light mode)",
-		Value:    1024,
+		Value:    1024, // Note: default is bumped to 4096 on mainnet in geth/main.go
 		Category: flags.PerfCategory,
 	}
 	CacheDatabaseFlag = &cli.IntFlag{

--- a/triedb/pathdb/config.go
+++ b/triedb/pathdb/config.go
@@ -35,7 +35,7 @@ const (
 	// Too large buffer will cause the system to pause for a long
 	// time when write happens. Also, the largest batch that pebble can
 	// support is 4GB, node will panic if batch size exceeds this limit.
-	maxBufferSize = 256 * 1024 * 1024
+	maxBufferSize = 1024 * 1024 * 1024
 
 	// defaultBufferSize is the default memory allowance of node buffer
 	// that aggregates the writes from above until it's flushed into the


### PR DESCRIPTION
We use different default on mainnet, bumping it to 1GB. Make sure we allow this here. Previously we had a warning and buffer was reset to 256MB.