### PR TITLE
core/filtermaps: reset startedTailIndex flag after tail rendering

### DIFF
--- a/core/filtermaps/indexer.go
+++ b/core/filtermaps/indexer.go
@@ -349,8 +349,8 @@ func (f *FilterMaps) tryIndexTail() (bool, error) {
 			"firstblock", f.indexedRange.blocks.First(), "lastblock", f.indexedRange.blocks.Last(),
 			"processed", f.ptrTailIndex-f.indexedRange.blocks.First(),
 			"elapsed", common.PrettyDuration(time.Since(f.startedTailIndexAt)))
-		f.loggedTailIndex = false
 	}
+	f.loggedTailIndex, f.startedTailIndex = false, false
 	return true, nil
 }
 


### PR DESCRIPTION
startedTailIndex was never reset to false after tail rendering finished, unlike startedHeadIndex which is properly reset in tryIndexHead.

This caused ptrTailIndex to not reinitialize on subsequent tail indexing runs, resulting in incorrect "processed" counts in progress logs.

Bug exists since the initial commit f9f1172d5.