### PR TITLE
all: use `NOTE` in comments

### DIFF
--- a/accounts/accounts.go
+++ b/accounts/accounts.go
@@ -113,7 +113,7 @@ type Wallet interface {
 	SignData(account Account, mimeType string, data []byte) ([]byte, error)
 
 	// SignDataWithPassphrase is identical to SignData, but also takes a password
-	// NOTE: there's a chance that an erroneous call might mistake the two strings, and
+	  // NOTE: there's a chance that an erroneous call might mistake the two strings, and
 	// supply password in the mimetype field, or vice versa. Thus, an implementation
 	// should never echo the mimetype or return the mimetype in the error-response
 	SignDataWithPassphrase(account Account, passphrase, mimeType string, data []byte) ([]byte, error)

--- a/accounts/keystore/account_cache.go
+++ b/accounts/keystore/account_cache.go
@@ -115,7 +115,7 @@ func (ac *accountCache) add(newAccount accounts.Account) {
 	ac.byAddr[newAccount.Address] = append(ac.byAddr[newAccount.Address], newAccount)
 }
 
-// note: removed needs to be unique here (i.e. both File and Address must be set).
+  // NOTE: removed needs to be unique here (i.e. both File and Address must be set).
 func (ac *accountCache) delete(removed accounts.Account) {
 	ac.mu.Lock()
 	defer ac.mu.Unlock()

--- a/accounts/usbwallet/ledger.go
+++ b/accounts/usbwallet/ledger.go
@@ -177,7 +177,7 @@ func (w *ledgerDriver) SignTx(path accounts.DerivationPath, tx *types.Transactio
 // SignTypedMessage implements usbwallet.driver, sending the message to the Ledger and
 // waiting for the user to sign or deny the transaction.
 //
-// Note: this was introduced in the ledger 1.5.0 firmware
+  // NOTE: this was introduced in the ledger 1.5.0 firmware
 func (w *ledgerDriver) SignTypedMessage(path accounts.DerivationPath, domainHash []byte, messageHash []byte) ([]byte, error) {
 	// If the Ethereum app doesn't run, abort
 	if w.offline() {

--- a/accounts/usbwallet/trezor/messages-ethereum.pb.go
+++ b/accounts/usbwallet/trezor/messages-ethereum.pb.go
@@ -263,7 +263,7 @@ func (x *EthereumAddress) GetAddressHex() string {
 // *
 // Request: Ask device to sign transaction
 // All fields are optional from the protocol's point of view. Each field defaults to value `0` if missing.
-// Note: the first at most 1024 bytes of data MUST be transmitted as part of this message.
+  // NOTE: the first at most 1024 bytes of data MUST be transmitted as part of this message.
 // @start
 // @next EthereumTxRequest
 // @next Failure

--- a/beacon/light/api/api_server.go
+++ b/beacon/light/api/api_server.go
@@ -100,7 +100,7 @@ func (s *ApiServer) SendRequest(id request.ID, req request.Request) {
 }
 
 // Unsubscribe implements request.requestServer.
-// Note: Unsubscribe should not be called concurrently with Subscribe.
+  // NOTE: Unsubscribe should not be called concurrently with Subscribe.
 func (s *ApiServer) Unsubscribe() {
 	if s.unsubscribe != nil {
 		s.unsubscribe()

--- a/beacon/light/api/light_api.go
+++ b/beacon/light/api/light_api.go
@@ -104,7 +104,7 @@ type fetcher interface {
 }
 
 // BeaconLightApi requests light client information from a beacon node REST API.
-// Note: all required API endpoints are currently only implemented by Lodestar.
+  // NOTE: all required API endpoints are currently only implemented by Lodestar.
 type BeaconLightApi struct {
 	url           string
 	client        fetcher

--- a/beacon/light/canonical.go
+++ b/beacon/light/canonical.go
@@ -28,7 +28,7 @@ import (
 
 // canonicalStore stores instances of the given type in a database and caches
 // them in memory, associated with a continuous range of period numbers.
-// Note: canonicalStore is not thread safe and it is the caller's responsibility
+  // NOTE: canonicalStore is not thread safe and it is the caller's responsibility
 // to avoid concurrent access.
 type canonicalStore[T any] struct {
 	keyPrefix []byte

--- a/beacon/light/committee_chain.go
+++ b/beacon/light/committee_chain.go
@@ -189,7 +189,7 @@ func (s *CommitteeChain) Reset() {
 }
 
 // CheckpointInit initializes a CommitteeChain based on a checkpoint.
-// Note: if the chain is already initialized and the committees proven by the
+  // NOTE: if the chain is already initialized and the committees proven by the
 // checkpoint do match the existing chain then the chain is retained and the
 // new checkpoint becomes fixed.
 func (s *CommitteeChain) CheckpointInit(bootstrap types.BootstrapData) error {
@@ -234,7 +234,7 @@ func (s *CommitteeChain) addFixedCommitteeRoot(period uint64, root common.Hash) 
 	batch := s.db.NewBatch()
 	oldRoot := s.getCommitteeRoot(period)
 	if !s.fixedCommitteeRoots.periods.canExpand(period) {
-		// Note: the fixed committee root range should always be continuous and
+		  // NOTE: the fixed committee root range should always be continuous and
 		// therefore the expected syncing method is to forward sync and optionally
 		// backward sync periods one by one, starting from a checkpoint. The only
 		// case when a root that is not adjacent to the already fixed ones can be
@@ -281,7 +281,7 @@ func (s *CommitteeChain) deleteFixedCommitteeRootsFrom(period uint64) error {
 	batch := s.db.NewBatch()
 	s.fixedCommitteeRoots.deleteFrom(batch, period)
 	if s.updates.periods.isEmpty() || period <= s.updates.periods.Start {
-		// Note: the first period of the update chain should always be fixed so if
+		  // NOTE: the first period of the update chain should always be fixed so if
 		// the fixed root at the first update is removed then the entire update chain
 		// and the proven committees have to be removed. Earlier committees in the
 		// remaining fixed root range can stay.
@@ -515,7 +515,7 @@ func (s *CommitteeChain) verifySignedHeader(head types.SignedHeader) (bool, time
 // fits into the specified constraints (assumes that the update has been
 // successfully validated previously)
 func (s *CommitteeChain) verifyUpdate(update *types.LightClientUpdate) (bool, error) {
-	// Note: SignatureSlot determines the sync period of the committee used for signature
+	  // NOTE: SignatureSlot determines the sync period of the committee used for signature
 	// verification. Though in reality SignatureSlot is always bigger than update.Header.Slot,
 	// setting them as equal here enforces the rule that they have to be in the same sync
 	// period in order for the light client update proof to be meaningful.

--- a/beacon/light/request/scheduler.go
+++ b/beacon/light/request/scheduler.go
@@ -42,7 +42,7 @@ type Module interface {
 	// Process is always called after an event is received or after a target data
 	// structure has been changed.
 	//
-	// Note: Process functions of different modules are never called concurrently;
+	  // NOTE: Process functions of different modules are never called concurrently;
 	// they are called by Scheduler in the same order of priority as they were
 	// registered in.
 	Process(Requester, []Event)
@@ -89,7 +89,7 @@ type Scheduler struct {
 
 type (
 	// Server identifies a server without allowing any direct interaction.
-	// Note: server interface is used by Scheduler and Tracker but not used by
+	  // NOTE: server interface is used by Scheduler and Tracker but not used by
 	// the modules that do not interact with them directly.
 	// In order to make module testing easier, Server interface is used in
 	// events and modules.
@@ -126,7 +126,7 @@ func NewScheduler() *Scheduler {
 		pending: make(map[ServerAndID]pendingRequest),
 		targets: make(map[targetData]uint64),
 		stopCh:  make(chan chan struct{}),
-		// Note: testWaitCh should not have capacity in order to ensure
+		  // NOTE: testWaitCh should not have capacity in order to ensure
 		// that after a trigger happens testWaitCh will block until the resulting
 		// processing round has been finished
 		triggerCh:  make(chan struct{}, 1),

--- a/beacon/light/request/server.go
+++ b/beacon/light/request/server.go
@@ -182,7 +182,7 @@ func (s *serverWithTimeout) eventCallback(event Event) {
 	case EvResponse, EvFail:
 		id := event.Data.(RequestResponse).ID
 		if timer, ok := s.timeouts[id]; ok {
-			// Note: if stopping the timer is unsuccessful then the resulting AfterFunc
+			  // NOTE: if stopping the timer is unsuccessful then the resulting AfterFunc
 			// call will just do nothing
 			timer.Stop()
 			delete(s.timeouts, id)
@@ -398,7 +398,7 @@ func (s *serverWithLimits) canRequestNow() bool {
 // the given period.
 func (s *serverWithLimits) delay(delay time.Duration) {
 	if s.delayTimer != nil {
-		// Note: if stopping the timer is unsuccessful then the resulting AfterFunc
+		  // NOTE: if stopping the timer is unsuccessful then the resulting AfterFunc
 		// call will just do nothing
 		s.delayTimer.Stop()
 		s.delayTimer = nil

--- a/beacon/types/exec_header.go
+++ b/beacon/types/exec_header.go
@@ -45,7 +45,7 @@ func ExecutionHeaderFromJSON(forkName string, data []byte) (*ExecutionHeader, er
 	switch forkName {
 	case "capella":
 		obj = new(capella.ExecutionPayloadHeader)
-	case "deneb", "electra": // note: the payload type was not changed in electra
+	case "deneb", "electra":   // NOTE: the payload type was not changed in electra
 		obj = new(deneb.ExecutionPayloadHeader)
 	default:
 		return nil, fmt.Errorf("unsupported fork: %s", forkName)

--- a/beacon/types/exec_payload.go
+++ b/beacon/types/exec_payload.go
@@ -74,7 +74,7 @@ func convertPayload[T payloadType](payload T, parentRoot *zrntcommon.Root, reque
 }
 
 func convertCapellaHeader(payload *capella.ExecutionPayload, h *types.Header) {
-	// note: h.TxHash is set in convertTransactions
+	  // NOTE: h.TxHash is set in convertTransactions
 	h.ParentHash = common.Hash(payload.ParentHash)
 	h.UncleHash = types.EmptyUncleHash
 	h.Coinbase = common.Address(payload.FeeRecipient)
@@ -93,7 +93,7 @@ func convertCapellaHeader(payload *capella.ExecutionPayload, h *types.Header) {
 }
 
 func convertDenebHeader(payload *deneb.ExecutionPayload, parentRoot common.Hash, h *types.Header) {
-	// note: h.TxHash is set in convertTransactions
+	  // NOTE: h.TxHash is set in convertTransactions
 	h.ParentHash = common.Hash(payload.ParentHash)
 	h.UncleHash = types.EmptyUncleHash
 	h.Coinbase = common.Address(payload.FeeRecipient)

--- a/beacon/types/light_sync.go
+++ b/beacon/types/light_sync.go
@@ -34,7 +34,7 @@ type HeadInfo struct {
 
 // BootstrapData contains a sync committee where light sync can be started,
 // together with a proof through a beacon header and corresponding state.
-// Note: BootstrapData is fetched from a server based on a known checkpoint hash.
+  // NOTE: BootstrapData is fetched from a server based on a known checkpoint hash.
 type BootstrapData struct {
 	Version         string
 	Header          Header
@@ -92,7 +92,7 @@ func (update *LightClientUpdate) Validate() error {
 }
 
 // Score returns the UpdateScore describing the proof strength of the update
-// Note: thread safety can be ensured by always calling Score on a newly received
+  // NOTE: thread safety can be ensured by always calling Score on a newly received
 // or decoded update before making it potentially available for other threads
 func (update *LightClientUpdate) Score() UpdateScore {
 	if update.score == nil {

--- a/cmd/devp2p/internal/ethtest/snap.go
+++ b/cmd/devp2p/internal/ethtest/snap.go
@@ -363,7 +363,7 @@ func (s *Suite) TestSnapGetStorageRanges(t *utesting.T) {
 				"root": "0xe318dff15b33aa7f2f12d5567d58628e3e3f2e8859e46b56981a4083b391da17",
 				"codeHash": "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
 				"storage": {
-					// Note: keys below are hashed!!!
+					  // NOTE: keys below are hashed!!!
 					"0x405787fa12a823e0f2b7631cc41b3ba8828b3321ca811111fa75cd3aa3bb5ace": "02",
 					"0xb10e2d527612073b26eecdfd717e6a320cf44b4afac2b0732d9fcbe2b7fa0cf6": "01",
 					"0xc2575a0e9e593c00f959f8c92f12db2869c3395a3b0502d05e2516446f71f85b": "03"

--- a/cmd/evm/internal/t8ntool/execution.go
+++ b/cmd/evm/internal/t8ntool/execution.go
@@ -408,7 +408,7 @@ func rlpHash(x interface{}) (h common.Hash) {
 // calcDifficulty is based on ethash.CalcDifficulty. This method is used in case
 // the caller does not provide an explicit difficulty, but instead provides only
 // parent timestamp + difficulty.
-// Note: this method only works for ethash engine.
+  // NOTE: this method only works for ethash engine.
 func calcDifficulty(config *params.ChainConfig, number, currentTime, parentTime uint64,
 	parentDifficulty *big.Int, parentUncleHash common.Hash) *big.Int {
 	uncleHash := parentUncleHash

--- a/cmd/geth/version_check.go
+++ b/cmd/geth/version_check.go
@@ -160,7 +160,7 @@ func verifySignature(pubkeys []string, data, sigdata []byte) error {
 }
 
 // keyID turns a binary minisign key ID into a hex string.
-// Note: key IDs are printed in reverse byte order.
+  // NOTE: key IDs are printed in reverse byte order.
 func keyID(id [8]byte) string {
 	var rev [8]byte
 	for i := range id {

--- a/common/math/big_test.go
+++ b/common/math/big_test.go
@@ -36,7 +36,7 @@ func TestHexOrDecimal256(t *testing.T) {
 		{"0x12345678", big.NewInt(0x12345678), true},
 		{"0X12345678", big.NewInt(0x12345678), true},
 		// Tests for leading zero behaviour:
-		{"0123456789", big.NewInt(123456789), true}, // note: not octal
+		{"0123456789", big.NewInt(123456789), true},   // NOTE: not octal
 		{"00", big.NewInt(0), true},
 		{"0x00", big.NewInt(0), true},
 		{"0x012345678abc", big.NewInt(0x12345678abc), true},

--- a/common/math/integer_test.go
+++ b/common/math/integer_test.go
@@ -79,7 +79,7 @@ func TestHexOrDecimal64(t *testing.T) {
 		{"0x12345678", 0x12345678, true},
 		{"0X12345678", 0x12345678, true},
 		// Tests for leading zero behaviour:
-		{"0123456789", 123456789, true}, // note: not octal
+		{"0123456789", 123456789, true},   // NOTE: not octal
 		{"0x00", 0, true},
 		{"0x012345678abc", 0x12345678abc, true},
 		// Invalid syntax:

--- a/common/types_test.go
+++ b/common/types_test.go
@@ -183,7 +183,7 @@ func TestMixedcaseAddressMarshal(t *testing.T) {
 
 func TestMixedcaseAccount_Address(t *testing.T) {
 	// https://github.com/ethereum/EIPs/blob/master/EIPS/eip-55.md
-	// Note: 0X{checksum_addr} is not valid according to spec above
+	  // NOTE: 0X{checksum_addr} is not valid according to spec above
 
 	var res []struct {
 		A     MixedcaseAddress

--- a/consensus/consensus.go
+++ b/consensus/consensus.go
@@ -83,14 +83,14 @@ type Engine interface {
 	// Finalize runs any post-transaction state modifications (e.g. block rewards
 	// or process withdrawals) but does not assemble the block.
 	//
-	// Note: The state database might be updated to reflect any consensus rules
+	  // NOTE: The state database might be updated to reflect any consensus rules
 	// that happen at finalization (e.g. block rewards).
 	Finalize(chain ChainHeaderReader, header *types.Header, state vm.StateDB, body *types.Body)
 
 	// FinalizeAndAssemble runs any post-transaction state modifications (e.g. block
 	// rewards or process withdrawals) and assembles the final block.
 	//
-	// Note: The block header and state database might be updated to reflect any
+	  // NOTE: The block header and state database might be updated to reflect any
 	// consensus rules that happen at finalization (e.g. block rewards).
 	FinalizeAndAssemble(chain ChainHeaderReader, header *types.Header, state *state.StateDB, body *types.Body, receipts []*types.Receipt) (*types.Block, error)
 

--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -650,7 +650,7 @@ func (bc *BlockChain) loadLastState() error {
 	}
 
 	// Restore the last known finalized block and safe block
-	// Note: the safe block is not stored on disk and it is set to the last
+	  // NOTE: the safe block is not stored on disk and it is set to the last
 	// known finalized block on startup
 	if head := rawdb.ReadFinalizedBlockHash(bc.db); head != (common.Hash{}) {
 		if block := bc.GetBlockByHash(head); block != nil {
@@ -1272,7 +1272,7 @@ func (bc *BlockChain) stopWithoutSaving() {
 	}
 	// Now wait for all chain modifications to end and persistent goroutines to exit.
 	//
-	// Note: Close waits for the mutex to become available, i.e. any running chain
+	  // NOTE: Close waits for the mutex to become available, i.e. any running chain
 	// modification will have exited when Close returns. Since we also called StopInsert,
 	// the mutex should become available quickly. It cannot be taken again after Close has
 	// returned.
@@ -2001,7 +2001,7 @@ func (bc *BlockChain) ProcessBlock(parentRoot common.Hash, block *types.Block, s
 		// If prefetching is enabled, run that against the current state to pre-cache
 		// transactions and probabilistically some of the account/storage trie nodes.
 		//
-		// Note: the main processor and prefetcher share the same reader with a local
+		  // NOTE: the main processor and prefetcher share the same reader with a local
 		// cache for mitigating the overhead of state access.
 		prefetch, process, err := bc.statedb.ReadersWithCacheStats(parentRoot)
 		if err != nil {

--- a/core/blockchain_reader.go
+++ b/core/blockchain_reader.go
@@ -316,7 +316,7 @@ func (bc *BlockChain) GetCanonicalHash(number uint64) common.Hash {
 // a close ancestor of it is canonical. maxNonCanonical points to a downwards counter limiting the
 // number of blocks to be individually checked before we reach the canonical chain.
 //
-// Note: ancestor == 0 returns the same block, 1 returns its parent and so on.
+  // NOTE: ancestor == 0 returns the same block, 1 returns its parent and so on.
 func (bc *BlockChain) GetAncestor(hash common.Hash, number, ancestor uint64, maxNonCanonical *uint64) (common.Hash, uint64) {
 	return bc.hc.GetAncestor(hash, number, ancestor, maxNonCanonical)
 }

--- a/core/filtermaps/filtermaps.go
+++ b/core/filtermaps/filtermaps.go
@@ -846,7 +846,7 @@ func (f *FilterMaps) deleteTailEpoch(epoch uint32) (bool, error) {
 
 // exportCheckpoints exports epoch checkpoints in the format used by checkpoints.go.
 //
-// Note: acquiring the indexLock read lock is unnecessary here, as this function
+  // NOTE: acquiring the indexLock read lock is unnecessary here, as this function
 // is always called within the indexLoop.
 func (f *FilterMaps) exportCheckpoints() {
 	finalLvPtr, err := f.getBlockLvPointer(f.finalBlock + 1)

--- a/core/filtermaps/indexer.go
+++ b/core/filtermaps/indexer.go
@@ -43,7 +43,7 @@ func (f *FilterMaps) indexerLoop() {
 	log.Info("Started log indexer")
 
 	for !f.stop {
-		// Note: acquiring the indexLock read lock is unnecessary here,
+		  // NOTE: acquiring the indexLock read lock is unnecessary here,
 		// as the `indexedRange` is accessed within the indexerLoop.
 		if !f.indexedRange.initialized {
 			if f.targetView.HeadNumber() == 0 {
@@ -180,7 +180,7 @@ func (f *FilterMaps) processSingleEvent(blocking bool) bool {
 	if f.stop {
 		return false
 	}
-	// Note: acquiring the indexLock read lock is unnecessary here,
+	  // NOTE: acquiring the indexLock read lock is unnecessary here,
 	// as this function is always called within the indexLoop.
 	if !f.hasTempRange {
 		for _, mb := range f.matcherSyncRequests {

--- a/core/filtermaps/matcher_backend.go
+++ b/core/filtermaps/matcher_backend.go
@@ -127,7 +127,7 @@ func (fm *FilterMapsMatcherBackend) GetLogByLvIndex(ctx context.Context, lvIndex
 // should be passed as a parameter and the existing log index should be consistent
 // with that chain.
 //
-// Note: acquiring the indexLock read lock is unnecessary here, as this function
+  // NOTE: acquiring the indexLock read lock is unnecessary here, as this function
 // is always called within the indexLoop.
 func (fm *FilterMapsMatcherBackend) synced() {
 	fm.f.matchersLock.Lock()
@@ -164,7 +164,7 @@ func (fm *FilterMapsMatcherBackend) SyncLogIndex(ctx context.Context) (SyncRange
 	case <-ctx.Done():
 		return SyncRange{}, ctx.Err()
 	case <-fm.f.disabledCh:
-		// Note: acquiring the indexLock read lock is unnecessary here,
+		  // NOTE: acquiring the indexLock read lock is unnecessary here,
 		// as the indexer has already been terminated.
 		return SyncRange{IndexedView: fm.f.indexedView}, nil
 	}
@@ -174,7 +174,7 @@ func (fm *FilterMapsMatcherBackend) SyncLogIndex(ctx context.Context) (SyncRange
 	case <-ctx.Done():
 		return SyncRange{}, ctx.Err()
 	case <-fm.f.disabledCh:
-		// Note: acquiring the indexLock read lock is unnecessary here,
+		  // NOTE: acquiring the indexLock read lock is unnecessary here,
 		// as the indexer has already been terminated.
 		return SyncRange{IndexedView: fm.f.indexedView}, nil
 	}
@@ -185,7 +185,7 @@ func (fm *FilterMapsMatcherBackend) SyncLogIndex(ctx context.Context) (SyncRange
 // whenever a part of the log index has been removed, before adding new blocks
 // to it.
 //
-// Note: acquiring the indexLock read lock is unnecessary here, as this function
+  // NOTE: acquiring the indexLock read lock is unnecessary here, as this function
 // is always called within the indexLoop.
 func (f *FilterMaps) updateMatchersValidRange() {
 	f.matchersLock.Lock()

--- a/core/filtermaps/math.go
+++ b/core/filtermaps/math.go
@@ -170,7 +170,7 @@ func (p *Params) rowIndex(mapIndex, layerIndex uint32, logValue common.Hash) uin
 func (p *Params) columnIndex(lvIndex uint64, logValue *common.Hash) uint32 {
 	var indexEnc [8]byte
 	binary.LittleEndian.PutUint64(indexEnc[:], lvIndex)
-	// Note: reusing the hasher brings practically no performance gain and would
+	  // NOTE: reusing the hasher brings practically no performance gain and would
 	// require passing it through the entire matcher logic because of multi-thread
 	// matching
 	hasher := fnv.New64a()

--- a/core/headerchain.go
+++ b/core/headerchain.go
@@ -239,7 +239,7 @@ func (hc *HeaderChain) WriteHeaders(headers []*types.Header) (int, error) {
 // writeHeadersAndSetHead writes a batch of block headers and applies the last
 // header as the chain head.
 //
-// Note: This method is not concurrent-safe with inserting blocks simultaneously
+  // NOTE: This method is not concurrent-safe with inserting blocks simultaneously
 // into the chain, as side effects caused by reorganisations cannot be emulated
 // without the real blocks. Hence, writing headers directly should only be done
 // in two scenarios: pure-header mode of operation (light clients), or properly
@@ -348,7 +348,7 @@ func (hc *HeaderChain) InsertHeaderChain(chain []*types.Header, start time.Time)
 // a close ancestor of it is canonical. maxNonCanonical points to a downwards counter limiting the
 // number of blocks to be individually checked before we reach the canonical chain.
 //
-// Note: ancestor == 0 returns the same block, 1 returns its parent and so on.
+  // NOTE: ancestor == 0 returns the same block, 1 returns its parent and so on.
 func (hc *HeaderChain) GetAncestor(hash common.Hash, number, ancestor uint64, maxNonCanonical *uint64) (common.Hash, uint64) {
 	if ancestor > number {
 		return common.Hash{}, 0

--- a/core/rawdb/accessors_chain.go
+++ b/core/rawdb/accessors_chain.go
@@ -463,7 +463,7 @@ func ReadCanonicalBodyRLP(db ethdb.Reader, number uint64, hash *common.Hash) rlp
 		if hash != nil {
 			data, _ = db.Get(blockBodyKey(number, *hash))
 		} else {
-			// Note: ReadCanonicalHash cannot be used here because it also
+			  // NOTE: ReadCanonicalHash cannot be used here because it also
 			// calls ReadAncients internally.
 			hashBytes, _ := db.Get(headerHashKey(number))
 			data, _ = db.Get(blockBodyKey(number, common.BytesToHash(hashBytes)))
@@ -562,7 +562,7 @@ func ReadCanonicalReceiptsRLP(db ethdb.Reader, number uint64, hash *common.Hash)
 		if hash != nil {
 			data, _ = db.Get(blockReceiptsKey(number, *hash))
 		} else {
-			// Note: ReadCanonicalHash cannot be used here because it also
+			  // NOTE: ReadCanonicalHash cannot be used here because it also
 			// calls ReadAncients internally.
 			hashBytes, _ := db.Get(headerHashKey(number))
 			data, _ = db.Get(blockReceiptsKey(number, common.BytesToHash(hashBytes)))
@@ -683,7 +683,7 @@ func (r *receiptLogs) DecodeRLP(s *rlp.Stream) error {
 
 // ReadLogs retrieves the logs for all transactions in a block. In case
 // receipts is not found, a nil is returned.
-// Note: ReadLogs does not derive unstored log fields.
+  // NOTE: ReadLogs does not derive unstored log fields.
 func ReadLogs(db ethdb.Reader, hash common.Hash, number uint64) [][]*types.Log {
 	// Retrieve the flattened receipt slice
 	data := ReadReceiptsRLP(db, hash, number)
@@ -871,7 +871,7 @@ func WriteBadBlock(db ethdb.KeyValueStore, block *types.Block) {
 		Body:   block.Body(),
 	})
 	slices.SortFunc(badBlocks, func(a, b *badBlock) int {
-		// Note: sorting in descending number order.
+		  // NOTE: sorting in descending number order.
 		return -a.Header.Number.Cmp(b.Header.Number)
 	})
 	if len(badBlocks) > badBlockToKeep {

--- a/core/rawdb/database_tablewriter_tinygo.go
+++ b/core/rawdb/database_tablewriter_tinygo.go
@@ -49,7 +49,7 @@ func newTableWriter(w io.Writer) *Table {
 //
 // All data rows and footer must have the same number of columns as the headers.
 //
-// Note: Headers are required - tables without headers will fail validation.
+  // NOTE: Headers are required - tables without headers will fail validation.
 func (t *Table) SetHeader(headers []string) {
 	t.headers = headers
 }

--- a/core/rawdb/freezer_test.go
+++ b/core/rawdb/freezer_test.go
@@ -337,7 +337,7 @@ func newFreezerForTesting(t *testing.T, tables map[string]freezerTableConfig) (*
 	t.Helper()
 
 	dir := t.TempDir()
-	// note: using low max table size here to ensure the tests actually
+	  // NOTE: using low max table size here to ensure the tests actually
 	// switch between multiple files.
 	f, err := NewFreezer(dir, "", false, 2049, tables)
 	if err != nil {

--- a/core/state/statedb_hooked_test.go
+++ b/core/state/statedb_hooked_test.go
@@ -31,7 +31,7 @@ import (
 // is accounted for.
 // (There is also a higher-level test in eth/tracers: TestSupplySelfDestruct )
 func TestBurn(t *testing.T) {
-	// Note: burn can happen even after EIP-6780, if within one single transaction,
+	  // NOTE: burn can happen even after EIP-6780, if within one single transaction,
 	// the following occur:
 	// 1. contract B creates contract A
 	// 2. contract A is destructed

--- a/core/state_processor.go
+++ b/core/state_processor.go
@@ -320,7 +320,7 @@ var depositTopic = common.HexToHash("0x649bbc62d0e31342afea4e5cd82d4049e7e1ee912
 // ParseDepositLogs extracts the EIP-6110 deposit values from logs emitted by
 // BeaconDepositContract.
 func ParseDepositLogs(requests *[][]byte, logs []*types.Log, config *params.ChainConfig) error {
-	deposits := make([]byte, 1) // note: first byte is 0x00 (== deposit request type)
+	deposits := make([]byte, 1)   // NOTE: first byte is 0x00 (== deposit request type)
 	for _, log := range logs {
 		if log.Address == config.DepositContractAddress && len(log.Topics) > 0 && log.Topics[0] == depositTopic {
 			request, err := types.DepositLogToRequest(log.Data)

--- a/core/txpool/blobpool/blobpool.go
+++ b/core/txpool/blobpool/blobpool.go
@@ -74,7 +74,7 @@ const (
 	// maxBlobsPerTx is the maximum number of blobs that a single transaction can
 	// carry. We choose a smaller limit than the protocol-permitted MaxBlobsPerBlock
 	// in order to ensure network and txpool stability.
-	// Note: if you increase this, validation will fail on txMaxSize.
+	  // NOTE: if you increase this, validation will fail on txMaxSize.
 	maxBlobsPerTx = params.BlobTxMaxBlobs
 
 	// maxTxsPerAccount is the maximum number of blob transactions admitted from

--- a/core/txpool/legacypool/legacypool.go
+++ b/core/txpool/legacypool/legacypool.go
@@ -1526,7 +1526,7 @@ func (pool *LegacyPool) truncateQueue() {
 // executable/pending queue and any subsequent transactions that become unexecutable
 // are moved back into the future queue.
 //
-// Note: transactions are not marked as removed in the priced list because re-heaping
+  // NOTE: transactions are not marked as removed in the priced list because re-heaping
 // is always explicitly triggered by SetBaseFee and it would be unnecessary and wasteful
 // to trigger a re-heap is this function
 func (pool *LegacyPool) demoteUnexecutables() {

--- a/core/txpool/legacypool/list.go
+++ b/core/txpool/legacypool/list.go
@@ -584,7 +584,7 @@ func (l *pricedList) Removed(count int) {
 // Underpriced checks whether a transaction is cheaper than (or as cheap as) the
 // lowest priced (remote) transaction currently being tracked.
 func (l *pricedList) Underpriced(tx *types.Transaction) bool {
-	// Note: with two queues, being underpriced is defined as being worse than the worst item
+	  // NOTE: with two queues, being underpriced is defined as being worse than the worst item
 	// in all non-empty queues if there is any. If both queues are empty then nothing is underpriced.
 	return (l.underpricedFor(&l.urgent, tx) || len(l.urgent.list) == 0) &&
 		(l.underpricedFor(&l.floating, tx) || len(l.floating.list) == 0) &&
@@ -669,7 +669,7 @@ func (l *pricedList) Reheap() {
 
 	// balance out the two heaps by moving the worse half of transactions into the
 	// floating heap
-	// Note: Discard would also do this before the first eviction but Reheap can do
+	  // NOTE: Discard would also do this before the first eviction but Reheap can do
 	// is more efficiently. Also, Underpriced would work suboptimally the first time
 	// if the floating queue was empty.
 	floatingCount := len(l.urgent.list) * floatingRatio / (urgentRatio + floatingRatio)

--- a/core/txpool/locals/tx_tracker.go
+++ b/core/txpool/locals/tx_tracker.go
@@ -73,13 +73,13 @@ func New(journalPath string, journalTime time.Duration, chainConfig *params.Chai
 }
 
 // Track adds a transaction to the tracked set.
-// Note: blob-type transactions are ignored.
+  // NOTE: blob-type transactions are ignored.
 func (tracker *TxTracker) Track(tx *types.Transaction) {
 	tracker.TrackAll([]*types.Transaction{tx})
 }
 
 // TrackAll adds a list of transactions to the tracked set.
-// Note: blob-type transactions are ignored.
+  // NOTE: blob-type transactions are ignored.
 func (tracker *TxTracker) TrackAll(txs []*types.Transaction) {
 	tracker.mu.Lock()
 	defer tracker.mu.Unlock()

--- a/core/types/bloom9.go
+++ b/core/types/bloom9.go
@@ -73,7 +73,7 @@ func (b *Bloom) AddWithBuffer(d []byte, buf *[6]byte) {
 }
 
 // Big converts b to a big integer.
-// Note: Converting a bloom filter to a big.Int and then calling GetBytes
+  // NOTE: Converting a bloom filter to a big.Int and then calling GetBytes
 // does not return the same bytes, since big.Int will trim leading zeroes
 func (b Bloom) Big() *big.Int {
 	return new(big.Int).SetBytes(b[:])

--- a/core/types/transaction.go
+++ b/core/types/transaction.go
@@ -354,7 +354,7 @@ func (tx *Transaction) GasTipCapIntCmp(other *big.Int) int {
 }
 
 // EffectiveGasTip returns the effective miner gasTipCap for the given base fee.
-// Note: if the effective gasTipCap would be negative, this method
+  // NOTE: if the effective gasTipCap would be negative, this method
 // returns ErrGasFeeCapTooLow, and value is undefined.
 func (tx *Transaction) EffectiveGasTip(baseFee *big.Int) (*big.Int, error) {
 	dst := new(uint256.Int)
@@ -494,7 +494,7 @@ func (tx *Transaction) WithBlobTxSidecar(sideCar *BlobTxSidecar) *Transaction {
 		inner: blobtx.withSidecar(sideCar),
 		time:  tx.time,
 	}
-	// Note: tx.size cache not carried over because the sidecar is included in size!
+	  // NOTE: tx.size cache not carried over because the sidecar is included in size!
 	if h := tx.hash.Load(); h != nil {
 		cpy.hash.Store(h)
 	}

--- a/core/vm/evm.go
+++ b/core/vm/evm.go
@@ -394,7 +394,7 @@ func (evm *EVM) DelegateCall(originCaller common.Address, caller common.Address,
 	} else {
 		// Initialise a new contract and make initialise the delegate values
 		//
-		// Note: The value refers to the original value from the parent call.
+		  // NOTE: The value refers to the original value from the parent call.
 		contract := NewContract(originCaller, caller, value, gas, evm.jumpDests)
 		contract.SetCallCode(evm.resolveCodeHash(addr), evm.resolveCode(addr))
 		ret, err = evm.Run(contract, input, false)

--- a/core/vm/program/program.go
+++ b/core/vm/program/program.go
@@ -335,7 +335,7 @@ func (p *Program) MemToStorage(memStart, memSize, startSlot int) *Program {
 // ReturnViaCodeCopy utilises CODECOPY to place the given data in the bytecode of
 // p, loads into memory (offset 0) and returns the code.
 // This is a typical "constructor".
-// Note: since all indexing is calculated immediately, the preceding bytecode
+  // NOTE: since all indexing is calculated immediately, the preceding bytecode
 // must not be expanded or shortened.
 func (p *Program) ReturnViaCodeCopy(data []byte) *Program {
 	p.Push(len(data))

--- a/crypto/bn256/gnark/g1.go
+++ b/crypto/bn256/gnark/g1.go
@@ -14,7 +14,7 @@ import (
 // points are not beneficial because there are no intermediate
 // points to allow us to save on inversions.
 //
-// Note: We also use this struct so that we can conform to the existing API
+  // NOTE: We also use this struct so that we can conform to the existing API
 // that the precompiles want.
 type G1 struct {
 	inner bn254.G1Affine

--- a/crypto/bn256/gnark/g2.go
+++ b/crypto/bn256/gnark/g2.go
@@ -13,7 +13,7 @@ import (
 // points are not beneficial because there are no intermediate
 // points and G2 in particular is only used for the pairing input.
 //
-// Note: We also use this struct so that we can conform to the existing API
+  // NOTE: We also use this struct so that we can conform to the existing API
 // that the precompiles want.
 type G2 struct {
 	inner bn254.G2Affine

--- a/crypto/bn256/gnark/gt.go
+++ b/crypto/bn256/gnark/gt.go
@@ -9,7 +9,7 @@ import (
 
 // GT is the affine representation of a GT field element.
 //
-// Note: GT is not explicitly used in mainline code.
+  // NOTE: GT is not explicitly used in mainline code.
 // It is needed for fuzzing.
 type GT struct {
 	inner bn254.GT
@@ -18,7 +18,7 @@ type GT struct {
 // Pair compute the optimal Ate pairing between a G1 and
 // G2 element.
 //
-// Note: This method is not explicitly used in mainline code.
+  // NOTE: This method is not explicitly used in mainline code.
 // It is needed for fuzzing. It should also be noted,
 // that the output of this function may not match other
 func Pair(a_ *G1, b_ *G2) *GT {
@@ -40,7 +40,7 @@ func Pair(a_ *G1, b_ *G2) *GT {
 
 // Unmarshal deserializes `buf` into `g`
 //
-// Note: This method is not explicitly used in mainline code.
+  // NOTE: This method is not explicitly used in mainline code.
 // It is needed for fuzzing.
 func (g *GT) Unmarshal(buf []byte) error {
 	return g.inner.SetBytes(buf)
@@ -48,7 +48,7 @@ func (g *GT) Unmarshal(buf []byte) error {
 
 // Marshal serializes the point into a byte slice.
 //
-// Note: This method is not explicitly used in mainline code.
+  // NOTE: This method is not explicitly used in mainline code.
 // It is needed for fuzzing.
 func (g *GT) Marshal() []byte {
 	bytes := g.inner.Bytes()
@@ -57,7 +57,7 @@ func (g *GT) Marshal() []byte {
 
 // Exp raises `base` to the power of `exponent`
 //
-// Note: This method is not explicitly used in mainline code.
+  // NOTE: This method is not explicitly used in mainline code.
 // It is needed for fuzzing.
 func (g *GT) Exp(base GT, exponent *big.Int) *GT {
 	g.inner.Exp(base.inner, exponent)

--- a/crypto/crypto.go
+++ b/crypto/crypto.go
@@ -148,7 +148,7 @@ func UnmarshalPubkey(pub []byte) (*ecdsa.PublicKey, error) {
 }
 
 // FromECDSAPub converts a secp256k1 public key to bytes.
-// Note: it does not use the curve from pub, instead it always
+  // NOTE: it does not use the curve from pub, instead it always
 // encodes using secp256k1.
 func FromECDSAPub(pub *ecdsa.PublicKey) []byte {
 	if pub == nil || pub.X == nil || pub.Y == nil {

--- a/crypto/secp256k1/scalar_mult_cgo.go
+++ b/crypto/secp256k1/scalar_mult_cgo.go
@@ -29,7 +29,7 @@ func (bitCurve *BitCurve) ScalarMult(Bx, By *big.Int, scalar []byte) (*big.Int, 
 	if len(scalar) > 32 {
 		panic("can't handle scalars > 256 bits")
 	}
-	// NOTE: potential timing issue
+	  // NOTE: potential timing issue
 	padded := make([]byte, 32)
 	copy(padded[32-len(scalar):], scalar)
 	scalar = padded

--- a/crypto/signature_nocgo.go
+++ b/crypto/signature_nocgo.go
@@ -147,7 +147,7 @@ func DecompressPubkey(pubkey []byte) (*ecdsa.PublicKey, error) {
 // elliptic.Unmarshal (see UnmarshalPubkey), or by ToECDSA and ecdsa.GenerateKey
 // when constructing a PrivateKey.
 func CompressPubkey(pubkey *ecdsa.PublicKey) []byte {
-	// NOTE: the coordinates may be validated with
+	  // NOTE: the coordinates may be validated with
 	// secp256k1.ParsePubKey(FromECDSAPub(pubkey))
 	var x, y secp256k1.FieldVal
 	x.SetByteSlice(pubkey.X.Bytes())

--- a/eth/fetcher/metrics.go
+++ b/eth/fetcher/metrics.go
@@ -49,7 +49,7 @@ var (
 	txFetcherFetchingHashes = metrics.NewRegisteredGauge("eth/fetcher/transaction/fetching/hashes", nil)
 
 	txFetcherSlowPeers = metrics.NewRegisteredGauge("eth/fetcher/transaction/slow/peers", nil)
-	// Note: this metric does not mean that the fetching of a transaction
+	  // NOTE: this metric does not mean that the fetching of a transaction
 	// was blocked by a specific peer during this period, since we request
 	// another peer to fetch the same transaction hash.
 	// The purpose of this metric is to measure how long it takes for a slow peer

--- a/eth/gasprice/feehistory.go
+++ b/eth/gasprice/feehistory.go
@@ -156,7 +156,7 @@ func (oracle *Oracle) processBlock(bf *blockFees, percentiles []float64) {
 // resolveBlockRange resolves the specified block range to absolute block numbers while also
 // enforcing backend specific limitations. The pending block and corresponding receipts are
 // also returned if requested and available.
-// Note: an error is only returned if retrieving the head header has failed. If there are no
+  // NOTE: an error is only returned if retrieving the head header has failed. If there are no
 // retrievable blocks in the specified range then zero block count is returned with no error.
 func (oracle *Oracle) resolveBlockRange(ctx context.Context, reqEnd rpc.BlockNumber, blocks uint64) (*types.Block, []*types.Receipt, uint64, uint64, error) {
 	var (
@@ -236,7 +236,7 @@ func (oracle *Oracle) resolveBlockRange(ctx context.Context, reqEnd rpc.BlockNum
 //   - blobBaseFee: the blob base fee per gas in the given block
 //   - blobGasUsedRatio: blobGasUsed/blobGasLimit in the given block
 //
-// Note: baseFee and blobBaseFee both include the next block after the newest of the returned range,
+  // NOTE: baseFee and blobBaseFee both include the next block after the newest of the returned range,
 // because this value can be derived from the newest block.
 func (oracle *Oracle) FeeHistory(ctx context.Context, blocks uint64, unresolvedLastBlock rpc.BlockNumber, rewardPercentiles []float64) (*big.Int, [][]*big.Int, []*big.Int, []float64, []*big.Int, []float64, error) {
 	if blocks < 1 {

--- a/eth/protocols/snap/gentrie.go
+++ b/eth/protocols/snap/gentrie.go
@@ -124,7 +124,7 @@ func (t *pathTrie) onTrieNode(path []byte, hash common.Hash, blob []byte) {
 	// If boundary filtering is not configured, or the node is not on the left
 	// boundary, commit it to database.
 	//
-	// Note: If the current committed node is an extension node, then the nodes
+	  // NOTE: If the current committed node is an extension node, then the nodes
 	// falling within the path between itself and its standalone (not embedded
 	// in parent) child should be cleaned out for exclusively occupy the inner
 	// path.

--- a/eth/protocols/snap/sync.go
+++ b/eth/protocols/snap/sync.go
@@ -688,7 +688,7 @@ func (s *Syncer) Sync(root common.Hash, cancel chan struct{}) error {
 		s.cleanAccountTasks()
 		if len(s.tasks) == 0 && s.healer.scheduler.Pending() == 0 {
 			// State healing phase completed, record the elapsed time in metrics.
-			// Note: healing may be rerun in subsequent cycles to fill gaps between
+			  // NOTE: healing may be rerun in subsequent cycles to fill gaps between
 			// pivot states (e.g., if chain sync takes longer).
 			if !s.healStartTime.IsZero() {
 				stateHealTimeGauge.Inc(int64(time.Since(s.healStartTime)))
@@ -704,7 +704,7 @@ func (s *Syncer) Sync(root common.Hash, cancel chan struct{}) error {
 
 		if len(s.tasks) == 0 {
 			// State sync phase completed, record the elapsed time in metrics.
-			// Note: the initial state sync runs only once, regardless of whether
+			  // NOTE: the initial state sync runs only once, regardless of whether
 			// a new cycle is started later. Any state differences in subsequent
 			// cycles will be handled by the state healer.
 			s.syncTimeOnce.Do(func() {

--- a/eth/state_accessor.go
+++ b/eth/state_accessor.go
@@ -221,7 +221,7 @@ func (eth *Ethereum) stateAtBlock(ctx context.Context, block *types.Block, reexe
 // stateAtTransaction returns the execution environment of a certain
 // transaction.
 //
-// Note: when a block is empty and the state for tx index 0 is requested, this
+  // NOTE: when a block is empty and the state for tx index 0 is requested, this
 // function will return the state of block after the pre-block operations have
 // been completed (e.g. updating system contracts), but before post-block
 // operations are completed (e.g. processing withdrawals).

--- a/eth/tracers/api.go
+++ b/eth/tracers/api.go
@@ -776,7 +776,7 @@ func (api *API) standardTraceBlockToFile(ctx context.Context, block *types.Block
 	// in order to obtain the state.
 	// Therefore, it's perfectly valid to specify `"futureForkBlock": 0`, to enable `futureFork`
 	if config != nil && config.Overrides != nil {
-		// Note: This copies the config, to not screw up the main config
+		  // NOTE: This copies the config, to not screw up the main config
 		chainConfig, canon = overrideConfig(chainConfig, config.Overrides)
 	}
 
@@ -1075,7 +1075,7 @@ func APIs(backend Backend) []rpc.API {
 
 // overrideConfig returns a copy of original with forks enabled by override enabled,
 // along with a boolean that indicates whether the copy is canonical (equivalent to the original).
-// Note: the Clique-part is _not_ deep copied
+  // NOTE: the Clique-part is _not_ deep copied
 func overrideConfig(original *params.ChainConfig, override *params.ChainConfig) (*params.ChainConfig, bool) {
 	copy := new(params.ChainConfig)
 	*copy = *original

--- a/eth/tracers/js/goja.go
+++ b/eth/tracers/js/goja.go
@@ -589,7 +589,7 @@ func (t *jsTracer) setTypeConverters() error {
 		return toBigFn(goja.Undefined(), vm.ToValue(val))
 	}
 	t.toBig = toBigWrapper
-	// NOTE: We need this workaround to create JS buffers because
+	  // NOTE: We need this workaround to create JS buffers because
 	// goja doesn't at the moment expose constructors for typed arrays.
 	//
 	// Cache uint8ArrayType once to be used every time for less overhead.

--- a/eth/tracers/live/supply.go
+++ b/eth/tracers/live/supply.go
@@ -197,7 +197,7 @@ func (s *supplyTracer) onGenesisBlock(b *types.Block, alloc types.GenesisAlloc) 
 func (s *supplyTracer) onBalanceChange(a common.Address, prevBalance, newBalance *big.Int, reason tracing.BalanceChangeReason) {
 	diff := new(big.Int).Sub(newBalance, prevBalance)
 
-	// NOTE: don't handle "BalanceIncreaseGenesisBalance" because it is handled in OnGenesisBlock
+	  // NOTE: don't handle "BalanceIncreaseGenesisBalance" because it is handled in OnGenesisBlock
 	switch reason {
 	case tracing.BalanceIncreaseRewardMineBlock, tracing.BalanceIncreaseRewardMineUncle:
 		s.delta.Issuance.Reward.Add(s.delta.Issuance.Reward, diff)

--- a/ethdb/iterator.go
+++ b/ethdb/iterator.go
@@ -55,7 +55,7 @@ type Iteratee interface {
 	// of database content with a particular key prefix, starting at a particular
 	// initial key (or after, if it does not exist).
 	//
-	// Note: This method assumes that the prefix is NOT part of the start, so there's
+	  // NOTE: This method assumes that the prefix is NOT part of the start, so there's
 	// no need for the caller to prepend the prefix to the start
 	NewIterator(prefix []byte, start []byte) Iterator
 }

--- a/internal/debug/api.go
+++ b/internal/debug/api.go
@@ -239,7 +239,7 @@ func (*HandlerT) SetGCPercent(v int) int {
 }
 
 // SetMemoryLimit sets the GOMEMLIMIT for the process. It returns the previous limit.
-// Note:
+  // NOTE:
 //
 //   - The input limit is provided as bytes. A negative input does not adjust the limit
 //

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -893,7 +893,7 @@ func DoEstimateGas(ctx context.Context, b Backend, args TransactionArgs, blockNr
 // returns error if the transaction would revert or if there are unexpected failures. The returned
 // value is capped by both `args.Gas` (if non-nil & non-zero) and the backend's RPCGasCap
 // configuration (if non-zero).
-// Note: Required blob gas is not computed in this method.
+  // NOTE: Required blob gas is not computed in this method.
 func (api *BlockChainAPI) EstimateGas(ctx context.Context, args TransactionArgs, blockNrOrHash *rpc.BlockNumberOrHash, overrides *override.StateOverride, blockOverrides *override.BlockOverrides) (hexutil.Uint64, error) {
 	bNrOrHash := rpc.BlockNumberOrHashWithNumber(rpc.LatestBlockNumber)
 	if blockNrOrHash != nil {

--- a/internal/ethapi/override/override.go
+++ b/internal/ethapi/override/override.go
@@ -173,7 +173,7 @@ func (o *BlockOverrides) Apply(blockCtx *vm.BlockContext) error {
 
 // MakeHeader returns a new header object with the overridden
 // fields.
-// Note: MakeHeader ignores BlobBaseFee if set. That's because
+  // NOTE: MakeHeader ignores BlobBaseFee if set. That's because
 // header has no such field.
 func (o *BlockOverrides) MakeHeader(header *types.Header) *types.Header {
 	if o == nil {

--- a/internal/ethapi/simulate.go
+++ b/internal/ethapi/simulate.go
@@ -396,7 +396,7 @@ func (sim *simulator) activePrecompiles(base *types.Header) vm.PrecompiledContra
 // sanitizeChain checks the chain integrity. Specifically it checks that
 // block numbers and timestamp are strictly increasing, setting default values
 // when necessary. Gaps in block numbers are filled with empty blocks.
-// Note: It modifies the block's override object.
+  // NOTE: It modifies the block's override object.
 func (sim *simulator) sanitizeChain(blocks []simBlock) ([]simBlock, error) {
 	var (
 		res           = make([]simBlock, 0, len(blocks))

--- a/metrics/resetting_timer.go
+++ b/metrics/resetting_timer.go
@@ -89,14 +89,14 @@ func (t *ResettingTimerSnapshot) Count() int {
 }
 
 // Percentiles returns the boundaries for the input percentiles.
-// note: this method is not thread safe
+  // NOTE: this method is not thread safe
 func (t *ResettingTimerSnapshot) Percentiles(percentiles []float64) []float64 {
 	t.calc(percentiles)
 	return t.thresholdBoundaries
 }
 
 // Mean returns the mean of the snapshotted values
-// note: this method is not thread safe
+  // NOTE: this method is not thread safe
 func (t *ResettingTimerSnapshot) Mean() float64 {
 	if !t.calculated {
 		t.calc(nil)
@@ -106,7 +106,7 @@ func (t *ResettingTimerSnapshot) Mean() float64 {
 }
 
 // Max returns the max of the snapshotted values
-// note: this method is not thread safe
+  // NOTE: this method is not thread safe
 func (t *ResettingTimerSnapshot) Max() int64 {
 	if !t.calculated {
 		t.calc(nil)
@@ -115,7 +115,7 @@ func (t *ResettingTimerSnapshot) Max() int64 {
 }
 
 // Min returns the min of the snapshotted values
-// note: this method is not thread safe
+  // NOTE: this method is not thread safe
 func (t *ResettingTimerSnapshot) Min() int64 {
 	if !t.calculated {
 		t.calc(nil)

--- a/metrics/runtimehistogram.go
+++ b/metrics/runtimehistogram.go
@@ -232,7 +232,7 @@ func (h *runtimeHistogramSnapshot) computePercentiles(thresh []float64) {
 	}
 }
 
-// Note: runtime/metrics.Float64Histogram is a collection of float64s, but the methods
+  // NOTE: runtime/metrics.Float64Histogram is a collection of float64s, but the methods
 // below need to return int64 to satisfy the interface. The histogram provided by runtime
 // also doesn't keep track of individual samples, so results are approximated.
 

--- a/metrics/sample.go
+++ b/metrics/sample.go
@@ -245,7 +245,7 @@ func SamplePercentile(values []int64, p float64) float64 {
 // int64. This method returns interpolated results, so e.g. if there are only two
 // values, [0, 10], a 50% percentile will land between them.
 //
-// Note: As a side-effect, this method will also sort the slice of values.
+  // NOTE: As a side-effect, this method will also sort the slice of values.
 // Note2: The input format for percentiles is NOT percent! To express 50%, use 0.5, not 50.
 func CalculatePercentiles(values []int64, ps []float64) []float64 {
 	scores := make([]float64, len(ps))

--- a/node/node_auth_test.go
+++ b/node/node_auth_test.go
@@ -176,7 +176,7 @@ func TestAuthEndpoints(t *testing.T) {
 		// claims of 5 seconds or more, older or newer, are not allowed
 		{name: "ws too old", endpoint: node.WSAuthEndpoint(), prov: offsetTimeAuth(secret, -tooLong), expectDialFail: true},
 		{name: "http too old", endpoint: node.HTTPAuthEndpoint(), prov: offsetTimeAuth(secret, -tooLong), expectCall1Fail: true},
-		// note: for it to be too long we need to add a delay, so that once we receive the request, the difference has not dipped below the "tooLong"
+		  // NOTE: for it to be too long we need to add a delay, so that once we receive the request, the difference has not dipped below the "tooLong"
 		{name: "ws too new", endpoint: node.WSAuthEndpoint(), prov: offsetTimeAuth(secret, tooLong+requestDelay), expectDialFail: true},
 		{name: "http too new", endpoint: node.HTTPAuthEndpoint(), prov: offsetTimeAuth(secret, tooLong+requestDelay), expectCall1Fail: true},
 

--- a/p2p/dnsdisc/sync.go
+++ b/p2p/dnsdisc/sync.go
@@ -99,7 +99,7 @@ func (ct *clientTree) syncRandom(ctx context.Context) (n *enode.Node, err error)
 
 // canSyncRandom checks if any meaningful action can be performed by syncRandom.
 func (ct *clientTree) canSyncRandom() bool {
-	// Note: the check for non-zero leaf count is very important here.
+	  // NOTE: the check for non-zero leaf count is very important here.
 	// If we're done syncing all nodes, and no leaves were found, the tree
 	// is empty and we can't use it for sync.
 	return ct.rootUpdateDue() || !ct.links.done() || !ct.enrs.done() || ct.enrs.leaves != 0

--- a/p2p/message.go
+++ b/p2p/message.go
@@ -125,7 +125,7 @@ type eofSignal struct {
 	eof     chan<- struct{}
 }
 
-// note: when using eofSignal to detect whether a message payload
+  // NOTE: when using eofSignal to detect whether a message payload
 // has been read, Read might not be called for zero sized messages.
 func (r *eofSignal) Read(buf []byte) (int, error) {
 	if r.count == 0 {

--- a/p2p/server_nat.go
+++ b/p2p/server_nat.go
@@ -46,7 +46,7 @@ type portMapping struct {
 }
 
 // setupPortMapping starts the port mapping loop if necessary.
-// Note: this needs to be called after the LocalNode instance has been set on the server.
+  // NOTE: this needs to be called after the LocalNode instance has been set on the server.
 func (srv *Server) setupPortMapping() {
 	// portMappingRegister will receive up to two values: one for the TCP port if
 	// listening is enabled, and one more for enabling UDP port mapping if discovery is

--- a/rlp/decode.go
+++ b/rlp/decode.go
@@ -1111,7 +1111,7 @@ func (s *Stream) readUint(size byte) (uint64, error) {
 			return 0, err
 		}
 		if buffer[start] == 0 {
-			// Note: readUint is also used to decode integer values.
+			  // NOTE: readUint is also used to decode integer values.
 			// The error needs to be adjusted to become ErrCanonInt in this case.
 			return 0, ErrCanonSize
 		}

--- a/rlp/encbuffer.go
+++ b/rlp/encbuffer.go
@@ -382,7 +382,7 @@ func (w EncoderBuffer) WriteUint64(i uint64) {
 }
 
 // WriteBigInt encodes a big.Int as an RLP string.
-// Note: Unlike with Encode, the sign of i is ignored.
+  // NOTE: Unlike with Encode, the sign of i is ignored.
 func (w EncoderBuffer) WriteBigInt(i *big.Int) {
 	w.buf.writeBigInt(i)
 }

--- a/rlp/encode.go
+++ b/rlp/encode.go
@@ -96,7 +96,7 @@ func EncodeToReader(val interface{}) (size int, r io.Reader, err error) {
 		encBufferPool.Put(buf)
 		return 0, nil, err
 	}
-	// Note: can't put the reader back into the pool here
+	  // NOTE: can't put the reader back into the pool here
 	// because it is held by encReader. The reader puts it
 	// back when it has been fully consumed.
 	return buf.size(), &encReader{buf: buf}, nil

--- a/rlp/raw_test.go
+++ b/rlp/raw_test.go
@@ -26,7 +26,7 @@ import (
 
 func TestCountValues(t *testing.T) {
 	tests := []struct {
-		input string // note: spaces in input are stripped by unhex
+		input string   // NOTE: spaces in input are stripped by unhex
 		count int
 		err   error
 	}{

--- a/rlp/rlpgen/gen.go
+++ b/rlp/rlpgen/gen.go
@@ -291,7 +291,7 @@ func (op basicOp) genDecode(ctx *genContext) (string, string) {
 		method  = op.decMethod
 	)
 	if op.decUseBitSize {
-		// Note: For now, this only works for platform-independent integer
+		  // NOTE: For now, this only works for platform-independent integer
 		// sizes. makeBasicOp forbids the platform-dependent types.
 		var sizes types.StdSizes
 		method = fmt.Sprintf("%s%d", op.decMethod, sizes.Sizeof(op.typ)*8)
@@ -476,7 +476,7 @@ func (bctx *buildContext) makePtrOp(elemTyp types.Type, tags rlpstruct.Tags) (op
 }
 
 func (op ptrOp) genWrite(ctx *genContext, v string) string {
-	// Note: in writer functions, accesses to v are read-only, i.e. v is any Go
+	  // NOTE: in writer functions, accesses to v are read-only, i.e. v is any Go
 	// expression. To make all accesses work through the pointer, we substitute
 	// v with (*v). This is required for most accesses including `v`, `call(v)`,
 	// and `v[index]` on slices.

--- a/rpc/client_opt.go
+++ b/rpc/client_opt.go
@@ -123,7 +123,7 @@ type HTTPAuth func(h http.Header) error
 
 // WithBatchItemLimit changes the maximum number of items allowed in batch requests.
 //
-// Note: this option applies when processing incoming batch requests. It does not affect
+  // NOTE: this option applies when processing incoming batch requests. It does not affect
 // batch requests sent by the client.
 func WithBatchItemLimit(limit int) ClientOption {
 	return optionFunc(func(cfg *clientConfig) {
@@ -135,7 +135,7 @@ func WithBatchItemLimit(limit int) ClientOption {
 // generated for batch requests. When this limit is reached, further calls in the batch
 // will not be processed.
 //
-// Note: this option applies when processing incoming batch requests. It does not affect
+  // NOTE: this option applies when processing incoming batch requests. It does not affect
 // batch requests sent by the client.
 func WithBatchResponseSizeLimit(sizeLimit int) ClientOption {
 	return optionFunc(func(cfg *clientConfig) {

--- a/rpc/client_test.go
+++ b/rpc/client_test.go
@@ -66,7 +66,7 @@ func TestClientResponseType(t *testing.T) {
 		t.Errorf("Passing nil as result should be fine, but got an error: %v", err)
 	}
 	var resultVar echoResult
-	// Note: passing the var, not a ref
+	  // NOTE: passing the var, not a ref
 	err := client.Call(resultVar, "test_echo", "hello", 10, &echoArgs{"world"})
 	if err == nil {
 		t.Error("Passing a var as result should be an error")

--- a/rpc/http.go
+++ b/rpc/http.go
@@ -385,7 +385,7 @@ func ContextRequestTimeout(ctx context.Context) (time.Duration, bool) {
 		// the HTTP server cuts connection. So our internal timeout must be earlier than
 		// the server's true timeout.
 		//
-		// Note: Timeouts are sanitized to be a minimum of 1 second.
+		  // NOTE: Timeouts are sanitized to be a minimum of 1 second.
 		// Also see issue: https://github.com/golang/go/issues/47229
 		wt -= 100 * time.Millisecond
 		setTimeout(wt)

--- a/rpc/websocket_test.go
+++ b/rpc/websocket_test.go
@@ -227,7 +227,7 @@ func TestClientWebsocketPing(t *testing.T) {
 	if err != nil {
 		t.Fatalf("client subscribe error: %v", err)
 	}
-	// Note: Unsubscribe is not called on this subscription because the mockup
+	  // NOTE: Unsubscribe is not called on this subscription because the mockup
 	// server can't handle the request.
 
 	// Wait for the context's deadline to be reached before proceeding.

--- a/trie/bintrie/iterator_test.go
+++ b/trie/bintrie/iterator_test.go
@@ -50,7 +50,7 @@ func TestBinaryIterator(t *testing.T) {
 		Root:     types.EmptyRootHash,
 		CodeHash: nil,
 	}
-	// NOTE: the code size isn't written to the trie via TryUpdateAccount
+	  // NOTE: the code size isn't written to the trie via TryUpdateAccount
 	// so it will be missing from the test nodes.
 	trie.UpdateAccount(common.Address{}, account0, 0)
 	account1 := &types.StateAccount{

--- a/trie/bintrie/trie.go
+++ b/trie/bintrie/trie.go
@@ -296,7 +296,7 @@ func (t *BinaryTrie) IsVerkle() bool {
 
 // UpdateContractCode updates the contract code into the trie.
 //
-// Note: the basic data leaf needs to have been previously created for this to work
+  // NOTE: the basic data leaf needs to have been previously created for this to work
 func (t *BinaryTrie) UpdateContractCode(addr common.Address, codeHash common.Hash, code []byte) error {
 	var (
 		chunks = trie.ChunkifyCode(code)

--- a/trie/committer.go
+++ b/trie/committer.go
@@ -97,7 +97,7 @@ func (c *committer) commitChildren(path []byte, n *fullNode, parallel bool) {
 			continue
 		}
 		// If it's the hashed child, save the hash value directly.
-		// Note: it's impossible that the child in range [0, 15]
+		  // NOTE: it's impossible that the child in range [0, 15]
 		// is a valueNode.
 		if _, ok := child.(hashNode); ok {
 			continue

--- a/trie/proof.go
+++ b/trie/proof.go
@@ -472,7 +472,7 @@ func hasRightElement(node node, key []byte) bool {
 // Except returning the error to indicate the proof is valid or not, the function will
 // also return a flag to indicate whether there exists more accounts/slots in the trie.
 //
-// Note: This method does not verify that the proof is of minimal form. If the input
+  // NOTE: This method does not verify that the proof is of minimal form. If the input
 // proofs are 'bloated' with neighbour leaves or random data, aside from the 'useful'
 // data, then the proof will still be accepted.
 func VerifyRangeProof(rootHash common.Hash, firstKey []byte, keys [][]byte, values [][]byte, proof ethdb.KeyValueReader) (bool, error) {

--- a/trie/transition.go
+++ b/trie/transition.go
@@ -133,7 +133,7 @@ func (t *TransitionTrie) UpdateStorage(address common.Address, key []byte, value
 
 // UpdateAccount abstract an account write to the trie.
 func (t *TransitionTrie) UpdateAccount(addr common.Address, account *types.StateAccount, codeLen int) error {
-	// NOTE: before the rebase, this was saving the state root, so that OpenStorageTrie
+	  // NOTE: before the rebase, this was saving the state root, so that OpenStorageTrie
 	// could still work during a replay. This is no longer needed, as OpenStorageTrie
 	// only needs to know what the account trie does now.
 	return t.overlay.UpdateAccount(addr, account, codeLen)

--- a/triedb/database/database.go
+++ b/triedb/database/database.go
@@ -47,7 +47,7 @@ type StateReader interface {
 	// the slim data format. An error will be returned if the read operation exits
 	// abnormally. Specifically, if the layer is already stale.
 	//
-	// Note:
+	  // NOTE:
 	// - the returned account object is safe to modify
 	// - no error will be returned if the requested account is not found in database
 	Account(hash common.Hash) (*types.SlimAccount, error)
@@ -56,7 +56,7 @@ type StateReader interface {
 	// within a particular account. An error will be returned if the read operation
 	// exits abnormally.
 	//
-	// Note:
+	  // NOTE:
 	// - the returned storage data is not a copy, please don't modify it
 	// - no error will be returned if the requested slot is not found in database
 	Storage(accountHash, storageHash common.Hash) ([]byte, error)

--- a/triedb/pathdb/database.go
+++ b/triedb/pathdb/database.go
@@ -42,7 +42,7 @@ type layer interface {
 	// if the read operation exits abnormally. Specifically, if the layer is
 	// already stale.
 	//
-	// Note:
+	  // NOTE:
 	// - the returned node is not a copy, please don't modify it.
 	// - no error will be returned if the requested node is not found in database.
 	node(owner common.Hash, path []byte, depth int) ([]byte, common.Hash, *nodeLoc, error)
@@ -51,7 +51,7 @@ type layer interface {
 	// hash in the slim data format. An error will be returned if the read
 	// operation exits abnormally. Specifically, if the layer is already stale.
 	//
-	// Note:
+	  // NOTE:
 	// - the returned account is not a copy, please don't modify it.
 	// - no error will be returned if the requested account is not found in database.
 	account(hash common.Hash, depth int) ([]byte, error)
@@ -60,7 +60,7 @@ type layer interface {
 	// within a particular account. An error will be returned if the read operation
 	// exits abnormally. Specifically, if the layer is already stale.
 	//
-	// Note:
+	  // NOTE:
 	// - the returned storage data is not a copy, please don't modify it.
 	// - no error will be returned if the requested slot is not found in database.
 	storage(accountHash, storageHash common.Hash, depth int) ([]byte, error)

--- a/triedb/pathdb/history_index_block.go
+++ b/triedb/pathdb/history_index_block.go
@@ -92,7 +92,7 @@ func (d *indexBlockDesc) decode(blob []byte) {
 //	  - Restart list: A list of 2-byte pointers, each pointing to the start position of a chunk
 //	  - Restart count: The number of restarts in the block, stored at the end of the block (1 byte)
 //
-// Note: the pointer is encoded as a uint16, which is sufficient within a chunk.
+  // NOTE: the pointer is encoded as a uint16, which is sufficient within a chunk.
 // A uint16 can cover offsets in the range [0, 65536), which is more than enough
 // to store 4096 integers.
 //

--- a/triedb/pathdb/history_reader.go
+++ b/triedb/pathdb/history_reader.go
@@ -55,7 +55,7 @@ func newIndexReaderWithLimitTag(db ethdb.KeyValueReader, state stateIdent, limit
 // readGreaterThan locates the first element that is greater than the specified
 // id. If no such element is found, MaxUint64 is returned.
 //
-// Note: It is possible that additional histories have been indexed since the
+  // NOTE: It is possible that additional histories have been indexed since the
 // reader was created. The reader should be refreshed as needed to load the
 // latest indexed data from disk.
 func (r *indexReaderWithLimitTag) readGreaterThan(id uint64, lastID uint64) (uint64, error) {

--- a/triedb/pathdb/history_trienode.go
+++ b/triedb/pathdb/history_trienode.go
@@ -100,7 +100,7 @@ import (
 //    | restart_1 key offset | restart_1 value offset | ... | restart number (4-bytes) |
 //    +----------------------+------------------------+-----+--------------------------+
 //
-// Note: Both the key offset and the value offset are relative to the start of
+  // NOTE: Both the key offset and the value offset are relative to the start of
 // the trie data chunk. To obtain the absolute offset, add the offset of the
 // trie data chunk itself.
 //
@@ -110,7 +110,7 @@ import (
 //    |  node data 1 |  node data 2 |  ...  |  node data n  |
 //    +--------------+--------------+-------+---------------+
 //
-// NOTE: All fixed-length integer are big-endian.
+  // NOTE: All fixed-length integer are big-endian.
 
 const (
 	trienodeHistoryV0           = uint8(0)                    // initial version of node history structure

--- a/triedb/pathdb/journal.go
+++ b/triedb/pathdb/journal.go
@@ -142,7 +142,7 @@ func loadGenerator(db ethdb.KeyValueReader, hash nodeHasher) (*journalGenerator,
 	// The state snapshot is inconsistent with the trie data and must
 	// be rebuilt.
 	//
-	// Note: The SnapshotRoot and SnapshotGenerator are always consistent
+	  // NOTE: The SnapshotRoot and SnapshotGenerator are always consistent
 	// with each other, both in the legacy state snapshot and the path database.
 	// Therefore, if the SnapshotRoot does not match the trie root,
 	// the entire generator is considered stale and must be discarded.

--- a/triedb/pathdb/reader.go
+++ b/triedb/pathdb/reader.go
@@ -96,7 +96,7 @@ func (r *reader) Node(owner common.Hash, path []byte, hash common.Hash) ([]byte,
 // An error will be returned if the read operation exits abnormally. Specifically,
 // if the layer is already stale.
 //
-// Note:
+  // NOTE:
 // - the returned account data is not a copy, please don't modify it
 // - no error will be returned if the requested account is not found in database
 func (r *reader) AccountRLP(hash common.Hash) ([]byte, error) {
@@ -123,7 +123,7 @@ func (r *reader) AccountRLP(hash common.Hash) ([]byte, error) {
 // the slim data format. An error will be returned if the read operation exits
 // abnormally. Specifically, if the layer is already stale.
 //
-// Note:
+  // NOTE:
 // - the returned account object is safe to modify
 // - no error will be returned if the requested account is not found in database
 func (r *reader) Account(hash common.Hash) (*types.SlimAccount, error) {
@@ -145,7 +145,7 @@ func (r *reader) Account(hash common.Hash) (*types.SlimAccount, error) {
 // within a particular account. An error will be returned if the read operation
 // exits abnormally. Specifically, if the layer is already stale.
 //
-// Note:
+  // NOTE:
 // - the returned storage data is not a copy, please don't modify it
 // - no error will be returned if the requested slot is not found in database
 func (r *reader) Storage(accountHash, storageHash common.Hash) ([]byte, error) {
@@ -242,7 +242,7 @@ func (db *Database) HistoricReader(root common.Hash) (*HistoricalStateReader, er
 // address in the slim data format. An error will be returned if the read
 // operation exits abnormally. Specifically, if the layer is already stale.
 //
-// Note:
+  // NOTE:
 // - the returned account is not a copy, please don't modify it.
 // - no error will be returned if the requested account is not found in database.
 func (r *HistoricalStateReader) AccountRLP(address common.Address) ([]byte, error) {
@@ -292,7 +292,7 @@ func (r *HistoricalStateReader) Account(address common.Address) (*types.SlimAcco
 // within a particular account. An error will be returned if the read operation
 // exits abnormally. Specifically, if the layer is already stale.
 //
-// Note:
+  // NOTE:
 // - the returned storage data is not a copy, please don't modify it.
 // - no error will be returned if the requested slot is not found in database.
 func (r *HistoricalStateReader) Storage(address common.Address, key common.Hash) ([]byte, error) {


### PR DESCRIPTION
The keyword 'note' now has three different ways of writing in the remarks:

- `// note:`
- `// Note:`
- `// NOTE:`

For the sake of consistency, we should use `// NOTE:` uniformly.