### PR TITLE
eth/downloader: remove dead proc counter

### DIFF
--- a/eth/downloader/queue.go
+++ b/eth/downloader/queue.go
@@ -418,7 +418,7 @@ func (q *queue) reserveHeaders(p *peerConnection, count int, taskPool map[common
 	skip := make([]*types.Header, 0)
 	progress := false
 	throttled := false
-	for proc := 0; len(send) < count && !taskQueue.Empty(); proc++ {
+	for len(send) < count && !taskQueue.Empty() {
 		// the task queue will pop items in order, so the highest prio block
 		// is also the lowest block number.
 		header, _ := taskQueue.Peek()
@@ -433,7 +433,6 @@ func (q *queue) reserveHeaders(p *peerConnection, count int, taskPool map[common
 			taskQueue.PopItem()
 			progress = true
 			delete(taskPool, header.Hash())
-			proc = proc - 1
 			log.Error("Fetch reservation already delivered", "number", header.Number.Uint64())
 			continue
 		}
@@ -455,7 +454,6 @@ func (q *queue) reserveHeaders(p *peerConnection, count int, taskPool map[common
 			// If it's a noop, we can skip this task
 			delete(taskPool, header.Hash())
 			taskQueue.PopItem()
-			proc = proc - 1
 			progress = true
 			continue
 		}


### PR DESCRIPTION
The reserveHeaders loop used a proc counter that was never read and had compensating decrements on stale and noop paths. Since loop termination depends solely on len(send) and taskQueue.Empty and each iteration advances by popping an item while skipped items are requeued after the loop, the proc variable served no purpose. Removing the counter and its decrements eliminates dead code and clarifies intent without changing behavior or performance.