### PR TITLE
Minor: Derivation path remove unreachable if condition

### DIFF
--- a/accounts/hd.go
+++ b/accounts/hd.go
@@ -71,9 +71,6 @@ func ParseDerivationPath(path string) (DerivationPath, error) {
 	// Handle absolute or relative paths
 	components := strings.Split(path, "/")
 	switch {
-	case len(components) == 0:
-		return nil, errors.New("empty derivation path")
-
 	case strings.TrimSpace(components[0]) == "":
 		return nil, errors.New("ambiguous path: use 'm/' prefix for absolute paths, or no leading '/' for relative ones")
 


### PR DESCRIPTION
Quickly removing some dead code as `strings.Split("", "/") == [""]` thus `len([""]) == 1` making this if condition unreachable, to speed up compilation output branching behaviour