### PR TITLE
internal/ethapi: add gas usage metric for eth_call

### DIFF
--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -822,6 +822,7 @@ func (api *BlockChainAPI) Call(ctx context.Context, args TransactionArgs, blockN
 	if err != nil {
 		return nil, err
 	}
+	ethCallGasUsedHist.Update(int64(result.UsedGas))
 	if errors.Is(result.Err, vm.ErrExecutionReverted) {
 		return nil, newRevertError(result.Revert())
 	}

--- a/internal/ethapi/metrics.go
+++ b/internal/ethapi/metrics.go
@@ -1,0 +1,7 @@
+package ethapi
+
+import "github.com/ethereum/go-ethereum/metrics"
+
+var (
+	ethCallGasUsedHist = metrics.NewRegisteredHistogram("rpc/gas_used/eth_call", nil, metrics.NewExpDecaySample(1028, 0.015))
+)


### PR DESCRIPTION
Add a Prometheus histogram metric (`rpc/gas_used/eth_call`) that tracks the gas consumed by `eth_call` requests. This is useful for RPC providers to monitor node capacity and correlate CPU usage with actual EVM computation load — traffic throughput alone offers limited insight.

**Changes:**
- New `internal/ethapi/metrics.go` with histogram definition using `ExpDecaySample`
- Record `result.UsedGas` in `BlockChainAPI.Call()` after successful execution (including reverts, since they still consume gas)

Reference: Besu added a similar metric in [hyperledger/besu#9019](https://github.com/hyperledger/besu/pull/9019).

Fixes #32774