### PR TITLE
core/txpool/legacypool: clarify and fix non-executable tx heartbeat

### DIFF
--- a/core/txpool/legacypool/queue.go
+++ b/core/txpool/legacypool/queue.go
@@ -88,8 +88,12 @@ func (q *queue) get(addr common.Address) (*list, bool) {
 	return l, ok
 }
 
+// bump updates the heartbeat for the given account address.
+// If the address is unknown, the call is a no-op.
 func (q *queue) bump(addr common.Address) {
-	q.beats[addr] = time.Now()
+	if _, ok := q.beats[addr]; ok {
+		q.beats[addr] = time.Now()
+	}
 }
 
 func (q *queue) addresses() []common.Address {


### PR DESCRIPTION
Heartbeats are used to drop non-executable transactions from the queue. The timeout mechanism was not clearly documented, and it was updates also when not necessary.