### PR TITLE
rpc: close ws handshake response body on error

### DIFF
--- a/rpc/websocket.go
+++ b/rpc/websocket.go
@@ -249,6 +249,9 @@ func newClientTransportWS(endpoint string, cfg *clientConfig) (reconnectFunc, er
 		}
 		conn, resp, err := dialer.DialContext(ctx, dialURL, header)
 		if err != nil {
+			if resp != nil {
+				resp.Body.Close()
+			}
 			hErr := wsHandshakeError{err: err}
 			if resp != nil {
 				hErr.status = resp.Status


### PR DESCRIPTION
When the WebSocket dialer fails during the handshake and still provides an HTTP response, make sure the response body is closed. This helps prevent unused HTTP responses from staying open and wasting resources. It also makes the WebSocket client follow the same cleanup logic already used in the diagnostics code.

This change applies only to the failure case in `DialWebsocketWithDialer`. It does not affect successful WebSocket connections, which continue to work as before through `NewWebsocketCodec`.