### PR TITLE
cmd/utils: make datadir.minfreedisk an IntFlag

### DIFF
--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -114,7 +114,7 @@ var (
 		Usage:    "Root directory for era1 history (default = inside ancient/chain)",
 		Category: flags.EthCategory,
 	}
-	MinFreeDiskSpaceFlag = &flags.DirectoryFlag{
+	MinFreeDiskSpaceFlag = &cli.IntFlag{
 		Name:     "datadir.minfreedisk",
 		Usage:    "Minimum free disk space in MB, once reached triggers auto shut down (default = --cache.gc converted to MB, 0 = disabled)",
 		Category: flags.EthCategory,


### PR DESCRIPTION
The flag datadir.minfreedisk was declared as a DirectoryFlag but is documented and consumed as a numeric threshold in megabytes. In StartNode() (cmd/utils/cmd.go) it is read using ctx.Int(...), and tests pass --datadir.minfreedisk 0, confirming numeric intent. With DirectoryFlag, non-zero values would not be parsed as integers and could silently disable the free space safeguard. Switching to cli.IntFlag ensures correct parsing and preserves existing defaults and behavior