### PR TITLE
core/stateless: cap witness depth metrics buckets

### DIFF
--- a/core/stateless/stats.go
+++ b/core/stateless/stats.go
@@ -63,12 +63,15 @@ func (s *WitnessStats) Add(nodes map[string][]byte, owner common.Hash) {
 		// The last path is always a leaf.
 		if i == len(paths)-1 || !strings.HasPrefix(paths[i+1], paths[i]) {
 			depth := len(path)
-			if depth >= len(s.accountTrieLeaves) {
-				depth = len(s.accountTrieLeaves) - 1
-			}
 			if owner == (common.Hash{}) {
+				if depth >= len(s.accountTrieLeaves) {
+					depth = len(s.accountTrieLeaves) - 1
+				}
 				s.accountTrieLeaves[depth] += 1
 			} else {
+				if depth >= len(s.storageTrieLeaves) {
+					depth = len(s.storageTrieLeaves) - 1
+				}
 				s.storageTrieLeaves[depth] += 1
 			}
 		}


### PR DESCRIPTION
WitnessStats.Add was indexing fixed-size depth arrays directly by len(path), where path is the trie node prefix in nibbles. For state and storage tries these prefixes can easily exceed 15, which makes the index out of range for the [16]int64 backing arrays and causes a panic when collecting witness statistics. This change clamps the computed depth to the last bucket (15+) so that all deeper leaves are still counted without risking an out-of-bounds access, while preserving the existing 0..15 metrics layout.