### PR TITLE
crypto/blake2b: remove unused helper functions

### DIFF
--- a/crypto/blake2b/blake2b.go
+++ b/crypto/blake2b/blake2b.go
@@ -302,20 +302,7 @@ func appendUint64(b []byte, x uint64) []byte {
 	return append(b, a[:]...)
 }
 
-//nolint:unused
-func appendUint32(b []byte, x uint32) []byte {
-	var a [4]byte
-	binary.BigEndian.PutUint32(a[:], x)
-	return append(b, a[:]...)
-}
-
 func consumeUint64(b []byte) ([]byte, uint64) {
 	x := binary.BigEndian.Uint64(b)
 	return b[8:], x
-}
-
-//nolint:unused
-func consumeUint32(b []byte) ([]byte, uint32) {
-	x := binary.BigEndian.Uint32(b)
-	return b[4:], x
 }


### PR DESCRIPTION
Removes two dead helper functions (appendUint32 and consumeUint32) that were suppressed with //nolint:unused directives but never actually used in the codebase.