### PR TITLE
core/state: fix bidirectional storage validation in StateDB test

### DIFF
--- a/core/state/statedb_test.go
+++ b/core/state/statedb_test.go
@@ -615,7 +615,7 @@ func (test *snapshotTest) checkEqual(state, checkstate *StateDB) error {
 				return checkeq("GetState("+key.Hex()+")", checkstate.GetState(addr, key), value)
 			})
 			forEachStorage(checkstate, addr, func(key, value common.Hash) bool {
-				return checkeq("GetState("+key.Hex()+")", checkstate.GetState(addr, key), value)
+				return checkeq("GetState("+key.Hex()+")", state.GetState(addr, key), value)
 			})
 			other := checkstate.getStateObject(addr)
 			// Check dirty storage which is not in trie


### PR DESCRIPTION
Corrects the checkEqual test function where the second storage iteration was comparing checkstate against itself instead of 
validating against state. This caused incomplete bidirectional verification and could allow storage inconsistencies to pass undetected during snapshot testing.

