### PR TITLE
eth/tracers: add bounds validation to MemoryPtr utility function

### DIFF
--- a/eth/tracers/internal/util.go
+++ b/eth/tracers/internal/util.go
@@ -69,6 +69,12 @@ func MemoryPtr(m []byte, offset, size int64) []byte {
 		return nil
 	}
 
+	if offset < 0 || size < 0 {
+		return nil
+	}
+	if offset+size > int64(len(m)) {
+		return nil
+	}
 	if len(m) > int(offset) {
 		return m[offset : offset+size]
 	}


### PR DESCRIPTION
This PR adds defensive bounds checking to the MemoryPtr utility function to prevent potential panics when slicing memory with invalid parameters.