### PR TITLE
core/rawdb: fix resource leaks in freezer table tests

### DIFF
--- a/core/rawdb/freezer_table_test.go
+++ b/core/rawdb/freezer_table_test.go
@@ -163,6 +163,7 @@ func TestFreezerRepairDanglingHead(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
+		defer f.Close()
 		// The last item should be missing
 		if _, err = f.Retrieve(0xff); err == nil {
 			t.Errorf("Expected error for missing index entry")
@@ -231,7 +232,11 @@ func TestFreezerRepairDanglingHeadLarge(t *testing.T) {
 
 	// And if we open it, we should now be able to read all of them (new values)
 	{
-		f, _ := newTable(os.TempDir(), fname, rm, wm, sg, 50, freezerTableConfig{noSnappy: true}, false)
+		f, err := newTable(os.TempDir(), fname, rm, wm, sg, 50, freezerTableConfig{noSnappy: true}, false)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer f.Close()
 		for y := 1; y < 255; y++ {
 			exp := getChunk(15, ^y)
 			got, err := f.Retrieve(uint64(y))


### PR DESCRIPTION
This commit fixes two resource leak issues in `freezer_table_test.go`:

1. `TestFreezerRepairDanglingHead`: Added missing `defer f.Close()` to ensure the freezer table is properly closed after test completion.

2. `TestFreezerRepairDanglingHeadLarge`: Fixed ignored error from `newTable()` call and added missing `defer f.Close()` to prevent file handle leaks.

These leaks could accumulate during test runs, potentially causing failures due to hitting open file descriptor limits.