### PR TITLE
core/types/bal: reduce alloc

### DIFF
--- a/core/types/bal/bal.go
+++ b/core/types/bal/bal.go
@@ -152,7 +152,9 @@ func (b *ConstructionBlockAccessList) PrettyPrint() string {
 
 // Copy returns a deep copy of the access list.
 func (b *ConstructionBlockAccessList) Copy() *ConstructionBlockAccessList {
-	res := NewConstructionBlockAccessList()
+	res := ConstructionBlockAccessList{
+		Accounts: make(map[common.Address]*ConstructionAccountAccess, len(b.Accounts)),
+	}
 	for addr, aa := range b.Accounts {
 		var aaCopy ConstructionAccountAccess
 


### PR DESCRIPTION
benchmark code:  
```
// Copyright 2025 The go-ethereum Authors
// This file is part of the go-ethereum library.
//
// The go-ethereum library is free software: you can redistribute it and/or modify
// it under the terms of the GNU Lesser General Public License as published by
// the Free Software Foundation, either version 3 of the License, or
// (at your option) any later version.
//
// The go-ethereum library is distributed in the hope that it will be useful,
// but WITHOUT ANY WARRANTY; without even the implied warranty of
// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
// GNU Lesser General Public License for more details.
//
// You should have received a copy of the GNU Lesser General Public License
// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.

package bal

import (
	"bytes"
	"encoding/binary"
	"testing"

	"github.com/ethereum/go-ethereum/common"
	"github.com/ethereum/go-ethereum/internal/testrand"
	"github.com/holiman/uint256"
)

// makeBenchmarkBAL creates a ConstructionBlockAccessList with the specified number of accounts
// for benchmarking purposes.
func makeBenchmarkBAL(numAccounts int) *ConstructionBlockAccessList {
	bal := NewConstructionBlockAccessList()

	for i := 0; i < numAccounts; i++ {
		addr := common.BytesToAddress(testrand.Bytes(20))
		aa := NewConstructionAccountAccess()

		// Add some storage writes (5-10 per account)
		numStorageWrites := 5 + (i % 6)
		for j := 0; j < numStorageWrites; j++ {
			key := testrand.Hash()
			aa.StorageWrites[key] = make(map[uint16]common.Hash)
			// Add 2-5 transaction indices per storage key
			numTxs := 2 + (j % 4)
			for k := 0; k < numTxs; k++ {
				aa.StorageWrites[key][uint16(k)] = testrand.Hash()
			}
		}

		// Add some storage reads (3-8 per account)
		numStorageReads := 3 + (i % 6)
		for j := 0; j < numStorageReads; j++ {
			aa.StorageReads[testrand.Hash()] = struct{}{}
		}

		// Add some balance changes (2-5 per account)
		numBalanceChanges := 2 + (i % 4)
		for j := 0; j < numBalanceChanges; j++ {
			aa.BalanceChanges[uint16(j)] = uint256.NewInt(binary.BigEndian.Uint64(testrand.Bytes(8)))
		}

		// Add some nonce changes (1-4 per account)
		numNonceChanges := 1 + (i % 4)
		for j := 0; j < numNonceChanges; j++ {
			aa.NonceChanges[uint16(j)] = binary.BigEndian.Uint64(testrand.Bytes(8))
		}

		// Add code change for every 10th account
		if i%10 == 0 {
			aa.CodeChange = &CodeChange{
				TxIndex: uint16(i % 100),
				Code:    bytes.Clone(testrand.Bytes(256)),
			}
		}

		bal.Accounts[addr] = aa
	}

	return &bal
}

func BenchmarkCopy_800Accounts(b *testing.B) {
	bal := makeBenchmarkBAL(800)

	b.ReportAllocs()
	b.ResetTimer()

	for i := 0; i < b.N; i++ {
		_ = bal.Copy()
	}
}

func BenchmarkCopy_1500Accounts(b *testing.B) {
	bal := makeBenchmarkBAL(1500)

	b.ReportAllocs()
	b.ResetTimer()

	for i := 0; i < b.N; i++ {
		_ = bal.Copy()
	}
}
```
benchmark result:  
```
goos: darwin
goarch: arm64
pkg: github.com/ethereum/go-ethereum/core/types/bal
cpu: Apple M4
                     │   old.txt    │              new.txt               │
                     │    sec/op    │   sec/op     vs base               │
Copy_800Accounts-10    1.411m ± 11%   1.381m ± 6%  -2.13% (p=0.029 n=10)
Copy_1500Accounts-10   2.679m ±  1%   2.588m ± 1%  -3.38% (p=0.000 n=10)
geomean                1.944m         1.891m       -2.76%

                     │   old.txt    │               new.txt               │
                     │     B/op     │     B/op      vs base               │
Copy_800Accounts-10    3.094Mi ± 0%   3.058Mi ± 0%  -1.15% (p=0.000 n=10)
Copy_1500Accounts-10   5.817Mi ± 0%   5.742Mi ± 0%  -1.28% (p=0.000 n=10)
geomean                4.242Mi        4.191Mi       -1.22%

                     │   old.txt   │              new.txt               │
                     │  allocs/op  │  allocs/op   vs base               │
Copy_800Accounts-10    22.70k ± 0%   22.69k ± 0%  -0.06% (p=0.000 n=10)
Copy_1500Accounts-10   42.57k ± 0%   42.56k ± 0%  -0.04% (p=0.000 n=10)
geomean                31.09k        31.07k       -0.05%
```