### PR TITLE
eth/filters: further optimize tx hash map in #32965

### DIFF
--- a/eth/filters/filter.go
+++ b/eth/filters/filter.go
@@ -563,7 +563,7 @@ type ReceiptWithTx struct {
 // In addition to returning receipts, it also returns the corresponding transactions.
 // This is because receipts only contain low-level data, while user-facing data
 // may require additional information from the Transaction.
-func filterReceipts(txHashes map[common.Hash]bool, ev core.ChainEvent) []*ReceiptWithTx {
+func filterReceipts(txHashes map[common.Hash]struct{}, ev core.ChainEvent) []*ReceiptWithTx {
 	var ret []*ReceiptWithTx
 
 	receipts := ev.Receipts
@@ -585,7 +585,7 @@ func filterReceipts(txHashes map[common.Hash]bool, ev core.ChainEvent) []*Receip
 		}
 	} else {
 		for i, receipt := range receipts {
-			if txHashes[receipt.TxHash] {
+			if _, ok := txHashes[receipt.TxHash]; ok {
 				ret = append(ret, &ReceiptWithTx{
 					Receipt:     receipt,
 					Transaction: txs[i],

--- a/eth/filters/filter_system.go
+++ b/eth/filters/filter_system.go
@@ -185,9 +185,9 @@ type subscription struct {
 	txs       chan []*types.Transaction
 	headers   chan *types.Header
 	receipts  chan []*ReceiptWithTx
-	txHashes  map[common.Hash]bool // contains transaction hashes for transactionReceipts subscription filtering
-	installed chan struct{}        // closed when the filter is installed
-	err       chan error           // closed when the filter is uninstalled
+	txHashes  map[common.Hash]struct{} // contains transaction hashes for transactionReceipts subscription filtering
+	installed chan struct{}            // closed when the filter is installed
+	err       chan error               // closed when the filter is uninstalled
 }
 
 // EventSystem creates subscriptions, processes events and broadcasts them to the
@@ -403,9 +403,9 @@ func (es *EventSystem) SubscribePendingTxs(txs chan []*types.Transaction) *Subsc
 // transactions when they are included in blocks. If txHashes is provided, only receipts
 // for those specific transaction hashes will be delivered.
 func (es *EventSystem) SubscribeTransactionReceipts(txHashes []common.Hash, receipts chan []*ReceiptWithTx) *Subscription {
-	hashSet := make(map[common.Hash]bool)
+	hashSet := make(map[common.Hash]struct{}, len(txHashes))
 	for _, h := range txHashes {
-		hashSet[h] = true
+		hashSet[h] = struct{}{}
 	}
 	sub := &subscription{
 		id:        rpc.NewID(),


### PR DESCRIPTION
Follow-up to #32965. 

The previous PR avoided rebuilding hash maps multiple times, but we can optimize further:
- Use `struct{}` instead of `bool` as map value (saves 1 byte per entry)
- Pre-allocate map capacity to avoid rehashing during construction