### PR TITLE
miner: avoid unnecessary work after payload resolution

### DIFF
--- a/miner/payload_building.go
+++ b/miner/payload_building.go
@@ -260,6 +260,13 @@ func (miner *Miner) buildPayload(args *BuildPayloadArgs, witness bool) (*Payload
 		for {
 			select {
 			case <-timer.C:
+				// Select is random, so we need to check if the payload has been stopped
+				select {
+				case <-payload.stop:
+					log.Info("Stopping work on payload", "id", payload.id, "reason", "delivery")
+					return
+				default:
+				}
 				start := time.Now()
 				r := miner.generateWork(fullParams, witness)
 				if r.err == nil {

--- a/miner/payload_building.go
+++ b/miner/payload_building.go
@@ -260,7 +260,11 @@ func (miner *Miner) buildPayload(args *BuildPayloadArgs, witness bool) (*Payload
 		for {
 			select {
 			case <-timer.C:
-				// Select is random, so we need to check if the payload has been stopped
+				// When block building takes close to the full recommit interval,
+				// the timer fires near-instantly on the next iteration. If the
+				// payload was resolved during that build, both timer.C and
+				// payload.stop are ready and Go's select picks one at random.
+				// Check payload.stop first to avoid an unnecessary generateWork.
 				select {
 				case <-payload.stop:
 					log.Info("Stopping work on payload", "id", payload.id, "reason", "delivery")


### PR DESCRIPTION
### Issue
In `buildPayload()`, the background goroutine uses a `select` to wait on the recommit timer, the stop channel, and the end timer. When both `timer.C` and `payload.stop` are ready simultaneously, Go's `select` picks a case non-deterministically. This means the loop can enter the `timer.C` case and perform an unnecessary `generateWork` call even after the payload has been resolved.

### Fix
Add a non-blocking check of `payload.stop` at the top of the `timer.C` case to exit immediately when the payload has already been delivered.