### PR TITLE
accounts/usbwallet: fix double hashing in SignTextWithPassphrase

### DIFF
--- a/accounts/usbwallet/wallet.go
+++ b/accounts/usbwallet/wallet.go
@@ -632,7 +632,7 @@ func (w *wallet) SignTx(account accounts.Account, tx *types.Transaction, chainID
 // data is not supported for Ledger wallets, so this method will always return
 // an error.
 func (w *wallet) SignTextWithPassphrase(account accounts.Account, passphrase string, text []byte) ([]byte, error) {
-	return w.SignText(account, accounts.TextHash(text))
+	return w.SignText(account, text)
 }
 
 // SignTxWithPassphrase implements accounts.Wallet, attempting to sign the given


### PR DESCRIPTION
- SignTextWithPassphrase calling w.SignText(account, accounts.TextHash(text)), SignText then calling accounts.TextHash() again. This would result in double-hashing
