### PR TITLE
eth/filters: avoid rebuild the hash map multi times

### DIFF
--- a/eth/filters/filter.go
+++ b/eth/filters/filter.go
@@ -563,7 +563,7 @@ type ReceiptWithTx struct {
 // In addition to returning receipts, it also returns the corresponding transactions.
 // This is because receipts only contain low-level data, while user-facing data
 // may require additional information from the Transaction.
-func filterReceipts(txHashMap map[common.Hash]bool, ev core.ChainEvent) []*ReceiptWithTx {
+func filterReceipts(txHashes map[common.Hash]bool, ev core.ChainEvent) []*ReceiptWithTx {
 	var ret []*ReceiptWithTx
 
 	receipts := ev.Receipts
@@ -574,7 +574,7 @@ func filterReceipts(txHashMap map[common.Hash]bool, ev core.ChainEvent) []*Recei
 		return ret
 	}
 
-	if len(txHashMap) == 0 {
+	if len(txHashes) == 0 {
 		// No filter, send all receipts with their transactions.
 		ret = make([]*ReceiptWithTx, len(receipts))
 		for i, receipt := range receipts {
@@ -585,14 +585,14 @@ func filterReceipts(txHashMap map[common.Hash]bool, ev core.ChainEvent) []*Recei
 		}
 	} else {
 		for i, receipt := range receipts {
-			if txHashMap[receipt.TxHash] {
+			if txHashes[receipt.TxHash] {
 				ret = append(ret, &ReceiptWithTx{
 					Receipt:     receipt,
 					Transaction: txs[i],
 				})
 
 				// Early exit if all receipts are found
-				if len(ret) == len(txHashMap) {
+				if len(ret) == len(txHashes) {
 					break
 				}
 			}

--- a/eth/filters/filter_system.go
+++ b/eth/filters/filter_system.go
@@ -185,7 +185,7 @@ type subscription struct {
 	txs       chan []*types.Transaction
 	headers   chan *types.Header
 	receipts  chan []*ReceiptWithTx
-	hashSet   map[common.Hash]bool // contains transaction hashes for transactionReceipts subscription filtering
+	txHashes  map[common.Hash]bool // contains transaction hashes for transactionReceipts subscription filtering
 	installed chan struct{}        // closed when the filter is installed
 	err       chan error           // closed when the filter is uninstalled
 }
@@ -415,7 +415,7 @@ func (es *EventSystem) SubscribeTransactionReceipts(txHashes []common.Hash, rece
 		txs:       make(chan []*types.Transaction),
 		headers:   make(chan *types.Header),
 		receipts:  receipts,
-		hashSet:   hashSet,
+		txHashes:  hashSet,
 		installed: make(chan struct{}),
 		err:       make(chan error),
 	}
@@ -449,7 +449,7 @@ func (es *EventSystem) handleChainEvent(filters filterIndex, ev core.ChainEvent)
 
 	// Handle transaction receipts subscriptions when a new block is added
 	for _, f := range filters[TransactionReceiptsSubscription] {
-		matchedReceipts := filterReceipts(f.hashSet, ev)
+		matchedReceipts := filterReceipts(f.txHashes, ev)
 		if len(matchedReceipts) > 0 {
 			f.receipts <- matchedReceipts
 		}


### PR DESCRIPTION
When every new `ChainEvent` comes, it can trigger the building of a `HashMap`, so to avoid that, we can build the `HashMap` at the beginning. This way can also prevent being attacked by mock hashes from dishonest clients. 