### PR TITLE
core/vm: add amsterdam instruction set etc.

### DIFF
--- a/core/gen_genesis.go
+++ b/core/gen_genesis.go
@@ -35,7 +35,7 @@ func (g Genesis) MarshalJSON() ([]byte, error) {
 		ExcessBlobGas       *math.HexOrDecimal64                       `json:"excessBlobGas"`
 		BlobGasUsed         *math.HexOrDecimal64                       `json:"blobGasUsed"`
 		BlockAccessListHash *common.Hash                               `json:"blockAccessListHash,omitempty"`
-		SlotNumber          *math.HexOrDecimal64                       `json:"slotNumber"`
+		SlotNumber          *uint64                                    `json:"slotNumber"`
 	}
 	var enc Genesis
 	enc.Config = g.Config
@@ -59,7 +59,7 @@ func (g Genesis) MarshalJSON() ([]byte, error) {
 	enc.ExcessBlobGas = (*math.HexOrDecimal64)(g.ExcessBlobGas)
 	enc.BlobGasUsed = (*math.HexOrDecimal64)(g.BlobGasUsed)
 	enc.BlockAccessListHash = g.BlockAccessListHash
-	enc.SlotNumber = (*math.HexOrDecimal64)(g.SlotNumber)
+	enc.SlotNumber = g.SlotNumber
 	return json.Marshal(&enc)
 }
 
@@ -82,7 +82,7 @@ func (g *Genesis) UnmarshalJSON(input []byte) error {
 		ExcessBlobGas       *math.HexOrDecimal64                       `json:"excessBlobGas"`
 		BlobGasUsed         *math.HexOrDecimal64                       `json:"blobGasUsed"`
 		BlockAccessListHash *common.Hash                               `json:"blockAccessListHash,omitempty"`
-		SlotNumber          *math.HexOrDecimal64                       `json:"slotNumber"`
+		SlotNumber          *uint64                                    `json:"slotNumber"`
 	}
 	var dec Genesis
 	if err := json.Unmarshal(input, &dec); err != nil {
@@ -143,7 +143,7 @@ func (g *Genesis) UnmarshalJSON(input []byte) error {
 		g.BlockAccessListHash = dec.BlockAccessListHash
 	}
 	if dec.SlotNumber != nil {
-		g.SlotNumber = (*uint64)(dec.SlotNumber)
+		g.SlotNumber = dec.SlotNumber
 	}
 	return nil
 }

--- a/core/genesis.go
+++ b/core/genesis.go
@@ -264,7 +264,6 @@ type genesisSpecMarshaling struct {
 	BaseFee       *math.HexOrDecimal256
 	ExcessBlobGas *math.HexOrDecimal64
 	BlobGasUsed   *math.HexOrDecimal64
-	SlotNumber    *math.HexOrDecimal64
 }
 
 // GenesisMismatchError is raised when trying to overwrite an existing


### PR DESCRIPTION
had to make these changes to successfully test eip-7843 via `consume engine`. could be useful to u.
edit: maybe the type change from `uint64` can be removed, i can fix that on our end