### PR TITLE
triedb/pathdb: remove unused trienode history code

### DIFF
--- a/triedb/pathdb/history.go
+++ b/triedb/pathdb/history.go
@@ -180,17 +180,6 @@ func newStorageIdentQuery(address common.Address, addressHash common.Hash, stora
 	}
 }
 
-// newTrienodeIdentQuery constructs a state identifier for a trie node.
-// the addressHash denotes the address hash of the associated account;
-// the path denotes the path of the node within the trie;
-//
-// nolint:unused
-func newTrienodeIdentQuery(addrHash common.Hash, path []byte) stateIdentQuery {
-	return stateIdentQuery{
-		stateIdent: newTrienodeIdent(addrHash, string(path)),
-	}
-}
-
 // history defines the interface of historical data, shared by stateHistory
 // and trienodeHistory.
 type history interface {

--- a/triedb/pathdb/metrics.go
+++ b/triedb/pathdb/metrics.go
@@ -73,13 +73,6 @@ var (
 	stateHistoryDataBytesMeter  = metrics.NewRegisteredMeter("pathdb/history/state/bytes/data", nil)
 	stateHistoryIndexBytesMeter = metrics.NewRegisteredMeter("pathdb/history/state/bytes/index", nil)
 
-	//nolint:unused
-	trienodeHistoryBuildTimeMeter = metrics.NewRegisteredResettingTimer("pathdb/history/trienode/time", nil)
-	//nolint:unused
-	trienodeHistoryDataBytesMeter = metrics.NewRegisteredMeter("pathdb/history/trienode/bytes/data", nil)
-	//nolint:unused
-	trienodeHistoryIndexBytesMeter = metrics.NewRegisteredMeter("pathdb/history/trienode/bytes/index", nil)
-
 	stateIndexHistoryTimer      = metrics.NewRegisteredResettingTimer("pathdb/history/state/index/time", nil)
 	stateUnindexHistoryTimer    = metrics.NewRegisteredResettingTimer("pathdb/history/state/unindex/time", nil)
 	trienodeIndexHistoryTimer   = metrics.NewRegisteredResettingTimer("pathdb/history/trienode/index/time", nil)


### PR DESCRIPTION
Removes unused trienode history code that was never integrated into the codebase. While `writeStateHistory` is actively used in disklayer.go, the trienode equivalents (`writeTrienodeHistory`, `newTrienodeIdentQuery`, and three associated metrics) have no callers.