### PR TITLE
core/vm: Switch to branchless normalization and extend EXCHANGE

### DIFF
--- a/core/vm/instructions.go
+++ b/core/vm/instructions.go
@@ -947,19 +947,12 @@ func opSelfdestruct6780(pc *uint64, evm *EVM, scope *ScopeContext) ([]byte, erro
 }
 
 func decodeSingle(x byte) int {
-	if x <= 90 {
-		return int(x) + 17
-	}
-	return int(x) - 20
+	return (int(x) + 145) % 256
 }
 
 func decodePair(x byte) (int, int) {
 	var k int
-	if x <= 79 {
-		k = int(x)
-	} else {
-		k = int(x) - 48
-	}
+	k = int(x ^ 143)
 	q, r := k/16, k%16
 	if q < r {
 		return q + 1, r + 1
@@ -1034,8 +1027,8 @@ func opExchange(pc *uint64, evm *EVM, scope *ScopeContext) ([]byte, error) {
 	}
 
 	// This range is excluded both to preserve compatibility with existing opcodes
-	// and to keep decode_pair’s 16-aligned arithmetic mapping valid (0–79, 128–255).
-	if x > 79 && x < 128 {
+	// and to keep decode_pair’s 16-aligned arithmetic mapping valid (0–81, 128–255).
+	if x > 81 && x < 128 {
 		return nil, &ErrInvalidOpCode{opcode: OpCode(x)}
 	}
 	n, m := decodePair(x)

--- a/core/vm/instructions.go
+++ b/core/vm/instructions.go
@@ -947,6 +947,7 @@ func opSelfdestruct6780(pc *uint64, evm *EVM, scope *ScopeContext) ([]byte, erro
 }
 
 // decodeSingle decodes the immediate operand of a backward-compatible DUPN or SWAPN instruction (EIP-8024)
+// https://eips.ethereum.org/EIPS/eip-8024
 func decodeSingle(x byte) int {
 	// Depths 1-16 are already covered by the legacy opcodes. The forbidden byte range [91, 127] removes
 	// 37 values from the 256 possible immediates, leaving 219 usable values, so this encoding covers depths
@@ -959,6 +960,7 @@ func decodeSingle(x byte) int {
 // instruction (EIP-8024) into stack indices (n, m) where 1 <= n < m
 // and n + m <= 30. The forbidden byte range [82, 127] removes 46 values from
 // the 256 possible immediates, leaving exactly 210 usable bytes.
+// https://eips.ethereum.org/EIPS/eip-8024
 func decodePair(x byte) (int, int) {
 	// XOR with 143 remaps the forbidden bytes [82, 127] to an unused corner
 	// of the 16x16 grid below.

--- a/core/vm/instructions.go
+++ b/core/vm/instructions.go
@@ -957,8 +957,8 @@ func decodeSingle(x byte) int {
 
 // decodePair decodes the immediate operand of a backward-compatible EXCHANGE
 // instruction (EIP-8024) into stack indices (n, m) where 1 <= n < m
-// and n + m <= 30. There are 210 such valid pairs, encoded into a single byte
-// that avoids the forbidden range [91, 127].
+// and n + m <= 30. The forbidden byte range [82, 127] removes 46 values from
+// the 256 possible immediates, leaving exactly 210 usable bytes.
 func decodePair(x byte) (int, int) {
 	// XOR with 143 remaps the forbidden bytes [82, 127] to an unused corner
 	// of the 16x16 grid below.

--- a/core/vm/instructions.go
+++ b/core/vm/instructions.go
@@ -960,7 +960,7 @@ func decodeSingle(x byte) int {
 // and n + m <= 30. There are 210 such valid pairs, encoded into a single byte
 // that avoids the forbidden range [91, 127].
 func decodePair(x byte) (int, int) {
-	// XOR with 143 remaps the forbidden bytes [91, 127] to an unused corner
+	// XOR with 143 remaps the forbidden bytes [82, 127] to an unused corner
 	// of the 16x16 grid below.
 	k := int(x ^ 143)
 	// Split into row q and column r of a 16x16 grid. The 210 valid pairs

--- a/core/vm/instructions_test.go
+++ b/core/vm/instructions_test.go
@@ -1022,7 +1022,7 @@ func TestEIP8024_Execution(t *testing.T) {
 	}{
 		{
 			name:    "DUPN",
-			codeHex: "60016000808080808080808080808080808080e600",
+			codeHex: "60016000808080808080808080808080808080e680",
 			wantVals: []uint64{
 				1,
 				0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
@@ -1030,17 +1030,14 @@ func TestEIP8024_Execution(t *testing.T) {
 			},
 		},
 		{
-			name:    "DUPN_MISSING_IMMEDIATE",
-			codeHex: "60016000808080808080808080808080808080e6",
-			wantVals: []uint64{
-				1,
-				0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-				1,
-			},
+			name:       "DUPN_MISSING_IMMEDIATE",
+			codeHex:    "60016000808080808080808080808080808080e6",
+			wantErr:    &ErrStackUnderflow{},
+			wantOpcode: DUPN,
 		},
 		{
 			name:    "SWAPN",
-			codeHex: "600160008080808080808080808080808080806002e700",
+			codeHex: "600160008080808080808080808080808080806002e780",
 			wantVals: []uint64{
 				1,
 				0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
@@ -1048,22 +1045,19 @@ func TestEIP8024_Execution(t *testing.T) {
 			},
 		},
 		{
-			name:    "SWAPN_MISSING_IMMEDIATE",
-			codeHex: "600160008080808080808080808080808080806002e7",
-			wantVals: []uint64{
-				1,
-				0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-				2,
-			},
+			name:       "SWAPN_MISSING_IMMEDIATE",
+			codeHex:    "600160008080808080808080808080808080806002e7",
+			wantErr:    &ErrStackUnderflow{},
+			wantOpcode: SWAPN,
 		},
 		{
 			name:     "EXCHANGE",
-			codeHex:  "600060016002e801",
+			codeHex:  "600060016002e88e",
 			wantVals: []uint64{2, 0, 1},
 		},
 		{
 			name:    "EXCHANGE_MISSING_IMMEDIATE",
-			codeHex: "600060006000600060006000600060006000600060006000600060006000600060006000600060006000600060006000600060006000600060016002e8",
+			codeHex: "600060006000600060006000600060006000600060006000600060006000600060006000600060006000600060006000600060006000600060016002e88f",
 			wantVals: []uint64{
 				2,
 				0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
@@ -1082,63 +1076,26 @@ func TestEIP8024_Execution(t *testing.T) {
 			wantErr: nil,
 		},
 		{
-			name:       "UNDERFLOW_DUPN_1",
-			codeHex:    "6000808080808080808080808080808080e600",
+			name:     "EXCHANGE",
+			codeHex:  "60008080e88e15",
+			wantVals: []uint64{1, 0, 0},
+		},
+		{
+			name:       "INVALID_EXCHANGE",
+			codeHex:    "e852",
+			wantErr:    &ErrInvalidOpCode{},
+			wantOpcode: EXCHANGE,
+		},
+		{
+			name:       "UNDERFLOW_DUPN",
+			codeHex:    "6000808080808080808080808080808080e680",
 			wantErr:    &ErrStackUnderflow{},
 			wantOpcode: DUPN,
 		},
 		// Additional test cases
 		{
-			name:       "INVALID_DUPN_LOW",
-			codeHex:    "e65b",
-			wantErr:    &ErrInvalidOpCode{},
-			wantOpcode: DUPN,
-		},
-		{
-			name:       "INVALID_EXCHANGE_LOW",
-			codeHex:    "e850",
-			wantErr:    &ErrInvalidOpCode{},
-			wantOpcode: EXCHANGE,
-		},
-		{
-			name:       "INVALID_DUPN_HIGH",
-			codeHex:    "e67f",
-			wantErr:    &ErrInvalidOpCode{},
-			wantOpcode: DUPN,
-		},
-		{
-			name:       "INVALID_SWAPN_HIGH",
-			codeHex:    "e77f",
-			wantErr:    &ErrInvalidOpCode{},
-			wantOpcode: SWAPN,
-		},
-		{
-			name:       "INVALID_EXCHANGE_HIGH",
-			codeHex:    "e87f",
-			wantErr:    &ErrInvalidOpCode{},
-			wantOpcode: EXCHANGE,
-		},
-		{
-			name:       "UNDERFLOW_DUPN_2",
-			codeHex:    "5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5fe600", // (n=17, need 17 items, have 16)
-			wantErr:    &ErrStackUnderflow{},
-			wantOpcode: DUPN,
-		},
-		{
-			name:       "UNDERFLOW_SWAPN",
-			codeHex:    "5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5fe700", // (n=17, need 18 items, have 17)
-			wantErr:    &ErrStackUnderflow{},
-			wantOpcode: SWAPN,
-		},
-		{
-			name:       "UNDERFLOW_EXCHANGE",
-			codeHex:    "60016002e801", // (n,m)=(1,2), need 3 items, have 2
-			wantErr:    &ErrStackUnderflow{},
-			wantOpcode: EXCHANGE,
-		},
-		{
 			name:     "PC_INCREMENT",
-			codeHex:  "600060006000e80115",
+			codeHex:  "600060006000e88e15",
 			wantVals: []uint64{1, 0, 0},
 		},
 	}

--- a/core/vm/instructions_test.go
+++ b/core/vm/instructions_test.go
@@ -1030,12 +1030,6 @@ func TestEIP8024_Execution(t *testing.T) {
 			},
 		},
 		{
-			name:       "DUPN_MISSING_IMMEDIATE",
-			codeHex:    "60016000808080808080808080808080808080e6",
-			wantErr:    &ErrStackUnderflow{},
-			wantOpcode: DUPN,
-		},
-		{
 			name:    "SWAPN",
 			codeHex: "600160008080808080808080808080808080806002e780",
 			wantVals: []uint64{
@@ -1045,10 +1039,14 @@ func TestEIP8024_Execution(t *testing.T) {
 			},
 		},
 		{
-			name:       "SWAPN_MISSING_IMMEDIATE",
-			codeHex:    "600160008080808080808080808080808080806002e7",
-			wantErr:    &ErrStackUnderflow{},
-			wantOpcode: SWAPN,
+			name:    "EXCHANGE_MISSING_IMMEDIATE",
+			codeHex: "600260008080808080600160008080808080808080e8",
+			wantVals: []uint64{
+				0, 0, 0, 0, 0, 0, 0, 0, 0,
+				2, // 10th from top
+				0, 0, 0, 0, 0, 0,
+				1, // bottom
+			},
 		},
 		{
 			name:     "EXCHANGE",
@@ -1056,8 +1054,8 @@ func TestEIP8024_Execution(t *testing.T) {
 			wantVals: []uint64{2, 0, 1},
 		},
 		{
-			name:    "EXCHANGE_MISSING_IMMEDIATE",
-			codeHex: "600060006000600060006000600060006000600060006000600060006000600060006000600060006000600060006000600060006000600060016002e88f",
+			name:    "EXCHANGE",
+			codeHex: "600080808080808080808080808080808080808080808080808080808060016002e88f",
 			wantVals: []uint64{
 				2,
 				0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
@@ -1071,7 +1069,7 @@ func TestEIP8024_Execution(t *testing.T) {
 			wantOpcode: SWAPN,
 		},
 		{
-			name:    "JUMP over INVALID_DUPN",
+			name:    "JUMP_OVER_INVALID_DUPN",
 			codeHex: "600456e65b",
 			wantErr: nil,
 		},


### PR DESCRIPTION
For bal-devnet-3 we need to update the EIP-8024 implementation to the latest spec changes: https://github.com/ethereum/EIPs/pull/11306

> Note: I deleted tests not specified in the EIP bc maintaining them through EIP changes is too error prone.