### PR TITLE
crypto: add hash length check in nocgo VerifySignature

### DIFF
--- a/crypto/signature_nocgo.go
+++ b/crypto/signature_nocgo.go
@@ -103,7 +103,7 @@ func Sign(hash []byte, prv *ecdsa.PrivateKey) ([]byte, error) {
 // The public key should be in compressed (33 bytes) or uncompressed (65 bytes) format.
 // The signature should have the 64 byte [R || S] format.
 func VerifySignature(pubkey, hash, signature []byte) bool {
-	if len(signature) != 64 {
+	if len(signature) != 64 || len(hash) != DigestLength {
 		return false
 	}
 	var r, s secp256k1.ModNScalar


### PR DESCRIPTION
I was tracing a signature verification issue in a nocgo build and found that `VerifySignature` doesn't validate hash length. #33104 added the check to `Sign` and `sigToPub` but missed this one. The cgo path in `secp256k1/secp256.go` already rejects non-32-byte hashes, so the nocgo path should do the same — otherwise a wrong-length hash gets passed to decred's `Verify` and silently gives a bogus result.