### PR TITLE
eth/tracers: align `traceBlockParallel` prestate with block pre-exec system calls

### DIFF
--- a/eth/tracers/api.go
+++ b/eth/tracers/api.go
@@ -692,6 +692,12 @@ func (api *API) traceBlockParallel(ctx context.Context, block *types.Block, stat
 	var failed error
 	blockCtx := core.NewEVMBlockContext(block.Header(), api.chainContext(ctx), nil)
 	evm := vm.NewEVM(blockCtx, statedb, api.backend.ChainConfig(), vm.Config{})
+	if beaconRoot := block.BeaconRoot(); beaconRoot != nil {
+		core.ProcessBeaconBlockRoot(*beaconRoot, evm)
+	}
+	if api.backend.ChainConfig().IsPrague(block.Number(), block.Time()) {
+		core.ProcessParentBlockHash(block.ParentHash(), evm)
+	}
 
 txloop:
 	for i, tx := range txs {


### PR DESCRIPTION
## Summary

This PR fixes a semantic mismatch between tracing paths in api.go.
traceBlockParallel previously replayed transactions from parent state without applying pre-exec system calls that other paths already apply (traceBlock / traceChain), which could produce divergent tracer-visible state on post-merge forks.

## Problem
traceBlockParallel skipped block-level pre-execution hooks before tx replay:

core.ProcessBeaconBlockRoot (EIP-4788)
core.ProcessParentBlockHash (Prague / EIP-2935)
As a result, parallel tracing could observe a state that does not match canonical block execution assumptions.

## Root Cause
In the parallel fast-replay path, EVM was initialized and transaction replay started immediately, but pre-exec system calls were not executed first.

## What This PR Changes

In api.go, traceBlockParallel now:

- Calls ProcessBeaconBlockRoot when block.BeaconRoot() is present.
- Calls ProcessParentBlockHash when Prague rules are active.

This aligns traceBlockParallel behavior with traceBlock and traceChain, ensuring consistent prestate preparation.
