### PR TITLE
eth/filters: return invalid params for getlogs query limit

### DIFF
--- a/eth/filters/api.go
+++ b/eth/filters/api.go
@@ -53,6 +53,7 @@ type invalidParamsError struct {
 
 func (e invalidParamsError) Error() string  { return e.err.Error() }
 func (e invalidParamsError) ErrorCode() int { return -32602 }
+func (e invalidParamsError) Unwrap() error  { return e.err }
 
 func invalidParamsErr(format string, args ...any) error {
 	return invalidParamsError{fmt.Errorf(format, args...)}
@@ -450,11 +451,11 @@ func (api *FilterAPI) GetLogs(ctx context.Context, crit FilterCriteria) ([]*type
 	}
 	if api.logQueryLimit != 0 {
 		if len(crit.Addresses) > api.logQueryLimit {
-			return nil, errExceedLogQueryLimit
+			return nil, invalidParamsErr("%w", errExceedLogQueryLimit)
 		}
 		for _, topics := range crit.Topics {
 			if len(topics) > api.logQueryLimit {
-				return nil, errExceedLogQueryLimit
+				return nil, invalidParamsErr("%w", errExceedLogQueryLimit)
 			}
 		}
 	}

--- a/eth/filters/filter_system_test.go
+++ b/eth/filters/filter_system_test.go
@@ -591,8 +591,19 @@ func TestExceedLogQueryLimit(t *testing.T) {
 		FromBlock: big.NewInt(0),
 		ToBlock:   big.NewInt(100),
 		Addresses: addresses,
-	}); err != errExceedLogQueryLimit {
+	}); !errors.Is(err, errExceedLogQueryLimit) {
 		t.Errorf("Expected GetLogs with 6 addresses to return errExceedLogQueryLimit, got: %v", err)
+	} else {
+		var re rpc.Error
+		if !errors.As(err, &re) {
+			t.Fatalf("expected rpc error, got %v", err)
+		}
+		if re.ErrorCode() != -32602 {
+			t.Fatalf("expected error code -32602, got %d", re.ErrorCode())
+		}
+		if re.Error() != "exceed max addresses or topics per search position" {
+			t.Fatalf("expected error message %q, got %q", "exceed max addresses or topics per search position", re.Error())
+		}
 	}
 
 	// Test that 5 topics at one position do not result in error
@@ -611,8 +622,19 @@ func TestExceedLogQueryLimit(t *testing.T) {
 		ToBlock:   big.NewInt(100),
 		Addresses: addresses[:1],
 		Topics:    [][]common.Hash{topics},
-	}); err != errExceedLogQueryLimit {
+	}); !errors.Is(err, errExceedLogQueryLimit) {
 		t.Errorf("Expected GetLogs with 6 topics at one position to return errExceedLogQueryLimit, got: %v", err)
+	} else {
+		var re rpc.Error
+		if !errors.As(err, &re) {
+			t.Fatalf("expected rpc error, got %v", err)
+		}
+		if re.ErrorCode() != -32602 {
+			t.Fatalf("expected error code -32602, got %d", re.ErrorCode())
+		}
+		if re.Error() != "exceed max addresses or topics per search position" {
+			t.Fatalf("expected error message %q, got %q", "exceed max addresses or topics per search position", re.Error())
+		}
 	}
 }
 


### PR DESCRIPTION
This change updates `eth_getLogs` so that when a request goes over the configured address/topic query limit, the RPC response returns `-32602` for invalid params instead of the generic `-32000` server error. The change is only applied in the `GetLogs` RPC path, so it does not affect other places that use the same internal error.

The error message stays the same: `exceed max addresses or topics per search position`. The tests were updated to check that this limit is still detected correctly and that the RPC response now returns code -32602 with the same message. 