### PR TITLE
eth/catalyst: return -32602 for FCU V2 wrong payloadAttributes version

### DIFF
--- a/eth/catalyst/api.go
+++ b/eth/catalyst/api.go
@@ -180,11 +180,11 @@ func (api *ConsensusAPI) ForkchoiceUpdatedV2(update engine.ForkchoiceStateV1, pa
 	if params != nil {
 		switch {
 		case params.BeaconRoot != nil:
-			return engine.STATUS_INVALID, attributesErr("unexpected beacon root")
+			return engine.STATUS_INVALID, paramsErr("unexpected beacon root")
 		case api.checkFork(params.Timestamp, forks.Paris) && params.Withdrawals != nil:
-			return engine.STATUS_INVALID, attributesErr("withdrawals before shanghai")
+			return engine.STATUS_INVALID, paramsErr("withdrawals before shanghai")
 		case api.checkFork(params.Timestamp, forks.Shanghai) && params.Withdrawals == nil:
-			return engine.STATUS_INVALID, attributesErr("missing withdrawals")
+			return engine.STATUS_INVALID, paramsErr("missing withdrawals")
 		case !api.checkFork(params.Timestamp, forks.Paris, forks.Shanghai):
 			return engine.STATUS_INVALID, unsupportedForkErr("fcuV2 must only be called with paris or shanghai payloads")
 		}

--- a/eth/catalyst/api_test.go
+++ b/eth/catalyst/api_test.go
@@ -1205,6 +1205,13 @@ func TestNilWithdrawals(t *testing.T) {
 			if err == nil {
 				t.Fatal("wanted error on fcuv2 with invalid withdrawals")
 			}
+			var engineErr *engine.EngineAPIError
+			if !errors.As(err, &engineErr) {
+				t.Fatalf("expected EngineAPIError, got %T", err)
+			}
+			if have, want := engineErr.ErrorCode(), -32602; have != want {
+				t.Fatalf("wrong error code, have %d want %d", have, want)
+			}
 			continue
 		}
 		if err != nil {

--- a/eth/catalyst/witness.go
+++ b/eth/catalyst/witness.go
@@ -53,11 +53,11 @@ func (api *ConsensusAPI) ForkchoiceUpdatedWithWitnessV2(update engine.Forkchoice
 	if params != nil {
 		switch {
 		case params.BeaconRoot != nil:
-			return engine.STATUS_INVALID, attributesErr("unexpected beacon root")
+			return engine.STATUS_INVALID, paramsErr("unexpected beacon root")
 		case api.checkFork(params.Timestamp, forks.Paris) && params.Withdrawals != nil:
-			return engine.STATUS_INVALID, attributesErr("withdrawals before shanghai")
+			return engine.STATUS_INVALID, paramsErr("withdrawals before shanghai")
 		case api.checkFork(params.Timestamp, forks.Shanghai) && params.Withdrawals == nil:
-			return engine.STATUS_INVALID, attributesErr("missing withdrawals")
+			return engine.STATUS_INVALID, paramsErr("missing withdrawals")
 		case !api.checkFork(params.Timestamp, forks.Paris, forks.Shanghai):
 			return engine.STATUS_INVALID, unsupportedForkErr("fcuV2 must only be called with paris or shanghai payloads")
 		}


### PR DESCRIPTION
I observed the following failure while running hive:

https://hive.ethpandaops.io/#/test/generic/1772351960-ad3e3e460605c670efe1b4f4178eb422?testnumber=153

  Relevant log excerpt:

  ```shell
{"jsonrpc":"2.0","id":1,"error":{"code":-38003,"message":"Invalid payload attributes","data":{"err":"missing withdrawals"}}}

  DEBUG (Corrupted Block Hash Payload (INVALID)): Sent shanghai fcu using PayloadAttributesV1, error is expected

  FAIL (Corrupted Block Hash Payload (INVALID)): Expected error code on EngineForkchoiceUpdatedV2: want=-32602, got=-38003
```

  In short: geth returns -38003 for this FCU V2 invalid-structure/version case, while hive expects -32602.

  ## Why return -32602

  Per Shanghai engine_forkchoiceUpdatedV2:
  - PayloadAttributesV1 MUST be used when timestamp < Shanghai.
  - PayloadAttributesV2 MUST be used when timestamp >= Shanghai.
  - If the wrong version is used, Client software MUST return -32602: Invalid params.

  Reference:

  - https://github.com/ethereum/execution-apis/blob/main/src/engine/shanghai.md#engine_forkchoiceupdatedv2

  This PR updates FCU V2 handling to follow that requirement.

  ## Note

  If my interpretation of the spec here is incorrect, please let me know and I can adjust the implementation accordingly.