### PR TITLE
eth/fetcher: fix flaky test by improving event unsubscription

### DIFF
--- a/eth/fetcher/tx_fetcher.go
+++ b/eth/fetcher/tx_fetcher.go
@@ -442,7 +442,9 @@ func (f *TxFetcher) loop() {
 	if f.chain != nil {
 		headEventCh = make(chan core.ChainEvent, 10)
 		sub := f.chain.SubscribeChainEvent(headEventCh)
-		defer sub.Unsubscribe()
+		if sub != nil {
+			defer sub.Unsubscribe()
+		}
 	}
 
 	for {


### PR DESCRIPTION
As seen [here](https://github.com/ethereum/go-ethereum/actions/runs/22658182441/job/65672871427?pr=33153#step:4:252), [here](https://github.com/ethereum/go-ethereum/actions/runs/22658484391/job/65673814294#step:4:251), and [here](https://github.com/ethereum/go-ethereum/actions/runs/22651693745/job/65652962958#step:4:252), eth currently has a flaky test, related to the tx fetcher. 

The issue seems to happen when Unsubscribe is called while sub is nil. It seems that chain.Stop() may be invoked before the loop starts in some tests, but the exact cause is still under investigation through repeated runs. I think this change will at least prevent the error.