### PR TITLE
rpc: add blockAccessListHash to RPC block header response

### DIFF
--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -969,6 +969,9 @@ func RPCMarshalHeader(head *types.Header) map[string]interface{} {
 	if head.RequestsHash != nil {
 		result["requestsHash"] = head.RequestsHash
 	}
+	if head.BlockAccessListHash != nil {
+		result["blockAccessListHash"] = head.BlockAccessListHash
+	}
 	if head.SlotNumber != nil {
 		result["slotNumber"] = head.SlotNumber
 	}


### PR DESCRIPTION
Adds support for returning `blockAccessListHash` in the RPC block header response.

This change includes `blockAccessListHash` in `RPCMarshalHeader` when `head.BlockAccessListHash` is not nil, aligning the RPC output with the Header struct which already contains this field.