### PR TITLE
core: fix txLookupLock mutex leak on error returns in reorg()

### DIFF
--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -2628,6 +2628,7 @@ func (bc *BlockChain) reorg(oldHead *types.Header, newHead *types.Header) error 
 	// as the txlookups should be changed atomically, and all subsequent
 	// reads should be blocked until the mutation is complete.
 	bc.txLookupLock.Lock()
+	defer bc.txLookupLock.Unlock()
 
 	// Reorg can be executed, start reducing the chain's old blocks and appending
 	// the new blocks
@@ -2729,9 +2730,6 @@ func (bc *BlockChain) reorg(oldHead *types.Header, newHead *types.Header) error 
 	}
 	// Reset the tx lookup cache to clear stale txlookup cache.
 	bc.txLookupCache.Purge()
-
-	// Release the tx-lookup lock after mutation.
-	bc.txLookupLock.Unlock()
 
 	return nil
 }


### PR DESCRIPTION
## Problem

`reorg()` acquires `txLookupLock` with `Lock()` but releases it with a manual `Unlock()` only at the end of the function (happy path). The function contains several early `return` statements that exit without calling `Unlock()`:

```go
bc.txLookupLock.Lock()
// ...
return errInvalidOldChain  // lock leaked
return errInvalidOldChain  // lock leaked  
return errInvalidNewChain  // lock leaked
// ...
bc.txLookupLock.Unlock() // only reached on success
return nil
```

When any of these error paths is taken (e.g. on a corrupt database detected during reorg), the mutex is never released. Any subsequent call that tries to acquire `txLookupLock` — including the next reorg attempt or a transaction lookup — will deadlock.

The lock was introduced in #29343 but the `defer` was not used, leaving the early-return paths unprotected.

## Fix

Replace the manual `Unlock()` at the end of the function with `defer bc.txLookupLock.Unlock()` placed immediately after `Lock()`. This guarantees the mutex is released on all return paths.

```go
bc.txLookupLock.Lock()
defer bc.txLookupLock.Unlock()  // +1 line
```

## Impact

- Without the fix: a single reorg that hits an `errInvalidOldChain` or `errInvalidNewChain` path permanently deadlocks all future transaction lookups and reorgs on this node
- With the fix: all return paths safely release the lock; no behaviour change on the happy path

## Testing

Existing `TestReorgSideEvent` and related tests cover the reorg path. The lock behaviour can be verified with `-race`.