### PR TITLE
core/vm: optimize opCreate and opCreate2 by not copy memory

### DIFF
--- a/core/vm/instructions.go
+++ b/core/vm/instructions.go
@@ -659,7 +659,7 @@ func opCreate(pc *uint64, evm *EVM, scope *ScopeContext) ([]byte, error) {
 	var (
 		value        = scope.Stack.pop()
 		offset, size = scope.Stack.pop(), scope.Stack.pop()
-		input        = scope.Memory.GetCopy(offset.Uint64(), size.Uint64())
+		input        = scope.Memory.GetPtr(offset.Uint64(), size.Uint64())
 		gas          = scope.Contract.Gas
 	)
 	if evm.chainRules.IsEIP150 {
@@ -703,7 +703,7 @@ func opCreate2(pc *uint64, evm *EVM, scope *ScopeContext) ([]byte, error) {
 		endowment    = scope.Stack.pop()
 		offset, size = scope.Stack.pop(), scope.Stack.pop()
 		salt         = scope.Stack.pop()
-		input        = scope.Memory.GetCopy(offset.Uint64(), size.Uint64())
+		input        = scope.Memory.GetPtr(offset.Uint64(), size.Uint64())
 		gas          = scope.Contract.Gas
 	)
 


### PR DESCRIPTION
```
goos: darwin
goarch: arm64
pkg: github.com/ethereum/go-ethereum/core/vm/runtime
cpu: Apple M1 Pro
                    │   old.txt    │               new.txt               │
                    │    sec/op    │   sec/op     vs base                │
EVM_CREATE_500-10     16.285m ± 2%   1.701m ± 1%  -89.55% (p=0.000 n=10)
EVM_CREATE2_500-10     97.04m ± 0%   93.26m ± 1%   -3.90% (p=0.000 n=10)
EVM_CREATE_1200-10    22.029m ± 1%   1.338m ± 1%  -93.93% (p=0.000 n=10)
EVM_CREATE2_1200-10    82.56m ± 0%   80.26m ± 1%   -2.78% (p=0.001 n=10)
geomean                41.17m        11.43m       -72.25%

                    │    old.txt     │               new.txt                │
                    │      B/op      │     B/op      vs base                │
EVM_CREATE_500-10     144.244Mi ± 0%   1.091Mi ± 0%  -99.24% (p=0.000 n=10)
EVM_CREATE2_500-10    37926.2Ki ± 0%   660.1Ki ± 0%  -98.26% (p=0.000 n=10)
EVM_CREATE_1200-10    256.900Mi ± 0%   1.606Mi ± 0%  -99.37% (p=0.000 n=10)
EVM_CREATE2_1200-10    32.245Mi ± 0%   1.208Mi ± 0%  -96.25% (p=0.000 n=10)
geomean                 81.56Mi        1.081Mi       -98.67%

                    │   old.txt   │              new.txt               │
                    │  allocs/op  │  allocs/op   vs base               │
EVM_CREATE_500-10     15.28k ± 0%   14.52k ± 0%  -4.93% (p=0.000 n=10)
EVM_CREATE2_500-10    3.888k ± 0%   3.700k ± 0%  -4.82% (p=0.000 n=10)
EVM_CREATE_1200-10    11.72k ± 0%   10.90k ± 0%  -6.94% (p=0.000 n=10)
EVM_CREATE2_1200-10   1.425k ± 0%   1.348k ± 0%  -5.44% (p=0.000 n=10)
geomean               5.612k        5.301k       -5.54%
```