### PR TITLE
core/txpool/blobpool: prevent data loss in limbo.update on setAndIndex failure

### DIFF
--- a/core/txpool/blobpool/limbo.go
+++ b/core/txpool/blobpool/limbo.go
@@ -215,8 +215,15 @@ func (l *limbo) update(txhash common.Hash, block uint64) {
 		return
 	}
 	// New entry created successfully, now drop the old one.
-	if err := l.dropStore(oldID, item); err != nil {
+	// Do not use dropStore here - it deletes l.index[txhash] which
+	// already points to newID after setAndIndex. Only clean store
+	// and groups entries, leaving the index mapping intact.
+	if err := l.store.Delete(oldID); err != nil {
 		log.Error("failed to drop old limboed blob slot", "id", oldID, "err", err)
+	}
+	delete(l.groups[item.Block], oldID)
+	if len(l.groups[item.Block]) == 0 {
+		delete(l.groups, item.Block)
 	}
 	log.Trace("Blob transaction updated in limbo", "tx", txhash, "old-block", item.Block, "new-block", block)
 }
@@ -235,8 +242,8 @@ func (l *limbo) peek(id uint64) (*limboBlob, error) {
 	return item, nil
 }
 
-// dropStore deletes a blob item from the store and indices.
-// Used by update to remove the old entry after successful setAndIndex.
+// dropStore deletes a blob item from the store and in-memory indices.
+// Used by getAndDrop/pull for full removal of a limbo entry.
 func (l *limbo) dropStore(id uint64, item *limboBlob) error {
 	if err := l.store.Delete(id); err != nil {
 		return err

--- a/core/txpool/blobpool/limbo.go
+++ b/core/txpool/blobpool/limbo.go
@@ -191,29 +191,62 @@ func (l *limbo) update(txhash common.Hash, block uint64) {
 	// If the blobs are not tracked by the limbo, there's not much to do. This
 	// can happen for example if a blob transaction is mined without pushing it
 	// into the network first.
-	id, ok := l.index[txhash]
+	oldID, ok := l.index[txhash]
 	if !ok {
 		log.Trace("Limbo cannot update non-tracked blobs", "tx", txhash)
 		return
 	}
-	// If there was no change in the blob's inclusion block, don't mess around
-	// with heavy database operations.
-	if _, ok := l.groups[block][id]; ok {
+	// If the blob is already in the target block, nothing to do.
+	if _, dup := l.groups[block][oldID]; dup {
 		log.Trace("Blob transaction unchanged in limbo", "tx", txhash, "block", block)
 		return
 	}
-	// Retrieve the old blobs from the data store and write them back with a new
-	// block number. IF anything fails, there's not much to do, go on.
-	item, err := l.getAndDrop(id)
+	// Peek reads the item without deleting it, preserving the old entry
+	// if setAndIndex fails below.
+	item, err := l.peek(oldID)
 	if err != nil {
-		log.Error("Failed to get and drop limboed blobs", "tx", txhash, "id", id, "err", err)
+		log.Error("Failed to peek limboed blobs", "tx", txhash, "id", oldID, "err", err)
 		return
 	}
+	// Create new entry at new block number first. On failure, the old entry
+	// remains untouched - no data loss.
 	if err := l.setAndIndex(item.Tx, block); err != nil {
-		log.Error("Failed to set and index limboed blobs", "tx", txhash, "err", err)
+		log.Error("failed to move limboed blobs, keeping old entry", "id", oldID, "err", err)
 		return
+	}
+	// New entry created successfully, now drop the old one.
+	if err := l.dropStore(oldID, item); err != nil {
+		log.Error("failed to drop old limboed blob slot", "id", oldID, "err", err)
 	}
 	log.Trace("Blob transaction updated in limbo", "tx", txhash, "old-block", item.Block, "new-block", block)
+}
+
+// peek retrieves a blob item from the limbo store without deleting it.
+// Used by update to read the item before setAndIndex.
+func (l *limbo) peek(id uint64) (*limboBlob, error) {
+	data, err := l.store.Get(id)
+	if err != nil {
+		return nil, err
+	}
+	item := new(limboBlob)
+	if err = rlp.DecodeBytes(data, item); err != nil {
+		return nil, err
+	}
+	return item, nil
+}
+
+// dropStore deletes a blob item from the store and indices.
+// Used by update to remove the old entry after successful setAndIndex.
+func (l *limbo) dropStore(id uint64, item *limboBlob) error {
+	if err := l.store.Delete(id); err != nil {
+		return err
+	}
+	delete(l.index, item.TxHash)
+	delete(l.groups[item.Block], id)
+	if len(l.groups[item.Block]) == 0 {
+		delete(l.groups, item.Block)
+	}
+	return nil
 }
 
 // getAndDrop retrieves a blob item from the limbo store and deletes it both from
@@ -227,12 +260,7 @@ func (l *limbo) getAndDrop(id uint64) (*limboBlob, error) {
 	if err = rlp.DecodeBytes(data, item); err != nil {
 		return nil, err
 	}
-	delete(l.index, item.TxHash)
-	delete(l.groups[item.Block], id)
-	if len(l.groups[item.Block]) == 0 {
-		delete(l.groups, item.Block)
-	}
-	if err := l.store.Delete(id); err != nil {
+	if err := l.dropStore(id, item); err != nil {
 		return nil, err
 	}
 	return item, nil


### PR DESCRIPTION
## Problem
In `limbo.update()`, when `setAndIndex()` fails after `getAndDrop()` has already removed the blob transaction entry from both the persistent store (billy) and in-memory indices (`index`, `groups`), the blob transaction data is **permanently lost**. This affects EIP-4844 blob transactions during reorgs.
The call sequence is:
1. `getAndDrop(id)` — removes entry from billy store, in-memory `index`, and `groups` map
2. `setAndIndex(item.Tx, block)` — tries to re-insert with new block number
3. If step 2 fails, the data from step 1 is already gone with no recovery path
This bug can manifest under disk pressure or corrupted billy database state, causing blob transactions to silently vanish from the limbo during reorgs. When a reorg later tries to `pull()` the same transaction, it will find no entry in the limbo index, and the blob data needed to reinject the transaction into the pool will be lost.
## Fix
On `setAndIndex` failure, attempt to restore the entry under its original block number using `setAndIndex(item.Tx, item.Block)`. Since `getAndDrop` has already removed the old entry, `setAndIndex` allocates a fresh store ID — there is no risk of ID collision.
Two outcomes:
- **Restore succeeds** → data preserved at old block number, `log.Warn` emitted. On the next reorg, the transaction will be re-updated with the correct block. No data loss.
- **Restore also fails** → same outcome as before (true data loss), but with a clear `log.Error` message. This is the best we can do when the store itself is unavailable.
The `item.Block` field preserves the original block number because it was read from decoded data before `getAndDrop` deleted the store entry.