### PR TITLE
core/rawdb: add trienode freezer support to InspectFreezerTable

### DIFF
--- a/core/rawdb/ancient_utils.go
+++ b/core/rawdb/ancient_utils.go
@@ -149,6 +149,8 @@ func InspectFreezerTable(ancient string, freezerName string, tableName string, s
 		path, tables = resolveChainFreezerDir(ancient), chainFreezerTableConfigs
 	case MerkleStateFreezerName, VerkleStateFreezerName:
 		path, tables = filepath.Join(ancient, freezerName), stateFreezerTableConfigs
+	case MerkleTrienodeFreezerName, VerkleTrienodeFreezerName:
+		path, tables = filepath.Join(ancient, freezerName), trienodeFreezerTableConfigs
 	default:
 		return fmt.Errorf("unknown freezer, supported ones: %v", freezers)
 	}


### PR DESCRIPTION
Adds missing trienode freezer case to InspectFreezerTable, making it consistent with InspectFreezer which already supports it.