### PR TITLE
trie: enforce strict per-depth fetch limit in Missing

### DIFF
--- a/trie/sync.go
+++ b/trie/sync.go
@@ -368,7 +368,7 @@ func (s *Sync) Missing(max int) ([]string, []common.Hash, []common.Hash) {
 
 		// If we have too many already-pending tasks for this depth, throttle
 		depth := int(prio >> 56)
-		if s.fetches[depth] > maxFetchesPerDepth {
+		if s.fetches[depth] >= maxFetchesPerDepth {
 			break
 		}
 		// Item is allowed to be scheduled, add it to the task list


### PR DESCRIPTION
The depth throttling in trie/sync’s Missing() used a strict-greater-than check (>) against maxFetchesPerDepth, which allowed scheduling one extra request per depth before breaking out of the loop. This behavior contradicts the comment that describes the value as a maximum and provides no tangible benefit, since the loop immediately breaks on the next iteration while the counter is already beyond the intended cap. Changing the comparison to greater-or-equal (>=) enforces the documented maximum precisely and prevents depth counters from exceeding the cap by one. This change aligns the implementation with the intended semantics without affecting completion logic, as decrements still occur on commit via commitNodeRequest and commitCodeRequest.