### PR TITLE
p2p/discover: preallocate bucketsCounter slice in init

### DIFF
--- a/p2p/discover/metrics.go
+++ b/p2p/discover/metrics.go
@@ -40,8 +40,9 @@ var (
 )
 
 func init() {
+	bucketsCounter = make([]*metrics.Counter, nBuckets)
 	for i := 0; i < nBuckets; i++ {
-		bucketsCounter = append(bucketsCounter, metrics.NewRegisteredCounter(fmt.Sprintf("%s/bucket/%d/count", moduleName, i), nil))
+		bucketsCounter[i] = metrics.NewRegisteredCounter(fmt.Sprintf("%s/bucket/%d/count", moduleName, i), nil)
 	}
 }
 


### PR DESCRIPTION
Pre-allocate bucketsCounter slice with make() to avoid multiple  reallocations during initialization. This matches the pattern used  elsewhere in the codebase and eliminates unnecessary memory allocations  for the 17-element slice.