### PR TITLE
rpc: propagate tracerProvider to ServeCodec handlers

### DIFF
--- a/rpc/client.go
+++ b/rpc/client.go
@@ -29,6 +29,7 @@ import (
 	"time"
 
 	"github.com/ethereum/go-ethereum/log"
+	"go.opentelemetry.io/otel/trace"
 )
 
 var (
@@ -88,6 +89,7 @@ type Client struct {
 	// config fields
 	batchItemLimit       int
 	batchResponseMaxSize int
+	tracerProvider       trace.TracerProvider
 
 	// writeConn is used for writing to the connection on the caller's goroutine. It should
 	// only be accessed outside of dispatch, with the write lock held. The write lock is
@@ -119,7 +121,7 @@ func (c *Client) newClientConn(conn ServerCodec) *clientConn {
 	ctx := context.Background()
 	ctx = context.WithValue(ctx, clientContextKey{}, c)
 	ctx = context.WithValue(ctx, peerInfoContextKey{}, conn.peerInfo())
-	handler := newHandler(ctx, conn, c.idgen, c.services, c.batchItemLimit, c.batchResponseMaxSize, nil)
+	handler := newHandler(ctx, conn, c.idgen, c.services, c.batchItemLimit, c.batchResponseMaxSize, c.tracerProvider)
 	return &clientConn{conn, handler}
 }
 
@@ -247,6 +249,7 @@ func initClient(conn ServerCodec, services *serviceRegistry, cfg *clientConfig) 
 		idgen:                cfg.idgen,
 		batchItemLimit:       cfg.batchItemLimit,
 		batchResponseMaxSize: cfg.batchResponseLimit,
+		tracerProvider:       cfg.tracerProvider,
 		writeConn:            conn,
 		close:                make(chan struct{}),
 		closing:              make(chan struct{}),

--- a/rpc/client_opt.go
+++ b/rpc/client_opt.go
@@ -20,6 +20,7 @@ import (
 	"net/http"
 
 	"github.com/gorilla/websocket"
+	"go.opentelemetry.io/otel/trace"
 )
 
 // ClientOption is a configuration option for the RPC client.
@@ -41,6 +42,7 @@ type clientConfig struct {
 	idgen              func() ID
 	batchItemLimit     int
 	batchResponseLimit int
+	tracerProvider     trace.TracerProvider
 }
 
 func (cfg *clientConfig) initHeaders() {

--- a/rpc/server.go
+++ b/rpc/server.go
@@ -126,6 +126,7 @@ func (s *Server) ServeCodec(codec ServerCodec, options CodecOption) {
 		idgen:              s.idgen,
 		batchItemLimit:     s.batchItemLimit,
 		batchResponseLimit: s.batchResponseLimit,
+		tracerProvider:     s.tracerProvider,
 	}
 	c := initClient(codec, &s.services, cfg)
 	<-codec.closed()


### PR DESCRIPTION
<!-- Cause: what was wrong before this change? -->
ServeCodec created handlers via initClient/newClientConn with a nil tracerProvider, so WebSocket/IPC RPC calls never used the Server-specific TracerProvider and only relied on the global no-op provider. The tracing tests also relied on a misleading
assumption that subscribe/unsubscribe emit no spans because of a nil tracerProvider.

<!-- Summary: concise description of what this PR changes -->
Propagate the Server's tracerProvider through clientConfig and Client into newHandler, so ServeCodec-based connections (WS/IPC/inproc) use the same TracerProvider as HTTP. Update tracing tests and comments to reflect the real behavior, asserting that subscribe/unsubscribe do not create main JSON-RPC server spans while allowing internal encoding spans.