### PR TITLE
triedb/pathdb: fix copy-paste error in version mismatch log

### DIFF
--- a/triedb/pathdb/history_indexer.go
+++ b/triedb/pathdb/history_indexer.go
@@ -741,7 +741,7 @@ func checkVersion(disk ethdb.KeyValueStore, typ historyType) {
 	if err == nil {
 		version = fmt.Sprintf("%d", m.Version)
 	}
-	log.Info("Cleaned up obsolete history index", "type", typ, "version", version, "want", version)
+	log.Info("Cleaned up obsolete history index", "type", typ, "version", version, "want", ver)
 }
 
 // newHistoryIndexer constructs the history indexer and launches the background


### PR DESCRIPTION
Looking at the checkVersion function and noticed the log message has the wrong variable for "want" field

it logs "version", version, "want", version but the wanted version is actually in "ver".

So if a user hits this log, they'd be told the same value twice instead of seeing actual vs expected version. Switched to using ver so the log can't go out of sync again.

Before: INFO "Cleaned up obsolete history index" type=state version=0 want=0
After:  INFO "Cleaned up obsolete history index" type=state version=0 want=1