### PR TITLE
core/rawdb: reduce allocs in block key functions

### DIFF
--- a/core/rawdb/schema.go
+++ b/core/rawdb/schema.go
@@ -191,7 +191,18 @@ func headerKeyPrefix(number uint64) []byte {
 
 // headerKey = headerPrefix + num (uint64 big endian) + hash
 func headerKey(number uint64, hash common.Hash) []byte {
-	return append(append(headerPrefix, encodeBlockNumber(number)...), hash.Bytes()...)
+	totalLen := len(headerPrefix) + 8 + common.HashLength
+	out := make([]byte, totalLen)
+
+	off := 0
+	off += copy(out[off:], headerPrefix)
+
+	var enc [8]byte
+	binary.BigEndian.PutUint64(enc[:], number)
+	off += copy(out[off:], enc[:])
+
+	copy(out[off:], hash.Bytes())
+	return out
 }
 
 // headerHashKey = headerPrefix + num (uint64 big endian) + headerHashSuffix


### PR DESCRIPTION
Optimize headerKey construction by using pre-allocated buffer instead of chained append operations, reducing memory allocations.