### PR TITLE
crypto/ecies: fix panic on short ciphertext in symDecrypt

### DIFF
--- a/crypto/ecies/ecies.go
+++ b/crypto/ecies/ecies.go
@@ -221,6 +221,9 @@ func symDecrypt(params *ECIESParams, key, ct []byte) (m []byte, err error) {
 	if err != nil {
 		return
 	}
+	if len(ct) < params.BlockSize {
+		return nil, ErrInvalidMessage
+	}
 
 	ctr := cipher.NewCTR(c, ct[:params.BlockSize])
 


### PR DESCRIPTION
Adds length check before slicing ciphertext in symDecrypt, prevents panic when ct is shorter than block size.