### PR TITLE
common/math: validate closing quote in HexOrDecimal64.UnmarshalJSON

### DIFF
--- a/common/math/integer.go
+++ b/common/math/integer.go
@@ -30,7 +30,7 @@ type HexOrDecimal64 uint64
 // It is similar to UnmarshalText, but allows parsing real decimals too, not just
 // quoted decimal strings.
 func (i *HexOrDecimal64) UnmarshalJSON(input []byte) error {
-	if len(input) > 1 && input[0] == '"' {
+	if len(input) >= 2 && input[0] == '"' && input[len(input)-1] == '"' {
 		input = input[1 : len(input)-1]
 	}
 	return i.UnmarshalText(input)


### PR DESCRIPTION
## Motivation

The `UnmarshalJSON` method for `HexOrDecimal64` only checked for an opening quote before stripping quotes, which could cause data truncation when called directly with malformed input (e.g., `"123` instead of `"123"`). This silently corrupted values instead of returning an error.

## Solution

Added validation to check both opening and closing quotes before stripping them. The method now requires `len(input) >= 2` and verifies `input[len(input)-1] == '"'` to ensure the input is a properly quoted string before processing.