### PR TITLE
p2p/tracker: fix head detection in Fulfil to avoid unnecessary timer reschedules

### DIFF
--- a/p2p/tracker/tracker.go
+++ b/p2p/tracker/tracker.go
@@ -185,7 +185,7 @@ func (t *Tracker) Fulfil(peer string, version uint, code uint64, id uint64) {
 		return
 	}
 	// Everything matches, mark the request serviced and meter it
-	wasHead := t.expire.Front() == req.expire
+	wasHead := req.expire.Prev() == nil
 	t.expire.Remove(req.expire)
 	delete(t.pending, id)
 	if wasHead {


### PR DESCRIPTION
The Fulfil path checked whether the removed list element was the head after calling list.Remove, using Prev()==nil. Since Remove clears the element’s links, Prev() is always nil post-removal, causing us to stop and reschedule the timer for every fulfil. Detect the head before removal via Front()==req.expire, then remove and only reschedule if the removed element was the head. This reduces timer churn and matches the intended scheduling semantics.