### PR TITLE
core: use defer to release txLookupLock in reorg

### DIFF
--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -2628,6 +2628,7 @@ func (bc *BlockChain) reorg(oldHead *types.Header, newHead *types.Header) error 
 	// as the txlookups should be changed atomically, and all subsequent
 	// reads should be blocked until the mutation is complete.
 	bc.txLookupLock.Lock()
+	defer bc.txLookupLock.Unlock()
 
 	// Reorg can be executed, start reducing the chain's old blocks and appending
 	// the new blocks
@@ -2729,9 +2730,6 @@ func (bc *BlockChain) reorg(oldHead *types.Header, newHead *types.Header) error 
 	}
 	// Reset the tx lookup cache to clear stale txlookup cache.
 	bc.txLookupCache.Purge()
-
-	// Release the tx-lookup lock after mutation.
-	bc.txLookupLock.Unlock()
 
 	return nil
 }


### PR DESCRIPTION
Fixes #34010

The `reorg` function acquires `txLookupLock` but has several early
return paths that skip the `Unlock()` call. While these paths only
trigger on database corruption, using `defer` is safer and guards
against future refactoring introducing new error paths.