### PR TITLE
eth/downloader: fix stale beacon header deletion

### DIFF
--- a/eth/downloader/downloader.go
+++ b/eth/downloader/downloader.go
@@ -248,7 +248,7 @@ func New(stateDb ethdb.Database, mode ethconfig.SyncMode, mux *event.TypeMux, ch
 		syncStartBlock:    chain.CurrentSnapBlock().Number.Uint64(),
 	}
 	// Create the post-merge skeleton syncer and start the process
-	dl.skeleton = newSkeleton(stateDb, dl.peers, dropPeer, newBeaconBackfiller(dl, success))
+	dl.skeleton = newSkeleton(stateDb, dl.peers, dropPeer, newBeaconBackfiller(dl, success), chain)
 
 	go dl.stateFetcher()
 	return dl


### PR DESCRIPTION
In this PR, two things have been fixed:

--- 

(a) truncate the stale beacon headers with latest snap block

Originally, b.filled is used as the indicator for deleting stale beacon headers. This field is set 
only after synchronization has been scheduled, under the assumption that the skeleton chain 
is already linked to the local chain.

However, the local chain can be mutated via `debug_setHead`, which may cause `b.filled` 
outdated. For instance, `b.filled` refers to the last head snap block in the last sync cycle
while after `debug_setHead`, the head snap block has been rewounded to 1.

As a result, Geth can enter an unintended loop: it repeatedly downloads the missing beacon 
headers for the skeleton chain and attempts to schedule the actual synchronization, but 
in the final step, all recently fetched headers are removed by `cleanStales` due to the stale 
`b.filled` value.

This issue is addressed by always using the latest snap block as the indicator, without 
relying on any cached value. However, note that before the skeleton chain is linked to 
the local chain, the latest snap block will always be below skeleton.tail, and this condition 
should not be treated as an error.

--- 

(b) merge the subchains once the skeleton chain links to local chain

Once the skeleton chain links with local one, it will try to schedule the synchronization by
fetching the missing blocks and import them then. It's possible the last subchain already
overwrites the previous subchain and results in having two subchains leftover. As a result,
an error log will printed https://github.com/ethereum/go-ethereum/blob/master/eth/downloader/skeleton.go#L1074
