### PR TITLE
cmd: fix staticcheck warnings QF1012

### DIFF
--- a/cmd/geth/consolecmd.go
+++ b/cmd/geth/consolecmd.go
@@ -152,7 +152,7 @@ func remoteConsole(ctx *cli.Context) error {
 func ephemeralConsole(ctx *cli.Context) error {
 	var b strings.Builder
 	for _, file := range ctx.Args().Slice() {
-		b.WriteString(fmt.Sprintf("loadScript('%s');", file))
+		fmt.Fprintf(&b, "loadScript('%s');", file)
 	}
 	utils.Fatalf(`The "js" command is deprecated. Please use the following instead:
 geth --exec "%s" console`, b.String())


### PR DESCRIPTION
This change replaces `WriteString(fmt.Sprintf(...))` with `fmt.Fprintf` to simplifythe code and avoid unnecessary string allocation.