### PR TITLE
triedb/pathdb: add bounds validation to prevent panic in blockIterator.seekGT

### DIFF
--- a/triedb/pathdb/history_index_iterator.go
+++ b/triedb/pathdb/history_index_iterator.go
@@ -217,6 +217,10 @@ func (it *blockIterator) seekGT(id uint64) bool {
 	if it.err != nil {
 		return false
 	}
+	if len(it.data) == 0 || len(it.restarts) == 0 {
+		it.exhausted = true
+		return false
+	}
 	var err error
 	index := sort.Search(len(it.restarts), func(i int) bool {
 		item, n := binary.Uvarint(it.data[it.restarts[i]:])


### PR DESCRIPTION
Adds a check for empty `data` or `restarts` slices before attempting to access them. Returns early with `exhausted = true` when the iterator has no data to process. Prevents potential out-of-bounds panic when accessing `it.restarts[0]` and during `sort.Search` callback execution