### PR TITLE
eth/catalyst: respect slot num if specified in payload attributes for `testing_buildBlockV1`

### DIFF
--- a/eth/catalyst/api_testing.go
+++ b/eth/catalyst/api_testing.go
@@ -74,6 +74,7 @@ func (api *testingAPI) BuildBlockV1(parentHash common.Hash, payloadAttributes en
 		Random:       payloadAttributes.Random,
 		Withdrawals:  payloadAttributes.Withdrawals,
 		BeaconRoot:   payloadAttributes.BeaconRoot,
+		SlotNum:      payloadAttributes.SlotNumber,
 	}
 	return api.eth.Miner().BuildTestingPayload(args, txs, buildEmpty, extra)
 }


### PR DESCRIPTION
This is a copy of #34721 but against `master` (rather than `bal-devnet-3`), as requested by @jwasinger, since the slotnum logic now exists on `master` as well.