### PR TITLE
fix: swap got/expected order in TestEncryption error message

### DIFF
--- a/signer/storage/aes_gcm_storage_test.go
+++ b/signer/storage/aes_gcm_storage_test.go
@@ -48,7 +48,7 @@ func TestEncryption(t *testing.T) {
 	}
 	t.Logf("Plaintext %v\n", string(p))
 	if !bytes.Equal(plaintext, p) {
-		t.Errorf("Failed: expected plaintext recovery, got %v expected %v", string(plaintext), string(p))
+		t.Errorf("Failed: expected plaintext recovery, got %v expected %v", string(p), string(plaintext))
 	}
 }
 


### PR DESCRIPTION
In TestEncryption, the error message displayed got and expected values in reversed order, which could mislead developers debugging test failures.