### PR TITLE
trie/bintrie: copy data in DeserializeNode instead of using slice references

### DIFF
--- a/trie/bintrie/binary_node.go
+++ b/trie/bintrie/binary_node.go
@@ -18,6 +18,7 @@ package bintrie
 
 import (
 	"errors"
+	"slices"
 
 	"github.com/ethereum/go-ethereum/common"
 )
@@ -119,12 +120,12 @@ func DeserializeNode(serialized []byte, depth int) (BinaryNode, error) {
 				if len(serialized) < offset+HashSize {
 					return nil, invalidSerializedLength
 				}
-				values[i] = serialized[offset : offset+HashSize]
+				values[i] = slices.Clone(serialized[offset : offset+HashSize])
 				offset += HashSize
 			}
 		}
 		return &StemNode{
-			Stem:   serialized[NodeTypeBytes : NodeTypeBytes+StemSize],
+			Stem:   slices.Clone(serialized[NodeTypeBytes : NodeTypeBytes+StemSize]),
 			Values: values[:],
 			depth:  depth,
 		}, nil


### PR DESCRIPTION
## Problem

`DeserializeNode` was creating slice references to the input `serialized` buffer for `StemNode` values and stem fields. This created a dependency on the original buffer, which could lead to data corruption if the buffer was modified or reused after deserialization.

## Solution

Use `slices.Clone()` to create independent copies of the stem and values during deserialization, ensuring deserialized nodes are independent of the input buffer. This matches the pattern already used in the `Copy()` method.