### PR TITLE
core/types: fix CopyHeader missing BlockAccessListHash deep copy

### DIFF
--- a/core/types/block.go
+++ b/core/types/block.go
@@ -333,6 +333,10 @@ func CopyHeader(h *Header) *Header {
 		cpy.RequestsHash = new(common.Hash)
 		*cpy.RequestsHash = *h.RequestsHash
 	}
+	if h.BlockAccessListHash != nil {
+		cpy.BlockAccessListHash = new(common.Hash)
+		*cpy.BlockAccessListHash = *h.BlockAccessListHash
+	}
 	if h.SlotNumber != nil {
 		cpy.SlotNumber = new(uint64)
 		*cpy.SlotNumber = *h.SlotNumber


### PR DESCRIPTION
## Summary

`CopyHeader()` deep-copies all pointer-typed header fields (`WithdrawalsHash`, `RequestsHash`, `ParentBeaconRoot`, `SlotNumber`, etc.) but was missing the deep copy for `BlockAccessListHash` added by EIP-7928.

This causes the BAL hash pointer to be shared between the original and the copy, which can lead to data races when headers are concurrently read/modified, and incorrect nil-checks on copied headers (e.g., during light client serving, header caching, or chain reorganization).

The fix adds the standard deep copy pattern matching all other optional hash fields.