### PR TITLE
core/state: short-circuit GetCommittedState for nil origin accounts

### DIFF
--- a/core/state/state_object.go
+++ b/core/state/state_object.go
@@ -188,6 +188,15 @@ func (s *stateObject) GetCommittedState(key common.Hash) common.Hash {
 	if value, cached := s.originStorage[key]; cached {
 		return value
 	}
+	// If the account has no on-disk origin and was not destructed in this
+	// block (which requires the reader call for the access list), all
+	// storage slots are empty.
+	if s.origin == nil {
+		if _, destructed := s.db.stateObjectsDestruct[s.address]; !destructed {
+			s.originStorage[key] = common.Hash{}
+			return common.Hash{}
+		}
+	}
 	// If the object was destructed in *this* block (and potentially resurrected),
 	// the storage has been cleared out, and we should *not* consult the previous
 	// database about any storage values. The only possible alternatives are:


### PR DESCRIPTION
## Summary

When the account has never been persisted (`origin == nil`), all storage slots are implicitly empty. Short-circuit `GetCommittedState` and cache the negative result to avoid unnecessary trie lookups for newly created contracts that write many slots.

## Benchmark (AMD EPYC 48-core, 500K entries, screening `--benchtime=1x`)

| Metric | Baseline | Negative cache | Delta |
|--------|----------|----------------|-------|
| Approve (Mgas/s) | 4.13 | 4.34 | **+5.1%** |
| BalanceOf (Mgas/s) | 168.3 | 172.7 | +2.6% |