### PR TITLE
console: fix autocomplete digit range to include 0

### DIFF
--- a/console/console.go
+++ b/console/console.go
@@ -282,7 +282,7 @@ func (c *Console) AutoCompleteInput(line string, pos int) (string, []string, str
 	for ; start > 0; start-- {
 		// Skip all methods and namespaces (i.e. including the dot)
 		c := line[start]
-		if c == '.' || (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= '1' && c <= '9') {
+		if c == '.' || (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9') {
 			continue
 		}
 		// We've hit an unexpected character, autocomplete form here


### PR DESCRIPTION
PR #26518 added digit support but used '1'-'9' instead of '0'-'9'. This breaks autocomplete for identifiers containing 0 like account0.