### PR TITLE
core: add code read statistics

### DIFF
--- a/core/blockchain_stats.go
+++ b/core/blockchain_stats.go
@@ -37,6 +37,7 @@ type ExecuteStats struct {
 	AccountCommits time.Duration // Time spent on the account trie commit
 	StorageUpdates time.Duration // Time spent on the storage trie update
 	StorageCommits time.Duration // Time spent on the storage trie commit
+	CodeReads      time.Duration // Time spent on the contract code read
 
 	AccountLoaded  int // Number of accounts loaded
 	AccountUpdated int // Number of accounts updated
@@ -44,6 +45,7 @@ type ExecuteStats struct {
 	StorageLoaded  int // Number of storage slots loaded
 	StorageUpdated int // Number of storage slots updated
 	StorageDeleted int // Number of storage slots deleted
+	CodeLoaded     int // Number of contract code loaded
 
 	Execution       time.Duration // Time spent on the EVM execution
 	Validation      time.Duration // Time spent on the block validation
@@ -61,19 +63,21 @@ type ExecuteStats struct {
 
 // reportMetrics uploads execution statistics to the metrics system.
 func (s *ExecuteStats) reportMetrics() {
-	accountReadTimer.Update(s.AccountReads) // Account reads are complete(in processing)
-	storageReadTimer.Update(s.StorageReads) // Storage reads are complete(in processing)
 	if s.AccountLoaded != 0 {
+		accountReadTimer.Update(s.AccountReads)
 		accountReadSingleTimer.Update(s.AccountReads / time.Duration(s.AccountLoaded))
 	}
 	if s.StorageLoaded != 0 {
+		storageReadTimer.Update(s.StorageReads)
 		storageReadSingleTimer.Update(s.StorageReads / time.Duration(s.StorageLoaded))
 	}
-
+	if s.CodeLoaded != 0 {
+		codeReadTimer.Update(s.CodeReads)
+		codeReadSingleTimer.Update(s.CodeReads / time.Duration(s.CodeLoaded))
+	}
 	accountUpdateTimer.Update(s.AccountUpdates) // Account updates are complete(in validation)
 	storageUpdateTimer.Update(s.StorageUpdates) // Storage updates are complete(in validation)
 	accountHashTimer.Update(s.AccountHashes)    // Account hashes are complete(in validation)
-
 	accountCommitTimer.Update(s.AccountCommits) // Account commits are complete, we can mark them
 	storageCommitTimer.Update(s.StorageCommits) // Storage commits are complete, we can mark them
 
@@ -112,22 +116,44 @@ Block: %v (%#x) txs: %d, mgasps: %.2f, elapsed: %v
 
 EVM execution: %v
 Validation: %v
-Account read: %v(%d)
-Storage read: %v(%d)
-Account hash: %v
-Storage hash: %v
-DB commit: %v
-Block write: %v
+State read: %v
+    Account read: %v(%d)
+    Storage read: %v(%d)
+    Code read: %v(%d)
+
+State hash: %v
+    Account hash: %v
+    Storage hash: %v
+    Trie commit: %v
+
+DB write: %v
+    State write: %v
+    Block write: %v
 
 %s
 ##############################
 `, block.Number(), block.Hash(), len(block.Transactions()), s.MgasPerSecond, common.PrettyDuration(s.TotalTime),
-		common.PrettyDuration(s.Execution), common.PrettyDuration(s.Validation+s.CrossValidation),
+		common.PrettyDuration(s.Execution),
+		common.PrettyDuration(s.Validation+s.CrossValidation),
+
+		// State read
+		common.PrettyDuration(s.AccountReads+s.StorageReads+s.CodeReads),
 		common.PrettyDuration(s.AccountReads), s.AccountLoaded,
 		common.PrettyDuration(s.StorageReads), s.StorageLoaded,
-		common.PrettyDuration(s.AccountHashes+s.AccountCommits+s.AccountUpdates),
-		common.PrettyDuration(s.StorageCommits+s.StorageUpdates),
-		common.PrettyDuration(s.TrieDBCommit+s.SnapshotCommit), common.PrettyDuration(s.BlockWrite),
+		common.PrettyDuration(s.CodeReads), s.CodeLoaded,
+
+		// State hash
+		common.PrettyDuration(s.AccountHashes+s.AccountUpdates+s.StorageUpdates+max(s.AccountCommits, s.StorageCommits)),
+		common.PrettyDuration(s.AccountHashes+s.AccountUpdates),
+		common.PrettyDuration(s.StorageUpdates),
+		common.PrettyDuration(max(s.AccountCommits, s.StorageCommits)),
+
+		// Database commit
+		common.PrettyDuration(s.TrieDBCommit+s.SnapshotCommit+s.BlockWrite),
+		common.PrettyDuration(s.TrieDBCommit+s.SnapshotCommit),
+		common.PrettyDuration(s.BlockWrite),
+
+		// cache statistics
 		s.StateReadCacheStats)
 	for _, line := range strings.Split(msg, "\n") {
 		if line == "" {

--- a/core/state/state_object.go
+++ b/core/state/state_object.go
@@ -531,6 +531,11 @@ func (s *stateObject) Code() []byte {
 	if bytes.Equal(s.CodeHash(), types.EmptyCodeHash.Bytes()) {
 		return nil
 	}
+	defer func(start time.Time) {
+		s.db.CodeLoaded += 1
+		s.db.CodeReads += time.Since(start)
+	}(time.Now())
+
 	code, err := s.db.reader.Code(s.address, common.BytesToHash(s.CodeHash()))
 	if err != nil {
 		s.db.setError(fmt.Errorf("can't load code hash %x: %v", s.CodeHash(), err))
@@ -552,6 +557,11 @@ func (s *stateObject) CodeSize() int {
 	if bytes.Equal(s.CodeHash(), types.EmptyCodeHash.Bytes()) {
 		return 0
 	}
+	defer func(start time.Time) {
+		s.db.CodeLoaded += 1
+		s.db.CodeReads += time.Since(start)
+	}(time.Now())
+
 	size, err := s.db.reader.CodeSize(s.address, common.BytesToHash(s.CodeHash()))
 	if err != nil {
 		s.db.setError(fmt.Errorf("can't load code size %x: %v", s.CodeHash(), err))

--- a/core/state/statedb.go
+++ b/core/state/statedb.go
@@ -151,6 +151,7 @@ type StateDB struct {
 	StorageCommits  time.Duration
 	SnapshotCommits time.Duration
 	TrieDBCommits   time.Duration
+	CodeReads       time.Duration
 
 	AccountLoaded  int          // Number of accounts retrieved from the database during the state transition
 	AccountUpdated int          // Number of accounts updated during the state transition
@@ -158,6 +159,7 @@ type StateDB struct {
 	StorageLoaded  int          // Number of storage slots retrieved from the database during the state transition
 	StorageUpdated atomic.Int64 // Number of storage slots updated during the state transition
 	StorageDeleted atomic.Int64 // Number of storage slots deleted during the state transition
+	CodeLoaded     int          // Number of contract code loaded during the state transition
 }
 
 // New creates a new state from a given trie.


### PR DESCRIPTION
This PR adds the code read statistics and exposes them via the metrics and slow block report.

```
INFO [12-18|07:45:25.098] ########## SLOW BLOCK #########
INFO [12-18|07:45:25.098] Block: 24038081 (0xcf0c89cc97026c89d98f60353d98a8b9459fa8635573152d240057d75473a7cb) txs: 390, mgasps: 428.54, elapsed: 97.611ms
INFO [12-18|07:45:25.098] EVM execution: 73.163ms
INFO [12-18|07:45:25.098] Validation: 2.634ms
INFO [12-18|07:45:25.098] State read: 5.967ms
INFO [12-18|07:45:25.098]     Account read: 2.201ms(1086)
INFO [12-18|07:45:25.098]     Storage read: 3.463ms(2512)
INFO [12-18|07:45:25.098] "    Code read: 302.534µs(467)"
INFO [12-18|07:45:25.098] State hash: 10.903ms
INFO [12-18|07:45:25.098]     Account hash: 4.110ms
INFO [12-18|07:45:25.098]     Storage hash: 3.279ms
INFO [12-18|07:45:25.098]     Trie commit: 3.513ms
INFO [12-18|07:45:25.098] DB write: 4.882ms
INFO [12-18|07:45:25.098]     State write: 3.119ms
INFO [12-18|07:45:25.098]     Block write: 1.762ms
INFO [12-18|07:45:25.098] Reader statistics
INFO [12-18|07:45:25.098] account: hit: 1057, miss: 29, rate: 97.33
INFO [12-18|07:45:25.098] storage: hit: 2405, miss: 107, rate: 95.74
INFO [12-18|07:45:25.098] ##############################
```