### PR TITLE
core/state/snapshot: handle bloom filter errors in diffLayer.rebloom

### DIFF
--- a/core/state/snapshot/difflayer.go
+++ b/core/state/snapshot/difflayer.go
@@ -29,6 +29,7 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/rlp"
 	bloomfilter "github.com/holiman/bloomfilter/v2"
 )
@@ -173,10 +174,20 @@ func (dl *diffLayer) rebloom(origin *diskLayer) {
 	// Retrieve the parent bloom or create a fresh empty one
 	if parent, ok := dl.parent.(*diffLayer); ok {
 		parent.lock.RLock()
-		dl.diffed, _ = parent.diffed.Copy()
+		bloom, err := parent.diffed.Copy()
 		parent.lock.RUnlock()
+		if err != nil {
+			log.Error("Failed to copy parent bloom filter", "err", err)
+			bloom, _ = bloomfilter.New(uint64(bloomSize), uint64(bloomFuncs))
+		}
+		dl.diffed = bloom
 	} else {
-		dl.diffed, _ = bloomfilter.New(uint64(bloomSize), uint64(bloomFuncs))
+		bloom, err := bloomfilter.New(uint64(bloomSize), uint64(bloomFuncs))
+		if err != nil {
+			log.Error("Failed to create bloom filter", "err", err)
+			return
+		}
+		dl.diffed = bloom
 	}
 	for hash := range dl.accountData {
 		dl.diffed.AddHash(accountBloomHash(hash))


### PR DESCRIPTION
In `diffLayer.rebloom` (difflayer.go:176,179), errors from both `parent.diffed.Copy()` and `bloomfilter.New()` are silently discarded:

```go
dl.diffed, _ = parent.diffed.Copy()
// ...
dl.diffed, _ = bloomfilter.New(uint64(bloomSize), uint64(bloomFuncs))
```

If either call fails (memory pressure, corrupted parent bloom), `dl.diffed` remains nil. The subsequent loop calls `dl.diffed.AddHash()` which will panic on a nil receiver.

This can occur under sustained memory pressure when the bloom filter allocation fails, or when a parent diffLayer has a corrupted bloom state that cannot be copied.

**Fix:** On copy failure, fall back to creating a fresh bloom filter. On allocation failure, log the error and return early (the layer will function without a bloom filter, falling through to the parent for lookups).