### PR TITLE
node: normalize HTTP vhost host matching

### DIFF
--- a/node/rpcstack.go
+++ b/node/rpcstack.go
@@ -463,6 +463,7 @@ func (h *virtualHostHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		// Either invalid (too many colons) or no port specified
 		host = r.Host
 	}
+	host = strings.ToLower(host)
 	if ipAddr := net.ParseIP(host); ipAddr != nil {
 		// It's an IP address, we can serve that
 		h.next.ServeHTTP(w, r)

--- a/node/rpcstack_test.go
+++ b/node/rpcstack_test.go
@@ -60,6 +60,9 @@ func TestVhosts(t *testing.T) {
 	resp := rpcRequest(t, url, testMethod, "host", "test")
 	assert.Equal(t, resp.StatusCode, http.StatusOK)
 
+	respUpper := rpcRequest(t, url, testMethod, "host", "TeSt:1234")
+	assert.Equal(t, respUpper.StatusCode, http.StatusOK)
+
 	resp2 := rpcRequest(t, url, testMethod, "host", "bad")
 	assert.Equal(t, resp2.StatusCode, http.StatusForbidden)
 }


### PR DESCRIPTION
## Summary

Fix HTTP RPC virtual-host validation to treat request hostnames case-insensitively.

Before this change, configured vhosts were normalized to lowercase, but the
incoming `Host` header was compared without lowercasing it first. This caused
valid requests such as `Host: TeSt:1234` to be rejected with `403 Forbidden`
even when `test` was present in the allowlist.

## Changes

- lowercase the parsed request host before vhost lookup in `virtualHostHandler`
- add a regression test covering mixed-case `Host` headers with an explicit port

## Reproduction

With HTTP RPC enabled and `test` in `--http.vhosts`, a request like:

```sh
curl -i \
  -H 'Host: TeSt:1234' \
  -H 'Content-Type: application/json' \
  --data '{"jsonrpc":"2.0","id":1,"method":"web3_clientVersion","params":[]}' \
  http://127.0.0.1:8545
```

was incorrectly rejected before this patch.

## Testing

- `make all`
- `go run ./build/ci.go test`
- `go run ./build/ci.go lint`
- `go run ./build/ci.go check_generate`
- `go run ./build/ci.go check_baddeps`

Fixes #34692