### PR TITLE
replace redundant fmt.Sprintf with fmt.Sprint in consoleOutput

### DIFF
--- a/signer/rules/rules.go
+++ b/signer/rules/rules.go
@@ -36,7 +36,7 @@ import (
 func consoleOutput(call goja.FunctionCall) goja.Value {
 	output := []string{"JS:> "}
 	for _, argument := range call.Arguments {
-		output = append(output, fmt.Sprintf("%v", argument))
+		output = append(output, fmt.Sprint(argument))
 	}
 	fmt.Fprintln(os.Stderr, strings.Join(output, " "))
 	return goja.Undefined()


### PR DESCRIPTION
simplify `consoleOutput` by replacing `fmt.Sprintf("%v", argument)` with `fmt.Sprint(argument)`, avoid the unnecessary parsing overhead while keeping the exact same string output