### PR TITLE
core, internal/ethapi: skip EIP-7702 auth signature validation in simulation mode

### DIFF
--- a/core/state_transition.go
+++ b/core/state_transition.go
@@ -607,7 +607,15 @@ func (st *stateTransition) validateAuthorization(auth *types.SetCodeAuthorizatio
 	// Validate signature values and recover authority.
 	authority, err = auth.Authority()
 	if err != nil {
-		return authority, fmt.Errorf("%w: %v", ErrAuthorizationInvalidSignature, err)
+		// In simulation mode (e.g. eth_estimateGas, eth_call), allow
+		// authorizations with invalid signatures by assuming the
+		// transaction sender is the authority. This lets callers estimate
+		// gas for EIP-7702 transactions before signing the authorization.
+		if st.msg.SkipTransactionChecks {
+			authority = st.msg.From
+		} else {
+			return authority, fmt.Errorf("%w: %v", ErrAuthorizationInvalidSignature, err)
+		}
 	}
 	// Check the authority account
 	//  1) doesn't have code or has exisiting delegation
@@ -619,7 +627,9 @@ func (st *stateTransition) validateAuthorization(auth *types.SetCodeAuthorizatio
 	if _, ok := types.ParseDelegation(code); len(code) != 0 && !ok {
 		return authority, ErrAuthorizationDestinationHasCode
 	}
-	if have := st.state.GetNonce(authority); have != auth.Nonce {
+	// Skip nonce validation in simulation mode, consistent with the
+	// top-level SkipNonceChecks behaviour for the sender account.
+	if have := st.state.GetNonce(authority); have != auth.Nonce && !st.msg.SkipNonceChecks {
 		return authority, ErrAuthorizationNonceMismatch
 	}
 	return authority, nil

--- a/internal/ethapi/api_test.go
+++ b/internal/ethapi/api_test.go
@@ -972,6 +972,23 @@ func TestEstimateGas(t *testing.T) {
 			},
 			expectErr: core.ErrSetCodeTxCreate,
 		},
+		// EstimateGas with unsigned (zero-signature) EIP-7702 authorization
+		// should succeed, using the sender as the authority. This allows
+		// callers to estimate gas before signing the authorization.
+		{
+			blockNumber: rpc.LatestBlockNumber,
+			call: TransactionArgs{
+				From:  &accounts[0].addr,
+				To:    &accounts[1].addr,
+				Value: (*hexutil.Big)(big.NewInt(0)),
+				AuthorizationList: []types.SetCodeAuthorization{{
+					ChainID: *uint256.NewInt(0),
+					Address: accounts[0].addr,
+					Nonce:   uint64(genBlocks + 1),
+				}},
+			},
+			want: 46000,
+		},
 	}
 	for i, tc := range testSuite {
 		result, err := api.EstimateGas(context.Background(), tc.call, &rpc.BlockNumberOrHash{BlockNumber: &tc.blockNumber}, &tc.overrides, &tc.blockOverrides)


### PR DESCRIPTION
Fixes #31617

When `eth_estimateGas` or `eth_call` is invoked with an `authorizationList` containing unsigned (zero-signature) entries, the signature recovery fails and the authorization is silently skipped. This means the sender's account never receives the delegated code, producing an incorrect gas estimate.

## Changes

- **`core/state_transition.go`**: In `validateAuthorization()`, when `SkipTransactionChecks` is true (RPC simulation mode) and signature recovery fails, fall back to `msg.From` as the authority instead of returning an error. Also skip authorization nonce validation when `SkipNonceChecks` is set, consistent with the existing sender nonce skip behaviour.
- **`internal/ethapi/api_test.go`**: Added test case verifying `EstimateGas` succeeds with zero-signature EIP-7702 authorizations.

## Rationale

Wallet developers need to estimate gas for EIP-7702 set-code transactions *before* the user signs the authorization. With this change, callers can pass authorizations with zeroed signature fields and the gas estimator will correctly apply the delegation using the transaction sender as the authority.

The existing workaround (using state overrides to manually set the sender's code) works but is awkward and requires the caller to construct the delegation prefix themselves.

## Test plan

- [x] Existing `TestEstimateGas` passes (including signed authorization cases)
- [x] Existing `TestEIP7702` core tests pass
- [x] New test case: unsigned authorization produces same gas estimate as signed
- [x] `gofmt` clean, full build passes