### PR TITLE
core/rawdb: preallocate slice in iterateTransactions

### DIFF
--- a/core/rawdb/chain_iterator.go
+++ b/core/rawdb/chain_iterator.go
@@ -153,9 +153,9 @@ func iterateTransactions(db ethdb.Database, from uint64, to uint64, reverse bool
 					err:    err,
 				}
 			} else {
-				var hashes []common.Hash
-				for _, tx := range body.Transactions {
-					hashes = append(hashes, tx.Hash())
+				hashes := make([]common.Hash, len(body.Transactions))
+				for i, tx := range body.Transactions {
+					hashes[i] = tx.Hash()
 				}
 				result = &blockTxHashes{
 					hashes: hashes,


### PR DESCRIPTION
Preallocate hashes slice with known length instead of using append in a loop.
This avoids multiple reallocations during transaction indexing.