### PR TITLE
core: remove duplicate toWordSize function

### DIFF
--- a/core/state_transition.go
+++ b/core/state_transition.go
@@ -99,7 +99,7 @@ func IntrinsicGas(data []byte, accessList types.AccessList, authList []types.Set
 		gas += z * params.TxDataZeroGas
 
 		if isContractCreation && isEIP3860 {
-			lenWords := toWordSize(dataLen)
+			lenWords := vm.ToWordSize(dataLen)
 			if (math.MaxUint64-gas)/params.InitCodeWordGas < lenWords {
 				return 0, ErrGasUintOverflow
 			}
@@ -131,14 +131,6 @@ func FloorDataGas(data []byte) (uint64, error) {
 	return params.TxGas + tokens*params.TxCostFloorPerToken, nil
 }
 
-// toWordSize returns the ceiled word size required for init code payment calculation.
-func toWordSize(size uint64) uint64 {
-	if size > math.MaxUint64-31 {
-		return math.MaxUint64/32 + 1
-	}
-
-	return (size + 31) / 32
-}
 
 // A Message contains the data derived from a single transaction that is relevant to state
 // processing.

--- a/core/vm/common.go
+++ b/core/vm/common.go
@@ -76,8 +76,8 @@ func getDataAndAdjustedBounds(data []byte, start uint64, size uint64) (codeCopyP
 	return common.RightPadBytes(data[start:end], int(size)), start, end - start
 }
 
-// toWordSize returns the ceiled word size required for memory expansion.
-func toWordSize(size uint64) uint64 {
+// ToWordSize returns the ceiled word size required for memory expansion.
+func ToWordSize(size uint64) uint64 {
 	if size > math.MaxUint64-31 {
 		return math.MaxUint64/32 + 1
 	}

--- a/core/vm/gas_table.go
+++ b/core/vm/gas_table.go
@@ -39,7 +39,7 @@ func memoryGasCost(mem *Memory, newMemSize uint64) (uint64, error) {
 	if newMemSize > 0x1FFFFFFFE0 {
 		return 0, ErrGasUintOverflow
 	}
-	newMemSizeWords := toWordSize(newMemSize)
+	newMemSizeWords := ToWordSize(newMemSize)
 	newMemSize = newMemSizeWords * 32
 
 	if newMemSize > uint64(mem.Len()) {
@@ -77,7 +77,7 @@ func memoryCopierGas(stackpos int) gasFunc {
 			return 0, ErrGasUintOverflow
 		}
 
-		if words, overflow = math.SafeMul(toWordSize(words), params.CopyGas); overflow {
+		if words, overflow = math.SafeMul(ToWordSize(words), params.CopyGas); overflow {
 			return 0, ErrGasUintOverflow
 		}
 
@@ -260,7 +260,7 @@ func gasKeccak256(evm *EVM, contract *Contract, stack *Stack, mem *Memory, memor
 	if overflow {
 		return 0, ErrGasUintOverflow
 	}
-	if wordGas, overflow = math.SafeMul(toWordSize(wordGas), params.Keccak256WordGas); overflow {
+	if wordGas, overflow = math.SafeMul(ToWordSize(wordGas), params.Keccak256WordGas); overflow {
 		return 0, ErrGasUintOverflow
 	}
 	if gas, overflow = math.SafeAdd(gas, wordGas); overflow {
@@ -294,7 +294,7 @@ func gasCreate2(evm *EVM, contract *Contract, stack *Stack, mem *Memory, memoryS
 	if overflow {
 		return 0, ErrGasUintOverflow
 	}
-	if wordGas, overflow = math.SafeMul(toWordSize(wordGas), params.Keccak256WordGas); overflow {
+	if wordGas, overflow = math.SafeMul(ToWordSize(wordGas), params.Keccak256WordGas); overflow {
 		return 0, ErrGasUintOverflow
 	}
 	if gas, overflow = math.SafeAdd(gas, wordGas); overflow {

--- a/core/vm/instructions_test.go
+++ b/core/vm/instructions_test.go
@@ -869,7 +869,7 @@ func TestOpMCopy(t *testing.T) {
 			t.Errorf("overflow")
 		} else {
 			var overflow bool
-			if memorySize, overflow = math.SafeMul(toWordSize(memSize), 32); overflow {
+			if memorySize, overflow = math.SafeMul(ToWordSize(memSize), 32); overflow {
 				t.Error(ErrGasUintOverflow)
 			}
 		}

--- a/core/vm/interpreter.go
+++ b/core/vm/interpreter.go
@@ -214,7 +214,7 @@ func (evm *EVM) Run(contract *Contract, input []byte, readOnly bool) (ret []byte
 				}
 				// memory is expanded in words of 32 bytes. Gas
 				// is also calculated in words.
-				if memorySize, overflow = math.SafeMul(toWordSize(memSize), 32); overflow {
+				if memorySize, overflow = math.SafeMul(ToWordSize(memSize), 32); overflow {
 					return nil, ErrGasUintOverflow
 				}
 			}


### PR DESCRIPTION
Remove duplicated toWordSize function from core/state_transition.go.
The same function already exists in core/vm/common.go.
Exported it as ToWordSize and reused across both packages.