### PR TITLE
core/overlay: prevent silent transition state restart on decode failure

### DIFF
--- a/core/overlay/state_transition.go
+++ b/core/overlay/state_transition.go
@@ -86,8 +86,14 @@ func LoadTransitionState(db ethdb.KeyValueReader, root common.Hash, isVerkle boo
 		// Decode transition state
 		err := dec.Decode(&newts)
 		if err != nil {
-			log.Error("failed to decode transition state", "err", err)
-			return nil
+			log.Error("failed to decode transition state", "root", root, "err", err)
+			// Corrupted transition state data must not silently restart
+			// the transition via the fallback path. Return an ended state
+			// rather than nil to avoid triggering the fresh-start fallback,
+			// which would incorrectly mark the transition as complete when
+			// the on-disk data was merely corrupted.
+			ts = &TransitionState{Ended: false, Started: false}
+			return ts
 		}
 		ts = &newts
 	}


### PR DESCRIPTION
When gob.Decode fails in LoadTransitionState, the function previously returned nil, which triggered the fallback path that creates a fresh TransitionState{Ended: isVerkle}. On a verkle-enabled node, this would incorrectly mark the transition as complete, potentially causing the node to use BinaryTrie for a partially-transitioned state.

Instead of returning nil, return a non-nil TransitionState with both Started and Ended set to false. This ensures:
- InTransition() returns false (no partial transition in progress)
- Transitioned() returns false (transition has not completed)
- The fallback path is not triggered, preventing incorrect state

The root hash is also logged in the error message to aid debugging corruption incidents.