### PR TITLE
core/txpool/blobpool: fix slotter size limit

### DIFF
--- a/core/txpool/blobpool/blobpool.go
+++ b/core/txpool/blobpool/blobpool.go
@@ -419,7 +419,7 @@ func (p *BlobPool) Init(gasTip uint64, head *types.Header, reserver txpool.Reser
 	p.state = state
 
 	// Create new slotter for pre-Osaka blob configuration.
-	slotter := newSlotter(eip4844.LatestMaxBlobsPerBlock(p.chain.Config()))
+	slotter := newSlotter(params.BlobTxMaxBlobs)
 
 	// See if we need to migrate the queue blob store after fusaka
 	slotter, err = tryMigrate(p.chain.Config(), slotter, queuedir)

--- a/core/txpool/blobpool/limbo.go
+++ b/core/txpool/blobpool/limbo.go
@@ -20,7 +20,6 @@ import (
 	"errors"
 
 	"github.com/ethereum/go-ethereum/common"
-	"github.com/ethereum/go-ethereum/consensus/misc/eip4844"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/params"
@@ -57,7 +56,7 @@ func newLimbo(config *params.ChainConfig, datadir string) (*limbo, error) {
 	}
 
 	// Create new slotter for pre-Osaka blob configuration.
-	slotter := newSlotter(eip4844.LatestMaxBlobsPerBlock(config))
+	slotter := newSlotter(params.BlobTxMaxBlobs)
 
 	// See if we need to migrate the limbo after fusaka.
 	slotter, err := tryMigrate(config, slotter, datadir)

--- a/core/txpool/blobpool/slotter.go
+++ b/core/txpool/blobpool/slotter.go
@@ -17,7 +17,6 @@
 package blobpool
 
 import (
-	"github.com/ethereum/go-ethereum/consensus/misc/eip4844"
 	"github.com/ethereum/go-ethereum/params"
 	"github.com/holiman/billy"
 )
@@ -42,7 +41,7 @@ func tryMigrate(config *params.ChainConfig, slotter billy.SlotSizeFn, datadir st
 		// If the version found is less than the currently configured store version,
 		// perform a migration then write the updated version of the store.
 		if version < storeVersion {
-			newSlotter := newSlotterEIP7594(eip4844.LatestMaxBlobsPerBlock(config))
+			newSlotter := newSlotterEIP7594(params.BlobTxMaxBlobs)
 			if err := billy.Migrate(billy.Options{Path: datadir, Repair: true}, slotter, newSlotter); err != nil {
 				return nil, err
 			}
@@ -54,7 +53,7 @@ func tryMigrate(config *params.ChainConfig, slotter billy.SlotSizeFn, datadir st
 			store.Close()
 		}
 		// Set the slotter to the format now that the Osaka is active.
-		slotter = newSlotterEIP7594(eip4844.LatestMaxBlobsPerBlock(config))
+		slotter = newSlotterEIP7594(params.BlobTxMaxBlobs)
 	}
 	return slotter, nil
 }


### PR DESCRIPTION
Blobs are stored per transaction in the pool, so we need billy to handle up to the per-tx limit, not to the per-block limit.

The per-block limit was larger than the per-tx limit, so it not a bug, we just created and handled a few billy files for no reason.