### PR TITLE
eth/catalyst: handle crypto/rand error when generating prevRandao

### DIFF
--- a/eth/catalyst/simulated_beacon.go
+++ b/eth/catalyst/simulated_beacon.go
@@ -21,6 +21,7 @@ import (
 	"crypto/sha256"
 	"errors"
 	"fmt"
+	"io"
 	"math"
 	"sync"
 	"time"
@@ -193,7 +194,9 @@ func (c *SimulatedBeacon) sealBlock(withdrawals []*types.Withdrawal, timestamp u
 	version := payloadVersion(c.eth.BlockChain().Config(), timestamp)
 
 	var random [32]byte
-	rand.Read(random[:])
+	if _, err := io.ReadFull(rand.Reader, random[:]); err != nil {
+		return fmt.Errorf("failed to read randomness: %w", err)
+	}
 	fcResponse, err := c.engineAPI.forkchoiceUpdated(c.curForkchoiceState, &engine.PayloadAttributes{
 		Timestamp:             timestamp,
 		SuggestedFeeRecipient: feeRecipient,


### PR DESCRIPTION
Replaced an unchecked call to crypto/rand.Read with io.ReadFull(rand.Reader, ...) in SimulatedBeacon.sealBlock and return an error if the randomness source fails. The previous implementation silently ignored failures, risking an all-zero prevRandao in PayloadAttributes.Random. Using io.ReadFull is a common, explicit pattern for securely filling fixed-size buffers and aligns with how randomness is handled elsewhere in the codebase for protocol-relevant values. If randomness generation fails, sealing is aborted and the error propagates to callers, which already handle and log sealing errors; in the normal case there is no behavior change.