### PR TITLE
metrics/json: extract common JSON marshaling logic to eliminate duplication

### DIFF
--- a/metrics/json.go
+++ b/metrics/json.go
@@ -6,10 +6,15 @@ import (
 	"time"
 )
 
+// Shared JSON serialization for registry types to avoid duplication.
+func marshalRegistryJSON(r Registry) ([]byte, error) {
+	return json.Marshal(r.GetAll())
+}
+
 // MarshalJSON returns a byte slice containing a JSON representation of all
 // the metrics in the Registry.
 func (r *StandardRegistry) MarshalJSON() ([]byte, error) {
-	return json.Marshal(r.GetAll())
+	return marshalRegistryJSON(r)
 }
 
 // WriteJSON writes metrics from the given registry  periodically to the
@@ -27,5 +32,5 @@ func WriteJSONOnce(r Registry, w io.Writer) {
 }
 
 func (r *PrefixedRegistry) MarshalJSON() ([]byte, error) {
-	return json.Marshal(r.GetAll())
+	return marshalRegistryJSON(r)
 }


### PR DESCRIPTION

Extract shared JSON marshaling logic into a private helper function to eliminate code duplication between `StandardRegistry.MarshalJSON` and `PrefixedRegistry.MarshalJSON`.

## 
- Both registry types had identical `MarshalJSON` implementations.
- Duplication increases maintenance burden and risk of inconsistencies.
- Common logic should be centralized to follow DRY principles.

## 
- Add private `marshalRegistryJSON(r Registry)` helper function.
- Update both `MarshalJSON` methods to use the shared helper.

