### PR TITLE
Cache trie hashes in copy test to avoid redundant work

### DIFF
--- a/trie/trie_test.go
+++ b/trie/trie_test.go
@@ -1356,8 +1356,10 @@ func testTrieCopy(t *testing.T, entries []kv) {
 	}
 	trCpy := tr.Copy()
 
-	if tr.Hash() != trCpy.Hash() {
-		t.Errorf("Hash mismatch: old %v, copy %v", tr.Hash(), trCpy.Hash())
+	trHash := tr.Hash()
+	copyHash := trCpy.Hash()
+	if trHash != copyHash {
+		t.Errorf("Hash mismatch: old %v, copy %v", trHash, copyHash)
 	}
 
 	// Check iterator


### PR DESCRIPTION
Capture trHash and copyHash once in trie/trie_test.go before comparing, removing repeated Hash() calls per trie.
Keeps test logic unchanged while trimming redundant computation.