### PR TITLE
accounts/abi: fix unittest code

### DIFF
--- a/accounts/abi/unpack_test.go
+++ b/accounts/abi/unpack_test.go
@@ -910,7 +910,7 @@ func TestUnpackTuple(t *testing.T) {
 			},
 		},
 		FieldT: T{
-			big.NewInt(0), big.NewInt(1),
+			big.NewInt(0).SetBits([]big.Word{}), big.NewInt(1),
 		},
 		A: big.NewInt(1),
 	}
@@ -919,7 +919,7 @@ func TestUnpackTuple(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	if reflect.DeepEqual(ret, expected) {
+	if !reflect.DeepEqual(ret, expected) {
 		t.Error("unexpected unpack value")
 	}
 }


### PR DESCRIPTION
1. should use !reflect.DeepEqual.
2. big.NewInt(0).SetBits([]big.Word{}) work around for DeepEqual when big.Int is zero, unpack return a []big.Word{}.