### PR TITLE
rpc: use strings.Cut instead of strings.Split

### DIFF
--- a/build/ci.go
+++ b/build/ci.go
@@ -775,10 +775,11 @@ func archiveUpload(archive string, blobstore string, signer string, signifyVar s
 	}
 	// If uploading to Azure was requested, push the archive possibly with its signature
 	if blobstore != "" {
+		account, container, _ := strings.Cut(blobstore, "/")
 		auth := build.AzureBlobstoreConfig{
-			Account:   strings.Split(blobstore, "/")[0],
+			Account:   account,
 			Token:     os.Getenv("AZURE_BLOBSTORE_TOKEN"),
-			Container: strings.SplitN(blobstore, "/", 2)[1],
+			Container: container,
 		}
 		if err := build.AzureBlobstoreUpload(archive, filepath.Base(archive), auth); err != nil {
 			return err
@@ -1282,10 +1283,11 @@ func doPurge(cmdline []string) {
 		os.Exit(0)
 	}
 	// Create the azure authentication and list the current archives
+	account, container, _ := strings.Cut(*store, "/")
 	auth := build.AzureBlobstoreConfig{
-		Account:   strings.Split(*store, "/")[0],
+		Account:   account,
 		Token:     os.Getenv("AZURE_BLOBSTORE_TOKEN"),
-		Container: strings.SplitN(*store, "/", 2)[1],
+		Container: container,
 	}
 	blobs, err := build.AzureBlobstoreList(auth)
 	if err != nil {

--- a/internal/build/env.go
+++ b/internal/build/env.go
@@ -158,7 +158,8 @@ func LocalEnv() Environment {
 }
 
 func firstLine(s string) string {
-	return strings.Split(s, "\n")[0]
+	line, _, _ := strings.Cut(s, "\n")
+	return line
 }
 
 func getDate(commit string) string {

--- a/internal/flags/helpers.go
+++ b/internal/flags/helpers.go
@@ -280,7 +280,7 @@ func CheckEnvVars(ctx *cli.Context, flags []cli.Flag, prefix string) {
 	sort.Strings(keyvals)
 
 	for _, keyval := range keyvals {
-		key := strings.Split(keyval, "=")[0]
+		key, _, _ := strings.Cut(keyval, "=")
 		if !strings.HasPrefix(key, prefix) {
 			continue
 		}

--- a/signer/core/apitypes/types.go
+++ b/signer/core/apitypes/types.go
@@ -338,7 +338,8 @@ func (t *Type) isArray() bool {
 // typeName returns the canonical name of the type. If the type is 'Person[]' or 'Person[2]', then
 // this method returns 'Person'
 func (t *Type) typeName() string {
-	return strings.Split(t.Type, "[")[0]
+	name, _, _ := strings.Cut(t.Type, "[")
+	return name
 }
 
 type Types map[string][]Type
@@ -389,7 +390,7 @@ func (typedData *TypedData) HashStruct(primaryType string, data TypedDataMessage
 
 // Dependencies returns an array of custom types ordered by their hierarchical reference tree
 func (typedData *TypedData) Dependencies(primaryType string, found []string) []string {
-	primaryType = strings.Split(primaryType, "[")[0]
+	primaryType, _, _ = strings.Cut(primaryType, "[")
 
 	if slices.Contains(found, primaryType) {
 		return found
@@ -500,7 +501,7 @@ func (typedData *TypedData) encodeArrayValue(encValue interface{}, encType strin
 	}
 
 	arrayBuffer := new(bytes.Buffer)
-	parsedType := strings.Split(encType, "[")[0]
+	parsedType, _, _ := strings.Cut(encType, "[")
 	for _, item := range arrayValue {
 		if reflect.TypeOf(item).Kind() == reflect.Slice ||
 			reflect.TypeOf(item).Kind() == reflect.Array {
@@ -899,7 +900,7 @@ func init() {
 
 // Checks if the primitive value is valid
 func isPrimitiveTypeValid(primitiveType string) bool {
-	input := strings.Split(primitiveType, "[")[0]
+	input, _, _ := strings.Cut(primitiveType, "[")
 	_, ok := validPrimitiveTypes[input]
 	return ok
 }


### PR DESCRIPTION
Replace strings.Split(s, sep)[0] with strings.Cut for cleaner code.