### PR TITLE
vm: add missing IsVerkle case to ActivePrecompiles

### DIFF
--- a/core/vm/contracts.go
+++ b/core/vm/contracts.go
@@ -240,6 +240,8 @@ func ActivePrecompiledContracts(rules params.Rules) PrecompiledContracts {
 // ActivePrecompiles returns the precompile addresses enabled with the current configuration.
 func ActivePrecompiles(rules params.Rules) []common.Address {
 	switch {
+	case rules.IsVerkle:
+		return PrecompiledAddressesBerlin
 	case rules.IsOsaka:
 		return PrecompiledAddressesOsaka
 	case rules.IsPrague:


### PR DESCRIPTION
The `activePrecompiledContracts` function handles `rules.IsVerkle` and returns `PrecompiledContractsVerkle` (which equals Berlin contracts), but `ActivePrecompiles` was missing this case entirely.

This could cause a mismatch when Verkle mode is enabled - one function returns Berlin-based contracts while the other would fall through to a different fork's addresses.

Added the missing `IsVerkle` case to return `PrecompiledAddressesBerlin`, keeping both functions in sync.