### PR TITLE
trie/bintrie: use sha256.Sum256 with stack buffer in InternalNode.Hash

### DIFF
--- a/trie/bintrie/internal_node.go
+++ b/trie/bintrie/internal_node.go
@@ -17,6 +17,7 @@
 package bintrie
 
 import (
+	"crypto/sha256"
 	"errors"
 	"fmt"
 
@@ -124,19 +125,14 @@ func (bt *InternalNode) Hash() common.Hash {
 		return bt.hash
 	}
 
-	h := newSha256()
-	defer returnSha256(h)
+	var buf [64]byte
 	if bt.left != nil {
-		h.Write(bt.left.Hash().Bytes())
-	} else {
-		h.Write(zero[:])
+		copy(buf[:32], bt.left.Hash().Bytes())
 	}
 	if bt.right != nil {
-		h.Write(bt.right.Hash().Bytes())
-	} else {
-		h.Write(zero[:])
+		copy(buf[32:], bt.right.Hash().Bytes())
 	}
-	bt.hash = common.BytesToHash(h.Sum(nil))
+	bt.hash = sha256.Sum256(buf[:])
 	bt.mustRecompute = false
 	return bt.hash
 }


### PR DESCRIPTION
## Summary

Replace the `sync.Pool`-based sha256 hashing in `InternalNode.Hash()` with a single `sha256.Sum256` call using a stack-allocated `[64]byte` buffer. This eliminates pool Get/Put overhead, two interface-dispatched `Write()` calls, the `Sum(nil)` heap allocation, and the `BytesToHash` conversion.

## Benchmark (AMD EPYC 48-core, 500K entries, screening `--benchtime=1x`)

| Metric | Baseline | Stack buf | Delta |
|--------|----------|-----------|-------|
| Approve (Mgas/s) | 3.95 | 4.21 | **+6.5%** |
| BalanceOf (Mgas/s) | 148.5 | 170.5 | **+14.8%** |