### PR TITLE
core/state/snapshot: remove dead code in generate tests

### DIFF
--- a/core/state/snapshot/generate_test.go
+++ b/core/state/snapshot/generate_test.go
@@ -631,9 +631,6 @@ func TestGenerateWithManyExtraAccounts(t *testing.T) {
 }
 
 func testGenerateWithManyExtraAccounts(t *testing.T, scheme string) {
-	if false {
-		enableLogging()
-	}
 	helper := newHelper(scheme)
 	{
 		// Account one in the trie


### PR DESCRIPTION
Removes unreachable `if false` blocks from snapshot generation tests that were guarding `enableLogging()` calls.