### PR TITLE
cmd/evm: remove unused VerbosityFlag from t8ntool

### DIFF
--- a/cmd/evm/internal/t8ntool/flags.go
+++ b/cmd/evm/internal/t8ntool/flags.go
@@ -162,9 +162,4 @@ var (
 			strings.Join(vm.ActivateableEips(), ", ")),
 		Value: "GrayGlacier",
 	}
-	VerbosityFlag = &cli.IntFlag{
-		Name:  "verbosity",
-		Usage: "sets the verbosity level",
-		Value: 3,
-	}
 )


### PR DESCRIPTION
VerbosityFlag was declared in cmd/evm/internal/t8ntool/flags.go but never used anywhere in the codebase. The verbosity flag is already provided by debug.Flags in main.go, making this a dead code duplicate.