### PR TITLE
consensus/misc/eip4844: expose TargetBlobsPerBlock

### DIFF
--- a/consensus/misc/eip4844/eip4844.go
+++ b/consensus/misc/eip4844/eip4844.go
@@ -209,21 +209,6 @@ func TargetBlobsPerBlock(cfg *params.ChainConfig, time uint64) int {
 	return blobConfig.Target
 }
 
-// TargetBlobGasPerBlock returns the target blob gas that can be spent in a block at the given timestamp.
-func TargetBlobGasPerBlock(cfg *params.ChainConfig, time uint64) uint64 {
-	return uint64(TargetBlobsPerBlock(cfg, time)) * params.BlobTxBlobGasPerBlob
-}
-
-// LatestTargetBlobsPerBlock returns the latest target blobs per block defined by the
-// configuration, regardless of the currently active fork.
-func LatestTargetBlobsPerBlock(cfg *params.ChainConfig) int {
-	bcfg := latestBlobConfig(cfg, math.MaxUint64)
-	if bcfg == nil {
-		return 0
-	}
-	return bcfg.Target
-}
-
 // fakeExponential approximates factor * e ** (numerator / denominator) using
 // Taylor expansion.
 func fakeExponential(factor, numerator, denominator *big.Int) *big.Int {


### PR DESCRIPTION
Rollups may want to use these to dynamically adjust blobs posted after BPO forks.