### PR TITLE
core/filtermaps: pre-allocate slices in writeFinishedMaps

### DIFF
--- a/core/filtermaps/map_renderer.go
+++ b/core/filtermaps/map_renderer.go
@@ -425,11 +425,11 @@ func (r *mapRenderer) writeFinishedMaps(pauseCb func() bool) error {
 		r.f.setRange(batch, r.f.indexedView, tempRange, true)
 	}
 	// add or update filter rows
+	// Pre-allocate slices to avoid repeated allocations during append
+	finishedCount := r.finished.Count()
 	for rowIndex := uint32(0); rowIndex < r.f.mapHeight; rowIndex++ {
-		var (
-			mapIndices []uint32
-			rows       []FilterRow
-		)
+		mapIndices := make([]uint32, 0, finishedCount)
+		rows := make([]FilterRow, 0, finishedCount)
 		for mapIndex := range r.finished.Iter() {
 			row := r.finishedMaps[mapIndex].filterMap[rowIndex]
 			if fm, _ := r.f.filterMapCache.Get(mapIndex); fm != nil && row.Equal(fm[rowIndex]) {


### PR DESCRIPTION
## Summary

Pre-allocate `mapIndices` and `rows` slices with capacity before the inner loop in `writeFinishedMaps` to avoid repeated slice growth allocations.

This reduces allocations during log index rendering, particularly when writing finished maps to the database. The slices are rebuilt for every row (`mapHeight` iterations), so pre-allocating with the known capacity (number of finished maps) significantly reduces memory pressure.

**Before:**
```go
var (
    mapIndices []uint32
    rows       []FilterRow
)
for mapIndex := range r.finished.Iter() {
    mapIndices = append(mapIndices, mapIndex) // grows slice repeatedly
```

**After:**
```go
mapIndices := make([]uint32, 0, finishedCount)
rows := make([]FilterRow, 0, finishedCount)
for mapIndex := range r.finished.Iter() {
    mapIndices = append(mapIndices, mapIndex) // no reallocation needed
```

Fixes #33040