### PR TITLE
internal/ethapi: include AuthorizationList in gas estimation callArgs

### DIFF
--- a/internal/ethapi/transaction_args.go
+++ b/internal/ethapi/transaction_args.go
@@ -155,6 +155,7 @@ func (args *TransactionArgs) setDefaults(ctx context.Context, b Backend, config 
 			AccessList:           args.AccessList,
 			BlobFeeCap:           args.BlobFeeCap,
 			BlobHashes:           args.BlobHashes,
+			AuthorizationList:    args.AuthorizationList,
 		}
 		latestBlockNr := rpc.BlockNumberOrHashWithNumber(rpc.LatestBlockNumber)
 		estimated, err := DoEstimateGas(ctx, b, callArgs, latestBlockNr, nil, nil, b.RPCGasCap())


### PR DESCRIPTION
The callArgs constructed for gas estimation in setDefaults copies AccessList, BlobHashes, etc. but misses AuthorizationList. This means SetCode (EIP-7702) transactions without an explicit gas value get estimated without their authorization list, leading to incorrect gas estimates.