### PR TITLE
core/filtermaps: replace panics with error returns in matcher

### DIFF
--- a/core/filtermaps/matcher.go
+++ b/core/filtermaps/matcher.go
@@ -109,7 +109,10 @@ func GetPotentialMatches(ctx context.Context, backend MatcherBackend, firstBlock
 	}
 	// matcher is the final sequence matcher that signals a match when all underlying
 	// matchers signal a match for consecutive log value indices.
-	matcher := newMatchSequence(params, matchers)
+	matcher, err := newMatchSequence(params, matchers)
+	if err != nil {
+		return nil, err
+	}
 
 	m := &matcherEnv{
 		ctx:        ctx,
@@ -389,7 +392,8 @@ func (m *singleMatcherInstance) getMatchesForLayer(ctx context.Context, layerInd
 			filterRow := groupRows[i]
 			filterRows, ok := m.filterRows[mapIndex]
 			if !ok {
-				panic("dropped map in mapIndices")
+				m.stats.setState(&st, stNone)
+				return nil, fmt.Errorf("internal inconsistency: mapIndex %d present in mapIndices but missing from filterRows", mapIndex)
 			}
 			if layerIndex == 0 {
 				matchBaseRowAccessMeter.Mark(1)
@@ -674,19 +678,23 @@ func (m *matchSequence) mergeNextStats(stats matchOrderStats) {
 // newMatchSequence creates a recursive sequence matcher from a list of underlying
 // matchers. The resulting matcher signals a match at log value index X when each
 // underlying matcher matchers[i] returns a match at X+i.
-func newMatchSequence(params *Params, matchers []matcher) matcher {
+func newMatchSequence(params *Params, matchers []matcher) (matcher, error) {
 	if len(matchers) == 0 {
-		panic("zero length sequence matchers are not allowed")
+		return nil, fmt.Errorf("zero length sequence matchers are not allowed")
 	}
 	if len(matchers) == 1 {
-		return matchers[0]
+		return matchers[0], nil
+	}
+	base, err := newMatchSequence(params, matchers[:len(matchers)-1])
+	if err != nil {
+		return nil, err
 	}
 	return &matchSequence{
 		params: params,
-		base:   newMatchSequence(params, matchers[:len(matchers)-1]),
+		base:   base,
 		next:   matchers[len(matchers)-1],
 		offset: uint64(len(matchers) - 1),
-	}
+	}, nil
 }
 
 // matchSequenceInstance is an instance of matchSequence.


### PR DESCRIPTION
Two panics in the filtermaps matcher can crash a running geth node:

1. `getMatchesForLayer` (matcher.go:392) panics with "dropped map in mapIndices" when a mapIndex is present in the iteration slice but missing from filterRows. This is an internal consistency issue that should be surfaced as an error, not a crash.

2. `newMatchSequence` (matcher.go:679) panics on an empty matchers list. This precondition can be violated by a malformed log filter query arriving via RPC.

Both paths are reachable from `GetPotentialMatches`, which is called by the public `eth_getLogs` / `eth_newFilter` RPC endpoints. A crafted or edge-case filter query can therefore take down the entire node.

**Fix:** Replace both panics with proper error returns propagated through the call chain. `getMatchesForLayer` now returns `fmt.Errorf` instead of panicking, and `newMatchSequence` returns `(matcher, error)` with its caller updated to check the error.

Similar approach to #33647 (core/types: fix panic on invalid signature length).