### PR TITLE
miner: fix nil statedb panic in applyTransaction pre-amsterdam

### DIFF
--- a/miner/worker.go
+++ b/miner/worker.go
@@ -438,6 +438,8 @@ func (miner *Miner) applyTransaction(env *environment, tx *types.Transaction) (*
 		prevReader = env.state.Reader()
 		stateCopy = env.state.WithReader(state.NewReaderWithTracker(env.state.Reader()))
 		env.evm.StateDB = stateCopy
+	} else {
+		stateCopy = env.state
 	}
 
 	mutations, receipt, err := core.ApplyTransaction(env.evm, env.gasPool, stateCopy, env.header, tx)


### PR DESCRIPTION
## Summary

- When `accessList` is nil (pre-Amsterdam blocks), `stateCopy` is never assigned and passed as nil to `core.ApplyTransaction`, causing a nil pointer dereference at `state_processor.go:224` (`statedb.Database().TrieDB().IsVerkle()`)
- This is a follow-up to 3e27b31d4 which fixed the `StateReaderTracker` type assertion panic but missed this second crash path in the same function
- Fix: set `stateCopy = env.state` in the non-Amsterdam path so `ApplyTransaction` always receives a valid statedb

## Test plan

- [x] Verified fix with 8-client Kurtosis network (`gloas_fork_epoch: 256`, pre-Amsterdam): 36+ slots, zero missed blocks, zero geth errors
- [x] Both geth nodes (lighthouse + lodestar CLs) proposing blocks successfully with spamoor tx load

🤖 Generated with [Claude Code](https://claude.com/claude-code)