### PR TITLE
trie: reduce allocations in parallel commit

### DIFF
--- a/trie/committer.go
+++ b/trie/committer.go
@@ -87,9 +87,7 @@ func (c *committer) commit(path []byte, n node, parallel bool) node {
 
 // commitChildren commits the children of the given fullnode
 func (c *committer) commitChildren(path []byte, n *fullNode, parallel bool) {
-	var (
-		index = make([]int, 0, 16)
-	)
+	childIndices := make([]int, 0, 16)
 	for i := 0; i < 16; i++ {
 		child := n.Children[i]
 		if child == nil {
@@ -101,13 +99,13 @@ func (c *committer) commitChildren(path []byte, n *fullNode, parallel bool) {
 		if _, ok := child.(hashNode); ok {
 			continue
 		}
-		index = append(index, i)
+		childIndices = append(childIndices, i)
 	}
 	if !parallel {
 		// Commit the child recursively and store the "hashed" value.
 		// Note the returned node can be some embedded nodes, so it's
 		// possible the type is not hashNode.
-		for _, i := range index {
+		for _, i := range childIndices {
 			n.Children[i] = c.commit(append(path, byte(i)), n.Children[i], false)
 		}
 	} else {
@@ -115,15 +113,15 @@ func (c *committer) commitChildren(path []byte, n *fullNode, parallel bool) {
 			wg      sync.WaitGroup
 			nodesMu sync.Mutex
 		)
-		wg.Add(len(index))
-		for _, i := range index {
+		wg.Add(len(childIndices))
+		for _, i := range childIndices {
 			go func(index int) {
 				defer wg.Done()
 
 				p := append(path, byte(index))
 				childSet := trienode.NewNodeSet(c.nodes.Owner)
 				childCommitter := newCommitter(childSet, c.tracer, c.collectLeaf)
-				n.Children[index] = childCommitter.commit(p, n.Children[i], false)
+				n.Children[index] = childCommitter.commit(p, n.Children[index], false)
 
 				nodesMu.Lock()
 				c.nodes.MergeDisjoint(childSet)


### PR DESCRIPTION

```
goos: linux
goarch: amd64
pkg: github.com/ethereum/go-ethereum/trie
cpu: Intel(R) Core(TM) Ultra 7 155U
                                      │ /tmp/old.txt  │             /tmp/new.txt             │
                                      │    sec/op     │    sec/op     vs base                │
CommitAfterHash/no-onleaf-14             1.436µ ± 12%   1.129µ ±  9%  -21.35% (p=0.000 n=10)
CommitAfterHash/with-onleaf-14           1.645µ ± 17%   1.440µ ± 13%  -12.49% (p=0.029 n=10)
CommitAfterHashFixedSize/10-14           13.54µ ±  3%   12.77µ ± 18%   -5.67% (p=0.022 n=10)
CommitAfterHashFixedSize/100-14         128.23µ ±  6%   82.15µ ±  2%  -35.93% (p=0.000 n=10)
CommitAfterHashFixedSize/1K-14           1.916m ± 30%   1.246m ± 11%  -34.95% (p=0.000 n=10)
CommitAfterHashFixedSize/10K-14          7.332m ±  9%   6.973m ± 51%        ~ (p=0.481 n=10)
CommitAfterHashFixedSize/100K-14         96.91m ± 17%   90.23m ± 20%        ~ (p=0.123 n=10)
Commit/commit-100nodes-sequential-14     77.24µ ± 27%   75.15µ ±  3%   -2.71% (p=0.011 n=10)
Commit/commit-100nodes-parallel-14       75.52µ ±  9%   74.73µ ±  1%        ~ (p=0.280 n=10)
Commit/commit-500nodes-sequential-14     380.7µ ± 29%   371.9µ ±  4%        ~ (p=0.143 n=10)
Commit/commit-500nodes-parallel-14       473.1µ ±  9%   454.1µ ± 15%        ~ (p=0.075 n=10)
Commit/commit-2000nodes-sequential-14    1.583m ±  2%   1.577m ± 21%        ~ (p=0.971 n=10)
Commit/commit-2000nodes-parallel-14      1.079m ±  4%   1.054m ±  8%        ~ (p=0.123 n=10)
Commit/commit-5000nodes-sequential-14    4.362m ±  6%   4.224m ±  3%        ~ (p=0.105 n=10)
Commit/commit-5000nodes-parallel-14      3.231m ±  6%   2.858m ± 14%  -11.53% (p=0.011 n=10)
geomean                                  349.4µ         311.7µ        -10.79%

                                      │ /tmp/old.txt │            /tmp/new.txt             │
                                      │     B/op     │     B/op      vs base               │
CommitAfterHash/no-onleaf-14             1020.0 ± 0%    1011.0 ± 0%  -0.88% (p=0.000 n=10)
CommitAfterHash/with-onleaf-14          1.142Ki ± 0%   1.133Ki ± 0%  -0.77% (p=0.000 n=10)
CommitAfterHashFixedSize/10-14          11.88Ki ± 0%   11.73Ki ± 0%  -1.31% (p=0.000 n=10)
CommitAfterHashFixedSize/100-14         72.61Ki ± 0%   71.80Ki ± 0%  -1.11% (p=0.000 n=10)
CommitAfterHashFixedSize/1K-14          964.4Ki ± 0%   953.5Ki ± 0%  -1.14% (p=0.000 n=10)
CommitAfterHashFixedSize/10K-14         9.476Mi ± 0%   9.383Mi ± 0%  -0.99% (p=0.000 n=10)
CommitAfterHashFixedSize/100K-14        112.6Mi ± 0%   111.7Mi ± 0%  -0.83% (p=0.000 n=10)
Commit/commit-100nodes-sequential-14    74.72Ki ± 0%   73.93Ki ± 0%  -1.05% (p=0.000 n=10)
Commit/commit-100nodes-parallel-14      74.72Ki ± 0%   73.93Ki ± 0%  -1.06% (p=0.000 n=10)
Commit/commit-500nodes-sequential-14    349.6Ki ± 0%   344.9Ki ± 0%  -1.35% (p=0.000 n=10)
Commit/commit-500nodes-parallel-14      505.5Ki ± 0%   500.8Ki ± 0%  -0.93% (p=0.000 n=10)
Commit/commit-2000nodes-sequential-14   1.370Mi ± 0%   1.354Mi ± 0%  -1.15% (p=0.000 n=10)
Commit/commit-2000nodes-parallel-14     1.953Mi ± 0%   1.937Mi ± 0%  -0.81% (p=0.000 n=10)
Commit/commit-5000nodes-sequential-14   3.326Mi ± 0%   3.278Mi ± 0%  -1.45% (p=0.000 n=10)
Commit/commit-5000nodes-parallel-14     4.787Mi ± 0%   4.744Mi ± 0%  -0.90% (p=0.000 n=10)
geomean                                 325.6Ki        322.1Ki       -1.05%

                                      │ /tmp/old.txt │            /tmp/new.txt             │
                                      │  allocs/op   │  allocs/op   vs base                │
CommitAfterHash/no-onleaf-14              8.000 ± 0%    7.000 ± 0%  -12.50% (p=0.000 n=10)
CommitAfterHash/with-onleaf-14            9.000 ± 0%    8.000 ± 0%  -11.11% (p=0.000 n=10)
CommitAfterHashFixedSize/10-14            185.0 ± 0%    171.0 ± 0%   -7.57% (p=0.000 n=10)
CommitAfterHashFixedSize/100-14           867.0 ± 0%    801.0 ± 0%   -7.61% (p=0.000 n=10)
CommitAfterHashFixedSize/1K-14           8.934k ± 0%   8.247k ± 0%   -7.69% (p=0.000 n=10)
CommitAfterHashFixedSize/10K-14          88.03k ± 0%   80.50k ± 0%   -8.56% (p=0.000 n=10)
CommitAfterHashFixedSize/100K-14         873.8k ± 0%   799.2k ± 0%   -8.54% (p=0.000 n=10)
Commit/commit-100nodes-sequential-14      966.0 ± 0%    902.0 ± 0%   -6.63% (p=0.000 n=10)
Commit/commit-100nodes-parallel-14        966.0 ± 0%    902.0 ± 0%   -6.63% (p=0.000 n=10)
Commit/commit-500nodes-sequential-14     4.909k ± 0%   4.530k ± 0%   -7.72% (p=0.000 n=10)
Commit/commit-500nodes-parallel-14       5.361k ± 0%   4.983k ± 0%   -7.04% (p=0.000 n=10)
Commit/commit-2000nodes-sequential-14    18.66k ± 0%   17.39k ± 0%   -6.83% (p=0.000 n=10)
Commit/commit-2000nodes-parallel-14      19.26k ± 0%   17.99k ± 0%   -6.61% (p=0.000 n=10)
Commit/commit-5000nodes-sequential-14    48.18k ± 0%   44.56k ± 0%   -7.52% (p=0.000 n=10)
Commit/commit-5000nodes-parallel-14      48.89k ± 0%   45.27k ± 0%   -7.40% (p=0.000 n=10)
geomean                                  3.530k        3.248k        -8.01%
```