### PR TITLE
core/vm/program: remove redundant allocation in New()

### DIFF
--- a/core/vm/program/program.go
+++ b/core/vm/program/program.go
@@ -42,9 +42,7 @@ type Program struct {
 
 // New creates a new Program
 func New() *Program {
-	return &Program{
-		code: make([]byte, 0),
-	}
+	return &Program{}
 }
 
 // add adds the op to the code.


### PR DESCRIPTION
Use nil slice instead of make([]byte, 0) - they behave identically for append operations but nil avoids one heap 
allocation per constructor call.