### PR TITLE
build: fix signify flag name in doWindowsInstaller

### DIFF
--- a/build/ci.go
+++ b/build/ci.go
@@ -1196,7 +1196,7 @@ func doWindowsInstaller(cmdline []string) {
 	var (
 		arch    = flag.String("arch", runtime.GOARCH, "Architecture for cross build packaging")
 		signer  = flag.String("signer", "", `Environment variable holding the signing key (e.g. WINDOWS_SIGNING_KEY)`)
-		signify = flag.String("signify key", "", `Environment variable holding the signify signing key (e.g. WINDOWS_SIGNIFY_KEY)`)
+		signify = flag.String("signify", "", `Environment variable holding the signify signing key (e.g. WINDOWS_SIGNIFY_KEY)`)
 		upload  = flag.String("upload", "", `Destination to upload the archives (usually "gethstore/builds")`)
 		workdir = flag.String("workdir", "", `Output directory for packages (uses temp dir if unset)`)
 	)


### PR DESCRIPTION
The signify flag in `doWindowsInstaller` was defined as "signify key" (with a space), making it impossible to pass via CLI (`-signify <value>`). This meant the Windows installer signify signing was silently never executed.

Fix by renaming the flag to "signify", consistent with `doArchive` and `doKeeperArchive`.