### PR TITLE
core: Check whether zero uncles check in verifyUncles is redundant

### DIFF
--- a/consensus/beacon/consensus.go
+++ b/consensus/beacon/consensus.go
@@ -45,7 +45,6 @@ var (
 // codebase, inherently breaking if the engine is swapped out. Please put common
 // error types into the consensus package.
 var (
-	errTooManyUncles    = errors.New("too many uncles")
 	errInvalidNonce     = errors.New("invalid nonce")
 	errInvalidUncleHash = errors.New("invalid uncle hash")
 	errInvalidTimestamp = errors.New("invalid timestamp")


### PR DESCRIPTION
Pulling this out from comment thread [here](https://github.com/ethereum/go-ethereum/pull/34007#discussion_r2939419097)