### PR TITLE
graphql: fix GasPrice for blob and setcode transactions

### DIFF
--- a/graphql/graphql.go
+++ b/graphql/graphql.go
@@ -272,7 +272,7 @@ func (t *Transaction) GasPrice(ctx context.Context) hexutil.Big {
 		return hexutil.Big{}
 	}
 	switch tx.Type() {
-	case types.DynamicFeeTxType:
+	case types.DynamicFeeTxType, types.BlobTxType, types.SetCodeTxType:
 		if block != nil {
 			if baseFee, _ := block.BaseFeePerGas(ctx); baseFee != nil {
 				// price = min(gasTipCap + baseFee, gasFeeCap)


### PR DESCRIPTION
Adds BlobTxType and SetCodeTxType to GasPrice switch case, aligning with `MaxFeePerGas` and `MaxPriorityFeePerGas` handling.