### PR TITLE
core/state: fix the flaky TestSizeTracker

### DIFF
--- a/core/state/state_sizer_test.go
+++ b/core/state/state_sizer_test.go
@@ -223,13 +223,12 @@ func TestSizeTracker(t *testing.T) {
 	if actualStats.ContractCodeBytes != expectedStats.ContractCodeBytes {
 		t.Errorf("Contract code bytes mismatch: expected %d, got %d", expectedStats.ContractCodeBytes, actualStats.ContractCodeBytes)
 	}
-	// TODO: failed on github actions, need to investigate
-	// if actualStats.AccountTrienodes != expectedStats.AccountTrienodes {
-	// 	t.Errorf("Account trie nodes mismatch: expected %d, got %d", expectedStats.AccountTrienodes, actualStats.AccountTrienodes)
-	// }
-	// if actualStats.AccountTrienodeBytes != expectedStats.AccountTrienodeBytes {
-	// 	t.Errorf("Account trie node bytes mismatch: expected %d, got %d", expectedStats.AccountTrienodeBytes, actualStats.AccountTrienodeBytes)
-	// }
+	if actualStats.AccountTrienodes != expectedStats.AccountTrienodes {
+		t.Errorf("Account trie nodes mismatch: expected %d, got %d", expectedStats.AccountTrienodes, actualStats.AccountTrienodes)
+	}
+	if actualStats.AccountTrienodeBytes != expectedStats.AccountTrienodeBytes {
+		t.Errorf("Account trie node bytes mismatch: expected %d, got %d", expectedStats.AccountTrienodeBytes, actualStats.AccountTrienodeBytes)
+	}
 	if actualStats.StorageTrienodes != expectedStats.StorageTrienodes {
 		t.Errorf("Storage trie nodes mismatch: expected %d, got %d", expectedStats.StorageTrienodes, actualStats.StorageTrienodes)
 	}


### PR DESCRIPTION
closes https://github.com/ethereum/go-ethereum/issues/32984

After some debugging, I found the flaky was failed of the mismatch of the `baseline` accounts, in the success test, it showed `52`, in the flaky it showed `51`:

```
--- FAIL: TestSizeTracker (0.09s)
    state_sizer_test.go:201: Account count mismatch: baseline(51) + tracked_changes = 131, but final_measurement = 132
    state_sizer_test.go:204: Account bytes mismatch: expected 6758, got 6798
FAIL
```

As the write buffer in `pathdb.Default`'s async writing, after `SnapshotCompleted()`, the buffer maybe not fully flushed, then the baseline iterating maybe missed some data. 

But in the final result, as we reopened the triedb, so all the buffer have been flushed into db, the result is matched. 

Here we propose to reopen the triedb before the baseline iterating. 