### PR TITLE
cmd/utils: fix archive mode detection for TransactionHistory override

### DIFF
--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -1822,7 +1822,7 @@ func SetEthConfig(ctx *cli.Context, stack *node.Node, cfg *ethconfig.Config) {
 		log.Warn("The flag --txlookuplimit is deprecated and will be removed, please use --history.transactions")
 		cfg.TransactionHistory = ctx.Uint64(TxLookupLimitFlag.Name)
 	}
-	if ctx.String(GCModeFlag.Name) == "archive" {
+	if cfg.NoPruning {
 		if cfg.TransactionHistory != 0 {
 			cfg.TransactionHistory = 0
 			log.Warn("Disabled transaction unindexing for archive node")

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -2415,7 +2415,6 @@ func MakeChain(ctx *cli.Context, stack *node.Node, readonly bool) (*core.BlockCh
 		TrieCleanLimit:          ethconfig.Defaults.TrieCleanCache,
 		NoPrefetch:              ctx.Bool(CacheNoPrefetchFlag.Name),
 		TrieDirtyLimit:          ethconfig.Defaults.TrieDirtyCache,
-		ArchiveMode:             ctx.String(GCModeFlag.Name) == "archive",
 		TrieTimeLimit:           ethconfig.Defaults.TrieTimeout,
 		SnapshotLimit:           ethconfig.Defaults.SnapshotCache,
 		Preimages:               ctx.Bool(CachePreimagesFlag.Name),
@@ -2438,6 +2437,9 @@ func MakeChain(ctx *cli.Context, stack *node.Node, readonly bool) (*core.BlockCh
 
 		// Configure the slow block statistic logger (disabled by default)
 		SlowBlockThreshold: ethconfig.Defaults.SlowBlockThreshold,
+	}
+	if ctx.IsSet(GCModeFlag.Name) {
+		options.ArchiveMode = ctx.String(GCModeFlag.Name) == "archive"
 	}
 	// Only enable slow block logging if the flag was explicitly set
 	if ctx.IsSet(LogSlowBlockFlag.Name) {

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -2415,6 +2415,7 @@ func MakeChain(ctx *cli.Context, stack *node.Node, readonly bool) (*core.BlockCh
 		TrieCleanLimit:          ethconfig.Defaults.TrieCleanCache,
 		NoPrefetch:              ctx.Bool(CacheNoPrefetchFlag.Name),
 		TrieDirtyLimit:          ethconfig.Defaults.TrieDirtyCache,
+		ArchiveMode:             ctx.String(GCModeFlag.Name) == "archive",
 		TrieTimeLimit:           ethconfig.Defaults.TrieTimeout,
 		SnapshotLimit:           ethconfig.Defaults.SnapshotCache,
 		Preimages:               ctx.Bool(CachePreimagesFlag.Name),
@@ -2437,9 +2438,6 @@ func MakeChain(ctx *cli.Context, stack *node.Node, readonly bool) (*core.BlockCh
 
 		// Configure the slow block statistic logger (disabled by default)
 		SlowBlockThreshold: ethconfig.Defaults.SlowBlockThreshold,
-	}
-	if ctx.IsSet(GCModeFlag.Name) {
-		options.ArchiveMode = ctx.String(GCModeFlag.Name) == "archive"
 	}
 	// Only enable slow block logging if the flag was explicitly set
 	if ctx.IsSet(LogSlowBlockFlag.Name) {


### PR DESCRIPTION
The `TransactionHistory` override for archive nodes checks `ctx.String(GCModeFlag.Name) == "archive"`, which only works when the flag is passed via CLI. When archive mode is configured through a TOML config file (setting `NoPruning = true`), this check sees the default value "full" and skips the override entirely.

Meanwhile the `Preimages` override right above already uses `cfg.NoPruning` which covers both paths. This inconsistency means a TOML-configured archive node silently keeps limited transaction indexing instead of the expected full history.

For example, a user with this in their config.toml:

    [Eth]
    NoPruning = true

would get `Preimages` correctly forced to true, but `TransactionHistory` stays at the default 2350000 instead of being set to 0. The node looks like an archive node but doesn't index all transactions, and there's nothing in the logs to indicate this.

Fix: use `cfg.NoPruning` to match the existing pattern.
