### PR TITLE
directory, .github: Update outdated GitHub Actions versions

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -12,18 +12,18 @@ jobs:
     name: Lint
     runs-on: [self-hosted-ghr, size-s-x64]
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
       with:
         submodules: false
 
     # Cache build tools to avoid downloading them each time
-    - uses: actions/cache@v4
+    - uses: actions/cache@v5
       with:
         path: build/cache
         key: ${{ runner.os }}-build-tools-cache-${{ hashFiles('build/checksums.txt') }}
 
     - name: Set up Go
-      uses: actions/setup-go@v5
+      uses: actions/setup-go@v6
       with:
         go-version: 1.25
         cache: false
@@ -39,12 +39,12 @@ jobs:
     needs: test
     runs-on: [self-hosted-ghr, size-l-x64]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           submodules: true
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version: '1.25'
           cache: false
@@ -57,12 +57,12 @@ jobs:
     needs: test
     runs-on: [self-hosted-ghr, size-l-x64]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           submodules: false
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version: '1.25'
           cache: false
@@ -85,12 +85,12 @@ jobs:
           - '1.25'
           - '1.24'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           submodules: true
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version: ${{ matrix.go }}
           cache: false

--- a/.github/workflows/validate_pr.yml
+++ b/.github/workflows/validate_pr.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check for Spam PR
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const prTitle = context.payload.pull_request.title;
@@ -48,10 +48,10 @@ jobs:
             console.log('✅ PR passed spam check');
 
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Check PR Title Format
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const fs = require('fs');


### PR DESCRIPTION
This PR updates outdated GitHub Action versions.

- Updated `actions/cache` from `v4` to `v5` in `.github/workflows/go.yml`
- Updated `actions/checkout` from `v4` to `v6` in `.github/workflows/go.yml`
- Updated `actions/setup-go` from `v5` to `v6` in `.github/workflows/go.yml`
- Updated `actions/github-script` from `v7` to `v8` in `.github/workflows/validate_pr.yml`
- Updated `actions/checkout` from `v4` to `v6` in `.github/workflows/validate_pr.yml`
