### PR TITLE
eth/tracers: fix accessList StorageKeys return null

### DIFF
--- a/eth/tracers/logger/access_list_tracer.go
+++ b/eth/tracers/logger/access_list_tracer.go
@@ -85,11 +85,14 @@ func (al accessList) equal(other accessList) bool {
 func (al accessList) accessList() types.AccessList {
 	acl := make(types.AccessList, 0, len(al))
 	for addr, slots := range al {
-		tuple := types.AccessTuple{Address: addr, StorageKeys: []common.Hash{}}
-		for slot := range slots {
-			tuple.StorageKeys = append(tuple.StorageKeys, slot)
-		}
 		keys := slices.SortedFunc(maps.Keys(slots), common.Hash.Cmp)
+		// Ensure keys is never nil to avoid JSON serialization issues.
+		// When slots is empty, slices.SortedFunc returns nil, but JSON marshaling
+		// will serialize nil slice as null instead of [], which breaks clients
+		// that expect storageKeys to always be an array.
+		if keys == nil {
+			keys = []common.Hash{}
+		}
 		acl = append(acl, types.AccessTuple{Address: addr, StorageKeys: keys})
 	}
 	slices.SortFunc(acl, func(a, b types.AccessTuple) int { return a.Address.Cmp(b.Address) })


### PR DESCRIPTION
```
curl -X POST -H "Content-Type: application/json" \                                                                                                                                                                                      --data '{
      "jsonrpc": "2.0",
      "method": "eth_createAccessList",
      "params": [{
        "from": "0x054a47B9E2a22aF6c0CE55020238C8FEcd7d334B",
        "to": "0xa13BAF47339d63B743e7Da8741db5456DAc1E556",
        "data": "0x9bbaa2ba000000000000000000000000000000000000000000000000000000000000000a"
      }, "latest"],
      "id": 1
    }' \ 
    <rpc-endpoint>
 ```
    
   return result
   
  ```
  {
  "jsonrpc": "2.0",
  "id": 1,
  "result": {
    "accessList": [
      {
        "address": "0x0a20703878e68e587c59204cc0ea86098b8c3ba7",
        "storageKeys": null    <---- here.
      },
      {
        "address": "0xa13baf47339d63b743e7da8741db5456dac1e556",
        "storageKeys": [
          "0x360894a13ba1a3210667c828492db98dca3e2076cc3735a920a3ca505d382bbc",
          "0xb53127684a568b3173ae13b9f8a6016e243e63b6e8ee1178d6a717850b5d6103"
        ]
      }
    ],
    "error": "execution reverted",
    "gasUsed": "0x77fb"
  }
}
  ```
  
  https://github.com/ethereum/go-ethereum/blob/1982437259a2353fa22050c55abeb40eca7300c3/core/types/gen_access_tuple.go#L28 required not null, so client gets `2026/03/09 22:14:28 CallContext failed:missing required field 'storageKeys' for AccessTuple ` error