### PR TITLE
eth: fix targetView==nil case

### DIFF
--- a/eth/backend.go
+++ b/eth/backend.go
@@ -495,6 +495,9 @@ func (s *Ethereum) updateFilterMapsHeads() {
 		if head == nil || newHead.Hash() != head.Hash() {
 			head = newHead
 			chainView := s.newChainView(head)
+			if chainView == nil {
+				return
+			}
 			historyCutoff, _ := s.blockchain.HistoryPruningCutoff()
 			var finalBlock uint64
 			if fb := s.blockchain.CurrentFinalBlock(); fb != nil {


### PR DESCRIPTION
This PR fixes a panic in a corner case situation when a `ChainEvent` is received by `eth.Ethereum.updateFilterMapsHeads()` but the given chain section does not exist in `BlockChain` any more. This can happen during chain rewind because chain events are processed asynchronously. Ignoring the event in this case is ok, the final event will point to the final rewound head and the indexer will be updated.
Note that similar issues will not happen once we transition to https://github.com/ethereum/go-ethereum/pull/32292 and the new indexer built on top of this. Until then, the current fix should be fine.