### PR TITLE
core/state: prevent uint64 underflow panic in SizeTracker eviction loop

### DIFF
--- a/core/state/state_sizer.go
+++ b/core/state/state_sizer.go
@@ -346,7 +346,7 @@ func (t *SizeTracker) run() {
 
 			// Evict the stale statistics
 			heap.Push(&h, stats[u.root])
-			for len(h) > 0 && u.blockNumber-h[0].BlockNumber > statEvictThreshold {
+			for len(h) > 0 && u.blockNumber > h[0].BlockNumber && u.blockNumber-h[0].BlockNumber > statEvictThreshold {
 				delete(stats, h[0].StateRoot)
 				heap.Pop(&h)
 			}


### PR DESCRIPTION
Fixes a potential panic in SizeTracker.run() eviction logic when processing out-of-order block updates. Adds an explicit ordering check before unsigned subtraction to prevent uint64 underflow.