### PR TITLE
all: replace Split with SplitSeq for better efficiency in Go 1.24

### DIFF
--- a/build/ci.go
+++ b/build/ci.go
@@ -499,7 +499,7 @@ func doCheckBadDeps() {
 		if err != nil {
 			log.Fatalf("Failed to list '%s' dependencies: %v", rule[0], err)
 		}
-		for _, line := range strings.Split(string(out), "\n") {
+		for line := range strings.SplitSeq(string(out), "\n") {
 			if strings.TrimSpace(line) == rule[1] {
 				log.Printf("Found bad dependency '%s' -> '%s'", rule[0], rule[1])
 				failed = true

--- a/cmd/geth/config.go
+++ b/cmd/geth/config.go
@@ -291,7 +291,7 @@ func makeFullNode(ctx *cli.Context) *node.Node {
 		stack.RegisterLifecycle(simBeacon)
 
 		banner := constructDevModeBanner(ctx, cfg)
-		for _, line := range strings.Split(banner, "\n") {
+		for line := range strings.SplitSeq(banner, "\n") {
 			log.Warn(line)
 		}
 	} else if ctx.IsSet(utils.BeaconApiFlag.Name) {

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -1584,7 +1584,7 @@ func setRequiredBlocks(ctx *cli.Context, cfg *ethconfig.Config) {
 		}
 	}
 	cfg.RequiredBlocks = make(map[uint64]common.Hash)
-	for _, entry := range strings.Split(requiredBlocks, ",") {
+	for entry := range strings.SplitSeq(requiredBlocks, ",") {
 		parts := strings.Split(entry, "=")
 		if len(parts) != 2 {
 			Fatalf("Invalid required block entry: %s", entry)
@@ -2348,7 +2348,7 @@ func MakeConsolePreloads(ctx *cli.Context) []string {
 	// Otherwise resolve absolute paths and return them
 	var preloads []string
 
-	for _, file := range strings.Split(ctx.String(PreloadJSFlag.Name), ",") {
+	for file := range strings.SplitSeq(ctx.String(PreloadJSFlag.Name), ",") {
 		preloads = append(preloads, strings.TrimSpace(file))
 	}
 	return preloads

--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -365,7 +365,7 @@ func NewBlockChain(db ethdb.Database, genesis *Genesis, engine consensus.Engine,
 	}
 	log.Info("")
 	log.Info(strings.Repeat("-", 153))
-	for _, line := range strings.Split(chainConfig.Description(), "\n") {
+	for line := range strings.SplitSeq(chainConfig.Description(), "\n") {
 		log.Info(line)
 	}
 	log.Info(strings.Repeat("-", 153))

--- a/internal/debug/api.go
+++ b/internal/debug/api.go
@@ -217,7 +217,7 @@ func (*HandlerT) Stacks(filter *string) string {
 		dump := buf.String()
 		buf.Reset()
 
-		for _, trace := range strings.Split(dump, "\n\n") {
+		for trace := range strings.SplitSeq(dump, "\n\n") {
 			if ok, _ := expr.Evaluate(map[string]string{"Value": trace}); ok {
 				buf.WriteString(trace)
 				buf.WriteString("\n\n")

--- a/log/handler_glog.go
+++ b/log/handler_glog.go
@@ -86,7 +86,7 @@ func (h *GlogHandler) Verbosity(level slog.Level) {
 //	 sets V to 3 in all files of any packages whose import path contains "foo"
 func (h *GlogHandler) Vmodule(ruleset string) error {
 	var filter []pattern
-	for _, rule := range strings.Split(ruleset, ",") {
+	for  rule := range strings.SplitSeq(ruleset, ",") {
 		// Empty strings such as from a trailing comma can be ignored
 		if len(rule) == 0 {
 			continue
@@ -113,7 +113,7 @@ func (h *GlogHandler) Vmodule(ruleset string) error {
 		}
 		// Compile the rule pattern into a regular expression
 		matcher := ".*"
-		for _, comp := range strings.Split(parts[0], "/") {
+		for comp := range strings.SplitSeq(parts[0], "/") {
 			if comp == "*" {
 				matcher += "(/.*)?"
 			} else if comp != "" {

--- a/node/api.go
+++ b/node/api.go
@@ -185,19 +185,19 @@ func (api *adminAPI) StartHTTP(host *string, port *int, cors *string, apis *stri
 	}
 	if cors != nil {
 		config.CorsAllowedOrigins = nil
-		for _, origin := range strings.Split(*cors, ",") {
+		for origin := range strings.SplitSeq(*cors, ",") {
 			config.CorsAllowedOrigins = append(config.CorsAllowedOrigins, strings.TrimSpace(origin))
 		}
 	}
 	if vhosts != nil {
 		config.Vhosts = nil
-		for _, vhost := range strings.Split(*vhosts, ",") {
+		for vhost := range strings.SplitSeq(*vhosts, ",") {
 			config.Vhosts = append(config.Vhosts, strings.TrimSpace(vhost))
 		}
 	}
 	if apis != nil {
 		config.Modules = nil
-		for _, m := range strings.Split(*apis, ",") {
+		for m := range strings.SplitSeq(*apis, ",") {
 			config.Modules = append(config.Modules, strings.TrimSpace(m))
 		}
 	}
@@ -263,13 +263,13 @@ func (api *adminAPI) StartWS(host *string, port *int, allowedOrigins *string, ap
 	}
 	if apis != nil {
 		config.Modules = nil
-		for _, m := range strings.Split(*apis, ",") {
+		for  m := range strings.SplitSeq(*apis, ",") {
 			config.Modules = append(config.Modules, strings.TrimSpace(m))
 		}
 	}
 	if allowedOrigins != nil {
 		config.Origins = nil
-		for _, origin := range strings.Split(*allowedOrigins, ",") {
+		for origin := range strings.SplitSeq(*allowedOrigins, ",") {
 			config.Origins = append(config.Origins, strings.TrimSpace(origin))
 		}
 	}

--- a/p2p/discover/v5wire/encoding_test.go
+++ b/p2p/discover/v5wire/encoding_test.go
@@ -648,7 +648,7 @@ func writeTestVector(file, comment string, data []byte) {
 	defer fd.Close()
 
 	if len(comment) > 0 {
-		for _, line := range strings.Split(strings.TrimSpace(comment), "\n") {
+		for line := range strings.SplitSeq(strings.TrimSpace(comment), "\n") {
 			fmt.Fprintf(fd, "# %s\n", line)
 		}
 		fmt.Fprintln(fd)

--- a/p2p/dnsdisc/tree.go
+++ b/p2p/dnsdisc/tree.go
@@ -367,7 +367,7 @@ func parseBranch(e string) (entry, error) {
 		return &branchEntry{}, nil // empty entry is OK
 	}
 	hashes := make([]string, 0, strings.Count(e, ","))
-	for _, c := range strings.Split(e, ",") {
+	for  c := range strings.SplitSeq(e, ",") {
 		if !isValidHash(c) {
 			return nil, entryError{"branch", errInvalidChild}
 		}

--- a/rlp/internal/rlpstruct/rlpstruct.go
+++ b/rlp/internal/rlpstruct/rlpstruct.go
@@ -148,7 +148,7 @@ func parseTag(field Field, lastPublic int) (Tags, error) {
 	name := field.Name
 	tag := reflect.StructTag(field.Tag)
 	var ts Tags
-	for _, t := range strings.Split(tag.Get("rlp"), ",") {
+	for t := range strings.SplitSeq(tag.Get("rlp"), ",") {
 		switch t = strings.TrimSpace(t); t {
 		case "":
 			// empty tag is allowed for some reason

--- a/rpc/server_test.go
+++ b/rpc/server_test.go
@@ -92,7 +92,7 @@ func runTestScript(t *testing.T, file string) {
 	defer clientConn.Close()
 	go server.ServeCodec(NewCodec(serverConn), 0)
 	readbuf := bufio.NewReader(clientConn)
-	for _, line := range strings.Split(string(content), "\n") {
+	for line := range strings.SplitSeq(string(content), "\n") {
 		line = strings.TrimSpace(line)
 		switch {
 		case len(line) == 0 || strings.HasPrefix(line, "//"):


### PR DESCRIPTION
This pr Replace strings.Split with strings.SplitSeq to improve memory efficiency and iteration performance in Go 1.24.