### PR TITLE
triedb/pathdb: use copy instead of append to reduce memory alloc

### DIFF
--- a/triedb/pathdb/disklayer.go
+++ b/triedb/pathdb/disklayer.go
@@ -275,8 +275,7 @@ func (dl *diskLayer) storage(accountHash, storageHash common.Hash, depth int) ([
 
 	// If the layer is being generated, ensure the requested storage slot
 	// has already been covered by the generator.
-	skey := storageKey(accountHash, storageHash)
-	key := skey[:]
+	key := storageKeySlice(accountHash, storageHash)
 	marker := dl.genMarker()
 	if marker != nil && bytes.Compare(key, marker) > 0 {
 		return nil, errNotCoveredYet

--- a/triedb/pathdb/flush.go
+++ b/triedb/pathdb/flush.go
@@ -116,8 +116,7 @@ func writeStates(batch ethdb.Batch, genMarker []byte, accountData map[common.Has
 				continue
 			}
 			slots += 1
-			skey := storageKey(addrHash, storageHash)
-			key := skey[:]
+			key := storageKeySlice(addrHash, storageHash)
 			if len(blob) == 0 {
 				rawdb.DeleteStorageSnapshot(batch, addrHash, storageHash)
 				if clean != nil {

--- a/triedb/pathdb/lookup.go
+++ b/triedb/pathdb/lookup.go
@@ -33,6 +33,13 @@ func storageKey(accountHash common.Hash, slotHash common.Hash) [64]byte {
 	return key
 }
 
+// storageKeySlice returns a key for uniquely identifying the storage slot in
+// the slice format.
+func storageKeySlice(accountHash common.Hash, slotHash common.Hash) []byte {
+	key := storageKey(accountHash, slotHash)
+	return key[:]
+}
+
 // lookup is an internal structure used to efficiently determine the layer in
 // which a state entry resides.
 type lookup struct {


### PR DESCRIPTION
use the `storageKey` helper func to reduce the dynamic memory alloc