### PR TITLE
triedb/pathdb: fix StateSetWithOrigin size accounting after decode

### DIFF
--- a/triedb/pathdb/states_test.go
+++ b/triedb/pathdb/states_test.go
@@ -373,6 +373,9 @@ func testStateWithOriginEncode(t *testing.T, rawStorageKey bool) {
 	if s.rawStorageKey != dec.rawStorageKey {
 		t.Fatal("Unexpected rawStorageKey flag")
 	}
+	if s.size != dec.size {
+		t.Fatalf("Unexpected size, want: %d, got: %d", s.size, dec.size)
+	}
 }
 
 func TestStateSizeTracking(t *testing.T) {


### PR DESCRIPTION
This PR fixes a bug where StateSetWithOrigin.decode() does not recalculate the size field after deserializing from RLP, leaving it zero. This causes incorrect memory accounting when loading diff layers from the journal.