### PR TITLE
signer: optimize parseBytes

### DIFF
--- a/signer/core/apitypes/types.go
+++ b/signer/core/apitypes/types.go
@@ -547,9 +547,9 @@ func parseBytes(encType interface{}) ([]byte, bool) {
 	// Handle array types.
 	val := reflect.ValueOf(encType)
 	if val.Kind() == reflect.Array && val.Type().Elem().Kind() == reflect.Uint8 {
-		v := reflect.ValueOf(make([]byte, val.Len()))
-		reflect.Copy(v, val)
-		return v.Bytes(), true
+		newV := reflect.New(val.Type()).Elem()
+		newV.Set(val)
+		return newV.Bytes(), true
 	}
 
 	switch v := encType.(type) {


### PR DESCRIPTION
```
func Benchmark_parseBytes(b *testing.B) {
	for b.Loop() {
		_, ok := parseBytes([32]byte{})
		if ok != true {
			b.Fatalf("expected true")
		}
	}
}
```

```
goos: darwin
goarch: arm64
pkg: github.com/ethereum/go-ethereum/signer/core/apitypes
cpu: Apple M1 Pro
               │   old.txt    │               new.txt               │
               │    sec/op    │   sec/op     vs base                │
_parseBytes-10   54.16n ± 27%   37.64n ± 0%  -30.51% (p=0.000 n=10)

               │  old.txt   │              new.txt               │
               │    B/op    │    B/op     vs base                │
_parseBytes-10   56.00 ± 0%   32.00 ± 0%  -42.86% (p=0.000 n=10)

               │  old.txt   │              new.txt               │
               │ allocs/op  │ allocs/op   vs base                │
_parseBytes-10   2.000 ± 0%   1.000 ± 0%  -50.00% (p=0.000 n=10)
```