### PR TITLE
node: disable http2 for auth API

### DIFF
--- a/node/node.go
+++ b/node/node.go
@@ -152,8 +152,10 @@ func New(conf *Config) (*Node, error) {
 	// Configure RPC servers.
 	node.http = newHTTPServer(node.log, conf.HTTPTimeouts)
 	node.httpAuth = newHTTPServer(node.log, conf.HTTPTimeouts)
+	node.httpAuth.disableHTTP2 = true // Engine API does not need HTTP/2
 	node.ws = newHTTPServer(node.log, rpc.DefaultHTTPTimeouts)
 	node.wsAuth = newHTTPServer(node.log, rpc.DefaultHTTPTimeouts)
+	node.wsAuth.disableHTTP2 = true
 	node.ipc = newIPCServer(node.log, conf.IPCEndpoint())
 
 	return node, nil

--- a/node/rpcstack.go
+++ b/node/rpcstack.go
@@ -90,6 +90,9 @@ type httpServer struct {
 	port     int
 
 	handlerNames map[string]string
+
+	// disableHTTP2 disables HTTP/2 support on this server when set to true.
+	disableHTTP2 bool
 }
 
 const (
@@ -140,7 +143,9 @@ func (h *httpServer) start() error {
 	h.server = &http.Server{Handler: h}
 	h.server.Protocols = new(http.Protocols)
 	h.server.Protocols.SetHTTP1(true)
-	h.server.Protocols.SetUnencryptedHTTP2(true)
+	if !h.disableHTTP2 {
+		h.server.Protocols.SetUnencryptedHTTP2(true)
+	}
 	if h.timeouts != (rpc.HTTPTimeouts{}) {
 		CheckTimeouts(&h.timeouts)
 		h.server.ReadTimeout = h.timeouts.ReadTimeout


### PR DESCRIPTION
We got a report that after v1.17.0 a geth-teku node starts to time out on engine_getBlobsV2 after around 3h of operation. The culprit seems to be our optional http2 service which Teku attempts first. The exact cause of the timeout is still unclear.

This PR is more of a workaround than proper fix until we figure out the underlying issue. But I don't expect http2 to particularly benefit engine API throughput and latency. Hence it should be fine to disable it for now.