### PR TITLE
Remove redundant nil checks in signer tests

### DIFF
--- a/signer/core/signed_data_test.go
+++ b/signer/core/signed_data_test.go
@@ -219,7 +219,7 @@ func TestSignData(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if signature == nil || len(signature) != 65 {
+	if len(signature) != 65 {
 		t.Errorf("Expected 65 byte signature (got %d bytes)", len(signature))
 	}
 	// data/typed via SignTypeData
@@ -228,7 +228,7 @@ func TestSignData(t *testing.T) {
 	var want []byte
 	if signature, err = api.SignTypedData(context.Background(), a, typedData); err != nil {
 		t.Fatal(err)
-	} else if signature == nil || len(signature) != 65 {
+	} else if len(signature) != 65 {
 		t.Errorf("Expected 65 byte signature (got %d bytes)", len(signature))
 	} else {
 		want = signature
@@ -241,7 +241,7 @@ func TestSignData(t *testing.T) {
 		t.Fatal(err)
 	} else if signature, err = api.SignData(context.Background(), apitypes.DataTyped.Mime, a, hexutil.Encode(typedDataJson)); err != nil {
 		t.Fatal(err)
-	} else if signature == nil || len(signature) != 65 {
+	} else if len(signature) != 65 {
 		t.Errorf("Expected 65 byte signature (got %d bytes)", len(signature))
 	} else if have := signature; !bytes.Equal(have, want) {
 		t.Fatalf("want %x, have %x", want, have)


### PR DESCRIPTION
simplify the signer/core signature tests by dropping the redundant `signature == nil` guard, rely on `len(signature) != 65`, which already covers nil slices and keeps the intent clearer