### PR TITLE
cmd/utils: fix disabling discovery through config file

### DIFF
--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -859,14 +859,14 @@ var (
 		Aliases:  []string{"discv4"},
 		Usage:    "Enables the V4 discovery mechanism",
 		Category: flags.NetworkingCategory,
-		Value:    true,
+		Value:    node.DefaultConfig.P2P.DiscoveryV4,
 	}
 	DiscoveryV5Flag = &cli.BoolFlag{
 		Name:     "discovery.v5",
 		Aliases:  []string{"discv5"},
 		Usage:    "Enables the V5 discovery mechanism",
 		Category: flags.NetworkingCategory,
-		Value:    true,
+		Value:    node.DefaultConfig.P2P.DiscoveryV5,
 	}
 	NetrestrictFlag = &cli.StringFlag{
 		Name:     "netrestrict",
@@ -1368,8 +1368,12 @@ func SetP2PConfig(ctx *cli.Context, cfg *p2p.Config) {
 
 	flags.CheckExclusive(ctx, DiscoveryV4Flag, NoDiscoverFlag)
 	flags.CheckExclusive(ctx, DiscoveryV5Flag, NoDiscoverFlag)
-	cfg.DiscoveryV4 = ctx.Bool(DiscoveryV4Flag.Name)
-	cfg.DiscoveryV5 = ctx.Bool(DiscoveryV5Flag.Name)
+	if ctx.IsSet(DiscoveryV4Flag.Name) {
+		cfg.DiscoveryV4 = ctx.Bool(DiscoveryV4Flag.Name)
+	}
+	if ctx.IsSet(DiscoveryV5Flag.Name) {
+		cfg.DiscoveryV5 = ctx.Bool(DiscoveryV5Flag.Name)
+	}
 
 	if netrestrict := ctx.String(NetrestrictFlag.Name); netrestrict != "" {
 		list, err := netutil.ParseNetlist(netrestrict)

--- a/node/defaults.go
+++ b/node/defaults.go
@@ -69,9 +69,11 @@ var DefaultConfig = Config{
 	BatchResponseMaxSize: 25 * 1000 * 1000,
 	GraphQLVirtualHosts:  []string{"localhost"},
 	P2P: p2p.Config{
-		ListenAddr: ":30303",
-		MaxPeers:   50,
-		NAT:        nat.Any(),
+		ListenAddr:  ":30303",
+		MaxPeers:    50,
+		NAT:         nat.Any(),
+		DiscoveryV4: true,
+		DiscoveryV5: true,
 	},
 	DBEngine: "", // Use whatever exists, will default to Pebble if non-existent and supported
 }


### PR DESCRIPTION
No matter what value of these two flag is set in config file, it will be overwriten in cli flag. See below:
https://github.com/ethereum/go-ethereum/blob/f8e5b53f887effb68ac0a9ac517432bba38c19ff/cmd/utils/flags.go#L1371-L1372