### PR TITLE
cmd/evm: propagate statetest stdin scanner errors

### DIFF
--- a/cmd/evm/staterunner.go
+++ b/cmd/evm/staterunner.go
@@ -92,6 +92,9 @@ func stateTestCmd(ctx *cli.Context) error {
 		}
 		report(ctx, results)
 	}
+	if err := scanner.Err(); err != nil {
+		return err
+	}
 	return nil
 }
 


### PR DESCRIPTION
The stdin scanner loop ignores scanner.Err(), so read errors (e.g., underlying IO issues or overly long lines) will be silently swallowed and reported as success. After the scan loop, check scanner.Err() and return it if non-nil.