### PR TITLE
fix: handle empty slice case when expLen < baseLen in modexp gas calculation

### DIFF
--- a/core/vm/contracts.go
+++ b/core/vm/contracts.go
@@ -591,8 +591,11 @@ func (c *bigModExp) RequiredGas(input []byte) uint64 {
 		if expLen > 32 {
 			expHead.SetBytes(getData(input, baseLen, 32))
 		} else {
-			// TODO: Check that if expLen < baseLen, then getData will return an empty slice
-			expHead.SetBytes(getData(input, baseLen, expLen))
+			if expLen < baseLen && uint64(len(input)) < baseLen+expLen {
+				expHead.SetBytes([]byte{})
+			} else {
+				expHead.SetBytes(getData(input, baseLen, expLen))
+			}
 		}
 	}
 


### PR DESCRIPTION
Implement TODO check for expLen < baseLen case in bigModExp.RequiredGas().

When expLen < baseLen and input length is insufficient, ensure expHead is set to empty slice instead of calling getData with invalid bounds.