### PR TITLE
core/rawdb: return iterator error in findTxInBlockBody

### DIFF
--- a/core/rawdb/accessors_indexes.go
+++ b/core/rawdb/accessors_indexes.go
@@ -148,7 +148,7 @@ func findTxInBlockBody(blockbody rlp.RawValue, target common.Hash) (*types.Trans
 	txIndex := uint64(0)
 	for iter.Next() {
 		if iter.Err() != nil {
-			return nil, 0, err
+			return nil, 0, iter.Err()
 		}
 		// The preimage for the hash calculation of legacy transactions
 		// is just their RLP encoding. For typed (EIP-2718) transactions,


### PR DESCRIPTION
The iterator loop in findTxInBlockBody returned the outer-scoped err when iter.Err() was non-nil, which could incorrectly propagate a nil or stale error and hide actual RLP decoding issues. This patch returns iter.Err() as intended by the rlp list iterator API, matching established patterns elsewhere in the codebase and improving diagnostics when encountering malformed transaction entries.