### PR TITLE
core/vm: use amsterdam jump table in lookup

### DIFF
--- a/core/vm/jump_table_test.go
+++ b/core/vm/jump_table_test.go
@@ -19,7 +19,6 @@ package vm
 import (
 	"testing"
 
-	"github.com/ethereum/go-ethereum/params"
 	"github.com/stretchr/testify/require"
 )
 
@@ -33,36 +32,4 @@ func TestJumpTableCopy(t *testing.T) {
 	deepCopy[SLOAD].constantGas = 100
 	require.Equal(t, uint64(100), deepCopy[SLOAD].constantGas)
 	require.Equal(t, uint64(0), tbl[SLOAD].constantGas)
-}
-
-func TestLookupInstructionSetAmsterdam(t *testing.T) {
-	jt, err := LookupInstructionSet(params.Rules{
-		IsMerge:     true,
-		IsShanghai:  true,
-		IsCancun:    true,
-		IsPrague:    true,
-		IsOsaka:     true,
-		IsAmsterdam: true,
-	})
-	require.NoError(t, err)
-
-	require.True(t, jt[SLOTNUM].HasCost())
-	require.True(t, jt[DUPN].HasCost())
-	require.True(t, jt[SWAPN].HasCost())
-	require.True(t, jt[EXCHANGE].HasCost())
-}
-
-func TestAmsterdamOpcodeActivation(t *testing.T) {
-	amsterdam := newAmsterdamInstructionSet()
-	osaka := newOsakaInstructionSet()
-
-	require.True(t, amsterdam[SLOTNUM].HasCost())
-	require.True(t, amsterdam[DUPN].HasCost())
-	require.True(t, amsterdam[SWAPN].HasCost())
-	require.True(t, amsterdam[EXCHANGE].HasCost())
-
-	require.False(t, osaka[SLOTNUM].HasCost())
-	require.False(t, osaka[DUPN].HasCost())
-	require.False(t, osaka[SWAPN].HasCost())
-	require.False(t, osaka[EXCHANGE].HasCost())
 }


### PR DESCRIPTION
Return the Amsterdam instruction set from `LookupInstructionSet` when `IsAmsterdam` is true, so Amsterdam rules no longer fall through to the Osaka jump table.