### PR TITLE
eth/gasprice: optimize using kth algorithm

### DIFF
--- a/eth/gasprice/gasprice.go
+++ b/eth/gasprice/gasprice.go
@@ -189,7 +189,6 @@ func findKthBigInt(values []*big.Int, k int) *big.Int {
 		} else {
 			right = pivotPos - 1
 		}
-
 	}
 	return values[left]
 }


### PR DESCRIPTION
with this test code:  
```
// Copyright 2015 The go-ethereum Authors
// This file is part of the go-ethereum library.
//
// The go-ethereum library is free software: you can redistribute it and/or modify
// it under the terms of the GNU Lesser General Public License as published by
// the Free Software Foundation, either version 3 of the License, or
// (at your option) any later version.
//
// The go-ethereum library is distributed in the hope that it will be useful,
// but WITHOUT ANY WARRANTY; without even the implied warranty of
// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
// GNU Lesser General Public License for more details.
//
// You should have received a copy of the GNU Lesser General Public License
// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.

package bench

import (
	"math/big"
	"math/rand"
	"slices"
	"testing"
)

const (
	sliceSize  = 20 // Number of *big.Int elements in slice
	percentile = 60 // 60% percentile
	iterations = 20 // N=20 iterations for data generation
)

// generateBigIntSlice creates a slice of n random *big.Int values
func generateBigIntSlice(n int) []*big.Int {
	values := make([]*big.Int, n)
	for i := 0; i < n; i++ {
		values[i] = big.NewInt(rand.Int63())
	}
	return values
}

// copyBigIntSlice creates a deep copy of a *big.Int slice
func copyBigIntSlice(src []*big.Int) []*big.Int {
	dst := make([]*big.Int, len(src))
	for i, v := range src {
		dst[i] = new(big.Int).Set(v)
	}
	return dst
}

// findPercentileBySorting finds the k-th percentile element by sorting the entire slice
func findPercentileBySorting(values []*big.Int, percentile int) *big.Int {
	slices.SortFunc(values, func(a, b *big.Int) int { return a.Cmp(b) })
	index := (len(values) - 1) * percentile / 100
	return values[index]
}

// partition partitions the slice around a pivot using Lomuto partition scheme
// Returns the final position of the pivot
func partition(values []*big.Int, left, right int) int {
	pivot := values[right]
	i := left
	for j := left; j < right; j++ {
		if values[j].Cmp(pivot) < 0 {
			values[i], values[j] = values[j], values[i]
			i++
		}
	}
	values[i], values[right] = values[right], values[i]
	return i
}

// findKthBigInt finds the k-th smallest element using QuickSelect algorithm
// k is 0-indexed (k=0 returns the smallest element)
// This is an in-place algorithm that modifies the input slice
func findKthBigInt(values []*big.Int, k int) *big.Int {
	if k < 0 || k >= len(values) {
		return nil
	}

	left, right := 0, len(values)-1
	for left < right {
		// Randomize pivot selection to avoid worst-case O(n²)
		pivotIndex := left + rand.Intn(right-left+1)
		values[pivotIndex], values[right] = values[right], values[pivotIndex]

		pivotPos := partition(values, left, right)
		if pivotPos == k {
			return values[k]
		} else if pivotPos < k {
			left = pivotPos + 1
		} else {
			right = pivotPos - 1
		}

	}
	return values[left]
}

// findPercentileByKth finds the k-th percentile element using QuickSelect
func findPercentileByKth(values []*big.Int, percentile int) *big.Int {
	index := (len(values) - 1) * percentile / 100
	return findKthBigInt(values, index)
}

// TestKthAlgorithmCorrectness verifies that both methods return the same result
func TestKthAlgorithmCorrectness(t *testing.T) {
	for i := 0; i < iterations; i++ {
		// Generate test data
		original := generateBigIntSlice(sliceSize)

		// Create copies for each method
		sortCopy := copyBigIntSlice(original)
		kthCopy := copyBigIntSlice(original)

		// Find percentile using both methods
		sortResult := findPercentileBySorting(sortCopy, percentile)
		kthResult := findPercentileByKth(kthCopy, percentile)

		// Verify results match
		if sortResult.Cmp(kthResult) != 0 {
			t.Errorf("Iteration %d: Results mismatch - Sort: %s, Kth: %s",
				i, sortResult.String(), kthResult.String())
		}
	}
}

// BenchmarkSortFuncPercentile benchmarks finding percentile by sorting
func BenchmarkSortFuncPercentile(b *testing.B) {
	// Pre-generate test data
	testData := make([][]*big.Int, b.N)
	for i := 0; i < b.N; i++ {
		testData[i] = generateBigIntSlice(sliceSize)
	}

	b.ResetTimer()
	for i := 0; i < b.N; i++ {
		values := testData[i]
		slices.SortFunc(values, func(a, b *big.Int) int { return a.Cmp(b) })
		index := (len(values) - 1) * percentile / 100
		_ = values[index]
	}
}

// BenchmarkKthAlgorithmPercentile benchmarks finding percentile using QuickSelect
func BenchmarkKthAlgorithmPercentile(b *testing.B) {
	// Pre-generate test data
	testData := make([][]*big.Int, b.N)
	for i := 0; i < b.N; i++ {
		testData[i] = generateBigIntSlice(sliceSize)
	}

	b.ResetTimer()
	for i := 0; i < b.N; i++ {
		values := testData[i]
		index := (len(values) - 1) * percentile / 100
		_ = findKthBigInt(values, index)
	}
}

// BenchmarkSortFuncPercentile_N20 benchmarks with exactly N=20 iterations
func BenchmarkSortFuncPercentile_N20(b *testing.B) {
	// Pre-generate 20 test datasets
	testData := make([][]*big.Int, iterations)
	for i := 0; i < iterations; i++ {
		testData[i] = generateBigIntSlice(sliceSize)
	}

	b.ResetTimer()
	for i := 0; i < b.N; i++ {
		for j := 0; j < iterations; j++ {
			values := copyBigIntSlice(testData[j])
			slices.SortFunc(values, func(a, b *big.Int) int { return a.Cmp(b) })
			index := (len(values) - 1) * percentile / 100
			_ = values[index]
		}
	}
}

// BenchmarkKthAlgorithmPercentile_N20 benchmarks with exactly N=20 iterations
func BenchmarkKthAlgorithmPercentile_N20(b *testing.B) {
	// Pre-generate 20 test datasets
	testData := make([][]*big.Int, iterations)
	for i := 0; i < iterations; i++ {
		testData[i] = generateBigIntSlice(sliceSize)
	}

	b.ResetTimer()
	for i := 0; i < b.N; i++ {
		for j := 0; j < iterations; j++ {
			values := copyBigIntSlice(testData[j])
			index := (len(values) - 1) * percentile / 100
			_ = findKthBigInt(values, index)
		}
	}
}

```

result in:  
```
goos: darwin
goarch: arm64
pkg: github.com/ethereum/go-ethereum/eth/gasprice/bench
cpu: Apple M4 Pro
BenchmarkSortFuncPercentile
BenchmarkSortFuncPercentile-14            	 2578401	       445.0 ns/op
BenchmarkKthAlgorithmPercentile
BenchmarkKthAlgorithmPercentile-14        	 3707203	       314.7 ns/op
BenchmarkSortFuncPercentile_N20
BenchmarkSortFuncPercentile_N20-14        	   82758	     13996 ns/op
BenchmarkKthAlgorithmPercentile_N20
BenchmarkKthAlgorithmPercentile_N20-14    	   90188	     13405 ns/op
PASS
```

improve:  
(445 - 314)/445 ~= 29%  

default 20 blocks in geth. about 3600 txs.  
set sliceSize = 3600 in above test code.  
get result as below:  
```
goos: darwin
goarch: arm64
pkg: github.com/ethereum/go-ethereum/eth/gasprice/bench
cpu: Apple M4 Pro
BenchmarkSortFuncPercentile
BenchmarkSortFuncPercentile-14            	    3834	    280374 ns/op
BenchmarkKthAlgorithmPercentile
BenchmarkKthAlgorithmPercentile-14        	   17641	     59873 ns/op
BenchmarkSortFuncPercentile_N20
BenchmarkSortFuncPercentile_N20-14        	     171	   6892258 ns/op
BenchmarkKthAlgorithmPercentile_N20
BenchmarkKthAlgorithmPercentile_N20-14    	     406	   2902993 ns/op
PASS
```
improve:
(280,374 - 59873)/280,374  ~= 78.6%