### PR TITLE
node: remove databases from map only after successful Close

### DIFF
--- a/node/node.go
+++ b/node/node.go
@@ -794,9 +794,10 @@ func (n *Node) wrapDatabase(db ethdb.Database) ethdb.Database {
 // closeDatabases closes all open databases.
 func (n *Node) closeDatabases() (errors []error) {
 	for db := range n.databases {
-		delete(n.databases, db)
 		if err := db.Database.Close(); err != nil {
 			errors = append(errors, err)
+		} else {
+			delete(n.databases, db)
 		}
 	}
 	return errors


### PR DESCRIPTION
Ensure `Node.closeDatabases` removes entries from `n.databases` only after a successful `Close()`, preserving failed entries for diagnostics.
Previously, databases were deleted from the map before close. On close errors, we lost traceability for which DB failed and prevented potential retries/inspection.

