### PR TITLE
github: add auto pr closer

### DIFF
--- a/.github/workflows/close.yml
+++ b/.github/workflows/close.yml
@@ -1,0 +1,23 @@
+name: Check author contributor status
+
+on:
+  pull_request_target:
+    types: [opened, reopened]
+
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+    - uses: actions/checkout@v4
+    - name: Checkout collaborator list repository
+      uses: actions/checkout@v4
+      with:
+        repository: lightclient/geth-collaborators
+        path: geth-collaborators
+    - uses: lightclient/close-pull-request@allowlist
+      with:
+        allowlist: geth-collaborators/COLLABORATORS
+        comment: "To combat excessive pull requests, the go-ethereum team now requires contributors to [register](https://pad.ethereum.org/form/#/3/form/view/8cfd7dbf415489a41cfefb7f4901d549/) as a collaborator. Please see the [policy](https://github.com/lightclient/geth-collaborators) for more information. Thank you for understanding, we look forward to reviewing your contribution!"

--- a/README.md
+++ b/README.md
@@ -218,7 +218,10 @@ There are three different solutions depending on your use case:
 Thank you for considering helping out with the source code! We welcome contributions
 from anyone on the internet, and are grateful for even the smallest of fixes!
 
-If you'd like to contribute to go-ethereum, please fork, fix, commit and send a pull request
+If you'd like to contribute to go-ethereum, please start by submitting the
+[request for collaborator status](https://pad.ethereum.org/form/#/3/form/view/8cfd7dbf415489a41cfefb7f4901d549/)
+form. This helps reduce spam PRs and allows us to thoroughly review
+contributions. After that fork, fix, commit and send a pull request
 for the maintainers to review and merge into the main code base. If you wish to submit
 more complex changes though, please check up with the core devs first on [our Discord Server](https://discord.gg/invite/nthXNEv)
 to ensure those changes are in line with the general philosophy of the project and/or get


### PR DESCRIPTION
_This is currently a proposal and is still waiting for team decision on the matter._

--

Over the past few months we've been thinking about how to improve the PR experience for both external contributors and the maintainers of the project. Over the past couple years, there has been an increase in AI generated or statically analyzable PRs. At the same time, the value of being a committer on go-ethereum is high due to potential airdrops. This creates a bad incentive where contributors want to land commits without caring about progressing the projects.

We value the external contributions, even the small stuff. It's part of what makes go-ethereum amazing. But we also have no way to combat contributors who are abusing the system and only submitting low-value pull requests that move around code. 

After a lot of deliberation, I am are proposing a collaborator allow-list. It will start out with all known GitHub contributors to the go-ethereum repository. New collaborators can request being added to the list be filling out this short [form](https://pad.ethereum.org/form/#/3/form/view/8cfd7dbf415489a41cfefb7f4901d549/). We're not looking to do KYC on contributors. We just want to create some very minimal friction to reduce the number of opportunistic and automated pull requests we encounter. Our intention is add contributions regularly and keep the bar to entry relatively low. What this system provides us is a an avenue to restrict contributors who consistently do not change their contributing behavior despite requests from the maintainers.