### PR TITLE
core, internal/ethapi: fix incorrect max-initcode RPC error mapping

### DIFF
--- a/core/error.go
+++ b/core/error.go
@@ -66,10 +66,6 @@ var (
 	// have enough funds for transfer(topmost call only).
 	ErrInsufficientFundsForTransfer = errors.New("insufficient funds for transfer")
 
-	// ErrMaxInitCodeSizeExceeded is returned if creation transaction provides the init code bigger
-	// than init code size limit.
-	ErrMaxInitCodeSizeExceeded = errors.New("max initcode size exceeded")
-
 	// ErrInsufficientBalanceWitness is returned if the transaction sender has enough
 	// funds to cover the transfer, but not enough to pay for witness access/modification
 	// costs for the transaction

--- a/internal/ethapi/errors.go
+++ b/internal/ethapi/errors.go
@@ -141,7 +141,7 @@ func txValidationError(err error) *invalidTxError {
 		return &invalidTxError{Message: err.Error(), Code: errCodeIntrinsicGas}
 	case errors.Is(err, core.ErrInsufficientFundsForTransfer):
 		return &invalidTxError{Message: err.Error(), Code: errCodeInsufficientFunds}
-	case errors.Is(err, core.ErrMaxInitCodeSizeExceeded):
+	case errors.Is(err, vm.ErrMaxInitCodeSizeExceeded):
 		return &invalidTxError{Message: err.Error(), Code: errCodeMaxInitCodeSizeExceeded}
 	}
 	return &invalidTxError{


### PR DESCRIPTION
Problem:

The max-initcode sentinel moved from core to vm, but RPC pre-check mapping still depended on core.ErrMaxInitCodeSizeExceeded. This mismatch could surface inconsistent error mapping when oversized initcode is submitted through JSON-RPC.

Solution:

- Remove core.ErrMaxInitCodeSizeExceeded from the core pre-check error set.
- Map max-initcode validation errors in RPC from vm.ErrMaxInitCodeSizeExceeded.
- Keep the RPC error code mapping unchanged (-38025).

Impact:

- Restores consistent max-initcode error mapping after the sentinel move.
- Preserves existing JSON-RPC client expectations for error code -38025.
- No consensus, state, or protocol behavior changes.
