### PR TITLE
.github/workflows: validate that the directories exist

### DIFF
--- a/.github/workflows/validate_pr.yml
+++ b/.github/workflows/validate_pr.yml
@@ -1,4 +1,4 @@
-name: PR Format Validatio
+name: PR Format Validation
 
 on:
   pull_request:


### PR DESCRIPTION
A new pointless fad appeared recently where people just create a fairly low information tag at the beginning of their github PR titles. Something like `feat` or other keywords.

This seems to originate from the angular community and to be used for automation scripts over there. We do not use any of those scripts and if we did we would be using the github labels, which offer strictly equivalent functionalities without wasting useful PR title space.

In order for these keywords to fail the validation, I am adding a check that these directories listed indeed exist in the repository.