### PR TITLE
core/vm: add missing PUSH0 handler in EIP-8024 test mini-interpreter

### DIFF
--- a/core/vm/instructions_test.go
+++ b/core/vm/instructions_test.go
@@ -1149,6 +1149,8 @@ func TestEIP8024_Execution(t *testing.T) {
 					_, err = opJumpdest(&pc, evm, scope)
 				case ISZERO:
 					_, err = opIszero(&pc, evm, scope)
+				case PUSH0:
+					_, err = opPush0(&pc, evm, scope)
 				case DUPN:
 					_, err = opDupN(&pc, evm, scope)
 				case SWAPN:


### PR DESCRIPTION
The UNDERFLOW_DUPN and UNDERFLOW_SWAPN test cases in TestEIP8024_Execution used PUSH0 (0x5f) to fill the stack, but the test's mini-interpreter had no case for PUSH0. The first 0x5f byte hit the default branch and returned ErrInvalidOpCode immediately — so the tests passed (wantErr: true) but never actually reached the DUPN/SWAPN instruction and never tested stack underflow.

Added `case PUSH0: opPush0()` to the mini-interpreter switch so these tests now exercise the intended underflow path.