### PR TITLE
graphql: respect rpc.rangelimit in Logs query

### DIFF
--- a/eth/filters/filter_system.go
+++ b/eth/filters/filter_system.go
@@ -94,6 +94,11 @@ func NewFilterSystem(backend Backend, config Config) *FilterSystem {
 	}
 }
 
+// RangeLimit returns the configured maximum block range for filter queries.
+func (sys *FilterSystem) RangeLimit() uint64 {
+	return sys.cfg.RangeLimit
+}
+
 type logCacheElem struct {
 	logs []*types.Log
 	body atomic.Pointer[types.Body]

--- a/graphql/graphql.go
+++ b/graphql/graphql.go
@@ -1445,7 +1445,7 @@ func (r *Resolver) Logs(ctx context.Context, args struct{ Filter FilterCriteria 
 		topics = *args.Filter.Topics
 	}
 	// Construct the range filter
-	filter := r.filterSystem.NewRangeFilter(begin, end, addresses, topics, 0)
+	filter := r.filterSystem.NewRangeFilter(begin, end, addresses, topics, r.filterSystem.RangeLimit())
 	return runFilter(ctx, r, filter)
 }
 


### PR DESCRIPTION
The GraphQL `Logs` resolver hardcodes `0` (unlimited) as the range limit, bypassing the `--rpc.rangelimit` protection. A node started with `--rpc.rangelimit 10000`:                                                                                              
   
  - `eth_getLogs` with a 50000-block range → **rejected** ✓                                                              
  - GraphQL `{ logs(filter: { fromBlock: 0, toBlock: 50000 }) }` → **allowed** ✗

adds a `RangeLimit()` getter to `FilterSystem` and uses it in the GraphQL resolver, so both endpoints consistently enforce the configured limit.