### PR TITLE
core/vm: optimze emit event using uint256.WriteToArray32

### DIFF
--- a/core/vm/instructions.go
+++ b/core/vm/instructions.go
@@ -933,7 +933,7 @@ func makeLog(size int) executionFunc {
 		mStart, mSize := stack.pop(), stack.pop()
 		for i := 0; i < size; i++ {
 			addr := stack.pop()
-			topics[i] = addr.Bytes32()
+			addr.WriteToArray32((*[32]byte)(&topics[i]))
 		}
 
 		d := scope.Memory.GetCopy(mStart.Uint64(), mSize.Uint64())


### PR DESCRIPTION
```
goos: darwin
goarch: arm64
pkg: github.com/ethereum/go-ethereum/core/vm
cpu: Apple M1 Pro
        │   old.txt   │              new.txt               │
        │   sec/op    │   sec/op     vs base               │
Log3-10   269.0n ± 6%   250.8n ± 3%  -6.75% (p=0.000 n=20)

        │  old.txt   │           new.txt            │
        │    B/op    │    B/op     vs base          │
Log3-10   627.0 ± 1%   629.0 ± 1%  ~ (p=0.963 n=20)

        │  old.txt   │            new.txt             │
        │ allocs/op  │ allocs/op   vs base            │
Log3-10   9.000 ± 0%   9.000 ± 0%  ~ (p=1.000 n=20) ¹
¹ all samples are equal
```