### PR TITLE
core/state: reduce one alloc

### DIFF
--- a/core/state/access_list.go
+++ b/core/state/access_list.go
@@ -61,9 +61,10 @@ func newAccessList() *accessList {
 
 // Copy creates an independent copy of an accessList.
 func (al *accessList) Copy() *accessList {
-	cp := newAccessList()
-	cp.addresses = maps.Clone(al.addresses)
-	cp.slots = make([]map[common.Hash]struct{}, len(al.slots))
+	cp := &accessList{
+		addresses: maps.Clone(al.addresses),
+		slots:     make([]map[common.Hash]struct{}, len(al.slots)),
+	}
 	for i, slotMap := range al.slots {
 		cp.slots[i] = maps.Clone(slotMap)
 	}


### PR DESCRIPTION
this code:
```
func BenchmarkAccessList_Copy(b *testing.B) {
	al := newAccessList()
	for b.Loop() {
		_ = al.Copy()
	}
}
```

```
goos: darwin
goarch: arm64
pkg: github.com/ethereum/go-ethereum/core/state
cpu: Apple M1 Pro
                   │   old.txt   │               new.txt               │
                   │   sec/op    │   sec/op     vs base                │
AccessList_Copy-10   69.95n ± 2%   42.52n ± 2%  -39.21% (p=0.000 n=20)

                   │   old.txt   │              new.txt               │
                   │    B/op     │    B/op     vs base                │
AccessList_Copy-10   128.00 ± 0%   80.00 ± 0%  -37.50% (p=0.000 n=20)

                   │  old.txt   │              new.txt               │
                   │ allocs/op  │ allocs/op   vs base                │
AccessList_Copy-10   3.000 ± 0%   2.000 ± 0%  -33.33% (p=0.000 n=20)
```

just elimate the make ```make(map[common.Address]int)```
