### PR TITLE
core/txpool/blobpool: return `txpool.ErrUnderpriced` on eviction 

### DIFF
--- a/core/txpool/blobpool/blobpool.go
+++ b/core/txpool/blobpool/blobpool.go
@@ -1476,17 +1476,13 @@ func (p *BlobPool) AvailableBlobs(vhashes []common.Hash) int {
 // Add inserts a set of blob transactions into the pool if they pass validation (both
 // consensus validity and pool restrictions).
 func (p *BlobPool) Add(txs []*types.Transaction, sync bool) []error {
-	var (
-		errs = make([]error, len(txs))
-		adds = make([]*types.Transaction, 0, len(txs))
-	)
+	errs := make([]error, len(txs))
+
 	for i, tx := range txs {
 		if errs[i] = p.ValidateTxBasics(tx); errs[i] != nil {
 			continue
 		}
-		if errs[i] = p.add(tx); errs[i] == nil {
-			adds = append(adds, tx.WithoutBlobTxSidecar())
-		}
+		errs[i] = p.add(tx)
 	}
 	return errs
 }


### PR DESCRIPTION
In the blobpool, the `ErrUnderpriced` was handled as one the possible result of validateTx(), but there was no actual path in which this error can be returned. What I understand from its usage in the legacypool is that, this `ErrUnderpriced` error is intended to be returned when the pool is full and a newly added transaction is the least attractive one (the eviction target).

In such case, the current blobpool was silently dropping such txs without returning an error. Since this does not provide sufficient notification to the user, this PR changes blobpool to explicitly return error.

We can also introduce new check to detect this case earlier in the future to reduce disk I/O

*I also removed unused variable in add function. Please let me know if this should be done with a separate PR