### PR TITLE
eth/tracers: remove redundant bounds check in memoryCopy

### DIFF
--- a/eth/tracers/internal/util.go
+++ b/eth/tracers/internal/util.go
@@ -53,13 +53,8 @@ func memoryCopy(m []byte, offset, size int64) (cpy []byte) {
 		return nil
 	}
 
-	if len(m) > int(offset) {
-		cpy = make([]byte, size)
-		copy(cpy, m[offset:offset+size])
-
-		return
-	}
-
+	cpy = make([]byte, size)
+	copy(cpy, m[offset:offset+size])
 	return
 }
 


### PR DESCRIPTION
Removes unnecessary bounds check in the `memoryCopy` helper function that was always true.