### PR TITLE
graphql: handle nil block in Raw method

### DIFF
--- a/graphql/graphql.go
+++ b/graphql/graphql.go
@@ -929,7 +929,7 @@ func (b *Block) RawHeader(ctx context.Context) (hexutil.Bytes, error) {
 
 func (b *Block) Raw(ctx context.Context) (hexutil.Bytes, error) {
 	block, err := b.resolve(ctx)
-	if err != nil {
+	if err != nil || block == nil {
 		return hexutil.Bytes{}, err
 	}
 	return rlp.EncodeToBytes(block)


### PR DESCRIPTION
Add a nil check for the resolved block to prevent a panic when encoding a nil block to RLP bytes.