### PR TITLE
crypto/signify: fix fuzz test compilation

### DIFF
--- a/crypto/signify/signify_fuzz.go
+++ b/crypto/signify/signify_fuzz.go
@@ -56,7 +56,7 @@ func Fuzz(data []byte) int {
 	fmt.Printf("untrusted: %v\n", untrustedComment)
 	fmt.Printf("trusted: %v\n", trustedComment)
 
-	err = SignifySignFile(tmpFile.Name(), tmpFile.Name()+".sig", testSecKey, untrustedComment, trustedComment)
+	err = SignFile(tmpFile.Name(), tmpFile.Name()+".sig", testSecKey, untrustedComment, trustedComment)
 	if err != nil {
 		panic(err)
 	}
@@ -68,7 +68,7 @@ func Fuzz(data []byte) int {
 		signify = path
 	}
 
-	_, err := exec.LookPath(signify)
+	_, err = exec.LookPath(signify)
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
The fuzz test file has been broken for a while - it doesn't compile with the `gofuzz` build tag.

Two issues:
- Line 59: called `SignifySignFile` which doesn't exist (should be `SignFile`)
- Line 71: used `:=` instead of `=` for already declared `err` variable

