### PR TITLE
core/state: deduplicate code in state update

### DIFF
--- a/core/state/state_sizer.go
+++ b/core/state/state_sizer.go
@@ -218,7 +218,7 @@ func calSizeStats(update *stateUpdate) (SizeStats, error) {
 	// this deviation is negligible and acceptable for measurement purposes.
 	for _, code := range update.codes {
 		stats.ContractCodes += 1
-		stats.ContractCodeBytes += codeKeySize + int64(len(code.blob))
+		stats.ContractCodeBytes += codeKeySize + int64(len(code))
 	}
 	return stats, nil
 }

--- a/core/state/statedb.go
+++ b/core/state/statedb.go
@@ -1324,8 +1324,8 @@ func (s *StateDB) commitAndFlush(block uint64, deleteEmptyObjects bool, noStorag
 	// Commit dirty contract code if any exists
 	if db := s.db.TrieDB().Disk(); db != nil && len(ret.codes) > 0 {
 		batch := db.NewBatch()
-		for _, code := range ret.codes {
-			rawdb.WriteCode(batch, code.hash, code.blob)
+		for hash, code := range ret.codes {
+			rawdb.WriteCode(batch, hash, code)
 		}
 		if err := batch.Write(); err != nil {
 			return nil, err


### PR DESCRIPTION
This PR optimizes the handling of contract codes by deduplicating them in state updates. The `codes` field in `stateUpdate` has been changed from `map[common.Address]contractCode` to `map[common.Hash][]byte`.

Previously, contract codes were tracked by address in the state update. During the commit phase when writing bytecodes to the db, it was possible for duplicate bytecodes to be written to the PebbleDB batch when multiple contracts deployed the same code in the same block. This is a simple optimization that reduces resource consumption by deduplicating bytecodes before committing.

Ran a full sync from genesis to block 1,700,000 with no issues found.

> Note: we may also want to not committing the bytecodes at all if they already exist in the db. This would require extra reads from the code cache or the db. It would need more changes and unsure if it's worth the effort. But from our data analysis, we can be sure that 97% of the contracts reuse existing bytecodes.

> EDIT: did a initial investigation. The total bytes saved from not persisting duplicated bytecode values is around 23GB from genesis to block 23M. Probably not worth it. 