### PR TITLE
core/rawdb: prevent uint64 underflow

### DIFF
--- a/core/rawdb/freezer_table.go
+++ b/core/rawdb/freezer_table.go
@@ -771,8 +771,9 @@ func (t *freezerTable) truncateTail(items uint64) error {
 		deleted    = t.itemOffset.Load()
 	)
 	// Hidden items exceed the current tail file, drop the relevant data files.
-	for current := items - 1; current >= deleted; current -= 1 {
-		if _, err := t.index.ReadAt(buffer, int64((current-deleted+1)*indexEntrySize)); err != nil {
+	for current := items; current > deleted; current-- {
+		idx := current - 1
+		if _, err := t.index.ReadAt(buffer, int64((idx-deleted+1)*indexEntrySize)); err != nil {
 			return err
 		}
 		var pre indexEntry
@@ -780,7 +781,7 @@ func (t *freezerTable) truncateTail(items uint64) error {
 		if pre.filenum != newTailId {
 			break
 		}
-		newDeleted = current
+		newDeleted = idx
 	}
 	// Close the index file before shorten it.
 	if err := t.index.Close(); err != nil {


### PR DESCRIPTION
The reverse loop in freezer_table.go:truncateTail used unsigned iteration with a >= guard, which can underflow after processing the deleted boundary if invariants are broken, leading to a wrapped index and an erroneous ReadAt offset. While the loop typically breaks earlier due to file boundary checks, relying on that invariant is fragile. This change rewrites the loop to iterate with a strictly greater-than guard and use an index variable (idx := current - 1) for access, preserving existing semantics and making the loop robust against underflow.