### PR TITLE
internal/jsre: pass only extra args to setTimeout/setInterval callbacks

### DIFF
--- a/internal/jsre/jsre.go
+++ b/internal/jsre/jsre.go
@@ -201,7 +201,7 @@ loop:
 			if !isFunc {
 				panic(re.vm.ToValue("js error: timer/timeout callback is not a function"))
 			}
-			call(goja.Null(), timer.call.Arguments...)
+			call(goja.Null(), timer.call.Arguments[2:]...)
 
 			_, inreg := registry[timer] // when clearInterval is called from within the callback don't reset it
 			if timer.interval && inreg {


### PR DESCRIPTION


## Description
- Summary: Correct the JS timer callback argument forwarding to match standard JS semantics.
- What changed: In `internal/jsre/jsre.go`, the callback is now invoked with only the arguments after the callback and delay.
- Why: Previously, the callback received the function and delay as parameters, causing unexpected behavior and logic bugs for consumers.
