### PR TITLE
eth/gasprice: reduce allocations

### DIFF
--- a/eth/gasprice/gasprice.go
+++ b/eth/gasprice/gasprice.go
@@ -259,7 +259,9 @@ func (oracle *Oracle) getBlockValues(ctx context.Context, blockNum uint64, limit
 	copy(sortedTxs, txs)
 	baseFee := block.BaseFee()
 	baseFee256 := new(uint256.Int)
-	baseFee256.SetFromBig(baseFee)
+	if baseFee != nil {
+		baseFee256.SetFromBig(baseFee)
+	}
 	slices.SortFunc(sortedTxs, func(a, b *types.Transaction) int {
 		return a.EffectiveGasTipCmp(b, baseFee256)
 	})


### PR DESCRIPTION
Recent pprof from our validator shows ~6% of all allocations because of the gas price oracle

<img width="519" height="812" alt="Screenshot_2026-01-28_14-08-18" src="https://github.com/user-attachments/assets/75c39dd2-de8b-47ba-906e-4a9660992d59" />
