### PR TITLE
eth/tracers/native: include SWAP16 in default ignored opcodes

### DIFF
--- a/eth/tracers/native/erc7562.go
+++ b/eth/tracers/native/erc7562.go
@@ -513,10 +513,9 @@ func defaultIgnoredOpcodes() []hexutil.Uint64 {
 	ignored := make([]hexutil.Uint64, 0, 64)
 
 	// Allow all PUSHx, DUPx and SWAPx opcodes as they have sequential codes
-	for op := vm.PUSH0; op < vm.SWAP16; op++ {
+	for op := vm.PUSH0; op <= vm.SWAP16; op++ {
 		ignored = append(ignored, hexutil.Uint64(op))
 	}
-	ignored = append(ignored, hexutil.Uint64(vm.SWAP16))
 
 	for _, op := range []vm.OpCode{
 		vm.POP, vm.ADD, vm.SUB, vm.MUL,


### PR DESCRIPTION
he default ignored-opcodes set intended to include all PUSHx, DUPx, and SWAPx, but SWAP16 was omitted due to an exclusive upper bound. This contradicted the comment and EVM opcode definitions where SWAP16 (0x9f) is valid. As a result, SWAP16 could appear in the used opcodes report while other SWAPx were filtered out. Include SWAP16 in the ignored set to align behavior and reduce noise.