### PR TITLE
internal/ethapi: return specific error codes from SubmitTransaction

### DIFF
--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -1553,7 +1553,7 @@ func SubmitTransaction(ctx context.Context, b Backend, tx *types.Transaction) (c
 		return common.Hash{}, errors.New("only replay-protected (EIP-155) transactions allowed over RPC")
 	}
 	if err := b.SendTx(ctx, tx); err != nil {
-		return common.Hash{}, err
+		return common.Hash{}, txValidationError(err)
 	}
 	// Print a log with full tx details for manual investigations and interventions
 	head := b.CurrentBlock()


### PR DESCRIPTION
Currently the `SubmitTransaction` returns raw errors from `SendTx`, which the RPC layer serializes with the default code `-32000`. The specific error codes defined in `errors.go` are only used by the simulate path.

This PR wraps the `SendTx` error through `txValidationError()` so that `eth_sendRawTransaction` and `eth_sendTransaction` return the corresponding error codes .