### PR TITLE
core/state/snapshot: preallocate keys and vals slices in proveRange

### DIFF
--- a/core/state/snapshot/generate.go
+++ b/core/state/snapshot/generate.go
@@ -161,8 +161,8 @@ func (result *proofResult) forEach(callback func(key []byte, val []byte) error) 
 // the error will be returned to abort the entire procedure.
 func (dl *diskLayer) proveRange(ctx *generatorContext, trieId *trie.ID, prefix []byte, kind string, origin []byte, max int, valueConvertFn func([]byte) ([]byte, error)) (*proofResult, error) {
 	var (
-		keys     [][]byte
-		vals     [][]byte
+		keys     = make([][]byte, 0, max)
+		vals     = make([][]byte, 0, max)
 		proof    = rawdb.NewMemoryDatabase()
 		diskMore = false
 		iter     = ctx.iterator(kind)


### PR DESCRIPTION
tl;dr: preallocate `keys` and `vals` slices in `proveRange` to avoid repeated slice growth during iteration.

`proveRange` iterates up to `max` entries from the disk iterator, appending to `keys` and `vals` on each step. with nil slices, Go has to reallocate and copy on every growth event. since we already know the upper bound (`max`), pre-sizing with `make([][]byte, 0, max)` avoids unnecessary allocations. less GC pressure during snapshot generation, especially with large `accountCheckRange` or `storageCheckRange` values.


Preallocate the `keys` and `vals` slices with capacity `max` in `proveRange` to avoid repeated memory allocations during the append loop. This reduces GC pressure in this hot path during state snapshot generation.