### PR TITLE
rpc: count error responses toward batch response size limit

### DIFF
--- a/rpc/testservice_test.go
+++ b/rpc/testservice_test.go
@@ -128,6 +128,19 @@ func (s *testService) ReturnError() error {
 	return testError{}
 }
 
+// largeDataError is used by tests to trigger error responses with large error data.
+type largeDataError struct {
+	Data string
+}
+
+func (e largeDataError) Error() string     { return "largeDataError" }
+func (e largeDataError) ErrorCode() int    { return 555 }
+func (e largeDataError) ErrorData() interface{} { return e.Data }
+
+func (s *testService) ReturnLargeDataError(n int) error {
+	return largeDataError{Data: strings.Repeat("x", n)}
+}
+
 func (s *testService) MarshalError() *MarshalErrObj {
 	return &MarshalErrObj{}
 }

--- a/rpc/testservice_test.go
+++ b/rpc/testservice_test.go
@@ -133,9 +133,9 @@ type largeDataError struct {
 	Data string
 }
 
-func (e largeDataError) Error() string     { return "largeDataError" }
-func (e largeDataError) ErrorCode() int    { return 555 }
-func (e largeDataError) ErrorData() interface{} { return e.Data }
+func (l largeDataError) Error() string          { return "largeDataError" }
+func (l largeDataError) ErrorCode() int         { return 555 }
+func (l largeDataError) ErrorData() interface{} { return l.Data }
 
 func (s *testService) ReturnLargeDataError(n int) error {
 	return largeDataError{Data: strings.Repeat("x", n)}


### PR DESCRIPTION

**Fixes #33814**

When `Server.SetBatchLimits(itemLimit, maxResponseSize)` is set, the server is supposed to stop processing batch items once the total response size exceeds `maxResponseSize`, and return `-32003 (response too large)` for the rest. That limit was only applied to **success** responses; **error** responses (including large `error.data` from `rpc.DataError`) were not counted, so batches could exceed the limit and `-32003` was not returned consistently.

This PR fixes that by counting both success and error responses toward the batch response size limit, and by avoiding double-serialization of error data as suggested in the review of #33815.

## Changes

- **rpc/json.go**
  - `jsonError.Data` is now `json.RawMessage`. In `errorMessage()`, `DataError.ErrorData()` is marshalled once and stored there, so error data is not serialized again when building the batch.
  - Added `jsonrpcMessage.encodedSize()` for accurate per-response size.
  - `jsonError.ErrorData()` decodes and returns the stored value so existing callers (e.g. client, tests) keep the same behavior.

- **rpc/handler.go**
  - In `handleBatch`, batch size is updated with `resp.encodedSize()` instead of `len(resp.Result)`, so both success and error responses (including `error.data`) are counted.
  - `formatErrorData()` updated to handle `json.RawMessage` so logging stays correct.

- **Tests**
  - `TestServerBatchResponseSizeLimit`: adjusted limit so it reflects full response size; still asserts that only the first two responses succeed and the rest get `-32003`.
  - New `TestServerBatchResponseSizeLimitCountsErrorResponses`: uses a method that returns errors with large `error.data` and a small batch size limit; asserts that at least one batch element gets `-32003`.
  - Added `ReturnLargeDataError(n int)` on the test service for the new test.
  - `TestServerRegisterName`: expected callback count updated to 15.

## Testing

- `go test ./rpc -count=1` (full RPC package) passes.
