### PR TITLE
cmd/utils: fix witness stats auto-enable to respect config file

### DIFF
--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -1899,7 +1899,7 @@ func SetEthConfig(ctx *cli.Context, stack *node.Node, cfg *ethconfig.Config) {
 		cfg.StatelessSelfValidation = ctx.Bool(VMStatelessSelfValidationFlag.Name)
 	}
 	// Auto-enable StatelessSelfValidation when witness stats are enabled
-	if ctx.Bool(VMWitnessStatsFlag.Name) {
+	if cfg.EnableWitnessStats {
 		cfg.StatelessSelfValidation = true
 	}
 


### PR DESCRIPTION
Auto-enable logic for `StatelessSelfValidation` was reading CLI flag directly via `ctx.Bool()`, bypassing the merged `cfg.EnableWitnessStats` value. Now uses `cfg.EnableWitnessStats` so config file settings trigger the same auto-enable behavior as CLI flags.