### PR TITLE
core/state: always emit self-destruct hook even for zero balance

### DIFF
--- a/core/state/statedb_hooked.go
+++ b/core/state/statedb_hooked.go
@@ -227,7 +227,7 @@ func (s *hookedStateDB) SelfDestruct(address common.Address) uint256.Int {
 
 	prev := s.inner.SelfDestruct(address)
 
-	if s.hooks.OnBalanceChange != nil && !prev.IsZero() {
+	if s.hooks.OnBalanceChange != nil {
 		s.hooks.OnBalanceChange(address, prev.ToBig(), new(big.Int), tracing.BalanceDecreaseSelfdestruct)
 	}
 
@@ -253,7 +253,7 @@ func (s *hookedStateDB) SelfDestruct6780(address common.Address) (uint256.Int, b
 
 	prev, changed := s.inner.SelfDestruct6780(address)
 
-	if s.hooks.OnBalanceChange != nil && !prev.IsZero() {
+	if s.hooks.OnBalanceChange != nil {
 		s.hooks.OnBalanceChange(address, prev.ToBig(), new(big.Int), tracing.BalanceDecreaseSelfdestruct)
 	}
 


### PR DESCRIPTION
The SelfDestruct method only emits OnBalanceChange when prev.Sign() != 0, but it should always emit the hook when a self-destruct occurs, even if the balance is zero. The hook consumer might want to track self-destructs regardless of balance. Consider checking the hook availability first, then invoking it for all self-destructs, not just those with non-zero balance.