### PR TITLE
core, eth: add new subscribe function for tx hashes

### DIFF
--- a/core/events.go
+++ b/core/events.go
@@ -26,6 +26,16 @@ import (
 // NewTxsEvent is posted when a batch of transactions enter the transaction pool.
 type NewTxsEvent struct{ Txs []*types.Transaction }
 
+type NewTxHashesEvent struct{ Hashes []common.Hash }
+
+func NewTxHashesEventFromTxs(txs []*types.Transaction) NewTxHashesEvent {
+	hashes := make([]common.Hash, 0, len(txs))
+	for _, tx := range txs {
+		hashes = append(hashes, tx.Hash())
+	}
+	return NewTxHashesEvent{Hashes: hashes}
+}
+
 // RemovedLogsEvent is posted when a reorg happens
 type RemovedLogsEvent struct{ Logs []*types.Log }
 

--- a/core/txpool/blobpool/lookup.go
+++ b/core/txpool/blobpool/lookup.go
@@ -87,7 +87,6 @@ func (l *lookup) senderOfTx(txhash common.Hash) (common.Address, bool) {
 		return common.Address{}, false
 	}
 	return meta.sender, true
-
 }
 
 // track inserts a new set of mappings from blob versioned hashes to transaction

--- a/core/txpool/blobpool/lookup.go
+++ b/core/txpool/blobpool/lookup.go
@@ -21,8 +21,9 @@ import (
 )
 
 type txMetadata struct {
-	id   uint64 // the billy id of transction
-	size uint64 // the RLP encoded size of transaction (blobs are included)
+	id     uint64 // the billy id of transction
+	size   uint64 // the RLP encoded size of transaction (blobs are included)
+	sender common.Address
 }
 
 // lookup maps blob versioned hashes to transaction hashes that include them,
@@ -79,6 +80,16 @@ func (l *lookup) sizeOfTx(txhash common.Hash) (uint64, bool) {
 	return meta.size, true
 }
 
+// senderOfTx returns sender of transaction
+func (l *lookup) senderOfTx(txhash common.Hash) (common.Address, bool) {
+	meta, ok := l.txIndex[txhash]
+	if !ok {
+		return common.Address{}, false
+	}
+	return meta.sender, true
+
+}
+
 // track inserts a new set of mappings from blob versioned hashes to transaction
 // hashes; and from transaction hashes to datastore storage item ids.
 func (l *lookup) track(tx *blobTxMeta) {
@@ -91,8 +102,9 @@ func (l *lookup) track(tx *blobTxMeta) {
 	}
 	// Map the transaction hash to the datastore id and RLP-encoded transaction size
 	l.txIndex[tx.hash] = &txMetadata{
-		id:   tx.id,
-		size: tx.size,
+		id:     tx.id,
+		size:   tx.size,
+		sender: tx.sender,
 	}
 }
 

--- a/core/txpool/subpool.go
+++ b/core/txpool/subpool.go
@@ -86,8 +86,11 @@ type PendingFilter struct {
 
 // TxMetadata denotes the metadata of a transaction.
 type TxMetadata struct {
-	Type uint8  // The type of the transaction
-	Size uint64 // The length of the 'rlp encoding' of a transaction
+	Type   uint8          // The type of the transaction
+	Size   uint64         // The length of the 'rlp encoding' of a transaction
+	Sender common.Address // The sender of the transaction.
+	//TODO: This is only for the broadcast decision. can we use something else for this ?
+	//TODO: Legacypool would have to resolve this every time GetMetadata() is called.
 }
 
 // SubPool represents a specialized transaction pool that lives on its own (e.g.
@@ -157,9 +160,13 @@ type SubPool interface {
 	Pending(filter PendingFilter) map[common.Address][]*LazyTransaction
 
 	// SubscribeTransactions subscribes to new transaction events. The subscriber
-	// can decide whether to receive notifications only for newly seen transactions
-	// or also for reorged out ones.
-	SubscribeTransactions(ch chan<- core.NewTxsEvent, reorgs bool) event.Subscription
+	// would receive only newly seen transactions.
+	SubscribeTransactions(ch chan<- core.NewTxsEvent) event.Subscription
+
+	// SubscribePropagationHashes subscribes to transaction hashes events, especially
+	// the ones to be propagated. This includes newly seen transactions and reorged
+	// transactions.
+	SubscribePropagationHashes(ch chan<- core.NewTxHashesEvent) event.Subscription
 
 	// Nonce returns the next nonce of an account, with all transactions executable
 	// by the pool already applied on top.

--- a/core/txpool/txpool.go
+++ b/core/txpool/txpool.go
@@ -371,10 +371,18 @@ func (p *TxPool) Pending(filter PendingFilter) map[common.Address][]*LazyTransac
 
 // SubscribeTransactions registers a subscription for new transaction events,
 // supporting feeding only newly seen or also resurrected transactions.
-func (p *TxPool) SubscribeTransactions(ch chan<- core.NewTxsEvent, reorgs bool) event.Subscription {
+func (p *TxPool) SubscribeTransactions(ch chan<- core.NewTxsEvent) event.Subscription {
 	subs := make([]event.Subscription, len(p.subpools))
 	for i, subpool := range p.subpools {
-		subs[i] = subpool.SubscribeTransactions(ch, reorgs)
+		subs[i] = subpool.SubscribeTransactions(ch)
+	}
+	return p.subs.Track(event.JoinSubscriptions(subs...))
+}
+
+func (p *TxPool) SubscribePropagationHashes(ch chan<- core.NewTxHashesEvent) event.Subscription {
+	subs := make([]event.Subscription, len(p.subpools))
+	for i, subpool := range p.subpools {
+		subs[i] = subpool.SubscribePropagationHashes(ch)
 	}
 	return p.subs.Track(event.JoinSubscriptions(subs...))
 }

--- a/eth/api_backend.go
+++ b/eth/api_backend.go
@@ -405,7 +405,7 @@ func (b *EthAPIBackend) TxPool() *txpool.TxPool {
 }
 
 func (b *EthAPIBackend) SubscribeNewTxsEvent(ch chan<- core.NewTxsEvent) event.Subscription {
-	return b.eth.txPool.SubscribeTransactions(ch, true)
+	return b.eth.txPool.SubscribeTransactions(ch)
 }
 
 func (b *EthAPIBackend) SyncProgress(ctx context.Context) ethereum.SyncProgress {

--- a/eth/catalyst/simulated_beacon_api.go
+++ b/eth/catalyst/simulated_beacon_api.go
@@ -48,7 +48,7 @@ func (a *simulatedBeaconAPI) loop() {
 	var (
 		newTxs    = make(chan core.NewTxsEvent)
 		newWxs    = make(chan newWithdrawalsEvent)
-		newTxsSub = a.sim.eth.TxPool().SubscribeTransactions(newTxs, true)
+		newTxsSub = a.sim.eth.TxPool().SubscribeTransactions(newTxs)
 		newWxsSub = a.sim.withdrawals.subscribe(newWxs)
 		doCommit  = make(chan struct{}, 1)
 	)

--- a/eth/handler.go
+++ b/eth/handler.go
@@ -91,7 +91,11 @@ type txPool interface {
 	// SubscribeTransactions subscribes to new transaction events. The subscriber
 	// can decide whether to receive notifications only for newly seen transactions
 	// or also for reorged out ones.
-	SubscribeTransactions(ch chan<- core.NewTxsEvent, reorgs bool) event.Subscription
+	// TODO: comment
+	SubscribeTransactions(ch chan<- core.NewTxsEvent) event.Subscription
+
+	// TODO: comment
+	SubscribePropagationHashes(ch chan<- core.NewTxHashesEvent) event.Subscription
 
 	// FilterType returns whether the given tx type is supported by the txPool.
 	FilterType(kind byte) bool
@@ -127,7 +131,7 @@ type handler struct {
 	txBroadcastKey [16]byte
 
 	eventMux   *event.TypeMux
-	txsCh      chan core.NewTxsEvent
+	txsCh      chan core.NewTxHashesEvent
 	txsSub     event.Subscription
 	blockRange *blockRangeState
 
@@ -416,8 +420,8 @@ func (h *handler) Start(maxPeers int) {
 
 	// broadcast and announce transactions (only new ones, not resurrected ones)
 	h.wg.Add(1)
-	h.txsCh = make(chan core.NewTxsEvent, txChanSize)
-	h.txsSub = h.txpool.SubscribeTransactions(h.txsCh, false)
+	h.txsCh = make(chan core.NewTxHashesEvent, txChanSize)
+	h.txsSub = h.txpool.SubscribePropagationHashes(h.txsCh)
 	go h.txBroadcastLoop()
 
 	// broadcast block range
@@ -457,7 +461,7 @@ func (h *handler) Stop() {
 // - To a square root of all peers for non-blob transactions
 // - And, separately, as announcements to all peers which are not known to
 // already have the given transaction.
-func (h *handler) BroadcastTransactions(txs types.Transactions) {
+func (h *handler) BroadcastTransactions(txs []common.Hash) {
 	var (
 		blobTxs  int // Number of blob transactions to announce only
 		largeTxs int // Number of large transactions to announce only
@@ -468,35 +472,34 @@ func (h *handler) BroadcastTransactions(txs types.Transactions) {
 		txset = make(map[*ethPeer][]common.Hash) // Set peer->hash to transfer directly
 		annos = make(map[*ethPeer][]common.Hash) // Set peer->hash to announce
 
-		signer = types.LatestSigner(h.chain.Config())
 		choice = newBroadcastChoice(h.nodeID, h.txBroadcastKey)
 		peers  = h.peers.all()
 	)
 
 	for _, tx := range txs {
 		var directSet map[*ethPeer]struct{}
+		meta := h.txpool.GetMetadata(tx)
 		switch {
-		case tx.Type() == types.BlobTxType:
+		case meta.Type == types.BlobTxType:
 			blobTxs++
-		case tx.Size() > txMaxBroadcastSize:
+		case meta.Size > txMaxBroadcastSize:
 			largeTxs++
 		default:
 			// Get transaction sender address. Here we can ignore any error
 			// since we're just interested in any value.
-			txSender, _ := types.Sender(signer, tx)
-			directSet = choice.choosePeers(peers, txSender)
+			directSet = choice.choosePeers(peers, meta.Sender)
 		}
 
 		for _, peer := range peers {
-			if peer.KnownTransaction(tx.Hash()) {
+			if peer.KnownTransaction(tx) {
 				continue
 			}
 			if _, ok := directSet[peer]; ok {
 				// Send direct.
-				txset[peer] = append(txset[peer], tx.Hash())
+				txset[peer] = append(txset[peer], tx)
 			} else {
 				// Send announcement.
-				annos[peer] = append(annos[peer], tx.Hash())
+				annos[peer] = append(annos[peer], tx)
 			}
 		}
 	}
@@ -519,7 +522,7 @@ func (h *handler) txBroadcastLoop() {
 	for {
 		select {
 		case event := <-h.txsCh:
-			h.BroadcastTransactions(event.Txs)
+			h.BroadcastTransactions(event.Hashes)
 		case <-h.txsSub.Err():
 			return
 		}

--- a/eth/handler_eth_test.go
+++ b/eth/handler_eth_test.go
@@ -237,8 +237,8 @@ func testRecvTransactions(t *testing.T, protocol uint) {
 
 	handler.handler.synced.Store(true) // mark synced to accept transactions
 
-	txs := make(chan core.NewTxsEvent)
-	sub := handler.txpool.SubscribeTransactions(txs, false)
+	txs := make(chan core.NewTxHashesEvent)
+	sub := handler.txpool.SubscribePropagationHashes(txs)
 	defer sub.Unsubscribe()
 
 	// Create a source peer to send messages through and a sink handler to receive them
@@ -267,10 +267,10 @@ func testRecvTransactions(t *testing.T, protocol uint) {
 	}
 	select {
 	case event := <-txs:
-		if len(event.Txs) != 1 {
-			t.Errorf("wrong number of added transactions: got %d, want 1", len(event.Txs))
-		} else if event.Txs[0].Hash() != tx.Hash() {
-			t.Errorf("added wrong tx hash: got %v, want %v", event.Txs[0].Hash(), tx.Hash())
+		if len(event.Hashes) != 1 {
+			t.Errorf("wrong number of added transactions: got %d, want 1", len(event.Hashes))
+		} else if event.Hashes[0] != tx.Hash() {
+			t.Errorf("added wrong tx hash: got %v, want %v", event.Hashes[0], tx.Hash())
 		}
 	case <-time.After(2 * time.Second):
 		t.Errorf("no NewTxsEvent received within 2 seconds")
@@ -398,7 +398,7 @@ func testTransactionPropagation(t *testing.T, protocol uint) {
 	for i := 0; i < len(sinks); i++ {
 		txChs[i] = make(chan core.NewTxsEvent, 1024)
 
-		sub := sinks[i].txpool.SubscribeTransactions(txChs[i], false)
+		sub := sinks[i].txpool.SubscribeTransactions(txChs[i])
 		defer sub.Unsubscribe()
 	}
 	// Fill the source pool with transactions and wait for them at the sinks


### PR DESCRIPTION
This PR adds a new subscribe function to txpool that emits events for tx hashes that are targeted for propagation.

Previously, `SubscribeTransactions` was shared with other parts and the distinction was made using a reorg flag. But as propagation strategies are expected to become more complex, introducing a dedicated function seems to be preferable. For example, under certain propagation strategies, blob transactions may not be propagated immediately after being stored, but propagated later under certain conditions. In such cases, reusing the same type of event stream would require `Get`, which is not optimal given that blob transactions can be propagated using metadata alone.

I considered alternative designs, for example using interface but the event feed appears to compare concrete types. Using generics was also not viable, since type parameters in method are not supported, preventing integration with subpool interface.

Additional comments should be added, but I am opening the PR first since I don't think I could work on this later today...