### PR TITLE
core/types, core/txpool: reduce allocs in fee cap checks

### DIFF
--- a/core/txpool/legacypool/list.go
+++ b/core/txpool/legacypool/list.go
@@ -378,8 +378,9 @@ func (l *list) Filter(costLimit *uint256.Int, gasLimit uint64) (types.Transactio
 	l.gascap = gasLimit
 
 	// Filter out all the transactions above the account's funds
+	costLimitBig := costLimit.ToBig()
 	removed := l.txs.Filter(func(tx *types.Transaction) bool {
-		return tx.Gas() > gasLimit || tx.Cost().Cmp(costLimit.ToBig()) > 0
+		return tx.Gas() > gasLimit || tx.Cost().Cmp(costLimitBig) > 0
 	})
 
 	if len(removed) == 0 {

--- a/core/txpool/validation.go
+++ b/core/txpool/validation.go
@@ -94,7 +94,8 @@ func ValidateTransaction(tx *types.Transaction, head *types.Header, signer types
 	}
 	// Transactions can't be negative. This may never happen using RLP decoded
 	// transactions but may occur for transactions created using the RPC.
-	if tx.Value().Sign() < 0 {
+	value := tx.Value()
+	if value.Sign() < 0 {
 		return ErrNegativeValue
 	}
 	// Ensure the transaction doesn't exceed the current block limit gas
@@ -102,14 +103,16 @@ func ValidateTransaction(tx *types.Transaction, head *types.Header, signer types
 		return ErrGasLimit
 	}
 	// Sanity check for extremely large numbers (supported by RLP or RPC)
-	if tx.GasFeeCap().BitLen() > 256 {
+	feeCap := tx.GasFeeCap()
+	if feeCap.BitLen() > 256 {
 		return core.ErrFeeCapVeryHigh
 	}
-	if tx.GasTipCap().BitLen() > 256 {
+	tipCap := tx.GasTipCap()
+	if tipCap.BitLen() > 256 {
 		return core.ErrTipVeryHigh
 	}
 	// Ensure gasFeeCap is greater than or equal to gasTipCap
-	if tx.GasFeeCapIntCmp(tx.GasTipCap()) < 0 {
+	if feeCap.Cmp(tipCap) < 0 {
 		return core.ErrTipAboveFeeCap
 	}
 	// Make sure the transaction is signed properly

--- a/core/types/transaction.go
+++ b/core/types/transaction.go
@@ -478,12 +478,12 @@ func (tx *Transaction) BlobTxSidecar() *BlobTxSidecar {
 
 // BlobGasFeeCapCmp compares the blob fee cap of two transactions.
 func (tx *Transaction) BlobGasFeeCapCmp(other *Transaction) int {
-	return tx.BlobGasFeeCap().Cmp(other.BlobGasFeeCap())
+	return tx.inner.(*BlobTx).BlobFeeCap.Cmp(other.inner.(*BlobTx).BlobFeeCap)
 }
 
 // BlobGasFeeCapIntCmp compares the blob fee cap of the transaction against the given blob fee cap.
 func (tx *Transaction) BlobGasFeeCapIntCmp(other *big.Int) int {
-	return tx.BlobGasFeeCap().Cmp(other)
+	return tx.inner.(*BlobTx).BlobFeeCap.CmpBig(other)
 }
 
 // WithoutBlobTxSidecar returns a copy of tx with the blob sidecar removed.


### PR DESCRIPTION
Use direct blob fee cap comparisons and cached fee values in txpool validation, reducing avoidable allocations in transaction fee checks without changing behavior.