### PR TITLE
core/txpool/blobpool: drop underpriced before adding to pool

### DIFF
--- a/core/txpool/blobpool/blobpool.go
+++ b/core/txpool/blobpool/blobpool.go
@@ -1578,13 +1578,13 @@ func (p *BlobPool) addLocked(tx *types.Transaction, checkGapped bool) (err error
 	meta.evictionBlobFeeJumps = meta.blobfeeJumps
 	if meta.nonce > next && len(p.index[from]) >= offset {
 		prev := p.index[from][int(meta.nonce-next-1)]
-		if meta.evictionExecTip.Cmp(meta.execTipCap) < 0 {
+		if meta.evictionExecTip.Cmp(prev.evictionExecTip) > 0 {
 			meta.evictionExecTip = prev.evictionExecTip
 		}
-		if meta.evictionExecFeeJumps < meta.basefeeJumps {
+		if meta.evictionExecFeeJumps > prev.evictionExecFeeJumps {
 			meta.evictionExecFeeJumps = prev.evictionExecFeeJumps
 		}
-		if meta.evictionBlobFeeJumps < meta.blobfeeJumps {
+		if meta.evictionBlobFeeJumps > prev.evictionBlobFeeJumps {
 			meta.evictionBlobFeeJumps = prev.evictionBlobFeeJumps
 		}
 	}

--- a/core/txpool/blobpool/blobpool.go
+++ b/core/txpool/blobpool/blobpool.go
@@ -1596,7 +1596,7 @@ func (p *BlobPool) addLocked(tx *types.Transaction, checkGapped bool) (err error
 	// This is to prevent constant replacement when the pool is full.
 	if p.stored+meta.size > p.config.Datacap {
 		if p.evict.Underpriced(meta) {
-			log.Warn("Dropping underpriced blob transaction", "tx", tx.Hash(), "feecap", tx.GasFeeCap(), "tipcap", tx.GasTipCap(), "blobfeecap", tx.BlobGasFeeCap())
+			log.Trace("Dropping underpriced blob transaction", "tx", tx.Hash(), "feecap", tx.GasFeeCap(), "tipcap", tx.GasTipCap(), "blobfeecap", tx.BlobGasFeeCap())
 			return txpool.ErrUnderpriced
 		}
 	}
@@ -1730,7 +1730,7 @@ func (p *BlobPool) addLocked(tx *types.Transaction, checkGapped bool) (err error
 	// We've already checked for this with approximate size, but do a final
 	// check in case it was dropped with the exact size.
 	if !p.lookup.exists(tx.Hash()) {
-		log.Warn("Added blob transaction was dropped immediately, indicating underpricing", "hash", tx.Hash())
+		log.Trace("Added blob transaction was dropped immediately, indicating underpricing", "hash", tx.Hash())
 		addUnderpricedMeter.Mark(1)
 		return txpool.ErrUnderpriced
 	}

--- a/core/txpool/blobpool/blobpool.go
+++ b/core/txpool/blobpool/blobpool.go
@@ -135,28 +135,38 @@ type blobTxMeta struct {
 	evictionBlobFeeJumps float64      // Worse blob fee (converted to fee jumps) across all previous nonces
 }
 
+// newStoredBlobTxMeta retrieves the indexed metadata fields from a blob transaction,
+// adds storage specific fields (ID and size), and assembles a helper struct to track in memory.
+// Requires the transaction to have a sidecar (or that we introduce a special version tag for no-sidecar).
+func newStoredBlobTxMeta(tx *types.Transaction, id uint64, storageSize uint32) *blobTxMeta {
+	meta := newBlobTxMeta(tx)
+	meta.id = id
+	meta.storageSize = storageSize
+	return meta
+}
+
 // newBlobTxMeta retrieves the indexed metadata fields from a blob transaction
 // and assembles a helper struct to track in memory.
-// Requires the transaction to have a sidecar (or that we introduce a special version tag for no-sidecar).
-func newBlobTxMeta(id uint64, size uint64, storageSize uint32, tx *types.Transaction) *blobTxMeta {
+// newBlobTxMeta leaves storage specific fields empty. Use newStoredBlobTxMeta
+// to also populate those.
+// Requires the transaction to have a sidecar.
+func newBlobTxMeta(tx *types.Transaction) *blobTxMeta {
 	if tx.BlobTxSidecar() == nil {
 		// This should never happen, as the pool only admits blob transactions with a sidecar
 		panic("missing blob tx sidecar")
 	}
 	meta := &blobTxMeta{
-		hash:        tx.Hash(),
-		vhashes:     tx.BlobHashes(),
-		version:     tx.BlobTxSidecar().Version,
-		id:          id,
-		storageSize: storageSize,
-		size:        size,
-		nonce:       tx.Nonce(),
-		costCap:     uint256.MustFromBig(tx.Cost()),
-		execTipCap:  uint256.MustFromBig(tx.GasTipCap()),
-		execFeeCap:  uint256.MustFromBig(tx.GasFeeCap()),
-		blobFeeCap:  uint256.MustFromBig(tx.BlobGasFeeCap()),
-		execGas:     tx.Gas(),
-		blobGas:     tx.BlobGas(),
+		hash:       tx.Hash(),
+		vhashes:    tx.BlobHashes(),
+		version:    tx.BlobTxSidecar().Version,
+		size:       tx.Size(),
+		nonce:      tx.Nonce(),
+		costCap:    uint256.MustFromBig(tx.Cost()),
+		execTipCap: uint256.MustFromBig(tx.GasTipCap()),
+		execFeeCap: uint256.MustFromBig(tx.GasFeeCap()),
+		blobFeeCap: uint256.MustFromBig(tx.BlobGasFeeCap()),
+		execGas:    tx.Gas(),
+		blobGas:    tx.BlobGas(),
 	}
 	meta.basefeeJumps = dynamicFeeJumps(meta.execFeeCap)
 	meta.blobfeeJumps = dynamicFeeJumps(meta.blobFeeCap)
@@ -531,7 +541,7 @@ func (p *BlobPool) parseTransaction(id uint64, size uint32, blob []byte) error {
 		return errors.New("missing blob sidecar")
 	}
 
-	meta := newBlobTxMeta(id, tx.Size(), size, tx)
+	meta := newStoredBlobTxMeta(tx, id, size)
 	if p.lookup.exists(meta.hash) {
 		// This path is only possible after a crash, where deleted items are not
 		// removed via the normal shutdown-startup procedure and thus may get
@@ -1071,7 +1081,7 @@ func (p *BlobPool) reinject(addr common.Address, txhash common.Hash) error {
 	}
 
 	// Update the indices and metrics
-	meta := newBlobTxMeta(id, tx.Size(), p.store.Size(id), tx)
+	meta := newStoredBlobTxMeta(tx, id, p.store.Size(id))
 	if _, ok := p.index[addr]; !ok {
 		if err := p.reserver.Hold(addr); err != nil {
 			log.Warn("Failed to reserve account for blob pool", "tx", tx.Hash(), "from", addr, "err", err)
@@ -1248,6 +1258,7 @@ func (p *BlobPool) validateTx(tx *types.Transaction) error {
 	if err := p.checkDelegationLimit(tx); err != nil {
 		return err
 	}
+
 	// If the transaction replaces an existing one, ensure that price bumps are
 	// adhered to.
 	var (
@@ -1551,9 +1562,47 @@ func (p *BlobPool) addLocked(tx *types.Transaction, checkGapped bool) (err error
 		}
 		return err
 	}
+
+	// Create meta, in preparation of adding to the pool.
+	// Having the meta simplifies the check below for underpriced transactions.
+	meta := newBlobTxMeta(tx)
+
+	// Calculate the eviction parameters for the transaction
+	var (
+		from, _ = types.Sender(p.signer, tx) // already validated above
+		next    = p.state.GetNonce(from)
+		offset  = int(meta.nonce - next)
+	)
+	meta.evictionExecTip = meta.execTipCap
+	meta.evictionExecFeeJumps = meta.basefeeJumps
+	meta.evictionBlobFeeJumps = meta.blobfeeJumps
+	if meta.nonce > next && len(p.index[from]) >= offset {
+		prev := p.index[from][int(meta.nonce-next-1)]
+		if meta.evictionExecTip.Cmp(meta.execTipCap) < 0 {
+			meta.evictionExecTip = prev.evictionExecTip
+		}
+		if meta.evictionExecFeeJumps < meta.basefeeJumps {
+			meta.evictionExecFeeJumps = prev.evictionExecFeeJumps
+		}
+		if meta.evictionBlobFeeJumps < meta.blobfeeJumps {
+			meta.evictionBlobFeeJumps = prev.evictionBlobFeeJumps
+		}
+	}
+
+	// Check pool size limits before inserting the transaction
+	// If at limit, check whether it is underpriced.
+	// Note: we do not have the exact storage size yet, so we try to guess
+	// Note: equal priority to worse of pool is still considered underpriced.
+	// This is to prevent constant replacement when the pool is full.
+	if p.stored+meta.size > p.config.Datacap {
+		if p.evict.Underpriced(meta) {
+			log.Warn("Dropping underpriced blob transaction", "tx", tx.Hash(), "feecap", tx.GasFeeCap(), "tipcap", tx.GasTipCap(), "blobfeecap", tx.BlobGasFeeCap())
+			return txpool.ErrUnderpriced
+		}
+	}
+
 	// If the address is not yet known, request exclusivity to track the account
 	// only by this subpool until all transactions are evicted
-	from, _ := types.Sender(p.signer, tx) // already validated above
 	if _, ok := p.index[from]; !ok {
 		if err := p.reserver.Hold(from); err != nil {
 			addNonExclusiveMeter.Mark(1)
@@ -1582,14 +1631,15 @@ func (p *BlobPool) addLocked(tx *types.Transaction, checkGapped bool) (err error
 	if err != nil {
 		return err
 	}
-	meta := newBlobTxMeta(id, tx.Size(), p.store.Size(id), tx)
+	// Finalize the meta with storage information
+	meta.id = id
+	meta.storageSize = p.store.Size(id)
 
 	var (
-		next   = p.state.GetNonce(from)
-		offset = int(tx.Nonce() - next)
-		newacc = false
+		newacc                  = false
+		oldEvictionExecFeeJumps float64
+		oldEvictionBlobFeeJumps float64
 	)
-	var oldEvictionExecFeeJumps, oldEvictionBlobFeeJumps float64
 	if txs, ok := p.index[from]; ok {
 		oldEvictionExecFeeJumps = txs[len(txs)-1].evictionExecFeeJumps
 		oldEvictionBlobFeeJumps = txs[len(txs)-1].evictionBlobFeeJumps
@@ -1677,9 +1727,10 @@ func (p *BlobPool) addLocked(tx *types.Transaction, checkGapped bool) (err error
 	p.updateStorageMetrics()
 
 	// If we've just dropped the added transaction, it was clearly underpriced.
-	// We could also try to check for this earlier, but it is compex because
-	// of the rolling fee caculations.
+	// We've already checked for this with approximate size, but do a final
+	// check in case it was dropped with the exact size.
 	if !p.lookup.exists(tx.Hash()) {
+		log.Warn("Added blob transaction was dropped immediately, indicating underpricing", "hash", tx.Hash())
 		addUnderpricedMeter.Mark(1)
 		return txpool.ErrUnderpriced
 	}

--- a/core/txpool/blobpool/blobpool.go
+++ b/core/txpool/blobpool/blobpool.go
@@ -1592,10 +1592,20 @@ func (p *BlobPool) addLocked(tx *types.Transaction, checkGapped bool) (err error
 
 	// Check pool size limits before inserting the transaction
 	// If at limit, check whether it is underpriced.
-	// Note: we do not have the exact storage size yet, so we try to guess
-	// Note: equal priority to worse of pool is still considered underpriced.
-	// This is to prevent constant replacement when the pool is full.
-	if p.stored+meta.size > p.config.Datacap {
+	// Note: equal priority as the current worse of the pool is still considered
+	// underpriced. This is to prevent constant replacement when the pool is full.
+	storageSizeDiff, err := getSlotSize(p.slotter, uint32(meta.size))
+	if err != nil {
+		// This should nver happen, but better safe than sorry.
+		log.Warn("Dropping blob transaction due to size", "tx", tx.Hash(), "size", meta.size, "err", err)
+		return err
+	}
+	// is this a possible replacent? If so, we need to consider the storage size difference
+	// instead of the full size of the new transaction.
+	if offset < len(p.index[from]) {
+		storageSizeDiff -= p.index[from][offset].storageSize
+	}
+	if p.stored+uint64(storageSizeDiff) > p.config.Datacap {
 		if p.evict.Underpriced(meta) {
 			log.Trace("Dropping underpriced blob transaction", "tx", tx.Hash(), "feecap", tx.GasFeeCap(), "tipcap", tx.GasTipCap(), "blobfeecap", tx.BlobGasFeeCap())
 			return txpool.ErrUnderpriced

--- a/core/txpool/blobpool/blobpool.go
+++ b/core/txpool/blobpool/blobpool.go
@@ -1564,56 +1564,10 @@ func (p *BlobPool) addLocked(tx *types.Transaction, checkGapped bool) (err error
 		return err
 	}
 
-	// Create meta, in preparation of adding to the pool.
-	// Having the meta simplifies the check below for underpriced transactions.
-	meta := newBlobTxMeta(tx)
-
-	// Calculate the eviction parameters for the transaction
-	var (
-		from, _ = types.Sender(p.signer, tx) // already validated above
-		next    = p.state.GetNonce(from)
-		offset  = int(meta.nonce - next)
-	)
-	meta.evictionExecTip = meta.execTipCap
-	meta.evictionExecFeeJumps = meta.basefeeJumps
-	meta.evictionBlobFeeJumps = meta.blobfeeJumps
-	if meta.nonce > next { // transaction can't be gapped, we filter for that in validateTx
-		prev := p.index[from][int(meta.nonce-next-1)]
-		if meta.evictionExecTip.Cmp(prev.evictionExecTip) > 0 {
-			meta.evictionExecTip = prev.evictionExecTip
-		}
-		if meta.evictionExecFeeJumps > prev.evictionExecFeeJumps {
-			meta.evictionExecFeeJumps = prev.evictionExecFeeJumps
-		}
-		if meta.evictionBlobFeeJumps > prev.evictionBlobFeeJumps {
-			meta.evictionBlobFeeJumps = prev.evictionBlobFeeJumps
-		}
-	}
-
-	// Check pool size limits before inserting the transaction
-	// If at limit, check whether it is underpriced.
-	// Note: equal priority as the current worse of the pool is still considered
-	// underpriced. This is to prevent constant replacement when the pool is full.
-	storageSizeDiff, err := getSlotSize(p.slotter, uint32(meta.size))
-	if err != nil {
-		// This should nver happen, but better safe than sorry.
-		log.Warn("Dropping blob transaction due to size", "tx", tx.Hash(), "size", meta.size, "err", err)
-		return err
-	}
-	// is this a possible replacent? If so, we need to consider the storage size difference
-	// instead of the full size of the new transaction.
-	if offset < len(p.index[from]) {
-		storageSizeDiff -= p.index[from][offset].storageSize
-	}
-	if p.stored+uint64(storageSizeDiff) > p.config.Datacap {
-		if p.evict.Underpriced(meta) {
-			log.Trace("Dropping underpriced blob transaction", "tx", tx.Hash(), "feecap", tx.GasFeeCap(), "tipcap", tx.GasTipCap(), "blobfeecap", tx.BlobGasFeeCap())
-			return txpool.ErrUnderpriced
-		}
-	}
-
 	// If the address is not yet known, request exclusivity to track the account
+	// This is a cheap check, so we do it before all the other checks.
 	// only by this subpool until all transactions are evicted
+	from, _ := types.Sender(p.signer, tx) // already validated above
 	if _, ok := p.index[from]; !ok {
 		if err := p.reserver.Hold(from); err != nil {
 			addNonExclusiveMeter.Mark(1)
@@ -1631,13 +1585,63 @@ func (p *BlobPool) addLocked(tx *types.Transaction, checkGapped bool) (err error
 			}
 		}()
 	}
-	// Transaction permitted into the pool from a nonce and cost perspective,
-	// insert it into the database and update the indices
+
+	// Create meta, in preparation of adding to the pool.
+	// Having the meta simplifies the check below for underpriced transactions.
+	// Note: the meta will be finalized with storage information after the transaction is stored
+	meta := newBlobTxMeta(tx)
+
+	// Calculate the eviction parameters for the transaction
+	var (
+		next   = p.state.GetNonce(from)
+		offset = int(meta.nonce - next)
+	)
+	meta.evictionExecTip = meta.execTipCap
+	meta.evictionExecFeeJumps = meta.basefeeJumps
+	meta.evictionBlobFeeJumps = meta.blobfeeJumps
+	if meta.nonce > next { // transaction can't be gapped, we filter for that in validateTx
+		prev := p.index[from][int(meta.nonce-next-1)]
+		if meta.evictionExecTip.Cmp(prev.evictionExecTip) > 0 {
+			meta.evictionExecTip = prev.evictionExecTip
+		}
+		if meta.evictionExecFeeJumps > prev.evictionExecFeeJumps {
+			meta.evictionExecFeeJumps = prev.evictionExecFeeJumps
+		}
+		if meta.evictionBlobFeeJumps > prev.evictionBlobFeeJumps {
+			meta.evictionBlobFeeJumps = prev.evictionBlobFeeJumps
+		}
+	}
+
+	// Check pool size limits before inserting the transaction. For this calculation
+	// we have to RLP encode the transaction to get the size.
+	// Note: equal priority as the current worse of the pool is still considered
+	// underpriced. This is to prevent constant replacement when the pool is full.
 	blob, err := rlp.EncodeToBytes(tx)
 	if err != nil {
+		// This should never happen, but better safe than sorry.
 		log.Error("Failed to encode transaction for storage", "hash", tx.Hash(), "err", err)
 		return err
 	}
+	storageSizeDiff, err := getSlotSize(p.slotter, uint32(len(blob)))
+	if err != nil {
+		// This should also not happen at this stage
+		log.Warn("Dropping blob transaction due to size", "tx", tx.Hash(), "size", meta.size, "err", err)
+		return err
+	}
+	// is this a possible replacent? If so, we need to consider the storage size difference
+	// instead of the full size of the new transaction.
+	if offset < len(p.index[from]) {
+		storageSizeDiff -= p.index[from][offset].storageSize
+	}
+	if p.stored+uint64(storageSizeDiff) > p.config.Datacap {
+		if p.evict.Underpriced(meta) {
+			log.Trace("Dropping underpriced blob transaction", "tx", tx.Hash(), "feecap", tx.GasFeeCap(), "tipcap", tx.GasTipCap(), "blobfeecap", tx.BlobGasFeeCap())
+			return txpool.ErrUnderpriced
+		}
+	}
+
+	// Transaction permitted into the pool from a nonce and cost perspective,
+	// insert it into the database and update the indices
 	id, err := p.store.Put(blob)
 	if err != nil {
 		return err

--- a/core/txpool/blobpool/blobpool.go
+++ b/core/txpool/blobpool/blobpool.go
@@ -1619,7 +1619,7 @@ func (p *BlobPool) addLocked(tx *types.Transaction, checkGapped bool) (err error
 
 	// Check pool size limits before inserting the transaction. For this calculation
 	// we have to RLP encode the transaction to get the size.
-	// Note: equal priority as the current worse of the pool is still considered
+	// Note: equal priority as the current worst of the pool is still considered
 	// underpriced. This is to prevent constant replacement when the pool is full.
 	blob, err := rlp.EncodeToBytes(tx)
 	if err != nil {
@@ -1627,18 +1627,19 @@ func (p *BlobPool) addLocked(tx *types.Transaction, checkGapped bool) (err error
 		log.Error("Failed to encode transaction for storage", "hash", tx.Hash(), "err", err)
 		return err
 	}
-	storageSizeDiff, err := getSlotSize(p.newSlotter(), uint32(len(blob)))
+	newStorageSize, err := getSlotSize(p.newSlotter(), uint32(len(blob)))
 	if err != nil {
 		// This should also not happen at this stage
 		log.Warn("Dropping blob transaction due to size", "tx", tx.Hash(), "size", meta.size, "err", err)
 		return err
 	}
-	// is this a possible replacent? If so, we need to consider the storage size difference
-	// instead of the full size of the new transaction.
+	// Is this a possible replacement? If so, we need to consider the storage size
+	// difference instead of the full size of the new transaction.
+	storageSizeDiff := int64(newStorageSize)
 	if offset < len(p.index[from]) {
-		storageSizeDiff -= p.index[from][offset].storageSize
+		storageSizeDiff -= int64(p.index[from][offset].storageSize)
 	}
-	if p.stored+uint64(storageSizeDiff) > p.config.Datacap {
+	if storageSizeDiff > 0 && p.stored+uint64(storageSizeDiff) > p.config.Datacap {
 		if p.evict.Underpriced(meta) {
 			log.Trace("Dropping underpriced blob transaction", "tx", tx.Hash(), "feecap", tx.GasFeeCap(), "tipcap", tx.GasTipCap(), "blobfeecap", tx.BlobGasFeeCap())
 			return txpool.ErrUnderpriced

--- a/core/txpool/blobpool/blobpool.go
+++ b/core/txpool/blobpool/blobpool.go
@@ -1576,7 +1576,7 @@ func (p *BlobPool) addLocked(tx *types.Transaction, checkGapped bool) (err error
 	meta.evictionExecTip = meta.execTipCap
 	meta.evictionExecFeeJumps = meta.basefeeJumps
 	meta.evictionBlobFeeJumps = meta.blobfeeJumps
-	if meta.nonce > next && len(p.index[from]) >= offset {
+	if meta.nonce > next { // transaction can't be gapped, we filter for that in validateTx
 		prev := p.index[from][int(meta.nonce-next-1)]
 		if meta.evictionExecTip.Cmp(prev.evictionExecTip) > 0 {
 			meta.evictionExecTip = prev.evictionExecTip
@@ -1672,20 +1672,13 @@ func (p *BlobPool) addLocked(tx *types.Transaction, checkGapped bool) (err error
 		p.lookup.track(meta)
 		p.stored += uint64(meta.storageSize)
 	}
-	// Recompute the rolling eviction fields. In case of a replacement, this will
-	// recompute all subsequent fields. In case of an append, this will only do
-	// the fresh calculation.
+	// Recompute the rolling eviction fields for subsequent transactions
+	// (we've already calculated for the new/updated transaction above).
+	// In case of a replacement, this will recompute all subsequent fields.
+	// In case of an append, this will only do the fresh calculation.
 	txs := p.index[from]
 
-	for i := offset; i < len(txs); i++ {
-		// The first transaction will always use itself
-		if i == 0 {
-			txs[0].evictionExecTip = txs[0].execTipCap
-			txs[0].evictionExecFeeJumps = txs[0].basefeeJumps
-			txs[0].evictionBlobFeeJumps = txs[0].blobfeeJumps
-
-			continue
-		}
+	for i := offset + 1; i < len(txs); i++ {
 		// Subsequent transactions will use a rolling calculation
 		txs[i].evictionExecTip = txs[i-1].evictionExecTip
 		if txs[i].evictionExecTip.Cmp(txs[i].execTipCap) > 0 {

--- a/core/txpool/blobpool/blobpool.go
+++ b/core/txpool/blobpool/blobpool.go
@@ -346,10 +346,10 @@ type BlobPool struct {
 	reserver       txpool.Reserver           // Address reserver to ensure exclusivity across subpools
 	hasPendingAuth func(common.Address) bool // Determine whether the specified address has a pending 7702-auth
 
-	store      billy.Database         // Persistent data store for the tx metadata and blobs
-	newSlotter func() billy.SlotSizeFn // Factory to create fresh slotter instances for slot size lookups
-	stored     uint64                  // Useful data size of all transactions on disk
-	limbo      *limbo                  // Persistent data store for the non-finalized blobs
+	store   billy.Database // Persistent data store for the tx metadata and blobs
+	slotter slotSizer      // O(1) slot size calculator matching the active billy shelves
+	stored  uint64         // Useful data size of all transactions on disk
+	limbo   *limbo         // Persistent data store for the non-finalized blobs
 
 	gapped       map[common.Address][]*types.Transaction // Transactions that are currently gapped (nonce too high)
 	gappedSource map[common.Hash]common.Address          // Source of gapped transactions to allow rechecking on inclusion
@@ -437,16 +437,19 @@ func (p *BlobPool) Init(gasTip uint64, head *types.Header, reserver txpool.Reser
 
 	// Create new slotter for pre-Osaka blob configuration.
 	slotter := newSlotter(params.BlobTxMaxBlobs)
-	p.newSlotter = func() billy.SlotSizeFn { return newSlotter(params.BlobTxMaxBlobs) }
 
 	// See if we need to migrate the queue blob store after fusaka
 	slotter, err = tryMigrate(p.chain.Config(), slotter, queuedir)
 	if err != nil {
 		return err
 	}
-	// Update the slotter factory if Osaka is active
+	// Build an O(1) slot size calculator from the active slotter configuration.
+	// We need a fresh slotter instance since tryMigrate may have consumed the
+	// previous one, and billy.Open below will consume this one.
 	if p.chain.Config().OsakaTime != nil {
-		p.newSlotter = func() billy.SlotSizeFn { return newSlotterEIP7594(params.BlobTxMaxBlobs) }
+		p.slotter = newSlotSizer(newSlotterEIP7594(params.BlobTxMaxBlobs))
+	} else {
+		p.slotter = newSlotSizer(newSlotter(params.BlobTxMaxBlobs))
 	}
 	// Index all transactions on disk and delete anything unprocessable
 	var fails []uint64
@@ -1593,7 +1596,7 @@ func (p *BlobPool) addLocked(tx *types.Transaction, checkGapped bool) (err error
 
 	// Create meta, in preparation of adding to the pool.
 	// Having the meta simplifies the check below for underpriced transactions.
-	// Note: the meta will be finalized with storage information after the transaction is stored
+	// Note: the meta will be finalized with storage information after the transaction is stored.
 	meta := newBlobTxMeta(tx)
 
 	// Calculate the eviction parameters for the transaction
@@ -1627,9 +1630,9 @@ func (p *BlobPool) addLocked(tx *types.Transaction, checkGapped bool) (err error
 		log.Error("Failed to encode transaction for storage", "hash", tx.Hash(), "err", err)
 		return err
 	}
-	newStorageSize, err := getSlotSize(p.newSlotter(), uint32(len(blob)))
+	newStorageSize, err := p.slotter.getSlotSize(uint32(len(blob)))
 	if err != nil {
-		// This should also not happen at this stage
+		// This should never happen, but better safe than sorry.
 		log.Warn("Dropping blob transaction due to size", "tx", tx.Hash(), "size", meta.size, "err", err)
 		return err
 	}

--- a/core/txpool/blobpool/blobpool.go
+++ b/core/txpool/blobpool/blobpool.go
@@ -1730,15 +1730,6 @@ func (p *BlobPool) addLocked(tx *types.Transaction, checkGapped bool) (err error
 	}
 	p.updateStorageMetrics()
 
-	// If we've just dropped the added transaction, it was clearly underpriced.
-	// We've already checked for this with approximate size, but do a final
-	// check in case it was dropped with the exact size.
-	if !p.lookup.exists(tx.Hash()) {
-		log.Trace("Added blob transaction was dropped immediately, indicating underpricing", "hash", tx.Hash())
-		addUnderpricedMeter.Mark(1)
-		return txpool.ErrUnderpriced
-	}
-
 	addValidMeter.Mark(1)
 
 	// Notify all listeners of the new arrival

--- a/core/txpool/blobpool/blobpool.go
+++ b/core/txpool/blobpool/blobpool.go
@@ -346,9 +346,10 @@ type BlobPool struct {
 	reserver       txpool.Reserver           // Address reserver to ensure exclusivity across subpools
 	hasPendingAuth func(common.Address) bool // Determine whether the specified address has a pending 7702-auth
 
-	store  billy.Database // Persistent data store for the tx metadata and blobs
-	stored uint64         // Useful data size of all transactions on disk
-	limbo  *limbo         // Persistent data store for the non-finalized blobs
+	store   billy.Database   // Persistent data store for the tx metadata and blobs
+	slotter billy.SlotSizeFn // Slotter function to determine the shelf sizes for the billy database
+	stored  uint64           // Useful data size of all transactions on disk
+	limbo   *limbo           // Persistent data store for the non-finalized blobs
 
 	gapped       map[common.Address][]*types.Transaction // Transactions that are currently gapped (nonce too high)
 	gappedSource map[common.Hash]common.Address          // Source of gapped transactions to allow rechecking on inclusion
@@ -435,10 +436,10 @@ func (p *BlobPool) Init(gasTip uint64, head *types.Header, reserver txpool.Reser
 	p.state = state
 
 	// Create new slotter for pre-Osaka blob configuration.
-	slotter := newSlotter(params.BlobTxMaxBlobs)
+	p.slotter = newSlotter(params.BlobTxMaxBlobs)
 
 	// See if we need to migrate the queue blob store after fusaka
-	slotter, err = tryMigrate(p.chain.Config(), slotter, queuedir)
+	p.slotter, err = tryMigrate(p.chain.Config(), p.slotter, queuedir)
 	if err != nil {
 		return err
 	}
@@ -449,7 +450,7 @@ func (p *BlobPool) Init(gasTip uint64, head *types.Header, reserver txpool.Reser
 			fails = append(fails, id)
 		}
 	}
-	store, err := billy.Open(billy.Options{Path: queuedir, Repair: true}, slotter, index)
+	store, err := billy.Open(billy.Options{Path: queuedir, Repair: true}, p.slotter, index)
 	if err != nil {
 		return err
 	}

--- a/core/txpool/blobpool/blobpool.go
+++ b/core/txpool/blobpool/blobpool.go
@@ -346,10 +346,10 @@ type BlobPool struct {
 	reserver       txpool.Reserver           // Address reserver to ensure exclusivity across subpools
 	hasPendingAuth func(common.Address) bool // Determine whether the specified address has a pending 7702-auth
 
-	store   billy.Database   // Persistent data store for the tx metadata and blobs
-	slotter billy.SlotSizeFn // Slotter function to determine the shelf sizes for the billy database
-	stored  uint64           // Useful data size of all transactions on disk
-	limbo   *limbo           // Persistent data store for the non-finalized blobs
+	store      billy.Database         // Persistent data store for the tx metadata and blobs
+	newSlotter func() billy.SlotSizeFn // Factory to create fresh slotter instances for slot size lookups
+	stored     uint64                  // Useful data size of all transactions on disk
+	limbo      *limbo                  // Persistent data store for the non-finalized blobs
 
 	gapped       map[common.Address][]*types.Transaction // Transactions that are currently gapped (nonce too high)
 	gappedSource map[common.Hash]common.Address          // Source of gapped transactions to allow rechecking on inclusion
@@ -436,12 +436,17 @@ func (p *BlobPool) Init(gasTip uint64, head *types.Header, reserver txpool.Reser
 	p.state = state
 
 	// Create new slotter for pre-Osaka blob configuration.
-	p.slotter = newSlotter(params.BlobTxMaxBlobs)
+	slotter := newSlotter(params.BlobTxMaxBlobs)
+	p.newSlotter = func() billy.SlotSizeFn { return newSlotter(params.BlobTxMaxBlobs) }
 
 	// See if we need to migrate the queue blob store after fusaka
-	p.slotter, err = tryMigrate(p.chain.Config(), p.slotter, queuedir)
+	slotter, err = tryMigrate(p.chain.Config(), slotter, queuedir)
 	if err != nil {
 		return err
+	}
+	// Update the slotter factory if Osaka is active
+	if p.chain.Config().OsakaTime != nil {
+		p.newSlotter = func() billy.SlotSizeFn { return newSlotterEIP7594(params.BlobTxMaxBlobs) }
 	}
 	// Index all transactions on disk and delete anything unprocessable
 	var fails []uint64
@@ -450,7 +455,7 @@ func (p *BlobPool) Init(gasTip uint64, head *types.Header, reserver txpool.Reser
 			fails = append(fails, id)
 		}
 	}
-	store, err := billy.Open(billy.Options{Path: queuedir, Repair: true}, p.slotter, index)
+	store, err := billy.Open(billy.Options{Path: queuedir, Repair: true}, slotter, index)
 	if err != nil {
 		return err
 	}
@@ -1622,7 +1627,7 @@ func (p *BlobPool) addLocked(tx *types.Transaction, checkGapped bool) (err error
 		log.Error("Failed to encode transaction for storage", "hash", tx.Hash(), "err", err)
 		return err
 	}
-	storageSizeDiff, err := getSlotSize(p.slotter, uint32(len(blob)))
+	storageSizeDiff, err := getSlotSize(p.newSlotter(), uint32(len(blob)))
 	if err != nil {
 		// This should also not happen at this stage
 		log.Warn("Dropping blob transaction due to size", "tx", tx.Hash(), "size", meta.size, "err", err)

--- a/core/txpool/blobpool/slotter.go
+++ b/core/txpool/blobpool/slotter.go
@@ -17,9 +17,24 @@
 package blobpool
 
 import (
+	"errors"
+
 	"github.com/ethereum/go-ethereum/params"
 	"github.com/holiman/billy"
 )
+
+// getSlotSize return the storage size for a given transaction size based on the current slotter.
+func getSlotSize(slotter billy.SlotSizeFn, size uint32) (uint32, error) {
+	for {
+		slotSize, done := slotter()
+		if size <= slotSize {
+			return slotSize, nil
+		}
+		if done {
+			return size, errors.New("size exceeds maximum slot size")
+		}
+	}
+}
 
 // tryMigrate checks if the billy needs to be migrated and migrates if needed.
 // Returns a slotter that can be used for the database.

--- a/core/txpool/blobpool/slotter.go
+++ b/core/txpool/blobpool/slotter.go
@@ -23,17 +23,47 @@ import (
 	"github.com/holiman/billy"
 )
 
-// getSlotSize return the storage size for a given transaction size based on the current slotter.
-func getSlotSize(slotter billy.SlotSizeFn, size uint32) (uint32, error) {
-	for {
-		slotSize, done := slotter()
-		if size <= slotSize {
-			return slotSize, nil
-		}
-		if done {
-			return size, errors.New("size exceeds maximum slot size")
-		}
+// slotSizer computes the storage shelf size for a given transaction size using
+// O(1) arithmetic. Shelf sizes form an arithmetic sequence:
+//
+//	base, base+step, base+2*step, ...
+//
+// This mirrors the progression in newSlotter and newSlotterEIP7594, but avoids
+// creating and iterating a stateful closure on every lookup.
+type slotSizer struct {
+	base uint32 // Size of the first shelf (txAvgSize)
+	step uint32 // Size increment per subsequent shelf
+	max  uint32 // Largest valid shelf size
+}
+
+// newSlotSizer creates a slotSizer by consuming a slotter closure once to
+// discover its base size, step size, and maximum shelf size.
+func newSlotSizer(slotter billy.SlotSizeFn) slotSizer {
+	first, done := slotter()
+	if done {
+		return slotSizer{base: first, step: 0, max: first}
 	}
+	second, done := slotter()
+	step := second - first
+	last := second
+	for !done {
+		last, done = slotter()
+	}
+	return slotSizer{base: first, step: step, max: last}
+}
+
+// getSlotSize returns the shelf size that can store a transaction of the given
+// byte size, or an error if it exceeds the largest shelf.
+func (s slotSizer) getSlotSize(size uint32) (uint32, error) {
+	if size <= s.base {
+		return s.base, nil
+	}
+	// Round up to the nearest shelf: base + ⌈(size-base)/step⌉ * step
+	slot := s.base + ((size-s.base+s.step-1)/s.step)*s.step
+	if slot > s.max {
+		return 0, errors.New("size exceeds maximum slot size")
+	}
+	return slot, nil
 }
 
 // tryMigrate checks if the billy needs to be migrated and migrates if needed.


### PR DESCRIPTION
This PR fixes several inefficiencies when we are at capacity and try to add underpriced transactions to the pool:

- transactions were first added, then removed, creating unnecessary disk I/O.
Now we check before even trying to add
- transactions were first added, then removed using heap ordering, which is not stable. Thus, in case of equal priority, whether the new or the old was dropped was random (not uniform random, but heap structure dependent).
Now we have explicit priority of the transaction that is already in the pool.
- transactions were announced even if dropped right after being added. This resulted in useless fetches from peers
Now we are only announcing if the tx was effectively added to the pool.

Note: the check on whether the blobpool is full is only approximate. To make it exact we would need to expose that info
from billy, or include the knowledge about shelf sizes here. For this reason we also add a second exact check after adding the transaction.