### PR TITLE
rpc: fix limitedBuffer.Write to properly enforce size limit

### DIFF
--- a/rpc/handler.go
+++ b/rpc/handler.go
@@ -612,8 +612,11 @@ type limitedBuffer struct {
 }
 
 func (buf *limitedBuffer) Write(data []byte) (int, error) {
-	avail := max(buf.limit, len(buf.output))
-	if len(data) < avail {
+	avail := buf.limit - len(buf.output)
+	if avail <= 0 {
+		return 0, errTruncatedOutput
+	}
+	if len(data) <= avail {
 		buf.output = append(buf.output, data...)
 		return len(data), nil
 	}


### PR DESCRIPTION


Updated the `avail` calculation to correctly compute remaining capacity: `buf.limit - len(buf.output)`, ensuring the buffer never exceeds its configured limit regardless of how many times `Write()` is called.

