### PR TITLE
node: Disable discv4 by default on main

### DIFF
--- a/common/bitutil/bitutil.go
+++ b/common/bitutil/bitutil.go
@@ -8,6 +8,7 @@
 package bitutil
 
 import (
+	"crypto/subtle"
 	"runtime"
 	"unsafe"
 )
@@ -15,6 +16,19 @@ import (
 const wordSize = int(unsafe.Sizeof(uintptr(0)))
 const supportsUnaligned = runtime.GOARCH == "386" || runtime.GOARCH == "amd64" || runtime.GOARCH == "ppc64" || runtime.GOARCH == "ppc64le" || runtime.GOARCH == "s390x"
 
+// XORBytes xors the bytes in a and b. The destination is assumed to have enough
+// space. Returns the number of bytes xor'd.
+//
+// If dst does not have length at least n,
+// XORBytes panics without writing anything to dst.
+//
+// dst and x or y may overlap exactly or not at all,
+// otherwise XORBytes may panic.
+//
+// Deprecated: use crypto/subtle.XORBytes
+func XORBytes(dst, a, b []byte) int {
+	return subtle.XORBytes(dst, a, b)
+}
 
 // ANDBytes ands the bytes in a and b. The destination is assumed to have enough
 // space. Returns the number of bytes and'd.


### PR DESCRIPTION
Per https://notes.ethereum.org/@cskiraly/el-discovery-v5-tracker discv4 might by sunsetted by Glamsterdam. In preparation for this, this change disables discv4 by default on main to determine readiness for this requirement. discv5 is enabled and should do the work.

In the event of issues, it should be possible to pass `--discovery.v4=true`, or rollback until further changes are made to improve support