### PR TITLE
Avoid recalculating elapsed time in history indexer logs

### DIFF
--- a/triedb/pathdb/history_indexer.go
+++ b/triedb/pathdb/history_indexer.go
@@ -608,8 +608,9 @@ func (i *indexIniter) index(done chan struct{}, interrupt *atomic.Int32, lastID 
 					left = lastID - current + 1
 					done = current - beginID
 				)
-				eta := common.CalculateETA(done, left, time.Since(start))
-				i.log.Info("Indexing history", "processed", done, "left", left, "elapsed", common.PrettyDuration(time.Since(start)), "eta", common.PrettyDuration(eta))
+				elapsed := time.Since(start)
+				eta := common.CalculateETA(done, left, elapsed)
+				i.log.Info("Indexing history", "processed", done, "left", left, "elapsed", common.PrettyDuration(elapsed), "eta", common.PrettyDuration(eta))
 			}
 		}
 		i.indexed.Store(current - 1) // update indexing progress


### PR DESCRIPTION
take a single time.Since(start) measurement when emitting progress logs, reuse the cached duration for both ETA calculation and the log message to avoid redundant work