### PR TITLE
accounts/abi: optimize mustArrayToByteSlice

### DIFF
--- a/accounts/abi/reflect.go
+++ b/accounts/abi/reflect.go
@@ -89,10 +89,11 @@ func reflectIntType(unsigned bool, size int) reflect.Type {
 
 // mustArrayToByteSlice creates a new byte slice with the exact same size as value
 // and copies the bytes in value to the new slice.
-func mustArrayToByteSlice(value reflect.Value) reflect.Value {
-	slice := reflect.ValueOf(make([]byte, value.Len()))
-	reflect.Copy(slice, value)
-	return slice
+func mustArrayToByteSlice(value reflect.Value) []byte {
+	ptr := reflect.New(value.Type())
+	ptr.Elem().Set(value)
+	ret := ptr.Elem().Bytes()
+	return ret
 }
 
 // set attempts to assign src to dst by either setting, copying or otherwise.


### PR DESCRIPTION
```
func BenchmarkMustArrayToByteSlice(b *testing.B) {
	for _, size := range []int{1, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024, 2048, 4096, 8192, 16384} {
		b.Run(fmt.Sprint(size), func(b *testing.B) {
			// Create array type
			arrayType := reflect.ArrayOf(size, reflect.TypeFor[byte]())
			// Create reflect value
			val := reflect.New(arrayType)
			// Benchmark
			b.ResetTimer()
			for i := 0; i < b.N; i++ {
				_ = mustArrayToByteSlice(val.Elem())
			}
		})
	}
}

```

```
goos: darwin
goarch: arm64
pkg: github.com/ethereum/go-ethereum/accounts/abi
cpu: Apple M1 Pro
                              │   old.txt    │               new.txt                │
                              │    sec/op    │    sec/op     vs base                │
MustArrayToByteSlice/1-10       36.37n ±  2%   30.03n ±  3%  -17.43% (p=0.000 n=10)
MustArrayToByteSlice/2-10       38.31n ±  2%   29.75n ±  0%  -22.35% (p=0.000 n=10)
MustArrayToByteSlice/4-10       39.51n ±  2%   31.05n ±  0%  -21.39% (p=0.000 n=10)
MustArrayToByteSlice/8-10       38.23n ±  0%   30.95n ±  2%  -19.04% (p=0.000 n=10)
MustArrayToByteSlice/16-10      41.68n ±  0%   33.81n ±  0%  -18.88% (p=0.000 n=10)
MustArrayToByteSlice/32-10      43.97n ±  0%   31.33n ±  1%  -28.75% (p=0.000 n=10)
MustArrayToByteSlice/64-10      46.21n ±  5%   37.73n ±  0%  -18.36% (p=0.000 n=10)
MustArrayToByteSlice/128-10     58.96n ±  0%   46.30n ±  7%  -21.46% (p=0.000 n=10)
MustArrayToByteSlice/256-10     71.98n ±  2%   57.97n ±  0%  -19.46% (p=0.000 n=10)
MustArrayToByteSlice/512-10     92.80n ±  1%   81.11n ±  2%  -12.60% (p=0.000 n=10)
MustArrayToByteSlice/1024-10    137.4n ± 19%   130.1n ±  1%   -5.31% (p=0.001 n=10)
MustArrayToByteSlice/2048-10    248.7n ±  8%   236.4n ±  1%   -4.93% (p=0.000 n=10)
MustArrayToByteSlice/4096-10    471.4n ±  3%   458.9n ±  1%   -2.65% (p=0.000 n=10)
MustArrayToByteSlice/8192-10    901.8n ± 20%   867.6n ±  1%   -3.79% (p=0.000 n=10)
MustArrayToByteSlice/16384-10   1.479µ ± 12%   1.505µ ± 24%        ~ (p=0.985 n=10)
geomean                         102.8n         87.62n        -14.75%

                              │   old.txt    │               new.txt                │
                              │     B/op     │     B/op      vs base                │
MustArrayToByteSlice/1-10        25.000 ± 0%     1.000 ± 0%  -96.00% (p=0.000 n=10)
MustArrayToByteSlice/2-10        26.000 ± 0%     2.000 ± 0%  -92.31% (p=0.000 n=10)
MustArrayToByteSlice/4-10        28.000 ± 0%     4.000 ± 0%  -85.71% (p=0.000 n=10)
MustArrayToByteSlice/8-10        32.000 ± 0%     8.000 ± 0%  -75.00% (p=0.000 n=10)
MustArrayToByteSlice/16-10        40.00 ± 0%     16.00 ± 0%  -60.00% (p=0.000 n=10)
MustArrayToByteSlice/32-10        56.00 ± 0%     32.00 ± 0%  -42.86% (p=0.000 n=10)
MustArrayToByteSlice/64-10        88.00 ± 0%     64.00 ± 0%  -27.27% (p=0.000 n=10)
MustArrayToByteSlice/128-10       152.0 ± 0%     128.0 ± 0%  -15.79% (p=0.000 n=10)
MustArrayToByteSlice/256-10       280.0 ± 0%     256.0 ± 0%   -8.57% (p=0.000 n=10)
MustArrayToByteSlice/512-10       536.0 ± 0%     512.0 ± 0%   -4.48% (p=0.000 n=10)
MustArrayToByteSlice/1024-10    1.023Ki ± 0%   1.000Ki ± 0%   -2.29% (p=0.000 n=10)
MustArrayToByteSlice/2048-10    2.023Ki ± 0%   2.000Ki ± 0%   -1.16% (p=0.000 n=10)
MustArrayToByteSlice/4096-10    4.023Ki ± 0%   4.000Ki ± 0%   -0.58% (p=0.000 n=10)
MustArrayToByteSlice/8192-10    8.023Ki ± 0%   8.000Ki ± 0%   -0.29% (p=0.000 n=10)
MustArrayToByteSlice/16384-10   16.02Ki ± 0%   16.00Ki ± 0%   -0.15% (p=0.000 n=10)
geomean                           271.2          128.0       -52.80%

                              │  old.txt   │              new.txt               │
                              │ allocs/op  │ allocs/op   vs base                │
MustArrayToByteSlice/1-10       2.000 ± 0%   1.000 ± 0%  -50.00% (p=0.000 n=10)
MustArrayToByteSlice/2-10       2.000 ± 0%   1.000 ± 0%  -50.00% (p=0.000 n=10)
MustArrayToByteSlice/4-10       2.000 ± 0%   1.000 ± 0%  -50.00% (p=0.000 n=10)
MustArrayToByteSlice/8-10       2.000 ± 0%   1.000 ± 0%  -50.00% (p=0.000 n=10)
MustArrayToByteSlice/16-10      2.000 ± 0%   1.000 ± 0%  -50.00% (p=0.000 n=10)
MustArrayToByteSlice/32-10      2.000 ± 0%   1.000 ± 0%  -50.00% (p=0.000 n=10)
MustArrayToByteSlice/64-10      2.000 ± 0%   1.000 ± 0%  -50.00% (p=0.000 n=10)
MustArrayToByteSlice/128-10     2.000 ± 0%   1.000 ± 0%  -50.00% (p=0.000 n=10)
MustArrayToByteSlice/256-10     2.000 ± 0%   1.000 ± 0%  -50.00% (p=0.000 n=10)
MustArrayToByteSlice/512-10     2.000 ± 0%   1.000 ± 0%  -50.00% (p=0.000 n=10)
MustArrayToByteSlice/1024-10    2.000 ± 0%   1.000 ± 0%  -50.00% (p=0.000 n=10)
MustArrayToByteSlice/2048-10    2.000 ± 0%   1.000 ± 0%  -50.00% (p=0.000 n=10)
MustArrayToByteSlice/4096-10    2.000 ± 0%   1.000 ± 0%  -50.00% (p=0.000 n=10)
MustArrayToByteSlice/8192-10    2.000 ± 0%   1.000 ± 0%  -50.00% (p=0.000 n=10)
MustArrayToByteSlice/16384-10   2.000 ± 0%   1.000 ± 0%  -50.00% (p=0.000 n=10)
geomean                         2.000        1.000       -50.00%
```