### PR TITLE
accounts: use hash pool in TextHash

### DIFF
--- a/accounts/accounts.go
+++ b/accounts/accounts.go
@@ -20,12 +20,13 @@ package accounts
 import (
 	"fmt"
 	"math/big"
+	"unsafe"
 
 	"github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/event"
-	"golang.org/x/crypto/sha3"
 )
 
 // Account represents an Ethereum account located at a specific location defined
@@ -196,9 +197,8 @@ func TextHash(data []byte) []byte {
 // This gives context to the signed message and prevents signing of transactions.
 func TextAndHash(data []byte) ([]byte, string) {
 	msg := fmt.Sprintf("\x19Ethereum Signed Message:\n%d%s", len(data), data)
-	hasher := sha3.NewLegacyKeccak256()
-	hasher.Write([]byte(msg))
-	return hasher.Sum(nil), msg
+	hash := crypto.Keccak256(unsafe.Slice(unsafe.StringData(msg), len(msg)))
+	return hash, msg
 }
 
 // WalletEventType represents the different event types that can be fired by


### PR DESCRIPTION
```
func BenchmarkTextHash(b *testing.B) {
	// warm up
	_ = TextHash([]byte("Hello Joe"))

	for b.Loop() {
		_ = TextHash([]byte("Hello Joe"))
	}
}
```

```
goos: darwin
goarch: arm64
pkg: github.com/ethereum/go-ethereum/accounts
cpu: Apple M1 Pro
            │   old.txt   │              new.txt               │
            │   sec/op    │   sec/op     vs base               │
TextHash-10   505.1n ± 1%   484.2n ± 0%  -4.15% (p=0.000 n=10)

            │  old.txt   │              new.txt               │
            │    B/op    │    B/op     vs base                │
TextHash-10   168.0 ± 0%   120.0 ± 0%  -28.57% (p=0.000 n=10)

            │  old.txt   │              new.txt               │
            │ allocs/op  │ allocs/op   vs base                │
TextHash-10   5.000 ± 0%   4.000 ± 0%  -20.00% (p=0.000 n=10)

```