### PR TITLE
core/state: increment storage counters in binary trie IntermediateRoot path

### DIFF
--- a/core/state/statedb.go
+++ b/core/state/statedb.go
@@ -881,10 +881,12 @@ func (s *StateDB) IntermediateRoot(deleteEmptyObjects bool) common.Hash {
 					if err := s.trie.UpdateStorage(addr, key[:], common.TrimLeftZeroes(value[:])); err != nil {
 						s.setError(err)
 					}
+					s.StorageUpdated.Add(1)
 				} else {
 					if err := s.trie.DeleteStorage(addr, key[:]); err != nil {
 						s.setError(err)
 					}
+					s.StorageDeleted.Add(1)
 				}
 			}
 		}


### PR DESCRIPTION
## Summary

- Add missing `StorageUpdated` and `StorageDeleted` counter increments in the binary trie fast path of `IntermediateRoot()`
- The fast path introduced in #34022 bypasses per-account `updateTrie()` but omitted the counter increments, causing `storage_slots_written` to always report 0 in binary trie mode

This caused the "Slow block" JSON log to report `storage_slots_written=0` for all blocks in binary trie mode, even though storage writes were happening correctly.