### PR TITLE
crypto: fix variable shadowing in Keccak256 functions

### DIFF
--- a/crypto/keccak.go
+++ b/crypto/keccak.go
@@ -41,8 +41,8 @@ func Keccak256(data ...[]byte) []byte {
 	b := make([]byte, 32)
 	d := hasherPool.Get().(KeccakState)
 	d.Reset()
-	for _, b := range data {
-		d.Write(b)
+	for _, chunk := range data {
+		d.Write(chunk)
 	}
 	d.Read(b)
 	hasherPool.Put(d)
@@ -54,8 +54,8 @@ func Keccak256(data ...[]byte) []byte {
 func Keccak256Hash(data ...[]byte) (h common.Hash) {
 	d := hasherPool.Get().(KeccakState)
 	d.Reset()
-	for _, b := range data {
-		d.Write(b)
+	for _, chunk := range data {
+		d.Write(chunk)
 	}
 	d.Read(h[:])
 	hasherPool.Put(d)


### PR DESCRIPTION
The loop variable `b` in `Keccak256` and `Keccak256Hash` shadows the outer `b` slice used for the hash result. While Go's scoping rules make the current code work correctly, this shadowing is confusing  and error-prone during refactoring.

Renamed the loop variable to `chunk` for clarity.

Found by running `go vet -shadow` / golangci-lint.