### PR TITLE
miner: restore GasUsed assignment in applyTransaction

### DIFF
--- a/miner/worker.go
+++ b/miner/worker.go
@@ -442,12 +442,6 @@ func (miner *Miner) applyTransaction(env *environment, tx *types.Transaction) (*
 		snap = env.state.Snapshot()
 		gp   = env.gasPool.Snapshot()
 	)
-	var stateCopy *state.StateDB
-	if env.accessList != nil {
-		stateCopy = env.state.WithReader(state.NewReaderWithTracker(env.state.Reader()))
-		env.evm.StateDB = stateCopy
-	}
-
 	mutations, receipt, err := core.ApplyTransaction(env.evm, env.gasPool, env.state, env.header, tx)
 	if err != nil {
 		if env.accessList != nil {


### PR DESCRIPTION
## Summary

- The BAL refactoring in 5808d212b removed the line `env.header.GasUsed = env.gasPool.Used()` from `applyTransaction()`, causing all geth-proposed blocks to have `GasUsed=0` in the header
- Every other client rejects these blocks during validation, so geth can never successfully propose on the network
- Restores the single line that was present in upstream master

## Test plan

- [x] Verified line exists in upstream/master at miner/worker.go:409
- [x] Confirmed all 34 geth-proposed blocks on a 4-client devnet had `GasUsed=0` via `debug_getBadBlocks` on besu
- [ ] Build local image and verify geth proposals are accepted in a multi-client Kurtosis network