### PR TITLE
ethdb/pebble: add configuration changes

### DIFF
--- a/ethdb/pebble/pebble.go
+++ b/ethdb/pebble/pebble.go
@@ -263,7 +263,9 @@ func New(file string, cache int, handles int, namespace string, readonly bool) (
 			{TargetFileSize: 16 * 1024 * 1024, FilterPolicy: bloom.FilterPolicy(10)},
 			{TargetFileSize: 32 * 1024 * 1024, FilterPolicy: bloom.FilterPolicy(10)},
 			{TargetFileSize: 64 * 1024 * 1024, FilterPolicy: bloom.FilterPolicy(10)},
-			{TargetFileSize: 128 * 1024 * 1024, FilterPolicy: bloom.FilterPolicy(10)},
+
+			// Pebble doesn't use the Bloom filter at level6 for read efficiency.
+			{TargetFileSize: 128 * 1024 * 1024},
 		},
 		ReadOnly: readonly,
 		EventListener: &pebble.EventListener{
@@ -294,10 +296,6 @@ func New(file string, cache int, handles int, namespace string, readonly bool) (
 		// debt will be less than 1GB, but with more frequent compactions scheduled.
 		L0CompactionThreshold: 2,
 	}
-	// Disable seek compaction explicitly. Check https://github.com/ethereum/go-ethereum/pull/20130
-	// for more details.
-	opt.Experimental.ReadSamplingMultiplier = -1
-
 	// Open the db and recover any potential corruptions
 	innerDB, err := pebble.Open(file, opt)
 	if err != nil {


### PR DESCRIPTION
This introduces two main changes to Pebble's configuration:

(a) Remove the Bloom filter at Level 6

The Bloom filter is never used at the bottom-most level, so keeping it serves 
no purpose. Removing it saves storage without affecting read performance.

(b) Re-enable read-sampling compaction

Read-sampling compaction was previously disabled in the hash-based scheme 
because all data was identified by hashes and basically no data overwrite. Read
sampling compaction makes no sense.

After switching to the path-based scheme, data overwrites are much more common, 
making read-sampling compaction beneficial and reasonable to re-enable.