### PR TITLE
txpool: log error for missing sidecar in blob transaction

### DIFF
--- a/core/txpool/blobpool/blobpool.go
+++ b/core/txpool/blobpool/blobpool.go
@@ -995,6 +995,10 @@ func (p *BlobPool) convertLegacySidecar(sender common.Address, hash common.Hash,
 		return false
 	}
 	sc := tx.BlobTxSidecar()
+	if sc == nil {
+		log.Error("Missing sidecar in blob transaction", "hash", hash, "id", id)
+		return false
+	}
 	if sc.Version >= types.BlobSidecarVersion1 {
 		log.Debug("Skipping conversion of blob tx", "hash", hash, "id", id)
 		return false


### PR DESCRIPTION
## Summary
1. Add nil-sidecar guard in convertLegacySidecar
2. Emit explicit error log with transaction hash and store id
3. Exit conversion early when sidecar data is absent