### PR TITLE
metrics: fix resource leak in Write function

### DIFF
--- a/metrics/writer.go
+++ b/metrics/writer.go
@@ -11,7 +11,9 @@ import (
 // Write sorts writes each metric in the given registry periodically to the
 // given io.Writer.
 func Write(r Registry, d time.Duration, w io.Writer) {
-	for range time.Tick(d) {
+	ticker := time.NewTicker(d)
+	defer ticker.Stop()
+	for range ticker.C {
 		WriteOnce(r, w)
 	}
 }


### PR DESCRIPTION


The `Write` function uses `time.Tick`, which creates an unrecoverable timer and goroutine that cannot be stopped. Each call to `Write` leaves behind a permanent background timer, leading to resource leaks over time.

