### PR TITLE
all: big.Int use `Sign()` to compare with zero

### DIFF
--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -424,7 +424,7 @@ func NewBlockChain(db ethdb.Database, genesis *Genesis, engine consensus.Engine,
 	// if there is no available state, waiting for state sync.
 	head := bc.CurrentBlock()
 	if !bc.HasState(head.Root) {
-		if head.Number.Uint64() == 0 {
+		if head.Number.Sign() == 0 {
 			// The genesis state is missing, which is only possible in the path-based
 			// scheme. This situation occurs when the initial state sync is not finished
 			// yet, or the chain head is rewound below the pivot point. In both scenarios,
@@ -501,7 +501,7 @@ func NewBlockChain(db ethdb.Database, genesis *Genesis, engine consensus.Engine,
 		bc.logger.OnBlockchainInit(chainConfig)
 	}
 	if bc.logger != nil && bc.logger.OnGenesisBlock != nil {
-		if block := bc.CurrentBlock(); block.Number.Uint64() == 0 {
+		if block := bc.CurrentBlock(); block.Number.Sign() == 0 {
 			alloc, err := getGenesisState(bc.db, block.Hash())
 			if err != nil {
 				return nil, fmt.Errorf("failed to get genesis state: %w", err)
@@ -742,7 +742,7 @@ func (bc *BlockChain) SetHead(head uint64) error {
 	if block := bc.GetBlock(header.Hash(), header.Number.Uint64()); block == nil {
 		// In a pruned node the genesis block will not exist in the freezer.
 		// It should not happen that we set head to any other pruned block.
-		if header.Number.Uint64() > 0 {
+		if header.Number.Sign() > 0 {
 			// This should never happen. In practice, previously currentBlock
 			// contained the entire block whereas now only a "marker", so there
 			// is an ever so slight chance for a race we should handle.
@@ -767,7 +767,7 @@ func (bc *BlockChain) SetHeadWithTimestamp(timestamp uint64) error {
 	if block := bc.GetBlock(header.Hash(), header.Number.Uint64()); block == nil {
 		// In a pruned node the genesis block will not exist in the freezer.
 		// It should not happen that we set head to any other pruned block.
-		if header.Number.Uint64() > 0 {
+		if header.Number.Sign() > 0 {
 			// This should never happen. In practice, previously currentBlock
 			// contained the entire block whereas now only a "marker", so there
 			// is an ever so slight chance for a race we should handle.
@@ -860,7 +860,7 @@ func (bc *BlockChain) rewindHashHead(head *types.Header, root common.Hash) (*typ
 			head = parent
 
 			// If the genesis block is reached, stop searching.
-			if head.Number.Uint64() == 0 {
+			if head.Number.Sign() == 0 {
 				log.Info("Genesis block reached", "number", head.Number, "hash", head.Hash())
 				return head, rootNumber
 			}
@@ -868,7 +868,7 @@ func (bc *BlockChain) rewindHashHead(head *types.Header, root common.Hash) (*typ
 		}
 		// Once the available state is found, ensure that the requested root
 		// has already been crossed. If not, continue rewinding.
-		if beyondRoot || head.Number.Uint64() == 0 {
+		if beyondRoot || head.Number.Sign() == 0 {
 			log.Info("Rewound to block with state", "number", head.Number, "hash", head.Hash())
 			return head, rootNumber
 		}
@@ -937,7 +937,7 @@ func (bc *BlockChain) rewindPathHead(head *types.Header, root common.Hash) (*typ
 		head = parent
 
 		// If the genesis block is reached, stop searching.
-		if head.Number.Uint64() == 0 {
+		if head.Number.Sign() == 0 {
 			log.Info("Genesis block reached", "number", head.Number, "hash", head.Hash())
 			return head, rootNumber
 		}
@@ -1015,7 +1015,7 @@ func (bc *BlockChain) setHeadBeyondRoot(head uint64, time uint64, root common.Ha
 			// approach except for rerunning a snap sync. Do nothing here until the
 			// state syncer picks it up.
 			if !bc.HasState(newHeadBlock.Root) {
-				if newHeadBlock.Number.Uint64() != 0 {
+				if newHeadBlock.Number.Sign() != 0 {
 					log.Crit("Chain is stateless at a non-genesis block")
 				}
 				log.Info("Chain is stateless, wait state sync", "number", newHeadBlock.Number, "hash", newHeadBlock.Hash())

--- a/eth/filters/filter.go
+++ b/eth/filters/filter.go
@@ -492,10 +492,10 @@ func (f *Filter) checkMatches(ctx context.Context, header *types.Header) ([]*typ
 // filterLogs creates a slice of logs matching the given criteria.
 func filterLogs(logs []*types.Log, fromBlock, toBlock *big.Int, addresses []common.Address, topics [][]common.Hash) []*types.Log {
 	var check = func(log *types.Log) bool {
-		if fromBlock != nil && fromBlock.Int64() >= 0 && fromBlock.Uint64() > log.BlockNumber {
+		if fromBlock != nil && fromBlock.Sign() >= 0 && fromBlock.Uint64() > log.BlockNumber {
 			return false
 		}
-		if toBlock != nil && toBlock.Int64() >= 0 && toBlock.Uint64() < log.BlockNumber {
+		if toBlock != nil && toBlock.Sign() >= 0 && toBlock.Uint64() < log.BlockNumber {
 			return false
 		}
 		if len(addresses) > 0 && !slices.Contains(addresses, log.Address) {

--- a/eth/gasprice/gasprice.go
+++ b/eth/gasprice/gasprice.go
@@ -93,15 +93,15 @@ func NewOracle(backend OracleBackend, params Config, startPrice *big.Int) *Oracl
 		log.Warn("Sanitizing invalid gasprice oracle sample percentile", "provided", params.Percentile, "updated", percent)
 	}
 	maxPrice := params.MaxPrice
-	if maxPrice == nil || maxPrice.Int64() <= 0 {
+	if maxPrice == nil || maxPrice.Sign() <= 0 {
 		maxPrice = DefaultMaxPrice
 		log.Warn("Sanitizing invalid gasprice oracle price cap", "provided", params.MaxPrice, "updated", maxPrice)
 	}
 	ignorePrice := params.IgnorePrice
-	if ignorePrice == nil || ignorePrice.Int64() <= 0 {
+	if ignorePrice == nil || ignorePrice.Sign() <= 0 {
 		ignorePrice = DefaultIgnorePrice
 		log.Warn("Sanitizing invalid gasprice oracle ignore price", "provided", params.IgnorePrice, "updated", ignorePrice)
-	} else if ignorePrice.Int64() > 0 {
+	} else if ignorePrice.Sign() > 0 {
 		log.Info("Gasprice oracle is ignoring threshold set", "threshold", ignorePrice)
 	}
 	maxHeaderHistory := params.MaxHeaderHistory

--- a/eth/handler.go
+++ b/eth/handler.go
@@ -171,7 +171,7 @@ func newHandler(config *handlerConfig) (*handler, error) {
 		//   time. But we don't have any recent state for full sync.
 		// In these cases however it's safe to reenable snap sync.
 		fullBlock, snapBlock := h.chain.CurrentBlock(), h.chain.CurrentSnapBlock()
-		if fullBlock.Number.Uint64() == 0 && snapBlock.Number.Uint64() > 0 {
+		if fullBlock.Number.Sign() == 0 && snapBlock.Number.Sign() > 0 {
 			h.snapSync.Store(true)
 			log.Warn("Switch sync mode from full sync to snap sync", "reason", "snap sync incomplete")
 		} else if !h.chain.HasState(fullBlock.Root) {
@@ -180,7 +180,7 @@ func newHandler(config *handlerConfig) (*handler, error) {
 		}
 	} else {
 		head := h.chain.CurrentBlock()
-		if head.Number.Uint64() > 0 && h.chain.HasState(head.Root) {
+		if head.Number.Sign() > 0 && h.chain.HasState(head.Root) {
 			log.Info("Switch sync mode from snap sync to full sync", "reason", "snap sync complete")
 		} else {
 			// If snap sync was requested and our database is empty, grant it


### PR DESCRIPTION
This PR uses `Sign()` to compare big.Int with zero, reasons:

- `Sign()` has better performance 
- prevent overflow when converting to 64 bit integers