### PR TITLE
cmd/geth: skip resolver for zero-commitment verkle children

### DIFF
--- a/cmd/geth/verkle.go
+++ b/cmd/geth/verkle.go
@@ -76,10 +76,10 @@ func checkChildren(root verkle.VerkleNode, resolver verkle.NodeResolverFn) error
 		for i, child := range node.Children() {
 			childC := child.Commit().Bytes()
 
-			childS, err := resolver(childC[:])
 			if bytes.Equal(childC[:], zero[:]) {
 				continue
 			}
+			childS, err := resolver(childC[:])
 			if err != nil {
 				return fmt.Errorf("could not find child %x in db: %w", childC, err)
 			}


### PR DESCRIPTION
Skip resolving zero‑commitment Verkle children in checkChildren() by checking for the identity commitment before calling the DB resolver; zero commitments represent empty/identity nodes that have no serialized entry, so avoiding the lookup removes unnecessary I/O without changing behavior.