### PR TITLE
build: fix check_generate not printing changed files

### DIFF
--- a/build/ci.go
+++ b/build/ci.go
@@ -343,7 +343,7 @@ func buildFlags(env build.Environment, staticLinking bool, buildTags []string) (
 		}
 		ld = append(ld, "-extldflags", "'"+strings.Join(extld, " ")+"'")
 	}
-    // TODO(gballet): revisit after the input api has been defined
+	// TODO(gballet): revisit after the input api has been defined
 	if runtime.GOARCH == "wasm" {
 		ld = append(ld, "-gcflags=all=-d=softfloat")
 	}
@@ -462,9 +462,14 @@ func doCheckGenerate() {
 	)
 	pathList := []string{filepath.Join(protocPath, "bin"), protocGenGoPath, os.Getenv("PATH")}
 
+	excludes := []string{"tests/testdata", "build/cache", ".git"}
+	for i := range excludes {
+		excludes[i] = filepath.FromSlash(excludes[i])
+	}
+
 	for _, mod := range goModules {
 		// Compute the origin hashes of all the files
-		hashes, err := build.HashFolder(mod, []string{"tests/testdata", "build/cache", ".git"})
+		hashes, err := build.HashFolder(mod, excludes)
 		if err != nil {
 			log.Fatal("Error computing hashes", "err", err)
 		}
@@ -474,7 +479,7 @@ func doCheckGenerate() {
 		c.Dir = mod
 		build.MustRun(c)
 		// Check if generate file hashes have changed
-		generated, err := build.HashFolder(mod, []string{"tests/testdata", "build/cache", ".git"})
+		generated, err := build.HashFolder(mod, excludes)
 		if err != nil {
 			log.Fatalf("Error re-computing hashes: %v", err)
 		}

--- a/internal/build/file.go
+++ b/internal/build/file.go
@@ -21,20 +21,21 @@ import (
 	"io"
 	"os"
 	"path/filepath"
-	"sort"
-	"strings"
+	"slices"
 )
 
 // HashFolder iterates all files under the given directory, computing the hash
 // of each.
-func HashFolder(folder string, exlude []string) (map[string][32]byte, error) {
+func HashFolder(folder string, excludes []string) (map[string][32]byte, error) {
 	res := make(map[string][32]byte)
 	err := filepath.WalkDir(folder, func(path string, d os.DirEntry, _ error) error {
 		// Skip anything that's exluded or not a regular file
-		for _, skip := range exlude {
-			if strings.HasPrefix(path, filepath.FromSlash(skip)) {
+		// Skip anything that's excluded or not a regular file
+		if slices.Contains(excludes, path) {
+			if d.IsDir() {
 				return filepath.SkipDir
 			}
+			return nil
 		}
 		if !d.Type().IsRegular() {
 			return nil
@@ -71,6 +72,6 @@ func DiffHashes(a map[string][32]byte, b map[string][32]byte) []string {
 			updates = append(updates, file)
 		}
 	}
-	sort.Strings(updates)
+	slices.Sort(updates)
 	return updates
 }


### PR DESCRIPTION
## 1. Fix bug

### 1.1 Issue

The function `doCheckGenerate` does not print the changed files as expected because the function `HashFolder` only iterate the following path: 

- `.`
- `.dockerignore`
- `.git`
- `.gitattributess `

then exits.

### 1.2 Reason

After researching, I found the reason. The parameter `exlude` passed to the `HashFolder` function contains the directory `.git`. Then, when the `filepath.WalkDir` encounters the file `.gitattributes`, it returns the error `filepath.SkipDir` because the prefix contains. `.git` .Due to encountering the error 'filepath.WalkDir' in the root directory, it immediately stopped.

### 1.3 how to fix

#### return right error

- return error`filepath.SkipDir` if it is an excluded directory
- return nil if it is an excluded file

#### handle directory `.github`

Since the directory `.github` has prefix `.git`, so we use equal to check if it is an excluded path.

## 2. Optimize code

Move 'filepath. FromSlash' from function 'HashFolder' to function 'doCheckGenerate', reducing the number of calls from 18000 to 3 times.

## 3. Fix typos

Change `exlude` to `excludes`.