### PR TITLE
core/vm: Idea for enabling an experimental evm

### DIFF
--- a/cmd/geth/main.go
+++ b/cmd/geth/main.go
@@ -136,6 +136,7 @@ var (
 		utils.DeveloperGasLimitFlag,
 		utils.DeveloperPeriodFlag,
 		utils.VMEnableDebugFlag,
+		utils.VMEnableExperimentalInterpFlag,
 		utils.VMTraceFlag,
 		utils.VMTraceJsonConfigFlag,
 		utils.VMWitnessStatsFlag,

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -598,6 +598,12 @@ var (
 		Usage:    "Record information useful for VM and contract debugging",
 		Category: flags.VMCategory,
 	}
+	VMEnableExperimentalInterpFlag = &cli.BoolFlag{
+		Name:     "evm.experimental",
+		Usage:    "Enable the experimental EVM interpreter. This flag may be removed or changed without notice.",
+		Category: flags.VMCategory,
+		Hidden:   true,
+	}
 	VMTraceFlag = &cli.StringFlag{
 		Name:     "vmtrace",
 		Usage:    "Name of tracer which should record internal VM operations (costly)",
@@ -1891,6 +1897,9 @@ func SetEthConfig(ctx *cli.Context, stack *node.Node, cfg *ethconfig.Config) {
 	}
 	if ctx.IsSet(VMEnableDebugFlag.Name) {
 		cfg.EnablePreimageRecording = ctx.Bool(VMEnableDebugFlag.Name)
+	}
+	if ctx.IsSet(VMEnableExperimentalInterpFlag.Name) {
+		cfg.EnableExperimentalInterpreter = ctx.Bool(VMEnableExperimentalInterpFlag.Name)
 	}
 	if ctx.IsSet(VMWitnessStatsFlag.Name) {
 		cfg.EnableWitnessStats = ctx.Bool(VMWitnessStatsFlag.Name)

--- a/core/vm/interpreter.go
+++ b/core/vm/interpreter.go
@@ -29,9 +29,10 @@ import (
 type Config struct {
 	Tracer *tracing.Hooks
 
-	NoBaseFee               bool  // Forces the EIP-1559 baseFee to 0 (needed for 0 price calls)
-	EnablePreimageRecording bool  // Enables recording of SHA3/keccak preimages
-	ExtraEips               []int // Additional EIPS that are to be enabled
+	NoBaseFee                     bool  // Forces the EIP-1559 baseFee to 0 (needed for 0 price calls)
+	EnablePreimageRecording       bool  // Enables recording of SHA3/keccak preimages
+	ExtraEips                     []int // Additional EIPS that are to be enabled
+	EnableExperimentalInterpreter bool  // Enables the experimental EVM interpreter
 }
 
 // ScopeContext contains the things that are per-call, such as stack and memory,
@@ -163,6 +164,17 @@ func (evm *EVM) Run(contract *Contract, input []byte, readOnly bool) (ret []byte
 	// the execution of one of the operations or until the done flag is set by the
 	// parent context.
 	_ = jumpTable[0] // nil-check the jumpTable out of the loop
+
+	// Use the experimental interpreter
+	if evm.Config.EnableExperimentalInterpreter && !debug && !isEIP4762 {
+		ret, err = evm.runExperimental(contract, stack, mem, callContext, jumpTable, contract.Code)
+		if err == errStopToken {
+			return ret, nil
+		}
+		return ret, err
+	}
+
+	// Slow path: full dispatch with tracing and Verkle support.
 	for {
 		if debug {
 			// Capture pre-execution values for tracing.
@@ -180,58 +192,15 @@ func (evm *EVM) Run(contract *Contract, input []byte, readOnly bool) (ret []byte
 			}
 		}
 
-		// Get the operation from the jump table and validate the stack to ensure there are
-		// enough stack items available to perform the operation.
 		op = contract.GetOp(pc)
-		operation := jumpTable[op]
-		cost = operation.constantGas // For tracing
-		// Validate stack
-		if sLen := stack.len(); sLen < operation.minStack {
-			return nil, &ErrStackUnderflow{stackLen: sLen, required: operation.minStack}
-		} else if sLen > operation.maxStack {
-			return nil, &ErrStackOverflow{stackLen: sLen, limit: operation.maxStack}
-		}
-		// for tracing: this gas consumption event is emitted below in the debug section.
-		if contract.Gas < cost {
-			return nil, ErrOutOfGas
-		} else {
-			contract.Gas -= cost
-		}
 
-		// All ops with a dynamic memory usage also has a dynamic gas cost.
+		var operation *operation
 		var memorySize uint64
-		if operation.dynamicGas != nil {
-			// calculate the new memory size and expand the memory to fit
-			// the operation
-			// Memory check needs to be done prior to evaluating the dynamic gas portion,
-			// to detect calculation overflows
-			if operation.memorySize != nil {
-				memSize, overflow := operation.memorySize(stack)
-				if overflow {
-					return nil, ErrGasUintOverflow
-				}
-				// memory is expanded in words of 32 bytes. Gas
-				// is also calculated in words.
-				if memorySize, overflow = math.SafeMul(toWordSize(memSize), 32); overflow {
-					return nil, ErrGasUintOverflow
-				}
-			}
-			// Consume the gas and return an error if not enough gas is available.
-			// cost is explicitly set so that the capture state defer method can get the proper cost
-			var dynamicCost uint64
-			dynamicCost, err = operation.dynamicGas(evm, contract, stack, mem, memorySize)
-			cost += dynamicCost // for tracing
-			if err != nil {
-				return nil, fmt.Errorf("%w: %v", ErrOutOfGas, err)
-			}
-			// for tracing: this gas consumption event is emitted below in the debug section.
-			if contract.Gas < dynamicCost {
-				return nil, ErrOutOfGas
-			} else {
-				contract.Gas -= dynamicCost
-			}
-		}
+		operation, cost, memorySize, err = chargeGasOp(op, evm, contract, stack, mem, jumpTable)
 
+		if err != nil {
+			break
+		}
 		// Do tracing before potential memory expansion
 		if debug {
 			if evm.Config.Tracer.OnGasChange != nil {
@@ -259,4 +228,66 @@ func (evm *EVM) Run(contract *Contract, input []byte, readOnly bool) (ret []byte
 	}
 
 	return res, err
+}
+
+// chargeGasOp performs stack validation and gas accounting (constant + dynamic)
+// for a single opcode.
+//
+// It returns the operation, total gas cost, the required
+// memory size, and any error.
+//
+// Memory is NOT resized here; the caller must call
+// mem.Resize(memorySize) after any tracing callbacks, preserving the original
+// ordering where tracers see pre-expansion memory state.
+func chargeGasOp(op OpCode, evm *EVM, contract *Contract, stack *Stack, mem *Memory, jumpTable *JumpTable) (*operation, uint64, uint64, error) {
+	// Get the operation from the jump table and validate the stack to ensure there are
+	// enough stack items available to perform the operation.
+	operation := jumpTable[op]
+	cost := operation.constantGas
+
+	// Validate stack
+	if sLen := len(stack.data); sLen < operation.minStack {
+		return nil, cost, 0, &ErrStackUnderflow{stackLen: sLen, required: operation.minStack}
+	} else if sLen > operation.maxStack {
+		return nil, cost, 0, &ErrStackOverflow{stackLen: sLen, limit: operation.maxStack}
+	}
+	// for tracing: this gas consumption event is emitted by the caller in the debug section.
+	if contract.Gas < cost {
+		return nil, cost, 0, ErrOutOfGas
+	}
+	contract.Gas -= cost
+
+	// All ops with a dynamic memory usage also has a dynamic gas cost.
+	var memorySize uint64
+	if operation.dynamicGas != nil {
+		// calculate the new memory size and expand the memory to fit
+		// the operation
+		// Memory check needs to be done prior to evaluating the dynamic gas portion,
+		// to detect calculation overflows
+		if operation.memorySize != nil {
+			memSize, overflow := operation.memorySize(stack)
+			if overflow {
+				return nil, cost, 0, ErrGasUintOverflow
+			}
+			// memory is expanded in words of 32 bytes. Gas
+			// is also calculated in words.
+			if memorySize, overflow = math.SafeMul(toWordSize(memSize), 32); overflow {
+				return nil, cost, 0, ErrGasUintOverflow
+			}
+		}
+		// Consume the gas and return an error if not enough gas is available.
+		// cost is explicitly set so that the capture state defer method can get the proper cost
+		dynamicCost, err := operation.dynamicGas(evm, contract, stack, mem, memorySize)
+		cost += dynamicCost // for tracing
+		if err != nil {
+			return nil, cost, 0, fmt.Errorf("%w: %v", ErrOutOfGas, err)
+		}
+		// for tracing: this gas consumption event is emitted by the caller in the debug section.
+		if contract.Gas < dynamicCost {
+			return nil, cost, 0, ErrOutOfGas
+		}
+		contract.Gas -= dynamicCost
+	}
+
+	return operation, cost, memorySize, nil
 }

--- a/core/vm/interpreter_experimental.go
+++ b/core/vm/interpreter_experimental.go
@@ -29,12 +29,12 @@ import (
 // Currently there are two optimizations over the standard loop:
 //
 //  1. Switch dispatch: the standard interpreter calls operation.execute() via a function
-//     pointer table. This is an indirect call that the CPU can't predict and the compiler won't
+//     pointer table. This is an indirect call that the CPU can't predict and the compiler can't
 //     inline.
 //     runExperimental replaces this with a switch statement for common
 //     opcodes, with the opcode logic inlined in each case. The remaining opcodes
 //     fall through to the default case which uses the standard jump table.
-//     TODO: Eventualy, we can migrate over everything.
+//     TODO: Eventually, we can migrate over everything.
 //
 //  2. Gas accumulation: the standard interpreter checks and writes contract.Gas (on the heap)
 //     on every opcode.

--- a/core/vm/interpreter_experimental.go
+++ b/core/vm/interpreter_experimental.go
@@ -1,0 +1,495 @@
+// Copyright 2014 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+
+package vm
+
+import (
+	"github.com/ethereum/go-ethereum/params"
+	"github.com/holiman/uint256"
+)
+
+// runExperimental is an optimized interpreter loop using modern optimization
+// techniques taken from reth and gevm.
+// It is used when tracing is disabled and Verkle (EIP-4762) is not active, since
+// the code does not deal with those cases yet.
+//
+// Currently there are two optimizations over the standard loop:
+//
+//  1. Switch dispatch: the standard interpreter calls operation.execute() via a function
+//     pointer table. This is an indirect call that the CPU can't predict and the compiler won't
+//     inline.
+//     runExperimental replaces this with a switch statement for common
+//     opcodes, with the opcode logic inlined in each case. The remaining opcodes
+//     fall through to the default case which uses the standard jump table.
+//     TODO: Eventualy, we can migrate over everything.
+//
+//  2. Gas accumulation: the standard interpreter checks and writes contract.Gas (on the heap)
+//     on every opcode.
+//     runExperimental instead accumulates gas in a local (register allocated) variable
+//     It flushes to contract.Gas only at:
+//     - Control flow boundaries (JUMP, JUMPI etc)
+//     - Halt points (STOP, end of code)
+//     - Error paths (stack underflow/overflow, OOG)
+//     - The default fallback (before dynamic-gas opcodes like SLOAD, CALL, etc.)
+//
+//     This is safe because:
+//     - all inlined opcodes only touch the stack, so executing a few extra ops
+//     before detecting OOG has no observable side effects.
+//     - the EVM spec consumes all gas on OOG errors regardless.
+//     - gas is always flushed before any opcode with external effects (storage, calls, logs)
+//     since those go through the default path.
+//     - JUMP/JUMPI flush before jumping, so loops can't run indefinitely without a gas check.
+func (evm *EVM) runExperimental(contract *Contract, stack *Stack, mem *Memory, callContext *ScopeContext, jumpTable *JumpTable, code []byte) (ret []byte, err error) {
+	var (
+		pc      uint64
+		codeLen = uint64(len(code))
+		gasUsed uint64 // accumulated gas for constant-gas opcodes
+	)
+
+	for {
+		if pc >= codeLen {
+			if contract.Gas < gasUsed {
+				return nil, ErrOutOfGas
+			}
+			contract.Gas -= gasUsed
+			return nil, errStopToken
+		}
+		op := OpCode(code[pc])
+
+		switch op {
+
+		case STOP:
+			if contract.Gas < gasUsed {
+				return nil, ErrOutOfGas
+			}
+			contract.Gas -= gasUsed
+			return nil, errStopToken
+
+		case ADD:
+			gasUsed += GasFastestStep
+			if stack.len() < 2 {
+				if contract.Gas < gasUsed {
+					return nil, ErrOutOfGas
+				}
+				contract.Gas -= gasUsed
+				return nil, &ErrStackUnderflow{stackLen: stack.len(), required: 2}
+			}
+			x, y := stack.pop(), stack.peek()
+			y.Add(&x, y)
+
+		case SUB:
+			gasUsed += GasFastestStep
+			if stack.len() < 2 {
+				if contract.Gas < gasUsed {
+					return nil, ErrOutOfGas
+				}
+				contract.Gas -= gasUsed
+				return nil, &ErrStackUnderflow{stackLen: stack.len(), required: 2}
+			}
+			x, y := stack.pop(), stack.peek()
+			y.Sub(&x, y)
+
+		case MUL:
+			gasUsed += GasFastStep
+			if stack.len() < 2 {
+				if contract.Gas < gasUsed {
+					return nil, ErrOutOfGas
+				}
+				contract.Gas -= gasUsed
+				return nil, &ErrStackUnderflow{stackLen: stack.len(), required: 2}
+			}
+			x, y := stack.pop(), stack.peek()
+			y.Mul(&x, y)
+
+		case DIV:
+			gasUsed += GasFastStep
+			if stack.len() < 2 {
+				if contract.Gas < gasUsed {
+					return nil, ErrOutOfGas
+				}
+				contract.Gas -= gasUsed
+				return nil, &ErrStackUnderflow{stackLen: stack.len(), required: 2}
+			}
+			x, y := stack.pop(), stack.peek()
+			y.Div(&x, y)
+
+		case SDIV:
+			gasUsed += GasFastStep
+			if stack.len() < 2 {
+				if contract.Gas < gasUsed {
+					return nil, ErrOutOfGas
+				}
+				contract.Gas -= gasUsed
+				return nil, &ErrStackUnderflow{stackLen: stack.len(), required: 2}
+			}
+			x, y := stack.pop(), stack.peek()
+			y.SDiv(&x, y)
+
+		case MOD:
+			gasUsed += GasFastStep
+			if stack.len() < 2 {
+				if contract.Gas < gasUsed {
+					return nil, ErrOutOfGas
+				}
+				contract.Gas -= gasUsed
+				return nil, &ErrStackUnderflow{stackLen: stack.len(), required: 2}
+			}
+			x, y := stack.pop(), stack.peek()
+			y.Mod(&x, y)
+
+		case SMOD:
+			gasUsed += GasFastStep
+			if stack.len() < 2 {
+				if contract.Gas < gasUsed {
+					return nil, ErrOutOfGas
+				}
+				contract.Gas -= gasUsed
+				return nil, &ErrStackUnderflow{stackLen: stack.len(), required: 2}
+			}
+			x, y := stack.pop(), stack.peek()
+			y.SMod(&x, y)
+
+		case LT:
+			gasUsed += GasFastestStep
+			if stack.len() < 2 {
+				if contract.Gas < gasUsed {
+					return nil, ErrOutOfGas
+				}
+				contract.Gas -= gasUsed
+				return nil, &ErrStackUnderflow{stackLen: stack.len(), required: 2}
+			}
+			x, y := stack.pop(), stack.peek()
+			if x.Lt(y) {
+				y.SetOne()
+			} else {
+				y.Clear()
+			}
+
+		case GT:
+			gasUsed += GasFastestStep
+			if stack.len() < 2 {
+				if contract.Gas < gasUsed {
+					return nil, ErrOutOfGas
+				}
+				contract.Gas -= gasUsed
+				return nil, &ErrStackUnderflow{stackLen: stack.len(), required: 2}
+			}
+			x, y := stack.pop(), stack.peek()
+			if x.Gt(y) {
+				y.SetOne()
+			} else {
+				y.Clear()
+			}
+
+		case SLT:
+			gasUsed += GasFastestStep
+			if stack.len() < 2 {
+				if contract.Gas < gasUsed {
+					return nil, ErrOutOfGas
+				}
+				contract.Gas -= gasUsed
+				return nil, &ErrStackUnderflow{stackLen: stack.len(), required: 2}
+			}
+			x, y := stack.pop(), stack.peek()
+			if x.Slt(y) {
+				y.SetOne()
+			} else {
+				y.Clear()
+			}
+
+		case SGT:
+			gasUsed += GasFastestStep
+			if stack.len() < 2 {
+				if contract.Gas < gasUsed {
+					return nil, ErrOutOfGas
+				}
+				contract.Gas -= gasUsed
+				return nil, &ErrStackUnderflow{stackLen: stack.len(), required: 2}
+			}
+			x, y := stack.pop(), stack.peek()
+			if x.Sgt(y) {
+				y.SetOne()
+			} else {
+				y.Clear()
+			}
+
+		case EQ:
+			gasUsed += GasFastestStep
+			if stack.len() < 2 {
+				if contract.Gas < gasUsed {
+					return nil, ErrOutOfGas
+				}
+				contract.Gas -= gasUsed
+				return nil, &ErrStackUnderflow{stackLen: stack.len(), required: 2}
+			}
+			x, y := stack.pop(), stack.peek()
+			if x.Eq(y) {
+				y.SetOne()
+			} else {
+				y.Clear()
+			}
+
+		case ISZERO:
+			gasUsed += GasFastestStep
+			if stack.len() < 1 {
+				if contract.Gas < gasUsed {
+					return nil, ErrOutOfGas
+				}
+				contract.Gas -= gasUsed
+				return nil, &ErrStackUnderflow{stackLen: stack.len(), required: 1}
+			}
+			x := stack.peek()
+			if x.IsZero() {
+				x.SetOne()
+			} else {
+				x.Clear()
+			}
+
+		case AND:
+			gasUsed += GasFastestStep
+			if stack.len() < 2 {
+				if contract.Gas < gasUsed {
+					return nil, ErrOutOfGas
+				}
+				contract.Gas -= gasUsed
+				return nil, &ErrStackUnderflow{stackLen: stack.len(), required: 2}
+			}
+			x, y := stack.pop(), stack.peek()
+			y.And(&x, y)
+
+		case OR:
+			gasUsed += GasFastestStep
+			if stack.len() < 2 {
+				if contract.Gas < gasUsed {
+					return nil, ErrOutOfGas
+				}
+				contract.Gas -= gasUsed
+				return nil, &ErrStackUnderflow{stackLen: stack.len(), required: 2}
+			}
+			x, y := stack.pop(), stack.peek()
+			y.Or(&x, y)
+
+		case XOR:
+			gasUsed += GasFastestStep
+			if stack.len() < 2 {
+				if contract.Gas < gasUsed {
+					return nil, ErrOutOfGas
+				}
+				contract.Gas -= gasUsed
+				return nil, &ErrStackUnderflow{stackLen: stack.len(), required: 2}
+			}
+			x, y := stack.pop(), stack.peek()
+			y.Xor(&x, y)
+
+		case NOT:
+			gasUsed += GasFastestStep
+			if stack.len() < 1 {
+				if contract.Gas < gasUsed {
+					return nil, ErrOutOfGas
+				}
+				contract.Gas -= gasUsed
+				return nil, &ErrStackUnderflow{stackLen: stack.len(), required: 1}
+			}
+			x := stack.peek()
+			x.Not(x)
+
+		case POP:
+			gasUsed += GasQuickStep
+			if stack.len() < 1 {
+				if contract.Gas < gasUsed {
+					return nil, ErrOutOfGas
+				}
+				contract.Gas -= gasUsed
+				return nil, &ErrStackUnderflow{stackLen: 0, required: 1}
+			}
+			stack.pop()
+
+		case DUP1, DUP2, DUP3, DUP4, DUP5, DUP6, DUP7:
+			gasUsed += GasFastestStep
+			n := int(op - DUP1 + 1)
+			sLen := stack.len()
+			if sLen < n {
+				if contract.Gas < gasUsed {
+					return nil, ErrOutOfGas
+				}
+				contract.Gas -= gasUsed
+				return nil, &ErrStackUnderflow{stackLen: sLen, required: n}
+			}
+			if sLen >= int(params.StackLimit) {
+				if contract.Gas < gasUsed {
+					return nil, ErrOutOfGas
+				}
+				contract.Gas -= gasUsed
+				return nil, &ErrStackOverflow{stackLen: sLen, limit: int(params.StackLimit)}
+			}
+			stack.dup(n)
+
+		case SWAP1:
+			gasUsed += GasFastestStep
+			if stack.len() < 2 {
+				if contract.Gas < gasUsed {
+					return nil, ErrOutOfGas
+				}
+				contract.Gas -= gasUsed
+				return nil, &ErrStackUnderflow{stackLen: stack.len(), required: 2}
+			}
+			stack.swap1()
+
+		case SWAP2:
+			gasUsed += GasFastestStep
+			if stack.len() < 3 {
+				if contract.Gas < gasUsed {
+					return nil, ErrOutOfGas
+				}
+				contract.Gas -= gasUsed
+				return nil, &ErrStackUnderflow{stackLen: stack.len(), required: 3}
+			}
+			stack.swap2()
+
+		case SWAP3:
+			gasUsed += GasFastestStep
+			if stack.len() < 4 {
+				if contract.Gas < gasUsed {
+					return nil, ErrOutOfGas
+				}
+				contract.Gas -= gasUsed
+				return nil, &ErrStackUnderflow{stackLen: stack.len(), required: 4}
+			}
+			stack.swap3()
+
+		case PUSH1:
+			gasUsed += GasFastestStep
+			if stack.len() >= int(params.StackLimit) {
+				if contract.Gas < gasUsed {
+					return nil, ErrOutOfGas
+				}
+				contract.Gas -= gasUsed
+				return nil, &ErrStackOverflow{stackLen: stack.len(), limit: int(params.StackLimit)}
+			}
+			pc++
+			var val uint256.Int
+			if pc < codeLen {
+				val.SetUint64(uint64(code[pc]))
+			}
+			stack.push(&val)
+
+		case PUSH2:
+			gasUsed += GasFastestStep
+			if stack.len() >= int(params.StackLimit) {
+				if contract.Gas < gasUsed {
+					return nil, ErrOutOfGas
+				}
+				contract.Gas -= gasUsed
+				return nil, &ErrStackOverflow{stackLen: stack.len(), limit: int(params.StackLimit)}
+			}
+			var val uint256.Int
+			if pc+2 < codeLen {
+				val.SetUint64(uint64(code[pc+1])<<8 | uint64(code[pc+2]))
+			} else if pc+1 < codeLen {
+				val.SetUint64(uint64(code[pc+1]) << 8)
+			}
+			stack.push(&val)
+			pc += 2
+
+		case PUSH0:
+			if !evm.chainRules.IsShanghai {
+				return nil, &ErrInvalidOpCode{opcode: op}
+			}
+			gasUsed += GasQuickStep
+			if stack.len() >= int(params.StackLimit) {
+				if contract.Gas < gasUsed {
+					return nil, ErrOutOfGas
+				}
+				contract.Gas -= gasUsed
+				return nil, &ErrStackOverflow{stackLen: stack.len(), limit: int(params.StackLimit)}
+			}
+			var zero uint256.Int
+			stack.push(&zero)
+
+		case JUMPDEST:
+			gasUsed += params.JumpdestGas
+
+		case JUMP:
+			gasUsed += GasMidStep
+			if contract.Gas < gasUsed {
+				return nil, ErrOutOfGas
+			}
+			contract.Gas -= gasUsed
+			gasUsed = 0
+
+			if stack.len() < 1 {
+				return nil, &ErrStackUnderflow{stackLen: stack.len(), required: 1}
+			}
+			pos := stack.pop()
+
+			if evm.abort.Load() {
+				return nil, errStopToken
+			}
+			if !contract.validJumpdest(&pos) {
+				return nil, ErrInvalidJump
+			}
+			pc = pos.Uint64()
+			continue // skip pc++
+
+		case JUMPI:
+			gasUsed += GasSlowStep
+			if contract.Gas < gasUsed {
+				return nil, ErrOutOfGas
+			}
+			contract.Gas -= gasUsed
+			gasUsed = 0
+
+			if stack.len() < 2 {
+				return nil, &ErrStackUnderflow{stackLen: stack.len(), required: 2}
+			}
+			pos, cond := stack.pop(), stack.pop()
+
+			if evm.abort.Load() {
+				return nil, errStopToken
+			}
+			if !cond.IsZero() {
+				if !contract.validJumpdest(&pos) {
+					return nil, ErrInvalidJump
+				}
+				pc = pos.Uint64()
+				continue // skip pc++
+			}
+		// Flush gas and fall back to normal dispatch
+		default:
+			if contract.Gas < gasUsed {
+				return nil, ErrOutOfGas
+			}
+			contract.Gas -= gasUsed
+			gasUsed = 0
+
+			// TODO: second return (cost) is for tracing — use it when adding a tracing to runExperimental.
+			operation, _, memorySize, gasErr := chargeGasOp(op, evm, contract, stack, mem, jumpTable)
+			if gasErr != nil {
+				return nil, gasErr
+			}
+			if memorySize > 0 {
+				mem.Resize(memorySize)
+			}
+			var res []byte
+			res, err = operation.execute(&pc, evm, callContext)
+			if err != nil {
+				return res, err
+			}
+		}
+
+		pc++
+	}
+}

--- a/core/vm/interpreter_experimental.go
+++ b/core/vm/interpreter_experimental.go
@@ -406,6 +406,10 @@ func (evm *EVM) runExperimental(contract *Contract, stack *Stack, mem *Memory, c
 
 		case PUSH0:
 			if !evm.chainRules.IsShanghai {
+				if contract.Gas < gasUsed {
+					return nil, ErrOutOfGas
+				}
+				contract.Gas -= gasUsed
 				return nil, &ErrInvalidOpCode{opcode: op}
 			}
 			gasUsed += GasQuickStep

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -241,8 +241,8 @@ func New(stack *node.Node, config *ethconfig.Config) (*Ethereum, error) {
 			HistoryPolicy:           histPolicy,
 			TxLookupLimit:           int64(min(config.TransactionHistory, math.MaxInt64)),
 			VmConfig: vm.Config{
-				EnablePreimageRecording: config.EnablePreimageRecording,
-				EnableExperimentalInterpreter:   config.EnableExperimentalInterpreter,
+				EnablePreimageRecording:       config.EnablePreimageRecording,
+				EnableExperimentalInterpreter: config.EnableExperimentalInterpreter,
 			},
 			// Enables file journaling for the trie database. The journal files will be stored
 			// within the data directory. The corresponding paths will be either:

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -242,6 +242,7 @@ func New(stack *node.Node, config *ethconfig.Config) (*Ethereum, error) {
 			TxLookupLimit:           int64(min(config.TransactionHistory, math.MaxInt64)),
 			VmConfig: vm.Config{
 				EnablePreimageRecording: config.EnablePreimageRecording,
+				EnableExperimentalInterpreter:   config.EnableExperimentalInterpreter,
 			},
 			// Enables file journaling for the trie database. The journal files will be stored
 			// within the data directory. The corresponding paths will be either:

--- a/eth/ethconfig/config.go
+++ b/eth/ethconfig/config.go
@@ -168,6 +168,9 @@ type Config struct {
 	// Enables tracking of SHA3 preimages in the VM
 	EnablePreimageRecording bool
 
+	// Enables the experimental EVM interpreter
+	EnableExperimentalInterpreter bool
+
 	// Enables collection of witness trie access statistics
 	EnableWitnessStats bool
 


### PR DESCRIPTION
> Opening this PR to get @fjl thoughts and to spur some ideas on pathways to optimizing the EVM in geth.

This is a simple idea for enabling an experimental EVM that can be developed/optimized alongside the normal EVM.

Currently it only optimizes, commonly used compute opcodes using a switch dispatch (the savings are about 50%), and then fallsback to the normal interpreter for everything else. None of the optimization techniques here are new.



