### PR TITLE
common/prque: eliminate redundant type assertion in sstack.Push

### DIFF
--- a/common/prque/sstack.go
+++ b/common/prque/sstack.go
@@ -52,7 +52,7 @@ func newSstack[P cmp.Ordered, V any](setIndex SetIndexCallback[V]) *sstack[P, V]
 // Push a value onto the stack, expanding it if necessary. Required by
 // heap.Interface.
 func (s *sstack[P, V]) Push(data any) {
-	item := data.(*item[P, V])
+	itm := data.(*item[P, V])
 	if s.size == s.capacity {
 		s.active = make([]*item[P, V], blockSize)
 		s.blocks = append(s.blocks, s.active)
@@ -63,9 +63,9 @@ func (s *sstack[P, V]) Push(data any) {
 		s.offset = 0
 	}
 	if s.setIndex != nil {
-		s.setIndex(item.value, s.size)
+		s.setIndex(itm.value, s.size)
 	}
-	s.active[s.offset] = item
+	s.active[s.offset] = itm
 	s.offset++
 	s.size++
 }


### PR DESCRIPTION
This PR removes a redundant type assertion in the `sstack.Push` method.