### PR TITLE
internal/debug: fix some minor issues in pyroscope.go

### DIFF
--- a/internal/debug/pyroscope.go
+++ b/internal/debug/pyroscope.go
@@ -47,8 +47,9 @@ var (
 	}
 	pyroscopeAuthPasswordFlag = &cli.StringFlag{
 		Name:     "pyroscope.password",
-		Usage:    "Pyroscope basic authentication password",
+		Usage:    "Pyroscope basic authentication password (prefer setting PYROSCOPE_PASSWORD env var instead of CLI flag)",
 		Value:    "",
+		EnvVars:  []string{"PYROSCOPE_PASSWORD"},
 		Category: flags.LoggingCategory,
 	}
 	pyroscopeTagsFlag = &cli.StringFlag{
@@ -74,7 +75,11 @@ func startPyroscope(ctx *cli.Context) error {
 		if tag == "" {
 			continue
 		}
-		k, v, _ := strings.Cut(tag, "=")
+		k, v, ok := strings.Cut(tag, "=")
+		if !ok || k == "" {
+			// Skip tags that do not conform to the expected key=value format
+			continue
+		}
 		tags[k] = v
 	}
 
@@ -105,7 +110,7 @@ func startPyroscope(ctx *cli.Context) error {
 		return err
 	}
 	pyroscopeProfiler = profiler
-	log.Info("Enabled Pyroscope")
+	log.Info("Enabled Pyroscope", "server", server)
 	return nil
 }
 


### PR DESCRIPTION
fix some minor issues in the file `internal/debug/pyroscope.go`:

- Passing passwords via command-line flags exposes them in process listings and shell history
- The tags parsing logic discards the third return value from strings.Cut which indicates whether a separator was found.
- The log message "Enabled Pyroscope" doesn't include any configuration details such as the server address