### PR TITLE
core/filtermaps: use buffered channel to avoid blocking

### DIFF
--- a/core/filtermaps/indexer.go
+++ b/core/filtermaps/indexer.go
@@ -143,7 +143,7 @@ func (f *FilterMaps) SetBlockProcessing(blockProcessing bool) {
 // latest targetView.
 func (f *FilterMaps) WaitIdle() {
 	for {
-		ch := make(chan bool)
+		ch := make(chan bool, 1) // buffered so the indexer response can't block
 		select {
 		case f.waitIdleCh <- ch:
 			if <-ch {


### PR DESCRIPTION
found in this job https://github.com/ethereum/go-ethereum/actions/runs/18737728369/job/53448010941?pr=33002 

```
panic: test timed out after 45m0s
	running tests:
		TestIndexerRandomRange (45m0s)

goroutine 23383 [running]:
testing.(*M).startAlarm.func1()
	/opt/actions-runner/_work/_tool/go/1.24.9/x64/src/testing/testing.go:2484 +0x394
created by time.goFunc
	/opt/actions-runner/_work/_tool/go/1.24.9/x64/src/time/sleep.go:215 +0x2d

goroutine 1 [chan receive, 44 minutes]:
testing.(*T).Run(0xc0001ee380, {0x8cab83?, 0xc0001cdb30?}, 0x9bcb30)
	/opt/actions-runner/_work/_tool/go/1.24.9/x64/src/testing/testing.go:1859 +0x431
testing.runTests.func1(0xc0001ee380)
	/opt/actions-runner/_work/_tool/go/1.24.9/x64/src/testing/testing.go:2279 +0x37
testing.tRunner(0xc0001ee380, 0xc0001cdc70)
	/opt/actions-runner/_work/_tool/go/1.24.9/x64/src/testing/testing.go:1792 +0xf4
testing.runTests(0xc0000112c0, {0xded260, 0x8, 0x8}, {0xe34a00?, 0x7?, 0xe324e0?})
	/opt/actions-runner/_work/_tool/go/1.24.9/x64/src/testing/testing.go:2277 +0x4b4
testing.(*M).Run(0xc00027c780)
	/opt/actions-runner/_work/_tool/go/1.24.9/x64/src/testing/testing.go:2142 +0x64a
main.main()
	_testmain.go:59 +0x9b

goroutine 7 [runnable]:
github.com/ethereum/go-ethereum/core/filtermaps.(*FilterMaps).WaitIdle(0xc003214a08)
	/opt/actions-runner/_work/go-ethereum/go-ethereum/core/filtermaps/indexer.go:147 +0x85
github.com/ethereum/go-ethereum/core/filtermaps.TestIndexerRandomRange(0xc0001ee540)
	/opt/actions-runner/_work/go-ethereum/go-ethereum/core/filtermaps/indexer_test.go:119 +0x425
testing.tRunner(0xc0001ee540, 0x9bcb30)
	/opt/actions-runner/_work/_tool/go/1.24.9/x64/src/testing/testing.go:1792 +0xf4
created by testing.(*T).Run in goroutine 1
	/opt/actions-runner/_work/_tool/go/1.24.9/x64/src/testing/testing.go:1851 +0x413

goroutine 23404 [chan send]:
github.com/ethereum/go-ethereum/core/filtermaps.(*FilterMaps).processSingleEvent(0xc003214a08, 0x1?)
	/opt/actions-runner/_work/go-ethereum/go-ethereum/core/filtermaps/indexer.go:206 +0x3db
github.com/ethereum/go-ethereum/core/filtermaps.(*FilterMaps).indexerLoop(0xc003214a08)
	/opt/actions-runner/_work/go-ethereum/go-ethereum/core/filtermaps/indexer.go:51 +0xee
created by github.com/ethereum/go-ethereum/core/filtermaps.(*FilterMaps).Start in goroutine 7
	/opt/actions-runner/_work/go-ethereum/go-ethereum/core/filtermaps/filtermaps.go:292 +0x185
FAIL	github.com/ethereum/go-ethereum/core/filtermaps	2700.047s
```

There's a race where `processSingleEvent` would send the idle status, while the caller hadn’t yet reached the receive, deadlocking both goroutines. 

So let's make the per-call channel buffered, then the indexer enqueue the ack even if the `WaitIdle` goroutine hasn’t reached the receive yet.