### PR TITLE
eth/catalyst: fix getBlobsV3 partial/complete metrics

### DIFF
--- a/eth/catalyst/api.go
+++ b/eth/catalyst/api.go
@@ -650,9 +650,16 @@ func (api *ConsensusAPI) getBlobs(hashes []common.Hash, v2 bool) ([]*engine.Blob
 			CellProofs: cellProofs,
 		}
 	}
-	if len(res) == len(hashes) {
+
+	nonNilCount := 0
+	for _, r := range res {
+		if r != nil {
+			nonNilCount++
+		}
+	}
+	if nonNilCount == len(hashes) {
 		getBlobsRequestCompleteHit.Inc(1)
-	} else if len(res) > 0 {
+	} else if nonNilCount > 0 {
 		getBlobsRequestPartialHit.Inc(1)
 	} else {
 		getBlobsRequestMiss.Inc(1)

--- a/eth/catalyst/api.go
+++ b/eth/catalyst/api.go
@@ -629,6 +629,7 @@ func (api *ConsensusAPI) getBlobs(hashes []common.Hash, v2 bool) ([]*engine.Blob
 		return nil, engine.InvalidParams.With(err)
 	}
 	// Validate the blobs from the pool and assemble the response
+	filled := 0
 	res := make([]*engine.BlobAndProofV2, len(hashes))
 	for i := range blobs {
 		// The blob has been evicted since the last AvailableBlobs call.
@@ -649,17 +650,11 @@ func (api *ConsensusAPI) getBlobs(hashes []common.Hash, v2 bool) ([]*engine.Blob
 			Blob:       blobs[i][:],
 			CellProofs: cellProofs,
 		}
+		filled++
 	}
-
-	nonNilCount := 0
-	for _, r := range res {
-		if r != nil {
-			nonNilCount++
-		}
-	}
-	if nonNilCount == len(hashes) {
+	if filled == len(hashes) {
 		getBlobsRequestCompleteHit.Inc(1)
-	} else if nonNilCount > 0 {
+	} else if filled > 0 {
 		getBlobsRequestPartialHit.Inc(1)
 	} else {
 		getBlobsRequestMiss.Inc(1)


### PR DESCRIPTION
In b2843a11d, metrics check len(res) == len(hashes) but res is pre-allocated with make(), so length is always equal. Partial hit metric never fires. Count non-nil elements instead.