### PR TITLE
triedb/pathdb: add bounds check in decodeKeyEntry to prevent panic

### DIFF
--- a/triedb/pathdb/history_trienode.go
+++ b/triedb/pathdb/history_trienode.go
@@ -352,6 +352,9 @@ func decodeHeader(data []byte) (*trienodeMetadata, []common.Hash, []uint32, []ui
 // the specified offset.
 func decodeKeyEntry(keySection []byte, offset int) (uint64, uint64, []byte, int, error) {
 	var byteRead int
+	if offset < 0 || offset >= len(keySection) {
+		return 0, 0, nil, 0, fmt.Errorf("key offset out of bounds, offset: %d, section size: %d", offset, len(keySection))
+	}
 
 	// Resolve the length of shared key
 	nShared, nn := binary.Uvarint(keySection[offset:]) // key length shared (varint)


### PR DESCRIPTION
This PR adds a bounds check to `decodeKeyEntry` before slicing `keySection[offset:]` to prevent potential runtime panics when processing corrupted or malformed trie data.
