### PR TITLE
Clarify behavior of deprecated `--metrics.expensive` flag in logs

### DIFF
--- a/cmd/geth/config.go
+++ b/cmd/geth/config.go
@@ -344,7 +344,8 @@ func applyMetricConfig(ctx *cli.Context, cfg *gethConfig) {
 		cfg.Metrics.Enabled = ctx.Bool(utils.MetricsEnabledFlag.Name)
 	}
 	if ctx.IsSet(utils.MetricsEnabledExpensiveFlag.Name) {
-		log.Warn("Expensive metrics are collected by default, please remove this flag", "flag", utils.MetricsEnabledExpensiveFlag.Name)
+		// Deprecated flag is ignored; expensive metrics stay disabled.
+		log.Warn("The flag is deprecated and ignored; expensive metrics remain disabled", "flag", utils.MetricsEnabledExpensiveFlag.Name)
 	}
 	if ctx.IsSet(utils.MetricsHTTPFlag.Name) {
 		cfg.Metrics.HTTP = ctx.String(utils.MetricsHTTPFlag.Name)


### PR DESCRIPTION
 Updates the warning log for the deprecated `--metrics.expensive` flag to clearly state that the flag is ignored and expensive metrics remain disabled.  
The previous message incorrectly implied that expensive metrics are collected by default, which could mislead operators about the actual metrics configuration.