### PR TITLE
core/vm: fix PC increment for EIP-8024 opcodes

### DIFF
--- a/core/vm/instructions.go
+++ b/core/vm/instructions.go
@@ -964,7 +964,7 @@ func opDupN(pc *uint64, evm *EVM, scope *ScopeContext) ([]byte, error) {
 
 	//The n‘th stack item is duplicated at the top of the stack.
 	scope.Stack.push(scope.Stack.Back(n - 1))
-	*pc += 2
+	*pc += 1
 	return nil, nil
 }
 
@@ -993,7 +993,7 @@ func opSwapN(pc *uint64, evm *EVM, scope *ScopeContext) ([]byte, error) {
 	indexTop := scope.Stack.len() - 1
 	indexN := scope.Stack.len() - 1 - n
 	scope.Stack.data[indexTop], scope.Stack.data[indexN] = scope.Stack.data[indexN], scope.Stack.data[indexTop]
-	*pc += 2
+	*pc += 1
 	return nil, nil
 }
 
@@ -1025,7 +1025,7 @@ func opExchange(pc *uint64, evm *EVM, scope *ScopeContext) ([]byte, error) {
 	indexN := scope.Stack.len() - 1 - n
 	indexM := scope.Stack.len() - 1 - m
 	scope.Stack.data[indexN], scope.Stack.data[indexM] = scope.Stack.data[indexM], scope.Stack.data[indexN]
-	*pc += 2
+	*pc += 1
 	return nil, nil
 }
 

--- a/core/vm/instructions_test.go
+++ b/core/vm/instructions_test.go
@@ -1107,6 +1107,11 @@ func TestEIP8024_Execution(t *testing.T) {
 			codeHex: "e8", // no operand
 			wantErr: true,
 		},
+		{
+			name:     "PC_INCREMENT",
+			codeHex:  "600060006000e80115",
+			wantVals: []uint64{1, 0, 0},
+		},
 	}
 
 	for _, tc := range tests {
@@ -1123,17 +1128,15 @@ func TestEIP8024_Execution(t *testing.T) {
 					return
 				case 0x60:
 					_, err = opPush1(&pc, evm, scope)
-					pc++
 				case 0x80:
 					dup1 := makeDup(1)
 					_, err = dup1(&pc, evm, scope)
-					pc++
 				case 0x56:
 					_, err = opJump(&pc, evm, scope)
-					pc++
 				case 0x5b:
 					_, err = opJumpdest(&pc, evm, scope)
-					pc++
+				case 0x15:
+					_, err = opIszero(&pc, evm, scope)
 				case 0xe6:
 					_, err = opDupN(&pc, evm, scope)
 				case 0xe7:
@@ -1143,6 +1146,7 @@ func TestEIP8024_Execution(t *testing.T) {
 				default:
 					err = &ErrInvalidOpCode{opcode: OpCode(op)}
 				}
+				pc++
 			}
 			if tc.wantErr {
 				if err == nil {


### PR DESCRIPTION
The EIP says to increment PC by 2 _instead of_ the standard increment by 1. The opcode handlers added in #33095 result in incrementing PC by 3, because they ignored the increment already present in `interpreter.go`.

Does this need to be better specified in the EIP? I've added a [new test case](https://github.com/ethereum/EIPs/pull/10859) for it anyway.

Found by @0xriptide.