### PR TITLE
ci: bump actions/cache to v5

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -17,7 +17,7 @@ jobs:
         submodules: false
 
     # Cache build tools to avoid downloading them each time
-    - uses: actions/cache@v4
+    - uses: actions/cache@v5
       with:
         path: build/cache
         key: ${{ runner.os }}-build-tools-cache-${{ hashFiles('build/checksums.txt') }}
@@ -97,3 +97,4 @@ jobs:
 
       - name: Run tests
         run: go run build/ci.go test -p 8
+

--- a/crypto/secp256k1/libsecp256k1/.github/actions/install-homebrew-valgrind/action.yml
+++ b/crypto/secp256k1/libsecp256k1/.github/actions/install-homebrew-valgrind/action.yml
@@ -16,7 +16,7 @@ runs:
         cat valgrind_fingerprint
       shell: bash
 
-    - uses: actions/cache@v4
+    - uses: actions/cache@v5
       id: cache
       with:
         path: ${{ env.CI_HOMEBREW_CELLAR_VALGRIND }}


### PR DESCRIPTION
Upgrade actions/cache from v4 to v5.

Ref: https://github.com/actions/cache/releases/tag/v5.0.1