### PR TITLE
docs: clarify geth binary location and PATH usage when built from source

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,10 @@ them using your favourite package manager. Once the dependencies are installed, 
 make geth
 ```
 
+> Note: If you built geth from source, the binary will be located at `build/bin/geth`.
+
+
+
 or, to build the full suite of utilities:
 
 ```shell
@@ -78,12 +82,7 @@ sync quickly to the current state of the network. To do so:
 $ geth console
 ```
 
-> Note: If you built geth from source, the binary will be located at `./build/bin/geth`.
-> You may run it directly via `./build/bin/geth` or add it to your PATH:
->
-> ```sh
-> export PATH="$PWD/build/bin:$PATH"
-> ```
+
 
 
 This command will:


### PR DESCRIPTION
This PR adds a clarification for users who build geth from source.
It explains where the `geth` binary is located and shows how to add
`./build/bin` to the PATH. This helps prevent the common `command not found`
issue for new users. No functional changes.
