### PR TITLE
signer/core: preallocate address slice capacity in List

### DIFF
--- a/signer/core/api.go
+++ b/signer/core/api.go
@@ -400,7 +400,7 @@ func (api *SignerAPI) List(ctx context.Context) ([]common.Address, error) {
 	if result.Accounts == nil {
 		return nil, ErrRequestDenied
 	}
-	addresses := make([]common.Address, 0)
+	addresses := make([]common.Address, 0, len(result.Accounts))
 	for _, acc := range result.Accounts {
 		addresses = append(addresses, acc.Address)
 	}


### PR DESCRIPTION
Preallocates the `addresses` slice with known capacity in `SignerAPI.List()` to avoid unnecessary memory reallocations during append operations.
