### PR TITLE
ethdb/pebble: fix CompactionDebtConcurrency comment

### DIFF
--- a/ethdb/pebble/pebble.go
+++ b/ethdb/pebble/pebble.go
@@ -307,7 +307,7 @@ func New(file string, cache int, handles int, namespace string, readonly bool) (
 	// These two settings define the conditions under which compaction concurrency
 	// is increased. Specifically, one additional compaction job will be enabled when:
 	// - there is one more overlapping sub-level0;
-	// - there is an additional 512 MB of compaction debt;
+	// - there is an additional 256 MB of compaction debt;
 	//
 	// The maximum concurrency is still capped by MaxConcurrentCompactions, but with
 	// these settings compactions can scale up more readily.


### PR DESCRIPTION
opuss, find a comment mistake.

Comment says 512 MB but the code is 1 << 28 which is 256 MB. Looks like it was wrong since the setting was first introduced in #33353.