### PR TITLE
refactor(common): replace manual slice copy with bytes.Clone

### DIFF
--- a/common/bytes.go
+++ b/common/bytes.go
@@ -38,13 +38,7 @@ func FromHex(s string) []byte {
 
 // CopyBytes returns an exact copy of the provided bytes.
 func CopyBytes(b []byte) (copiedBytes []byte) {
-	if b == nil {
-		return nil
-	}
-	copiedBytes = make([]byte, len(b))
-	copy(copiedBytes, b)
-
-	return
+	return bytes.Clone(b)
 }
 
 // has0xPrefix validates str begins with '0x' or '0X'.


### PR DESCRIPTION
Simplified CopyBytes function by replacing manual memory allocation and copy operations with the standard library bytes.Clone function.