### PR TITLE
cmd/evm: don't strip prefixes on requests over t8n

### DIFF
--- a/cmd/evm/internal/t8ntool/execution.go
+++ b/cmd/evm/internal/t8ntool/execution.go
@@ -365,10 +365,6 @@ func (pre *Prestate) Apply(vmConfig vm.Config, chainConfig *params.ChainConfig, 
 		// Set requestsHash on block.
 		h := types.CalcRequestsHash(requests)
 		execRs.RequestsHash = &h
-		for i := range requests {
-			// remove prefix
-			requests[i] = requests[i][1:]
-		}
 		execRs.Requests = requests
 	}
 


### PR DESCRIPTION
Found this bug while implementing the Amsterdam changes t8n changes for benchmark test filling in EELS.

Prefixes were incorrectly being stripped on requests over t8n and this was leading to `fill` correctly catching hash mismatches on the EELS side for some BAL tests. Though this was caught there, I think this change might as well be cherry-picked there instead and merged to `master`.

This PR brings this behavior to parity with EELS for Osaka filling. There are still some quirks with regards to invalid block tests but I did not investigate this further.