### PR TITLE
Remove redundant slice allocation in testExternalUI

### DIFF
--- a/cmd/clef/main.go
+++ b/cmd/clef/main.go
@@ -899,7 +899,7 @@ func testExternalUI(api *core.SignerAPI) {
 	ctx := context.WithValue(context.Background(), "remote", "clef binary")
 	ctx = context.WithValue(ctx, "scheme", "in-proc")
 	ctx = context.WithValue(ctx, "local", "main")
-	errs := make([]string, 0)
+	var errs []string
 
 	a := common.HexToAddress("0xdeadbeef000000000000000000000000deadbeef")
 	addErr := func(errStr string) {


### PR DESCRIPTION
replace make([]string, 0) with the zero-value declaration to avoid an unnecessary allocation keep the error collection logic unchanged while following idiomatic Go practices