### PR TITLE
trie, core, core/state, core/vm, params: add EIP-8032

### DIFF
--- a/core/state/statedb_hooked.go
+++ b/core/state/statedb_hooked.go
@@ -97,6 +97,26 @@ func (s *hookedStateDB) GetStorageRoot(addr common.Address) common.Hash {
 	return s.inner.GetStorageRoot(addr)
 }
 
+func (s *hookedStateDB) GetStorageCount(addr common.Address) uint64 {
+	return s.inner.GetStorageCount(addr)
+}
+
+func (s *hookedStateDB) CountStorageSlots(addr common.Address) uint64 {
+	return s.inner.CountStorageSlots(addr)
+}
+
+func (s *hookedStateDB) IsEIP8032TransitionComplete() bool {
+	return s.inner.IsEIP8032TransitionComplete()
+}
+
+func (s *hookedStateDB) IsSlotInEIP8032ConvertedStorage(addr common.Address, slotnr common.Hash) bool {
+	return s.inner.IsSlotInEIP8032ConvertedStorage(addr, slotnr)
+}
+
+func (s *hookedStateDB) ProcessEIP8032Transition(maxSlots uint64) {
+	s.inner.ProcessEIP8032Transition(maxSlots)
+}
+
 func (s *hookedStateDB) GetTransientState(addr common.Address, key common.Hash) common.Hash {
 	return s.inner.GetTransientState(addr, key)
 }

--- a/core/types/gen_account_rlp.go
+++ b/core/types/gen_account_rlp.go
@@ -16,6 +16,14 @@ func (obj *StateAccount) EncodeRLP(_w io.Writer) error {
 	}
 	w.WriteBytes(obj.Root[:])
 	w.WriteBytes(obj.CodeHash)
+	_tmp1 := obj.StorageCount != nil
+	if _tmp1 {
+		if obj.StorageCount == nil {
+			w.Write([]byte{0x80})
+		} else {
+			w.WriteUint64((*obj.StorageCount))
+		}
+	}
 	w.ListEnd(_tmp0)
 	return w.Flush()
 }

--- a/core/vm/eips.go
+++ b/core/vm/eips.go
@@ -43,6 +43,7 @@ var activators = map[int]func(*JumpTable){
 	7702: enable7702,
 	7939: enable7939,
 	8024: enable8024,
+	8032: enable8032,
 }
 
 // EnableEIP enables the given EIP on the config.
@@ -578,4 +579,9 @@ func enable7702(jt *JumpTable) {
 	jt[CALLCODE].dynamicGas = gasCallCodeEIP7702
 	jt[STATICCALL].dynamicGas = gasStaticCallEIP7702
 	jt[DELEGATECALL].dynamicGas = gasDelegateCallEIP7702
+}
+
+// enable8032 applies EIP-8032 (Size-Based Storage Gas Pricing)
+func enable8032(jt *JumpTable) {
+	jt[SSTORE].dynamicGas = gasSStoreEIP8032
 }

--- a/core/vm/evm.go
+++ b/core/vm/evm.go
@@ -181,6 +181,13 @@ func NewEVM(blockCtx BlockContext, statedb StateDB, chainConfig *params.ChainCon
 	default:
 		evm.table = &frontierInstructionSet
 	}
+
+	// Apply EIP-8032 if active
+	if evm.chainRules.IsEIP8032 {
+		evm.table = copyJumpTable(evm.table)
+		enable8032(evm.table)
+	}
+
 	var extraEips []int
 	if len(evm.Config.ExtraEips) > 0 {
 		// Deep-copy jumptable to prevent modification of opcodes in other tables

--- a/core/vm/gas_table_test.go
+++ b/core/vm/gas_table_test.go
@@ -180,3 +180,37 @@ func TestCreateGas(t *testing.T) {
 		}
 	}
 }
+
+func TestStorageCounting(t *testing.T) {
+	statedb, _ := state.New(types.EmptyRootHash, state.NewDatabaseForTesting())
+
+	addr := common.HexToAddress("0x1234")
+	statedb.CreateAccount(addr)
+
+	key1 := common.HexToHash("0x01")
+	key2 := common.HexToHash("0x02")
+	value := common.HexToHash("0x1234")
+
+	count := statedb.GetStorageCount(addr)
+	if count != 0 {
+		t.Errorf("initial storage count should be 0, got %d", count)
+	}
+
+	statedb.SetState(addr, key1, value)
+	count = statedb.GetStorageCount(addr)
+	if count != 1 {
+		t.Errorf("storage count after first set should be 1, got %d", count)
+	}
+
+	statedb.SetState(addr, key2, value)
+	count = statedb.GetStorageCount(addr)
+	if count != 2 {
+		t.Errorf("storage count after second set should be 2, got %d", count)
+	}
+
+	statedb.SetState(addr, key1, common.Hash{})
+	count = statedb.GetStorageCount(addr)
+	if count != 1 {
+		t.Errorf("storage count after deletion should be 1, got %d", count)
+	}
+}

--- a/core/vm/interface.go
+++ b/core/vm/interface.go
@@ -54,6 +54,11 @@ type StateDB interface {
 	GetState(common.Address, common.Hash) common.Hash
 	SetState(common.Address, common.Hash, common.Hash) common.Hash
 	GetStorageRoot(addr common.Address) common.Hash
+	GetStorageCount(addr common.Address) uint64
+	CountStorageSlots(addr common.Address) uint64
+	IsEIP8032TransitionComplete() bool
+	IsSlotInEIP8032ConvertedStorage(addr common.Address, slotnr common.Hash) bool
+	ProcessEIP8032Transition(maxSlots uint64)
 
 	GetTransientState(addr common.Address, key common.Hash) common.Hash
 	SetTransientState(addr common.Address, key, value common.Hash)

--- a/params/config.go
+++ b/params/config.go
@@ -467,6 +467,7 @@ type ChainConfig struct {
 	BPO5Time      *uint64 `json:"bpo5Time,omitempty"`      // BPO5 switch time (nil = no fork, 0 = already on bpo5)
 	AmsterdamTime *uint64 `json:"amsterdamTime,omitempty"` // Amsterdam switch time (nil = no fork, 0 = already on amsterdam)
 	VerkleTime    *uint64 `json:"verkleTime,omitempty"`    // Verkle switch time (nil = no fork, 0 = already on verkle)
+	EIP8032Time   *uint64 `json:"eip8032Time,omitempty"`   // EIP-8032 switch time (nil = no fork, 0 = already on eip8032)
 
 	// TerminalTotalDifficulty is the amount of total difficulty reached by
 	// the network that triggers the consensus upgrade.
@@ -883,6 +884,11 @@ func (c *ChainConfig) IsVerkle(num *big.Int, time uint64) bool {
 // those cases.
 func (c *ChainConfig) IsVerkleGenesis() bool {
 	return c.EnableVerkleAtGenesis
+}
+
+// IsEIP8032 returns whether time is either equal to the EIP-8032 fork time or greater.
+func (c *ChainConfig) IsEIP8032(num *big.Int, time uint64) bool {
+	return c.IsLondon(num) && isTimestampForked(c.EIP8032Time, time)
 }
 
 // IsEIP4762 returns whether eip 4762 has been activated at given block.
@@ -1381,7 +1387,7 @@ type Rules struct {
 	IsByzantium, IsConstantinople, IsPetersburg, IsIstanbul bool
 	IsBerlin, IsLondon                                      bool
 	IsMerge, IsShanghai, IsCancun, IsPrague, IsOsaka        bool
-	IsAmsterdam, IsVerkle                                   bool
+	IsAmsterdam, IsVerkle, IsEIP8032                        bool
 }
 
 // Rules ensures c's ChainID is not nil.
@@ -1414,5 +1420,6 @@ func (c *ChainConfig) Rules(num *big.Int, isMerge bool, timestamp uint64) Rules 
 		IsAmsterdam:      isMerge && c.IsAmsterdam(num, timestamp),
 		IsVerkle:         isVerkle,
 		IsEIP4762:        isVerkle,
+		IsEIP8032:        isMerge && c.IsEIP8032(num, timestamp),
 	}
 }

--- a/params/protocol_params.go
+++ b/params/protocol_params.go
@@ -75,6 +75,10 @@ const (
 	// Which becomes: 5000 - 2100 + 1900 = 4800
 	SstoreClearsScheduleRefundEIP3529 uint64 = SstoreResetGasEIP2200 - ColdSloadCostEIP2929 + TxAccessListStorageKeyGas
 
+	// EIP-8032: Size-Based Storage Gas Pricing parameters
+	EIP8032LinFactor           uint64 = 5000 // Linear factor for storage size based pricing
+	EIP8032ActivationThreshold uint64 = 100  // Threshold for activation of size-based pricing
+
 	JumpdestGas   uint64 = 1     // Once per JUMPDEST operation.
 	EpochDuration uint64 = 30000 // Duration between proof-of-work epochs.
 
@@ -219,4 +223,12 @@ var (
 	// EIP-7251 - Increase the MAX_EFFECTIVE_BALANCE
 	ConsolidationQueueAddress = common.HexToAddress("0x0000BBdDc7CE488642fb579F8B00f3a590007251")
 	ConsolidationQueueCode    = common.FromHex("3373fffffffffffffffffffffffffffffffffffffffe1460d35760115f54807fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff1461019a57600182026001905f5b5f82111560685781019083028483029004916001019190604d565b9093900492505050366060146088573661019a573461019a575f5260205ff35b341061019a57600154600101600155600354806004026004013381556001015f358155600101602035815560010160403590553360601b5f5260605f60143760745fa0600101600355005b6003546002548082038060021160e7575060025b5f5b8181146101295782810160040260040181607402815460601b815260140181600101548152602001816002015481526020019060030154905260010160e9565b910180921461013b5790600255610146565b90505f6002555f6003555b5f54807fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff141561017357505f5b6001546001828201116101885750505f61018e565b01600190035b5f555f6001556074025ff35b5f5ffd")
+
+	// EIP-8032 - Size-Based Storage Gas Pricing
+	EIP8032TransitionRegistryAddress = common.HexToAddress("0x0000000000000000000000000000000000008032")
+)
+
+// EIP-8032 transition parameters
+const (
+	EIP8032TransitionMaxStepsPerBlock uint64 = 10000 // Maximum number of accounts to process during transition
 )


### PR DESCRIPTION
This pull request introduces support for EIP-8032, which implements size-based gas pricing for storage by tracking the number of storage slots per account. The changes add mechanisms to count storage slot counts for accounts, update the state and RLP encoding, and integrate the transition process into block processing.