### PR TITLE
eth/tracers: add WithRemovedLog option to mark failed logs as removed

### DIFF
--- a/eth/tracers/native/call.go
+++ b/eth/tracers/native/call.go
@@ -45,7 +45,7 @@ type callLog struct {
 	// Position of the log relative to subcalls within the same trace
 	// See https://github.com/ethereum/go-ethereum/pull/28389 for details
 	Position hexutil.Uint `json:"position"`
-	Removed  bool          `json:"removed,omitempty"`
+	Removed  bool         `json:"removed,omitempty"`
 }
 
 type callFrame struct {
@@ -121,9 +121,9 @@ type callTracer struct {
 }
 
 type callTracerConfig struct {
-	OnlyTopCall     bool `json:"onlyTopCall"`     // If true, call tracer won't collect any subcalls
-	WithLog         bool `json:"withLog"`         // If true, call tracer will collect event logs
-	WithRemovedLog  bool `json:"withRemovedLog"`  // If true, mark failed logs as removed instead of deleting them
+	OnlyTopCall    bool `json:"onlyTopCall"`    // If true, call tracer won't collect any subcalls
+	WithLog        bool `json:"withLog"`        // If true, call tracer will collect event logs
+	WithRemovedLog bool `json:"withRemovedLog"` // If true, mark failed logs as removed instead of deleting them
 }
 
 // newCallTracer returns a native go tracer which tracks


### PR DESCRIPTION
## Summary
- Add `WithRemovedLog` config option to `callTracerConfig`
- Add `Removed` field to `callLog` struct
- Modify `clearFailedLogs` to mark logs as removed instead of deleting them when `WithRemovedLog` is true

## Motivation
When analyzing failed transactions, reverted logs can provide valuable information for debugging and understanding transaction behavior.

## Test plan
- [ ] Test callTracer with `WithRemovedLog: true` on failed transactions
- [ ] Verify logs are marked as removed rather than deleted
- [ ] Ensure backward compatibility when `WithRemovedLog: false` (default)