### PR TITLE
triedb/pathdb: use known size for history slice allocation

### DIFF
--- a/triedb/pathdb/history_state.go
+++ b/triedb/pathdb/history_state.go
@@ -568,11 +568,11 @@ func readStateHistory(reader ethdb.AncientReader, id uint64) (*stateHistory, err
 
 // readStateHistories reads a list of state history records within the specified range.
 func readStateHistories(freezer ethdb.AncientReader, start uint64, count uint64) ([]history, error) {
-	var histories []history
 	metaList, aIndexList, sIndexList, aDataList, sDataList, err := rawdb.ReadStateHistoryList(freezer, start, count)
 	if err != nil {
 		return nil, err
 	}
+	histories := make([]history, 0, len(metaList))
 	for i := 0; i < len(metaList); i++ {
 		var m meta
 		if err := m.decode(metaList[i]); err != nil {

--- a/triedb/pathdb/history_trienode.go
+++ b/triedb/pathdb/history_trienode.go
@@ -842,7 +842,7 @@ func readTrienodeHistories(reader ethdb.AncientReader, start uint64, count uint6
 	if err != nil {
 		return nil, err
 	}
-	var res []history
+	res := make([]history, 0, len(headers))
 	for i, header := range headers {
 		var h trienodeHistory
 		if err := h.decode(header, keySections[i], valueSections[i]); err != nil {


### PR DESCRIPTION
Allocate slice with proper capacity in readStateHistories and readTrienodeHistories since the size is known from input data length. Avoids slice reallocations during append loop (up to 1000 items per batch).