### PR TITLE
beacon: fix capitalized error strings

### DIFF
--- a/beacon/light/api/light_api.go
+++ b/beacon/light/api/light_api.go
@@ -411,7 +411,7 @@ func (api *BeaconLightApi) GetBeaconBlock(blockRoot common.Hash) (*types.BeaconB
 	}
 	computedRoot := block.Root()
 	if computedRoot != blockRoot {
-		return nil, fmt.Errorf("Beacon block root hash mismatch (expected: %x, got: %x)", blockRoot, computedRoot)
+		return nil, fmt.Errorf("beacon block root hash mismatch (expected: %x, got: %x)", blockRoot, computedRoot)
 	}
 	return block, nil
 }


### PR DESCRIPTION
error strings should not be capitalized