### PR TITLE
cmd/geth, core/rawdb, internal/version: replace deprecated strings.Title

### DIFF
--- a/cmd/geth/misccmd.go
+++ b/cmd/geth/misccmd.go
@@ -20,10 +20,11 @@ import (
 	"fmt"
 	"os"
 	"runtime"
-	"strings"
 
 	"github.com/ethereum/go-ethereum/internal/version"
 	"github.com/urfave/cli/v2"
+	"golang.org/x/text/cases"
+	"golang.org/x/text/language"
 )
 
 var (
@@ -47,7 +48,7 @@ The output of this command is supposed to be machine-readable.
 func printVersion(ctx *cli.Context) error {
 	git, _ := version.VCS()
 
-	fmt.Println(strings.Title(clientIdentifier))
+	fmt.Println(cases.Title(language.English, cases.NoLower).String(clientIdentifier))
 	fmt.Println("Version:", version.WithMeta)
 	if git.Commit != "" {
 		fmt.Println("Git Commit:", git.Commit)

--- a/core/rawdb/database.go
+++ b/core/rawdb/database.go
@@ -38,6 +38,8 @@ import (
 	"github.com/ethereum/go-ethereum/internal/tablewriter"
 	"github.com/ethereum/go-ethereum/log"
 	"golang.org/x/sync/errgroup"
+	"golang.org/x/text/cases"
+	"golang.org/x/text/language"
 )
 
 var ErrDeleteRangeInterrupted = errors.New("safe delete range operation interrupted")
@@ -657,11 +659,12 @@ func InspectDatabase(db ethdb.Database, keyPrefix, keyStart []byte) error {
 	if err != nil {
 		return err
 	}
+	caser := cases.Title(language.English, cases.NoLower)
 	for _, ancient := range ancients {
 		for _, table := range ancient.sizes {
 			stats = append(stats, []string{
-				fmt.Sprintf("Ancient store (%s)", strings.Title(ancient.name)),
-				strings.Title(table.name),
+				fmt.Sprintf("Ancient store (%s)", caser.String(ancient.name)),
+				caser.String(table.name),
 				table.size.String(),
 				fmt.Sprintf("%d", ancient.count),
 			})

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -24,6 +24,8 @@ import (
 	"strings"
 
 	"github.com/ethereum/go-ethereum/version"
+	"golang.org/x/text/cases"
+	"golang.org/x/text/language"
 )
 
 const ourPath = "github.com/ethereum/go-ethereum" // Path to our module
@@ -73,7 +75,7 @@ func Archive(gitCommit string) string {
 func ClientName(clientIdentifier string) string {
 	git, _ := VCS()
 	return fmt.Sprintf("%s/v%v/%v-%v/%v",
-		strings.Title(clientIdentifier),
+		cases.Title(language.English, cases.NoLower).String(clientIdentifier),
 		WithCommit(git.Commit, git.Date),
 		runtime.GOOS, runtime.GOARCH,
 		runtime.Version(),


### PR DESCRIPTION
strings.Title has been deprecated since Go 1.18 because it does not handle Unicode punctuation properly. Replace all 4 call sites with cases.Title from golang.org/x/text which is already a dependency.

Use cases.NoLower to preserve the original strings.Title behavior of only capitalizing the first letter of each word without lowering the rest.