### PR TITLE
eth/downloader: log progress in periodic only

### DIFF
--- a/eth/downloader/skeleton.go
+++ b/eth/downloader/skeleton.go
@@ -1104,7 +1104,7 @@ func (s *skeleton) processResponse(res *headerResponse) (linked bool, merged boo
 	if linked {
 		left = 0
 	}
-	if time.Since(s.logged) > 8*time.Second || left == 0 {
+	if time.Since(s.logged) > 8*time.Second {
 		s.logged = time.Now()
 
 		if s.pulled == 0 {


### PR DESCRIPTION
closes https://github.com/ethereum/go-ethereum/issues/32608

When beacon header syncing appears to reach completion(`left==0`), the progress logging triggers repeatedly, those logs are misleading, propose to remove the `left==0` condition.