### PR TITLE
eth/protocols/snap: clean up outdated TODO and adjust log level

### DIFF
--- a/eth/protocols/snap/sync.go
+++ b/eth/protocols/snap/sync.go
@@ -1978,12 +1978,10 @@ func (s *Syncer) processAccountResponse(res *accountResponse) {
 		// The hash of last delivered account in the response
 		last := res.hashes[len(res.hashes)-1]
 		for hash := range res.task.SubTasks {
-			// TODO(rjl493456442) degrade the log level before merging.
 			if hash.Cmp(last) > 0 {
-				log.Info("Keeping suspended storage retrieval", "account", hash)
+				log.Debug("Keeping suspended storage retrieval", "account", hash)
 				continue
 			}
-			// TODO(rjl493456442) degrade the log level before merging.
 			// It should never happen in ethereum.
 			if _, ok := resumed[hash]; !ok {
 				log.Error("Aborting suspended storage retrieval", "account", hash)


### PR DESCRIPTION
The TODO from #29378 requested degrading log level before merging but was overlooked, this removes the outdated comments and changes log.Info to log.Debug as intended.