### PR TITLE
.github/workflows: preventively close PRs that seem AI-generated

### DIFF
--- a/.github/workflows/validate_pr.yml
+++ b/.github/workflows/validate_pr.yml
@@ -8,6 +8,45 @@ jobs:
   validate-pr:
     runs-on: ubuntu-latest
     steps:
+      - name: Check for Spam PR
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const prTitle = context.payload.pull_request.title;
+            const spamRegex = /^(feat|chore|fix)(\(.*\))?\s*:/i;
+
+            if (spamRegex.test(prTitle)) {
+              // Leave a comment explaining why
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.payload.pull_request.number,
+                body: `## PR Closed as Spam
+
+            This PR was automatically closed because the title format \`feat:\`, \`fix:\`, or \`chore:\` is commonly associated with spam contributions.
+
+            If this is a legitimate contribution, please:
+            1. Review our contribution guidelines
+            2. Use the correct PR title format: \`directory, ...: description\`
+            3. Open a new PR with the proper title format
+
+            Thank you for your understanding.`
+              });
+
+              // Close the PR
+              await github.rest.pulls.update({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                pull_number: context.payload.pull_request.number,
+                state: 'closed'
+              });
+
+              core.setFailed('PR closed as spam due to suspicious title format');
+              return;
+            }
+
+            console.log('✅ PR passed spam check');
+
       - name: Checkout repository
         uses: actions/checkout@v4
 


### PR DESCRIPTION
This is a new step in my crusade against the braindead fad of starting PR titles with a word that is completely redundant with github labels, thus wasting prime first-line real-estate for something that isn't necessary.

I noticed that every single one of these PRs are low-quality AI-slop, so I think there is a strong case to be made for these PRs to be auto-closed. A message is added before closing the PR, redirecting to our contribution guidelines, so I expect quality first-time contributors to read them and reopen the PR. In the case of spam PRs, the author is unlikely to revisit a given PR, and so auto-closing might have a positive impact. That's an experiment worth trying, imo.