### PR TITLE
common: fix size comparison in StorageSize

### DIFF
--- a/common/size.go
+++ b/common/size.go
@@ -26,13 +26,13 @@ type StorageSize float64
 
 // String implements the stringer interface.
 func (s StorageSize) String() string {
-	if s > 1099511627776 {
+	if s >= 1099511627776 {
 		return fmt.Sprintf("%.2f TiB", s/1099511627776)
-	} else if s > 1073741824 {
+	} else if s >= 1073741824 {
 		return fmt.Sprintf("%.2f GiB", s/1073741824)
-	} else if s > 1048576 {
+	} else if s >= 1048576 {
 		return fmt.Sprintf("%.2f MiB", s/1048576)
-	} else if s > 1024 {
+	} else if s >= 1024 {
 		return fmt.Sprintf("%.2f KiB", s/1024)
 	} else {
 		return fmt.Sprintf("%.2f B", s)
@@ -42,13 +42,13 @@ func (s StorageSize) String() string {
 // TerminalString implements log.TerminalStringer, formatting a string for console
 // output during logging.
 func (s StorageSize) TerminalString() string {
-	if s > 1099511627776 {
+	if s >= 1099511627776 {
 		return fmt.Sprintf("%.2fTiB", s/1099511627776)
-	} else if s > 1073741824 {
+	} else if s >= 1073741824 {
 		return fmt.Sprintf("%.2fGiB", s/1073741824)
-	} else if s > 1048576 {
+	} else if s >= 1048576 {
 		return fmt.Sprintf("%.2fMiB", s/1048576)
-	} else if s > 1024 {
+	} else if s >= 1024 {
 		return fmt.Sprintf("%.2fKiB", s/1024)
 	} else {
 		return fmt.Sprintf("%.2fB", s)


### PR DESCRIPTION
Exactly 1024 bytes gets displayed as "1024.00 B" instead of "1.00 KiB" because we're using `>` instead of `>=`. Fixed both String() and erminalString() so boundary values show up in the right unit.