### PR TITLE
fix(miner): correct confMu comment to reflect all protected fields

### DIFF
--- a/miner/miner.go
+++ b/miner/miner.go
@@ -65,7 +65,7 @@ var DefaultConfig = Config{
 // Miner is the main object which takes care of submitting new work to consensus
 // engine and gathering the sealing result.
 type Miner struct {
-	confMu      sync.RWMutex // The lock used to protect the config fields: GasCeil, GasTip and Extradata
+	confMu      sync.RWMutex // Protects config fields (GasCeil, GasPrice used as min tip, ExtraData, Recommit) and prio addresses list
 	config      *Config
 	chainConfig *params.ChainConfig
 	engine      consensus.Engine


### PR DESCRIPTION
Update confMu comment to accurately list all protected fields. The comment now correctly refers to GasPrice (not GasTip) and includes the missing Recommit field and prio addresses list that are also protected by this lock.