### PR TITLE
trie: simplify code

### DIFF
--- a/trie/encoding.go
+++ b/trie/encoding.go
@@ -138,16 +138,13 @@ func decodeNibbles(nibbles []byte, bytes []byte) {
 
 // prefixLen returns the length of the common prefix of a and b.
 func prefixLen(a, b []byte) int {
-	var i, length = 0, len(a)
-	if len(b) < length {
-		length = len(b)
-	}
-	for ; i < length; i++ {
+	n := min(len(a), len(b))
+	for i := range n {
 		if a[i] != b[i] {
-			break
+			return i
 		}
 	}
-	return i
+	return n
 }
 
 // hasTerm returns whether a hex key has the terminator flag.


### PR DESCRIPTION
align to sharedLen in 
https://github.com/ethereum/go-ethereum/blob/11c0fb98af8ba14deb6abe77b357cbe927ba05ba/triedb/pathdb/history_trienode.go#L163-L169