### PR TITLE
eth/protocols/eth: fix handshake timeout metrics classification

### DIFF
--- a/eth/protocols/eth/handshake.go
+++ b/eth/protocols/eth/handshake.go
@@ -191,22 +191,16 @@ func markError(p *Peer, err error) {
 		return
 	}
 	m := meters.get(p.Inbound())
-
-	base := errors.Unwrap(err)
-	if base == nil {
-		base = err
-	}
-
-	switch base {
-	case errNetworkIDMismatch:
+	switch {
+	case errors.Is(err, errNetworkIDMismatch):
 		m.networkIDMismatch.Mark(1)
-	case errProtocolVersionMismatch:
+	case errors.Is(err, errProtocolVersionMismatch):
 		m.protocolVersionMismatch.Mark(1)
-	case errGenesisMismatch:
+	case errors.Is(err, errGenesisMismatch):
 		m.genesisMismatch.Mark(1)
-	case errForkIDRejected:
+	case errors.Is(err, errForkIDRejected):
 		m.forkidRejected.Mark(1)
-	case p2p.DiscReadTimeout:
+	case errors.Is(err, p2p.DiscReadTimeout):
 		m.timeoutError.Mark(1)
 	default:
 		m.peerError.Mark(1)


### PR DESCRIPTION
Previously, handshake timeouts were recorded as generic peer errors instead of timeout errors. waitForHandshake passed a raw p2p.DiscReadTimeout into markError, but markError classified errors only via errors.Unwrap(err), which returns nil for non-wrapped errors. As a result, the timeoutError meter was never incremented and all such failures fell into the peerError bucket.

This change makes markError switch on the base error, using errors.Unwrap(err) when available and falling back to the original error otherwise. With this adjustment, p2p.DiscReadTimeout is correctly mapped to timeoutError, while existing behaviour for the other wrapped sentinel errors remains unchanged