### PR TITLE
triedb/pathdb: allow single-element history ranges

### DIFF
--- a/triedb/pathdb/history_inspect.go
+++ b/triedb/pathdb/history_inspect.go
@@ -55,7 +55,7 @@ func sanitizeRange(start, end uint64, freezer ethdb.AncientReader) (uint64, uint
 		last = end
 	}
 	// Make sure the range is valid
-	if first >= last {
+	if first > last {
 		return 0, 0, fmt.Errorf("range is invalid, first: %d, last: %d", first, last)
 	}
 	return first, last, nil


### PR DESCRIPTION
I made this change to ensure inclusive range semantics in sanitizeRange() because the valid ID range is [tail+1, head] and the code elsewhere iterates <= end. This gives us correct handling of single-entry stores and consistency with documented API behavior