### PR TITLE
core/rawdb: revert "check pruning tail in HasBody and HasReceipts"

### DIFF
--- a/core/rawdb/accessors_chain.go
+++ b/core/rawdb/accessors_chain.go
@@ -424,13 +424,7 @@ func WriteBodyRLP(db ethdb.KeyValueWriter, hash common.Hash, number uint64, rlp 
 // HasBody verifies the existence of a block body corresponding to the hash.
 func HasBody(db ethdb.Reader, hash common.Hash, number uint64) bool {
 	if isCanon(db, number, hash) {
-		// Block is in ancient store, but bodies can be pruned.
-		// Check if the block number is above the pruning tail.
-		tail, _ := db.Tail()
-		if number >= tail {
-			return true
-		}
-		return false
+		return true
 	}
 	if has, err := db.Has(blockBodyKey(number, hash)); !has || err != nil {
 		return false
@@ -472,13 +466,7 @@ func DeleteBody(db ethdb.KeyValueWriter, hash common.Hash, number uint64) {
 // to a block.
 func HasReceipts(db ethdb.Reader, hash common.Hash, number uint64) bool {
 	if isCanon(db, number, hash) {
-		// Block is in ancient store, but receipts can be pruned.
-		// Check if the block number is above the pruning tail.
-		tail, _ := db.Tail()
-		if number >= tail {
-			return true
-		}
-		return false
+		return true
 	}
 	if has, err := db.Has(blockReceiptsKey(number, hash)); !has || err != nil {
 		return false


### PR DESCRIPTION
Reverts ethereum/go-ethereum#33747

This change suffers an unexpected issue during the sync with `history.chain=postmerge`

```
execution-1  | INFO [02-18|10:52:25.601] Syncing beacon headers                   downloaded=10,285,082 left=0          eta=0s
execution-1  | INFO [02-18|10:52:25.602] Block synchronisation started
execution-1  | INFO [02-18|10:52:25.602] Disabled trie database due to state sync
execution-1  | INFO [02-18|10:52:25.603] Skip chain segment before cutoff         origin=0 cutoff=1,450,409
execution-1  | INFO [02-18|10:52:25.650] Wrote genesis to ancient store
execution-1  | INFO [02-18|10:52:33.701] Syncing: state download in progress      synced=0.21% state=302.36MiB accounts=310,447@68.04MiB slots=610,400@133.20MiB codes=45048@101.13MiB eta=1h3m59.031s
execution-1  | WARN [02-18|10:52:36.845] Local chain has been trimmed             tailnumber=0 tailhash=25a5cc..3e6dd9
execution-1  | WARN [02-18|10:52:36.849] Failed to insert ancient header chain    number=507,905    hash=3dcd86..12e68d parent=8d525b..3ba534 err=aborted
execution-1  | INFO [02-18|10:52:36.856] Syncing: state download in progress      synced=0.31% state=423.25MiB accounts=469,363@102.85MiB slots=815,053@178.17MiB codes=63908@142.23MiB eta=59m14.446s
execution-1  | WARN [02-18|10:52:36.860] Unexpected storage ranges packet         peer=21956df7 reqid=8,502,411,705,060,295,791
execution-1  | WARN [02-18|10:52:36.863] Unexpected bytecode packet               peer=21956df7 reqid=2,763,720,557,925,101,160
execution-1  | WARN [02-18|10:52:36.883] Unexpected storage ranges packet         peer=a836e08e reqid=7,219,349,022,029,629,226
execution-1  | ERROR[02-18|10:52:36.894] Beacon backfilling failed                err="retrieved hash chain is invalid: aborted"
```

Specifically, this function will never return true if the chain segment is pruned, resulting in beacon headers can never link to the local chain.

```go
// linked returns the flag indicating whether the skeleton has been linked with
// the local chain.
func (s *skeleton) linked(number uint64, hash common.Hash) bool {
	linked := rawdb.HasHeader(s.db, hash, number) &&
		rawdb.HasBody(s.db, hash, number) &&
		rawdb.HasReceipts(s.db, hash, number)

	// Ensure the skeleton chain links to the local chain below the chain head.
	// This accounts for edge cases where leftover chain segments above the head
	// may still link to the skeleton chain. In such cases, synchronization is
	// likely to fail due to potentially missing segments in the middle.
	//
	// You can try to produce the edge case by these steps:
	// - sync the chain
	// - debug.setHead(`0x1`)
	// - kill the geth process (the chain segment will be left with chain head rewound)
	// - restart
	if s.chain.CurrentSnapBlock() != nil {
		linked = linked && s.chain.CurrentSnapBlock().Number.Uint64() >= number
	}
	return linked
}
```

The original checks for the presence of the chain segment were indeed incorrect, but we need to reimplement them properly.