### PR TITLE
cmd/evm: fix gasUsed reporting in --create path to return gas used, not gas left

### DIFF
--- a/cmd/evm/runner.go
+++ b/cmd/evm/runner.go
@@ -318,7 +318,7 @@ func runCmd(ctx *cli.Context) error {
 			// don't mutate the state!
 			runtimeConfig.State = prestate.Copy()
 			output, _, gasLeft, err := runtime.Create(input, &runtimeConfig)
-			return output, gasLeft, err
+			return output, initialGas - gasLeft, err
 		}
 	} else {
 		if len(code) > 0 {


### PR DESCRIPTION
In the --create path, execFunc returns gasLeft as the second return value, but the rest of the code treats this value as "gas used" (printed as such, and compared in timedExec). This makes gas reporting incorrect and can cause benchmark consistency checks to fail.