### PR TITLE
rlp: improve SplitListValues allocation efficiency

### DIFF
--- a/rlp/raw.go
+++ b/rlp/raw.go
@@ -165,7 +165,10 @@ func SplitListValues(b []byte) ([][]byte, error) {
 	var elements = make([][]byte, 0, n)
 
 	for len(b) > 0 {
-		_, tagsize, size, _ := readKind(b)
+		_, tagsize, size, err := readKind(b)
+		if err != nil {
+			return nil, err
+		}
 		elements = append(elements, b[:tagsize+size])
 		b = b[tagsize+size:]
 	}


### PR DESCRIPTION
Improve the SplitListValues method by setting the capacity.

Benchmark code: 
```
// splitListValues_origin extracts the raw elements from the list RLP-encoding blob.
func splitListValues_origin(b []byte) ([][]byte, error) {
	b, _, err := SplitList(b)
	if err != nil {
		return nil, err
	}
	var elements [][]byte
	for len(b) > 0 {
		_, tagsize, size, err := readKind(b)
		if err != nil {
			return nil, err
		}
		elements = append(elements, b[:tagsize+size])
		b = b[tagsize+size:]
	}
	return elements, nil
}

func BenchmarkSplitListValues(b *testing.B) {
	input := "F877A12000BF49F440A1CD0527E4D06E2765654C0F56452257516D793A9B8D604DCFDF2AB853F851808D10000000000000000000000000A056E81F171BCC55A6FF8345E692C0F86E5B48E01B996CADC001622FB5E363B421A0C5D2460186F7233C927E7DB2DCC703C0E500B653CA82273B7BFAD8045D85A470"
	data := unhex(input)

	b.Run("SplitListValues(origin)", func(b *testing.B) {
		for i := 0; i < b.N; i++ {
			splitListValues_origin(data) // warm up
		}
	})

	b.Run("SplitListValues(improved)", func(b *testing.B) {
		for i := 0; i < b.N; i++ {
			SplitListValues(data)
		}
	})
}
```

Result:
```
goos: darwin
goarch: arm64
pkg: github.com/ethereum/go-ethereum/rlp
cpu: Apple M3 Pro
BenchmarkSplitListValues
BenchmarkSplitListValues/SplitListValues(origin)
BenchmarkSplitListValues/SplitListValues(origin)-12         	12957044	        82.61 ns/op
BenchmarkSplitListValues/SplitListValues(improved)
BenchmarkSplitListValues/SplitListValues(improved)-12       	22989550	        51.51 ns/op
```