### PR TITLE
refactor(ethapi): optimize receipt validation and deduplicate blob sidecar conversion

### DIFF
--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -612,15 +612,17 @@ func (api *BlockChainAPI) GetBlockReceipts(ctx context.Context, blockNrOrHash rp
 		}
 	}
 	txs := block.Transactions()
-	if len(txs) != len(receipts) {
-		return nil, fmt.Errorf("receipts length mismatch: %d vs %d", len(txs), len(receipts))
+	txCount := len(txs)
+	receiptCount := len(receipts)
+	if txCount != receiptCount {
+		return nil, fmt.Errorf("receipts length mismatch: %d vs %d", txCount, receiptCount)
 	}
 	// Derive the sender.
 	signer := types.MakeSigner(api.b.ChainConfig(), block.Number(), block.Time())
 
 	result := make([]map[string]interface{}, len(receipts))
 	for i, receipt := range receipts {
-		result[i] = MarshalReceipt(receipt, block.Hash(), block.NumberU64(), signer, txs[i], i)
+		result := make([]map[string]interface{}, receiptCount)
 	}
 	return result, nil
 }
@@ -1636,6 +1638,20 @@ func (api *TransactionAPI) currentBlobSidecarVersion() byte {
 	return types.BlobSidecarVersion0
 }
 
+func (api *TransactionAPI) convertLegacyBlobSidecar(tx *types.Transaction) (*types.Transaction, error) {
+	if sc := tx.BlobTxSidecar(); sc != nil {
+		exp := api.currentBlobSidecarVersion()
+		if sc.Version == types.BlobSidecarVersion0 && exp == types.BlobSidecarVersion1 {
+			if err := sc.ToV1(); err != nil {
+				return nil, fmt.Errorf("blob sidecar conversion failed: %v", err)
+			}
+			tx = tx.WithBlobTxSidecar(sc)
+		}
+	}
+	return tx, nil
+}
+
+
 // SendRawTransaction will add the signed transaction to the transaction pool.
 // The sender is responsible for signing the transaction and using the correct nonce.
 func (api *TransactionAPI) SendRawTransaction(ctx context.Context, input hexutil.Bytes) (common.Hash, error) {
@@ -1646,14 +1662,9 @@ func (api *TransactionAPI) SendRawTransaction(ctx context.Context, input hexutil
 
 	// Convert legacy blob transaction proofs.
 	// TODO: remove in go-ethereum v1.17.x
-	if sc := tx.BlobTxSidecar(); sc != nil {
-		exp := api.currentBlobSidecarVersion()
-		if sc.Version == types.BlobSidecarVersion0 && exp == types.BlobSidecarVersion1 {
-			if err := sc.ToV1(); err != nil {
-				return common.Hash{}, fmt.Errorf("blob sidecar conversion failed: %v", err)
-			}
-			tx = tx.WithBlobTxSidecar(sc)
-		}
+	tx, err := api.convertLegacyBlobSidecar(tx)
+	if err != nil {
+		return common.Hash{}, err
 	}
 
 	return SubmitTransaction(ctx, api.b, tx)
@@ -1669,14 +1680,9 @@ func (api *TransactionAPI) SendRawTransactionSync(ctx context.Context, input hex
 
 	// Convert legacy blob transaction proofs.
 	// TODO: remove in go-ethereum v1.17.x
-	if sc := tx.BlobTxSidecar(); sc != nil {
-		exp := api.currentBlobSidecarVersion()
-		if sc.Version == types.BlobSidecarVersion0 && exp == types.BlobSidecarVersion1 {
-			if err := sc.ToV1(); err != nil {
-				return nil, fmt.Errorf("blob sidecar conversion failed: %v", err)
-			}
-			tx = tx.WithBlobTxSidecar(sc)
-		}
+	tx, err := api.convertLegacyBlobSidecar(tx)
+	if err != nil {
+		return nil, err
 	}
 
 	ch := make(chan core.ChainEvent, 128)


### PR DESCRIPTION
This PR introduces two improvements to the `internal/ethapi` package: optimize receipt validation: Cache slice lengths to avoid redundant `len()` calls, extract duplicate code: Refactor blob sidecar conversion logic into a dedicated method