### PR TITLE
core/state: add bounds check in heap eviction loop

### DIFF
--- a/core/state/state_sizer.go
+++ b/core/state/state_sizer.go
@@ -346,7 +346,7 @@ func (t *SizeTracker) run() {
 
 			// Evict the stale statistics
 			heap.Push(&h, stats[u.root])
-			for u.blockNumber-h[0].BlockNumber > statEvictThreshold {
+			for len(h) > 0 && u.blockNumber-h[0].BlockNumber > statEvictThreshold {
 				delete(stats, h[0].StateRoot)
 				heap.Pop(&h)
 			}


### PR DESCRIPTION
core/state: add bounds check in heap eviction loop

Add len(h) > 0 check before accessing h[0] to prevent potential panic and align with existing heap access patterns in txpool, p2p, and mclock packages.