### PR TITLE
build: fix keeper build

### DIFF
--- a/build/ci.go
+++ b/build/ci.go
@@ -284,6 +284,7 @@ func doInstallKeeper(cmdline []string) {
 		tc.GOOS = target.GOOS
 		tc.CC = target.CC
 		gobuild := tc.Go("build", buildFlags(env, true, []string{target.Tags})...)
+		gobuild.Dir = "./cmd/keeper"
 		gobuild.Args = append(gobuild.Args, "-v")
 
 		for key, value := range target.Env {
@@ -293,7 +294,7 @@ func doInstallKeeper(cmdline []string) {
 
 		args := slices.Clone(gobuild.Args)
 		args = append(args, "-o", executablePath(outputName))
-		args = append(args, "./cmd/keeper")
+		args = append(args, ".")
 		build.MustRun(&exec.Cmd{Path: gobuild.Path, Args: args, Env: gobuild.Env})
 	}
 }


### PR DESCRIPTION
At the time keeper support was added into ci.go, we were using a go.work file to make ./cmd/keeper accessible from within the main go-ethereum module. The workspace file has since been removed, so we need to build keeper from within its own module instead.