### PR TITLE
fix(pathdb): use MaxInt instead of MaxUint32 for int overflow check

### DIFF
--- a/triedb/pathdb/history_trienode.go
+++ b/triedb/pathdb/history_trienode.go
@@ -404,7 +404,7 @@ func decodeSingle(keySection []byte, onValue func([]byte, int, int) error) ([]st
 		keyOff += nn
 
 		// Validate that the values can fit in an int to prevent overflow on 32-bit systems
-		if nShared > uint64(math.MaxUint32) || nUnshared > uint64(math.MaxUint32) || nValue > uint64(math.MaxUint32) {
+		if nShared > uint64(math.MaxInt) || nUnshared > uint64(math.MaxInt) || nValue > uint64(math.MaxInt) {
 			return nil, errors.New("key size too large")
 		}
 


### PR DESCRIPTION
The overflow check in decodeSingle() used math.MaxUint32 to validate values before casting to int. This is incorrect on 32-bit systems where int is signed 32-bit (max 2^31-1), not unsigned (max 2^32-1).

Values between 2.1B and 4.3B would pass the check but overflow when cast to int, causing incorrect behavior. This matters for mipsle builds used by ziren target.

