### PR TITLE
 core: use scheme-aware empty root in flushAlloc

### DIFF
--- a/core/genesis.go
+++ b/core/genesis.go
@@ -190,7 +190,7 @@ func flushAlloc(ga *types.GenesisAlloc, triedb *triedb.Database) (common.Hash, e
 		return common.Hash{}, err
 	}
 	// Commit newly generated states into disk if it's not empty.
-	if root != types.EmptyRootHash {
+	if root != emptyRoot {
 		if err := triedb.Commit(root, true); err != nil {
 			return common.Hash{}, err
 		}


### PR DESCRIPTION
The flushAlloc() routine used a hard-coded check against types.EmptyRootHash to decide whether to commit state to triedb. This is incorrect when the trie is Verkle, where the empty root is types.EmptyVerkleHash. As a result, an empty Verkle genesis (no alloc) would still trigger triedb.Commit, which can fail because there are no diff layers to persist. This change compares the computed root against the scheme-appropriate emptyRoot selected earlier in the function, ensuring we do not commit a truly empty state for both MPT and Verkle.