### PR TITLE
cmd/geth: remove unreachable check in readPasswordFromFile

### DIFF
--- a/cmd/geth/accountcmd.go
+++ b/cmd/geth/accountcmd.go
@@ -232,9 +232,6 @@ func readPasswordFromFile(path string) (string, bool) {
 		utils.Fatalf("Failed to read password file: %v", err)
 	}
 	lines := strings.Split(string(text), "\n")
-	if len(lines) == 0 {
-		return "", false
-	}
 	// Sanitise DOS line endings.
 	return strings.TrimRight(lines[0], "\r"), true
 }


### PR DESCRIPTION
strings.Split always returns a slice with at least one element, even for an empty input string. The len(lines) == 0 check after Split can never be true and is misleading — drop it.
