### PR TITLE
core/state: remove unused TransitionStatePerRoot cache from CachingDB

### DIFF
--- a/core/state/database.go
+++ b/core/state/database.go
@@ -160,21 +160,17 @@ type CachingDB struct {
 	codeCache     *lru.SizeConstrainedCache[common.Hash, []byte]
 	codeSizeCache *lru.Cache[common.Hash, int]
 	pointCache    *utils.PointCache
-
-	// Transition-specific fields
-	TransitionStatePerRoot *lru.Cache[common.Hash, *overlay.TransitionState]
 }
 
 // NewDatabase creates a state database with the provided data sources.
 func NewDatabase(triedb *triedb.Database, snap *snapshot.Tree) *CachingDB {
 	return &CachingDB{
-		disk:                   triedb.Disk(),
-		triedb:                 triedb,
-		snap:                   snap,
-		codeCache:              lru.NewSizeConstrainedCache[common.Hash, []byte](codeCacheSize),
-		codeSizeCache:          lru.NewCache[common.Hash, int](codeSizeCacheSize),
-		pointCache:             utils.NewPointCache(pointCacheSize),
-		TransitionStatePerRoot: lru.NewCache[common.Hash, *overlay.TransitionState](1000),
+		disk:          triedb.Disk(),
+		triedb:        triedb,
+		snap:          snap,
+		codeCache:     lru.NewSizeConstrainedCache[common.Hash, []byte](codeCacheSize),
+		codeSizeCache: lru.NewCache[common.Hash, int](codeSizeCacheSize),
+		pointCache:    utils.NewPointCache(pointCacheSize),
 	}
 }
 


### PR DESCRIPTION
This change removes the TransitionStatePerRoot field and its initialization from core/state/database.go because it is never referenced anywhere in the codebase. All transition state lookups use overlay.LoadTransitionState directly, and no documentation or comments indicate that an in-memory cache is intended here. Keeping an unreferenced lru cache is misleading, increases maintenance surface, and risks confusion about how transition state is managed. Removing the dead code clarifies intent and avoids allocating unnecessary structures without altering runtime behavior