### PR TITLE
params: include amsterdam in fork config lookups

### DIFF
--- a/params/config.go
+++ b/params/config.go
@@ -1172,6 +1172,8 @@ func (c *ChainConfig) LatestFork(time uint64) forks.Fork {
 // BlobConfig returns the blob config associated with the provided fork.
 func (c *ChainConfig) BlobConfig(fork forks.Fork) *BlobConfig {
 	switch fork {
+	case forks.Amsterdam:
+		return c.BlobScheduleConfig.Amsterdam
 	case forks.BPO5:
 		return c.BlobScheduleConfig.BPO5
 	case forks.BPO4:
@@ -1217,6 +1219,8 @@ func (c *ChainConfig) ActiveSystemContracts(time uint64) map[string]common.Addre
 // the fork isn't defined or isn't a time-based fork.
 func (c *ChainConfig) Timestamp(fork forks.Fork) *uint64 {
 	switch {
+	case fork == forks.Amsterdam:
+		return c.AmsterdamTime
 	case fork == forks.BPO5:
 		return c.BPO5Time
 	case fork == forks.BPO4:

--- a/params/config_test.go
+++ b/params/config_test.go
@@ -23,6 +23,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/ethereum/go-ethereum/params/forks"
 	"github.com/stretchr/testify/require"
 )
 
@@ -154,4 +155,17 @@ func TestTimestampCompatError(t *testing.T) {
 
 	require.Equal(t, newTimestampCompatError(errWhat, newUint64(0), newUint64(1681338455)).Error(),
 		"mismatching Shanghai fork timestamp in database (have timestamp 0, want timestamp 1681338455, rewindto timestamp 0)")
+}
+
+func TestAmsterdamBlobConfigAndTimestamp(t *testing.T) {
+	amsterdamTime := uint64(100)
+	cfg := &ChainConfig{
+		LondonBlock:   big.NewInt(0),
+		AmsterdamTime: &amsterdamTime,
+		BlobScheduleConfig: &BlobScheduleConfig{
+			Amsterdam: DefaultPragueBlobConfig,
+		},
+	}
+	require.Equal(t, DefaultPragueBlobConfig, cfg.BlobConfig(forks.Amsterdam))
+	require.Equal(t, &amsterdamTime, cfg.Timestamp(forks.Amsterdam))
 }


### PR DESCRIPTION
Add Amsterdam handling to `ChainConfig.BlobConfig` and `ChainConfig.Timestamp`, so `eth_config` can return the expected blob schedule and activation timestamp when Amsterdam is the latest fork.