### PR TITLE
trie: let set the whole children a bit faster

### DIFF
--- a/trie/stacktrie.go
+++ b/trie/stacktrie.go
@@ -157,6 +157,7 @@ const (
 	hashedNode
 )
 
+// emptyNodes is a pre-initialized array of nil pointers used to efficiently clear stNode children arrays during reset operations.
 var emptyNodes = [16]*stNode{}
 
 func (n *stNode) reset() *stNode {


### PR DESCRIPTION
This optimization yields insignificant results, but it may be worthwhile.

Benchmark code:
```
func BenchmarkChildrenCover(b *testing.B) {
	var (
		children   = [16]*stNode{}
		emptyNodes = [16]*stNode{}
	)
	b.Run("coverA", func(b *testing.B) {
		for i := 0; i < b.N; i++ {
			for j := 0; j < 16; j++ {
				children[j] = nil
			}
		}
	})

	b.Run("coverB", func(b *testing.B) {
		for i := 0; i < b.N; i++ {
			copy(children[:], emptyNodes[:])
		}
	})
}
```

result:
```
BenchmarkChildrenCover
BenchmarkChildrenCover/coverA
BenchmarkChildrenCover/coverA-12         	154278429	         7.821 ns/op
BenchmarkChildrenCover/coverB
BenchmarkChildrenCover/coverB-12         	333880758	         3.586 ns/op
```