### PR TITLE
eth/catalyst: use payload v4 for amsterdam

### DIFF
--- a/eth/catalyst/simulated_beacon.go
+++ b/eth/catalyst/simulated_beacon.go
@@ -103,12 +103,29 @@ type SimulatedBeacon struct {
 
 func payloadVersion(config *params.ChainConfig, time uint64) engine.PayloadVersion {
 	switch config.LatestFork(time) {
+	case forks.Amsterdam:
+		return engine.PayloadV4
 	case forks.BPO5, forks.BPO4, forks.BPO3, forks.BPO2, forks.BPO1, forks.Osaka, forks.Prague, forks.Cancun:
 		return engine.PayloadV3
 	case forks.Paris, forks.Shanghai:
 		return engine.PayloadV2
 	}
 	panic("invalid fork, simulated beacon needs to be started post-merge")
+}
+
+func payloadAttributes(version engine.PayloadVersion, timestamp uint64, feeRecipient common.Address, withdrawals []*types.Withdrawal, random [32]byte) *engine.PayloadAttributes {
+	attributes := &engine.PayloadAttributes{
+		Timestamp:             timestamp,
+		SuggestedFeeRecipient: feeRecipient,
+		Withdrawals:           withdrawals,
+		Random:                random,
+		BeaconRoot:            &common.Hash{},
+	}
+	if version == engine.PayloadV4 {
+		slotNumber := uint64(0)
+		attributes.SlotNumber = &slotNumber
+	}
+	return attributes
 }
 
 // NewSimulatedBeacon constructs a new simulated beacon chain.
@@ -198,13 +215,7 @@ func (c *SimulatedBeacon) sealBlock(withdrawals []*types.Withdrawal, timestamp u
 
 	var random [32]byte
 	rand.Read(random[:])
-	fcResponse, err := c.engineAPI.forkchoiceUpdated(c.curForkchoiceState, &engine.PayloadAttributes{
-		Timestamp:             timestamp,
-		SuggestedFeeRecipient: feeRecipient,
-		Withdrawals:           withdrawals,
-		Random:                random,
-		BeaconRoot:            &common.Hash{},
-	}, version, false)
+	fcResponse, err := c.engineAPI.forkchoiceUpdated(c.curForkchoiceState, payloadAttributes(version, timestamp, feeRecipient, withdrawals, random), version, false)
 	if err != nil {
 		return err
 	}

--- a/eth/catalyst/simulated_beacon_test.go
+++ b/eth/catalyst/simulated_beacon_test.go
@@ -23,6 +23,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/ethereum/go-ethereum/beacon/engine"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core"
 	"github.com/ethereum/go-ethereum/core/types"
@@ -68,6 +69,25 @@ func startSimulatedBeaconEthService(t *testing.T, genesis *core.Genesis, period 
 
 	ethservice.SetSynced()
 	return n, ethservice, simBeacon
+}
+
+func TestPayloadVersionAmsterdam(t *testing.T) {
+	amsterdamTime := uint64(1)
+	cfg := &params.ChainConfig{
+		LondonBlock:   big.NewInt(0),
+		AmsterdamTime: &amsterdamTime,
+	}
+	if got := payloadVersion(cfg, amsterdamTime); got != engine.PayloadV4 {
+		t.Fatalf("unexpected payload version: have %v want %v", got, engine.PayloadV4)
+	}
+}
+
+func TestPayloadAttributesAmsterdamSlotNumber(t *testing.T) {
+	var random [32]byte
+	attrs := payloadAttributes(engine.PayloadV4, 1, common.Address{}, nil, random)
+	if attrs.SlotNumber == nil {
+		t.Fatal("missing slot number for payload v4")
+	}
 }
 
 // send 20 transactions, >10 withdrawals and ensure they are included in order


### PR DESCRIPTION
Switch simulated beacon Amsterdam payload selection to `PayloadV4` and always populate `PayloadAttributes.SlotNumber` for that version, so Amsterdam block building no longer fails on missing post-amsterdam slot number.