### PR TITLE
metrics/log: replace time.Tick with time.NewTicker to prevent timer leaks

### DIFF
--- a/metrics/log.go
+++ b/metrics/log.go
@@ -18,7 +18,10 @@ func LogScaled(r Registry, freq time.Duration, scale time.Duration, l Logger) {
 	du := float64(scale)
 	duSuffix := scale.String()[1:]
 
-	for range time.Tick(freq) {
+	ticker := time.NewTicker(freq)
+	defer ticker.Stop()
+
+	for range ticker.C {
 		r.Each(func(name string, i interface{}) {
 			switch metric := i.(type) {
 			case *Counter:


### PR DESCRIPTION


### PR Description 
Replace `time.Tick` with `time.NewTicker` in `metrics/log.go` to enable proper teardown and avoid leaking timers.

## Rationale
- `time.Tick` cannot be stopped, which may lead to timer/goroutine leaks.
- `time.NewTicker` allows explicit stopping and supports graceful shutdown.

## Changes
- Use `time.NewTicker(freq)` with `defer ticker.Stop()` in `LogScaled`.

