### PR TITLE
eth/catalyst: add api benchmarks

### DIFF
--- a/eth/catalyst/api_benchmark_test.go
+++ b/eth/catalyst/api_benchmark_test.go
@@ -1,4 +1,4 @@
-// Copyright 2024 The go-ethereum Authors
+// Copyright 2026 The go-ethereum Authors
 // This file is part of the go-ethereum library.
 //
 // The go-ethereum library is free software: you can redistribute it and/or modify

--- a/eth/catalyst/api_benchmark_test.go
+++ b/eth/catalyst/api_benchmark_test.go
@@ -1,0 +1,612 @@
+// Copyright 2024 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+
+package catalyst
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"crypto/sha256"
+	"encoding/json"
+	"fmt"
+	"math/big"
+	"testing"
+	"time"
+
+	"github.com/ethereum/go-ethereum/beacon/engine"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/ethereum/go-ethereum/crypto/kzg4844"
+	"github.com/ethereum/go-ethereum/eth"
+	"github.com/ethereum/go-ethereum/node"
+	"github.com/ethereum/go-ethereum/params"
+	"github.com/ethereum/go-ethereum/rlp"
+	"github.com/holiman/uint256"
+)
+
+// encodingType specifies which encoding to use in benchmarks
+type encodingType int
+
+const (
+	encNone encodingType = iota
+	encJSON
+	encRLP
+)
+
+func (e encodingType) String() string {
+	switch e {
+	case encNone:
+		return "none"
+	case encJSON:
+		return "json"
+	case encRLP:
+		return "rlp"
+	default:
+		return "unknown"
+	}
+}
+
+var encodingTypes = []encodingType{encNone, encJSON, encRLP}
+
+// benchEncode encodes the value using the specified encoding type.
+// It fails the benchmark if encoding fails.
+func benchEncode(b *testing.B, enc encodingType, v any) {
+	var err error
+	switch enc {
+	case encJSON:
+		_, err = json.Marshal(v)
+		if err != nil {
+			b.Fatalf("JSON marshal failed: %v", err)
+		}
+	case encRLP:
+		_, err = rlp.EncodeToBytes(v)
+		if err != nil {
+			b.Fatalf("RLP encode failed: %v", err)
+		}
+	}
+}
+
+// benchmarkBlobCounts defines the blob counts for benchmarks
+var benchmarkBlobCounts = []int{21, 72}
+
+// maxBenchmarkBlobs is the maximum number of blobs we need for benchmarks
+var maxBenchmarkBlobs = benchmarkBlobCounts[len(benchmarkBlobCounts)-1]
+
+var (
+	// Pre-computed blobs for benchmarks
+	benchBlobs          []*kzg4844.Blob
+	benchBlobCommits    []kzg4844.Commitment
+	benchBlobProofs     []kzg4844.Proof
+	benchBlobCellProofs [][]kzg4844.Proof
+	benchBlobVHashes    []common.Hash
+)
+
+func init() {
+	// Pre-compute blobs for benchmarks
+	for i := 0; i < maxBenchmarkBlobs; i++ {
+		blob := &kzg4844.Blob{byte(i), byte(i >> 8)}
+		benchBlobs = append(benchBlobs, blob)
+
+		commit, _ := kzg4844.BlobToCommitment(blob)
+		benchBlobCommits = append(benchBlobCommits, commit)
+
+		proof, _ := kzg4844.ComputeBlobProof(blob, commit)
+		benchBlobProofs = append(benchBlobProofs, proof)
+
+		cellProofs, _ := kzg4844.ComputeCellProofs(blob)
+		benchBlobCellProofs = append(benchBlobCellProofs, cellProofs)
+
+		vhash := kzg4844.CalcBlobHashV1(sha256.New(), &commit)
+		benchBlobVHashes = append(benchBlobVHashes, vhash)
+	}
+}
+
+// benchFork specifies which fork to use in benchmark environments
+type benchFork int
+
+const (
+	forkCancun benchFork = iota
+	forkPrague
+	forkOsaka
+)
+
+// benchmarkBlobEnv holds the environment for blob benchmarks
+type benchmarkBlobEnv struct {
+	node      *node.Node
+	eth       *eth.Ethereum
+	api       *ConsensusAPI
+	config    *params.ChainConfig
+	keys      []*ecdsa.PrivateKey
+	vhashes   []common.Hash
+	version   byte
+	blobCount int
+	nonces    []uint64 // current nonce for each key
+}
+
+// makeBenchBlobTx creates a blob transaction with the specified number of blobs.
+// blobOffset indicates which pre-computed blobs to use.
+func makeBenchBlobTx(chainConfig *params.ChainConfig, nonce uint64, blobCount int, blobOffset int, key *ecdsa.PrivateKey, version byte) *types.Transaction {
+	var (
+		blobs       []kzg4844.Blob
+		blobHashes  []common.Hash
+		commitments []kzg4844.Commitment
+		proofs      []kzg4844.Proof
+	)
+	for i := 0; i < blobCount; i++ {
+		idx := blobOffset + i
+		blobs = append(blobs, *benchBlobs[idx])
+		commitments = append(commitments, benchBlobCommits[idx])
+		if version == types.BlobSidecarVersion0 {
+			proofs = append(proofs, benchBlobProofs[idx])
+		} else {
+			proofs = append(proofs, benchBlobCellProofs[idx]...)
+		}
+		blobHashes = append(blobHashes, benchBlobVHashes[idx])
+	}
+	blobtx := &types.BlobTx{
+		ChainID:    uint256.MustFromBig(chainConfig.ChainID),
+		Nonce:      nonce,
+		GasTipCap:  uint256.NewInt(params.GWei),
+		GasFeeCap:  uint256.NewInt(10 * params.GWei),
+		Gas:        21000,
+		BlobFeeCap: uint256.NewInt(params.GWei),
+		BlobHashes: blobHashes,
+		Value:      uint256.NewInt(100),
+		Sidecar:    types.NewBlobTxSidecar(version, blobs, commitments, proofs),
+	}
+	return types.MustSignNewTx(key, types.LatestSigner(chainConfig), blobtx)
+}
+
+// newBenchmarkBlobEnv creates an environment for blob benchmarks.
+// It creates multiple keys and fills the pool with blob transactions totaling the specified blob count.
+// version: 0 = BlobSidecarVersion0 (pre-Osaka), 1 = BlobSidecarVersion1 (Osaka+)
+// fork: which fork to enable
+func newBenchmarkBlobEnv(b *testing.B, blobCount int, version byte, fork benchFork) *benchmarkBlobEnv {
+	// Create a configuration that allows enough blobs
+	config := *params.MergedTestChainConfig
+
+	// Set blob schedule to allow for large blob counts (up to 128 blobs per block)
+	config.BlobScheduleConfig = &params.BlobScheduleConfig{
+		Cancun: &params.BlobConfig{Target: 6, Max: 128, UpdateFraction: 3338477},
+		Prague: &params.BlobConfig{Target: 6, Max: 128, UpdateFraction: 5007716},
+		Osaka:  &params.BlobConfig{Target: 6, Max: 128, UpdateFraction: 5007716},
+	}
+
+	// Configure fork times based on requested fork
+	switch fork {
+	case forkCancun:
+		config.PragueTime = nil
+		config.OsakaTime = nil
+	case forkPrague:
+		config.OsakaTime = nil
+	case forkOsaka:
+		// All forks enabled (default)
+	}
+
+	// Generate enough keys for all the blob transactions
+	// Each tx can have up to 6 blobs, so we need ceil(blobCount/6) keys
+	numTxs := (blobCount + 5) / 6
+	keys := make([]*ecdsa.PrivateKey, numTxs)
+	addrs := make([]common.Address, numTxs)
+	alloc := make(types.GenesisAlloc)
+	alloc[testAddr] = types.Account{Balance: testBalance}
+
+	for i := 0; i < numTxs; i++ {
+		key, _ := crypto.GenerateKey()
+		keys[i] = key
+		addrs[i] = crypto.PubkeyToAddress(key.PublicKey)
+		// Give each account enough balance for many transactions
+		alloc[addrs[i]] = types.Account{Balance: new(big.Int).Mul(big.NewInt(1e18), big.NewInt(10000))}
+	}
+
+	gspec := &core.Genesis{
+		Config:     &config,
+		Alloc:      alloc,
+		Difficulty: common.Big0,
+	}
+	n, ethServ := startEthService(b, gspec, nil)
+
+	// Collect versioned hashes for the blobs we'll use
+	var vhashes []common.Hash
+	for i := 0; i < blobCount; i++ {
+		vhashes = append(vhashes, benchBlobVHashes[i])
+	}
+
+	// Fill initial blob txs into the pool
+	env := &benchmarkBlobEnv{
+		node:      n,
+		eth:       ethServ,
+		api:       newConsensusAPIWithoutHeartbeat(ethServ),
+		config:    &config,
+		keys:      keys,
+		vhashes:   vhashes,
+		version:   version,
+		blobCount: blobCount,
+		nonces:    make([]uint64, numTxs),
+	}
+	env.addBlobTxs(b)
+
+	return env
+}
+
+// addBlobTxs adds blob transactions to the pool using the stored blobCount and per-key nonces.
+// It increments each key's nonce after adding transactions.
+func (env *benchmarkBlobEnv) addBlobTxs(b *testing.B) {
+	numTxs := (env.blobCount + 5) / 6
+	var txs []*types.Transaction
+	blobsRemaining := env.blobCount
+	blobOffset := 0
+
+	for i := 0; i < numTxs && blobsRemaining > 0; i++ {
+		// Each tx gets up to 6 blobs
+		txBlobCount := 6
+		if blobsRemaining < 6 {
+			txBlobCount = blobsRemaining
+		}
+
+		tx := makeBenchBlobTx(env.config, env.nonces[i], txBlobCount, blobOffset, env.keys[i], env.version)
+		txs = append(txs, tx)
+
+		blobOffset += txBlobCount
+		blobsRemaining -= txBlobCount
+	}
+
+	errs := env.eth.TxPool().Add(txs, true)
+	for i, err := range errs {
+		if err != nil {
+			b.Fatalf("Failed to add blob tx %d to pool: %v", i, err)
+		}
+	}
+	// Increment nonce for each key used
+	for i := 0; i < numTxs; i++ {
+		env.nonces[i]++
+	}
+}
+
+// Close closes the environment
+func (env *benchmarkBlobEnv) Close() {
+	env.node.Close()
+}
+
+// BenchmarkGetBlobsV1 benchmarks the GetBlobsV1 method with various blob counts.
+// GetBlobsV1 is available at Cancun/Prague (pre-Osaka).
+func BenchmarkGetBlobsV1(b *testing.B) {
+	for _, blobCount := range benchmarkBlobCounts {
+		for _, enc := range encodingTypes {
+			b.Run(fmt.Sprintf("blobs=%d/enc=%s", blobCount, enc), func(b *testing.B) {
+				env := newBenchmarkBlobEnv(b, blobCount, 0, forkPrague)
+				defer env.Close()
+
+				b.ResetTimer()
+				for b.Loop() {
+					result, err := env.api.GetBlobsV1(env.vhashes)
+					if err != nil {
+						b.Fatalf("GetBlobsV1 failed: %v", err)
+					}
+					// Verify we got the expected number of blobs
+					if len(result) != blobCount {
+						b.Fatalf("expected %d blobs, got %d", blobCount, len(result))
+					}
+					benchEncode(b, enc, result)
+				}
+			})
+		}
+	}
+}
+
+// BenchmarkGetBlobsV2Extended benchmarks the GetBlobsV2 method with various blob counts.
+// GetBlobsV2 is available at Osaka+.
+func BenchmarkGetBlobsV2Extended(b *testing.B) {
+	for _, blobCount := range benchmarkBlobCounts {
+		for _, enc := range encodingTypes {
+			b.Run(fmt.Sprintf("blobs=%d/enc=%s", blobCount, enc), func(b *testing.B) {
+				env := newBenchmarkBlobEnv(b, blobCount, 1, forkOsaka)
+				defer env.Close()
+
+				b.ResetTimer()
+				for b.Loop() {
+					result, err := env.api.GetBlobsV2(env.vhashes)
+					if err != nil {
+						b.Fatalf("GetBlobsV2 failed: %v", err)
+					}
+					// Verify we got the expected number of blobs
+					if len(result) != blobCount {
+						b.Fatalf("expected %d blobs, got %d", blobCount, len(result))
+					}
+					benchEncode(b, enc, result)
+				}
+			})
+		}
+	}
+}
+
+// BenchmarkGetBlobsV3 benchmarks the GetBlobsV3 method with various blob counts.
+// GetBlobsV3 is available at Osaka+.
+func BenchmarkGetBlobsV3(b *testing.B) {
+	for _, blobCount := range benchmarkBlobCounts {
+		for _, enc := range encodingTypes {
+			b.Run(fmt.Sprintf("blobs=%d/enc=%s", blobCount, enc), func(b *testing.B) {
+				env := newBenchmarkBlobEnv(b, blobCount, 1, forkOsaka)
+				defer env.Close()
+
+				b.ResetTimer()
+				for b.Loop() {
+					result, err := env.api.GetBlobsV3(env.vhashes)
+					if err != nil {
+						b.Fatalf("GetBlobsV3 failed: %v", err)
+					}
+					// Verify we got the expected number of blobs
+					if len(result) != blobCount {
+						b.Fatalf("expected %d blobs, got %d", blobCount, len(result))
+					}
+					benchEncode(b, enc, result)
+				}
+			})
+		}
+	}
+}
+
+// BenchmarkGetPayloadV5WithBlobs benchmarks GetPayloadV5 (Osaka fork) with blobs.
+// Note: Measures single iteration performance due to NewPayload complexity at Osaka.
+func BenchmarkGetPayloadV5WithBlobs(b *testing.B) {
+	for _, blobCount := range benchmarkBlobCounts {
+		for _, enc := range encodingTypes {
+			b.Run(fmt.Sprintf("blobs=%d/enc=%s", blobCount, enc), func(b *testing.B) {
+				env := newBenchmarkBlobEnv(b, blobCount, 1, forkOsaka)
+				defer env.Close()
+
+				parent := env.api.eth.BlockChain().CurrentHeader()
+				beaconRoot := common.Hash{0x42}
+
+				b.ResetTimer()
+				for i := 0; i < b.N; i++ {
+					// Note: We don't call addBlobTxs here because we can't advance the chain
+					// (NewPayloadV5 requires execution requests). The same transactions are
+					// reused for each iteration, which still benchmarks the GetPayload performance.
+
+					timestamp := parent.Time + 12
+					fcState := engine.ForkchoiceStateV1{
+						HeadBlockHash:      parent.Hash(),
+						SafeBlockHash:      parent.Hash(),
+						FinalizedBlockHash: parent.Hash(),
+					}
+					payloadAttr := &engine.PayloadAttributes{
+						Timestamp:             timestamp,
+						Random:                common.Hash{byte(i)},
+						SuggestedFeeRecipient: testAddr,
+						Withdrawals:           []*types.Withdrawal{},
+						BeaconRoot:            &beaconRoot,
+					}
+
+					resp, err := env.api.ForkchoiceUpdatedV3(fcState, payloadAttr)
+					if err != nil {
+						b.Fatalf("ForkchoiceUpdatedV3 failed: %v", err)
+					}
+					if resp.PayloadID == nil {
+						b.Fatalf("ForkchoiceUpdatedV3 returned nil PayloadID")
+					}
+
+					// Wait for the payload to be built with transactions
+					time.Sleep(100 * time.Millisecond)
+
+					envelope, err := env.api.GetPayloadV5(*resp.PayloadID)
+					if err != nil {
+						b.Fatalf("GetPayloadV5 failed: %v", err)
+					}
+					if envelope.BlobsBundle == nil {
+						b.Fatalf("BlobsBundle is nil")
+					}
+					// Verify we got the expected number of blobs
+					if len(envelope.BlobsBundle.Blobs) != blobCount {
+						b.Fatalf("expected %d blobs, got %d", blobCount, len(envelope.BlobsBundle.Blobs))
+					}
+					benchEncode(b, enc, envelope)
+				}
+			})
+		}
+	}
+}
+
+// BenchmarkNewPayloadV3WithBlobs benchmarks the NewPayloadV3 method with various blob counts.
+// Each iteration processes a payload with the full blob count.
+func BenchmarkNewPayloadV3WithBlobs(b *testing.B) {
+	for _, blobCount := range benchmarkBlobCounts {
+		for _, enc := range encodingTypes {
+			b.Run(fmt.Sprintf("blobs=%d/enc=%s", blobCount, enc), func(b *testing.B) {
+				env := newBenchmarkBlobEnv(b, blobCount, 0, forkCancun)
+				defer env.Close()
+
+				parent := env.api.eth.BlockChain().CurrentHeader()
+				beaconRoot := common.Hash{0x42}
+
+				// Build a payload first to get valid executable data
+				timestamp := parent.Time + 12
+				fcState := engine.ForkchoiceStateV1{
+					HeadBlockHash:      parent.Hash(),
+					SafeBlockHash:      parent.Hash(),
+					FinalizedBlockHash: parent.Hash(),
+				}
+				payloadAttr := &engine.PayloadAttributes{
+					Timestamp:             timestamp,
+					Random:                common.Hash{0x01},
+					SuggestedFeeRecipient: testAddr,
+					Withdrawals:           []*types.Withdrawal{},
+					BeaconRoot:            &beaconRoot,
+				}
+
+				resp, err := env.api.ForkchoiceUpdatedV3(fcState, payloadAttr)
+				if err != nil {
+					b.Fatalf("ForkchoiceUpdatedV3 failed: %v", err)
+				}
+				if resp.PayloadID == nil {
+					b.Fatalf("ForkchoiceUpdatedV3 returned nil PayloadID")
+				}
+
+				// Wait for the payload to be built with transactions
+				time.Sleep(100 * time.Millisecond)
+
+				// Get the payload
+				envelope, err := env.api.GetPayloadV3(*resp.PayloadID)
+				if err != nil {
+					b.Fatalf("GetPayloadV3 failed: %v", err)
+				}
+
+				// Verify we got the expected number of blobs
+				if len(envelope.BlobsBundle.Blobs) != blobCount {
+					b.Fatalf("expected %d blobs in setup, got %d", blobCount, len(envelope.BlobsBundle.Blobs))
+				}
+
+				execData := envelope.ExecutionPayload
+
+				// Collect versioned hashes from blobs bundle
+				vhashes := make([]common.Hash, len(envelope.BlobsBundle.Commitments))
+				for j, commitment := range envelope.BlobsBundle.Commitments {
+					var commit kzg4844.Commitment
+					copy(commit[:], commitment)
+					vhashes[j] = kzg4844.CalcBlobHashV1(sha256.New(), &commit)
+				}
+
+				b.ResetTimer()
+				for i := 0; i < b.N; i++ {
+					// NewPayload is idempotent, calling it multiple times with the same data
+					// should return the same result. The payload contains blobCount blobs.
+					result, err := env.api.NewPayloadV3(context.Background(), *execData, vhashes, &beaconRoot)
+					if err != nil {
+						b.Fatalf("NewPayloadV3 failed: %v", err)
+					}
+					benchEncode(b, enc, result)
+				}
+			})
+		}
+	}
+}
+
+// BenchmarkForkchoiceUpdatedWithBlobPayload benchmarks forkchoice updates that trigger
+// payload building with blob transactions.
+// Note: Measures ForkchoiceUpdated performance with blob transactions in the pool.
+func BenchmarkForkchoiceUpdatedWithBlobPayload(b *testing.B) {
+	for _, blobCount := range benchmarkBlobCounts {
+		for _, enc := range encodingTypes {
+			b.Run(fmt.Sprintf("blobs=%d/enc=%s", blobCount, enc), func(b *testing.B) {
+				env := newBenchmarkBlobEnv(b, blobCount, 0, forkCancun)
+				defer env.Close()
+
+				parent := env.api.eth.BlockChain().CurrentHeader()
+				beaconRoot := common.Hash{0x42}
+
+				b.ResetTimer()
+				for i := 0; i < b.N; i++ {
+					// Note: We don't call addBlobTxs here because the blob pool has
+					// a per-account limit of 16 transactions. The same transactions are
+					// reused for each iteration, which still benchmarks the ForkchoiceUpdated
+					// performance with blob transactions in the pool.
+
+					timestamp := parent.Time + 12
+					fcState := engine.ForkchoiceStateV1{
+						HeadBlockHash:      parent.Hash(),
+						SafeBlockHash:      parent.Hash(),
+						FinalizedBlockHash: parent.Hash(),
+					}
+					payloadAttr := &engine.PayloadAttributes{
+						Timestamp:             timestamp,
+						Random:                common.Hash{byte(i)},
+						SuggestedFeeRecipient: testAddr,
+						Withdrawals:           []*types.Withdrawal{},
+						BeaconRoot:            &beaconRoot,
+					}
+
+					resp, err := env.api.ForkchoiceUpdatedV3(fcState, payloadAttr)
+					if err != nil {
+						b.Fatalf("ForkchoiceUpdatedV3 failed: %v", err)
+					}
+					if resp.PayloadID == nil {
+						b.Fatalf("ForkchoiceUpdatedV3 returned nil PayloadID")
+					}
+					benchEncode(b, enc, resp)
+				}
+			})
+		}
+	}
+}
+
+// BenchmarkFullBlobWorkflowOsaka benchmarks the complete blob workflow at Osaka:
+// ForkchoiceUpdated -> GetPayload
+// Note: Measures single iteration performance due to NewPayload complexity at Osaka.
+func BenchmarkFullBlobWorkflowOsaka(b *testing.B) {
+	for _, blobCount := range benchmarkBlobCounts {
+		for _, enc := range encodingTypes {
+			b.Run(fmt.Sprintf("blobs=%d/enc=%s", blobCount, enc), func(b *testing.B) {
+				env := newBenchmarkBlobEnv(b, blobCount, 1, forkOsaka)
+				defer env.Close()
+
+				parent := env.api.eth.BlockChain().CurrentHeader()
+				beaconRoot := common.Hash{0x42}
+
+				b.ResetTimer()
+				for i := 0; i < b.N; i++ {
+					// Note: We don't call addBlobTxs here because we can't advance the chain
+					// (NewPayloadV5 requires execution requests). The same transactions are
+					// reused for each iteration, which still benchmarks the workflow performance.
+
+					// 1. ForkchoiceUpdated to build payload
+					timestamp := parent.Time + 12
+					fcState := engine.ForkchoiceStateV1{
+						HeadBlockHash:      parent.Hash(),
+						SafeBlockHash:      parent.Hash(),
+						FinalizedBlockHash: parent.Hash(),
+					}
+					payloadAttr := &engine.PayloadAttributes{
+						Timestamp:             timestamp,
+						Random:                common.Hash{byte(i)},
+						SuggestedFeeRecipient: testAddr,
+						Withdrawals:           []*types.Withdrawal{},
+						BeaconRoot:            &beaconRoot,
+					}
+
+					resp, err := env.api.ForkchoiceUpdatedV3(fcState, payloadAttr)
+					if err != nil {
+						b.Fatalf("ForkchoiceUpdatedV3 failed: %v", err)
+					}
+					if resp.PayloadID == nil {
+						b.Fatalf("ForkchoiceUpdatedV3 returned nil PayloadID")
+					}
+					// Encode ForkchoiceUpdated response
+					benchEncode(b, enc, resp)
+
+					// Wait for the payload to be built with transactions
+					time.Sleep(100 * time.Millisecond)
+
+					// 2. GetPayload
+					envelope, err := env.api.GetPayloadV5(*resp.PayloadID)
+					if err != nil {
+						b.Fatalf("GetPayloadV5 failed: %v", err)
+					}
+					if envelope.BlobsBundle == nil {
+						b.Fatalf("BlobsBundle is nil")
+					}
+					// Verify we got the expected number of blobs
+					if len(envelope.BlobsBundle.Blobs) != blobCount {
+						b.Fatalf("expected %d blobs, got %d", blobCount, len(envelope.BlobsBundle.Blobs))
+					}
+					// Encode GetPayload response
+					benchEncode(b, enc, envelope)
+				}
+			})
+		}
+	}
+}


### PR DESCRIPTION
```
goos: linux
goarch: amd64
pkg: github.com/ethereum/go-ethereum/eth/catalyst
cpu: Intel(R) Core(TM) Ultra 7 155U
BenchmarkGetBlobsV1/blobs=21/enc=none-14        	     612	   1885914 ns/op	10909965 B/op	     229 allocs/op
BenchmarkGetBlobsV1/blobs=21/enc=json-14        	     109	  10879175 ns/op	28477092 B/op	     281 allocs/op
BenchmarkGetBlobsV1/blobs=21/enc=rlp-14         	     386	   3192015 ns/op	17896863 B/op	     238 allocs/op
BenchmarkGetBlobsV1/blobs=72/enc=none-14        	     154	   7825103 ns/op	39723762 B/op	     739 allocs/op
BenchmarkGetBlobsV1/blobs=72/enc=json-14        	      30	  38436460 ns/op	97178624 B/op	     893 allocs/op
BenchmarkGetBlobsV1/blobs=72/enc=rlp-14         	      92	  11162196 ns/op	55928897 B/op	     747 allocs/op
BenchmarkGetBlobsV2Extended/blobs=21/enc=none-14         	     513	   2298556 ns/op	11954311 B/op	    3160 allocs/op
BenchmarkGetBlobsV2Extended/blobs=21/enc=json-14         	      90	  13404840 ns/op	31825485 B/op	    5882 allocs/op
BenchmarkGetBlobsV2Extended/blobs=21/enc=rlp-14          	     325	   3960216 ns/op	18200910 B/op	    3168 allocs/op
BenchmarkGetBlobsV2Extended/blobs=72/enc=none-14         	     100	  10185470 ns/op	43354657 B/op	   10748 allocs/op
BenchmarkGetBlobsV2Extended/blobs=72/enc=json-14         	      25	  48207486 ns/op	117935919 B/op	   20052 allocs/op
BenchmarkGetBlobsV2Extended/blobs=72/enc=rlp-14          	      87	  12293796 ns/op	55770122 B/op	   10752 allocs/op
BenchmarkGetBlobsV3/blobs=21/enc=none-14                 	     435	   2476177 ns/op	11915258 B/op	    3160 allocs/op
BenchmarkGetBlobsV3/blobs=21/enc=json-14                 	      87	  13843402 ns/op	32477236 B/op	    5882 allocs/op
BenchmarkGetBlobsV3/blobs=21/enc=rlp-14                  	     292	   4084295 ns/op	19835028 B/op	    3170 allocs/op
BenchmarkGetBlobsV3/blobs=72/enc=none-14                 	     121	   9955731 ns/op	43295816 B/op	   10748 allocs/op
BenchmarkGetBlobsV3/blobs=72/enc=json-14                 	      26	  44499527 ns/op	116286186 B/op	   20049 allocs/op
BenchmarkGetBlobsV3/blobs=72/enc=rlp-14                  	      86	  13245669 ns/op	57674296 B/op	   10754 allocs/op
BenchmarkGetPayloadV5WithBlobs/blobs=21/enc=none-14      	      10	 100718897 ns/op	12423173 B/op	    4145 allocs/op
BenchmarkGetPayloadV5WithBlobs/blobs=21/enc=json-14      	       8	 132742776 ns/op	40068712 B/op	    6961 allocs/op
BenchmarkGetPayloadV5WithBlobs/blobs=21/enc=rlp-14       	      10	 105106078 ns/op	30871458 B/op	    4186 allocs/op
BenchmarkGetPayloadV5WithBlobs/blobs=72/enc=none-14      	      10	 101413962 ns/op	44080654 B/op	   12430 allocs/op
BenchmarkGetPayloadV5WithBlobs/blobs=72/enc=json-14      	       5	 250721101 ns/op	159551582 B/op	   21974 allocs/op
BenchmarkGetPayloadV5WithBlobs/blobs=72/enc=rlp-14       	       9	 116302339 ns/op	106313922 B/op	   12499 allocs/op
BenchmarkNewPayloadV3WithBlobs/blobs=21/enc=none-14      	   64479	     20400 ns/op	   16443 B/op	     153 allocs/op
BenchmarkNewPayloadV3WithBlobs/blobs=21/enc=json-14      	   54351	     22618 ns/op	   16878 B/op	     155 allocs/op
BenchmarkNewPayloadV3WithBlobs/blobs=21/enc=rlp-14       	   54752	     25074 ns/op	   16844 B/op	     155 allocs/op
BenchmarkNewPayloadV3WithBlobs/blobs=72/enc=none-14      	   20606	     55895 ns/op	   31524 B/op	     303 allocs/op
BenchmarkNewPayloadV3WithBlobs/blobs=72/enc=json-14      	   22930	     56530 ns/op	   31732 B/op	     305 allocs/op
BenchmarkNewPayloadV3WithBlobs/blobs=72/enc=rlp-14       	   21771	     53347 ns/op	   31572 B/op	     304 allocs/op
BenchmarkForkchoiceUpdatedWithBlobPayload/blobs=21/enc=none-14         	    2720	    910119 ns/op	 4484979 B/op	     831 allocs/op
BenchmarkForkchoiceUpdatedWithBlobPayload/blobs=21/enc=json-14         	    3130	   1582162 ns/op	 5226225 B/op	    1311 allocs/op
BenchmarkForkchoiceUpdatedWithBlobPayload/blobs=21/enc=rlp-14          	    2636	   6325297 ns/op	 6582732 B/op	    2365 allocs/op
BenchmarkForkchoiceUpdatedWithBlobPayload/blobs=72/enc=none-14         	    2400	    649251 ns/op	 5234604 B/op	     671 allocs/op
BenchmarkForkchoiceUpdatedWithBlobPayload/blobs=72/enc=json-14         	    2702	   3699314 ns/op	 7541657 B/op	    2539 allocs/op
BenchmarkForkchoiceUpdatedWithBlobPayload/blobs=72/enc=rlp-14          	    3156	    427542 ns/op	 4418017 B/op	     933 allocs/op
BenchmarkFullBlobWorkflowOsaka/blobs=21/enc=none-14                    	      10	 100879941 ns/op	12987464 B/op	    9140 allocs/op
BenchmarkFullBlobWorkflowOsaka/blobs=21/enc=json-14                    	       8	 133535410 ns/op	35658243 B/op	   23004 allocs/op
BenchmarkFullBlobWorkflowOsaka/blobs=21/enc=rlp-14                     	      10	 103919805 ns/op	31995998 B/op	   20461 allocs/op
BenchmarkFullBlobWorkflowOsaka/blobs=72/enc=none-14                    	      10	 101290718 ns/op	43572349 B/op	   12460 allocs/op
BenchmarkFullBlobWorkflowOsaka/blobs=72/enc=json-14                    	       5	 237346315 ns/op	138550635 B/op	   21992 allocs/op
BenchmarkFullBlobWorkflowOsaka/blobs=72/enc=rlp-14                     	       9	 118295219 ns/op	106127421 B/op	   12483 allocs/op
PASS
ok  	github.com/ethereum/go-ethereum/eth/catalyst	156.725s
```