### PR TITLE
core: add missing IsVerkle check for ProcessParentBlockHash calls

### DIFF
--- a/cmd/evm/internal/t8ntool/execution.go
+++ b/cmd/evm/internal/t8ntool/execution.go
@@ -215,7 +215,7 @@ func (pre *Prestate) Apply(vmConfig vm.Config, chainConfig *params.ChainConfig, 
 	if beaconRoot := pre.Env.ParentBeaconBlockRoot; beaconRoot != nil {
 		core.ProcessBeaconBlockRoot(*beaconRoot, evm)
 	}
-	if pre.Env.BlockHashes != nil && chainConfig.IsPrague(new(big.Int).SetUint64(pre.Env.Number), pre.Env.Timestamp) {
+	if pre.Env.BlockHashes != nil && (chainConfig.IsPrague(new(big.Int).SetUint64(pre.Env.Number), pre.Env.Timestamp) || chainConfig.IsVerkle(new(big.Int).SetUint64(pre.Env.Number), pre.Env.Timestamp)) {
 		var (
 			prevNumber = pre.Env.Number - 1
 			prevHash   = pre.Env.BlockHashes[math.HexOrDecimal64(prevNumber)]

--- a/eth/state_accessor.go
+++ b/eth/state_accessor.go
@@ -247,8 +247,8 @@ func (eth *Ethereum) stateAtTransaction(ctx context.Context, block *types.Block,
 	if beaconRoot := block.BeaconRoot(); beaconRoot != nil {
 		core.ProcessBeaconBlockRoot(*beaconRoot, evm)
 	}
-	// If prague hardfork, insert parent block hash in the state as per EIP-2935.
-	if eth.blockchain.Config().IsPrague(block.Number(), block.Time()) {
+	// If prague/verkle hardfork, insert parent block hash in the state as per EIP-2935.
+	if eth.blockchain.Config().IsPrague(block.Number(), block.Time()) || eth.blockchain.Config().IsVerkle(block.Number(), block.Time()) {
 		core.ProcessParentBlockHash(block.ParentHash(), evm)
 	}
 	if txIndex == 0 && len(block.Transactions()) == 0 {

--- a/eth/tracers/api.go
+++ b/eth/tracers/api.go
@@ -387,7 +387,7 @@ func (api *API) traceChain(start, end *types.Block, config *TraceConfig, closed 
 				core.ProcessBeaconBlockRoot(*beaconRoot, evm)
 			}
 			// Insert parent hash in history contract.
-			if api.backend.ChainConfig().IsPrague(next.Number(), next.Time()) {
+			if api.backend.ChainConfig().IsPrague(next.Number(), next.Time()) || api.backend.ChainConfig().IsVerkle(next.Number(), next.Time()) {
 				core.ProcessParentBlockHash(next.ParentHash(), evm)
 			}
 			// Clean out any pending release functions of trace state. Note this
@@ -542,7 +542,7 @@ func (api *API) IntermediateRoots(ctx context.Context, hash common.Hash, config 
 	if beaconRoot := block.BeaconRoot(); beaconRoot != nil {
 		core.ProcessBeaconBlockRoot(*beaconRoot, evm)
 	}
-	if chainConfig.IsPrague(block.Number(), block.Time()) {
+	if chainConfig.IsPrague(block.Number(), block.Time()) || chainConfig.IsVerkle(block.Number(), block.Time()) {
 		core.ProcessParentBlockHash(block.ParentHash(), evm)
 	}
 	for i, tx := range block.Transactions() {
@@ -606,7 +606,7 @@ func (api *API) traceBlock(ctx context.Context, block *types.Block, config *Trac
 	if beaconRoot := block.BeaconRoot(); beaconRoot != nil {
 		core.ProcessBeaconBlockRoot(*beaconRoot, evm)
 	}
-	if api.backend.ChainConfig().IsPrague(block.Number(), block.Time()) {
+	if api.backend.ChainConfig().IsPrague(block.Number(), block.Time()) || api.backend.ChainConfig().IsVerkle(block.Number(), block.Time()) {
 		core.ProcessParentBlockHash(block.ParentHash(), evm)
 	}
 
@@ -784,7 +784,7 @@ func (api *API) standardTraceBlockToFile(ctx context.Context, block *types.Block
 	if beaconRoot := block.BeaconRoot(); beaconRoot != nil {
 		core.ProcessBeaconBlockRoot(*beaconRoot, evm)
 	}
-	if chainConfig.IsPrague(block.Number(), block.Time()) {
+	if chainConfig.IsPrague(block.Number(), block.Time()) || chainConfig.IsVerkle(block.Number(), block.Time()) {
 		core.ProcessParentBlockHash(block.ParentHash(), evm)
 	}
 	for i, tx := range block.Transactions() {

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -263,7 +263,7 @@ func (miner *Miner) prepareWork(genParams *generateParams, witness bool) (*envir
 	if header.ParentBeaconRoot != nil {
 		core.ProcessBeaconBlockRoot(*header.ParentBeaconRoot, env.evm)
 	}
-	if miner.chainConfig.IsPrague(header.Number, header.Time) {
+	if miner.chainConfig.IsPrague(header.Number, header.Time) || miner.chainConfig.IsVerkle(header.Number, header.Time) {
 		core.ProcessParentBlockHash(header.ParentHash, env.evm)
 	}
 	return env, nil


### PR DESCRIPTION
several `ProcessParentBlockHash` call sites only check `IsPrague`, while `state_processor.go` and `chain_makers.go` already use `IsPrague || IsVerkle`. Since `PragueTime` and `VerkleTime` are independent fields in the config, this mismatch could lead to silently skipping EIP-2935 when Verkle is active without Prague.

Verkle isn't activated on any live network yet so this doesn't affect anything right now, just making sure we won't get bitten by it later~
