### PR TITLE
core/txpool/legacypool: fix empty cache sentinel

### DIFF
--- a/core/txpool/legacypool/legacypool.go
+++ b/core/txpool/legacypool/legacypool.go
@@ -1595,7 +1595,7 @@ func (pool *LegacyPool) demoteUnexecutables() {
 type accountSet struct {
 	accounts map[common.Address]struct{}
 	signer   types.Signer
-	cache    []common.Address
+	cache    *[]common.Address
 }
 
 // newAccountSet creates a new address set with an associated signer for sender
@@ -1628,9 +1628,10 @@ func (as *accountSet) addTx(tx *types.Transaction) {
 // reuse. The returned slice should not be changed!
 func (as *accountSet) flatten() []common.Address {
 	if as.cache == nil {
-		as.cache = slices.Collect(maps.Keys(as.accounts))
+		accounts := slices.Collect(maps.Keys(as.accounts))
+		as.cache = &accounts
 	}
-	return as.cache
+	return *as.cache
 }
 
 // merge adds all addresses from the 'other' set into 'as'.


### PR DESCRIPTION
Restore pointer-based cache sentinel in accountSet to preserve cached-empty state.

With slices.Collect(maps.Keys(emptyMap)), the returned slice can be nil. Using []common.Address directly makes as.cache == nil true after flatten() on an empty set, causing repeated recomputation. Switching cache back to *[]common.Address keeps 'cache initialized' distinct from 'cached value is nil/empty'.