### PR TITLE
core/state: optimize map usage

### DIFF
--- a/core/state/statedb.go
+++ b/core/state/statedb.go
@@ -1479,19 +1479,23 @@ func (s *StateDB) SlotInAccessList(addr common.Address, slot common.Hash) (addre
 // not yet committed. The pending mutation is cached and will be applied
 // all together
 func (s *StateDB) markDelete(addr common.Address) {
-	if _, ok := s.mutations[addr]; !ok {
-		s.mutations[addr] = &mutation{}
+	v, ok := s.mutations[addr]
+	if !ok {
+		v = &mutation{}
+		s.mutations[addr] = v
 	}
-	s.mutations[addr].applied = false
-	s.mutations[addr].typ = deletion
+	v.applied = false
+	v.typ = deletion
 }
 
 func (s *StateDB) markUpdate(addr common.Address) {
-	if _, ok := s.mutations[addr]; !ok {
-		s.mutations[addr] = &mutation{}
+	v, ok := s.mutations[addr]
+	if !ok {
+		v = &mutation{}
+		s.mutations[addr] = v
 	}
-	s.mutations[addr].applied = false
-	s.mutations[addr].typ = update
+	v.applied = false
+	v.typ = update
 }
 
 // Witness retrieves the current state witness being collected.


### PR DESCRIPTION
benchmark code:  
```
// Copyright 2014 The go-ethereum Authors
// This file is part of the go-ethereum library.
//
// The go-ethereum library is free software: you can redistribute it and/or modify
// it under the terms of the GNU Lesser General Public License as published by
// the Free Software Foundation, either version 3 of the License, or
// (at your option) any later version.
//
// The go-ethereum library is distributed in the hope that it will be useful,
// but WITHOUT ANY WARRANTY; without even the implied warranty of
// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
// GNU Lesser General Public License for more details.
//
// You should have received a copy of the GNU Lesser General Public License
// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.

package state

import (
	"testing"

	"github.com/ethereum/go-ethereum/common"
	"github.com/ethereum/go-ethereum/core/types"
)

func BenchmarkMarkDelete(b *testing.B) {
	sdb, _ := New(types.EmptyRootHash, NewDatabaseForTesting())
	addr := common.BytesToAddress([]byte{0x01, 0x02, 0x03})

	b.ReportAllocs()
	b.ResetTimer()
	for i := 0; i < b.N; i++ {
		sdb.markDelete(addr)
	}
}

func BenchmarkMarkUpdate(b *testing.B) {
	sdb, _ := New(types.EmptyRootHash, NewDatabaseForTesting())
	addr := common.BytesToAddress([]byte{0x01, 0x02, 0x03})

	b.ReportAllocs()
	b.ResetTimer()
	for i := 0; i < b.N; i++ {
		sdb.markUpdate(addr)
	}
}

```
benchmark result:  
```
goos: darwin
goarch: arm64
pkg: github.com/ethereum/go-ethereum/core/state
cpu: Apple M4
              │   old.txt    │               new.txt               │
              │    sec/op    │   sec/op     vs base                │
MarkDelete-10   17.595n ± 7%   6.098n ± 1%  -65.34% (p=0.000 n=10)
MarkUpdate-10   17.675n ± 2%   6.196n ± 0%  -64.94% (p=0.000 n=10)
geomean          17.63n        6.147n       -65.14%

              │   old.txt    │               new.txt               │
              │     B/op     │    B/op     vs base                 │
MarkDelete-10   0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
MarkUpdate-10   0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
geomean                    ²               +0.00%                ²
¹ all samples are equal
² summaries must be >0 to compute geomean

              │   old.txt    │               new.txt               │
              │  allocs/op   │ allocs/op   vs base                 │
MarkDelete-10   0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
MarkUpdate-10   0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
geomean                    ²               +0.00%                ²
¹ all samples are equal
² summaries must be >0 to compute geomean

```