### PR TITLE
beacon/light/sync: clear reqFinalityEpoch on server unregistration

### DIFF
--- a/beacon/light/sync/head_sync.go
+++ b/beacon/light/sync/head_sync.go
@@ -105,6 +105,7 @@ func (s *HeadSync) Process(requester request.Requester, events []request.Event) 
 			delete(s.serverHeads, event.Server)
 			delete(s.unvalidatedOptimistic, event.Server)
 			delete(s.unvalidatedFinality, event.Server)
+			delete(s.reqFinalityEpoch, event.Server)
 		}
 	}
 }


### PR DESCRIPTION
HeadSync kept reqFinalityEpoch entries for servers after receiving EvUnregistered, while other per-server maps were cleared. This left stale request.Server keys reachable from HeadSync, which can lead to a slow memory leak in setups that dynamically register and unregister servers.

The fix adds deletion of the reqFinalityEpoch entry in the EvUnregistered handler. This aligns HeadSync with the cleanup pattern used by other sync modules and keeps the finality request bookkeeping strictly limited to currently registered servers.