### PR TITLE
core/rawdb: fix incorrect tail value in unindexTransactions log output

### DIFF
--- a/core/rawdb/chain_iterator.go
+++ b/core/rawdb/chain_iterator.go
@@ -357,9 +357,9 @@ func unindexTransactions(db ethdb.Database, from uint64, to uint64, interrupt ch
 	}
 	select {
 	case <-interrupt:
-		logger("Transaction unindexing interrupted", "blocks", blocks, "txs", txs, "tail", to, "elapsed", common.PrettyDuration(time.Since(start)))
+		logger("Transaction unindexing interrupted", "blocks", blocks, "txs", txs, "tail", nextNum, "elapsed", common.PrettyDuration(time.Since(start)))
 	default:
-		logger("Unindexed transactions", "blocks", blocks, "txs", txs, "tail", to, "elapsed", common.PrettyDuration(time.Since(start)))
+		logger("Unindexed transactions", "blocks", blocks, "txs", txs, "tail", nextNum, "elapsed", common.PrettyDuration(time.Since(start)))
 	}
 }
 


### PR DESCRIPTION
The log messages at the end of unindexTransactions were using `to` instead of `nextNum` for the tail value. When the process gets interrupted, this reports the target tail rather than the actual tail written to the database, which is misleading. The counterpart indexTransactions already does this correctly with lastNum.

For example, when unindexing blocks [5, 10) and the process gets interrupted after block 7:
- Database writes: WriteTxIndexTail(batch, 8)  // nextNum = 8
- Log printed:     "tail", 10                   // to = 10 (wrong)
- Should print:    "tail", 8                    // nextNum = 8

Before:
```
  logger("Transaction unindexing interrupted", ..., "tail", to, ...)
  logger("Unindexed transactions", ..., "tail", to, ...)
```

After:
```
  logger("Transaction unindexing interrupted", ..., "tail", nextNum, ...)
  logger("Unindexed transactions", ..., "tail", nextNum, ...)
```
