### PR TITLE
ethdb/leveldb: add logging for database corruption recovery

### DIFF
--- a/ethdb/leveldb/leveldb.go
+++ b/ethdb/leveldb/leveldb.go
@@ -122,7 +122,12 @@ func NewCustom(file string, namespace string, customize func(options *opt.Option
 	// Open the db and recover any potential corruptions
 	db, err := leveldb.OpenFile(file, options)
 	if _, corrupted := err.(*lerrors.ErrCorrupted); corrupted {
+		logger.Error("Database corrupted, attempting recovery", "error", err)
 		db, err = leveldb.RecoverFile(file, nil)
+		if err != nil {
+			return nil, fmt.Errorf("database recovery failed: %w", err)
+		}
+		logger.Warn("Database recovery succeeded")
 	}
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
The corruption recovery path in NewCustom was completely silent — if the DB got corrupted and RecoverFile kicked in, there was zero indication in the logs. This adds error/warn level logging so operators actually know when corruption happens and whether recovery succeeded. Also wraps the recovery failure error to distinguish it from a plain open failure.