### PR TITLE
core: remove redundant return statement

### DIFF
--- a/core/state_prefetcher.go
+++ b/core/state_prefetcher.go
@@ -118,5 +118,4 @@ func (p *statePrefetcher) Prefetch(block *types.Block, statedb *state.StateDB, c
 
 	blockPrefetchTxsValidMeter.Mark(int64(len(block.Transactions())) - fails.Load())
 	blockPrefetchTxsInvalidMeter.Mark(fails.Load())
-	return
 }


### PR DESCRIPTION
remove redundant return statement