### PR TITLE
beacon/engine, miner: fix testing_buildBlockV1 response

### DIFF
--- a/beacon/engine/gen_ed.go
+++ b/beacon/engine/gen_ed.go
@@ -34,7 +34,7 @@ func (e ExecutableData) MarshalJSON() ([]byte, error) {
 		Withdrawals   []*types.Withdrawal `json:"withdrawals"`
 		BlobGasUsed   *hexutil.Uint64     `json:"blobGasUsed"`
 		ExcessBlobGas *hexutil.Uint64     `json:"excessBlobGas"`
-		SlotNumber    *hexutil.Uint64     `json:"slotNumber"`
+		SlotNumber    *hexutil.Uint64     `json:"slotNumber,omitempty"`
 	}
 	var enc ExecutableData
 	enc.ParentHash = e.ParentHash
@@ -83,7 +83,7 @@ func (e *ExecutableData) UnmarshalJSON(input []byte) error {
 		Withdrawals   []*types.Withdrawal `json:"withdrawals"`
 		BlobGasUsed   *hexutil.Uint64     `json:"blobGasUsed"`
 		ExcessBlobGas *hexutil.Uint64     `json:"excessBlobGas"`
-		SlotNumber    *hexutil.Uint64     `json:"slotNumber"`
+		SlotNumber    *hexutil.Uint64     `json:"slotNumber,omitempty"`
 	}
 	var dec ExecutableData
 	if err := json.Unmarshal(input, &dec); err != nil {

--- a/beacon/engine/types.go
+++ b/beacon/engine/types.go
@@ -99,7 +99,7 @@ type ExecutableData struct {
 	Withdrawals   []*types.Withdrawal `json:"withdrawals"`
 	BlobGasUsed   *uint64             `json:"blobGasUsed"`
 	ExcessBlobGas *uint64             `json:"excessBlobGas"`
-	SlotNumber    *uint64             `json:"slotNumber"`
+	SlotNumber    *uint64             `json:"slotNumber,omitempty"`
 }
 
 // JSON type overrides for executableData.

--- a/miner/payload_building.go
+++ b/miner/payload_building.go
@@ -360,5 +360,5 @@ func (miner *Miner) BuildTestingPayload(args *BuildPayloadArgs, transactions []*
 	if res.err != nil {
 		return nil, res.err
 	}
-	return engine.BlockToExecutableData(res.block, new(big.Int), res.sidecars, res.requests), nil
+	return engine.BlockToExecutableData(res.block, res.fees, res.sidecars, res.requests), nil
 }


### PR DESCRIPTION
Two fixes for `testing_buildBlockV1`:

1. Add `omitempty` to `SlotNumber` in `ExecutableData` so it is omitted for pre-Amsterdam payloads. The spec defines the response as `ExecutionPayloadV3` which does not include `slotNumber`.

2. Pass `res.fees` instead of `new(big.Int)` in `BuildTestingPayload` so `blockValue` reflects actual priority fees instead of always being zero.

Corresponding fixture update: ethereum/execution-apis#783