### PR TITLE
core/state: track slot reads for empty storage

### DIFF
--- a/core/state/state_object.go
+++ b/core/state/state_object.go
@@ -188,6 +188,19 @@ func (s *stateObject) GetCommittedState(key common.Hash) common.Hash {
 	//      have been handles via pendingStorage above.
 	//   2) we don't have new values, and can deliver empty response back
 	if _, destructed := s.db.stateObjectsDestruct[s.address]; destructed {
+		// Invoke the reader regardless and discard the returned value.
+		// The returned value may not be empty, as it could belong to a
+		// self-destructed contract.
+		//
+		// The read operation is still essential for correctly building
+		// the block-level access list.
+		//
+		// TODO(rjl493456442) the reader interface can be extended with
+		// Touch, recording the read access without the actual disk load.
+		_, err := s.db.reader.Storage(s.address, key)
+		if err != nil {
+			s.db.setError(err)
+		}
 		s.originStorage[key] = common.Hash{} // track the empty slot as origin value
 		return common.Hash{}
 	}


### PR DESCRIPTION
From the https://eips.ethereum.org/EIPS/eip-7928

> SELFDESTRUCT (in-transaction): Accounts destroyed within a transaction 
  MUST be included in AccountChanges without nonce or code changes. 
  However, if the account had a positive balance pre-transaction, the balance 
  change to zero MUST be recorded. Storage keys within the self-destructed 
  contracts that were modified or read MUST be included as a storage_reads entry.

The storage read against the empty contract (zero storage) should also be
recorded in the BAL's readlist.