### PR TITLE
eth/api: report syncing on startup until CL sends first update

### DIFF
--- a/eth/api_backend.go
+++ b/eth/api_backend.go
@@ -418,6 +418,9 @@ func (b *EthAPIBackend) SyncProgress(ctx context.Context) ethereum.SyncProgress 
 	if err == nil {
 		prog.StateIndexRemaining = remain
 	}
+	// SyncedWithCL is true when the node has received at least one successful
+	// ForkchoiceUpdated from the consensus layer with a known block.
+	prog.SyncedWithCL = b.eth.Synced()
 	return prog
 }
 


### PR DESCRIPTION
## Summary

This PR fixes an issue where geth reports "synced" via `eth_syncing` RPC immediately on startup even before receiving any blocks from the consensus layer (CL). This causes problems for:
- HAProxy and other load balancers that route requests to out-of-sync nodes
- L2 nodes that require a synced L1 to function properly

## Root Cause

The `SyncProgress.Done()` method only checks if `CurrentBlock >= HighestBlock`, which is true on startup before any CL communication. The node reports "synced" immediately even though:
1. It hasn't received any blocks from the CL yet
2. It may be behind the actual chain head

## Solution

Following the suggestion from @jwasinger and @MariusVanDerWijden:
> "we hardcode the node to report unsynced on startup and only change to synced once we learn about a new block"

**Changes:**
1. Added `SyncedWithCL` field to `SyncProgress` struct in `interfaces.go`
2. Modified `SyncProgress.Done()` to require `SyncedWithCL == true`
3. Updated `EthAPIBackend.SyncProgress()` to set `prog.SyncedWithCL = b.eth.Synced()`

The existing `handler.synced` atomic flag (set when ForkchoiceUpdated succeeds with a known block) is now exposed through the sync progress.

## Test plan

- [x] Existing tests pass (`go test ./eth/...`)
- [x] The implementation leverages the existing `handler.synced` flag which is already correctly managed

## Considerations

- **Pre-merge networks**: On networks without CL, behavior may differ. However, post-merge this is the expected behavior.
- **Backward compatibility**: The `SyncedWithCL` field defaults to `false`, which is the safe (syncing) state.

Fixes #33687

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)