### PR TITLE
core/rawdb: remove unused storage snapshot iterator

### DIFF
--- a/core/rawdb/accessors_chain.go
+++ b/core/rawdb/accessors_chain.go
@@ -102,13 +102,6 @@ func WriteHeaderNumber(db ethdb.KeyValueWriter, hash common.Hash, number uint64)
 	}
 }
 
-// DeleteHeaderNumber removes hash->number mapping.
-func DeleteHeaderNumber(db ethdb.KeyValueWriter, hash common.Hash) {
-	if err := db.Delete(headerNumberKey(hash)); err != nil {
-		log.Crit("Failed to delete hash to number mapping", "err", err)
-	}
-}
-
 // ReadHeadHeaderHash retrieves the hash of the current canonical head header.
 func ReadHeadHeaderHash(db ethdb.KeyValueReader) common.Hash {
 	data, _ := db.Get(headHeaderKey)

--- a/core/rawdb/accessors_sync.go
+++ b/core/rawdb/accessors_sync.go
@@ -36,14 +36,6 @@ func WriteSkeletonSyncStatus(db ethdb.KeyValueWriter, status []byte) {
 	}
 }
 
-// DeleteSkeletonSyncStatus deletes the serialized sync status saved at the last
-// shutdown
-func DeleteSkeletonSyncStatus(db ethdb.KeyValueWriter) {
-	if err := db.Delete(skeletonSyncStatusKey); err != nil {
-		log.Crit("Failed to remove skeleton sync status", "err", err)
-	}
-}
-
 // ReadSkeletonHeader retrieves a block header from the skeleton sync store,
 func ReadSkeletonHeader(db ethdb.KeyValueReader, number uint64) *types.Header {
 	data, _ := db.Get(skeletonHeaderKey(number))


### PR DESCRIPTION
 Removes `IterateStorageSnapshots` and its helper `storageSnapshotsKey` which became obsolete after PR #30752 removed the destruct flag. With the Cancun fork's self-destruct behavior change, storage deletions no longer require iteration and these functions have no callers.