### PR TITLE
core/txpool/blobpool: remove unused adds slice in Add()

### DIFF
--- a/core/txpool/blobpool/blobpool.go
+++ b/core/txpool/blobpool/blobpool.go
@@ -1476,17 +1476,12 @@ func (p *BlobPool) AvailableBlobs(vhashes []common.Hash) int {
 // Add inserts a set of blob transactions into the pool if they pass validation (both
 // consensus validity and pool restrictions).
 func (p *BlobPool) Add(txs []*types.Transaction, sync bool) []error {
-	var (
-		errs = make([]error, len(txs))
-		adds = make([]*types.Transaction, 0, len(txs))
-	)
+	errs := make([]error, len(txs))
 	for i, tx := range txs {
 		if errs[i] = p.ValidateTxBasics(tx); errs[i] != nil {
 			continue
 		}
-		if errs[i] = p.add(tx); errs[i] == nil {
-			adds = append(adds, tx.WithoutBlobTxSidecar())
-		}
+		errs[i] = p.add(tx)
 	}
 	return errs
 }


### PR DESCRIPTION
## Summary
Fixes #33871

The `adds` slice in `BlobPool.Add()` is populated with `tx.WithoutBlobTxSidecar()` results for each successfully added transaction, but the slice is never read or used afterward.

This causes unnecessary:
- Memory allocation (`make([]*types.Transaction, 0, len(txs))`)
- `WithoutBlobTxSidecar()` calls on every successful add

Note: The similar pattern in `reinject()` (line ~866) correctly uses `adds` to fire `insertFeed.Send()`, so that code is left as-is.

### Changes
- Removed the `adds` slice declaration
- Simplified the `p.add(tx)` call to assign directly to `errs[i]`