### PR TITLE
cmd/evm: fix trace.noreturndata usage string

### DIFF
--- a/cmd/evm/main.go
+++ b/cmd/evm/main.go
@@ -115,7 +115,7 @@ var (
 		Name:     "trace.noreturndata",
 		Aliases:  []string{"noreturndata"},
 		Value:    true,
-		Usage:    "enable return data output",
+		Usage:    "disable return data output",
 		Category: traceCategory,
 	}
 


### PR DESCRIPTION
`trace.noreturndata` is documented as "enable return data output" but the flag name/value imply it disables return data. This is confusing for users and likely inverted wording. Update the Usage string to reflect the actual behavior (disable return data output).