### PR TITLE
refactor: replace Split in loops with more efficient SplitSeq

### DIFF
--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -1188,8 +1188,8 @@ func setNAT(ctx *cli.Context, cfg *p2p.Config) {
 // SplitAndTrim splits input separated by a comma
 // and trims excessive white space from the substrings.
 func SplitAndTrim(input string) (ret []string) {
-	l := strings.Split(input, ",")
-	for _, r := range l {
+	l := strings.SplitSeq(input, ",")
+	for r := range l {
 		if r = strings.TrimSpace(r); r != "" {
 			ret = append(ret, r)
 		}
@@ -1498,8 +1498,8 @@ func setGPO(ctx *cli.Context, cfg *gasprice.Config) {
 
 func setTxPool(ctx *cli.Context, cfg *legacypool.Config) {
 	if ctx.IsSet(TxPoolLocalsFlag.Name) {
-		locals := strings.Split(ctx.String(TxPoolLocalsFlag.Name), ",")
-		for _, account := range locals {
+		locals := strings.SplitSeq(ctx.String(TxPoolLocalsFlag.Name), ",")
+		for account := range locals {
 			if trimmed := strings.TrimSpace(account); !common.IsHexAddress(trimmed) {
 				Fatalf("Invalid account in --txpool.locals: %s", trimmed)
 			} else {
@@ -1584,7 +1584,7 @@ func setRequiredBlocks(ctx *cli.Context, cfg *ethconfig.Config) {
 		}
 	}
 	cfg.RequiredBlocks = make(map[uint64]common.Hash)
-	for _, entry := range strings.Split(requiredBlocks, ",") {
+	for entry := range strings.SplitSeq(requiredBlocks, ",") {
 		parts := strings.Split(entry, "=")
 		if len(parts) != 2 {
 			Fatalf("Invalid required block entry: %s", entry)
@@ -2348,7 +2348,7 @@ func MakeConsolePreloads(ctx *cli.Context) []string {
 	// Otherwise resolve absolute paths and return them
 	var preloads []string
 
-	for _, file := range strings.Split(ctx.String(PreloadJSFlag.Name), ",") {
+	for file := range strings.SplitSeq(ctx.String(PreloadJSFlag.Name), ",") {
 		preloads = append(preloads, strings.TrimSpace(file))
 	}
 	return preloads

--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -365,7 +365,7 @@ func NewBlockChain(db ethdb.Database, genesis *Genesis, engine consensus.Engine,
 	}
 	log.Info("")
 	log.Info(strings.Repeat("-", 153))
-	for _, line := range strings.Split(chainConfig.Description(), "\n") {
+	for line := range strings.SplitSeq(chainConfig.Description(), "\n") {
 		log.Info(line)
 	}
 	log.Info(strings.Repeat("-", 153))

--- a/internal/cmdtest/test_cmd.go
+++ b/internal/cmdtest/test_cmd.go
@@ -255,8 +255,8 @@ type testlogger struct {
 }
 
 func (tl *testlogger) Write(b []byte) (n int, err error) {
-	lines := bytes.Split(b, []byte("\n"))
-	for _, line := range lines {
+	lines := bytes.SplitSeq(b, []byte("\n"))
+	for line := range lines {
 		if len(line) > 0 {
 			tl.t.Logf("(stderr:%v) %s", tl.name, line)
 		}

--- a/internal/debug/api.go
+++ b/internal/debug/api.go
@@ -217,7 +217,7 @@ func (*HandlerT) Stacks(filter *string) string {
 		dump := buf.String()
 		buf.Reset()
 
-		for _, trace := range strings.Split(dump, "\n\n") {
+		for trace := range strings.SplitSeq(dump, "\n\n") {
 			if ok, _ := expr.Evaluate(map[string]string{"Value": trace}); ok {
 				buf.WriteString(trace)
 				buf.WriteString("\n\n")

--- a/log/handler_glog.go
+++ b/log/handler_glog.go
@@ -86,7 +86,7 @@ func (h *GlogHandler) Verbosity(level slog.Level) {
 //	 sets V to 3 in all files of any packages whose import path contains "foo"
 func (h *GlogHandler) Vmodule(ruleset string) error {
 	var filter []pattern
-	for _, rule := range strings.Split(ruleset, ",") {
+	for rule := range strings.SplitSeq(ruleset, ",") {
 		// Empty strings such as from a trailing comma can be ignored
 		if len(rule) == 0 {
 			continue
@@ -113,7 +113,7 @@ func (h *GlogHandler) Vmodule(ruleset string) error {
 		}
 		// Compile the rule pattern into a regular expression
 		matcher := ".*"
-		for _, comp := range strings.Split(parts[0], "/") {
+		for comp := range strings.SplitSeq(parts[0], "/") {
 			if comp == "*" {
 				matcher += "(/.*)?"
 			} else if comp != "" {

--- a/node/api.go
+++ b/node/api.go
@@ -185,19 +185,19 @@ func (api *adminAPI) StartHTTP(host *string, port *int, cors *string, apis *stri
 	}
 	if cors != nil {
 		config.CorsAllowedOrigins = nil
-		for _, origin := range strings.Split(*cors, ",") {
+		for origin := range strings.SplitSeq(*cors, ",") {
 			config.CorsAllowedOrigins = append(config.CorsAllowedOrigins, strings.TrimSpace(origin))
 		}
 	}
 	if vhosts != nil {
 		config.Vhosts = nil
-		for _, vhost := range strings.Split(*vhosts, ",") {
+		for vhost := range strings.SplitSeq(*vhosts, ",") {
 			config.Vhosts = append(config.Vhosts, strings.TrimSpace(vhost))
 		}
 	}
 	if apis != nil {
 		config.Modules = nil
-		for _, m := range strings.Split(*apis, ",") {
+		for m := range strings.SplitSeq(*apis, ",") {
 			config.Modules = append(config.Modules, strings.TrimSpace(m))
 		}
 	}
@@ -263,13 +263,13 @@ func (api *adminAPI) StartWS(host *string, port *int, allowedOrigins *string, ap
 	}
 	if apis != nil {
 		config.Modules = nil
-		for _, m := range strings.Split(*apis, ",") {
+		for m := range strings.SplitSeq(*apis, ",") {
 			config.Modules = append(config.Modules, strings.TrimSpace(m))
 		}
 	}
 	if allowedOrigins != nil {
 		config.Origins = nil
-		for _, origin := range strings.Split(*allowedOrigins, ",") {
+		for origin := range strings.SplitSeq(*allowedOrigins, ",") {
 			config.Origins = append(config.Origins, strings.TrimSpace(origin))
 		}
 	}

--- a/node/rpcstack_test.go
+++ b/node/rpcstack_test.go
@@ -74,8 +74,8 @@ type originTest struct {
 // and trims excessive white space from the substrings.
 // Copied over from flags.go
 func splitAndTrim(input string) (ret []string) {
-	l := strings.Split(input, ",")
-	for _, r := range l {
+	l := strings.SplitSeq(input, ",")
+	for r := range l {
 		r = strings.TrimSpace(r)
 		if len(r) > 0 {
 			ret = append(ret, r)

--- a/p2p/discover/v5wire/encoding_test.go
+++ b/p2p/discover/v5wire/encoding_test.go
@@ -620,7 +620,7 @@ func hexFile(file string) []byte {
 
 	// Gather hex data, ignore comments.
 	var text []byte
-	for _, line := range bytes.Split(fileContent, []byte("\n")) {
+	for line := range bytes.SplitSeq(fileContent, []byte("\n")) {
 		line = bytes.TrimSpace(line)
 		if len(line) > 0 && line[0] == '#' {
 			continue
@@ -648,7 +648,7 @@ func writeTestVector(file, comment string, data []byte) {
 	defer fd.Close()
 
 	if len(comment) > 0 {
-		for _, line := range strings.Split(strings.TrimSpace(comment), "\n") {
+		for line := range strings.SplitSeq(strings.TrimSpace(comment), "\n") {
 			fmt.Fprintf(fd, "# %s\n", line)
 		}
 		fmt.Fprintln(fd)

--- a/p2p/dnsdisc/tree.go
+++ b/p2p/dnsdisc/tree.go
@@ -367,7 +367,7 @@ func parseBranch(e string) (entry, error) {
 		return &branchEntry{}, nil // empty entry is OK
 	}
 	hashes := make([]string, 0, strings.Count(e, ","))
-	for _, c := range strings.Split(e, ",") {
+	for c := range strings.SplitSeq(e, ",") {
 		if !isValidHash(c) {
 			return nil, entryError{"branch", errInvalidChild}
 		}

--- a/rlp/internal/rlpstruct/rlpstruct.go
+++ b/rlp/internal/rlpstruct/rlpstruct.go
@@ -148,7 +148,7 @@ func parseTag(field Field, lastPublic int) (Tags, error) {
 	name := field.Name
 	tag := reflect.StructTag(field.Tag)
 	var ts Tags
-	for _, t := range strings.Split(tag.Get("rlp"), ",") {
+	for t := range strings.SplitSeq(tag.Get("rlp"), ",") {
 		switch t = strings.TrimSpace(t); t {
 		case "":
 			// empty tag is allowed for some reason

--- a/rpc/server_test.go
+++ b/rpc/server_test.go
@@ -92,7 +92,7 @@ func runTestScript(t *testing.T, file string) {
 	defer clientConn.Close()
 	go server.ServeCodec(NewCodec(serverConn), 0)
 	readbuf := bufio.NewReader(clientConn)
-	for _, line := range strings.Split(string(content), "\n") {
+	for line := range strings.SplitSeq(string(content), "\n") {
 		line = strings.TrimSpace(line)
 		switch {
 		case len(line) == 0 || strings.HasPrefix(line, "//"):


### PR DESCRIPTION
strings.SplitSeq (introduced in Go 1.23)  returns a lazy sequence (strings.Seq), allowing gopher to iterate over tokens one by one without creating an intermediate slice.

It significantly reduces memory allocations and can improve performance for long strings.

More info: https://github.com/golang/go/issues/61901