### PR TITLE
p2p/discover/v5wire: remove redundant bytes clone in WHOAREYOU encoding

### DIFF
--- a/p2p/discover/v5wire/encoding.go
+++ b/p2p/discover/v5wire/encoding.go
@@ -326,7 +326,6 @@ func (c *Codec) encodeWhoareyou(toID enode.ID, packet *Whoareyou) (Header, error
 
 	// Create header.
 	head := c.makeHeader(toID, flagWhoareyou, 0)
-	head.AuthData = slices.Clone(c.buf.Bytes())
 	head.Nonce = packet.Nonce
 
 	// Encode auth data.


### PR DESCRIPTION
drop the unused slices.Clone(c.buf.Bytes()) assignment before head.AuthData is rebuilt, eliminating a needless allocation without changing behaviour, keep the encode path exactly as before while trimming away the redundant work