### PR TITLE
core/rawdb: close directory fd on Readdirnames error in cleanup

### DIFF
--- a/core/rawdb/freezer_resettable.go
+++ b/core/rawdb/freezer_resettable.go
@@ -221,12 +221,11 @@ func cleanup(path string) error {
 	if err != nil {
 		return err
 	}
+	defer dir.Close()
+
 	names, err := dir.Readdirnames(0)
 	if err != nil {
 		return err
-	}
-	if cerr := dir.Close(); cerr != nil {
-		return cerr
 	}
 	for _, name := range names {
 		if name == filepath.Base(path)+tmpSuffix {


### PR DESCRIPTION
If Readdirnames returns an error in cleanup(), the opened directory file descriptor is never closed — the manual dir.Close() call sits
below the early return and is unreachable on that path.

Replaced the manual Close with defer dir.Close() right after os.Open so the descriptor is always released regardless of the exit path.