### PR TITLE
cmd/utils: optimize history import with batched insertion

### DIFF
--- a/cmd/utils/cmd.go
+++ b/cmd/utils/cmd.go
@@ -297,10 +297,6 @@ func ImportHistory(chain *core.BlockChain, dir string, network string, from func
 			if got != checksums[i] {
 				return fmt.Errorf("%s checksum mismatch: have %s want %s", file, got, checksums[i])
 			}
-			if _, err := f.Seek(0, io.SeekStart); err != nil {
-				return fmt.Errorf("seek %s: %w", path, err)
-			}
-
 			// Import all block data from Era1.
 			e, err := from(f)
 			if err != nil {


### PR DESCRIPTION
Rework ImportHistory to collect up to 2500 blocks per flush instead of flushing after each block, reducing database commit overhead.

Replace full receipt deserialization with raw RLP-level conversion via GetRawReceiptsByNumber, avoiding allocation of Receipt/Log/Bloom structs and eliminating the decode–reencode round-trip for both era1 and erae formats.

Centralize consensus receipt conversion into types.ConvertConsensusReceiptsToStorage (shared by the eradb runtime path and the import command), and add a new slim receipt converter for the erae format that strips the tx-type field and validates tx/receipt count consistency.

Fix resource management by explicitly closing file handles and era objects at each error return instead of relying on defer-in-closure patterns.

## era1 sepolia
### Before

```bash
INFO [02-26|12:22:20.065] Wrote genesis to ancients
INFO [02-26|12:22:28.077] Importing Era files                      head=220 imported=220 elapsed=8.013s
INFO [02-26|12:22:36.105] Importing Era files                      head=445 imported=225 elapsed=16.041s
INFO [02-26|12:22:44.111] Importing Era files                      head=675 imported=230 elapsed=24.047s
INFO [02-26|12:22:52.141] Importing Era files                      head=909 imported=234 elapsed=32.077s
INFO [02-26|12:23:00.236] Importing Era files                      head=1134 imported=225 elapsed=40.172s
...
```

### After
```bash
INFO [02-26|12:13:34.168] Wrote genesis to ancients
INFO [02-26|12:13:42.118] Importing Era files                      head=100,803 imported=100,803 elapsed=8.071s
INFO [02-26|12:13:50.237] Importing Era files                      head=201,607 imported=100,804 elapsed=16.189s
INFO [02-26|12:13:58.377] Importing Era files                      head=305,603 imported=103,996 elapsed=24.329s
INFO [02-26|12:14:06.526] Importing Era files                      head=408,907 imported=103,304 elapsed=32.479s
INFO [02-26|12:14:14.600] Importing Era files                      head=512,903 imported=103,996 elapsed=40.552s
INFO [02-26|12:14:22.661] Importing Era files                      head=616,899 imported=103,996 elapsed=48.613s
INFO [02-26|12:14:30.714] Importing Era files                      head=720,203 imported=103,304 elapsed=56.667s
INFO [02-26|12:14:38.825] Importing Era files                      head=826,699 imported=106,496 elapsed=1m4.777s
INFO [02-26|12:14:46.892] Importing Era files                      head=933,887 imported=107,188 elapsed=1m12.844s
INFO [02-26|12:14:54.986] Importing Era files                      head=1,042,883 imported=108,996 elapsed=1m20.938s
INFO [02-26|12:15:03.161] Importing Era files                      head=1,149,379 imported=106,496 elapsed=1m29.113s
INFO [02-26|12:15:11.357] Importing Era files                      head=1,252,683 imported=103,304 elapsed=1m37.309s
INFO [02-26|12:15:19.444] Importing Era files                      head=1,345,987 imported=93304   elapsed=1m45.396s
INFO [02-26|12:15:27.601] Importing Era files                      head=1,441,099 imported=95112   elapsed=1m53.554s
Import done in 1m57.598848134s
```

## eraE sepolia

### Before

```bash
INFO [02-26|12:23:34.861] Wrote genesis to ancients
INFO [02-26|12:23:42.893] Importing Era files                      head=202 imported=202 elapsed=8.033s
INFO [02-26|12:23:50.918] Importing Era files                      head=411 imported=209 elapsed=16.058s
INFO [02-26|12:23:58.928] Importing Era files                      head=625 imported=214 elapsed=24.068s
INFO [02-26|12:24:06.944] Importing Era files                      head=862 imported=237 elapsed=32.084s
INFO [02-26|12:24:14.967] Importing Era files                      head=1091 imported=229 elapsed=40.107s
...
```

### After

```bash
INFO [02-26|12:24:32.896] Wrote genesis to ancients
INFO [02-26|12:24:40.938] Importing Era files                      head=136,071 imported=136,071 elapsed=8.129s
INFO [02-26|12:24:49.037] Importing Era files                      head=272,835 imported=136,764 elapsed=16.228s
INFO [02-26|12:24:57.063] Importing Era files                      head=406,407 imported=133,572 elapsed=24.255s
INFO [02-26|12:25:05.069] Importing Era files                      head=540,671 imported=134,264 elapsed=32.261s
INFO [02-26|12:25:13.131] Importing Era files                      head=676,743 imported=136,072 elapsed=40.323s
INFO [02-26|12:25:21.148] Importing Era files                      head=810,315 imported=133,572 elapsed=48.340s
INFO [02-26|12:25:29.162] Importing Era files                      head=947,079 imported=136,764 elapsed=56.354s
INFO [02-26|12:25:37.202] Importing Era files                      head=1,086,343 imported=139,264 elapsed=1m4.394s
INFO [02-26|12:25:45.280] Importing Era files                      head=1,217,415 imported=131,072 elapsed=1m12.471s
INFO [02-26|12:25:53.419] Importing Era files                      head=1,342,795 imported=125,380 elapsed=1m20.610s
INFO [02-26|12:26:01.556] Importing Era files                      head=1,457,483 imported=114,688 elapsed=1m28.748s
INFO [02-26|12:26:09.589] Importing Era files                      head=1,580,363 imported=122,880 elapsed=1m36.781s
INFO [02-26|12:26:17.623] Importing Era files                      head=1,695,051 imported=114,688 elapsed=1m44.814s
INFO [02-26|12:26:25.714] Importing Era files                      head=1,809,739 imported=114,688 elapsed=1m52.905s
INFO [02-26|12:26:33.835] Importing Era files                      head=1,932,619 imported=122,880 elapsed=2m1.026s
INFO [02-26|12:26:41.882] Importing Era files                      head=2,056,191 imported=123,572 elapsed=2m9.074s
...
```
