### PR TITLE
core/rawdb: close freezer table in InspectFreezerTable

### DIFF
--- a/core/rawdb/ancient_utils.go
+++ b/core/rawdb/ancient_utils.go
@@ -166,6 +166,7 @@ func InspectFreezerTable(ancient string, freezerName string, tableName string, s
 	if err != nil {
 		return err
 	}
+	defer table.Close()
 	table.dumpIndexStdout(start, end)
 	return nil
 }


### PR DESCRIPTION
`InspectFreezerTable`https://github.com/ethereum/go-ethereum/blob/ad459f4fac247e066d7b0514a215b32b400d4cf0/core/rawdb/ancient_utils.go#L138-L171 opens a `freezerTable`https://github.com/ethereum/go-ethereum/blob/ad459f4fac247e066d7b0514a215b32b400d4cf0/core/rawdb/freezer_table.go#L89-L125 via `newFreezerTable`https://github.com/ethereum/go-ethereum/blob/ad459f4fac247e066d7b0514a215b32b400d4cf0/core/rawdb/freezer_table.go#L128-L131 but never closes it. Since `freezerTable` holds multiple open `*os.File` descriptors (index, head, data files), this leaks file descriptors on every call.

Add defer `table.Close()`https://github.com/ethereum/go-ethereum/blob/ad459f4fac247e066d7b0514a215b32b400d4cf0/core/rawdb/freezer_table.go#L839-L868 after the table is successfully opened.