### PR TITLE
internal/ethapi: select precompiles using the simulated header

### DIFF
--- a/internal/ethapi/simulate.go
+++ b/internal/ethapi/simulate.go
@@ -233,7 +233,7 @@ func (sim *simulator) processBlock(ctx context.Context, block *simBlock, header,
 	if block.BlockOverrides.BlobBaseFee != nil {
 		blockContext.BlobBaseFee = block.BlockOverrides.BlobBaseFee.ToInt()
 	}
-	precompiles := sim.activePrecompiles(sim.base)
+	precompiles := sim.activePrecompiles(header)
 	// State overrides are applied prior to execution of a block
 	if err := block.StateOverrides.Apply(sim.state, precompiles); err != nil {
 		return nil, nil, nil, err


### PR DESCRIPTION
The simulator computed active precompiles from the base header, which is incorrect when simulations cross fork boundaries. This change selects precompiles using the current simulated header so the precompile set matches the block’s number/time. It brings simulate in line with doCall, tracing, and mining, and keeps precompile state overrides applied on the correct epoch set.