### PR TITLE
core/vm: don't call SetCode after contract creation if initcode didn't return anything

### DIFF
--- a/core/vm/evm.go
+++ b/core/vm/evm.go
@@ -601,7 +601,9 @@ func (evm *EVM) initNewContract(contract *Contract, address common.Address) ([]b
 		}
 	}
 
-	evm.StateDB.SetCode(address, ret, tracing.CodeChangeContractCreation)
+	if len(ret) > 0 {
+		evm.StateDB.SetCode(address, ret, tracing.CodeChangeContractCreation)
+	}
 	return ret, nil
 }
 


### PR DESCRIPTION
The code change is a noop here, and the tracing hook shouldn't be invoked if the account code doesn't actually change.