### PR TITLE
core: fix initialization of `parallelProcessor`

### DIFF
--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -437,6 +437,7 @@ func NewBlockChain(db ethdb.Database, genesis *Genesis, engine consensus.Engine,
 	bc.validator = NewBlockValidator(chainConfig, bc)
 	bc.prefetcher = newStatePrefetcher(chainConfig, bc.hc)
 	bc.processor = NewStateProcessor(bc.hc)
+	bc.parallelProcessor = NewParallelStateProcessor(bc.hc, &cfg.VmConfig)
 
 	genesisHeader := bc.GetHeaderByNumber(0)
 	if genesisHeader == nil {


### PR DESCRIPTION
while trying to re-run 7843 tests again i saw geth panic (no clean hive errors btw) and this fixes it. i think `parallelProcessor` field in `BlockChain` was never initialized, so if u get a block with bal u run `processBlockWithAccessList()` which then calls `bc.parallelProcessor.Process(...)` which eventually calls `p.chainConfig()` which then tries `p.chain.Config()` but `p.chain` is still `nil`, ripbozo. i applied this fix and now geth again passes all 7843 tests. you also pass 179/184 tests of eip-8024, but those 5 failing could be on our side and have nothing to do with this pr