### PR TITLE
triedb/pathdb: fix ID assignment in history inspection

### DIFF
--- a/triedb/pathdb/history_inspect.go
+++ b/triedb/pathdb/history_inspect.go
@@ -143,10 +143,6 @@ func historyRange(freezer ethdb.AncientReader) (uint64, uint64, error) {
 	if err != nil {
 		return 0, 0, err
 	}
-	// If there is no history available, return an explicit error.
-	if head == tail {
-		return 0, 0, fmt.Errorf("no history available")
-	}
 	last := head
 
 	fh, err := readStateHistory(freezer, first)


### PR DESCRIPTION
State history uses 1-based IDs, and rawdb.ReadStateHistory maps an ID to the ancient index by subtracting one (id-1). Therefore, the last ID equals the number of ancient items (head), not head-1.
Using last := head - 1 incorrectly treats Ancients() as the last 0-based index, which causes:
- Skipping the newest history (ID head) when iterating [start, end].
- Rejecting valid single-ID ranges due to first >= last being true when only one item exists (first == last).
- Potential invalid reads or underflow handling in empty-store scenarios.

The corrected logic aligns with 1-based ID semantics used across pathdb (e.g., oldest ID is tail+1) and with rawdb’s accessor contracts.