### PR TITLE
all: use direct equality for Hash/Address instead of bytes.Equal on .Bytes()

### DIFF
--- a/accounts/abi/abi.go
+++ b/accounts/abi/abi.go
@@ -219,7 +219,7 @@ func (abi *ABI) MethodById(sigdata []byte) (*Method, error) {
 // ABI and returns nil if none found.
 func (abi *ABI) EventByID(topic common.Hash) (*Event, error) {
 	for _, event := range abi.Events {
-		if bytes.Equal(event.ID.Bytes(), topic.Bytes()) {
+		if event.ID == topic {
 			return &event, nil
 		}
 	}

--- a/core/blockchain_snapshot_test.go
+++ b/core/blockchain_snapshot_test.go
@@ -20,7 +20,6 @@
 package core
 
 import (
-	"bytes"
 	"fmt"
 	"math/big"
 	"os"
@@ -110,7 +109,7 @@ func (basic *snapshotTestBasic) prepare(t *testing.T) (*BlockChain, []*types.Blo
 			// will be persisted atomically.
 			chain.snaps.Cap(blocks[point-1].Root(), 0)
 			diskRoot, blockRoot := chain.snaps.DiskRoot(), blocks[point-1].Root()
-			if !bytes.Equal(diskRoot.Bytes(), blockRoot.Bytes()) {
+			if diskRoot != blockRoot {
 				t.Fatalf("Failed to flush disk layer change, want %x, got %x", blockRoot, diskRoot)
 			}
 		}
@@ -149,7 +148,7 @@ func (basic *snapshotTestBasic) verify(t *testing.T, chain *BlockChain, blocks [
 	if block == nil {
 		t.Errorf("The corresponding block[%d] of snapshot disk layer is missing", basic.expSnapshotBottom)
 	} else if basic.scheme == rawdb.HashScheme {
-		if !bytes.Equal(chain.snaps.DiskRoot().Bytes(), block.Root().Bytes()) {
+		if chain.snaps.DiskRoot() != block.Root() {
 			t.Errorf("The snapshot disk layer root is incorrect, want %x, get %x", block.Root(), chain.snaps.DiskRoot())
 		}
 	}

--- a/core/vm/instructions_test.go
+++ b/core/vm/instructions_test.go
@@ -680,7 +680,7 @@ func TestCreate2Addresses(t *testing.T) {
 			fmt.Printf("Example %d\n* address `0x%x`\n* salt `0x%x`\n* init_code `0x%x`\n* gas (assuming no mem expansion): `%v`\n* result: `%s`\n\n", i,origin, salt, code, gas, address.String())
 		*/
 		expected := common.BytesToAddress(common.FromHex(tt.expected))
-		if !bytes.Equal(expected.Bytes(), address.Bytes()) {
+		if expected != address {
 			t.Errorf("test %d: expected %s, got %s", i, expected.String(), address.String())
 		}
 	}

--- a/signer/fourbyte/validation.go
+++ b/signer/fourbyte/validation.go
@@ -74,7 +74,7 @@ func (db *Database) ValidateTransaction(selector *string, tx *apitypes.SendTxArg
 	if !tx.To.ValidChecksum() {
 		messages.Warn("Invalid checksum on recipient address")
 	}
-	if bytes.Equal(tx.To.Address().Bytes(), common.Address{}.Bytes()) {
+	if tx.To.Address() == (common.Address{}) {
 		messages.Crit("Transaction recipient is the zero address")
 	}
 	switch {

--- a/triedb/pathdb/journal.go
+++ b/triedb/pathdb/journal.go
@@ -91,7 +91,7 @@ func (db *Database) loadJournal(diskRoot common.Hash) (layer, error) {
 	}
 	// The journal is not matched with persistent state, discard them.
 	// It can happen that geth crashes without persisting the journal.
-	if !bytes.Equal(root.Bytes(), diskRoot.Bytes()) {
+	if root != diskRoot {
 		return nil, fmt.Errorf("%w want %x got %x", errUnmatchedJournal, root, diskRoot)
 	}
 	// Load the disk layer from the journal


### PR DESCRIPTION
Replaced slice-based comparisons with direct equality for fixed-size types to improve clarity and avoid unnecessary slice creation and function calls. In common/types.go, Hash and Address are defined as fixed-size arrays ([32]byte and [20]byte), so comparing them with ==/!= is safe and idiomatic. Updated triedb/pathdb/journal.go (loadJournal) to compare roots via root != diskRoot; accounts/abi/abi.go (EventByID) to compare event.ID == topic; core/blockchain_snapshot_test.go to compare diskRoot != blockRoot and chain.snaps.DiskRoot() != block.Root() and removed the now-unused bytes import;