### PR TITLE
eth/catalyst: remove the outdated comments of ForkchoiceUpdatedV1

### DIFF
--- a/eth/catalyst/api.go
+++ b/eth/catalyst/api.go
@@ -163,9 +163,6 @@ func newConsensusAPIWithoutHeartbeat(eth *eth.Ethereum) *ConsensusAPI {
 //
 // We try to set our blockchain to the headBlock.
 //
-// If the method is called with an empty head block: we return success, which can be used
-// to check if the engine API is enabled.
-//
 // If the total difficulty was not reached: we return INVALID.
 //
 // If the finalizedBlockHash is set: we check if we have the finalizedBlockHash in our db,


### PR DESCRIPTION
The ForkchoiceUpdatedV1 comment shows can pass `an empty head block` to `ForkchoiceUpdatedV1`, but it changed now 

https://github.com/ethereum/go-ethereum/blob/f4817b7a5326a14b5648904a5881396f22fcbc37/eth/catalyst/api.go#L231-L234