### PR TITLE
core/types: improve effectiveGasPrice

### DIFF
--- a/core/types/tx_blob.go
+++ b/core/types/tx_blob.go
@@ -295,11 +295,12 @@ func (tx *BlobTx) effectiveGasPrice(dst *big.Int, baseFee *big.Int) *big.Int {
 	if baseFee == nil {
 		return dst.Set(tx.GasFeeCap.ToBig())
 	}
-	tip := dst.Sub(tx.GasFeeCap.ToBig(), baseFee)
-	if tip.Cmp(tx.GasTipCap.ToBig()) > 0 {
-		tip.Set(tx.GasTipCap.ToBig())
+	effectiveGasPrice := dst.Add(tx.GasTipCap.ToBig(), baseFee)
+	gasFeeCap := tx.GasFeeCap.ToBig()
+	if effectiveGasPrice.Cmp(gasFeeCap) > 0 {
+		effectiveGasPrice.Set(gasFeeCap)
 	}
-	return tip.Add(tip, baseFee)
+	return effectiveGasPrice
 }
 
 func (tx *BlobTx) rawSignatureValues() (v, r, s *big.Int) {

--- a/core/types/tx_dynamic_fee.go
+++ b/core/types/tx_dynamic_fee.go
@@ -101,11 +101,11 @@ func (tx *DynamicFeeTx) effectiveGasPrice(dst *big.Int, baseFee *big.Int) *big.I
 	if baseFee == nil {
 		return dst.Set(tx.GasFeeCap)
 	}
-	tip := dst.Sub(tx.GasFeeCap, baseFee)
-	if tip.Cmp(tx.GasTipCap) > 0 {
-		tip.Set(tx.GasTipCap)
+	effectiveGasPrice := dst.Add(tx.GasTipCap, baseFee)
+	if effectiveGasPrice.Cmp(tx.GasFeeCap) > 0 {
+		effectiveGasPrice.Set(tx.GasFeeCap)
 	}
-	return tip.Add(tip, baseFee)
+	return effectiveGasPrice
 }
 
 func (tx *DynamicFeeTx) rawSignatureValues() (v, r, s *big.Int) {

--- a/core/types/tx_setcode.go
+++ b/core/types/tx_setcode.go
@@ -202,11 +202,12 @@ func (tx *SetCodeTx) effectiveGasPrice(dst *big.Int, baseFee *big.Int) *big.Int 
 	if baseFee == nil {
 		return dst.Set(tx.GasFeeCap.ToBig())
 	}
-	tip := dst.Sub(tx.GasFeeCap.ToBig(), baseFee)
-	if tip.Cmp(tx.GasTipCap.ToBig()) > 0 {
-		tip.Set(tx.GasTipCap.ToBig())
+	effectiveGasPrice := dst.Add(tx.GasTipCap.ToBig(), baseFee)
+	gasTipCap := tx.GasFeeCap.ToBig()
+	if effectiveGasPrice.Cmp(gasTipCap) > 0 {
+		effectiveGasPrice.Set(gasTipCap)
 	}
-	return tip.Add(tip, baseFee)
+	return effectiveGasPrice
 }
 
 func (tx *SetCodeTx) rawSignatureValues() (v, r, s *big.Int) {


### PR DESCRIPTION
benchmark result:
```
goos: darwin
goarch: arm64
pkg: github.com/ethereum/go-ethereum/core/types
cpu: Apple M4
                                             │   old.txt    │               new.txt               │
                                             │    sec/op    │   sec/op     vs base                │
BlobTxEffectiveGasPrice/WithBaseFee-10          62.75n ± 3%   56.84n ± 7%   -9.43% (p=0.002 n=10)
DynamicFeeTxEffectiveGasPrice/WithBaseFee-10   14.565n ± 1%   7.614n ± 1%  -47.72% (p=0.000 n=10)
SetCodeTxEffectiveGasPrice/WithBaseFee-10       61.95n ± 3%   57.08n ± 6%   -7.86% (p=0.002 n=10)
geomean                                         38.40n        29.12n       -24.16%

                                             │   old.txt    │               new.txt               │
                                             │     B/op     │    B/op     vs base                 │
BlobTxEffectiveGasPrice/WithBaseFee-10         128.0 ± 0%     128.0 ± 0%       ~ (p=1.000 n=10) ¹
DynamicFeeTxEffectiveGasPrice/WithBaseFee-10   0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
SetCodeTxEffectiveGasPrice/WithBaseFee-10      128.0 ± 0%     128.0 ± 0%       ~ (p=1.000 n=10) ¹
geomean                                                   ²               +0.00%                ²
¹ all samples are equal
² summaries must be >0 to compute geomean

                                             │   old.txt    │               new.txt               │
                                             │  allocs/op   │ allocs/op   vs base                 │
BlobTxEffectiveGasPrice/WithBaseFee-10         4.000 ± 0%     4.000 ± 0%       ~ (p=1.000 n=10) ¹
DynamicFeeTxEffectiveGasPrice/WithBaseFee-10   0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
SetCodeTxEffectiveGasPrice/WithBaseFee-10      4.000 ± 0%     4.000 ± 0%       ~ (p=1.000 n=10) ¹
geomean                                                   ²               +0.00%                ²
¹ all samples are equal
² summaries must be >0 to compute geomean
```
benchmark code: 
```
// Copyright 2024 The go-ethereum Authors
// This file is part of the go-ethereum library.
//
// The go-ethereum library is free software: you can redistribute it and/or modify
// it under the terms of the GNU Lesser General Public License as published by
// the Free Software Foundation, either version 3 of the License, or
// (at your option) any later version.
//
// The go-ethereum library is distributed in the hope that it will be useful,
// but WITHOUT ANY WARRANTY; without even the implied warranty of
// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
// GNU Lesser General Public License for more details.
//
// You should have received a copy of the GNU Lesser General Public License
// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.

package types

import (
	"math/big"
	"testing"

	"github.com/ethereum/go-ethereum/common"
	"github.com/holiman/uint256"
)

func BenchmarkBlobTxEffectiveGasPrice(b *testing.B) {
	gasTipCap := uint256.NewInt(2000000000)  // 2 gwei
	gasFeeCap := uint256.NewInt(3000000000)  // 3 gwei
	baseFee := big.NewInt(1000000000)        // 1 gwei

	tx := &BlobTx{
		ChainID:   uint256.NewInt(1),
		Nonce:     0,
		GasTipCap: gasTipCap,
		GasFeeCap: gasFeeCap,
		Gas:       21000,
		To:        common.Address{},
		Value:     uint256.NewInt(0),
		Data:      nil,
	}

	b.Run("WithBaseFee", func(b *testing.B) {
		b.ReportAllocs()
		dst := new(big.Int)
		for b.Loop() {
			tx.effectiveGasPrice(dst, baseFee)
		}
	})
}

func BenchmarkDynamicFeeTxEffectiveGasPrice(b *testing.B) {
	gasTipCap := big.NewInt(2000000000)  // 2 gwei
	gasFeeCap := big.NewInt(3000000000)  // 3 gwei
	baseFee := big.NewInt(1000000000)    // 1 gwei

	tx := &DynamicFeeTx{
		ChainID:   big.NewInt(1),
		Nonce:     0,
		GasTipCap: gasTipCap,
		GasFeeCap: gasFeeCap,
		Gas:       21000,
		To:        &common.Address{},
		Value:     big.NewInt(0),
		Data:      nil,
	}

	b.Run("WithBaseFee", func(b *testing.B) {
		b.ReportAllocs()
		dst := new(big.Int)
		for b.Loop() {
			tx.effectiveGasPrice(dst, baseFee)
		}
	})
}

func BenchmarkSetCodeTxEffectiveGasPrice(b *testing.B) {
	gasTipCap := uint256.NewInt(2000000000)  // 2 gwei
	gasFeeCap := uint256.NewInt(3000000000)  // 3 gwei
	baseFee := big.NewInt(1000000000)        // 1 gwei

	tx := &SetCodeTx{
		ChainID:   uint256.NewInt(1),
		Nonce:     0,
		GasTipCap: gasTipCap,
		GasFeeCap: gasFeeCap,
		Gas:       21000,
		To:        common.Address{},
		Value:     uint256.NewInt(0),
		Data:      nil,
	}

	b.Run("WithBaseFee", func(b *testing.B) {
		b.ReportAllocs()
		dst := new(big.Int)
		for b.Loop() {
			tx.effectiveGasPrice(dst, baseFee)
		}
	})
}
```