### PR TITLE
accounts/scwallet: fix panic in decryptAPDU

### DIFF
--- a/accounts/scwallet/securechannel.go
+++ b/accounts/scwallet/securechannel.go
@@ -300,6 +300,10 @@ func (s *SecureChannelSession) decryptAPDU(data []byte) ([]byte, error) {
 		return nil, err
 	}
 
+	if len(data) == 0 || len(data)%aes.BlockSize != 0 {
+		return nil, fmt.Errorf("invalid ciphertext length: %d", len(data))
+	}
+
 	ret := make([]byte, len(data))
 
 	crypter := cipher.NewCBCDecrypter(a, s.iv)


### PR DESCRIPTION
Validate ciphertext length in decryptAPDU, preventing runtime panics on invalid input.