### PR TITLE
ethdb/pebble: disable seek compaction for Pebble

### DIFF
--- a/ethdb/pebble/pebble.go
+++ b/ethdb/pebble/pebble.go
@@ -300,6 +300,10 @@ func New(file string, cache int, handles int, namespace string, readonly bool) (
 		// debt will be less than 1GB, but with more frequent compactions scheduled.
 		L0CompactionThreshold: 2,
 	}
+	// Disable seek compaction explicitly. Check https://github.com/ethereum/go-ethereum/pull/20130
+	// for more details.
+	opt.Experimental.ReadSamplingMultiplier = -1
+
 	// These two settings define the conditions under which compaction concurrency
 	// is increased. Specifically, one additional compaction job will be enabled when:
 	// - there is one more overlapping sub-level0;


### PR DESCRIPTION
This PR restores the previous Pebble configuration, disabling seek compaction.

This feature is still needed by hash mode archive node, mitigating the overhead
of frequent compaction.