### PR TITLE
internal/debug: fix log memory limit format

### DIFF
--- a/internal/debug/api.go
+++ b/internal/debug/api.go
@@ -252,7 +252,7 @@ func (*HandlerT) SetGCPercent(v int) int {
 //   - Geth also allocates memory off-heap, particularly for fastCache and Pebble,
 //     which can be non-trivial (a few gigabytes by default).
 func (*HandlerT) SetMemoryLimit(limit int64) int64 {
-	log.Info("Setting memory limit", "size", common.PrettyDuration(limit))
+	log.Info("Setting memory limit", "size", common.StorageSize(limit))
 	return debug.SetMemoryLimit(limit)
 }
 


### PR DESCRIPTION
Swapped PrettyDuration for StorageSize when logging SetMemoryLimit so the limit prints as bytes. This avoids misleading "seconds" in the operator logs when GOMEMLIMIT changes.