### PR TITLE
trie: remove unused UpdateStem method from TransitionTrie

### DIFF
--- a/trie/transitiontrie/transition.go
+++ b/trie/transitiontrie/transition.go
@@ -208,14 +208,6 @@ func (t *TransitionTrie) IsVerkle() bool {
 	return true
 }
 
-// UpdateStem updates a group of values, given the stem they are using. If
-// a value already exists, it is overwritten.
-// TODO: This is Verkle-specific and requires access to private fields.
-// Not currently used in the codebase.
-func (t *TransitionTrie) UpdateStem(key []byte, values [][]byte) error {
-	panic("UpdateStem is not implemented for TransitionTrie")
-}
-
 // Copy creates a deep copy of the transition trie.
 func (t *TransitionTrie) Copy() *TransitionTrie {
 	return &TransitionTrie{


### PR DESCRIPTION
Removes the `UpdateStem` method from `TransitionTrie` which was never implemented and explicitly marked as unused in the codebase.