### PR TITLE
cmd/geth: cover attach header flag order in test

### DIFF
--- a/cmd/geth/attach_test.go
+++ b/cmd/geth/attach_test.go
@@ -42,10 +42,13 @@ func TestAttachWithHeaders(t *testing.T) {
 	}
 	port := ln.Addr().(*net.TCPAddr).Port
 	testReceiveHeaders(t, ln, "attach", "-H", "first: one", "-H", "second: two", fmt.Sprintf("http://localhost:%d", port))
-	// This way to do it fails due to flag ordering:
-	//
-	// testReceiveHeaders(t, ln, "-H", "first: one", "-H", "second: two", "attach", fmt.Sprintf("http://localhost:%d", port))
-	// This is fixed in a follow-up PR.
+
+	ln, err = net.Listen("tcp", "localhost:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	port = ln.Addr().(*net.TCPAddr).Port
+	testReceiveHeaders(t, ln, "-H", "first: one", "-H", "second: two", "attach", fmt.Sprintf("http://localhost:%d", port))
 }
 
 // TestRemoteDbWithHeaders tests that 'geth db --remotedb' with custom headers works, i.e


### PR DESCRIPTION
## Summary

This PR updates `TestAttachWithHeaders` to cover both accepted flag orders for custom RPC headers in `geth attach`:

- `geth attach -H "first: one" -H "second: two" <endpoint>`
- `geth -H "first: one" -H "second: two" attach <endpoint>`

The previous test only executed the first form and kept the second as a commented follow-up note. This change turns the second form into an active assertion.

## Why

This makes the expected CLI behavior explicit and protected by test coverage, so future flag parsing changes won't regress either invocation style.

## Testing

- `go test ./cmd/geth -run TestAttachWithHeaders -count=1`
