### PR TITLE
refactor: remove redundant slice expression in bytes.NewBuffer call

### DIFF
--- a/core/overlay/state_transition.go
+++ b/core/overlay/state_transition.go
@@ -80,7 +80,7 @@ func LoadTransitionState(db ethdb.KeyValueReader, root common.Hash, isVerkle boo
 	if len(data) > 0 {
 		var (
 			newts TransitionState
-			buf   = bytes.NewBuffer(data[:])
+			buf   = bytes.NewBuffer(data)
 			dec   = gob.NewDecoder(buf)
 		)
 		// Decode transition state


### PR DESCRIPTION
Found this redundant [:] while going through the code. The data[:] doesn't actually copy anything, just creates a new slice header pointing to the same data. Checked the rest of the codebase and this is the only place using bytes.NewBuffer(data[:]) - everywhere else uses the standard patterns. Cleaned it up for consistency.