### PR TITLE
core/rawdb: fix size counting in memory freezer

### DIFF
--- a/core/rawdb/freezer_memory.go
+++ b/core/rawdb/freezer_memory.go
@@ -91,15 +91,14 @@ func (t *memoryTable) truncateHead(items uint64) error {
 	if items < t.offset {
 		return errors.New("truncation below tail")
 	}
-	removeFrom := items - t.offset
-	for i := int(removeFrom); i < len(t.data); i++ {
+	for i := int(items - t.offset); i < len(t.data); i++ {
 		if t.size > uint64(len(t.data[i])) {
 			t.size -= uint64(len(t.data[i]))
 		} else {
 			t.size = 0
 		}
 	}
-	t.data = t.data[:removeFrom]
+	t.data = t.data[:items-t.offset]
 	t.items = items
 	return nil
 }
@@ -116,25 +115,15 @@ func (t *memoryTable) truncateTail(items uint64) error {
 	if t.items < items {
 		return errors.New("truncation above head")
 	}
-	drop := items - t.offset
-	var removed uint64
-	for i := uint64(0); i < drop; i++ {
-		removed += uint64(len(t.data[i]))
+	for i := uint64(0); i < items-t.offset; i++ {
+		if t.size > uint64(len(t.data[i])) {
+			t.size -= uint64(len(t.data[i]))
+		} else {
+			t.size = 0
+		}
 	}
-	newLen := uint64(len(t.data)) - drop
-	if newLen == 0 {
-		t.data = nil
-	} else {
-		newData := make([][]byte, newLen)
-		copy(newData, t.data[drop:])
-		t.data = newData
-	}
+	t.data = t.data[items-t.offset:]
 	t.offset = items
-	if removed >= t.size {
-		t.size = 0
-	} else {
-		t.size -= removed
-	}
 	return nil
 }
 


### PR DESCRIPTION
AncientSize for the in-memory freezer could over-report because memoryTable.size was not decremented on head or tail truncations. This change subtracts the sizes of removed items in truncateHead and truncateTail, and re-allocates the slice on tail truncation to avoid retaining the backing array. The result brings the in-memory freezer’s size accounting in line with the on-disk freezer’s semantics and the documented meaning of size.