### PR TITLE
Remove redundant slice allocation in Program constructor

### DIFF
--- a/core/vm/program/program.go
+++ b/core/vm/program/program.go
@@ -42,9 +42,7 @@ type Program struct {
 
 // New creates a new Program
 func New() *Program {
-	return &Program{
-		code: make([]byte, 0),
-	}
+	return &Program{}
 }
 
 // add adds the op to the code.


### PR DESCRIPTION
rely on the zero value of Program.code instead of allocating an empty slice, avoid one needless heap allocation whenever program.New() is called