### PR TITLE
accounts/abi/bind/v2: fix error assertion in test

### DIFF
--- a/accounts/abi/bind/v2/util_test.go
+++ b/accounts/abi/bind/v2/util_test.go
@@ -144,10 +144,9 @@ func TestWaitDeployedCornerCases(t *testing.T) {
 	done := make(chan struct{})
 	go func() {
 		defer close(done)
-		want := errors.New("context canceled")
 		_, err := bind.WaitDeployed(ctx, backend.Client(), tx.Hash())
-		if err == nil || errors.Is(want, err) {
-			t.Errorf("error mismatch: want %v, got %v", want, err)
+		if !errors.Is(err, context.Canceled) {
+			t.Errorf("error mismatch: want %v, got %v", context.Canceled, err)
 		}
 	}()
 


### PR DESCRIPTION
This part of the `WaitDeployedCornerCases` test has many issues.
- The real error that should be checked is `context.Canceled`, which can easily be used.
- The boolean for `errors.Is` is incorrect, allowing the test to still pass even though the incorrect error is returned.
- The errors are in the wrong order for `errors.Is`
- `err == nil` doesn't change the output of this test, since `want` isn't `nil`.