### PR TITLE
core/state: clear journal entries on reset

### DIFF
--- a/core/state/journal.go
+++ b/core/state/journal.go
@@ -68,6 +68,7 @@ func newJournal() *journal {
 // It is semantically similar to calling 'newJournal', but the underlying slices
 // can be reused.
 func (j *journal) reset() {
+	clear(j.entries)
 	j.entries = j.entries[:0]
 	j.validRevisions = j.validRevisions[:0]
 	clear(j.dirties)


### PR DESCRIPTION
journal.reset() reslices j.entries to length 0 but does not clear the underlying array. Since j.entries holds interface values that can reference large objects (e.g., codeChange.prevCode), this can retain memory across transactions/blocks compared to the previous newJournal() behavior.