### PR TITLE
eth/syncer: respect close signal during retry backoff

### DIFF
--- a/eth/syncer/syncer.go
+++ b/eth/syncer/syncer.go
@@ -117,7 +117,12 @@ func (s *Syncer) run() {
 						logged = true
 						log.Info("Waiting for peers to retrieve sync target", "hash", req.hash)
 					}
-					time.Sleep(time.Second * time.Duration(retries+1))
+					select {
+					case <-time.After(time.Second * time.Duration(retries+1)):
+					case <-s.closed:
+						req.errc <- errors.New("syncer closed")
+						return
+					}
 					retries++
 					continue
 				}


### PR DESCRIPTION
The retry loop in the syncer uses time.Sleep for backoff, which blocks up to 10s and can't be interrupted by the close signal. Replace it with a select on time.After and s.closed so shutdown isn't held up waiting for the sleep to finish.