### PR TITLE
cmd/devp2p: fix discv5 PingMultiIP handshake reply addr

### DIFF
--- a/cmd/devp2p/internal/v5test/discv5tests.go
+++ b/cmd/devp2p/internal/v5test/discv5tests.go
@@ -137,10 +137,13 @@ the attempt from a different IP.`)
 		t.Fatal("expected WHOAREYOU, got", resp)
 	}
 
-	// Catch the PONG on l2.
+	// Catch the PONG on l2. Only check the request ID here because cross-network
+	// routing may rewrite the source IP, making PONG.ToIP differ from laddr(l2).IP.
 	switch resp := conn.read(l2).(type) {
 	case *v5wire.Pong:
-		checkPong(t, resp, ping2, l2)
+		if !bytes.Equal(resp.ReqID, ping2.ReqID) {
+			t.Fatalf("wrong request ID %x in PONG, want %x", resp.ReqID, ping2.ReqID)
+		}
 	default:
 		t.Fatal("expected PONG, got", resp)
 	}

--- a/cmd/devp2p/internal/v5test/framework.go
+++ b/cmd/devp2p/internal/v5test/framework.go
@@ -22,6 +22,7 @@ import (
 	"encoding/binary"
 	"fmt"
 	"net"
+	"slices"
 	"time"
 
 	"github.com/ethereum/go-ethereum/common/mclock"

--- a/cmd/devp2p/internal/v5test/framework.go
+++ b/cmd/devp2p/internal/v5test/framework.go
@@ -22,7 +22,6 @@ import (
 	"encoding/binary"
 	"fmt"
 	"net"
-	"slices"
 	"time"
 
 	"github.com/ethereum/go-ethereum/common/mclock"
@@ -66,8 +65,7 @@ type conn struct {
 	log       logger
 	codec     *v5wire.Codec
 	idCounter uint32
-	lastFrom  string
-	lastLocal net.IP
+	sources   map[v5wire.Nonce]string // source addr of WHOAREYOU challenges
 }
 
 type logger interface {
@@ -93,6 +91,7 @@ func newConn(dest *enode.Node, log logger) *conn {
 		remoteAddr: &net.UDPAddr{IP: dest.IP(), Port: dest.UDP()},
 		codec:      v5wire.NewCodec(ln, key, mclock.System{}, nil),
 		log:        log,
+		sources:    make(map[v5wire.Nonce]string),
 	}
 }
 
@@ -203,16 +202,12 @@ func (tc *conn) findnode(c net.PacketConn, dists []uint) ([]*enode.Node, error) 
 
 // write sends a packet on the given connection.
 func (tc *conn) write(c net.PacketConn, p v5wire.Packet, challenge *v5wire.Whoareyou) v5wire.Nonce {
-	lip := laddr(c).IP
-	if tc.lastLocal != nil && !tc.lastLocal.Equal(lip) && challenge == nil {
-		// New local endpoint: drop old sessions to avoid reusing them across IPs.
-		tc.codec = v5wire.NewCodec(tc.localNode, tc.localKey, mclock.System{}, nil)
-	}
-	tc.lastLocal = slices.Clone(lip)
-
 	addr := tc.remoteAddr.String()
-	if challenge != nil && tc.lastFrom != "" {
-		addr = tc.lastFrom
+	if challenge != nil {
+		if from, ok := tc.sources[challenge.Nonce]; ok {
+			addr = from
+			delete(tc.sources, challenge.Nonce)
+		}
 	}
 	packet, nonce, err := tc.codec.Encode(tc.remote.ID(), addr, p, challenge)
 	if err != nil {
@@ -236,10 +231,12 @@ func (tc *conn) read(c net.PacketConn) v5wire.Packet {
 	if err != nil {
 		return &readError{err}
 	}
-	tc.lastFrom = fromAddr.String()
 	_, _, p, err := tc.codec.Decode(buf[:n], fromAddr.String())
 	if err != nil {
 		return &readError{err}
+	}
+	if w, ok := p.(*v5wire.Whoareyou); ok {
+		tc.sources[w.Nonce] = fromAddr.String()
 	}
 	tc.logf("<< %s", p.Name())
 	return p


### PR DESCRIPTION
Found this failure testcase in hive https://hive.ethpandaops.io/#/test/generic/1771137661-f7ff1563d8034411193b6255134c2eaf?testnumber=20

```
 This test establishes a session from one IP as usual. The session is then reused
 on another IP, which shouldn't work. The remote node should respond with WHOAREYOU for
 the attempt from a different IP.
 (b860ea4034c1e4a8) >> PING/v5
 (b860ea4034c1e4a8) << WHOAREYOU/v5
 (b860ea4034c1e4a8) >> PING/v5
 (b860ea4034c1e4a8) << PONG/v5
 sending ping from alternate IP 172.18.0.2:38642
 (b860ea4034c1e4a8) >> PING/v5
 (b860ea4034c1e4a8) << WHOAREYOU/v5
 got WHOAREYOU for new session as expected
 (b860ea4034c1e4a8) >> PING/v5
 (b860ea4034c1e4a8) << UNKNOWN/v5
 expected PONG, got &{[0 0 0 1 25 149 78 23 45 40 68 93]}
```

So let's track the last packet source address, and then use it when replying to a WHOAREYOU challenge, so the session cache is keyed to the actual sender address, avoid the UNKNOWN.