### PR TITLE
internal: implement BatchGetStorageAt

### DIFF
--- a/internal/web3ext/web3ext.go
+++ b/internal/web3ext/web3ext.go
@@ -416,6 +416,11 @@ web3._extend({
 			params: 5,
 		}),
 		new web3._extend.Method({
+			name: 'batchGetStorageAt',
+			call: 'debug_batchGetStorageAt',
+			params: 3,
+		}),
+		new web3._extend.Method({
 			name: 'getModifiedAccountsByNumber',
 			call: 'debug_getModifiedAccountsByNumber',
 			params: 2,


### PR DESCRIPTION
Similar to ```GetStorageAt``` , follows the same convention added an additional method now called ```BatchGetStorageAt``` to fetch multiple slots from a address using a single call to avoid overhead of repeated calls.