### PR TITLE
eth: make txIndex optional in debug_storageRangeAt

### DIFF
--- a/internal/web3ext/web3ext.go
+++ b/internal/web3ext/web3ext.go
@@ -414,6 +414,7 @@ web3._extend({
 			name: 'storageRangeAt',
 			call: 'debug_storageRangeAt',
 			params: 5,
+			inputFormatter: [null, null, null, null, null],
 		}),
 		new web3._extend.Method({
 			name: 'getModifiedAccountsByNumber',


### PR DESCRIPTION
The `debug_storageRangeAt` RPC method currently requires `txIndex` as a mandatory parameter, meaning callers can only query the state *before* a specific transaction in a block. There is no way to query the post-block state (after the last transaction), unlike other debug methods such as `debug_traceCall`.

### Fix

Make `txIndex` a pointer (`*int`) so it becomes optional in JSON-RPC:

- **When provided** (e.g., `"txIndex": 0`): use `stateAtTransaction` to get state before that tx (existing behavior, unchanged)
- **When omitted** (`null` or missing): use `stateAtBlock` to get the post-block state

This is consistent with how other debug API endpoints handle optional state references.

Also updates the JS console API definition in `web3ext.go` to allow the optional parameter.

Fixes #31344