### PR TITLE
core/filtermaps: close batch after write in map renderer

### DIFF
--- a/core/filtermaps/map_renderer.go
+++ b/core/filtermaps/map_renderer.go
@@ -410,6 +410,7 @@ func (r *mapRenderer) writeFinishedMaps(pauseCb func() bool) error {
 			if err := batch.Write(); err != nil {
 				log.Crit("Error writing log index update batch", "error", err)
 			}
+			batch.Close()
 			// do not exit while in partially written state but do allow processing
 			// events and pausing while block processing is in progress
 			r.f.indexLock.Unlock()
@@ -509,6 +510,7 @@ func (r *mapRenderer) writeFinishedMaps(pauseCb func() bool) error {
 	if err := batch.Write(); err != nil {
 		log.Crit("Error writing log index update batch", "error", err)
 	}
+	batch.Close()
 	totalTime += time.Since(start)
 	mapWriteTimer.Update(totalTime)
 	return nil


### PR DESCRIPTION
In `writeFinishedMaps`, when the write count threshold is reached, the old batch is written and a new one is created, but the old batch is never closed. The final batch at the end of the function is also not closed after writing.

Since pebble's `Batch.Close()` returns the batch to an internal pool, skipping it causes a continuous memory leak during filter map indexing.

Fix by calling `batch.Close()` after each `batch.Write()`.
