### PR TITLE
build, cmd/keeper: add "womir" target

### DIFF
--- a/build/ci.go
+++ b/build/ci.go
@@ -109,7 +109,7 @@ var (
 		},
 		{
 			Name:   "womir",
-			GOOS:   "js",
+			GOOS:   "wasip1",
 			GOARCH: "wasm",
 			Tags:   "womir",
 		},

--- a/build/ci.go
+++ b/build/ci.go
@@ -108,6 +108,12 @@ var (
 			Env:  map[string]string{"GOMIPS": "softfloat", "CGO_ENABLED": "0"},
 		},
 		{
+			Name:   "womir",
+			GOOS:   "js",
+			GOARCH: "wasm",
+			Tags:   "womir",
+		},
+		{
 			Name:   "wasm-js",
 			GOOS:   "js",
 			GOARCH: "wasm",
@@ -163,11 +169,11 @@ var (
 
 	// Distros for which packages are created
 	debDistros = []string{
-		"xenial",   // 16.04, EOL: 04/2026
-		"bionic",   // 18.04, EOL: 04/2028
-		"focal",    // 20.04, EOL: 04/2030
-		"jammy",    // 22.04, EOL: 04/2032
-		"noble",    // 24.04, EOL: 04/2034
+		"xenial", // 16.04, EOL: 04/2026
+		"bionic", // 18.04, EOL: 04/2028
+		"focal",  // 20.04, EOL: 04/2030
+		"jammy",  // 22.04, EOL: 04/2032
+		"noble",  // 24.04, EOL: 04/2034
 	}
 
 	// This is where the tests should be unpacked.

--- a/build/ci.go
+++ b/build/ci.go
@@ -117,13 +117,11 @@ var (
 			Name:   "wasm-js",
 			GOOS:   "js",
 			GOARCH: "wasm",
-			Tags:   "example",
 		},
 		{
 			Name:   "wasm-wasi",
 			GOOS:   "wasip1",
 			GOARCH: "wasm",
-			Tags:   "example",
 		},
 		{
 			Name: "example",

--- a/build/ci.go
+++ b/build/ci.go
@@ -311,7 +311,7 @@ func doInstallKeeper(cmdline []string) {
 		args := slices.Clone(gobuild.Args)
 		args = append(args, "-o", executablePath(outputName))
 		args = append(args, ".")
-		build.MustRun(&exec.Cmd{Path: gobuild.Path, Args: args, Env: gobuild.Env})
+		build.MustRun(&exec.Cmd{Path: gobuild.Path, Args: args, Env: gobuild.Env, Dir: gobuild.Dir})
 	}
 }
 

--- a/cmd/keeper/getpayload_example.go
+++ b/cmd/keeper/getpayload_example.go
@@ -15,6 +15,7 @@
 // along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
 
 //go:build example
+// +build example
 
 package main
 

--- a/cmd/keeper/getpayload_womir.go
+++ b/cmd/keeper/getpayload_womir.go
@@ -14,23 +14,36 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
 
-//go:build wasm && !womir
-// +build wasm,!womir
+//go:build womir
 
 package main
 
-import (
-	"unsafe"
-)
+import "unsafe"
 
-//go:wasmimport geth_io len
-func hintLen() uint32
+// These match the WOMIR guest-io imports (env module).
+// Protocol: __hint_input prepares next item, __hint_buffer reads words.
+// Each item has format: [byte_len_u32_le, ...data_words_padded_to_4bytes]
+//
+//go:wasmimport env __hint_input
+func hintInput()
 
-//go:wasmimport geth_io read
-func hintRead(data unsafe.Pointer)
+//go:wasmimport env __hint_buffer
+func hintBuffer(ptr unsafe.Pointer, numWords uint32)
+func readWord() uint32 {
+	var buf [4]byte
+	hintBuffer(unsafe.Pointer(&buf[0]), 1)
+	return uint32(buf[0]) | uint32(buf[1])<<8 | uint32(buf[2])<<16 | uint32(buf[3])<<24
+}
+func readBytes() []byte {
+	hintInput()
+	byteLen := readWord()
+	numWords := (byteLen + 3) / 4
+	data := make([]byte, numWords*4)
+	hintBuffer(unsafe.Pointer(&data[0]), numWords)
+	return data[:byteLen]
+}
 
+// getInput reads the RLP-encoded Payload from the WOMIR hint stream.
 func getInput() []byte {
-	data := make([]byte, hintLen())
-	hintRead(unsafe.Pointer(&data[0]))
-	return data
+	return readBytes()
 }

--- a/cmd/keeper/stubs.go
+++ b/cmd/keeper/stubs.go
@@ -14,8 +14,8 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
 
-//go:build !example && !ziren && !wasm
-// +build !example,!ziren,!wasm
+//go:build !example && !ziren && !wasm && !womir
+// +build !example,!ziren,!wasm,!womir
 
 package main
 


### PR DESCRIPTION
This PR enables the block validation of keeper in the womir/openvm zkvm.

It also fixes some issues related to building the executables in CI. Namely, it activates the build which was actually disabled, and also resolves some resulting build conflicts by fixing the tags.