### PR TITLE
internal/download: distinguish missing file from stale in era download

### DIFF
--- a/internal/download/download.go
+++ b/internal/download/download.go
@@ -180,12 +180,14 @@ func (db *ChecksumDB) DownloadFile(url, dstPath string) error {
 		return fmt.Errorf("no known hash for file %q", basename)
 	}
 	// Shortcut if already downloaded.
-	if verifyHash(dstPath, hash) == nil {
+	if err := verifyHash(dstPath, hash); err == nil {
 		fmt.Printf("%s is up-to-date\n", dstPath)
 		return nil
+	} else if os.IsNotExist(err) {
+		fmt.Printf("%s not found, downloading\n", dstPath)
+	} else {
+		fmt.Printf("%s is stale\n", dstPath)
 	}
-
-	fmt.Printf("%s is stale\n", dstPath)
 	fmt.Printf("downloading from %s\n", url)
 	resp, err := http.Get(url)
 	if err != nil {


### PR DESCRIPTION
When downloading era files via `geth era-download`, all files are reported as "stale" even when they simply haven't been downloaded yet:

```
/home/user/.ethereum/geth/chaindata/ancient/era/mainnet-00261-a6f4bfca.era1 is stale
downloading from https://mainnet.era1.nimbus.team/mainnet-00261-a6f4bfca.era1
```

This is confusing because "stale" implies the file exists but has a mismatched hash.

### Root cause

`verifyHash()` returns an error for both cases (file not found via `os.Open` and hash mismatch), and `DownloadFile` unconditionally prints "is stale" for any error.

### Fix

Check `os.IsNotExist` on the error from `verifyHash` to distinguish the two cases:
- **File missing**: print `"not found, downloading"`
- **Hash mismatch**: print `"is stale"` (existing behavior, now only for actual staleness)

Fixes #31917