### PR TITLE
p2p/discover: fix a deadlock

### DIFF
--- a/p2p/discover/table.go
+++ b/p2p/discover/table.go
@@ -462,7 +462,6 @@ func (tab *Table) loadSeedNodes() {
 		tab.mutex.Unlock()
 
 		// Send notification outside of mutex to avoid deadlock.
-		// See: goroutine_deadlock_analysis_97c19bb9.plan.md
 		if addedNode != nil {
 			tab.nodeFeed.Send(addedNode)
 		}
@@ -590,7 +589,6 @@ func (tab *Table) nodeAdded(b *bucket, n *tableNode) *enode.Node {
 
 	// NOTE: nodeFeed.Send() is NOT called here to avoid deadlock.
 	// The caller must send the notification after releasing the mutex.
-	// See: goroutine_deadlock_analysis_97c19bb9.plan.md
 
 	if tab.nodeAddedHook != nil {
 		tab.nodeAddedHook(b, n)


### PR DESCRIPTION
# Root Cause of the Deadlock

nodeFeed.Send() is called while holding the Table.mutex lock, and FeedOf.Send() blocks synchronously until all subscribers have consumed the event.

The problem unfolds as follows:

1. loadSeedNodes() acquires the Table.mutex lock

2. It calls handleAddNode() → nodeAdded() → nodeFeed.Send()

3. nodeFeed.Send() waits for subscribers to consume the event (including the channel used in waitForNodes)

4. However, waitForNodes needs to acquire Table.mutex to proceed to the next iteration and process the event

5. A deadlock is formed

# how to fix
## Changes to :
nodeAdded(): Changed to return *enode.Node instead of calling nodeFeed.Send() directly
handleAddNode(): Changed to return (bool, *enode.Node) to pass the added node to callers
loadSeedNodes(): Now sends notifications after releasing mutex
loop() addNodeCh case: Now sends notification after releasing mutex
handleTrackRequest(): Collects nodes and sends notifications after releasing mutex
deleteInBucket(): Changed to return (*tableNode, *enode.Node) to pass replacement node for notification
deleteNode(): Now sends notification after releasing mutex
## Changes to :
handleResponse(): Now sends notification after releasing mutex when a replacement node is added
## Changes to :
Updated to handle the new deleteInBucket return type

unittest to reproduce:
```
// Copyright 2024 The go-ethereum Authors
// This file is part of the go-ethereum library.
//
// The go-ethereum library is free software: you can redistribute it and/or modify
// it under the terms of the GNU Lesser General Public License as published by
// the Free Software Foundation, either version 3 of the License, or
// (at your option) any later version.
//
// The go-ethereum library is distributed in the hope that it will be useful,
// but WITHOUT ANY WARRANTY; without even the implied warranty of
// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
// GNU Lesser General Public License for more details.
//
// You should have received a copy of the GNU Lesser General Public License
// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.

package discover

import (
	"net"
	"testing"
	"time"

	"github.com/ethereum/go-ethereum/p2p/enode"
)

// TestTableNodeFeedDeadlock tests for a deadlock that can occur when nodeFeed.Send()
// is called while holding Table.mutex.
//
// The deadlock scenario (from goroutine_deadlock_analysis_97c19bb9.plan.md):
// 1. Sender holds mutex, calls nodeFeed.Send() with unbuffered channel subscriber
// 2. nodeFeed.Send() blocks waiting for subscriber to receive (channel is full/unbuffered)
// 3. Subscriber is blocked waiting for mutex (it needs mutex before it can receive again)
// 4. DEADLOCK
//
// This test deterministically creates this scenario by:
// 1. Sender acquires mutex FIRST
// 2. Subscriber tries to acquire mutex (blocked)
// 3. Sender calls nodeFeed.Send() while holding mutex
// 4. nodeFeed.Send() blocks because subscriber can't receive (blocked on mutex)
func TestTableNodeFeedDeadlock(t *testing.T) {
	transport := newPingRecorder()
	tab, db := newInactiveTestTable(transport, Config{})
	defer db.Close()

	// Subscribe to nodeFeed with an unbuffered channel
	ch := make(chan *enode.Node) // unbuffered - this is key to the deadlock
	sub := tab.nodeFeed.Subscribe(ch)
	defer sub.Unsubscribe()

	node := nodeAtDistance(tab.self().ID(), 256, net.IP{88, 77, 66, 1})

	// Synchronization to force exact ordering
	senderHasMutex := make(chan struct{})
	subscriberWaiting := make(chan struct{})

	testComplete := make(chan struct{})

	// Step 1: Sender acquires mutex first and signals
	go func() {
		tab.mutex.Lock()
		close(senderHasMutex) // Signal that sender has mutex

		// Wait for subscriber to start waiting for mutex
		<-subscriberWaiting

		// Step 3: Now call handleAddNode which does nodeFeed.Send while holding mutex
		// If there's a deadlock bug, this will block forever because:
		// - nodeFeed.Send tries to send to unbuffered channel
		// - Subscriber can't receive because it's blocked on mutex
		tab.handleAddNode(addNodeOp{node: node, isInbound: false, forceSetLive: true})

		tab.mutex.Unlock()
	}()

	// Wait for sender to acquire mutex
	<-senderHasMutex

	// Step 2: Subscriber tries to acquire mutex (will block), then receive
	go func() {
		// Signal that we're about to wait for mutex
		close(subscriberWaiting)

		// This blocks because sender holds the mutex
		tab.mutex.Lock()
		tab.mutex.Unlock()

		// After getting mutex, try to receive
		// With the fix, this should work because Send happens outside lock
		select {
		case <-ch:
			// Success - received the event
		case <-time.After(100 * time.Millisecond):
			// Fine - send might have completed before we got here
		}
		close(testComplete)
	}()

	// Wait with timeout - if deadlock occurs, this times out
	select {
	case <-testComplete:
		// Test passed
	case <-time.After(3 * time.Second):
		t.Fatal("DEADLOCK: nodeFeed.Send() blocked while holding mutex, subscriber waiting for mutex")
	}
}

// Subscription interface for testing
type Subscription interface {
	Unsubscribe()
}

```