### PR TITLE
ethclient: pass BlockNumberOrHash to eth_getBlockReceipts

### DIFF
--- a/ethclient/ethclient.go
+++ b/ethclient/ethclient.go
@@ -124,7 +124,7 @@ func (ec *Client) PeerCount(ctx context.Context) (uint64, error) {
 // BlockReceipts returns the receipts of a given block number or hash.
 func (ec *Client) BlockReceipts(ctx context.Context, blockNrOrHash rpc.BlockNumberOrHash) ([]*types.Receipt, error) {
 	var r []*types.Receipt
-	err := ec.c.CallContext(ctx, &r, "eth_getBlockReceipts", blockNrOrHash.String())
+	err := ec.c.CallContext(ctx, &r, "eth_getBlockReceipts", blockNrOrHash)
 	if err == nil && r == nil {
 		return nil, ethereum.NotFound
 	}


### PR DESCRIPTION
Previously `BlockReceipts` sent `blockNrOrHash.String()` to eth_getBlockReceipts, which dropped the RequireCanonical flag and could emit the invalid literal "nil" for zero values. This change passes the `rpc.BlockNumberOrHash` object directly so the server can honor RequireCanonical and fail clearly on invalid input. This aligns with other ethclient methods (e.g., BalanceAtHash, CodeAtHash) and remains compatible with the server, which accepts structured parameters.