### PR TITLE
core,core/vm: remove BlobFeeCap field in TxContext  that do not need anymore

### DIFF
--- a/core/evm.go
+++ b/core/evm.go
@@ -83,9 +83,7 @@ func NewEVMTxContext(msg *Message) vm.TxContext {
 		GasPrice:   new(big.Int).Set(msg.GasPrice),
 		BlobHashes: msg.BlobHashes,
 	}
-	if msg.BlobGasFeeCap != nil {
-		ctx.BlobFeeCap = new(big.Int).Set(msg.BlobGasFeeCap)
-	}
+
 	return ctx
 }
 

--- a/core/vm/evm.go
+++ b/core/vm/evm.go
@@ -75,7 +75,6 @@ type TxContext struct {
 	Origin       common.Address      // Provides information for ORIGIN
 	GasPrice     *big.Int            // Provides information for GASPRICE (and is used to zero the basefee if NoBaseFee is set)
 	BlobHashes   []common.Hash       // Provides information for BLOBHASH
-	BlobFeeCap   *big.Int            // Is used to zero the blobbasefee if NoBaseFee is set
 	AccessEvents *state.AccessEvents // Capture all state accesses for this tx
 }
 

--- a/core/vm/runtime/env.go
+++ b/core/vm/runtime/env.go
@@ -26,7 +26,6 @@ func NewEnv(cfg *Config) *vm.EVM {
 		Origin:     cfg.Origin,
 		GasPrice:   cfg.GasPrice,
 		BlobHashes: cfg.BlobHashes,
-		BlobFeeCap: cfg.BlobFeeCap,
 	}
 	blockContext := vm.BlockContext{
 		CanTransfer: core.CanTransfer,


### PR DESCRIPTION
[reference has been removed here](https://github.com/ethereum/go-ethereum/commit/8f4fac7b86227e3ceca095e60d58f126d692f379#diff-64508d317d86e7a4a5294d76455a5e74148e26883da9e8b4ffc9bbfa3cc8550eL137-L147)
