### PR TITLE
node: handle JWT secret generation error

### DIFF
--- a/node/node.go
+++ b/node/node.go
@@ -346,7 +346,9 @@ func ObtainJWTSecret(fileName string) ([]byte, error) {
 	}
 	// Need to generate one
 	jwtSecret := make([]byte, 32)
-	crand.Read(jwtSecret)
+	if _, err := crand.Read(jwtSecret); err != nil {
+		return nil, fmt.Errorf("failed to generate JWT secret: %w", err)
+	}
 	// if we're in --dev mode, don't bother saving, just show it
 	if fileName == "" {
 		log.Info("Generated ephemeral JWT secret", "secret", hexutil.Encode(jwtSecret))


### PR DESCRIPTION


The `ObtainJWTSecret` function in `node/node.go` was ignoring errors from `crypto/rand.Read()` when generating JWT secrets. If the cryptographic random number generator fails, the function would continue with a potentially predictable or zero-filled secret.

