### PR TITLE
common: fix duration comparison in PrettyAge

### DIFF
--- a/common/format.go
+++ b/common/format.go
@@ -69,7 +69,7 @@ func (t PrettyAge) String() string {
 	result, prec := "", 0
 
 	for _, unit := range ageUnits {
-		if diff > unit.Size {
+		if diff >= unit.Size {
 			result = fmt.Sprintf("%s%d%s", result, diff/unit.Size, unit.Symbol)
 			diff %= unit.Size
 


### PR DESCRIPTION
This pull request updates `PrettyAge.String` so that the age formatter now treats exact unit boundaries (like a full day or week) as that unit instead of spilling into smaller components, keeping duration output aligned with human expectations.