### PR TITLE
core/state: make test output message readable

### DIFF
--- a/core/state/statedb_hooked_test.go
+++ b/core/state/statedb_hooked_test.go
@@ -129,7 +129,7 @@ func TestHooks(t *testing.T) {
 
 	for i, want := range wants {
 		if have := result[i]; have != want {
-			t.Fatalf("error event %d, have\n%v\nwant%v\n", i, have, want)
+			t.Fatalf("error event %d\nhave: %v\nwant: %v", i, have, want)
 		}
 	}
 }
@@ -165,7 +165,7 @@ func TestHooks_OnCodeChangeV2(t *testing.T) {
 
 	for i, want := range wants {
 		if have := result[i]; have != want {
-			t.Fatalf("error event %d, have\n%v\nwant%v\n", i, have, want)
+			t.Fatalf("error event %d\nhave: %v\nwant: %v", i, have, want)
 		}
 	}
 }


### PR DESCRIPTION
This PR improves the output messages for test case `TestHooks` and `TestHooks_OnCodeChangeV2` when encountering error:

Without this PR:

```text
    statedb_hooked_test.go:126: error event 2, have
        0xaa00000000000000000000000000000000000000.nonce: 0->1337
        want0xaa00000000000000000000000000000000000000.nonce: 1336->1337
```

With this PR:
```text
    statedb_hooked_test.go:126: error event 2
        have: 0xaa00000000000000000000000000000000000000.nonce: 0->1337
        want: 0xaa00000000000000000000000000000000000000.nonce: 1336->1337
```