### PR TITLE
internal/ethapi: drop redundant big.Int multiplications in tests

### DIFF
--- a/internal/ethapi/api_test.go
+++ b/internal/ethapi/api_test.go
@@ -785,7 +785,7 @@ func TestEstimateGas(t *testing.T) {
 			blockNumber: rpc.LatestBlockNumber,
 			call:        TransactionArgs{},
 			overrides: override.StateOverride{
-				randomAccounts[0].addr: override.OverrideAccount{Balance: newRPCBalance(new(big.Int).Mul(big.NewInt(1), big.NewInt(params.Ether)))},
+			randomAccounts[0].addr: override.OverrideAccount{Balance: newRPCBalance(big.NewInt(params.Ether))},
 			},
 			expectErr: nil,
 			want:      53000,
@@ -1091,7 +1091,7 @@ func TestCall(t *testing.T) {
 				Value: (*hexutil.Big)(big.NewInt(1000)),
 			},
 			overrides: override.StateOverride{
-				randomAccounts[0].addr: override.OverrideAccount{Balance: newRPCBalance(new(big.Int).Mul(big.NewInt(1), big.NewInt(params.Ether)))},
+			randomAccounts[0].addr: override.OverrideAccount{Balance: newRPCBalance(big.NewInt(params.Ether))},
 			},
 			want: "0x",
 		},


### PR DESCRIPTION
replace new(big.Int).Mul(big.NewInt(1), big.NewInt(params.Ether)) with big.NewInt(params.Ether) when creating OverrideAccount balances in internal/ethapi/api_test.go
removes an unnecessary allocation + multiplication by 1 while keeping identical semantics for the state override helpers