### PR TITLE
node: http2 for JSON-RPC API

### DIFF
--- a/node/rpcstack.go
+++ b/node/rpcstack.go
@@ -138,6 +138,9 @@ func (h *httpServer) start() error {
 
 	// Initialize the server.
 	h.server = &http.Server{Handler: h}
+	h.server.Protocols = new(http.Protocols)
+	h.server.Protocols.SetHTTP1(true)
+	h.server.Protocols.SetUnencryptedHTTP2(true)
 	if h.timeouts != (rpc.HTTPTimeouts{}) {
 		CheckTimeouts(&h.timeouts)
 		h.server.ReadTimeout = h.timeouts.ReadTimeout

--- a/node/rpcstack_test.go
+++ b/node/rpcstack_test.go
@@ -593,6 +593,38 @@ func TestHTTPWriteTimeout(t *testing.T) {
 	})
 }
 
+func TestHTTP2H2C(t *testing.T) {
+	srv := createAndStartServer(t, &httpConfig{}, false, &wsConfig{}, nil)
+	defer srv.stop()
+
+	// Create an HTTP/2 cleartext client.
+	transport := &http.Transport{}
+	transport.Protocols = new(http.Protocols)
+	transport.Protocols.SetUnencryptedHTTP2(true)
+	client := &http.Client{Transport: transport}
+
+	body := strings.NewReader(`{"jsonrpc":"2.0","id":1,"method":"rpc_modules","params":[]}`)
+	resp, err := client.Post("http://"+srv.listenAddr(), "application/json", body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != 200 {
+		t.Fatalf("expected status 200, got %d", resp.StatusCode)
+	}
+	if resp.Proto != "HTTP/2.0" {
+		t.Fatalf("expected HTTP/2.0, got %s", resp.Proto)
+	}
+	result, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(result), "jsonrpc") {
+		t.Fatalf("unexpected response: %s", result)
+	}
+}
+
 func apis() []rpc.API {
 	return []rpc.API{
 		{


### PR DESCRIPTION
The reasoning for using the cleartext format here is that the JSON-RPC API is internal only. Providers which expose it publicly already put it behind a proxy which handles also the encryption.