### PR TITLE
core/vm: disable the value transfer in syscall

### DIFF
--- a/core/vm/evm.go
+++ b/core/vm/evm.go
@@ -281,8 +281,9 @@ func (evm *EVM) Call(caller common.Address, addr common.Address, input []byte, g
 		}
 		evm.StateDB.CreateAccount(addr)
 	}
-	// Perform the value transfer in non-syscall mode. This is essential for zero-value
-	// transfers to ensure the clearing mechanism is applied.
+	// Perform the value transfer only in non-syscall mode.
+	// Calling this is required even for zero-value transfers,
+	// to ensure the state clearing mechanism is applied.
 	if !syscall {
 		evm.Context.Transfer(evm.StateDB, caller, addr, value)
 	}


### PR DESCRIPTION
In src/ethereum/forks/amsterdam/vm/interpreter.py:299-304, the caller address is 
only tracked for block level accessList when there's a value transfer:

```python
if message.should_transfer_value and message.value != 0:  
    # Track value transfer  
    sender_balance = get_account(state, message.caller).balance  
    recipient_balance = get_account(state, message.current_target).balance  

    track_address(message.state_changes, message.caller)  # Line 304
```

Since system transactions have should_transfer_value=False and value=0, 
this condition is never met, so the caller (SYSTEM_ADDRESS) is not tracked.

This condition is applied for the syscall in the geth implementation, aligning with
the spec of EIP7928.