### PR TITLE
p2p/enode: migrate node database from leveldb to pebble

### DIFF
--- a/p2p/enode/nodedb.go
+++ b/p2p/enode/nodedb.go
@@ -230,7 +230,6 @@ func (db *DB) fetchUint64(key []byte) uint64 {
 
 // storeUint64 stores an integer in the given key.
 func (db *DB) storeUint64(key []byte, n uint64) error {
-
 	blob := make([]byte, binary.MaxVarintLen64)
 	blob = blob[:binary.PutUvarint(blob, n)]
 	return db.lvl.Set(key, blob, pebble.Sync)


### PR DESCRIPTION
p2p/enode: migrate node database from leveldb to pebble

This PR migrates the node database (p2p/enode/nodedb.go) from LevelDB to Pebble.

Background:
While most parts of go-ethereum have moved to Pebble as the storage backend,
the node database used by the discovery protocol still relied on LevelDB.
This change aligns the node database with the rest of the codebase and removes
the remaining LevelDB dependency from this component.

Changes:
- Replace LevelDB usage with Pebble
- Update database initialization and open logic
- Replace LevelDB iterators with Pebble iterators
- Use vfs.NewMem() for the in-memory database implementation

Testing:
- go build ./...
- go test ./...
- go test ./p2p/enode -v
- make geth
- ./build/bin/geth --dev

All tests pass successfully.

Closes #33000