### PR TITLE
core/state: optimize transient storage

### DIFF
--- a/core/state/statedb_test.go
+++ b/core/state/statedb_test.go
@@ -641,7 +641,7 @@ func (test *snapshotTest) checkEqual(state, checkstate *StateDB) error {
 		{
 			have := state.transientStorage
 			want := checkstate.transientStorage
-			if !maps.EqualFunc(have, want, maps.Equal) {
+			if !maps.Equal(have, want) {
 				return fmt.Errorf("transient storage differs ,have\n%v\nwant\n%v",
 					have.PrettyPrint(),
 					want.PrettyPrint())


### PR DESCRIPTION
benchmark result:  
```
goos: darwin
goarch: arm64
pkg: github.com/ethereum/go-ethereum/core/state
cpu: Apple M4 Pro
                                     │    old.txt    │                new.txt                │
                                     │    sec/op     │    sec/op     vs base                 │
TransientStorageSetEmpty-14            20.545n ±  2%   9.697n ±  3%   -52.80% (p=0.000 n=10)
TransientStorageSetSmall-14             19.48n ±  5%   10.10n ± 20%   -48.14% (p=0.000 n=10)
TransientStorageSetMedium-14            19.48n ±  9%   10.11n ±  1%   -48.11% (p=0.000 n=10)
TransientStorageSetMainnetLike-14       19.39n ± 10%   10.07n ±  1%   -48.03% (p=0.000 n=10)
TransientStorageSetLarge-14            19.685n ±  2%   9.986n ±  2%   -49.27% (p=0.000 n=10)
TransientStorageGetMiss-14              1.306n ±  2%   2.725n ±  2%  +108.65% (p=0.000 n=10)
TransientStorageGetHitEmpty-14         12.725n ±  1%   7.871n ±  2%   -38.15% (p=0.000 n=10)
TransientStorageGetHitSmall-14         12.180n ±  3%   7.640n ±  2%   -37.27% (p=0.000 n=10)
TransientStorageGetHitMedium-14        12.285n ± 14%   7.622n ±  5%   -37.96% (p=0.000 n=10)
TransientStorageGetHitMainnetLike-14   12.265n ±  3%   7.603n ±  1%   -38.01% (p=0.000 n=10)
TransientStorageGetHitLarge-14         12.390n ±  2%   7.659n ±  1%   -38.19% (p=0.000 n=10)
TransientStorageSetDelete-14           147.90n ±  7%   25.73n ±  1%   -82.61% (p=0.000 n=10)
TransientStorageMixedMainnetLike-14    16.520n ±  3%   8.561n ±  4%   -48.18% (p=0.000 n=10)
geomean                                 15.40n         8.684n         -43.63%

                                     │   old.txt    │                 new.txt                 │
                                     │     B/op     │    B/op     vs base                     │
TransientStorageSetEmpty-14            0.000 ± 0%     0.000 ± 0%         ~ (p=1.000 n=10) ¹
TransientStorageSetSmall-14            0.000 ± 0%     0.000 ± 0%         ~ (p=1.000 n=10) ¹
TransientStorageSetMedium-14           0.000 ± 0%     0.000 ± 0%         ~ (p=1.000 n=10) ¹
TransientStorageSetMainnetLike-14      0.000 ± 0%     0.000 ± 0%         ~ (p=1.000 n=10) ¹
TransientStorageSetLarge-14            0.000 ± 0%     0.000 ± 0%         ~ (p=1.000 n=10) ¹
TransientStorageGetMiss-14             0.000 ± 0%     0.000 ± 0%         ~ (p=1.000 n=10) ¹
TransientStorageGetHitEmpty-14         0.000 ± 0%     0.000 ± 0%         ~ (p=1.000 n=10) ¹
TransientStorageGetHitSmall-14         0.000 ± 0%     0.000 ± 0%         ~ (p=1.000 n=10) ¹
TransientStorageGetHitMedium-14        0.000 ± 0%     0.000 ± 0%         ~ (p=1.000 n=10) ¹
TransientStorageGetHitMainnetLike-14   0.000 ± 0%     0.000 ± 0%         ~ (p=1.000 n=10) ¹
TransientStorageGetHitLarge-14         0.000 ± 0%     0.000 ± 0%         ~ (p=1.000 n=10) ¹
TransientStorageSetDelete-14           624.0 ± 0%       0.0 ± 0%  -100.00% (p=0.000 n=10)
TransientStorageMixedMainnetLike-14    0.000 ± 0%     0.000 ± 0%         ~ (p=1.000 n=10) ¹
geomean                                           ²               ?                       ² ³
¹ all samples are equal
² summaries must be >0 to compute geomean
³ ratios must be >0 to compute geomean

                                     │   old.txt    │                 new.txt                 │
                                     │  allocs/op   │ allocs/op   vs base                     │
TransientStorageSetEmpty-14            0.000 ± 0%     0.000 ± 0%         ~ (p=1.000 n=10) ¹
TransientStorageSetSmall-14            0.000 ± 0%     0.000 ± 0%         ~ (p=1.000 n=10) ¹
TransientStorageSetMedium-14           0.000 ± 0%     0.000 ± 0%         ~ (p=1.000 n=10) ¹
TransientStorageSetMainnetLike-14      0.000 ± 0%     0.000 ± 0%         ~ (p=1.000 n=10) ¹
TransientStorageSetLarge-14            0.000 ± 0%     0.000 ± 0%         ~ (p=1.000 n=10) ¹
TransientStorageGetMiss-14             0.000 ± 0%     0.000 ± 0%         ~ (p=1.000 n=10) ¹
TransientStorageGetHitEmpty-14         0.000 ± 0%     0.000 ± 0%         ~ (p=1.000 n=10) ¹
TransientStorageGetHitSmall-14         0.000 ± 0%     0.000 ± 0%         ~ (p=1.000 n=10) ¹
TransientStorageGetHitMedium-14        0.000 ± 0%     0.000 ± 0%         ~ (p=1.000 n=10) ¹
TransientStorageGetHitMainnetLike-14   0.000 ± 0%     0.000 ± 0%         ~ (p=1.000 n=10) ¹
TransientStorageGetHitLarge-14         0.000 ± 0%     0.000 ± 0%         ~ (p=1.000 n=10) ¹
TransientStorageSetDelete-14           2.000 ± 0%     0.000 ± 0%  -100.00% (p=0.000 n=10)
TransientStorageMixedMainnetLike-14    0.000 ± 0%     0.000 ± 0%         ~ (p=1.000 n=10) ¹
geomean                                           ²               ?                       ² ³
¹ all samples are equal
² summaries must be >0 to compute geomean
³ ratios must be >0 to compute geomean
```
benchmark code:  
```
// Copyright 2022 The go-ethereum Authors
// This file is part of the go-ethereum library.
//
// The go-ethereum library is free software: you can redistribute it and/or modify
// it under the terms of the GNU Lesser General Public License as published by
// the Free Software Foundation, either version 3 of the License, or
// (at your option) any later version.
//
// The go-ethereum library is distributed in the hope that it will be useful,
// but WITHOUT ANY WARRANTY; without even the implied warranty of
// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
// GNU Lesser General Public License for more details.
//
// You should have received a copy of the GNU Lesser General Public License
// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.

package state

import (
	"testing"

	"github.com/ethereum/go-ethereum/common"
	"github.com/ethereum/go-ethereum/crypto"
)

// mainnetLikeFixture builds deterministic addr/key/value triples that resemble
// mainnet usage: multiple contract addresses (e.g. pool, router, hook) and
// multiple storage slots per contract (mapping/slot indices). Addresses are
// derived from Keccak256 so they look like contract addresses; keys like slot hashes.
func mainnetLikeFixture(n int) (addrs []common.Address, keys []common.Hash, values []common.Hash) {
	addrs = make([]common.Address, n)
	keys = make([]common.Hash, n)
	values = make([]common.Hash, n)
	for i := 0; i < n; i++ {
		// Address: last 20 bytes of Keccak256(seed) — contract-like.
		h := crypto.Keccak256Hash([]byte("transient_addr"), []byte{byte(i), byte(i >> 8)})
		copy(addrs[i][:], h[12:])
		// Key: slot-like (e.g. mapping key or slot index).
		keys[i] = crypto.Keccak256Hash([]byte("transient_slot"), []byte{byte(i), byte(i >> 8)})
		values[i] = crypto.Keccak256Hash([]byte("transient_val"), []byte{byte(i), byte(i >> 8)})
	}
	return addrs, keys, values
}

// fillTransientStorage pre-fills t with n mainnet-like entries.
func fillTransientStorage(t transientStorage, n int) {
	addrs, keys, values := mainnetLikeFixture(n)
	for i := 0; i < n; i++ {
		t.Set(addrs[i], keys[i], values[i])
	}
}

func BenchmarkTransientStorageSetEmpty(b *testing.B) {
	addrs, keys, values := mainnetLikeFixture(1)
	addr, key, value := addrs[0], keys[0], values[0]
	t := newTransientStorage()
	b.ResetTimer()
	for i := 0; i < b.N; i++ {
		t.Set(addr, key, value)
	}
}

// BenchmarkTransientStorageSet*: Set into a pre-filled map (simulates tx with existing transient state).
func BenchmarkTransientStorageSetSmall(b *testing.B) {
	benchmarkTransientStorageSet(b, 8)
}

func BenchmarkTransientStorageSetMedium(b *testing.B) {
	benchmarkTransientStorageSet(b, 64)
}

func BenchmarkTransientStorageSetMainnetLike(b *testing.B) {
	benchmarkTransientStorageSet(b, 256)
}

func BenchmarkTransientStorageSetLarge(b *testing.B) {
	benchmarkTransientStorageSet(b, 1024)
}

func benchmarkTransientStorageSet(b *testing.B, size int) {
	addrs, keys, values := mainnetLikeFixture(size + 1)
	t := newTransientStorage()
	fillTransientStorage(t, size)
	addr, key, value := addrs[size], keys[size], values[size]
	b.ResetTimer()
	for i := 0; i < b.N; i++ {
		t.Set(addr, key, value)
	}
}

// BenchmarkTransientStorageGetMiss: Get with key not present (cold slot).
func BenchmarkTransientStorageGetMiss(b *testing.B) {
	t := newTransientStorage()
	addr := common.Address(crypto.Keccak256Hash([]byte("miss_addr")).Bytes()[12:])
	key := crypto.Keccak256Hash([]byte("miss_key"))
	b.ResetTimer()
	for i := 0; i < b.N; i++ {
		t.Get(addr, key)
	}
}

// BenchmarkTransientStorageGetHit*: Get with key present, varying map size.
func BenchmarkTransientStorageGetHitEmpty(b *testing.B) {
	benchmarkTransientStorageGetHit(b, 0)
}

func BenchmarkTransientStorageGetHitSmall(b *testing.B) {
	benchmarkTransientStorageGetHit(b, 8)
}

func BenchmarkTransientStorageGetHitMedium(b *testing.B) {
	benchmarkTransientStorageGetHit(b, 64)
}

func BenchmarkTransientStorageGetHitMainnetLike(b *testing.B) {
	benchmarkTransientStorageGetHit(b, 256)
}

func BenchmarkTransientStorageGetHitLarge(b *testing.B) {
	benchmarkTransientStorageGetHit(b, 1024)
}

func benchmarkTransientStorageGetHit(b *testing.B, size int) {
	addrs, keys, _ := mainnetLikeFixture(size + 1)
	t := newTransientStorage()
	fillTransientStorage(t, size)
	addr, key := addrs[size], keys[size]
	t.Set(addr, key, common.Hash{0xde, 0xad, 0xbe, 0xef})
	b.ResetTimer()
	for i := 0; i < b.N; i++ {
		t.Get(addr, key)
	}
}

// BenchmarkTransientStorageSetDelete: Set with value zero (delete path).
func BenchmarkTransientStorageSetDelete(b *testing.B) {
	addrs, keys, values := mainnetLikeFixture(1)
	addr, key, value := addrs[0], keys[0], values[0]
	t := newTransientStorage()
	t.Set(addr, key, value)
	b.ResetTimer()
	for i := 0; i < b.N; i++ {
		t.Set(addr, key, common.Hash{}) // delete
		t.Set(addr, key, value)         // re-insert for next iteration
	}
}

// BenchmarkTransientStorageMixedMainnetLike: simulate a mainnet-like tx — fill then repeated Gets (read-heavy).
func BenchmarkTransientStorageMixedMainnetLike(b *testing.B) {
	const size = 128
	addrs, keys, values := mainnetLikeFixture(size)
	t := newTransientStorage()
	for i := 0; i < size; i++ {
		t.Set(addrs[i], keys[i], values[i])
	}
	b.ResetTimer()
	for i := 0; i < b.N; i++ {
		idx := i % size
		t.Get(addrs[idx], keys[idx])
	}
}

```

I think get miss is acceptable, since it would not happen frequently.  