### PR TITLE
core/rawdb: fix file descriptor leak in freezer error paths

### DIFF
--- a/core/rawdb/freezer_table.go
+++ b/core/rawdb/freezer_table.go
@@ -157,6 +157,7 @@ func newTable(path string, name string, readMeter, writeMeter *metrics.Meter, si
 		}
 		meta, err = openFreezerFileForReadOnly(filepath.Join(path, fmt.Sprintf("%s.meta", name)))
 		if err != nil {
+			index.Close()
 			return nil, err
 		}
 	} else {
@@ -166,6 +167,7 @@ func newTable(path string, name string, readMeter, writeMeter *metrics.Meter, si
 		}
 		meta, err = openFreezerFileForAppend(filepath.Join(path, fmt.Sprintf("%s.meta", name)))
 		if err != nil {
+			index.Close()
 			return nil, err
 		}
 	}
@@ -173,6 +175,8 @@ func newTable(path string, name string, readMeter, writeMeter *metrics.Meter, si
 	// is detected.
 	metadata, err := newMetadata(meta)
 	if err != nil {
+		meta.Close()
+		index.Close()
 		return nil, err
 	}
 	// Create the table and repair any past inconsistency

--- a/core/rawdb/freezer_utils.go
+++ b/core/rawdb/freezer_utils.go
@@ -129,6 +129,7 @@ func openFreezerFileForAppend(filename string) (*os.File, error) {
 	}
 	// Seek to end for append
 	if _, err = file.Seek(0, io.SeekEnd); err != nil {
+		file.Close()
 		return nil, err
 	}
 	return file, nil


### PR DESCRIPTION
In openFreezerFileForAppend, if Seek fails after the file is successfully opened, the file handle is not closed, leaking a descriptor.

Similarly in newTable, if opening the meta file fails, the already-opened index file is not closed. And if newMetadata fails, both the index and meta files are leaked.

Under repeated error conditions (e.g., corrupted filesystem), these leaks accumulate and may exhaust the OS file descriptor limit, causing cascading failures.