### PR TITLE
Simplify SyncProgress.Done condition

### DIFF
--- a/interfaces.go
+++ b/interfaces.go
@@ -145,10 +145,9 @@ type SyncProgress struct {
 
 // Done returns the indicator if the initial sync is finished or not.
 func (prog SyncProgress) Done() bool {
-	if prog.CurrentBlock < prog.HighestBlock {
-		return false
-	}
-	return prog.TxIndexRemainingBlocks == 0 && prog.StateIndexRemaining == 0
+	return prog.CurrentBlock >= prog.HighestBlock &&
+		prog.TxIndexRemainingBlocks == 0 &&
+		prog.StateIndexRemaining == 0
 }
 
 // ChainSyncReader wraps access to the node's current sync status. If there's no


### PR DESCRIPTION
replace the redundant early return in SyncProgress.Done with a single boolean expression so the method still returns true only when all completion criteria are met, keep the existing behaviour while removing unnecessary branching for clearer intent