### PR TITLE
fix eip-7778 in the miner and BAL parallel state processor

### DIFF
--- a/core/state_processor.go
+++ b/core/state_processor.go
@@ -108,16 +108,9 @@ func (p *StateProcessor) Process(block *types.Block, statedb *state.StateDB, cfg
 		if err != nil {
 			return nil, fmt.Errorf("could not apply tx %d [%v]: %w", i, tx.Hash().Hex(), err)
 		}
-		usedGas += receipt.GasUsed
+		usedGas += receipt.BlockGasUsed
 		receipts = append(receipts, receipt)
 		allLogs = append(allLogs, receipt.Logs...)
-
-		/*
-			enc, _ := json.MarshalIndent(receipt, "", "    ")
-			fmt.Printf("receipt json %s\n", string(enc))
-			encRLP, _ := rlp.EncodeToBytes(receipt)
-			fmt.Printf("receipt rlp %x\n", encRLP)
-		*/
 	}
 
 	// Read requests if Prague is enabled.
@@ -210,10 +203,11 @@ func MakeReceipt(evm *vm.EVM, result *ExecutionResult, statedb *state.StateDB, b
 		receipt.Status = types.ReceiptStatusSuccessful
 	}
 	receipt.TxHash = tx.Hash()
+	receipt.GasUsed = result.UsedGas
 	if evm.ChainConfig().IsAmsterdam(blockNumber, blockTime) {
-		receipt.GasUsed = result.MaxUsedGas
+		receipt.BlockGasUsed = result.MaxUsedGas
 	} else {
-		receipt.GasUsed = result.UsedGas
+		receipt.BlockGasUsed = result.UsedGas
 	}
 
 	if tx.Type() == types.BlobTxType {

--- a/core/state_transition.go
+++ b/core/state_transition.go
@@ -33,7 +33,7 @@ import (
 // ExecutionResult includes all output after executing given evm
 // message no matter the execution itself is successful or not.
 type ExecutionResult struct {
-	UsedGas    uint64 // Total used gas, not including the refunded gas
+	UsedGas    uint64 // Total gas used, with refunds subtracted
 	MaxUsedGas uint64 // Maximum gas consumed during execution, excluding gas refunds.
 	Err        error  // Any error encountered during the execution(listed in core/vm/errors.go)
 	ReturnData []byte // Returned data from evm(function result or data supplied with revert opcode)

--- a/core/types/receipt.go
+++ b/core/types/receipt.go
@@ -63,6 +63,7 @@ type Receipt struct {
 	TxHash            common.Hash    `json:"transactionHash" gencodec:"required"`
 	ContractAddress   common.Address `json:"contractAddress"`
 	GasUsed           uint64         `json:"gasUsed" gencodec:"required"`
+	BlockGasUsed      uint64         `json:"blockGasUsed"`
 	EffectiveGasPrice *big.Int       `json:"effectiveGasPrice"` // required, but tag omitted for backwards compatibility
 	BlobGasUsed       uint64         `json:"blobGasUsed,omitempty"`
 	BlobGasPrice      *big.Int       `json:"blobGasPrice,omitempty"`


### PR DESCRIPTION
alternative to https://github.com/ethereum/go-ethereum/pull/33754

Adds an extra non-consensus field on the `Receipt`: `BlockGasUsed`.  This reflects the gas used as it counts towards the block gas limit, whereas the existing field `GasUsed` is the consensus field: the gas used with refunds subtracted.

Changes an incorrect comment describing the field `ExecutionResult.UsedGas`.