### PR TITLE
eth/catalyst: fix invalid timestamp log message

### DIFF
--- a/eth/catalyst/api.go
+++ b/eth/catalyst/api.go
@@ -757,7 +757,7 @@ func (api *ConsensusAPI) newPayload(params engine.ExecutableData, versionedHashe
 		return api.delayPayloadImport(block), nil
 	}
 	if block.Time() <= parent.Time() {
-		log.Warn("Invalid timestamp", "parent", block.Time(), "block", block.Time())
+		log.Warn("Invalid timestamp", "parent", parent.Time(), "block", block.Time())
 		return api.invalid(errors.New("invalid timestamp"), parent.Header()), nil
 	}
 	// Another corner case: if the node is in snap sync mode, but the CL client


### PR DESCRIPTION
Fixes a typo in the NewPayload invalid timestamp warning where the parent timestamp was incorrectly logged as the block timestamp.