### PR TITLE
build: add wasm targets for keeper

### DIFF
--- a/build/ci.go
+++ b/build/ci.go
@@ -343,6 +343,7 @@ func buildFlags(env build.Environment, staticLinking bool, buildTags []string) (
 		}
 		ld = append(ld, "-extldflags", "'"+strings.Join(extld, " ")+"'")
 	}
+    // TODO(gballet): revisit after the input api has been defined
 	if runtime.GOARCH == "wasm" {
 		ld = append(ld, "-gcflags=all=-d=softfloat")
 	}


### PR DESCRIPTION
[powdr](github.com/powdr-labs/powdr) has tested keeper in their womir system and managed to get it to work. This PR adds wasm as a keeper target. There's another plan by the zkevm team to support wasm with wasi as well, so these PR adds both targets.

These currently uses the `example` tag, as there is no precompile intefrace defined for either target yet. Nonetheless, this is useful for testing these zkvms so it makes sense to support these experimental targets already.