### PR TITLE
eth/catalyst: get blob v2 using system timestamp

### DIFF
--- a/eth/catalyst/api.go
+++ b/eth/catalyst/api.go
@@ -544,8 +544,8 @@ func (api *ConsensusAPI) GetBlobsV1(hashes []common.Hash) ([]*engine.BlobAndProo
 // Client software MUST return null if syncing or otherwise unable to serve
 // blob pool data.
 func (api *ConsensusAPI) GetBlobsV2(hashes []common.Hash) ([]*engine.BlobAndProofV2, error) {
-	head := api.eth.BlockChain().CurrentHeader()
-	if api.config().LatestFork(head.Time) < forks.Osaka {
+	ts := time.Now().Unix()
+	if api.config().LatestFork(uint64(ts)) < forks.Osaka {
 		return nil, unsupportedForkErr("engine_getBlobsV2 is not available before Osaka fork")
 	}
 	if len(hashes) > 128 {


### PR DESCRIPTION
I fixed issue #33091 by using the system time instead of the currentHeader’s timestamp in the getBlobV2 API to determine whether the network has passed the Osaka/Fulu upgrade.

The Consensus client(Prysm) determines the upgrade state based on the checkpoint epoch synced at startup, while Geth relies on the block timestamp. During Snap sync, the latest block header is unavailable (the head is at height 0 with a placeholder timestamp 1742212800). The consensus client (Prysm) will still continue to sync new block data, retrieving blobs (cells) and proofs from Geth. At the same time, Geth is still syncing block data, so it cannot provide an accurate latest block timestamp.

This caused Geth to log that engine_getBlobsV2 is not available before the Osaka fork, even though it was already running the Osaka version. Using the system time as a fallback provides more accurate fork detection during early sync and prevents misleading pre-Osaka warning logs. Even if the retrieved data is empty, it should have no impact, since the spec allows blobs/cells to be null.

Please let me know if I have misunderstood anything.