### PR TITLE
rpc: use range over int in tests

### DIFF
--- a/rpc/client_test.go
+++ b/rpc/client_test.go
@@ -529,7 +529,7 @@ func TestClientCloseUnsubscribeRace(t *testing.T) {
 	server := newTestServer()
 	defer server.Stop()
 
-	for i := 0; i < 20; i++ {
+	for range 20 {
 		client := DialInProc(server)
 		nc := make(chan int)
 		sub, err := client.Subscribe(context.Background(), "nftest", nc, "someSubscription", 3, 1)
@@ -690,7 +690,7 @@ func TestClientSubscriptionChannelClose(t *testing.T) {
 	client, _ := Dial(wsURL)
 	defer client.Close()
 
-	for i := 0; i < 100; i++ {
+	for range 100 {
 		ch := make(chan int, 100)
 		sub, err := client.Subscribe(context.Background(), "nftest", ch, "someSubscription", 100, 1)
 		if err != nil {

--- a/rpc/server_test.go
+++ b/rpc/server_test.go
@@ -144,7 +144,7 @@ func TestServerShortLivedConn(t *testing.T) {
 		wantResp = `{"jsonrpc":"2.0","id":1,"result":{"nftest":"1.0","rpc":"1.0","test":"1.0"}}` + "\n"
 		deadline = time.Now().Add(10 * time.Second)
 	)
-	for i := 0; i < 20; i++ {
+	for range 20 {
 		conn, err := net.Dial("tcp", listener.Addr().String())
 		if err != nil {
 			t.Fatal("can't dial:", err)
@@ -178,7 +178,7 @@ func TestServerBatchResponseSizeLimit(t *testing.T) {
 		batch  []BatchElem
 		client = DialInProc(server)
 	)
-	for i := 0; i < 5; i++ {
+	for range 5 {
 		batch = append(batch, BatchElem{
 			Method: "test_echo",
 			Args:   []any{"x", 1},


### PR DESCRIPTION
Use range over integer syntax where loop variable is unused.