### PR TITLE
metrics: add missing ResettingTimer case in GetAll()

### DIFF
--- a/metrics/registry.go
+++ b/metrics/registry.go
@@ -186,6 +186,18 @@ func (r *StandardRegistry) GetAll() map[string]map[string]interface{} {
 			values["5m.rate"] = t.Rate5()
 			values["15m.rate"] = t.Rate15()
 			values["mean.rate"] = t.RateMean()
+		case *ResettingTimer:
+			t := metric.Snapshot()
+			ps := t.Percentiles([]float64{0.5, 0.75, 0.95, 0.99, 0.999})
+			values["count"] = t.Count()
+			values["min"] = t.Min()
+			values["max"] = t.Max()
+			values["mean"] = t.Mean()
+			values["median"] = ps[0]
+			values["75%"] = ps[1]
+			values["95%"] = ps[2]
+			values["99%"] = ps[3]
+			values["99.9%"] = ps[4]
 		}
 		data[name] = values
 	})


### PR DESCRIPTION
Follow-up to https://github.com/ethereum/go-ethereum/pull/33748                                                                                                                                                                                                                                         
                                                                                                                                                                                                                                                                                       
Same issue - ResettingTimer can be registered via loadOrRegister() but GetAll() silently drops it during JSON export. The prometheus exporter handles it fine (collector.go:70), so this is just an oversight in the JSON path.                                                      
                                                                                                                                                                                                                                                                                       
Note: ResettingTimer.Snapshot() resets the timer by design, which is consistent with how the prometheus exporter uses it.                                                                                                                                                            
                                                                                                                                 