### PR TITLE
core/rawdb: enhance database key construction

### DIFF
--- a/core/rawdb/schema.go
+++ b/core/rawdb/schema.go
@@ -235,7 +235,15 @@ func blockBodyKey(number uint64, hash common.Hash) []byte {
 
 // blockReceiptsKey = blockReceiptsPrefix + num (uint64 big endian) + hash
 func blockReceiptsKey(number uint64, hash common.Hash) []byte {
-	return append(append(blockReceiptsPrefix, encodeBlockNumber(number)...), hash.Bytes()...)
+	totalLen := len(blockReceiptsPrefix) + 8 + common.HashLength
+	out := make([]byte, totalLen)
+
+	off := 0
+	off += copy(out[off:], blockReceiptsPrefix)
+	off += copy(out[off:], encodeBlockNumber(number))
+	copy(out[off:], hash.Bytes())
+
+	return out
 }
 
 // txLookupKey = txLookupPrefix + hash


### PR DESCRIPTION
This change optimizes key construction by reducing allocations.
Cherry Pick #32431 

```
goos: linux
goarch: amd64
pkg: github.com/ethereum/go-ethereum/core/rawdb
cpu: Intel(R) Core(TM) i7-8565U CPU @ 1.80GHz
            │ old_bench.txt │            new_bench.txt             │
            │    sec/op     │    sec/op     vs base                │
HeaderKey-8    75.14n ± 10%   47.07n ± 16%  -37.36% (p=0.000 n=10)

            │ old_bench.txt │           new_bench.txt            │
            │     B/op      │    B/op     vs base                │
HeaderKey-8      64.00 ± 0%   48.00 ± 0%  -25.00% (p=0.000 n=10)

            │ old_bench.txt │           new_bench.txt            │
            │   allocs/op   │ allocs/op   vs base                │
HeaderKey-8      2.000 ± 0%   1.000 ± 0%  -50.00% (p=0.000 n=10)
```

Benchmark Test
```
var sink []byte

func BenchmarkHeaderKey(b *testing.B) {
	var h common.Hash
	for i := range h {
		h[i] = byte(rand.Intn(256))
	}

	b.ResetTimer()
	for i := 0; b.Loop(); i++ {
		sink = headerKey(uint64(i), h)
	}
	b.StopTimer()
}
```