### PR TITLE
core: Remove duplicate code of CheckConfigForkOrder()

### DIFF
--- a/core/genesis.go
+++ b/core/genesis.go
@@ -377,11 +377,6 @@ func SetupGenesisBlockWithOverride(db ethdb.Database, triedb *triedb.Database, g
 		return nil, common.Hash{}, nil, err
 	}
 
-	// Sanity-check the new configuration.
-	if err := newCfg.CheckConfigForkOrder(); err != nil {
-		return nil, common.Hash{}, nil, err
-	}
-
 	// TODO(rjl493456442) better to define the comparator of chain config
 	// and short circuit if the chain config is not changed.
 	compatErr := storedCfg.CheckCompatible(newCfg, head.Number.Uint64(), head.Time)


### PR DESCRIPTION
Remove CheckConfigForkOrder call because it has already been called in overrides.apply() a few lines above: https://github.com/ethereum/go-ethereum/blob/eaaa5b716dcf97e94eb17a1469a7385a7101ffab/core/genesis.go#L376

inside `overrides.apply()`, `CheckConfigForkOrder ` is called here:
https://github.com/ethereum/go-ethereum/blob/eaaa5b716dcf97e94eb17a1469a7385a7101ffab/core/genesis.go#L284
