### PR TITLE
Simplify SyncProgress.Done completion check

### DIFF
--- a/interfaces.go
+++ b/interfaces.go
@@ -145,10 +145,9 @@ type SyncProgress struct {
 
 // Done returns the indicator if the initial sync is finished or not.
 func (prog SyncProgress) Done() bool {
-	if prog.CurrentBlock < prog.HighestBlock {
-		return false
-	}
-	return prog.TxIndexRemainingBlocks == 0 && prog.StateIndexRemaining == 0
+	return prog.CurrentBlock >= prog.HighestBlock &&
+		prog.TxIndexRemainingBlocks == 0 &&
+		prog.StateIndexRemaining == 0
 }
 
 // ChainSyncReader wraps access to the node's current sync status. If there's no


### PR DESCRIPTION
rewrite SyncProgress.Done to return the completion predicate directly, remove redundant early-return branch without changing behaviour