### PR TITLE
core/state: optimize Logs by using index sort

### DIFF
--- a/core/state/statedb.go
+++ b/core/state/statedb.go
@@ -22,7 +22,6 @@ import (
 	"fmt"
 	"maps"
 	"slices"
-	"sort"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -263,13 +262,12 @@ func (s *StateDB) GetLogs(hash common.Hash, blockNumber uint64, blockHash common
 }
 
 func (s *StateDB) Logs() []*types.Log {
-	logs := make([]*types.Log, 0, s.logSize)
+	logs := make([]*types.Log, s.logSize)
 	for _, lgs := range s.logs {
-		logs = append(logs, lgs...)
+		for _, l := range lgs {
+			logs[l.Index] = l
+		}
 	}
-	sort.Slice(logs, func(i, j int) bool {
-		return logs[i].Index < logs[j].Index
-	})
 	return logs
 }
 


### PR DESCRIPTION
benchmark with this code:  
```
// Copyright 2014 The go-ethereum Authors
// This file is part of the go-ethereum library.
//
// The go-ethereum library is free software: you can redistribute it and/or modify
// it under the terms of the GNU Lesser General Public License as published by
// the Free Software Foundation, either version 3 of the License, or
// (at your option) any later version.
//
// The go-ethereum library is distributed in the hope that it will be useful,
// but WITHOUT ANY WARRANTY; without even the implied warranty of
// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
// GNU Lesser General Public License for more details.
//
// You should have received a copy of the GNU Lesser General Public License
// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.

package state

import (
	"testing"

	"github.com/ethereum/go-ethereum/common"
	"github.com/ethereum/go-ethereum/core/rawdb"
	"github.com/ethereum/go-ethereum/core/types"
	"github.com/ethereum/go-ethereum/triedb"
)

// setupStateDBWithLogs creates a StateDB instance and populates it with the specified number of logs
func setupStateDBWithLogs(logCount int) *StateDB {
	db := rawdb.NewMemoryDatabase()
	tdb := triedb.NewDatabase(db, nil)
	sdb := NewDatabase(tdb, nil)
	state, _ := New(types.EmptyRootHash, sdb)

	// Create multiple transaction hashes to simulate real-world scenarios
	// where logs come from different transactions
	txCount := logCount / 10
	if txCount == 0 {
		txCount = 1
	}

	logsPerTx := logCount / txCount
	remainingLogs := logCount % txCount

	for i := 0; i < txCount; i++ {
		thash := common.BytesToHash(common.BigToHash(common.Big1).Bytes())
		// Create unique transaction hash for each transaction
		thash[i%32] = byte(i)
		state.SetTxContext(thash, i)

		logsToAdd := logsPerTx
		if i < remainingLogs {
			logsToAdd++
		}

		for j := 0; j < logsToAdd; j++ {
			log := &types.Log{
				Address: common.BytesToAddress([]byte{byte(i), byte(j)}),
				Topics:  []common.Hash{common.BytesToHash([]byte{byte(i), byte(j), 0})},
				Data:    []byte{byte(i), byte(j), byte(i + j)},
			}
			state.AddLog(log)
		}
	}

	return state
}

func BenchmarkLogs_100(b *testing.B) {
	state := setupStateDBWithLogs(100)
	b.ResetTimer()

	for i := 0; i < b.N; i++ {
		_ = state.Logs()
	}
}

func BenchmarkLogs_1000(b *testing.B) {
	state := setupStateDBWithLogs(1000)
	b.ResetTimer()

	for i := 0; i < b.N; i++ {
		_ = state.Logs()
	}
}

func BenchmarkLogs_2000(b *testing.B) {
	state := setupStateDBWithLogs(2000)
	b.ResetTimer()

	for i := 0; i < b.N; i++ {
		_ = state.Logs()
	}
}

```

result in:  

```
goos: darwin
goarch: arm64
pkg: github.com/ethereum/go-ethereum/core/state
cpu: Apple M4
          │   old.txt    │               new.txt               │
          │    sec/op    │   sec/op     vs base                │
Logs_100    2457.5n ± 8%   333.3n ± 7%  -86.44% (p=0.000 n=10)
Logs_1000   43.416µ ± 2%   3.483µ ± 4%  -91.98% (p=0.000 n=10)
Logs_2000   97.707µ ± 2%   7.324µ ± 2%  -92.50% (p=0.000 n=10)
geomean      21.85µ        2.041µ       -90.66%

          │   old.txt    │               new.txt               │
          │     B/op     │     B/op      vs base               │
Logs_100      952.0 ± 0%     896.0 ± 0%  -5.88% (p=0.000 n=10)
Logs_1000   8.055Ki ± 0%   8.000Ki ± 0%  -0.68% (p=0.000 n=10)
Logs_2000   16.05Ki ± 0%   16.00Ki ± 0%  -0.34% (p=0.000 n=10)
geomean     4.935Ki        4.820Ki       -2.33%

          │  old.txt   │              new.txt               │
          │ allocs/op  │ allocs/op   vs base                │
Logs_100    3.000 ± 0%   1.000 ± 0%  -66.67% (p=0.000 n=10)
Logs_1000   3.000 ± 0%   1.000 ± 0%  -66.67% (p=0.000 n=10)
Logs_2000   3.000 ± 0%   1.000 ± 0%  -66.67% (p=0.000 n=10)
geomean     3.000        1.000       -66.67%

```