### PR TITLE
accounts/abi/bind/v2: replace rng in test

### DIFF
--- a/accounts/abi/bind/v2/dep_tree_test.go
+++ b/accounts/abi/bind/v2/dep_tree_test.go
@@ -158,10 +158,10 @@ func testLinkCase(tcInput linkTestCaseInput) error {
 		overrideAddrs  = make(map[rune]common.Address)
 	)
 	// generate deterministic addresses for the override set.
-	rand.Seed(42)
+	rng := rand.New(rand.NewSource(42))
 	for contract := range tcInput.overrides {
 		var addr common.Address
-		rand.Read(addr[:])
+		rng.Read(addr[:])
 		overrideAddrs[contract] = addr
 		overridesAddrs[addr] = struct{}{}
 	}


### PR DESCRIPTION
Replace deprecated rand.Seed() with rand.New(rand.NewSource()) in dep_tree_test.go.