### PR TITLE
core/state/snapshot: race resulting in `generate()` goroutine leak

### DIFF
--- a/core/state/snapshot/generate_test.go
+++ b/core/state/snapshot/generate_test.go
@@ -34,6 +34,7 @@ import (
 	"github.com/ethereum/go-ethereum/triedb/hashdb"
 	"github.com/ethereum/go-ethereum/triedb/pathdb"
 	"github.com/holiman/uint256"
+	"go.uber.org/goleak"
 	"golang.org/x/crypto/sha3"
 )
 
@@ -53,6 +54,8 @@ func TestGeneration(t *testing.T) {
 }
 
 func testGeneration(t *testing.T, scheme string) {
+	defer goleak.VerifyNone(t)
+
 	// We can't use statedb to make a test trie (circular dependency), so make
 	// a fake one manually. We're going with a small account trie of 3 accounts,
 	// two of which also has the same 3-slot storage trie attached.
@@ -80,9 +83,7 @@ func testGeneration(t *testing.T, scheme string) {
 	checkSnapRoot(t, snap, root)
 
 	// Signal abortion to the generator and wait for it to tear down
-	stop := make(chan *generatorStats)
-	snap.genAbort <- stop
-	<-stop
+	snap.stopGeneration()
 }
 
 // Tests that snapshot generation with existent flat state.


### PR DESCRIPTION
If `snapshot.diskLayer.generate()` completes early enough it set its `genMarker` field to `nil` and races with the `diskLayer.stopGeneration()` method, possibly leaking the `generate()` goroutine as it never receives on the `genAbort` channel. In practice this only means that `Disable()` would leak the goroutine, and that any test with `goleak.Verify*()` needs to ignore it. A cursory read suggests that `Journal()` will successfully release resources.

I've so far only demonstrated this in the test but not fixed it. Before doing so, I wanted to see if anyone thought it was worth it. For me it's only a minor annoyance in always having to ignore the method when checking for my own leaks.