### PR TITLE
core: fix EIP-7778 receipt vs block gas separation

### DIFF
--- a/core/block_validator.go
+++ b/core/block_validator.go
@@ -19,6 +19,7 @@ package core
 import (
 	"errors"
 	"fmt"
+
 	"github.com/ethereum/go-ethereum/consensus"
 	"github.com/ethereum/go-ethereum/core/state"
 	"github.com/ethereum/go-ethereum/core/types"

--- a/core/chain_makers.go
+++ b/core/chain_makers.go
@@ -44,11 +44,12 @@ type BlockGen struct {
 	header  *types.Header
 	statedb *state.StateDB
 
-	gasPool     *GasPool
-	txs         []*types.Transaction
-	receipts    []*types.Receipt
-	uncles      []*types.Header
-	withdrawals []*types.Withdrawal
+	gasPool        *GasPool
+	txs            []*types.Transaction
+	receipts       []*types.Receipt
+	uncles         []*types.Header
+	withdrawals    []*types.Withdrawal
+	receiptGasUsed uint64
 
 	engine consensus.Engine
 }
@@ -117,7 +118,8 @@ func (b *BlockGen) addTx(bc *BlockChain, vmConfig vm.Config, tx *types.Transacti
 		evm          = vm.NewEVM(blockContext, b.statedb, b.cm.config, vmConfig)
 	)
 	b.statedb.SetTxContext(tx.Hash(), len(b.txs))
-	receipt, err := ApplyTransaction(evm, b.gasPool, b.statedb, b.header, tx, &b.header.GasUsed)
+	receipt, blockGasUsed, err := ApplyTransaction(evm, b.gasPool, b.statedb, b.header, tx, &b.receiptGasUsed)
+	b.header.GasUsed += blockGasUsed
 	if err != nil {
 		panic(err)
 	}

--- a/eth/tracers/api.go
+++ b/eth/tracers/api.go
@@ -1055,7 +1055,7 @@ func (api *API) traceTx(ctx context.Context, tx *types.Transaction, message *cor
 
 	// Call Prepare to clear out the statedb access list
 	statedb.SetTxContext(txctx.TxHash, txctx.TxIndex)
-	_, err = core.ApplyTransactionWithEVM(message, new(core.GasPool).AddGas(message.GasLimit), statedb, vmctx.BlockNumber, txctx.BlockHash, vmctx.Time, tx, &usedGas, evm)
+	_, _, err = core.ApplyTransactionWithEVM(message, new(core.GasPool).AddGas(message.GasLimit), statedb, vmctx.BlockNumber, txctx.BlockHash, vmctx.Time, tx, &usedGas, evm)
 	if err != nil {
 		return nil, fmt.Errorf("tracing failed: %w", err)
 	}

--- a/eth/tracers/internal/tracetest/selfdestruct_state_test.go
+++ b/eth/tracers/internal/tracetest/selfdestruct_state_test.go
@@ -621,7 +621,7 @@ func TestSelfdestructStateTracer(t *testing.T) {
 			context := core.NewEVMBlockContext(block.Header(), blockchain, nil)
 			evm := vm.NewEVM(context, hookedState, tt.genesis.Config, vm.Config{Tracer: tracer.Hooks()})
 			usedGas := uint64(0)
-			_, err = core.ApplyTransactionWithEVM(msg, new(core.GasPool).AddGas(tx.Gas()), statedb, block.Number(), block.Hash(), block.Time(), tx, &usedGas, evm)
+			_, _, err = core.ApplyTransactionWithEVM(msg, new(core.GasPool).AddGas(tx.Gas()), statedb, block.Number(), block.Hash(), block.Time(), tx, &usedGas, evm)
 			if err != nil {
 				t.Fatalf("failed to execute transaction: %v", err)
 			}

--- a/internal/ethapi/simulate.go
+++ b/internal/ethapi/simulate.go
@@ -239,7 +239,7 @@ func (sim *simulator) processBlock(ctx context.Context, block *simBlock, header,
 		return nil, nil, nil, err
 	}
 	var (
-		gasUsed, blobGasUsed uint64
+		gasUsed, blockGasUsed, blobGasUsed uint64
 		txes                 = make([]*types.Transaction, len(block.Calls))
 		callResults          = make([]simCallResult, len(block.Calls))
 		receipts             = make([]*types.Receipt, len(block.Calls))
@@ -275,7 +275,7 @@ func (sim *simulator) processBlock(ctx context.Context, block *simBlock, header,
 		if err := ctx.Err(); err != nil {
 			return nil, nil, nil, err
 		}
-		if err := sim.sanitizeCall(&call, sim.state, header, blockContext, &gasUsed); err != nil {
+		if err := sim.sanitizeCall(&call, sim.state, header, blockContext, &blockGasUsed); err != nil {
 			return nil, nil, nil, err
 		}
 		var (
@@ -300,11 +300,12 @@ func (sim *simulator) processBlock(ctx context.Context, block *simBlock, header,
 		} else {
 			root = sim.state.IntermediateRoot(sim.chainConfig.IsEIP158(blockContext.BlockNumber)).Bytes()
 		}
+		gasUsed += result.UsedGas
 		// EIP-7778: block gas accounting excludes refunds.
 		if sim.chainConfig.IsAmsterdam(blockContext.BlockNumber, blockContext.Time) {
-			gasUsed += result.MaxUsedGas
+			blockGasUsed += result.MaxUsedGas
 		} else {
-			gasUsed += result.UsedGas
+			blockGasUsed += result.UsedGas
 		}
 		receipts[i] = core.MakeReceipt(evm, result, sim.state, blockContext.BlockNumber, common.Hash{}, blockContext.Time, tx, gasUsed, root)
 		blobGasUsed += receipts[i].BlobGasUsed
@@ -325,7 +326,7 @@ func (sim *simulator) processBlock(ctx context.Context, block *simBlock, header,
 		}
 		callResults[i] = callRes
 	}
-	header.GasUsed = gasUsed
+	header.GasUsed = blockGasUsed
 	if sim.chainConfig.IsCancun(header.Number, header.Time) {
 		header.BlobGasUsed = &blobGasUsed
 	}


### PR DESCRIPTION
## Summary

- Separates post-refund gas (for receipt `CumulativeGasUsed`) from pre-refund gas (for block `header.GasUsed`) in EIP-7778 (Block Gas Accounting Without Refunds)
- `ApplyTransactionWithEVM` now returns `(receipt, blockGasUsed, error)` — receipt uses post-refund gas, `blockGasUsed` uses pre-refund for Amsterdam
- All callers updated: state_processor, chain_makers, parallel_state_processor, miner/worker, t8ntool, simulate, tracers

## Problem

EIP-7778 requires block-level gas to exclude refunds, but receipts must continue using post-refund `CumulativeGasUsed`. The previous fix changed `state_transition.go` to return `MaxUsedGas` (pre-refund), but this single value was used for **both** block gas and receipt gas, causing receipt root hash mismatches when validating blocks from other clients (e.g., Besu).

## Test plan

- [x] Tested locally with Kurtosis: lighthouse+geth supernode + lodestar+besu×2
- [x] Verified geth and besu agree on block hashes through 100+ slots with spamoor transactions (evm-fuzz, eoatx, uniswap-swaps)
- [x] No receipt root hash mismatches after the fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)