### PR TITLE
core/vm: in selfdestruct gas calculation, return early if there isn't enough gas to cover cold account access costs

### DIFF
--- a/core/vm/operations_acl.go
+++ b/core/vm/operations_acl.go
@@ -235,7 +235,6 @@ func makeSelfdestructGasFn(refundsEnabled bool) gasFunc {
 				return gas, nil
 			}
 		}
-
 		// if empty and transfers value
 		if evm.StateDB.Empty(address) && evm.StateDB.GetBalance(contract.Address()).Sign() != 0 {
 			gas += params.CreateBySelfdestructGas


### PR DESCRIPTION
There's no need to perform the subsequent state access on the target if we already know that we are out of gas.

This aligns the state access behavior of selfdestruct with EIP-7928