### PR TITLE
ethclient: fix variable shadowing in `FeeHistory()` loop

### DIFF
--- a/ethclient/ethclient.go
+++ b/ethclient/ethclient.go
@@ -639,8 +639,8 @@ func (ec *Client) FeeHistory(ctx context.Context, blockCount uint64, lastBlock *
 	reward := make([][]*big.Int, len(res.Reward))
 	for i, r := range res.Reward {
 		reward[i] = make([]*big.Int, len(r))
-		for j, r := range r {
-			reward[i][j] = (*big.Int)(r)
+		for j, v := range r {
+			reward[i][j] = (*big.Int)(v)
 		}
 	}
 	baseFee := make([]*big.Int, len(res.BaseFee))


### PR DESCRIPTION
Avoid reusing variable name `r` in nested loop inside FeeHistory.The inner loop variable is renamed to `v` to prevent shadowing and improve readability