### PR TITLE
all: check error returned from `rlp.Encode()`

### DIFF
--- a/core/rawdb/accessors_chain_test.go
+++ b/core/rawdb/accessors_chain_test.go
@@ -75,7 +75,9 @@ func TestBodyStorage(t *testing.T) {
 	body := &types.Body{Uncles: []*types.Header{{Extra: []byte("test header")}}}
 
 	hasher := sha3.NewLegacyKeccak256()
-	rlp.Encode(hasher, body)
+	if err := rlp.Encode(hasher, body); err != nil {
+		t.Fatalf("encode body err: %v", err)
+	}
 	hash := common.BytesToHash(hasher.Sum(nil))
 
 	if entry := ReadBody(db, hash, 0); entry != nil {

--- a/core/types/types_test.go
+++ b/core/types/types_test.go
@@ -127,7 +127,9 @@ func benchRLP(b *testing.B, encode bool) {
 				b.ReportAllocs()
 				var null = &devnull{}
 				for b.Loop() {
-					rlp.Encode(null, tc.obj)
+					if err := rlp.Encode(null, tc.obj); err != nil {
+						b.Fatal(err)
+					}
 				}
 				b.SetBytes(int64(null.len / b.N))
 			})

--- a/p2p/enode/idscheme.go
+++ b/p2p/enode/idscheme.go
@@ -50,7 +50,10 @@ func SignV4(r *enr.Record, privkey *ecdsa.PrivateKey) error {
 	cpy.Set(Secp256k1(privkey.PublicKey))
 
 	h := sha3.NewLegacyKeccak256()
-	rlp.Encode(h, cpy.AppendElements(nil))
+	if err := rlp.Encode(h, cpy.AppendElements(nil)); err != nil {
+		panic("can't encode: " + err.Error())
+	}
+
 	sig, err := crypto.Sign(h.Sum(nil), privkey)
 	if err != nil {
 		return err
@@ -71,7 +74,10 @@ func (V4ID) Verify(r *enr.Record, sig []byte) error {
 	}
 
 	h := sha3.NewLegacyKeccak256()
-	rlp.Encode(h, r.AppendElements(nil))
+	if err := rlp.Encode(h, r.AppendElements(nil)); err != nil {
+		panic("can't encode: " + err.Error())
+	}
+
 	if !crypto.VerifySignature(entry, h.Sum(nil), sig) {
 		return enr.ErrInvalidSig
 	}

--- a/trie/node_test.go
+++ b/trie/node_test.go
@@ -45,7 +45,9 @@ func TestDecodeNestedNode(t *testing.T) {
 	fullNodeData[15] = data
 
 	buf := bytes.NewBuffer([]byte{})
-	rlp.Encode(buf, fullNodeData)
+	if err := rlp.Encode(buf, fullNodeData); err != nil {
+		t.Fatalf("encode full node err: %v", err)
+	}
 
 	if _, err := decodeNode([]byte("testdecode"), buf.Bytes()); err != nil {
 		t.Fatalf("decode nested full node err: %v", err)
@@ -56,7 +58,9 @@ func TestDecodeFullNodeWrongSizeChild(t *testing.T) {
 	fullNodeData := newTestFullNode([]byte("wrongsizechild"))
 	fullNodeData[0] = []byte("00")
 	buf := bytes.NewBuffer([]byte{})
-	rlp.Encode(buf, fullNodeData)
+	if err := rlp.Encode(buf, fullNodeData); err != nil {
+		t.Fatalf("encode full node err: %v", err)
+	}
 
 	_, err := decodeNode([]byte("testdecode"), buf.Bytes())
 	if _, ok := err.(*decodeError); !ok {
@@ -75,7 +79,9 @@ func TestDecodeFullNodeWrongNestedFullNode(t *testing.T) {
 	fullNodeData[15] = data
 
 	buf := bytes.NewBuffer([]byte{})
-	rlp.Encode(buf, fullNodeData)
+	if err := rlp.Encode(buf, fullNodeData); err != nil {
+		t.Fatalf("encode full node err: %v", err)
+	}
 
 	_, err := decodeNode([]byte("testdecode"), buf.Bytes())
 	if _, ok := err.(*decodeError); !ok {
@@ -86,7 +92,9 @@ func TestDecodeFullNodeWrongNestedFullNode(t *testing.T) {
 func TestDecodeFullNode(t *testing.T) {
 	fullNodeData := newTestFullNode([]byte("decodefullnode"))
 	buf := bytes.NewBuffer([]byte{})
-	rlp.Encode(buf, fullNodeData)
+	if err := rlp.Encode(buf, fullNodeData); err != nil {
+		t.Fatalf("encode full node err: %v", err)
+	}
 
 	_, err := decodeNode([]byte("testdecode"), buf.Bytes())
 	if err != nil {


### PR DESCRIPTION
This PR checks error which is returned by the function `rlp.Encode()`.