### PR TITLE
core/types: prealloc map

### DIFF
--- a/core/types/account.go
+++ b/core/types/account.go
@@ -75,7 +75,7 @@ func (ga *GenesisAlloc) UnmarshalJSON(data []byte) error {
 	if err := json.Unmarshal(data, &m); err != nil {
 		return err
 	}
-	*ga = make(GenesisAlloc)
+	*ga = make(GenesisAlloc, len(m))
 	for addr, a := range m {
 		(*ga)[common.Address(addr)] = a
 	}


### PR DESCRIPTION
```
var sink GenesisAlloc

func BenchmarkGenesisAlloc_UnmarshalJSON(b *testing.B) {
	m := make(GenesisAlloc)
	for i := 0; i < 100000; i++ {
		m[common.Address{byte(i >> 24), byte(i >> 16), byte(i >> 8), byte(i)}] = Account{
			Balance: common.Big1,
		}
	}
	data, err := json.Marshal(&m)
	if err != nil {
		b.Fatal(err)
	}
	for b.Loop() {
		var alloc GenesisAlloc
		if err := json.Unmarshal(data, &alloc); err != nil {
			b.Fatal(err)
		}
		sink = alloc
	}
}

```

```
goos: darwin
goarch: arm64
pkg: github.com/ethereum/go-ethereum/core/types
cpu: Apple M1 Pro
                              │   old.txt   │            new.txt            │
                              │   sec/op    │   sec/op     vs base          │
GenesisAlloc_UnmarshalJSON-10   160.7m ± 1%   158.9m ± 4%  ~ (p=0.089 n=10)

                              │   old.txt    │               new.txt                │
                              │     B/op     │     B/op      vs base                │
GenesisAlloc_UnmarshalJSON-10   76.64Mi ± 0%   66.63Mi ± 0%  -13.05% (p=0.000 n=10)

                              │   old.txt   │              new.txt               │
                              │  allocs/op  │  allocs/op   vs base               │
GenesisAlloc_UnmarshalJSON-10   1.101M ± 0%   1.101M ± 0%  -0.02% (p=0.000 n=10)
```