### PR TITLE
tests/fuzzers: remove unused field from kv struct in rangeproof fuzzer

### DIFF
--- a/tests/fuzzers/rangeproof/rangeproof-fuzzer.go
+++ b/tests/fuzzers/rangeproof/rangeproof-fuzzer.go
@@ -32,7 +32,6 @@ import (
 
 type kv struct {
 	k, v []byte
-	t    bool
 }
 
 type fuzzer struct {
@@ -62,8 +61,8 @@ func (f *fuzzer) randomTrie(n int) (*trie.Trie, map[string]*kv) {
 	size := f.readInt()
 	// Fill it with some fluff
 	for i := byte(0); i < byte(size); i++ {
-		value := &kv{common.LeftPadBytes([]byte{i}, 32), []byte{i}, false}
-		value2 := &kv{common.LeftPadBytes([]byte{i + 10}, 32), []byte{i}, false}
+		value := &kv{common.LeftPadBytes([]byte{i}, 32), []byte{i}}
+		value2 := &kv{common.LeftPadBytes([]byte{i + 10}, 32), []byte{i}}
 		trie.MustUpdate(value.k, value.v)
 		trie.MustUpdate(value2.k, value2.v)
 		vals[string(value.k)] = value
@@ -76,7 +75,7 @@ func (f *fuzzer) randomTrie(n int) (*trie.Trie, map[string]*kv) {
 	for i := 0; i < n; i++ {
 		k := f.randBytes(32)
 		v := f.randBytes(20)
-		value := &kv{k, v, false}
+		value := &kv{k, v}
 		trie.MustUpdate(k, v)
 		vals[string(k)] = value
 		if f.exhausted {


### PR DESCRIPTION
Removes the unused `t bool` field from the `kv` struct in the rangeproof fuzzer.