### PR TITLE
discover: use hash bits value instead of hardcoded 256

### DIFF
--- a/p2p/discover/table.go
+++ b/p2p/discover/table.go
@@ -46,9 +46,9 @@ const (
 
 	// We keep buckets for the upper 1/15 of distances because
 	// it's very unlikely we'll ever encounter a node that's closer.
-	hashBits          = len(common.Hash{}) * 8
-	nBuckets          = hashBits / 15       // Number of buckets
-	bucketMinDistance = hashBits - nBuckets // Log distance of closest bucket
+	hashBits          = uint(len(common.Hash{}) * 8)
+	nBuckets          = int(hashBits / 15)       // Number of buckets
+	bucketMinDistance = int(hashBits) - nBuckets // Log distance of closest bucket
 
 	// IP address limits.
 	bucketIPLimit, bucketSubnet = 2, 24 // at most 2 addresses from the same /24
@@ -272,7 +272,7 @@ func (tab *Table) findnodeByID(target enode.ID, nresults int, preferLive bool) *
 // appendBucketNodes adds nodes at the given distance to the result slice.
 // This is used by the FINDNODE/v5 handler.
 func (tab *Table) appendBucketNodes(dist uint, result []*enode.Node, checkLive bool) []*enode.Node {
-	if dist > 256 {
+	if dist > hashBits {
 		return result
 	}
 	if dist == 0 {

--- a/p2p/discover/v5_udp.go
+++ b/p2p/discover/v5_udp.go
@@ -926,7 +926,7 @@ func (t *UDPv5) collectTableNodes(rip netip.Addr, distances []uint, limit int) [
 	for _, dist := range distances {
 		// Reject duplicate / invalid distances.
 		_, seen := processed[dist]
-		if seen || dist > 256 {
+		if seen || dist > hashBits {
 			continue
 		}
 		processed[dist] = struct{}{}


### PR DESCRIPTION
The 2 places where I have replaced the harcoded values require to be changed, depending on the `hashBits`, if they are left hardcoded and the `hashBits` was changed to the number larger than `256` - the code will have a bug, where certain buckets will be unreachable.