### PR TITLE
eth/filters: check history pruning cutoff in GetFilterLogs

### DIFF
--- a/eth/filters/api.go
+++ b/eth/filters/api.go
@@ -532,6 +532,9 @@ func (api *FilterAPI) GetFilterLogs(ctx context.Context, id rpc.ID) ([]*types.Lo
 		if f.crit.ToBlock != nil {
 			end = f.crit.ToBlock.Int64()
 		}
+		if begin >= 0 && begin < int64(api.events.backend.HistoryPruningCutoff()) {
+			return nil, &history.PrunedHistoryError{}
+		}
 		// Construct the range filter
 		filter = api.sys.NewRangeFilter(begin, end, f.crit.Addresses, f.crit.Topics, api.rangeLimit)
 	}


### PR DESCRIPTION
`GetFilterLogs` was missing the `HistoryPruningCutoff` check that `GetLogs` already had. When querying pruned historical logs via `eth_newFilter` + `eth_getFilterLogs`, users would get a vague database error instead of the proper EIP-4444 error. Align the behavior with `GetLogs`.