### PR TITLE
eth/catalyst: wire up slotnum for `testing_buildBlockV1`

### DIFF
--- a/eth/catalyst/api_testing.go
+++ b/eth/catalyst/api_testing.go
@@ -74,6 +74,7 @@ func (api *testingAPI) BuildBlockV1(parentHash common.Hash, payloadAttributes en
 		Random:       payloadAttributes.Random,
 		Withdrawals:  payloadAttributes.Withdrawals,
 		BeaconRoot:   payloadAttributes.BeaconRoot,
+		SlotNum:      payloadAttributes.SlotNumber,
 	}
 	return api.eth.Miner().BuildTestingPayload(args, txs, buildEmpty, extra)
 }


### PR DESCRIPTION
Wire up slotnum for `testing_buildBlockV1` for `bal-devnet-3` branch

We are experimenting testing block building through hive via EELS (PR [here](https://github.com/ethereum/execution-specs/pull/2679)). This is the only change needed to test against `bal-devnet-3` - missing slotnum.