### PR TITLE
common: avoid allocation in isHex by iterating string bytes directly

### DIFF
--- a/common/bytes.go
+++ b/common/bytes.go
@@ -62,8 +62,8 @@ func isHex(str string) bool {
 	if len(str)%2 != 0 {
 		return false
 	}
-	for _, c := range []byte(str) {
-		if !isHexCharacter(c) {
+	for i := 0; i < len(str); i++ {
+		if !isHexCharacter(str[i]) {
 			return false
 		}
 	}


### PR DESCRIPTION
Replace range-over-[]byte with index-based iteration over the string in isHex to avoid the string→[]byte conversion and its allocation.
Preserves behavior (ASCII hex check, odd-length rejection).
Aligns with hexutil validation style and optimizes a path used by IsHexAddress.