### PR TITLE
node Fix typo in comment about service shutdown

### DIFF
--- a/node/node_test.go
+++ b/node/node_test.go
@@ -341,7 +341,7 @@ func TestLifecycleTerminationGuarantee(t *testing.T) {
 		stack.RegisterLifecycle(lifecycle)
 	}
 
-	// Register a service that fails to shot down cleanly
+	// Register a service that fails to shut down cleanly
 	failure := errors.New("fail")
 	failer := &InstrumentedService{stop: failure}
 	stack.RegisterLifecycle(failer)


### PR DESCRIPTION
Previously : // Register a service that fails to **shot** down cleanly
Updated: // Register a service that fails to **shut** down cleanly