### PR TITLE
core/types: prealloc map in HashDifference as in TxDifference

### DIFF
--- a/core/types/transaction.go
+++ b/core/types/transaction.go
@@ -648,7 +648,7 @@ func TxDifference(a, b Transactions) Transactions {
 func HashDifference(a, b []common.Hash) []common.Hash {
 	keep := make([]common.Hash, 0, len(a))
 
-	remove := make(map[common.Hash]struct{})
+	remove := make(map[common.Hash]struct{}, len(b))
 	for _, hash := range b {
 		remove[hash] = struct{}{}
 	}


### PR DESCRIPTION
Align  to this:
https://github.com/ethereum/go-ethereum/blob/10421edf3e8527c653cae0359410b60ca118fdc4/core/types/transaction.go#L633