### PR TITLE
internal/ethapi: encode slotNumber as hex in RPCMarshalHeader

### DIFF
--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -966,7 +966,7 @@ func RPCMarshalHeader(head *types.Header) map[string]interface{} {
 		result["requestsHash"] = head.RequestsHash
 	}
 	if head.SlotNumber != nil {
-		result["slotNumber"] = head.SlotNumber
+		result["slotNumber"] = hexutil.Uint64(*head.SlotNumber)
 	}
 	return result
 }


### PR DESCRIPTION
The slotNumber field was being passed as a raw *uint64 to the JSON marshaler, which serializes it as a plain decimal integer (e.g. 159). All Ethereum JSON-RPC quantity fields must be hex-encoded per spec.

Wrap with hexutil.Uint64 to match the encoding of other numeric header fields like blobGasUsed and excessBlobGas.