### PR TITLE
Refactor blob sidecar conversion to reduce code duplication

### DIFF
--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -1644,6 +1644,24 @@ func (api *TransactionAPI) currentBlobSidecarVersion() byte {
 	return types.BlobSidecarVersion0
 }
 
+// convertLegacyBlobTxSidecar converts legacy blob transaction proofs to the
+// current version if necessary.
+// TODO: remove in go-ethereum v1.17.x
+func (api *TransactionAPI) convertLegacyBlobTxSidecar(tx *types.Transaction) (*types.Transaction, error) {
+	sc := tx.BlobTxSidecar()
+	if sc == nil {
+		return tx, nil
+	}
+	exp := api.currentBlobSidecarVersion()
+	if sc.Version == types.BlobSidecarVersion0 && exp == types.BlobSidecarVersion1 {
+		if err := sc.ToV1(); err != nil {
+			return nil, fmt.Errorf("blob sidecar conversion failed: %v", err)
+		}
+		tx = tx.WithBlobTxSidecar(sc)
+	}
+	return tx, nil
+}
+
 // SendRawTransaction will add the signed transaction to the transaction pool.
 // The sender is responsible for signing the transaction and using the correct nonce.
 func (api *TransactionAPI) SendRawTransaction(ctx context.Context, input hexutil.Bytes) (common.Hash, error) {
@@ -1652,16 +1670,10 @@ func (api *TransactionAPI) SendRawTransaction(ctx context.Context, input hexutil
 		return common.Hash{}, err
 	}
 
-	// Convert legacy blob transaction proofs.
-	// TODO: remove in go-ethereum v1.17.x
-	if sc := tx.BlobTxSidecar(); sc != nil {
-		exp := api.currentBlobSidecarVersion()
-		if sc.Version == types.BlobSidecarVersion0 && exp == types.BlobSidecarVersion1 {
-			if err := sc.ToV1(); err != nil {
-				return common.Hash{}, fmt.Errorf("blob sidecar conversion failed: %v", err)
-			}
-			tx = tx.WithBlobTxSidecar(sc)
-		}
+	var err error
+	tx, err = api.convertLegacyBlobTxSidecar(tx)
+	if err != nil {
+		return common.Hash{}, err
 	}
 
 	return SubmitTransaction(ctx, api.b, tx)
@@ -1675,16 +1687,10 @@ func (api *TransactionAPI) SendRawTransactionSync(ctx context.Context, input hex
 		return nil, err
 	}
 
-	// Convert legacy blob transaction proofs.
-	// TODO: remove in go-ethereum v1.17.x
-	if sc := tx.BlobTxSidecar(); sc != nil {
-		exp := api.currentBlobSidecarVersion()
-		if sc.Version == types.BlobSidecarVersion0 && exp == types.BlobSidecarVersion1 {
-			if err := sc.ToV1(); err != nil {
-				return nil, fmt.Errorf("blob sidecar conversion failed: %v", err)
-			}
-			tx = tx.WithBlobTxSidecar(sc)
-		}
+	var err error
+	tx, err = api.convertLegacyBlobTxSidecar(tx)
+	if err != nil {
+		return nil, err
 	}
 
 	ch := make(chan core.ChainEvent, 128)


### PR DESCRIPTION
Extracts duplicated blob transaction sidecar conversion logic into a dedicated 
method to improve code maintainability and follow DRY principles.