### PR TITLE
eth/filters: add optional getLogs limit support

### DIFF
--- a/eth/filters/api_test.go
+++ b/eth/filters/api_test.go
@@ -29,6 +29,7 @@ func TestUnmarshalJSONNewFilterArgs(t *testing.T) {
 	var (
 		fromBlock rpc.BlockNumber = 0x123435
 		toBlock   rpc.BlockNumber = 0xabcdef
+		limit     uint64          = 0x2
 		address0                  = common.HexToAddress("70c87d191324e6712a591f304b4eedef6ad9bb9d")
 		address1                  = common.HexToAddress("9b2055d370f73ec7d8a03e965129118dc8f5bf83")
 		topic0                    = common.HexToHash("3ac225168df54212a25c1c01fd35bebfea408fdac2e31ddd6f80a4bbf9a5f1ca")
@@ -53,6 +54,9 @@ func TestUnmarshalJSONNewFilterArgs(t *testing.T) {
 	if len(test0.Topics) != 0 {
 		t.Fatalf("expected 0 topics, got %d topics", len(test0.Topics))
 	}
+	if test0.Limit != nil {
+		t.Fatalf("expected nil limit, got %d", *test0.Limit)
+	}
 
 	// from, to block number
 	var test1 FilterCriteria
@@ -65,6 +69,22 @@ func TestUnmarshalJSONNewFilterArgs(t *testing.T) {
 	}
 	if test1.ToBlock.Int64() != toBlock.Int64() {
 		t.Fatalf("expected ToBlock %d, got %d", toBlock, test1.ToBlock)
+	}
+	if test1.Limit != nil {
+		t.Fatalf("expected nil limit, got %d", *test1.Limit)
+	}
+
+	// limit
+	var testLimit FilterCriteria
+	vector = fmt.Sprintf(`{"limit":"0x%x"}`, limit)
+	if err := json.Unmarshal([]byte(vector), &testLimit); err != nil {
+		t.Fatal(err)
+	}
+	if testLimit.Limit == nil {
+		t.Fatal("expected non-nil limit")
+	}
+	if *testLimit.Limit != limit {
+		t.Fatalf("expected limit %d, got %d", limit, *testLimit.Limit)
 	}
 
 	// single address

--- a/interfaces.go
+++ b/interfaces.go
@@ -205,6 +205,11 @@ type FilterQuery struct {
 	// {{A}, {B}}         matches topic A in first position AND B in second position
 	// {{A, B}, {C, D}}   matches topic (A OR B) in first position AND (C OR D) in second position
 	Topics [][]common.Hash
+
+	// Limit caps the maximum number of logs returned.
+	// When non-nil and non-zero, at most Limit matching logs are returned.
+	// Example: set Limit to 1 to receive a single matching event.
+	Limit *uint64
 }
 
 // LogFilterer provides access to contract log events using a one-off query or continuous


### PR DESCRIPTION
## Problem

`eth_getLogs` and `eth_getFilterLogs` currently scan every block in the requested range, returning all matching logs regardless of how many the caller actually needs. Applications that only want the most-recent matching event are forced to fetch potentially thousands of logs and discard all but the last one.

Closes #20593

## Solution

Add an optional `limit` field to `FilterCriteria` (and the public `ethereum.FilterQuery` interface). When `limit` is non-zero, the filter stops accumulating results once that many logs have been found.

The limit is enforced in two places:

1. **`unindexedLogs`** - early-exit from the block-by-block loop once `len(matches) >= limit`.
2. **`Filter.Logs`** - a final hard-cap on the returned slice so indexed searches also respect the limit.

Backward compatibility is fully preserved: omitting `limit` (or setting it to `0`) produces identical behavior to the existing code.

## Usage

```json
{"method": "eth_getLogs", "params": [{"address": "0x...", "limit": "0x1"}]}
```

## Changes

- `interfaces.go`: add `Limit *uint64` to `ethereum.FilterQuery`
- `eth/filters/filter.go`: add `limit` field to `Filter`, new `NewRangeFilterWithLimit` constructor, early-exit in `unindexedLogs`, hard-cap in `Filter.Logs`
- `eth/filters/api.go`: parse `"limit"` from JSON in `FilterCriteria.UnmarshalJSON`; use `NewRangeFilterWithLimit` in `GetLogs` when limit is set