### PR TITLE
eth/protocols/snap: handle StateReader error in ServiceTrieNodesQuery

### DIFF
--- a/eth/protocols/snap/handler.go
+++ b/eth/protocols/snap/handler.go
@@ -561,7 +561,11 @@ func ServiceGetTrieNodesQuery(chain *core.BlockChain, req *GetTrieNodesPacket, s
 		reader = chain.Snapshots().Snapshot(req.Root)
 	}
 	if reader == nil {
-		reader, _ = triedb.StateReader(req.Root)
+		var err error
+		reader, err = triedb.StateReader(req.Root)
+		if err != nil {
+			return nil, fmt.Errorf("failed to create state reader for root %x: %w", req.Root, err)
+		}
 	}
 
 	// Retrieve trie nodes until the packet size limit is reached


### PR DESCRIPTION
In `ServiceTrieNodesQuery` (handler.go:564), when the snapshot layer is unavailable the code falls back to `triedb.StateReader(req.Root)` but discards the error:

```go
reader, _ = triedb.StateReader(req.Root)
```

If `StateReader` fails (state has been pruned, database corruption, or the requested root is simply not available), `reader` remains nil. This nil reader is then passed into the trie node resolution loop below, where it will cause a nil pointer dereference when the peer requests storage trie nodes.

This is reachable remotely: any snap sync peer can send a `GetTrieNodes` request for a pruned state root, crashing the serving node.

**Fix:** Check the error from `StateReader` and return it to the caller instead of proceeding with a nil reader.