### PR TITLE
core, core/vm:  Rename selfdestruct log to burn

### DIFF
--- a/core/state_processor.go
+++ b/core/state_processor.go
@@ -176,14 +176,14 @@ func ApplyTransactionWithEVM(msg *Message, gp *GasPool, statedb *state.StateDB, 
 		return nil, cumulativeGas, err
 	}
 	if evm.ChainConfig().IsAmsterdam(blockNumber, blockTime) {
-		// Emit Selfdesctruct logs where accounts with non-empty balances have been deleted
+		// Emit burn logs where accounts with non-empty balances have been deleted
 		removedWithBalance := statedb.GetRemovedAccountsWithBalance()
 		if removedWithBalance != nil {
 			sort.Slice(removedWithBalance, func(i, j int) bool {
 				return removedWithBalance[i].Address.Cmp(removedWithBalance[j].Address) < 0
 			})
 			for _, sd := range removedWithBalance {
-				statedb.AddLog(types.EthSelfDestructLog(blockNumber, sd.Address, sd.Balance))
+				statedb.AddLog(types.EthBurnLog(blockNumber, sd.Address, sd.Balance))
 			}
 		}
 	}

--- a/core/types/log.go
+++ b/core/types/log.go
@@ -85,14 +85,14 @@ func EthTransferLog(blockNumber *big.Int, from, to common.Address, amount *uint2
 	}
 }
 
-// EthSelfDestructLog creates and ETH self-destruct burn log according to EIP-7708.
+// EthBurnLog creates an ETH burn log according to EIP-7708.
 // Specification: https://eips.ethereum.org/EIPS/eip-7708
-func EthSelfDestructLog(blockNumber *big.Int, from common.Address, amount *uint256.Int) *Log {
+func EthBurnLog(blockNumber *big.Int, from common.Address, amount *uint256.Int) *Log {
 	amount32 := amount.Bytes32()
 	return &Log{
 		Address: params.SystemAddress,
 		Topics: []common.Hash{
-			params.EthSelfDestructLogEvent,
+			params.EthBurnLogEvent,
 			common.BytesToHash(from.Bytes()),
 		},
 		Data: amount32[:],

--- a/core/vm/instructions.go
+++ b/core/vm/instructions.go
@@ -937,7 +937,7 @@ func opSelfdestruct6780(pc *uint64, evm *EVM, scope *ScopeContext) ([]byte, erro
 		if this != beneficiary {
 			evm.StateDB.AddLog(types.EthTransferLog(evm.Context.BlockNumber, this, beneficiary, balance))
 		} else if newContract {
-			evm.StateDB.AddLog(types.EthSelfDestructLog(evm.Context.BlockNumber, this, balance))
+			evm.StateDB.AddLog(types.EthBurnLog(evm.Context.BlockNumber, this, balance))
 		}
 	}
 

--- a/params/protocol_params.go
+++ b/params/protocol_params.go
@@ -223,8 +223,8 @@ var (
 
 // System log events.
 var (
-	// EIP-7708 - System logs emitted for ETH transfer and self-destruct balance burn
-	EthTransferLogEvent     = common.HexToHash("0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef") // keccak256('Transfer(address,address,uint256)')
-	EthSelfDestructLogEvent = common.HexToHash("0x4bfaba3443c1a1836cd362418edc679fc96cae8449cbefccb6457cdf2c943083") // keccak256('Selfdestruct(address,uint256)')
+	// EIP-7708 - System logs emitted for ETH transfer and burn
+	EthTransferLogEvent = common.HexToHash("0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef") // keccak256('Transfer(address,address,uint256)')
+	EthBurnLogEvent     = common.HexToHash("0xcc16f5dbb4873280815c1ee09dbd06736cffcc184412cf7a71a0fdb75d397ca5") // keccak256('Burn(address,uint256)')
 
 )


### PR DESCRIPTION
https://github.com/ethereum/EIPs/pull/11311 renamed the "Selfdestruct" log topic to "Burn" in the EIP-7708 specification.

The rationale is that "Burn" better describes what happens (ETH is destroyed) rather than how it happens (via the SELFDESTRUCT opcode). This creates a more consistent API, which reflects the outcome, not the mechanism.