### PR TITLE
rlp: add AppendList method to RawList

### DIFF
--- a/rlp/raw.go
+++ b/rlp/raw.go
@@ -168,6 +168,18 @@ func (r *RawList[T]) AppendRaw(b []byte) error {
 	return nil
 }
 
+// AppendList appends all items from another RawList to this list.
+func (r *RawList[T]) AppendList(other *RawList[T]) {
+	if other.enc == nil || other.length == 0 {
+		return
+	}
+	if r.enc == nil {
+		r.enc = make([]byte, 9)
+	}
+	r.enc = append(r.enc, other.Content()...)
+	r.length += other.length
+}
+
 // StringSize returns the encoded size of a string.
 func StringSize(s string) uint64 {
 	switch n := len(s); n {

--- a/rlp/raw_test.go
+++ b/rlp/raw_test.go
@@ -246,6 +246,54 @@ func TestRawListAppendRaw(t *testing.T) {
 		t.Fatalf("wrong Len %d after invalid appends, want 2", rl.Len())
 	}
 }
+func TestRawListAppendList(t *testing.T) {
+	var rl1 RawList[uint64]
+	if err := rl1.Append(uint64(1)); err != nil {
+		t.Fatal("append 1 failed:", err)
+	}
+	if err := rl1.Append(uint64(2)); err != nil {
+		t.Fatal("append 2 failed:", err)
+	}
+
+	var rl2 RawList[uint64]
+	if err := rl2.Append(uint64(3)); err != nil {
+		t.Fatal("append 3 failed:", err)
+	}
+	if err := rl2.Append(uint64(4)); err != nil {
+		t.Fatal("append 4 failed:", err)
+	}
+
+	rl1.AppendList(&rl2)
+
+	if rl1.Len() != 4 {
+		t.Fatalf("wrong Len %d, want 4", rl1.Len())
+	}
+	if rl1.Size() != 5 {
+		t.Fatalf("wrong Size %d, want 5", rl1.Size())
+	}
+
+	items, err := rl1.Items()
+	if err != nil {
+		t.Fatal("Items failed:", err)
+	}
+	if !reflect.DeepEqual(items, []uint64{1, 2, 3, 4}) {
+		t.Fatalf("wrong items: %v", items)
+	}
+
+	var empty RawList[uint64]
+	prevLen := rl1.Len()
+	rl1.AppendList(&empty)
+
+	if rl1.Len() != prevLen {
+		t.Fatalf("appending empty list changed Len: got %d, want %d", rl1.Len(), prevLen)
+	}
+
+	empty.AppendList(&rl1)
+
+	if empty.Len() != 4 {
+		t.Fatalf("wrong Len %d, want 4", empty.Len())
+	}
+}
 
 func TestRawListDecodeInvalid(t *testing.T) {
 	tests := []struct {


### PR DESCRIPTION
This PR adds AppendList method to merge two RawList instances by appending the raw content. Related to #33153 