### PR TITLE
cmd/devp2p: fix discv5 PingMultiIP test session key mismatch

### DIFF
--- a/cmd/devp2p/internal/v5test/framework.go
+++ b/cmd/devp2p/internal/v5test/framework.go
@@ -218,11 +218,15 @@ func (tc *conn) read(c net.PacketConn) v5wire.Packet {
 	if err := c.SetReadDeadline(time.Now().Add(waitTime)); err != nil {
 		return &readError{err}
 	}
-	n, fromAddr, err := c.ReadFrom(buf)
+	n, _, err := c.ReadFrom(buf)
 	if err != nil {
 		return &readError{err}
 	}
-	_, _, p, err := tc.codec.Decode(buf[:n], fromAddr.String())
+	// Always use tc.remoteAddr for session lookup. The actual source address of
+	// the packet may differ from tc.remoteAddr when the remote node is reachable
+	// via multiple networks (e.g. Docker bridge vs. overlay), but the codec's
+	// session cache is keyed by the address used during Encode.
+	_, _, p, err := tc.codec.Decode(buf[:n], tc.remoteAddr.String())
 	if err != nil {
 		return &readError{err}
 	}


### PR DESCRIPTION
conn.read() used the actual UDP packet source address for codec.Decode(), but conn.write() always used tc.remoteAddr. When the remote node is reachable via multiple Docker networks, the packet source IP differs from tc.remoteAddr, causing a session key lookup failure in the codec.

Use tc.remoteAddr.String() consistently in conn.read() so the session cache key matches what was used during Encode.