### PR TITLE
core/state: parallelize account trie updates in IntermediateRoot

### DIFF
--- a/core/state/statedb.go
+++ b/core/state/statedb.go
@@ -855,8 +855,6 @@ func (s *StateDB) IntermediateRoot(deleteEmptyObjects bool) common.Hash {
 			continue
 		}
 		obj := s.stateObjects[addr] // closure for the task runner below
-		addr := addr
-		op := op
 		workers.Go(func() error {
 			if s.db.TrieDB().IsVerkle() {
 				obj.updateTrie()


### PR DESCRIPTION
It refactors IntermediateRoot to parallelize account trie updates, improving performance by hashing the account trie and storage tries concurrently.