### PR TITLE
beacon/params: explicitly handle Fulu fork indices

### DIFF
--- a/beacon/params/params.go
+++ b/beacon/params/params.go
@@ -52,6 +52,8 @@ func StateIndexFinalBlock(forkName string) uint64 {
 	switch forkName {
 	case "bellatrix", "capella", "deneb":
 		return StateIndexFinalBlockOld
+	case "electra", "fulu":
+		return StateIndexFinalBlockElectra
 	default:
 		return StateIndexFinalBlockElectra
 	}
@@ -60,6 +62,8 @@ func StateIndexSyncCommittee(forkName string) uint64 {
 	switch forkName {
 	case "bellatrix", "capella", "deneb":
 		return StateIndexSyncCommitteeOld
+	case "electra", "fulu":
+		return StateIndexSyncCommitteeElectra
 	default:
 		return StateIndexSyncCommitteeElectra
 	}
@@ -68,6 +72,8 @@ func StateIndexNextSyncCommittee(forkName string) uint64 {
 	switch forkName {
 	case "bellatrix", "capella", "deneb":
 		return StateIndexNextSyncCommitteeOld
+	case "electra", "fulu":
+		return StateIndexNextSyncCommitteeElectra
 	default:
 		return StateIndexNextSyncCommitteeElectra
 	}


### PR DESCRIPTION
State index functions in beacon/params were updated to explicitly include "fulu" alongside "electra" in fork handling, aligning with coding style consistency in other parts of the codebase and clarifying Fulu's parameter usage.