### PR TITLE
internal/download: distinguish missing file from stale in era download

### DIFF
--- a/internal/download/download.go
+++ b/internal/download/download.go
@@ -22,6 +22,7 @@ import (
 	"bytes"
 	"crypto/sha256"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"io"
 	"iter"
@@ -180,12 +181,16 @@ func (db *ChecksumDB) DownloadFile(url, dstPath string) error {
 		return fmt.Errorf("no known hash for file %q", basename)
 	}
 	// Shortcut if already downloaded.
-	if verifyHash(dstPath, hash) == nil {
+	verifyErr := verifyHash(dstPath, hash)
+	if verifyErr == nil {
 		fmt.Printf("%s is up-to-date\n", dstPath)
 		return nil
 	}
-
-	fmt.Printf("%s is stale\n", dstPath)
+	if errors.Is(verifyErr, os.ErrNotExist) {
+		fmt.Printf("%s not found, downloading\n", dstPath)
+	} else {
+		fmt.Printf("%s is stale\n", dstPath)
+	}
 	fmt.Printf("downloading from %s\n", url)
 	resp, err := http.Get(url)
 	if err != nil {


### PR DESCRIPTION
## Summary

When downloading era files via `geth era-download`, all files are reported as "stale" even when they simply haven't been downloaded yet. This is confusing because "stale" implies the file exists but has a mismatched hash.

## Root cause

`verifyHash()` returns an error for both cases (file not found via `os.Open` and hash mismatch), and `DownloadFile` unconditionally printed "is stale" for any error.

## Fix

Check `errors.Is(err, os.ErrNotExist)` on the error from `verifyHash` to distinguish the two cases:
- **File missing**: print `"not found, downloading"`
- **Hash mismatch**: print `"is stale"` (existing behavior, now only for actual staleness)

Fixes #31917

Made with [Cursor](https://cursor.com)