### PR TITLE
refactor: remove redundant ternary operator in formatOutputBool

### DIFF
--- a/internal/jsre/deps/web3.js
+++ b/internal/jsre/deps/web3.js
@@ -1070,7 +1070,7 @@ var formatOutputUReal = function (param) {
  * @returns {Boolean} right-aligned input bytes formatted to bool
  */
 var formatOutputBool = function (param) {
-    return param.staticPart() === '0000000000000000000000000000000000000000000000000000000000000001' ? true : false;
+    return param.staticPart() === '0000000000000000000000000000000000000000000000000000000000000001';
 };
 
 /**


### PR DESCRIPTION
Simplified boolean return in `formatOutputBool` function by removing redundant ternary operator.