### PR TITLE
common: simplify FileExist helper

### DIFF
--- a/common/path.go
+++ b/common/path.go
@@ -17,6 +17,8 @@
 package common
 
 import (
+	"errors"
+	"io/fs"
 	"os"
 	"path/filepath"
 )


### PR DESCRIPTION
replace the manual if err != nil && os.IsNotExist(err) check with return !os.IsNotExist(err) in common/path.go. Remove the redundant branch while keeping behaviour identical and relying on the standard-library helper for readability