### PR TITLE
rpc: count error responses towards batch response size limit

### DIFF
--- a/rpc/batch_limit_test.go
+++ b/rpc/batch_limit_test.go
@@ -1,0 +1,100 @@
+// Copyright 2026 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+
+package rpc
+
+import (
+	"strings"
+	"sync/atomic"
+	"testing"
+)
+
+const bigDataErrorCode = 555
+
+type bigDataError struct {
+	data string
+}
+
+func (e bigDataError) Error() string          { return "big data error" }
+func (e bigDataError) ErrorCode() int         { return bigDataErrorCode }
+func (e bigDataError) ErrorData() interface{} { return e.data }
+
+type bigDataErrorService struct {
+	calls int32
+	data  string
+}
+
+func (s *bigDataErrorService) Fail() error {
+	atomic.AddInt32(&s.calls, 1)
+	return bigDataError{data: s.data}
+}
+
+func TestBatchResponseSizeLimitCountsErrorResponses(t *testing.T) {
+	t.Parallel()
+
+	server := newTestServer()
+	defer server.Stop()
+	server.SetBatchLimits(100, 50)
+
+	svc := &bigDataErrorService{data: strings.Repeat("a", 200)}
+	if err := server.RegisterName("big", svc); err != nil {
+		t.Fatalf("RegisterName: %v", err)
+	}
+
+	client := DialInProc(server)
+	defer client.Close()
+
+	batch := make([]BatchElem, 5)
+	for i := range batch {
+		batch[i] = BatchElem{Method: "big_fail"}
+	}
+	if err := client.BatchCall(batch); err != nil {
+		t.Fatalf("BatchCall: %v", err)
+	}
+
+	if got := atomic.LoadInt32(&svc.calls); got != 1 {
+		t.Fatalf("expected 1 processed call, got %d", got)
+	}
+
+	// The first item was processed and returned the original error.
+	if batch[0].Error == nil {
+		t.Fatal("batch elem 0 missing error")
+	}
+	if re, ok := batch[0].Error.(Error); !ok {
+		t.Fatalf("batch elem 0 wrong error type: %T", batch[0].Error)
+	} else if re.ErrorCode() != bigDataErrorCode {
+		t.Fatalf("batch elem 0 wrong error code: have %d want %d", re.ErrorCode(), bigDataErrorCode)
+	}
+	if de, ok := batch[0].Error.(DataError); !ok {
+		t.Fatalf("batch elem 0 missing error data: %T", batch[0].Error)
+	} else if data, ok := de.ErrorData().(string); !ok || len(data) != len(svc.data) {
+		t.Fatalf("batch elem 0 wrong error data size: have %v want %d", de.ErrorData(), len(svc.data))
+	}
+
+	// Remaining items should return "response too large" without being processed.
+	for i := 1; i < len(batch); i++ {
+		if batch[i].Error == nil {
+			t.Fatalf("batch elem %d missing error", i)
+		}
+		re, ok := batch[i].Error.(Error)
+		if !ok {
+			t.Fatalf("batch elem %d wrong error type: %T", i, batch[i].Error)
+		}
+		if re.ErrorCode() != errcodeResponseTooLarge {
+			t.Fatalf("batch elem %d wrong error code: have %d want %d", i, re.ErrorCode(), errcodeResponseTooLarge)
+		}
+	}
+}

--- a/rpc/handler.go
+++ b/rpc/handler.go
@@ -238,13 +238,7 @@ func (h *handler) handleBatch(msgs []*jsonrpcMessage) {
 			callBuffer.pushResponse(resp)
 			if resp != nil && h.batchResponseMaxSize != 0 {
 				if resp.Error != nil {
-					b, err := json.Marshal(resp.Error)
-					if err != nil {
-						// If we can't marshal the error, don't continue processing further calls.
-						responseBytes = h.batchResponseMaxSize + 1
-					} else {
-						responseBytes += len(b)
-					}
+					responseBytes += resp.Error.encodedSize()
 				} else {
 					responseBytes += len(resp.Result)
 				}

--- a/rpc/json.go
+++ b/rpc/json.go
@@ -24,6 +24,7 @@ import (
 	"fmt"
 	"io"
 	"reflect"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -132,15 +133,19 @@ func errorMessage(err error) *jsonrpcMessage {
 	}
 	de, ok := err.(DataError)
 	if ok {
-		msg.Error.Data = de.ErrorData()
+		data, err := marshalErrorData(de.ErrorData())
+		if err != nil {
+			return errorMessage(&internalServerError{errcodeMarshalError, err.Error()})
+		}
+		msg.Error.Data = data
 	}
 	return msg
 }
 
 type jsonError struct {
-	Code    int         `json:"code"`
-	Message string      `json:"message"`
-	Data    interface{} `json:"data,omitempty"`
+	Code    int             `json:"code"`
+	Message string          `json:"message"`
+	Data    json.RawMessage `json:"data,omitempty"`
 }
 
 func (err *jsonError) Error() string {
@@ -155,7 +160,44 @@ func (err *jsonError) ErrorCode() int {
 }
 
 func (err *jsonError) ErrorData() interface{} {
-	return err.Data
+	if len(err.Data) == 0 {
+		return nil
+	}
+	dec := json.NewDecoder(bytes.NewReader(err.Data))
+	dec.UseNumber()
+
+	var data interface{}
+	if err := dec.Decode(&data); err != nil {
+		return nil
+	}
+	return data
+}
+
+func (err *jsonError) encodedSize() int {
+	size := len(`{"code":`) + len(strconv.Itoa(err.Code)) + len(`,"message":`) + jsonStringSize(err.Message)
+	if len(err.Data) > 0 {
+		size += len(`,"data":`) + len(err.Data)
+	}
+	return size + len(`}`)
+}
+
+func marshalErrorData(data interface{}) (json.RawMessage, error) {
+	if data == nil {
+		return nil, nil
+	}
+	enc, err := json.Marshal(data)
+	if err != nil {
+		return nil, err
+	}
+	return json.RawMessage(enc), nil
+}
+
+func jsonStringSize(s string) int {
+	enc, err := json.Marshal(s)
+	if err != nil {
+		return 0
+	}
+	return len(enc)
 }
 
 // Conn is a subset of the methods of net.Conn which are sufficient for ServerCodec.


### PR DESCRIPTION
Fixes #33814


**Description**

This PR fixes batch response size limit accounting for error responses.

Currently, `(*handler).handleBatch` only adds `len(resp.Result)` to `responseBytes`. For error responses, `resp.Result` is nil, so large `error.data` payloads are not counted and batch responses may exceed `maxResponseSize`.

Changes:

* `rpc/handler.go`: include error responses in `responseBytes` accounting.
* `rpc`: add regression test `TestBatchResponseSizeLimitCountsErrorResponses`.

#### Expected behaviour

When `Server.SetBatchLimits(itemLimit, maxResponseSize)` (or `WithBatchResponseSizeLimit`) is configured, the server should stop processing additional items in a batch once the cumulative response size exceeds `maxResponseSize`.

This limit should apply uniformly to both:

- Successful responses (`result`)
- Error responses (`error`, including `error.data` via `rpc.DataError`)

Once the limit is exceeded, subsequent batch items should return `-32003 (response too large)`.

#### Actual behaviour

In `rpc/handler.go`, `(*handler).handleBatch` only accounts for `len(resp.Result)` when accumulating `responseBytes`.

For error responses:

- `resp.Result` is `nil`
- Large error payloads (especially large `error.data`) are not counted toward `BatchResponseMaxSize`

As a result, batch responses can significantly exceed `maxResponseSize`, and `-32003 (response too large)` is not reliably returned for later batch items.

---

#### Proposed fix

In `rpc/handler.go` (`(*handler).handleBatch`):

* Include error responses in `responseBytes`
* For example, account for the serialized JSON size of `resp.Error`
* Enforce `maxResponseSize` consistently for both success and error responses

Conceptually:

```go
if resp.Error != nil {
    b, _ := json.Marshal(resp.Error)
    responseBytes += len(b)
} else {
    responseBytes += len(resp.Result)
}
```

(Exact implementation details can be refined.)

---

#### Tests

Add a regression test in `rpc/`:

* `TestBatchResponseSizeLimitCountsErrorResponses`
* Verify that large error responses:

  * Contribute to batch size accounting
  * Trigger `-32003`
  * Cause subsequent batch items to return `-32003`

Run with:

```
go test ./rpc
```
