### PR TITLE
core: end telemetry span for ApplyTransactionWithEVM if error is returned

### DIFF
--- a/core/state_processor.go
+++ b/core/state_processor.go
@@ -108,12 +108,12 @@ func (p *StateProcessor) Process(ctx context.Context, block *types.Block, stated
 
 		receipt, err := ApplyTransactionWithEVM(msg, gp, statedb, blockNumber, blockHash, context.Time, tx, evm)
 		if err != nil {
+			spanEnd(&err)
 			return nil, fmt.Errorf("could not apply tx %d [%v]: %w", i, tx.Hash().Hex(), err)
 		}
 		receipts = append(receipts, receipt)
 		allLogs = append(allLogs, receipt.Logs...)
-
-		spanEnd(&err)
+		spanEnd(nil)
 	}
 	requests, err := postExecution(ctx, config, block, allLogs, evm)
 	if err != nil {


### PR DESCRIPTION
This looked like it could be an error.