### PR TITLE
core/types: using defined struct to optimize sigHash

### DIFF
--- a/core/types/tx_access_list.go
+++ b/core/types/tx_access_list.go
@@ -128,17 +128,30 @@ func (tx *AccessListTx) decode(input []byte) error {
 	return rlp.DecodeBytes(input, tx)
 }
 
+// accessListTxSigHash represents the fields used for computing the signature hash
+// of an AccessListTx transaction.
+type accessListTxSigHash struct {
+	ChainID    *big.Int
+	Nonce      uint64
+	GasPrice   *big.Int
+	Gas        uint64
+	To         *common.Address `rlp:"nil"`
+	Value      *big.Int
+	Data       []byte
+	AccessList AccessList
+}
+
 func (tx *AccessListTx) sigHash(chainID *big.Int) common.Hash {
 	return prefixedRlpHash(
 		AccessListTxType,
-		[]any{
-			chainID,
-			tx.Nonce,
-			tx.GasPrice,
-			tx.Gas,
-			tx.To,
-			tx.Value,
-			tx.Data,
-			tx.AccessList,
+		&accessListTxSigHash{
+			ChainID:    chainID,
+			Nonce:      tx.Nonce,
+			GasPrice:   tx.GasPrice,
+			Gas:        tx.Gas,
+			To:         tx.To,
+			Value:      tx.Value,
+			Data:       tx.Data,
+			AccessList: tx.AccessList,
 		})
 }

--- a/core/types/tx_blob.go
+++ b/core/types/tx_blob.go
@@ -421,20 +421,36 @@ func (tx *BlobTx) decode(input []byte) error {
 	return nil
 }
 
+// blobTxSigHash represents the fields used for computing the signature hash
+// of a BlobTx transaction.
+type blobTxSigHash struct {
+	ChainID    *big.Int
+	Nonce      uint64
+	GasTipCap  *uint256.Int
+	GasFeeCap  *uint256.Int
+	Gas        uint64
+	To         common.Address
+	Value      *uint256.Int
+	Data       []byte
+	AccessList AccessList
+	BlobFeeCap *uint256.Int
+	BlobHashes []common.Hash
+}
+
 func (tx *BlobTx) sigHash(chainID *big.Int) common.Hash {
 	return prefixedRlpHash(
 		BlobTxType,
-		[]any{
-			chainID,
-			tx.Nonce,
-			tx.GasTipCap,
-			tx.GasFeeCap,
-			tx.Gas,
-			tx.To,
-			tx.Value,
-			tx.Data,
-			tx.AccessList,
-			tx.BlobFeeCap,
-			tx.BlobHashes,
+		&blobTxSigHash{
+			ChainID:    chainID,
+			Nonce:      tx.Nonce,
+			GasTipCap:  tx.GasTipCap,
+			GasFeeCap:  tx.GasFeeCap,
+			Gas:        tx.Gas,
+			To:         tx.To,
+			Value:      tx.Value,
+			Data:       tx.Data,
+			AccessList: tx.AccessList,
+			BlobFeeCap: tx.BlobFeeCap,
+			BlobHashes: tx.BlobHashes,
 		})
 }

--- a/core/types/tx_dynamic_fee.go
+++ b/core/types/tx_dynamic_fee.go
@@ -124,18 +124,32 @@ func (tx *DynamicFeeTx) decode(input []byte) error {
 	return rlp.DecodeBytes(input, tx)
 }
 
+// dynamicFeeTxSigHash represents the fields used for computing the signature hash
+// of a DynamicFeeTx transaction.
+type dynamicFeeTxSigHash struct {
+	ChainID    *big.Int
+	Nonce      uint64
+	GasTipCap  *big.Int
+	GasFeeCap  *big.Int
+	Gas        uint64
+	To         *common.Address `rlp:"nil"`
+	Value      *big.Int
+	Data       []byte
+	AccessList AccessList
+}
+
 func (tx *DynamicFeeTx) sigHash(chainID *big.Int) common.Hash {
 	return prefixedRlpHash(
 		DynamicFeeTxType,
-		[]any{
-			chainID,
-			tx.Nonce,
-			tx.GasTipCap,
-			tx.GasFeeCap,
-			tx.Gas,
-			tx.To,
-			tx.Value,
-			tx.Data,
-			tx.AccessList,
+		&dynamicFeeTxSigHash{
+			ChainID:    chainID,
+			Nonce:      tx.Nonce,
+			GasTipCap:  tx.GasTipCap,
+			GasFeeCap:  tx.GasFeeCap,
+			Gas:        tx.Gas,
+			To:         tx.To,
+			Value:      tx.Value,
+			Data:       tx.Data,
+			AccessList: tx.AccessList,
 		})
 }

--- a/core/types/tx_legacy.go
+++ b/core/types/tx_legacy.go
@@ -124,15 +124,31 @@ func (tx *LegacyTx) decode([]byte) error {
 	panic("decode called on LegacyTx)")
 }
 
+// legacyTxSigHash represents the fields used for computing the signature hash
+// of a LegacyTx transaction (post-EIP155).
+type legacyTxSigHash struct {
+	Nonce    uint64
+	GasPrice *big.Int
+	Gas      uint64
+	To       *common.Address `rlp:"nil"`
+	Value    *big.Int
+	Data     []byte
+	ChainID  *big.Int
+	V        uint
+	R        uint
+}
+
 // OBS: This is the post-EIP155 hash, the pre-EIP155 does not contain a chainID.
 func (tx *LegacyTx) sigHash(chainID *big.Int) common.Hash {
-	return rlpHash([]any{
-		tx.Nonce,
-		tx.GasPrice,
-		tx.Gas,
-		tx.To,
-		tx.Value,
-		tx.Data,
-		chainID, uint(0), uint(0),
+	return rlpHash(&legacyTxSigHash{
+		Nonce:    tx.Nonce,
+		GasPrice: tx.GasPrice,
+		Gas:      tx.Gas,
+		To:       tx.To,
+		Value:    tx.Value,
+		Data:     tx.Data,
+		ChainID:  chainID,
+		V:        uint(0),
+		R:        uint(0),
 	})
 }

--- a/core/types/tx_setcode.go
+++ b/core/types/tx_setcode.go
@@ -225,19 +225,34 @@ func (tx *SetCodeTx) decode(input []byte) error {
 	return rlp.DecodeBytes(input, tx)
 }
 
+// setCodeTxSigHash represents the fields used for computing the signature hash
+// of a SetCodeTx transaction.
+type setCodeTxSigHash struct {
+	ChainID    *big.Int
+	Nonce      uint64
+	GasTipCap  *uint256.Int
+	GasFeeCap  *uint256.Int
+	Gas        uint64
+	To         common.Address
+	Value      *uint256.Int
+	Data       []byte
+	AccessList AccessList
+	AuthList   []SetCodeAuthorization
+}
+
 func (tx *SetCodeTx) sigHash(chainID *big.Int) common.Hash {
 	return prefixedRlpHash(
 		SetCodeTxType,
-		[]any{
-			chainID,
-			tx.Nonce,
-			tx.GasTipCap,
-			tx.GasFeeCap,
-			tx.Gas,
-			tx.To,
-			tx.Value,
-			tx.Data,
-			tx.AccessList,
-			tx.AuthList,
+		&setCodeTxSigHash{
+			ChainID:    chainID,
+			Nonce:      tx.Nonce,
+			GasTipCap:  tx.GasTipCap,
+			GasFeeCap:  tx.GasFeeCap,
+			Gas:        tx.Gas,
+			To:         tx.To,
+			Value:      tx.Value,
+			Data:       tx.Data,
+			AccessList: tx.AccessList,
+			AuthList:   tx.AuthList,
 		})
 }


### PR DESCRIPTION
benchmark code:  
```
// Copyright 2021 The go-ethereum Authors
// This file is part of the go-ethereum library.
//
// The go-ethereum library is free software: you can redistribute it and/or modify
// it under the terms of the GNU Lesser General Public License as published by
// the Free Software Foundation, either version 3 of the License, or
// (at your option) any later version.
//
// The go-ethereum library is distributed in the hope that it will be useful,
// but WITHOUT ANY WARRANTY; without even the implied warranty of
// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
// GNU Lesser General Public License for more details.
//
// You should have received a copy of the GNU Lesser General Public License
// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.

package types

import (
	"math/big"
	"testing"

	"github.com/ethereum/go-ethereum/common"
	"github.com/holiman/uint256"
)

// BenchmarkSigHash_DynamicFeeTx benchmarks the sigHash method for DynamicFeeTx
// with all fields populated.
func BenchmarkSigHash_DynamicFeeTx(b *testing.B) {
	// Create a DynamicFeeTx with all fields populated
	to := common.HexToAddress("0x000000000000000000000000000000000000dead")
	chainID := big.NewInt(1337)
	tx := &DynamicFeeTx{
		ChainID:    big.NewInt(1337),
		Nonce:      42,
		GasTipCap:  big.NewInt(1000000000),  // 1 gwei
		GasFeeCap:  big.NewInt(2000000000),  // 2 gwei
		Gas:        21000,
		To:         &to,
		Value:      big.NewInt(1000000000000000000), // 1 ether
		Data:       []byte{0x12, 0x34, 0x56, 0x78, 0x9a, 0xbc, 0xde, 0xf0},
		AccessList: AccessList{
			AccessTuple{
				Address:     common.HexToAddress("0x0000000000000000000000000000000000000001"),
				StorageKeys: []common.Hash{
					common.HexToHash("0x0000000000000000000000000000000000000000000000000000000000000001"),
					common.HexToHash("0x0000000000000000000000000000000000000000000000000000000000000002"),
				},
			},
			AccessTuple{
				Address:     common.HexToAddress("0x0000000000000000000000000000000000000002"),
				StorageKeys: []common.Hash{
					common.HexToHash("0x0000000000000000000000000000000000000000000000000000000000000003"),
				},
			},
		},
		V: big.NewInt(27),
		R: big.NewInt(123456789),
		S: big.NewInt(987654321),
	}

	b.ResetTimer()
	for i := 0; i < b.N; i++ {
		_ = tx.sigHash(chainID)
	}
}

// BenchmarkSigHash_AccessListTx benchmarks the sigHash method for AccessListTx
// with all fields populated.
func BenchmarkSigHash_AccessListTx(b *testing.B) {
	to := common.HexToAddress("0x000000000000000000000000000000000000dead")
	chainID := big.NewInt(1337)
	tx := &AccessListTx{
		ChainID:  big.NewInt(1337),
		Nonce:    42,
		GasPrice: big.NewInt(2000000000), // 2 gwei
		Gas:      21000,
		To:       &to,
		Value:    big.NewInt(1000000000000000000), // 1 ether
		Data:     []byte{0x12, 0x34, 0x56, 0x78, 0x9a, 0xbc, 0xde, 0xf0},
		AccessList: AccessList{
			AccessTuple{
				Address:     common.HexToAddress("0x0000000000000000000000000000000000000001"),
				StorageKeys: []common.Hash{
					common.HexToHash("0x0000000000000000000000000000000000000000000000000000000000000001"),
					common.HexToHash("0x0000000000000000000000000000000000000000000000000000000000000002"),
				},
			},
			AccessTuple{
				Address:     common.HexToAddress("0x0000000000000000000000000000000000000002"),
				StorageKeys: []common.Hash{
					common.HexToHash("0x0000000000000000000000000000000000000000000000000000000000000003"),
				},
			},
		},
		V: big.NewInt(27),
		R: big.NewInt(123456789),
		S: big.NewInt(987654321),
	}

	b.ResetTimer()
	for i := 0; i < b.N; i++ {
		_ = tx.sigHash(chainID)
	}
}

// BenchmarkSigHash_LegacyTx benchmarks the sigHash method for LegacyTx
// with all fields populated.
func BenchmarkSigHash_LegacyTx(b *testing.B) {
	to := common.HexToAddress("0x000000000000000000000000000000000000dead")
	chainID := big.NewInt(1337)
	tx := &LegacyTx{
		Nonce:    42,
		GasPrice: big.NewInt(2000000000), // 2 gwei
		Gas:      21000,
		To:       &to,
		Value:    big.NewInt(1000000000000000000), // 1 ether
		Data:     []byte{0x12, 0x34, 0x56, 0x78, 0x9a, 0xbc, 0xde, 0xf0},
		V:        big.NewInt(27),
		R:        big.NewInt(123456789),
		S:        big.NewInt(987654321),
	}

	b.ResetTimer()
	for i := 0; i < b.N; i++ {
		_ = tx.sigHash(chainID)
	}
}

// BenchmarkSigHash_BlobTx benchmarks the sigHash method for BlobTx
// with all fields populated.
func BenchmarkSigHash_BlobTx(b *testing.B) {
	to := common.HexToAddress("0x000000000000000000000000000000000000dead")
	chainID := big.NewInt(1337)
	tx := &BlobTx{
		ChainID:    uint256.MustFromBig(big.NewInt(1337)),
		Nonce:      42,
		GasTipCap:  uint256.MustFromBig(big.NewInt(1000000000)),  // 1 gwei
		GasFeeCap:  uint256.MustFromBig(big.NewInt(2000000000)),  // 2 gwei
		Gas:        21000,
		To:         to,
		Value:      uint256.MustFromBig(big.NewInt(1000000000000000000)), // 1 ether
		Data:       []byte{0x12, 0x34, 0x56, 0x78, 0x9a, 0xbc, 0xde, 0xf0},
		AccessList: AccessList{
			AccessTuple{
				Address:     common.HexToAddress("0x0000000000000000000000000000000000000001"),
				StorageKeys: []common.Hash{
					common.HexToHash("0x0000000000000000000000000000000000000000000000000000000000000001"),
					common.HexToHash("0x0000000000000000000000000000000000000000000000000000000000000002"),
				},
			},
			AccessTuple{
				Address:     common.HexToAddress("0x0000000000000000000000000000000000000002"),
				StorageKeys: []common.Hash{
					common.HexToHash("0x0000000000000000000000000000000000000000000000000000000000000003"),
				},
			},
		},
		BlobFeeCap: uint256.MustFromBig(big.NewInt(100000000)), // blob fee cap
		BlobHashes: []common.Hash{
			common.HexToHash("0x0100000000000000000000000000000000000000000000000000000000000000"),
			common.HexToHash("0x0200000000000000000000000000000000000000000000000000000000000000"),
		},
		V: uint256.MustFromBig(big.NewInt(27)),
		R: uint256.MustFromBig(big.NewInt(123456789)),
		S: uint256.MustFromBig(big.NewInt(987654321)),
	}

	b.ResetTimer()
	for i := 0; i < b.N; i++ {
		_ = tx.sigHash(chainID)
	}
}

```
result in:  

```
goos: darwin
goarch: arm64
pkg: github.com/ethereum/go-ethereum/core/types
cpu: Apple M4
                        │   old.txt    │               new.txt               │
                        │    sec/op    │   sec/op     vs base                │
SigHash_DynamicFeeTx-10    928.7n ± 7%   715.0n ± 1%  -23.00% (p=0.000 n=10)
SigHash_AccessListTx-10    876.4n ± 2%   706.2n ± 1%  -19.41% (p=0.000 n=10)
SigHash_LegacyTx-10        550.9n ± 1%   372.1n ± 3%  -32.45% (p=0.000 n=10)
SigHash_BlobTx-10         1291.5n ± 1%   987.0n ± 2%  -23.58% (p=0.000 n=10)
geomean                    872.3n        656.3n       -24.77%

                        │  old.txt   │              new.txt               │
                        │    B/op    │    B/op     vs base                │
SigHash_DynamicFeeTx-10   264.0 ± 0%   145.0 ± 0%  -45.08% (p=0.000 n=10)
SigHash_AccessListTx-10   248.0 ± 0%   129.0 ± 0%  -47.98% (p=0.000 n=10)
SigHash_LegacyTx-10       232.0 ± 0%   128.0 ± 0%  -44.83% (p=0.000 n=10)
SigHash_BlobTx-10         368.0 ± 0%   193.0 ± 0%  -47.55% (p=0.000 n=10)
geomean                   273.4        146.6       -46.38%

                        │   old.txt   │              new.txt               │
                        │  allocs/op  │ allocs/op   vs base                │
SigHash_DynamicFeeTx-10    7.000 ± 0%   3.000 ± 0%  -57.14% (p=0.000 n=10)
SigHash_AccessListTx-10    7.000 ± 0%   3.000 ± 0%  -57.14% (p=0.000 n=10)
SigHash_LegacyTx-10        5.000 ± 0%   2.000 ± 0%  -60.00% (p=0.000 n=10)
SigHash_BlobTx-10         10.000 ± 0%   3.000 ± 0%  -70.00% (p=0.000 n=10)
geomean                    7.035        2.711       -61.47%
```