### PR TITLE
p2p/enode: add Pebble database support for node database

### DIFF
--- a/common/bytes.go
+++ b/common/bytes.go
@@ -149,3 +149,24 @@ func TrimRightZeroes(s []byte) []byte {
 	}
 	return s[:idx]
 }
+
+// UpperBound returns the upper bound for iteration over keys with the given prefix.
+// It returns the next key in lexicographic order that is greater than all keys with
+// the given prefix. This is useful for setting iteration bounds in databases.
+// Returns nil if no such upper bound exists (e.g., if prefix is empty or all 0xff bytes).
+func UpperBound(prefix []byte) []byte {
+	if len(prefix) == 0 {
+		return nil
+	}
+	var limit []byte
+	for i := len(prefix) - 1; i >= 0; i-- {
+		c := prefix[i]
+		if c < 0xff {
+			limit = make([]byte, i+1)
+			copy(limit, prefix)
+			limit[i] = c + 1
+			break
+		}
+	}
+	return limit
+}

--- a/ethdb/pebble/pebble.go
+++ b/ethdb/pebble/pebble.go
@@ -450,21 +450,6 @@ func (d *Database) NewBatchWithSize(size int) ethdb.Batch {
 	}
 }
 
-// upperBound returns the upper bound for the given prefix
-func upperBound(prefix []byte) (limit []byte) {
-	for i := len(prefix) - 1; i >= 0; i-- {
-		c := prefix[i]
-		if c == 0xff {
-			continue
-		}
-		limit = make([]byte, i+1)
-		copy(limit, prefix)
-		limit[i] = c + 1
-		break
-	}
-	return limit
-}
-
 // Stat returns the internal metrics of Pebble in a text format. It's a developer
 // method to read everything there is to read, independent of Pebble version.
 func (d *Database) Stat() (string, error) {
@@ -731,7 +716,7 @@ type pebbleIterator struct {
 func (d *Database) NewIterator(prefix []byte, start []byte) ethdb.Iterator {
 	iter, _ := d.db.NewIter(&pebble.IterOptions{
 		LowerBound: append(prefix, start...),
-		UpperBound: upperBound(prefix),
+		UpperBound: common.UpperBound(prefix),
 	})
 	iter.First()
 	return &pebbleIterator{iter: iter, moved: true, released: false}


### PR DESCRIPTION
This PR try to close https://github.com/ethereum/go-ethereum/issues/33000. It adds support for both LevelDB and Pebble in the p2p node database, allowing users to configure the database for migration to Pebble while maintaining backward compatibility.