### PR TITLE
trie: fix embedded node size validation

### DIFF
--- a/trie/node.go
+++ b/trie/node.go
@@ -225,7 +225,7 @@ func decodeRef(buf []byte) (node, []byte, error) {
 	case kind == rlp.List:
 		// 'embedded' node reference. The encoding must be smaller
 		// than a hash in order to be valid.
-		if size := len(buf) - len(rest); size > hashLen {
+		if size := len(buf) - len(rest); size >= hashLen {
 			err := fmt.Errorf("oversized embedded node (size is %d bytes, want size < %d)", size, hashLen)
 			return nil, buf, err
 		}


### PR DESCRIPTION
The `decodeRef` function used `size > hashLen` to reject oversized embedded nodes, but this incorrectly allowed nodes of exactly 32 bytes through. The encoding side (hasher.go, stacktrie.go) consistently uses `len(enc) < 32` to decide whether to embed a node inline, meaning nodes of 32+ bytes are always hash-referenced. The error message itself already stated `want size < 32`, confirming the intended threshold.
Changed `size > hashLen` to `size >= hashLen` in `decodeRef` to align the decoding validation with the encoding logic, the Yellow Paper spec, and the surrounding comments.