### PR TITLE
eth/catalyst: always reset timer after sealing error

### DIFF
--- a/eth/catalyst/simulated_beacon.go
+++ b/eth/catalyst/simulated_beacon.go
@@ -280,9 +280,8 @@ func (c *SimulatedBeacon) loop() {
 		case <-timer.C:
 			if err := c.sealBlock(c.withdrawals.pop(10), uint64(time.Now().Unix())); err != nil {
 				log.Warn("Error performing sealing work", "err", err)
-			} else {
-				timer.Reset(time.Second * time.Duration(c.period))
 			}
+			timer.Reset(time.Second * time.Duration(c.period))
 		}
 	}
 }


### PR DESCRIPTION
The periodic sealing loop failed to reset its timer when sealBlock returned an error, causing the timer to never fire again and effectively halting block production in developer periodic mode after the first failure. This is a bug because the loop relies on the timer to trigger subsequent sealing attempts, and transient errors (e.g., pool races or chain rewinds) should not permanently stop the loop. The change moves timer.Reset after the sealing attempt unconditionally, ensuring the loop continues ticking and retrying even when sealing fails, which matches how other periodic timers in the codebase behave and preserves forward progress.