### PR TITLE
console/prompt: use PromptInput in PromptConfirm method

### DIFF
--- a/console/prompt/prompter.go
+++ b/console/prompt/prompter.go
@@ -142,7 +142,7 @@ func (p *terminalPrompter) PromptPassword(prompt string) (passwd string, err err
 // PromptConfirm displays the given prompt to the user and requests a boolean
 // choice to be made, returning that choice.
 func (p *terminalPrompter) PromptConfirm(prompt string) (bool, error) {
-	input, err := p.Prompt(prompt + " [y/n] ")
+	input, err := p.PromptInput(prompt + " [y/n] ")
 	if len(input) > 0 && strings.EqualFold(input[:1], "y") {
 		return true, nil
 	}


### PR DESCRIPTION
## Problem

The `PromptConfirm` method was calling `p.Prompt()` directly, which bypasses the terminal mode management and unsupported terminal handling logic present in `PromptInput`. This could cause inconsistent behavior in unsupported terminals and improper terminal mode switching.

## Solution

Changed `PromptConfirm` to use `PromptInput()` instead, ensuring it benefits from the same terminal mode management and fallback handling as other prompt methods.