### PR TITLE
.github/workflows: fix FreeBSD CI to use ubuntu-latest runner

### DIFF
--- a/.github/workflows/freebsd.yml
+++ b/.github/workflows/freebsd.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   build:
     name: FreeBSD-build
-    runs-on: [self-hosted-ghr, size-l-x64]
+    runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v6
       with:
@@ -19,8 +19,11 @@ jobs:
       uses: vmactions/freebsd-vm@v1
       with:
         release: "15.0"
+        usesh: true
+        prepare: |
+          pkg install -y go
         run: |
           freebsd-version
           uname -a
-          pkg install -y go
+          go version
           go run ./build/ci.go test -p 8


### PR DESCRIPTION
vmactions/freebsd-vm uses QEMU to run FreeBSD in a VM, which requires a standard GitHub-hosted runner with KVM support. The self-hosted-ghr runner was failing with SSH exit code 255 because the VM couldn't boot.

Changes:
- Use ubuntu-latest instead of self-hosted-ghr
- Move pkg install to prepare: (runs before code sync)
- Add usesh: true for consistent shell behavior
- Print go version for debugging