### PR TITLE
core/filtermaps: return 0 on error in tailPartialBlocks

### DIFF
--- a/core/filtermaps/indexer.go
+++ b/core/filtermaps/indexer.go
@@ -440,12 +440,14 @@ func (f *FilterMaps) tailPartialBlocks() uint64 {
 	end, _, err := f.getLastBlockOfMap(f.indexedRange.maps.First() - f.mapsPerEpoch + f.indexedRange.tailPartialEpoch - 1)
 	if err != nil {
 		log.Error("Error fetching last block of map", "mapIndex", f.indexedRange.maps.First()-f.mapsPerEpoch+f.indexedRange.tailPartialEpoch-1, "error", err)
+		return 0
 	}
 	var start uint64
 	if f.indexedRange.maps.First()-f.mapsPerEpoch > 0 {
 		start, _, err = f.getLastBlockOfMap(f.indexedRange.maps.First() - f.mapsPerEpoch - 1)
 		if err != nil {
 			log.Error("Error fetching last block of map", "mapIndex", f.indexedRange.maps.First()-f.mapsPerEpoch-1, "error", err)
+			return 0
 		}
 	}
 	return end - start


### PR DESCRIPTION
In `tailPartialBlocks` (indexer.go:~440), when `getLastBlockOfMap` fails the error is logged but the uninitialized `end` variable (value 0) is still used in the final `return end - start` computation.

If the first call fails but the second succeeds, or if `start` has already been assigned a non-zero value from a previous successful call, the function returns a wrapped-around `uint64` value (since `0 - start` underflows). This incorrect block count propagates to the caller and can cause the indexer to miscalculate tail rendering progress.

**Fix:** Return 0 immediately when `getLastBlockOfMap` fails, so that the caller gets a safe default rather than an incorrect count derived from a partial computation.