### PR TITLE
core/rawdb: fix freezer dir.Sync() failure on Windows

### DIFF
--- a/core/rawdb/freezer_utils.go
+++ b/core/rawdb/freezer_utils.go
@@ -26,13 +26,7 @@ func atomicRename(src, dest string) error {
 	if err := os.Rename(src, dest); err != nil {
 		return err
 	}
-	dir, err := os.Open(filepath.Dir(src))
-	if err != nil {
-		return err
-	}
-	defer dir.Close()
-
-	return dir.Sync()
+	return syncDir(filepath.Dir(src))
 }
 
 // copyFrom copies data from 'srcPath' at offset 'offset' into 'destPath'.

--- a/core/rawdb/freezer_utils_unix.go
+++ b/core/rawdb/freezer_utils_unix.go
@@ -1,0 +1,49 @@
+// Copyright 2022 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+
+//go:build !windows
+// +build !windows
+
+package rawdb
+
+import (
+	"errors"
+	"os"
+	"syscall"
+)
+
+// syncDir ensures that the directory metadata (e.g. newly renamed files)
+// is flushed to durable storage.
+func syncDir(name string) error {
+	f, err := os.Open(name)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	// Some file systems do not support fsyncing directories (e.g. some FUSE
+	// mounts). Ignore EINVAL in those cases.
+	if err := f.Sync(); err != nil {
+		if errors.Is(err, os.ErrInvalid) {
+			return nil
+		}
+		if patherr, ok := err.(*os.PathError); ok && patherr.Err == syscall.EINVAL {
+			return nil
+		}
+		return err
+	}
+	return nil
+}

--- a/core/rawdb/freezer_utils_windows.go
+++ b/core/rawdb/freezer_utils_windows.go
@@ -1,0 +1,26 @@
+// Copyright 2022 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+
+//go:build windows
+// +build windows
+
+package rawdb
+
+// syncDir is a no-op on Windows. Fsyncing a directory handle is not
+// supported and returns "Access is denied".
+func syncDir(name string) error {
+	return nil
+}


### PR DESCRIPTION
## Summary

- Fix `atomicRename()` calling `dir.Sync()` on a directory handle, which fails on Windows with "Access is denied"
- Extract directory sync into platform-specific `syncDir()`: no-op on Windows, fsync with EINVAL handling on Unix
- Follows the same pattern already used in `triedb/pathdb/fileutils_{unix,windows}.go`

Fixes #34114

## Background

Three `core/rawdb` freezer table tests fail consistently on Windows (AppVeyor CI):

- `TestTruncateTail` — "file already closed" on `.ridx`
- `TestTruncateHead` — "file already closed" on `.ridx`  
- `TestTruncateOverHead` — "Access is denied" on directory sync

The root cause is `atomicRename()` calling `dir.Sync()` on a directory handle. Windows does not support this operation. When `truncateTail`/`resetTo` call `atomicRename` and it fails, the index file has already been closed but is never reopened, causing subsequent reads to fail with "file already closed".

## Test plan

- [x] `go vet ./core/rawdb/...` passes
- [x] `go test ./core/rawdb/...` passes locally (macOS)
- [ ] AppVeyor CI (Windows amd64 + 386) passes