### PR TITLE
ethclient: omit empty address/topics fields in RPC filter requests

### DIFF
--- a/ethclient/ethclient.go
+++ b/ethclient/ethclient.go
@@ -498,7 +498,11 @@ func (ec *Client) SubscribeFilterLogs(ctx context.Context, q ethereum.FilterQuer
 
 func toFilterArg(q ethereum.FilterQuery) (interface{}, error) {
 	arg := map[string]interface{}{}
-	if q.Addresses != nil {
+	// Only include "address" when there are actual address filters.
+	// An empty slice is treated the same as nil (no filter), and omitting
+	// the field avoids sending "address":[] to nodes that reject empty arrays
+	// (e.g. Hedera, some non-Geth implementations).
+	if len(q.Addresses) > 0 {
 		arg["address"] = q.Addresses
 	}
 	if q.Topics != nil {

--- a/ethclient/types_test.go
+++ b/ethclient/types_test.go
@@ -54,6 +54,22 @@ func TestToFilterArg(t *testing.T) {
 			nil,
 		},
 		{
+			// empty Addresses slice must be treated same as nil:
+			// the "address" field must be omitted so that non-Geth nodes
+			// (e.g. Hedera) do not reject the request with an error.
+			"with empty addresses slice",
+			ethereum.FilterQuery{
+				Addresses: []common.Address{},
+				FromBlock: big.NewInt(1),
+				ToBlock:   big.NewInt(2),
+			},
+			map[string]interface{}{
+				"fromBlock": "0x1",
+				"toBlock":   "0x2",
+			},
+			nil,
+		},
+		{
 			"without BlockHash",
 			ethereum.FilterQuery{
 				Addresses: addresses,


### PR DESCRIPTION
## Problem

`toFilterArg` in `ethclient` serializes empty (non-nil) `[]common.Address{}` as `"address":[]` in the JSON-RPC request body. Several Ethereum-compatible implementations (e.g. Hedera, some non-Geth nodes) reject this empty array with an error, breaking client compatibility.

According to the Ethereum JSON-RPC specification the `address` field is **optional** — it should simply be omitted when no address filter is needed.

## Fix

Change the condition from `q.Addresses != nil` to `len(q.Addresses) > 0`. An empty slice is now treated identically to `nil`: the field is omitted from the request.

## Tests

Added test case `"with empty addresses slice"` to `TestToFilterArg` that verifies an empty `[]common.Address{}` does not produce an `"address"` key in the serialized filter argument.