### PR TITLE
p2p: silence on listener shutdown

### DIFF
--- a/p2p/server.go
+++ b/p2p/server.go
@@ -813,11 +813,10 @@ func (srv *Server) listenLoop() {
 				time.Sleep(time.Millisecond * 200)
 				continue
 			} else if err != nil {
-				slots <- struct{}{}
-				if errors.Is(err, net.ErrClosed) {
-					return
+				if !errors.Is(err, net.ErrClosed) {
+					srv.log.Debug("Read error", "err", err)
 				}
-				srv.log.Debug("Read error", "err", err)
+				slots <- struct{}{}
 				return
 			}
 			break


### PR DESCRIPTION
When running with debug log(`--verbosity 5`), it will always print the below log just before the node shutdown:

```
INFO [10-21|15:23:28.155] Blockchain stopped
TRACE[10-21|15:23:28.184] P2P networking is spinning down
DEBUG[10-21|15:23:28.184] Read error                               err="accept tcp [::]:30303: use of closed network connection"
```

The `Read error` msg is annoying, so propose to remove it.