### PR TITLE
core: skip duplicate block and state writes in ProcessBlock() on block re-execution

### DIFF
--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -2234,7 +2234,10 @@ func (bc *BlockChain) ProcessBlock(parentRoot common.Hash, block *types.Block, s
 	)
 	if !setHead {
 		// Don't set the head, only insert the block
-		err = bc.writeBlockWithState(block, res.Receipts, statedb)
+		// Do not write block and state if it already exists
+		if !bc.HasBlockAndState(block.Hash(), block.NumberU64()) {
+			err = bc.writeBlockWithState(block, res.Receipts, statedb)
+		}
 	} else {
 		status, err = bc.writeBlockAndSetHead(block, res.Receipts, res.Logs, statedb, false)
 	}


### PR DESCRIPTION
Per issue #33572, the experimental RPC `debug_executionWitness` called on blocks behind the tip can cause a state corruption issue which causes `geth` to incorrectly identify future blocks as invalid.

The RPC command `debug_executionWitness` calls `blockchain.ProcessBlock()` with setHead=`false` and makeWitness=`true` when re-executing a block to generate the execution witness,  which causes `ProcessBlock()` to write the block and state even if it already exists. This doesn't just overwrite existing previous data for the re-executed block; for example when using pathdb the eventual call to `addLayer()`  will fetch the mutation history of the address and append the new account state diff:

```
for accountHash := range diff.states.accountData {
	list, exists := l.accounts[accountHash]
<snip>
	list = append(list, state)
	l.accounts[accountHash] = list
}
```

If we have blocks [C0, C1, C2] and run the `ProcessBlock()` command again for C1, then the resulting account mutation list will have entries for state changes from [C0, C1, C2, C1], then when `accountTip()` is called when processing the next block C3, it traverses these layers in reverse and hits the state change from block C1 first, and this stale data results in an invalid nonce being used for block execution which fails, as if blocks C3 and C2 both have transactions from the same account, the transactions in C3 will appear to have too high of a nonce, since the nonce of the account at block C1 is being used.

This PR modifies `ProcessBlock()` to only write the block and state when it does not already exist, preventing double-writing on block re-execution which causes this state corruption.