### PR TITLE
node/endpoints: prealloc map in checkModuleAvailability

### DIFF
--- a/node/endpoints.go
+++ b/node/endpoints.go
@@ -53,7 +53,7 @@ func StartHTTPEndpoint(endpoint string, timeouts rpc.HTTPTimeouts, handler http.
 // available API services. It assumes that the MetadataApi module ("rpc") is always available;
 // the registration of this "rpc" module happens in NewServer() and is thus common to all endpoints.
 func checkModuleAvailability(modules []string, apis []rpc.API) (bad, available []string) {
-	availableSet := make(map[string]struct{})
+	availableSet := make(map[string]struct{}, len(apis))
 	for _, api := range apis {
 		if _, ok := availableSet[api.Namespace]; !ok {
 			availableSet[api.Namespace] = struct{}{}


### PR DESCRIPTION
**Align to this:**

  [go-ethereum/core/types/transaction.go](https://github.com/ethereum/go-ethereum/blob/10421ed/core/types/transaction.go#L633)
  Line 633 in `10421ed`

  ```go
  633    remove := make(map[common.Hash]struct{}, b.Len())