### PR TITLE
eth/tracers/native: fix parity mapping for wrapped max code size errors

### DIFF
--- a/eth/tracers/native/call_flat.go
+++ b/eth/tracers/native/call_flat.go
@@ -368,12 +368,18 @@ func convertErrorToParity(call *flatCallFrame) {
 
 	if parityError, ok := parityErrorMapping[call.Error]; ok {
 		call.Error = parityError
-	} else {
-		for gethError, parityError := range parityErrorMappingStartingWith {
-			if strings.HasPrefix(call.Error, gethError) {
-				call.Error = parityError
-				break
-			}
+		return
+	}
+	if i := strings.IndexByte(call.Error, ':'); i > 0 {
+		if parityError, ok := parityErrorMapping[call.Error[:i]]; ok {
+			call.Error = parityError
+			return
+		}
+	}
+	for gethError, parityError := range parityErrorMappingStartingWith {
+		if strings.HasPrefix(call.Error, gethError) {
+			call.Error = parityError
+			return
 		}
 	}
 }

--- a/eth/tracers/native/call_flat_error_mapping_test.go
+++ b/eth/tracers/native/call_flat_error_mapping_test.go
@@ -1,0 +1,58 @@
+// Copyright 2024 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+
+package native
+
+import "testing"
+
+func TestConvertErrorToParity(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{
+			name: "exact map key",
+			in:   "max code size exceeded",
+			want: "Out of gas",
+		},
+		{
+			name: "wrapped map key",
+			in:   "max code size exceeded: code size 32769 limit 32768",
+			want: "Out of gas",
+		},
+		{
+			name: "existing prefix rule",
+			in:   "out of gas: not enough gas for reentrancy sentry",
+			want: "Out of gas",
+		},
+		{
+			name: "unknown error unchanged",
+			in:   "some unknown error",
+			want: "some unknown error",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			frame := &flatCallFrame{Error: tc.in}
+			convertErrorToParity(frame)
+			if frame.Error != tc.want {
+				t.Fatalf("unexpected mapped error, got=%q want=%q", frame.Error, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Problem:

- flatCallTracer only matched the exact string "max code size exceeded".
- EVM now emits wrapped errors (for example, "max code size exceeded: code size ... limit ..."), causing parity error mapping to miss.

Solution:

- Update convertErrorToParity matching order: exact match first, then unwrap base error by splitting at the first colon, then keep existing prefix-based mappings.
- Add call_flat_error_mapping_test.go to cover exact match, wrapped match, prefix match, and unknown error passthrough.

Impact:

- Restores parity compatibility for wrapped max code size errors in flat call tracer output.
- Preserves existing mapping behavior for known and unknown error messages.

Validation:

- go test ./eth/tracers/native