### PR TITLE
core/types/bal: change code change type to list

### DIFF
--- a/core/types/bal/bal_encoding_rlp_generated.go
+++ b/core/types/bal/bal_encoding_rlp_generated.go
@@ -49,7 +49,7 @@ func (obj *BlockAccessList) EncodeRLP(_w io.Writer) error {
 		}
 		w.ListEnd(_tmp15)
 		_tmp18 := w.List()
-		for _, _tmp19 := range _tmp2.Code {
+		for _, _tmp19 := range _tmp2.CodeChanges {
 			_tmp20 := w.List()
 			w.WriteUint64(uint64(_tmp19.TxIndex))
 			w.WriteBytes(_tmp19.Code)
@@ -228,13 +228,13 @@ func (obj *BlockAccessList) DecodeRLP(dec *rlp.Stream) error {
 					return err
 				}
 				_tmp2.NonceChanges = _tmp17
-				// Code:
-				var _tmp21 []CodeChange
+				// CodeChanges:
+				var _tmp21 []encodingCodeChange
 				if _, err := dec.List(); err != nil {
 					return err
 				}
 				for dec.MoreDataInList() {
-					var _tmp22 CodeChange
+					var _tmp22 encodingCodeChange
 					{
 						if _, err := dec.List(); err != nil {
 							return err
@@ -260,7 +260,7 @@ func (obj *BlockAccessList) DecodeRLP(dec *rlp.Stream) error {
 				if err := dec.ListEnd(); err != nil {
 					return err
 				}
-				_tmp2.Code = _tmp21
+				_tmp2.CodeChanges = _tmp21
 				if err := dec.ListEnd(); err != nil {
 					return err
 				}

--- a/core/types/bal/bal_test.go
+++ b/core/types/bal/bal_test.go
@@ -60,9 +60,8 @@ func makeTestConstructionBAL() *ConstructionBlockAccessList {
 					1: 2,
 					2: 6,
 				},
-				CodeChange: &CodeChange{
-					TxIndex: 0,
-					Code:    common.Hex2Bytes("deadbeef"),
+				CodeChange: map[uint16][]byte{
+					0: common.Hex2Bytes("deadbeef"),
 				},
 			},
 			common.BytesToAddress([]byte{0xff, 0xff, 0xff}): {
@@ -84,6 +83,9 @@ func makeTestConstructionBAL() *ConstructionBlockAccessList {
 				},
 				NonceChanges: map[uint16]uint64{
 					1: 2,
+				},
+				CodeChange: map[uint16][]byte{
+					0: common.Hex2Bytes("deadbeef"),
 				},
 			},
 		},
@@ -179,7 +181,7 @@ func makeTestAccountAccess(sort bool) AccountAccess {
 		StorageReads:   storageReads,
 		BalanceChanges: balances,
 		NonceChanges:   nonces,
-		Code: []CodeChange{
+		CodeChanges: []encodingCodeChange{
 			{
 				TxIndex: 100,
 				Code:    testrand.Bytes(256),


### PR DESCRIPTION
To align with the latest spec of EIP-7928:

```
# CodeChange: [block_access_index, new_code]
CodeChange = [BlockAccessIndex, Bytecode]
```