### PR TITLE
build: update ubuntu distros list

### DIFF
--- a/build/ci.go
+++ b/build/ci.go
@@ -168,7 +168,6 @@ var (
 		"focal",    // 20.04, EOL: 04/2030
 		"jammy",    // 22.04, EOL: 04/2032
 		"noble",    // 24.04, EOL: 04/2034
-		"questing", // 25.10, EOL: 07/2026
 	}
 
 	// This is where the tests should be unpacked.


### PR DESCRIPTION
The`plucky` and `oracular` have reached end of life. That's why launchpad isn't building them anymore: https://launchpad.net/~ethereum/+archive/ubuntu/ethereum/+packages.