### PR TITLE
internal/ethapi: prevent panic for pruned blocks

### DIFF
--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -1446,6 +1446,10 @@ func (api *TransactionAPI) GetTransactionByHash(ctx context.Context, hash common
 	if err != nil {
 		return nil, err
 	}
+	if header == nil {
+		// header was pruned at this point
+		return nil, nil
+	}
 	return newRPCTransaction(tx, blockHash, blockNumber, header.Time, index, header.BaseFee, api.b.ChainConfig()), nil
 }
 


### PR DESCRIPTION
Fixes a small panic when trying to query pruned blocks