### PR TITLE
crypto,core/state: lru cache address to hash

### DIFF
--- a/core/state/database.go
+++ b/core/state/database.go
@@ -261,7 +261,7 @@ func (db *CachingDB) OpenStorageTrie(stateRoot common.Hash, address common.Addre
 	if db.triedb.IsVerkle() {
 		return self, nil
 	}
-	tr, err := trie.NewStateTrie(trie.StorageTrieID(stateRoot, crypto.Keccak256Hash(address.Bytes()), root), db.triedb)
+	tr, err := trie.NewStateTrie(trie.StorageTrieID(stateRoot, crypto.Keccak256AddressHash(address), root), db.triedb)
 	if err != nil {
 		return nil, err
 	}

--- a/core/state/reader.go
+++ b/core/state/reader.go
@@ -254,7 +254,7 @@ func (r *flatReader) Account(addr common.Address) (*types.StateAccount, error) {
 //
 // The returned storage slot might be empty if it's not existent.
 func (r *flatReader) Storage(addr common.Address, key common.Hash) (common.Hash, error) {
-	addrHash := crypto.Keccak256Hash(addr.Bytes())
+	addrHash := crypto.Keccak256AddressHash(addr)
 	slotHash := crypto.Keccak256Hash(key.Bytes())
 	ret, err := r.reader.Storage(addrHash, slotHash)
 	if err != nil {
@@ -402,7 +402,7 @@ func (r *trieReader) Storage(addr common.Address, key common.Hash) (common.Hash,
 				root = r.subRoots[addr]
 			}
 			var err error
-			tr, err = trie.NewStateTrie(trie.StorageTrieID(r.root, crypto.Keccak256Hash(addr.Bytes()), root), r.db)
+			tr, err = trie.NewStateTrie(trie.StorageTrieID(r.root, crypto.Keccak256AddressHash(addr), root), r.db)
 			if err != nil {
 				return common.Hash{}, err
 			}

--- a/core/state/state_object.go
+++ b/core/state/state_object.go
@@ -99,10 +99,11 @@ func newObject(db *StateDB, address common.Address, acct *types.StateAccount) *s
 	if acct == nil {
 		acct = types.NewEmptyStateAccount()
 	}
+
 	return &stateObject{
 		db:                 db,
 		address:            address,
-		addrHash:           crypto.Keccak256Hash(address[:]),
+		addrHash:           crypto.Keccak256AddressHash(address),
 		origin:             origin,
 		data:               *acct,
 		originStorage:      make(Storage),

--- a/core/state/statedb.go
+++ b/core/state/statedb.go
@@ -28,7 +28,6 @@ import (
 	"time"
 
 	"github.com/ethereum/go-ethereum/common"
-	"github.com/ethereum/go-ethereum/common/lru"
 	"github.com/ethereum/go-ethereum/core/rawdb"
 	"github.com/ethereum/go-ethereum/core/state/snapshot"
 	"github.com/ethereum/go-ethereum/core/stateless"
@@ -52,17 +51,6 @@ const (
 	update mutationType = iota
 	deletion
 )
-
-var addressHashCache = lru.NewCache[common.Address, common.Hash](10240)
-
-func getAddressHash(addr common.Address) common.Hash {
-	if hash, ok := addressHashCache.Get(addr); ok {
-		return hash
-	}
-	hash := crypto.Keccak256Hash(addr.Bytes())
-	addressHashCache.Add(addr, hash)
-	return hash
-}
 
 type mutation struct {
 	typ     mutationType

--- a/core/state/stateupdate.go
+++ b/core/state/stateupdate.go
@@ -241,7 +241,7 @@ func (sc *stateUpdate) ToTracingUpdate() (*tracing.StateUpdate, error) {
 	}
 	// Gather all account changes
 	for addr, oldData := range sc.accountsOrigin {
-		addrHash := crypto.Keccak256Hash(addr.Bytes())
+		addrHash := crypto.Keccak256AddressHash(addr)
 		newData, exists := sc.accounts[addrHash]
 		if !exists {
 			return nil, fmt.Errorf("account %x not found", addr)
@@ -277,7 +277,8 @@ func (sc *stateUpdate) ToTracingUpdate() (*tracing.StateUpdate, error) {
 
 	// Gather all storage slot changes
 	for addr, slots := range sc.storagesOrigin {
-		addrHash := crypto.Keccak256Hash(addr.Bytes())
+		addrHash := crypto.Keccak256AddressHash(addr)
+
 		subset, exists := sc.storages[addrHash]
 		if !exists {
 			return nil, fmt.Errorf("storage %x not found", addr)


### PR DESCRIPTION
benchmark command:  
```
go test ./core/vm/runtime  -run '^$' -bench 'BenchmarkCall' -benchmem -cpu=1  -count=20
```
result in: 
```
goos: darwin
goarch: arm64
pkg: github.com/ethereum/go-ethereum/core/vm/runtime
cpu: Apple M4 Pro
     │   old.txt   │              new.txt               │
     │   sec/op    │   sec/op     vs base               │
Call   12.05m ± 6%   11.02m ± 2%  -8.52% (p=0.000 n=20)

     │   old.txt    │               new.txt               │
     │     B/op     │     B/op      vs base               │
Call   13.96Mi ± 0%   13.77Mi ± 0%  -1.38% (p=0.000 n=20)

     │   old.txt   │              new.txt               │
     │  allocs/op  │  allocs/op   vs base               │
Call   191.6k ± 0%   184.4k ± 0%  -3.76% (p=0.000 n=20)
```