### PR TITLE
accounts/abi: correct regex group index in ABI type size parsing

### DIFF
--- a/accounts/abi/type.go
+++ b/accounts/abi/type.go
@@ -126,7 +126,7 @@ func NewType(t string, internalType string, components []ArgumentMarshaling) (ty
 	var varSize int
 	if len(parsedType[3]) > 0 {
 		var err error
-		varSize, err = strconv.Atoi(parsedType[2])
+		varSize, err = strconv.Atoi(parsedType[3])
 		if err != nil {
 			return Type{}, fmt.Errorf("abi: error parsing variable size: %v", err)
 		}


### PR DESCRIPTION
Fixed incorrect array index when parsing type size from regex match.

The code was checking parsedType[3] but then using parsedType[2] in strconv.Atoi(). 

Since the regex groups are:
- [0] = full match (e.g. "uint256")
- [1] = type name (e.g. "uint")
- [2] = full number part including suffix (e.g. "128x18")
- [3] = first number only (e.g. "128")

This inconsistency doesn't cause issues with current types (where [2] and [3] are identical), but violates code consistency and would break if fixed-point types (e.g., fixed128x18) are ever implemented.