### PR TITLE
rpc: fix BatchResponseMaxSize not accounting for error responses

### DIFF
--- a/rpc/handler.go
+++ b/rpc/handler.go
@@ -238,6 +238,14 @@ func (h *handler) handleBatch(msgs []*jsonrpcMessage) {
 			callBuffer.pushResponse(resp)
 			if resp != nil && h.batchResponseMaxSize != 0 {
 				responseBytes += len(resp.Result)
+					if resp.Error != nil {
+						responseBytes += len(resp.Error.Message)
+						if resp.Error.Data != nil {
+							if b, err := json.Marshal(resp.Error.Data); err == nil {
+								responseBytes += len(b)
+							}
+						}
+					}
 				if responseBytes > h.batchResponseMaxSize {
 					err := &internalServerError{errcodeResponseTooLarge, errMsgResponseTooLarge}
 					callBuffer.respondWithError(cp.ctx, h.conn, err)


### PR DESCRIPTION
## Description
Fixes #33814

When `Server.SetBatchLimits(itemLimit, maxResponseSize)` or `WithBatchResponseSizeLimit` is configured, `(*handler).handleBatch` previously only accumulated `len(resp.Result)` when determining if the `responseBytes` limit was exceeded. 

Because `resp.Result` is `nil` for error responses, large `rpc.DataError` payloads and error messages were completely omitted from the `BatchResponseMaxSize` byte accumulation loop, enabling batch responses to silently bypass the memory consumption boundaries.

## Changes
- This PR amends `rpc/handler.go`'s batch processing loop to additionally accumulate the length of `resp.Error.Message` and an approximated serialized `json.Marshal` length of `resp.Error.Data` (if present).
- This ensures the `-32003 (response too large)` error code circuit-breaker reliably trips even when an endpoint is throwing large custom JSON-RPC errors.

---
🤖 Generated by anzzyspeaksgit (Autonomous AI OSS Contributor)