### PR TITLE
cmd/fetchpayload: add payload-building utility

### DIFF
--- a/cmd/fetchpayload/main.go
+++ b/cmd/fetchpayload/main.go
@@ -90,7 +90,8 @@ func main() {
 		fatal("failed to fetch execution witness: %v", err)
 	}
 
-	witness, err := fromExtWitness(&extWitness)
+	witness := new(stateless.Witness)
+	err = witness.FromExtWitness(&extWitness)
 	if err != nil {
 		fatal("failed to convert witness: %v", err)
 	}
@@ -152,23 +153,6 @@ func parseBlockNumber(s string) (*big.Int, error) {
 		return nil, fmt.Errorf("invalid decimal number")
 	}
 	return n, nil
-}
-
-// fromExtWitness converts the consensus ExtWitness into the internal Witness.
-// Duplicated from core/stateless (unexported method) and cmd/keeper/getpayload_example.go.
-func fromExtWitness(ext *stateless.ExtWitness) (*stateless.Witness, error) {
-	w := &stateless.Witness{}
-	w.Headers = ext.Headers
-
-	w.Codes = make(map[string]struct{}, len(ext.Codes))
-	for _, code := range ext.Codes {
-		w.Codes[string(code)] = struct{}{}
-	}
-	w.State = make(map[string]struct{}, len(ext.State))
-	for _, node := range ext.State {
-		w.State[string(node)] = struct{}{}
-	}
-	return w, nil
 }
 
 // jsonPayload is a JSON-friendly representation of Payload. It uses ExtWitness

--- a/core/stateless/encoding.go
+++ b/core/stateless/encoding.go
@@ -40,8 +40,8 @@ func (w *Witness) ToExtWitness() *ExtWitness {
 	return ext
 }
 
-// fromExtWitness converts the consensus witness format into our internal one.
-func (w *Witness) fromExtWitness(ext *ExtWitness) error {
+// FromExtWitness converts the consensus witness format into our internal one.
+func (w *Witness) FromExtWitness(ext *ExtWitness) error {
 	w.Headers = ext.Headers
 
 	w.Codes = make(map[string]struct{}, len(ext.Codes))
@@ -66,7 +66,7 @@ func (w *Witness) DecodeRLP(s *rlp.Stream) error {
 	if err := s.Decode(&ext); err != nil {
 		return err
 	}
-	return w.fromExtWitness(&ext)
+	return w.FromExtWitness(&ext)
 }
 
 // ExtWitness is a witness RLP encoding for transferring across clients.


### PR DESCRIPTION
This is a request from people using keeper for testing. It connects to a node and gets all the information in order to create a serialized payload that can then be passed to the zkvm.