### PR TITLE
cmd/utils: guard SampleRatio flag with IsSet check

### DIFF
--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -1584,7 +1584,9 @@ func setOpenTelemetry(ctx *cli.Context, cfg *node.Config) {
 	if ctx.IsSet(RPCTelemetryTagsFlag.Name) {
 		tcfg.Tags = ctx.String(RPCTelemetryTagsFlag.Name)
 	}
-	tcfg.SampleRatio = ctx.Float64(RPCTelemetrySampleRatioFlag.Name)
+	if ctx.IsSet(RPCTelemetrySampleRatioFlag.Name) {
+		tcfg.SampleRatio = ctx.Float64(RPCTelemetrySampleRatioFlag.Name)
+	}
 
 	if tcfg.Endpoint != "" && !tcfg.Enabled {
 		log.Warn(fmt.Sprintf("OpenTelemetry endpoint configured but telemetry is not enabled, use --%s to enable.", RPCTelemetryFlag.Name))


### PR DESCRIPTION
In `setOpenTelemetry`, all other fields (Enabled, Endpoint, AuthUser, AuthPassword, InstanceID, Tags) are guarded by `ctx.IsSet()` checks, so they only override the config file when explicitly set via CLI flags. `SampleRatio` was the only field missing this guard, causing the flag default (`1.0`) to always overwrite whatever was loaded from the config file.

- Fix OpenTelemetry `SampleRatio` being unconditionally overwritten by the CLI flag default value (`1.0`), even when the user did not pass `--rpc.telemetry.sample-ratio`
- This caused config file values for `SampleRatio` to be silently ignored