### PR TITLE
miner: abstract txpool from miner

### DIFF
--- a/miner/miner.go
+++ b/miner/miner.go
@@ -40,6 +40,11 @@ type Backend interface {
 	TxPool() *txpool.TxPool
 }
 
+// TxPool wraps all methods required for mining from the txPool.
+type TxPool interface {
+	Pending(filter txpool.PendingFilter) map[common.Address][]*txpool.LazyTransaction
+}
+
 // Config is the configuration parameters of mining.
 type Config struct {
 	Etherbase           common.Address `toml:"-"`          // Deprecated
@@ -70,7 +75,7 @@ type Miner struct {
 	config      *Config
 	chainConfig *params.ChainConfig
 	engine      consensus.Engine
-	txpool      *txpool.TxPool
+	txpool      TxPool
 	prio        []common.Address // A list of senders to prioritize
 	chain       *core.BlockChain
 	pending     *pending


### PR DESCRIPTION
fixes #33762 

Open for discussions on this , Thought thru the soln for a bit 

1) decoupled the *txpool.Txpool from miner to abstract how txn are being fed in from test 
2) Created a mock Txpool and for tests also used payload envelope.resolveFull() to wait until the payload is ready 

More to add:

 I guess the req was to make this adapt to blockchain_test.go , I just wanted to chk whether this approach is good , if yes in a follow up PR will adapt these change in blockchain_test.go .  This PR  is just to ensure testing block production in miner while abstracting txpool
 
 cc: @jwasinger 