### PR TITLE
core/filtermaps: fix operator precedence in delete logging condition

### DIFF
--- a/core/filtermaps/filtermaps.go
+++ b/core/filtermaps/filtermaps.go
@@ -434,7 +434,7 @@ func (f *FilterMaps) safeDeleteWithLogs(deleteFn func(db ethdb.KeyValueStore, ha
 		lastLogPrinted = start
 	)
 	switch err := deleteFn(f.db, f.hashScheme, func(deleted bool) bool {
-		if deleted && !logPrinted || time.Since(lastLogPrinted) > time.Second*10 {
+		if deleted && (!logPrinted || time.Since(lastLogPrinted) > time.Second*10) {
 			log.Info(action+" in progress...", "elapsed", common.PrettyDuration(time.Since(start)))
 			logPrinted, lastLogPrinted = true, time.Now()
 		}


### PR DESCRIPTION
The original condition `deleted && !logPrinted || time.Since(...)` was incorrectly grouping due to operator precedence, causing logs to print every 10 seconds even when no deletion was happening (deleted=false).

According to SafeDeleteRange documentation, the 'deleted' parameter is "true if entries have actually been deleted already". The logging should only happen when deletion is active.

Fixed by adding parentheses: `deleted && (!logPrinted || time.Since(...))`Now logs print only when items are being deleted AND either it's the first log or 10+ seconds have passed since the last one.