### PR TITLE
fix: use proper map key check in stateSet.revertTo

### DIFF
--- a/triedb/pathdb/states.go
+++ b/triedb/pathdb/states.go
@@ -299,8 +299,8 @@ func (s *stateSet) revertTo(accountOrigin map[common.Hash][]byte, storageOrigin 
 	}
 	// Overwrite the storage data with original value blindly
 	for addrHash, storage := range storageOrigin {
-		slots := s.storageData[addrHash]
-		if len(slots) == 0 {
+		slots, ok := s.storageData[addrHash]
+		if !ok {
 			panic(fmt.Sprintf("non-existent storage set for reverting, %x", addrHash))
 		}
 		for storageHash, blob := range storage {


### PR DESCRIPTION
Fix incorrect check for storage map existence in revertTo function.

The old code used `len(slots) == 0` to detect missing storage entries, but this doesn't distinguish between a missing key (returns nil) and an empty map (also len == 0). This could cause a panic when accessing a nil map.

Changed to use the proper two-value map lookup with `ok` check, matching the pattern used for accountData in the same function and throughout the codebase.