### PR TITLE
Remove unused StdIOTransport from Clef python signer sample

### DIFF
--- a/cmd/clef/pythonsigner.py
+++ b/cmd/clef/pythonsigner.py
@@ -27,16 +27,6 @@ except ImportError:
     import urllib as urlparse
 
 
-class StdIOTransport(ServerTransport):
-    """Uses std input/output for RPC"""
-
-    def receive_message(self):
-        return None, urlparse.unquote(sys.stdin.readline())
-
-    def send_reply(self, context, reply):
-        print(reply)
-
-
 class PipeTransport(ServerTransport):
     """Uses std a pipe for RPC"""
 


### PR DESCRIPTION
delete the dead StdIOTransport class from cmd/clef/pythonsigner.py
keep only the pipe-based transport that is actually used, reducing unused code paths