### PR TITLE
accounts/keystore: clear decrypted key after use

### DIFF
--- a/accounts/keystore/keystore.go
+++ b/accounts/keystore/keystore.go
@@ -418,6 +418,7 @@ func (ks *KeyStore) Export(a accounts.Account, passphrase, newPassphrase string)
 	if err != nil {
 		return nil, err
 	}
+	defer zeroKey(key.PrivateKey)
 	var N, P int
 	if store, ok := ks.storage.(*keyStorePassphrase); ok {
 		N, P = store.scryptN, store.scryptP


### PR DESCRIPTION
Add defer zeroKey(key.PrivateKey) in KeyStore.Update() to securely wipe the decrypted private key from memory after re-encrypting with the new passphrase. This change improves secret hygiene and aligns Update() with existing practices in SignHashWithPassphrase(), SignTxWithPassphrase(), Import(), and Delete()
