### PR TITLE
crypto/kzg4844: preallocate proof slice in ComputeCellProofs

### DIFF
--- a/crypto/kzg4844/kzg4844_ckzg_cgo.go
+++ b/crypto/kzg4844/kzg4844_ckzg_cgo.go
@@ -143,9 +143,9 @@ func ckzgComputeCellProofs(blob *Blob) ([]Proof, error) {
 	if err != nil {
 		return []Proof{}, err
 	}
-	var p []Proof
-	for _, proof := range proofs {
-		p = append(p, (Proof)(proof))
+	p := make([]Proof, len(proofs))
+	for i, proof := range proofs {
+		p[i] = (Proof)(proof)
 	}
 	return p, nil
 }

--- a/crypto/kzg4844/kzg4844_gokzg.go
+++ b/crypto/kzg4844/kzg4844_gokzg.go
@@ -108,9 +108,9 @@ func gokzgComputeCellProofs(blob *Blob) ([]Proof, error) {
 	if err != nil {
 		return []Proof{}, err
 	}
-	var p []Proof
-	for _, proof := range proofs {
-		p = append(p, (Proof)(proof))
+	p := make([]Proof, len(proofs))
+	for i, proof := range proofs {
+		p[i] = (Proof)(proof)
 	}
 	return p, nil
 }


### PR DESCRIPTION
Preallocate the proof slice with the known size instead of growing it via append in a loop. The length is already known from the source slice.