### PR TITLE
core: don't modify the shared chainId between tests

### DIFF
--- a/core/verkle_witness_test.go
+++ b/core/verkle_witness_test.go
@@ -455,7 +455,7 @@ func verkleTestGenesis(config *params.ChainConfig) *Genesis {
 func TestProcessVerkleContractWithEmptyCode(t *testing.T) {
 	// The test txs were taken from a secondary testnet with chain id 69421
 	config := *testKaustinenLikeChainConfig
-	config.ChainID.SetUint64(69421)
+	config.ChainID = new(big.Int).SetUint64(69421)
 	gspec := verkleTestGenesis(&config)
 
 	genesisH, _, _, _, _, statediffs := GenerateVerkleChainWithGenesis(gspec, beacon.New(ethash.NewFaker()), 1, func(i int, gen *BlockGen) {
@@ -511,7 +511,7 @@ func TestProcessVerkleContractWithEmptyCode(t *testing.T) {
 func TestProcessVerkleExtCodeHashOpcode(t *testing.T) {
 	// The test txs were taken from a secondary testnet with chain id 69421
 	config := *testKaustinenLikeChainConfig
-	config.ChainID.SetUint64(69421)
+	config.ChainID = new(big.Int).SetUint64(69421)
 
 	var (
 		signer     = types.LatestSigner(&config)
@@ -615,7 +615,7 @@ func TestProcessVerkleExtCodeHashOpcode(t *testing.T) {
 func TestProcessVerkleBalanceOpcode(t *testing.T) {
 	// The test txs were taken from a secondary testnet with chain id 69421
 	config := *testKaustinenLikeChainConfig
-	config.ChainID.SetUint64(69421)
+	config.ChainID = new(big.Int).SetUint64(69421)
 
 	var (
 		signer     = types.LatestSigner(&config)
@@ -672,7 +672,7 @@ func TestProcessVerkleBalanceOpcode(t *testing.T) {
 func TestProcessVerkleSelfDestructInSeparateTx(t *testing.T) {
 	// The test txs were taken from a secondary testnet with chain id 69421
 	config := *testKaustinenLikeChainConfig
-	config.ChainID.SetUint64(69421)
+	config.ChainID = new(big.Int).SetUint64(69421)
 
 	var (
 		signer     = types.LatestSigner(&config)
@@ -792,7 +792,7 @@ func TestProcessVerkleSelfDestructInSeparateTx(t *testing.T) {
 func TestProcessVerkleSelfDestructInSameTx(t *testing.T) {
 	// The test txs were taken from a secondary testnet with chain id 69421
 	config := *testKaustinenLikeChainConfig
-	config.ChainID.SetUint64(69421)
+	config.ChainID = new(big.Int).SetUint64(69421)
 
 	var (
 		signer     = types.LatestSigner(&config)
@@ -888,7 +888,7 @@ func TestProcessVerkleSelfDestructInSameTx(t *testing.T) {
 func TestProcessVerkleSelfDestructInSeparateTxWithSelfBeneficiary(t *testing.T) {
 	// The test txs were taken from a secondary testnet with chain id 69421
 	config := *testKaustinenLikeChainConfig
-	config.ChainID.SetUint64(69421)
+	config.ChainID = new(big.Int).SetUint64(69421)
 
 	var (
 		signer     = types.LatestSigner(&config)
@@ -978,7 +978,7 @@ func TestProcessVerkleSelfDestructInSeparateTxWithSelfBeneficiary(t *testing.T) 
 func TestProcessVerkleSelfDestructInSameTxWithSelfBeneficiary(t *testing.T) {
 	// The test txs were taken from a secondary testnet with chain id 69421
 	config := *testKaustinenLikeChainConfig
-	config.ChainID.SetUint64(69421)
+	config.ChainID = new(big.Int).SetUint64(69421)
 
 	var (
 		signer     = types.LatestSigner(&config)
@@ -1042,7 +1042,7 @@ func TestProcessVerkleSelfDestructInSameTxWithSelfBeneficiary(t *testing.T) {
 func TestProcessVerkleSelfDestructInSameTxWithSelfBeneficiaryAndPrefundedAccount(t *testing.T) {
 	// The test txs were taken from a secondary testnet with chain id 69421
 	config := *testKaustinenLikeChainConfig
-	config.ChainID.SetUint64(69421)
+	config.ChainID = new(big.Int).SetUint64(69421)
 
 	var (
 		signer     = types.LatestSigner(&config)


### PR DESCRIPTION
Run the tests locally, sometimes one or test tests failed as below:

```
--- FAIL: TestProcessVerkleInvalidContractCreation (0.00s)
panic: invalid chain id for signer: have 69420 want 69421 [recovered, repanicked]

goroutine 1050165 [running]:
testing.tRunner.func1.2({0xfcc920, 0xc019b9a880})
        /usr/local/go/src/testing/testing.go:1872 +0x237
testing.tRunner.func1()
        /usr/local/go/src/testing/testing.go:1875 +0x35b
panic({0xfcc920?, 0xc019b9a880?})
        /usr/local/go/src/runtime/panic.go:783 +0x132
github.com/ethereum/go-ethereum/core.(*BlockGen).addTx(0xc02261c500, 0xc01bf94388?, {0x0, 0x0, 0x0, {0x0, 0x0, 0x0}, 0x0, 0x0}, ...)
        /root/code/go-ethereum/core/chain_makers.go:123 +0x5a9
github.com/ethereum/go-ethereum/core.(*BlockGen).AddTx(...)
        /root/code/go-ethereum/core/chain_makers.go:148
github.com/ethereum/go-ethereum/core.TestProcessVerkleInvalidContractCreation.func1(0x0, 0xc02261c500)
        /root/code/go-ethereum/core/verkle_witness_test.go:316 +0x1fb
github.com/ethereum/go-ethereum/core.GenerateVerkleChain.func1(0x0, 0xc012f2a240, 0xc01bf0a150, 0xc012f4b080)
        /root/code/go-ethereum/core/chain_makers.go:509 +0x29f
github.com/ethereum/go-ethereum/core.GenerateVerkleChain(0xc01bf0a150?, 0xc012f2a240, {0x13cf290, 0xc01bb14630}, {0xc00159c9e8?, 0xc00159c9d0?}, 0xc01bf0a150, 0x2, 0xc01c51bee8)
        /root/code/go-ethereum/core/chain_makers.go:550 +0x29b
github.com/ethereum/go-ethereum/core.GenerateVerkleChainWithGenesis(0xc027ade750, {0x13cf290, 0xc01bb14630}, 0x2, 0xc01c51bee8)
        /root/code/go-ethereum/core/chain_makers.go:592 +0x47e
github.com/ethereum/go-ethereum/core.TestProcessVerkleInvalidContractCreation(0xc01be80700)
        /root/code/go-ethereum/core/verkle_witness_test.go:300 +0x22e
testing.tRunner(0xc01be80700, 0x127ee70)
        /usr/local/go/src/testing/testing.go:1934 +0xea
created by testing.(*T).Run in goroutine 1
        /usr/local/go/src/testing/testing.go:1997 +0x465
FAIL    github.com/ethereum/go-ethereum/core    181.630s
```

After reviewing the code, seems as the `config` is a copy of the `testKaustinenLikeChainConfig`, but the `config.ChainID` is a pointer to `testKaustinenLikeChainConfig's`, so in the testcases, after `config.ChainID.SetUint64(69421)`, it will change the origin's value. 

