### PR TITLE
core/txpool/blobpool: drain and signal pending conversion tasks on shutdown

### DIFF
--- a/core/txpool/blobpool/conversion.go
+++ b/core/txpool/blobpool/conversion.go
@@ -183,6 +183,15 @@ func (q *conversionQueue) loop() {
 				log.Debug("Waiting for blobpool billy conversion to exit")
 				<-q.billyTaskDone
 			}
+			// Signal any tasks that were queued for the next batch but never started
+			// so callers blocked in convert() receive an error instead of hanging.
+			for _, t := range txTasks {
+				// Best-effort notify; t.done is a buffered channel of size 1
+				// created by convert(), and we send exactly once per task.
+				t.done <- errors.New("conversion queue closed")
+			}
+			// Drop references to allow GC of the backing array.
+			txTasks = txTasks[:0]
 			return
 		}
 	}


### PR DESCRIPTION
On shutdown, the conversion queue previously interrupted the running batch and optionally waited for an in-flight billy task but returned without notifying tasks buffered for the next batch. Callers of convert() that had successfully enqueued during the active batch would then block forever waiting on their per-task done channel. This change drains txTasks in the quit case and sends a “conversion queue closed” error to each pending task before returning, ensuring all convert() callers are released deterministically. The running batch is still interrupted via interrupt and awaited as before, and billy shutdown semantics remain unchanged.