### PR TITLE
p2p/discover: fix flaky TestUDPv5_findnodeHandling

### DIFF
--- a/p2p/discover/v5_udp_test.go
+++ b/p2p/discover/v5_udp_test.go
@@ -937,6 +937,7 @@ func newUDPV5Test(t *testing.T) *udpV5Test {
 		PrivateKey:   test.localkey,
 		Log:          testlog.Logger(t, log.LvlTrace),
 		ValidSchemes: enode.ValidSchemesForTesting,
+		PingInterval: 1000 * time.Hour,
 	})
 	test.udp.codec = &testCodec{test: test, id: ln.ID()}
 	test.table = test.udp.tab


### PR DESCRIPTION
Fixes #34108

The UDPv5 test harness (`newUDPV5Test`) uses the default `PingInterval` of 3 seconds. When tests like `TestUDPv5_findnodeHandling` insert nodes into the routing table via `fillTable`, the table's revalidation loop may schedule PING packets for those nodes. Under the race detector or on slow CI runners, the test runs long enough for revalidation to fire, causing background pings to be written to the test pipe. The `close()` method then finds these as unmatched packets and fails.

The fix sets `PingInterval` to a very large value in the test harness so revalidation never fires during tests.

Verified locally: 100 iterations with `-race -count=100` pass reliably, where previously the test would fail within ~50 iterations.