### PR TITLE
metrics: add missing GaugeInfo case in GetAll()

### DIFF
--- a/metrics/registry.go
+++ b/metrics/registry.go
@@ -143,6 +143,8 @@ func (r *StandardRegistry) GetAll() map[string]map[string]interface{} {
 			values["value"] = metric.Snapshot().Value()
 		case *GaugeFloat64:
 			values["value"] = metric.Snapshot().Value()
+		case *GaugeInfo:
+			values["value"] = metric.Snapshot().Value()
 		case *Healthcheck:
 			values["error"] = nil
 			metric.Check()


### PR DESCRIPTION
I was setting up a Grafana dashboard for my geth nodes and noticed that `chain/info` and `geth/info` metrics were missing from the `/debug/metrics` JSON endpoint, but they showed up fine in `/debug/metrics/prometheus.  `                                                                 
                                                                                                                                                                                                                                                                                       
  $ curl -s localhost:6060/debug/metrics | jq 'keys | map(select(startswith("chain/") or startswith("geth/")))'                                                                                                                                                                        
  []                                                                                                                                                                                                                                                                                   
                                                                                                                                                                                                                                                                                       
But prometheus endpoint works:                                                                                                                                                                                                                                                       
                                                                                                                                                                                                                                                                                       
  $ curl -s localhost:6060/debug/metrics/prometheus | grep -E "^(chain_info|geth_info)"                                                                                                                                                                                                
  chain_info{chain_id="1"} 1                                                                                                                                                                                                                                                           
  geth_info{arch="arm64",os="darwin",version="1.15.0-unstable",...} 1                                                                                                                                                                                                                  
                                                                                                                                                                                                                                                                                       
Turns out `GetAll()` handles all metric types except `*GaugeInfo` - it can be registered but gets silently dropped during JSON export. 