### PR TITLE
core/txpool/locals: fix unsafe nonce comparator in TxTracker.recheck journal sort

### DIFF
--- a/core/txpool/locals/tx_tracker.go
+++ b/core/txpool/locals/tx_tracker.go
@@ -151,7 +151,13 @@ func (tracker *TxTracker) recheck(journalCheck bool) []*types.Transaction {
 		for _, list := range rejournal {
 			// cmp(a, b) should return a negative number when a < b,
 			slices.SortFunc(list, func(a, b *types.Transaction) int {
-				return int(a.Nonce() - b.Nonce())
+				if a.Nonce() < b.Nonce() {
+					return -1
+				}
+				if a.Nonce() > b.Nonce() {
+					return 1
+				}
+				return 0
 			})
 		}
 		// Rejournal the tracker while holding the lock. No new transactions will


### PR DESCRIPTION
Replace the SortFunc comparator used to order transactions by nonce during journal rotation in TxTracker.recheck with explicit comparisons instead of subtracting uint64 nonces and casting to int. The previous int(a.Nonce() - b.Nonce()) could overflow due to unsigned subtraction and then convert to a potentially negative or truncated int in an architecture-dependent way, violating comparator properties and risking non-deterministic ordering. The new comparator uses < and > checks to establish a strict ordering safely and matches the established pattern elsewhere in the codebase (e.g., types.TxByNonce in core/types/transaction.go and legacypool list sorting). This change is isolated to locals’ journal sorting, requires no additional imports, and preserves behavior while removing undefined edge cases.