### PR TITLE
core: prioritize the heavy transaction for prefetching

### DIFF
--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -108,6 +108,7 @@ var (
 	blockPrefetchInterruptMeter  = metrics.NewRegisteredMeter("chain/prefetch/interrupts", nil)
 	blockPrefetchTxsInvalidMeter = metrics.NewRegisteredMeter("chain/prefetch/txs/invalid", nil)
 	blockPrefetchTxsValidMeter   = metrics.NewRegisteredMeter("chain/prefetch/txs/valid", nil)
+	blockPrefetchHeavyTxsMeter   = metrics.NewRegisteredMeter("chain/prefetch/txs/heavy", nil)
 
 	errInsertionInterrupted = errors.New("insertion is interrupted")
 	errChainStopped         = errors.New("blockchain is stopped")

--- a/core/state_prefetcher.go
+++ b/core/state_prefetcher.go
@@ -120,15 +120,19 @@ func (p *statePrefetcher) Prefetch(block *types.Block, statedb *state.StateDB, c
 		}
 	}
 	for {
-		tx, done := fetchTx()
+		next, done := fetchTx()
 		if done {
 			break
 		}
-		if _, exists := processed[tx.Hash()]; exists {
+		if _, exists := processed[next.Hash()]; exists {
 			continue
 		}
-		stateCpy := statedb.Copy() // closure
+		processed[next.Hash()] = struct{}{}
 
+		var (
+			stateCpy = statedb.Copy() // closure
+			tx       = next           // closure
+		)
 		workers.Go(func() error {
 			// If block precaching was interrupted, abort
 			if interrupt != nil && interrupt.Load() {


### PR DESCRIPTION
This PR purposes a new way of transaction prefetching priority. The core idea is "heavy transaction"
should have higher priority as prefetching, giving them more time to prefetch the states before
execution.