### PR TITLE
consensus/misc/eip4844: fix nil panic in Amsterdam blob config

### DIFF
--- a/consensus/misc/eip4844/eip4844.go
+++ b/consensus/misc/eip4844/eip4844.go
@@ -70,7 +70,7 @@ func latestBlobConfig(cfg *params.ChainConfig, time uint64) *BlobConfig {
 	case cfg.IsBPO3(london, time) && s.BPO3 != nil:
 		bc = s.BPO3
 	case cfg.IsAmsterdam(london, time) && s.Amsterdam != nil:
-		bc = s.BPO2
+		bc = s.Amsterdam
 	case cfg.IsBPO2(london, time) && s.BPO2 != nil:
 		bc = s.BPO2
 	case cfg.IsBPO1(london, time) && s.BPO1 != nil:


### PR DESCRIPTION
## Summary
- Fix nil pointer dereference in `latestBlobConfig` that causes Geth to panic at startup on bal-devnet-2
- The Amsterdam case in the blob config switch incorrectly assigned `s.BPO2` instead of `s.Amsterdam`, causing a nil dereference when `BPO2` is not defined in the genesis config

## Root Cause
In commit `4c36eaf53`, the Amsterdam case was added to `latestBlobConfig()` but assigned `bc = s.BPO2` instead of `bc = s.Amsterdam`. When the genesis config defines an Amsterdam blob schedule but not BPO2, `bc` is set to nil and dereferenced at line 89.

## Stack trace
```
panic: runtime error: invalid memory address or nil pointer dereference
goroutine 1 [running]:
github.com/ethereum/go-ethereum/consensus/misc/eip4844.latestBlobConfig(...)
    consensus/misc/eip4844/eip4844.go:89
github.com/ethereum/go-ethereum/core/txpool/blobpool.(*BlobPool).updateStorageMetrics(...)
    core/txpool/blobpool/blobpool.go:1892
github.com/ethereum/go-ethereum/core/txpool/blobpool.(*BlobPool).Init(...)
    core/txpool/blobpool/blobpool.go:484
```

## Test plan
- [x] Built local image with fix
- [x] Tested in Kurtosis with Lighthouse CL - network starts, passes Gloas fork, achieves finality
- [x] Verified no panics or errors in Geth logs through 5+ epochs