### PR TITLE
eth, eth/filters: allow queries to fall through to era files on pruned nodes

### DIFF
--- a/eth/api_backend.go
+++ b/eth/api_backend.go
@@ -29,7 +29,6 @@ import (
 	"github.com/ethereum/go-ethereum/consensus/misc/eip4844"
 	"github.com/ethereum/go-ethereum/core"
 	"github.com/ethereum/go-ethereum/core/filtermaps"
-	"github.com/ethereum/go-ethereum/core/history"
 	"github.com/ethereum/go-ethereum/core/rawdb"
 	"github.com/ethereum/go-ethereum/core/state"
 	"github.com/ethereum/go-ethereum/core/txpool"
@@ -155,11 +154,7 @@ func (b *EthAPIBackend) BlockByNumber(ctx context.Context, number rpc.BlockNumbe
 	if number == rpc.EarliestBlockNumber {
 		bn = b.HistoryPruningCutoff()
 	}
-	block := b.eth.blockchain.GetBlockByNumber(bn)
-	if block == nil && bn < b.HistoryPruningCutoff() {
-		return nil, &history.PrunedHistoryError{}
-	}
-	return block, nil
+	return b.eth.blockchain.GetBlockByNumber(bn), nil
 }
 
 func (b *EthAPIBackend) BlockByHash(ctx context.Context, hash common.Hash) (*types.Block, error) {
@@ -167,11 +162,7 @@ func (b *EthAPIBackend) BlockByHash(ctx context.Context, hash common.Hash) (*typ
 	if number == nil {
 		return nil, nil
 	}
-	block := b.eth.blockchain.GetBlock(hash, *number)
-	if block == nil && *number < b.HistoryPruningCutoff() {
-		return nil, &history.PrunedHistoryError{}
-	}
-	return block, nil
+	return b.eth.blockchain.GetBlock(hash, *number), nil
 }
 
 // GetBody returns body of a block. It does not resolve special block numbers.
@@ -181,9 +172,6 @@ func (b *EthAPIBackend) GetBody(ctx context.Context, hash common.Hash, number rp
 	}
 	body := b.eth.blockchain.GetBody(hash)
 	if body == nil {
-		if uint64(number) < b.HistoryPruningCutoff() {
-			return nil, &history.PrunedHistoryError{}
-		}
 		return nil, errors.New("block body not found")
 	}
 	return body, nil
@@ -205,9 +193,6 @@ func (b *EthAPIBackend) BlockByNumberOrHash(ctx context.Context, blockNrOrHash r
 		}
 		block := b.eth.blockchain.GetBlock(hash, header.Number.Uint64())
 		if block == nil {
-			if header.Number.Uint64() < b.HistoryPruningCutoff() {
-				return nil, &history.PrunedHistoryError{}
-			}
 			return nil, errors.New("header found, but block body is missing")
 		}
 		return block, nil

--- a/eth/filters/api.go
+++ b/eth/filters/api.go
@@ -28,7 +28,6 @@ import (
 	"github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
-	"github.com/ethereum/go-ethereum/core/history"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/internal/ethapi"
 	"github.com/ethereum/go-ethereum/rpc"
@@ -481,9 +480,6 @@ func (api *FilterAPI) GetLogs(ctx context.Context, crit FilterCriteria) ([]*type
 		if begin > 0 && end > 0 && begin > end {
 			return nil, errInvalidBlockRange
 		}
-		if begin >= 0 && begin < int64(api.events.backend.HistoryPruningCutoff()) {
-			return nil, &history.PrunedHistoryError{}
-		}
 		// Construct the range filter
 		filter = api.sys.NewRangeFilter(begin, end, crit.Addresses, crit.Topics, api.rangeLimit)
 	}
@@ -535,9 +531,6 @@ func (api *FilterAPI) GetFilterLogs(ctx context.Context, id rpc.ID) ([]*types.Lo
 		end := rpc.LatestBlockNumber.Int64()
 		if f.crit.ToBlock != nil {
 			end = f.crit.ToBlock.Int64()
-		}
-		if begin >= 0 && begin < int64(api.events.backend.HistoryPruningCutoff()) {
-			return nil, &history.PrunedHistoryError{}
 		}
 		// Construct the range filter
 		filter = api.sys.NewRangeFilter(begin, end, f.crit.Addresses, f.crit.Topics, api.rangeLimit)

--- a/eth/filters/filter.go
+++ b/eth/filters/filter.go
@@ -28,7 +28,6 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core"
 	"github.com/ethereum/go-ethereum/core/filtermaps"
-	"github.com/ethereum/go-ethereum/core/history"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/rpc"
@@ -90,9 +89,6 @@ func (f *Filter) Logs(ctx context.Context) ([]*types.Log, error) {
 		}
 		if header == nil {
 			return nil, errUnknownBlock
-		}
-		if header.Number.Uint64() < f.sys.backend.HistoryPruningCutoff() {
-			return nil, &history.PrunedHistoryError{}
 		}
 		return f.blockLogs(ctx, header)
 	}

--- a/eth/filters/filter_system.go
+++ b/eth/filters/filter_system.go
@@ -30,7 +30,6 @@ import (
 	"github.com/ethereum/go-ethereum/common/lru"
 	"github.com/ethereum/go-ethereum/core"
 	"github.com/ethereum/go-ethereum/core/filtermaps"
-	"github.com/ethereum/go-ethereum/core/history"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/ethdb"
 	"github.com/ethereum/go-ethereum/event"
@@ -327,10 +326,6 @@ func (es *EventSystem) SubscribeLogs(crit ethereum.FilterQuery, logs chan []*typ
 
 	if from == rpc.EarliestBlockNumber {
 		from = rpc.BlockNumber(es.backend.HistoryPruningCutoff())
-	}
-	// Queries beyond the pruning cutoff are not supported.
-	if uint64(from) < es.backend.HistoryPruningCutoff() {
-		return nil, &history.PrunedHistoryError{}
 	}
 
 	// only interested in new mined logs


### PR DESCRIPTION
This PR removes premature `HistoryPruningCutoff` checks in the RPC
layer that returned `PrunedHistoryError` before block-number-based
queries could reach the era file fallback already present in the
chain freezer.

## Problem

When history is pruned but era files (`.era1`/`.erae`) are available,
the chain freezer's `Ancient()` method correctly falls back to era
files for block bodies and receipts. However, the RPC API layer
intercepted queries with `HistoryPruningCutoff()` checks and returned
errors *before* the request could reach this fallback path. This
meant that `eth_getBlockByNumber`, `eth_getLogs`, and similar
block-number-based methods failed unnecessarily on pruned nodes with
era files.

## Changes

- **`eth/api_backend.go`**: Remove `PrunedHistoryError` returns in
  `BlockByNumber`, `BlockByHash`, `BlockByNumberOrHash`, and
  `GetBody`. When a block isn't found, `nil` is returned naturally
  if era files don't cover it either.
  
- **`eth/filters/api.go`**: Remove `PrunedHistoryError` returns in
  `GetLogs` and `GetFilterLogs` that blocked log queries from
  reaching the range log search engine.
  
- **`eth/filters/filter.go`**: Remove `PrunedHistoryError` return
  in `Logs()` for single-block filters.
  
- **`eth/filters/filter_system.go`**: Remove `PrunedHistoryError`
  return in `SubscribeLogs`. Keep the `EarliestBlockNumber` →
  `HistoryPruningCutoff()` resolution as a sensible default.

## What this does NOT address

Hash-based transaction lookups (`eth_getTransactionByHash`,
`eth_getTransactionReceipt`) still require the transaction index,
which is pruned alongside chain data. Solving this requires
redesigning the transaction indexer to support gaps, which is
tracked separately.

Fixes #33666
