### PR TITLE
chore(common): cache elapsed milliseconds when computing ETA

### DIFF
--- a/common/eta.go
+++ b/common/eta.go
@@ -21,10 +21,11 @@ import "time"
 // CalculateETA calculates the estimated remaining time based on the
 // number of finished task, remaining task, and the time cost for finished task.
 func CalculateETA(done, left uint64, elapsed time.Duration) time.Duration {
-	if done == 0 || elapsed.Milliseconds() == 0 {
+	ms := elapsed.Milliseconds()
+	if done == 0 || ms == 0 {
 		return 0
 	}
 
-	speed := float64(done) / float64(elapsed.Milliseconds())
+	speed := float64(done) / float64(ms)
 	return time.Duration(float64(left)/speed) * time.Millisecond
 }


### PR DESCRIPTION
cache elapsed.Milliseconds() once in CalculateETA ,reuse the cached value for both the zero-time guard and speed calculation, avoid repeating the same duration-to-millisecond conversion while keeping behaviour identical