### PR TITLE
core: move fee calculation behind skipFeePayment guard

### DIFF
--- a/core/state_transition.go
+++ b/core/state_transition.go
@@ -563,17 +563,19 @@ func (st *stateTransition) execute() (*ExecutionResult, error) {
 	if err != nil {
 		return nil, err
 	}
-	effectiveTip := msg.GasPrice
-	if rules.IsLondon {
-		effectiveTip = new(big.Int).Sub(msg.GasPrice, st.evm.Context.BaseFee)
-	}
-	effectiveTipU256, _ := uint256.FromBig(effectiveTip)
 
-	if st.evm.Config.NoBaseFee && msg.GasFeeCap.Sign() == 0 && msg.GasTipCap.Sign() == 0 {
-		// Skip fee payment when NoBaseFee is set and the fee fields
-		// are 0. This avoids a negative effectiveTip being applied to
-		// the coinbase when simulating calls.
-	} else {
+	skipFeePayment := st.evm.Config.NoBaseFee && msg.GasFeeCap.Sign() == 0 && msg.GasTipCap.Sign() == 0
+
+	// Skip fee payment when NoBaseFee is set and the fee fields
+	// are 0. This avoids a negative effectiveTip being applied to
+	// the coinbase when simulating calls.
+	if !skipFeePayment {
+		effectiveTip := msg.GasPrice
+		if rules.IsLondon {
+			effectiveTip = new(big.Int).Sub(msg.GasPrice, st.evm.Context.BaseFee)
+		}
+		effectiveTipU256, _ := uint256.FromBig(effectiveTip)
+
 		fee := new(uint256.Int).SetUint64(st.gasUsed())
 		fee.Mul(fee, effectiveTipU256)
 		st.state.AddBalance(st.evm.Context.Coinbase, fee, tracing.BalanceIncreaseRewardTransactionFee)


### PR DESCRIPTION
### Summary

Refactor the fee-payment guard in `core/state_transition.go` to make the skip condition explicit and keep fee-related calculations inside the payment path.

### Changes

- Introduce `skipFeePayment`:

  - `st.evm.Config.NoBaseFee && msg.GasFeeCap.Sign() == 0 && msg.GasTipCap.Sign() == 0`

- Move the following logic inside `if !skipFeePayment`:

  - `effectiveTip` calculation
  - `uint256.FromBig(effectiveTip)` conversion
  - fee computation and coinbase balance update
  - EIP-4762 witness coinbase inclusion

### Motivation

- Improve readability by naming the skip condition.
- Avoid unnecessary tip/fee calculations on the skip path.
- Keep the negative-tip simulation guard behavior clearly scoped to fee payment.

### Behavior Impact

No functional change intended.

- The skip condition is unchanged.
- Fee payment still happens under exactly the same circumstances as before.
- Only control-flow structure and calculation placement are refactored.