### PR TITLE
fix(bintrie): prevent OOB on 31-byte stems at depth 248

### DIFF
--- a/trie/bintrie/hashed_node.go
+++ b/trie/bintrie/hashed_node.go
@@ -47,6 +47,9 @@ func (h HashedNode) GetValuesAtStem(_ []byte, _ NodeResolverFn) ([][]byte, error
 }
 
 func (h HashedNode) InsertValuesAtStem(stem []byte, values [][]byte, resolver NodeResolverFn, depth int) (BinaryNode, error) {
+	if depth >= StemSize*8 {
+		return nil, errors.New("InsertValuesAtStem resolve error: node too deep")
+	}
 	// Step 1: Generate the path for this node's position in the tree
 	path, err := keyToPath(depth, stem)
 	if err != nil {

--- a/trie/bintrie/internal_node.go
+++ b/trie/bintrie/internal_node.go
@@ -44,7 +44,7 @@ type InternalNode struct {
 
 // GetValuesAtStem retrieves the group of values located at the given stem key.
 func (bt *InternalNode) GetValuesAtStem(stem []byte, resolver NodeResolverFn) ([][]byte, error) {
-	if bt.depth > 31*8 {
+	if bt.depth >= StemSize*8 {
 		return nil, errors.New("node too deep")
 	}
 
@@ -134,6 +134,9 @@ func (bt *InternalNode) Hash() common.Hash {
 // Already-existing values will be overwritten.
 func (bt *InternalNode) InsertValuesAtStem(stem []byte, values [][]byte, resolver NodeResolverFn, depth int) (BinaryNode, error) {
 	var err error
+	if bt.depth >= StemSize*8 {
+		return nil, errors.New("node too deep")
+	}
 	bit := stem[bt.depth/8] >> (7 - (bt.depth % 8)) & 1
 	if bit == 0 {
 		if bt.left == nil {


### PR DESCRIPTION
This change enforces stem-depth guards in bintrie to avoid out-of-bounds reads when operating on 31-byte stems at depth 248. Internal nodes now reject depth >= StemSize*8 before reading a stem bit, and HashedNode.InsertValuesAtStem rejects generating a path for the same boundary. The keyToPath function remains unchanged because it intentionally supports depth == StemSize*8 for full 32-byte keys as covered by tests; the bug was in callers passing 31-byte stems at that depth.