### PR TITLE
oss-fuzz: fix missing '!' in shebang of generated fuzz scripts

### DIFF
--- a/oss-fuzz.sh
+++ b/oss-fuzz.sh
@@ -35,7 +35,7 @@ function coverbuild {
   sed -i -e 's/TestFuzzCorpus/Test'$function'Corpus/' ./"${function,,}"_test.go
 
 cat << DOG > $OUT/$fuzzer
-#/bin/sh
+#!/bin/sh
 
   cd $OUT/$path
   go test -run Test${function}Corpus -v $tags -coverprofile \$1 -coverpkg $coverpkg


### PR DESCRIPTION
## Summary

`oss-fuzz.sh` line 38 writes `#/bin/sh` instead of `#!/bin/sh` as the shebang of generated fuzz test runner scripts.

```diff
cat << DOG > $OUT/$fuzzer
-#/bin/sh
+#!/bin/sh
```

Without the `!`, the kernel does not recognize the interpreter directive, and the generated fuzz test runners may fail to execute on systems that don't fall back to the default shell.

One-character fix.