### PR TITLE
core/rawdb: fix readOnly mode for database

### DIFF
--- a/core/rawdb/database.go
+++ b/core/rawdb/database.go
@@ -330,6 +330,7 @@ func Open(db ethdb.KeyValueStore, opts OpenOptions) (ethdb.Database, error) {
 		}()
 	}
 	return &freezerdb{
+		readOnly:      opts.ReadOnly,
 		ancientRoot:   opts.Ancient,
 		KeyValueStore: db,
 		chainFreezer:  frdb,


### PR DESCRIPTION
- Assign readOnly: opts.ReadOnly in Open() when constructing freezerdb
- Without this, calling freezerdb.Freeze() in read-only mode attempts to send on chainFreezer.trigger while the freezer loop isn’t running, causing a permanent block.
- The change enforces the intended behavior where Freeze() returns errReadOnly under read-only operation, avoiding deadlock and aligning with the function’s guard.