### PR TITLE
 cmd/geth: remove-tablewriter.patch

### DIFF
--- a/remove-tablewriter.patch
+++ b/remove-tablewriter.patch
@@ -1,0 +1,36 @@
+diff --git a/cmd/geth/dbcmd.go b/cmd/geth/dbcmd.go
+index c57add065..219417ce8 100644
+--- a/cmd/geth/dbcmd.go
++++ b/cmd/geth/dbcmd.go
+@@ -41,7 +41,6 @@ import (
+        "github.com/ethereum/go-ethereum/rlp"
+        "github.com/ethereum/go-ethereum/trie"
+        "github.com/ethereum/go-ethereum/triedb"
+-       "github.com/olekukonko/tablewriter"
+        "github.com/urfave/cli/v2"
+ )
+
+@@ -760,10 +759,18 @@ func showMetaData(ctx *cli.Context) error {
+                data = append(data, []string{"headHeader.Root", fmt.Sprintf("%v", h.Root)})
+                data = append(data, []string{"headHeader.Number", fmt.Sprintf("%d (%#x)", h.Number, h.Number)})
+        }
+-
+-       table := tablewriter.NewWriter(os.Stdout)
+-       table.SetHeader([]string{"Field", "Value"})
+-       table.AppendBulk(data)
+-       table.Render()
++
++       fmt.Println(strings.Repeat("-", 60))
++       fmt.Printf("%-32s | %s\n", "Field", "Value")
++       fmt.Println(strings.Repeat("-", 60))
++
++       for _, row := range data {
++               if len(row) == 2 {
++                       fmt.Printf("%-32s | %s\n", row[0], row[1])
++               }
++       }
++
++       fmt.Println(strings.Repeat("-", 60))
+ 
+        return nil
+ }


### PR DESCRIPTION
The patch contains the minimal and isolated diff required to remove all direct references to tablewriter, without touching unrelated files or introducing functional changes.
It is submitted separately to ensure clarity, maintain clean review boundaries, and avoid mixing it with intermediate experimental changes made during local development.