### PR TITLE
miner: enable trie prefetcher in block builder

### DIFF
--- a/miner/worker.go
+++ b/miner/worker.go
@@ -306,13 +306,14 @@ func (miner *Miner) makeEnv(parent *types.Header, header *types.Header, coinbase
 	if err != nil {
 		return nil, err
 	}
+	var bundle *stateless.Witness
 	if witness {
-		bundle, err := stateless.NewWitness(header, miner.chain)
+		bundle, err = stateless.NewWitness(header, miner.chain)
 		if err != nil {
 			return nil, err
 		}
-		state.StartPrefetcher("miner", bundle, nil)
 	}
+	state.StartPrefetcher("miner", bundle, nil)
 	// Note the passed coinbase may be different with header.Coinbase.
 	return &environment{
 		signer:   types.MakeSigner(miner.chainConfig, header.Number, header.Time),

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -78,6 +78,11 @@ func (env *environment) txFitsSize(tx *types.Transaction) bool {
 	return env.size+tx.Size() < params.MaxBlockSize-maxBlockSizeBufferZone
 }
 
+// discard terminates the background threads before discarding it.
+func (env *environment) discard() {
+	env.state.StopPrefetcher()
+}
+
 const (
 	commitInterruptNone int32 = iota
 	commitInterruptNewHead
@@ -125,6 +130,7 @@ func (miner *Miner) generateWork(genParam *generateParams, witness bool) *newPay
 	if err != nil {
 		return &newPayloadResult{err: err}
 	}
+	defer work.discard()
 
 	// Check withdrawals fit max block size.
 	// Due to the cap on withdrawal count, this can actually never happen, but we still need to


### PR DESCRIPTION
### Issue

Intermediate root calculation slows down block building.

<img width="1619" height="86" alt="image" src="https://github.com/user-attachments/assets/76ab0dd3-c0f0-40ce-a4f6-64aa7ab0f6ae" />

### Fix

Enable trie prefetcher in the block building path.

<img width="1619" height="92" alt="image" src="https://github.com/user-attachments/assets/e26b4578-5977-4ee6-9943-ebb6e45f6cec" />
