### PR TITLE
core/rawdb: fix incorrect fsync ordering for index file truncation

### DIFF
--- a/core/rawdb/freezer_utils.go
+++ b/core/rawdb/freezer_utils.go
@@ -76,6 +76,11 @@ func copyFrom(srcPath, destPath string, offset uint64, before func(f *os.File) e
 	// we do the final move.
 	src.Close()
 
+	// Permanently persist the content into disk
+	if err := f.Sync(); err != nil {
+		return err
+	}
+
 	if err := f.Close(); err != nil {
 		return err
 	}


### PR DESCRIPTION
closes #34711 

The `copyFrom` function does the fsync in the following sequence:
1. Creates a tmp file
2. Copy data to tmp
3. Rename tmp to index
4. fsync dir
5. fsync new index file

The bug is b/w steps 4 and 5 when a crash happens. On reboot, the index file exists under the right name but is either empty or truncated which leads to data loss

Fix: fsync the tmp file before the rename, matching what reset in the same file already does. Now order in copyFrom. I did these: 

1. Write tmp
2. fsync tmo
3. Rename
4. fsync the dir (via `atomicRename`)