### PR TITLE
common/hexutil: deduplicate UnmarshalFixedText functions

### DIFF
--- a/common/hexutil/json.go
+++ b/common/hexutil/json.go
@@ -108,14 +108,17 @@ func UnmarshalFixedJSON(typ reflect.Type, input, out []byte) error {
 // determines the required input length. This function is commonly used to implement the
 // UnmarshalText method for fixed-size types.
 func UnmarshalFixedText(typname string, input, out []byte) error {
-	raw, err := checkText(input, true)
+	return unmarshalFixedText(typname, input, out, true)
+}
+
+func unmarshalFixedText(typname string, input, out []byte, wantPrefix bool) error {
+	raw, err := checkText(input, wantPrefix)
 	if err != nil {
 		return err
 	}
 	if len(raw)/2 != len(out) {
 		return fmt.Errorf("hex string has length %d, want %d for %s", len(raw), len(out)*2, typname)
 	}
-	// Pre-verify syntax before modifying out.
 	for _, b := range raw {
 		if decodeNibble(b) == badNibble {
 			return ErrSyntax
@@ -129,21 +132,7 @@ func UnmarshalFixedText(typname string, input, out []byte) error {
 // length of out determines the required input length. This function is commonly used to
 // implement the UnmarshalText method for fixed-size types.
 func UnmarshalFixedUnprefixedText(typname string, input, out []byte) error {
-	raw, err := checkText(input, false)
-	if err != nil {
-		return err
-	}
-	if len(raw)/2 != len(out) {
-		return fmt.Errorf("hex string has length %d, want %d for %s", len(raw), len(out)*2, typname)
-	}
-	// Pre-verify syntax before modifying out.
-	for _, b := range raw {
-		if decodeNibble(b) == badNibble {
-			return ErrSyntax
-		}
-	}
-	hex.Decode(out, raw)
-	return nil
+	return unmarshalFixedText(typname, input, out, false)
 }
 
 // Big marshals/unmarshals as a JSON string with 0x prefix.


### PR DESCRIPTION
UnmarshalFixedText and UnmarshalFixedUnprefixedText had identical implementations (17 lines of copy-paste), differing only in the wantPrefix parameter.

Extracted shared logic into unmarshalFixedText helper. Now if there's a bug in decoding logic, we fix it once instead of twice.