### PR TITLE
params: update P256VerifyGas to 3450 for RIP-7212 L2 compatibility

### DIFF
--- a/params/protocol_params.go
+++ b/params/protocol_params.go
@@ -165,7 +165,7 @@ const (
 	Bls12381MapG1Gas          uint64 = 5500  // Gas price for BLS12-381 mapping field element to G1 operation
 	Bls12381MapG2Gas          uint64 = 23800 // Gas price for BLS12-381 mapping field element to G2 operation
 
-	P256VerifyGas uint64 = 6900 // secp256r1 elliptic curve signature verifier gas price
+	P256VerifyGas uint64 = 3450 // RIP-7212 (L2 compatibility)
 
 	// The Refund Quotient is the cap on how much of the used gas can be refunded. Before EIP-3529,
 	// up to half the consumed gas could be refunded. Redefined as 1/5th in EIP-3529


### PR DESCRIPTION
Update P256VerifyGas from 6900 (EIP-7951) to 3450 (RIP-7212) to ensure compatibility with L2 networks using the RIP-7212 gas pricing standard.