### PR TITLE
core/state/snapshot: fix condition in iterator traversal test

### DIFF
--- a/core/state/snapshot/iterator_test.go
+++ b/core/state/snapshot/iterator_test.go
@@ -342,7 +342,7 @@ func TestAccountIteratorTraversalValues(t *testing.T) {
 		if i%8 == 0 {
 			e[common.Hash{i}] = fmt.Appendf(nil, "layer-%d, key %d", 4, i)
 		}
-		if i > 50 || i < 85 {
+		if i > 50 && i < 85 {
 			f[common.Hash{i}] = fmt.Appendf(nil, "layer-%d, key %d", 5, i)
 		}
 		if i%64 == 0 {
@@ -441,7 +441,7 @@ func TestStorageIteratorTraversalValues(t *testing.T) {
 		if i%8 == 0 {
 			e[common.Hash{i}] = fmt.Appendf(nil, "layer-%d, key %d", 4, i)
 		}
-		if i > 50 || i < 85 {
+		if i > 50 && i < 85 {
 			f[common.Hash{i}] = fmt.Appendf(nil, "layer-%d, key %d", 5, i)
 		}
 		if i%64 == 0 {


### PR DESCRIPTION
The layer-5 diff condition used `i > 50 || i < 85`, which is true for almost all keys in the 0..255 loop. Use `i > 50 && i < 85` so layer 5 only covers the intended band (51..84), matching the comment intent in the test setup.