### PR TITLE
perf(core/vm): preallocate extraEips slice to eliminate reallocations

### DIFF
--- a/core/vm/evm.go
+++ b/core/vm/evm.go
@@ -176,7 +176,7 @@ func NewEVM(blockCtx BlockContext, statedb StateDB, chainConfig *params.ChainCon
 	default:
 		evm.table = &frontierInstructionSet
 	}
-	var extraEips []int
+	extraEips := make([]int, 0, len(evm.Config.ExtraEips))
 	if len(evm.Config.ExtraEips) > 0 {
 		// Deep-copy jumptable to prevent modification of opcodes in other tables
 		evm.table = copyJumpTable(evm.table)


### PR DESCRIPTION
Preallocates the `extraEips` slice capacity in `NewEVM()` to eliminate repeated reallocations during EIP activation loop.