### PR TITLE
internal/download: show progress bar only if server gives length

### DIFF
--- a/internal/download/download.go
+++ b/internal/download/download.go
@@ -205,7 +205,10 @@ func (db *ChecksumDB) DownloadFile(url, dstPath string) error {
 	if err != nil {
 		return err
 	}
-	dst := newDownloadWriter(fd, resp.ContentLength)
+	var dst io.WriteCloser = fd
+	if resp.ContentLength > 0 {
+		dst = newDownloadWriter(fd, resp.ContentLength)
+	}
 	_, err = io.Copy(dst, resp.Body)
 	dst.Close()
 	if err != nil {


### PR DESCRIPTION
Fixes this: https://ci.appveyor.com/project/ethereum/go-ethereum/builds/53538177/job/ptosr48pvvwkjskb#L43