### PR TITLE
eth/downloader: fix incorrect waitgroup in test `XTestDelivery`

### DIFF
--- a/eth/downloader/queue_test.go
+++ b/eth/downloader/queue_test.go
@@ -351,6 +351,7 @@ func XTestDelivery(t *testing.T) {
 			}
 		}
 	}()
+	wg.Add(1)
 	go func() {
 		defer wg.Done()
 		// reserve receiptfetch


### PR DESCRIPTION
There are 6 `wg.Done()` and 5 `wg.Add (1)` in the test case `XTestDelivery`.

