### PR TITLE
trie/trienode: Fix incorrect handling of deleted trie nodes

### DIFF
--- a/trie/trienode/node.go
+++ b/trie/trienode/node.go
@@ -40,7 +40,7 @@ func (n *Node) Size() int {
 
 // IsDeleted returns the indicator if the node is marked as deleted.
 func (n *Node) IsDeleted() bool {
-	return len(n.Blob) == 0
+	return n.Blob == nil
 }
 
 // New constructs a node with provided node information.


### PR DESCRIPTION
Previously, a node was considered deleted when `len(Blob) == 0`, which incorrectly classified valid nodes with an empty but allocated blob ([]byte{}) as deleted. According to the Node documentation, a node is deleted only when Blob is nil.

Line 31  https://github.com/ethereum/go-ethereum/blob/master/trie/trienode/node.go
```go
type Node struct {
	Hash common.Hash // Node hash, empty for deleted node
	Blob []byte      // Encoded node blob, nil for the deleted node.  <----------
} 
```
This patch updates IsDeleted to check for nil blobs instead, aligning behaviour with the documented contract.
Correct version includes `return n.Blob == nil`