### PR TITLE
core/state: fix bug about getting stable LogsHash result.

### DIFF
--- a/core/state/statedb.go
+++ b/core/state/statedb.go
@@ -265,7 +265,6 @@ func (s *StateDB) Logs() []*types.Log {
 	for _, lgs := range s.logs {
 		logs = append(logs, lgs...)
 	}
-	// Because map iteration is not stable, we need to sort the logs by TxIndex, then the LogsHash result is stable.
 	sort.Slice(logs, func(i, j int) bool {
 		return logs[i].Index < logs[j].Index
 	})


### PR DESCRIPTION
Because the map iteration is unstable, we need to order logs by tx index and keep the same order with receipts and their logs, so we can still get the same `LogsHash` across runs.