### PR TITLE
trie: remove redundant string conversion in encoding test

### DIFF
--- a/trie/encoding_test.go
+++ b/trie/encoding_test.go
@@ -99,7 +99,7 @@ func TestHexToCompactInPlaceRandom(t *testing.T) {
 		key := make([]byte, l)
 		crand.Read(key)
 		hexBytes := keybytesToHex(key)
-		hexOrig := []byte(string(hexBytes))
+		hexOrig := append([]byte(nil), hexBytes...) // copy without extra string alloc
 		exp := hexToCompact(hexBytes)
 		got := hexToCompactInPlace(hexBytes)
 


### PR DESCRIPTION
Optimizes `TestHexToCompactInPlaceRandom` by removing unnecessary allocations in the test's error logging path.