### PR TITLE
core:  prevent no-op code change for 7702 edge-cases

### DIFF
--- a/core/state_transition.go
+++ b/core/state_transition.go
@@ -19,6 +19,9 @@ package core
 import (
 	"bytes"
 	"fmt"
+	"math"
+	"math/big"
+
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/tracing"
 	"github.com/ethereum/go-ethereum/core/types"
@@ -26,8 +29,6 @@ import (
 	"github.com/ethereum/go-ethereum/crypto/kzg4844"
 	"github.com/ethereum/go-ethereum/params"
 	"github.com/holiman/uint256"
-	"math"
-	"math/big"
 )
 
 // ExecutionResult includes all output after executing given evm


### PR DESCRIPTION
There's two 7702 edge-cases where we will set code of an account when it did not actually change:

* clearing a 7702 delegation on an account that wasn't previously delegated
* re-delegating to the same contract that was previously-delegated to.

The motivation behind this PR is mainly that I think tracing code change hooks should only be invoked if there is an actual code change.