### PR TITLE
miner: account for generateWork elapsed time in payload rebuild timer

### DIFF
--- a/miner/payload_building.go
+++ b/miner/payload_building.go
@@ -267,7 +267,7 @@ func (miner *Miner) buildPayload(args *BuildPayloadArgs, witness bool) (*Payload
 				} else {
 					log.Info("Error while generating work", "id", payload.id, "err", r.err)
 				}
-				timer.Reset(miner.config.Recommit)
+				timer.Reset(max(0, miner.config.Recommit-time.Since(start)))
 			case <-payload.stop:
 				log.Info("Stopping work on payload", "id", payload.id, "reason", "delivery")
 				return


### PR DESCRIPTION
The payload rebuild loop resets the timer with the full Recommit duration after generateWork returns, making the actual interval generateWork_elapsed + Recommit instead of Recommit alone.

Since fillTransactions uses Recommit (2s) as its timeout ceiling, the effective rebuild interval can reach ~4s under heavy blob workloads — only 1–2 rebuilds in a 6s half-slot window instead of the intended 3.

Fix by subtracting elapsed time from the timer reset.

### Before this fix

```
t=0s  timer fires, generateWork starts
t=2s  fillTransactions times out, timer.Reset(2s)
t=4s  second rebuild starts
t=6s  CL calls getPayload — gets the t=2s result (1 effective rebuild)
```

### After

```
t=0s  timer fires, generateWork starts
t=2s  fillTransactions times out, timer.Reset(2s - 2s = 0)
t=2s  second rebuild starts immediately
t=4s  timer.Reset(0), third rebuild starts
t=6s  CL calls getPayload — gets the t=4s result (3 effective rebuilds)
```