### PR TITLE
docs: add Termux setup guide for Android developers

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,3 +254,13 @@ also included in our repository in the `COPYING.LESSER` file.
 The go-ethereum binaries (i.e. all code inside of the `cmd` directory) are licensed under the
 [GNU General Public License v3.0](https://www.gnu.org/licenses/gpl-3.0.en.html), also
 included in our repository in the `COPYING` file.
+
+## Termux Setup (Android)
+
+You can also set up go-ethereum in Termux on Android for lightweight development or documentation contributions:
+
+```bash
+pkg update && pkg upgrade -y
+pkg install git golang make clang -y
+git clone https://github.com/Tinu280/go-ethereum.git
+cd go-ethereum


### PR DESCRIPTION
Description:
This PR adds a short setup guide for developers using Termux on Android devices.
It provides instructions to install required dependencies (git, golang, make, clang) and verify the environment to build and test go-ethereum natively from Termux.

Motivation:
Many contributors use Android devices for lightweight development.
This guide helps them quickly set up a compatible environment for building and contributing to go-ethereum without needing a desktop system.