### PR TITLE
apitypes: fix truncation of opening parenthesis

### DIFF
--- a/signer/core/apitypes/types.go
+++ b/signer/core/apitypes/types.go
@@ -432,7 +432,9 @@ func (typedData *TypedData) EncodeType(primaryType string) hexutil.Bytes {
 			buffer.WriteString(obj.Name)
 			buffer.WriteString(",")
 		}
-		buffer.Truncate(buffer.Len() - 1)
+		if len(typedData.Types[dep]) > 0 {
+			buffer.Truncate(buffer.Len() - 1)
+		}
 		buffer.WriteString(")")
 	}
 	return buffer.Bytes()


### PR DESCRIPTION
This fixes a truncation bug that results in an invalid serialization of empty EIP712.

For example:

```json
{
    "method": "eth_signTypedData_v4",
    "request": {
        "types": {
            "EIP712Domain": [
                {
                    "name": "version",
                    "type": "string"
                }
            ],
            "Empty": []
        },
        "primaryType": "Empty",
        "domain": {
            "version": "0"
        },
        "message": {}
    }
}
``` 

When calculating the type-hash for the stuct-hash, it will incorrectly use `Empty)` instead of `Empty()`