### PR TITLE
common/fdlimit: remove incorrect MacOS comment from unix file

### DIFF
--- a/common/fdlimit/fdlimit_unix.go
+++ b/common/fdlimit/fdlimit_unix.go
@@ -38,7 +38,6 @@ func Raise(max uint64) (uint64, error) {
 	if err := syscall.Setrlimit(syscall.RLIMIT_NOFILE, &limit); err != nil {
 		return 0, err
 	}
-	// MacOS can silently apply further caps, so retrieve the actually set limit
 	if err := syscall.Getrlimit(syscall.RLIMIT_NOFILE, &limit); err != nil {
 		return 0, err
 	}


### PR DESCRIPTION
The comment about MacOS silently applying caps was copy-pasted from fdlimit_darwin.go but doesn't belong here since this file is only built for linux, netbsd, openbsd and solaris.