### PR TITLE
eth/protocols, eth/downloader: allow skipping unavailable responses

### DIFF
--- a/eth/downloader/downloader.go
+++ b/eth/downloader/downloader.go
@@ -65,6 +65,7 @@ var (
 	errInvalidChain            = errors.New("retrieved hash chain is invalid")
 	errInvalidBody             = errors.New("retrieved block body is invalid")
 	errInvalidReceipt          = errors.New("retrieved receipt is invalid")
+	errSkippedResponse         = errors.New("retrieved response is skipped by peer")
 	errCancelStateFetch        = errors.New("state data download canceled (requested)")
 	errCancelContentProcessing = errors.New("content processing canceled (requested)")
 	errCanceled                = errors.New("syncing canceled (requested)")

--- a/eth/downloader/queue.go
+++ b/eth/downloader/queue.go
@@ -562,9 +562,10 @@ func (q *queue) DeliverBodies(id string, hashes eth.BlockBodyHashes, bodies []et
 	q.lock.Lock()
 	defer q.lock.Unlock()
 
-	txLists := make([][]*types.Transaction, len(bodies))
-	uncleLists := make([][]*types.Header, len(bodies))
-	withdrawalLists := make([][]*types.Withdrawal, len(bodies))
+	nresults := len(hashes.TransactionRoots)
+	txLists := make([][]*types.Transaction, nresults)
+	uncleLists := make([][]*types.Header, nresults)
+	withdrawalLists := make([][]*types.Withdrawal, nresults)
 
 	validate := func(index int, header *types.Header) error {
 		// Detect skipped response: the peer returned an empty body for a non-empty block
@@ -618,8 +619,9 @@ func (q *queue) DeliverBodies(id string, hashes eth.BlockBodyHashes, bodies []et
 		result.Withdrawals = withdrawalLists[index]
 		result.SetBodyDone()
 	}
+
 	return q.deliver(id, q.blockTaskPool, q.blockTaskQueue, q.blockPendPool,
-		bodyReqTimer, bodyInMeter, bodyDropMeter, len(bodies), validate, reconstruct)
+		bodyReqTimer, bodyInMeter, bodyDropMeter, nresults, validate, reconstruct)
 }
 
 // DeliverReceipts injects a receipt retrieval response into the results queue.

--- a/eth/downloader/queue.go
+++ b/eth/downloader/queue.go
@@ -562,11 +562,15 @@ func (q *queue) DeliverBodies(id string, hashes eth.BlockBodyHashes, bodies []et
 	q.lock.Lock()
 	defer q.lock.Unlock()
 
-	var txLists [][]*types.Transaction
-	var uncleLists [][]*types.Header
-	var withdrawalLists [][]*types.Withdrawal
+	txLists := make([][]*types.Transaction, len(bodies))
+	uncleLists := make([][]*types.Header, len(bodies))
+	withdrawalLists := make([][]*types.Withdrawal, len(bodies))
 
 	validate := func(index int, header *types.Header) error {
+		// Detect skipped response: the peer returned an empty body for a non-empty block
+		if !header.EmptyBody() && hashes.TransactionRoots[index] == types.EmptyTxsHash && hashes.UncleHashes[index] == types.EmptyUncleHash {
+			return errSkippedResponse
+		}
 		if hashes.TransactionRoots[index] != header.TxHash {
 			return errInvalidBody
 		}
@@ -592,20 +596,18 @@ func (q *queue) DeliverBodies(id string, hashes eth.BlockBodyHashes, bodies []et
 		if err != nil {
 			return fmt.Errorf("%w: bad transactions: %v", errInvalidBody, err)
 		}
-		txLists = append(txLists, txs)
+		txLists[index] = txs
 		uncles, err := bodies[index].Uncles.Items()
 		if err != nil {
 			return fmt.Errorf("%w: bad uncles: %v", errInvalidBody, err)
 		}
-		uncleLists = append(uncleLists, uncles)
+		uncleLists[index] = uncles
 		if bodies[index].Withdrawals != nil {
 			withdrawals, err := bodies[index].Withdrawals.Items()
 			if err != nil {
 				return fmt.Errorf("%w: bad withdrawals: %v", errInvalidBody, err)
 			}
-			withdrawalLists = append(withdrawalLists, withdrawals)
-		} else {
-			withdrawalLists = append(withdrawalLists, nil)
+			withdrawalLists[index] = withdrawals
 		}
 		return nil
 	}
@@ -616,9 +618,8 @@ func (q *queue) DeliverBodies(id string, hashes eth.BlockBodyHashes, bodies []et
 		result.Withdrawals = withdrawalLists[index]
 		result.SetBodyDone()
 	}
-	nresults := len(hashes.TransactionRoots)
 	return q.deliver(id, q.blockTaskPool, q.blockTaskQueue, q.blockPendPool,
-		bodyReqTimer, bodyInMeter, bodyDropMeter, nresults, validate, reconstruct)
+		bodyReqTimer, bodyInMeter, bodyDropMeter, len(bodies), validate, reconstruct)
 }
 
 // DeliverReceipts injects a receipt retrieval response into the results queue.
@@ -629,6 +630,9 @@ func (q *queue) DeliverReceipts(id string, receiptList []rlp.RawValue, receiptLi
 	defer q.lock.Unlock()
 
 	validate := func(index int, header *types.Header) error {
+		if header.ReceiptHash != types.EmptyReceiptsHash && receiptListHashes[index] == types.EmptyReceiptsHash {
+			return errSkippedResponse
+		}
 		if receiptListHashes[index] != header.ReceiptHash {
 			return errInvalidReceipt
 		}
@@ -671,28 +675,40 @@ func (q *queue) deliver(id string, taskPool map[common.Hash]*types.Header,
 	}
 	// Assemble each of the results with their headers and retrieved data parts
 	var (
+		valid    []int
 		accepted int
 		failure  error
-		i        int
-		hashes   []common.Hash
+		cutoff   = len(request.Headers)
 	)
-	for _, header := range request.Headers {
+	for i, header := range request.Headers {
 		// Short circuit assembly if no more fetch results are found
 		if i >= results {
-			break
+			taskQueue.Push(header, -int64(header.Number.Uint64()))
+			continue
 		}
 		// Validate the fields
 		if err := validate(i, header); err != nil {
-			failure = err
-			break
+			if err != errSkippedResponse {
+				failure = err
+				cutoff = i
+				break
+			}
+			// Return skipped hashes to the queue
+			request.Peer.MarkLacking(header.Hash())
+			taskQueue.Push(header, -int64(header.Number.Uint64()))
+			continue
 		}
-		hashes = append(hashes, header.Hash())
-		i++
+		valid = append(valid, i)
+	}
+	// Return headers after the validation failure point to the queue
+	for _, header := range request.Headers[cutoff:] {
+		taskQueue.Push(header, -int64(header.Number.Uint64()))
 	}
 
-	for _, header := range request.Headers[:i] {
+	for _, index := range valid {
+		header := request.Headers[index]
 		if res, stale, err := q.resultCache.GetDeliverySlot(header.Number.Uint64()); err == nil && !stale {
-			reconstruct(accepted, res)
+			reconstruct(index, res)
 		} else {
 			// else: between here and above, some other peer filled this result,
 			// or it was indeed a no-op. This should not happen, but if it does it's
@@ -701,15 +717,11 @@ func (q *queue) deliver(id string, taskPool map[common.Hash]*types.Header,
 			failure = errStaleDelivery
 		}
 		// Clean up a successful fetch
-		delete(taskPool, hashes[accepted])
+		delete(taskPool, header.Hash())
 		accepted++
 	}
 	resDropMeter.Mark(int64(results - accepted))
 
-	// Return all failed or missing fetches to the queue
-	for _, header := range request.Headers[accepted:] {
-		taskQueue.Push(header, -int64(header.Number.Uint64()))
-	}
 	// Wake up Results
 	if accepted > 0 {
 		q.active.Signal()

--- a/eth/protocols/eth/handler_test.go
+++ b/eth/protocols/eth/handler_test.go
@@ -422,7 +422,7 @@ func testGetBlockBodies(t *testing.T, protocol uint) {
 		{limit + 1, nil, nil, limit}, // No more than the possible block count should be returned
 		{0, []common.Hash{backend.chain.Genesis().Hash()}, []bool{true}, 1},      // The genesis block should be retrievable
 		{0, []common.Hash{backend.chain.CurrentBlock().Hash()}, []bool{true}, 1}, // The chains head block should be retrievable
-		{0, []common.Hash{{}}, []bool{false}, 0},                                 // A non existent block should not be returned
+		{0, []common.Hash{{}}, []bool{false}, 1},                                 // A non existent block should not be returned
 
 		// Existing and non-existing blocks interleaved should not cause problems
 		{0, []common.Hash{
@@ -433,7 +433,7 @@ func testGetBlockBodies(t *testing.T, protocol uint) {
 			{},
 			backend.chain.GetBlockByNumber(100).Hash(),
 			{},
-		}, []bool{false, true, false, true, false, true, false}, 3},
+		}, []bool{false, true, false, true, false, true, false}, 7},
 	}
 	// Run each of the tests and verify the results against the chain
 	for i, tt := range tests {
@@ -460,9 +460,13 @@ func testGetBlockBodies(t *testing.T, protocol uint) {
 		}
 		for j, hash := range tt.explicit {
 			hashes = append(hashes, hash)
-			if tt.available[j] && len(bodies) < tt.expected {
-				block := backend.chain.GetBlockByHash(hash)
-				bodies = append(bodies, encodeBody(block))
+			if len(bodies) < tt.expected {
+				if tt.available[j] {
+					block := backend.chain.GetBlockByHash(hash)
+					bodies = append(bodies, encodeBody(block))
+				} else {
+					bodies = append(bodies, BlockBody{})
+				}
 			}
 		}
 
@@ -590,9 +594,9 @@ func testGetBlockReceipts(t *testing.T, protocol uint) {
 	)
 	for i := uint64(0); i <= backend.chain.CurrentBlock().Number.Uint64(); i++ {
 		if i == 1 {
-			// Insert a missing block hash to verify the server returns a nil placeholder
+			// Insert a missing block hash to verify the server returns an empty placeholder
 			hashes = append(hashes, common.HexToHash("0xdeadbeef"))
-			receipts.Append(nil)
+			receipts.AppendRaw(rlp.EmptyList)
 		}
 		block := backend.chain.GetBlockByNumber(i)
 		hashes = append(hashes, block.Hash())

--- a/eth/protocols/eth/handler_test.go
+++ b/eth/protocols/eth/handler_test.go
@@ -589,6 +589,11 @@ func testGetBlockReceipts(t *testing.T, protocol uint) {
 		receipts rlp.RawList[*ReceiptList]
 	)
 	for i := uint64(0); i <= backend.chain.CurrentBlock().Number.Uint64(); i++ {
+		if i == 1 {
+			// Insert a missing block hash to verify the server returns a nil placeholder
+			hashes = append(hashes, common.HexToHash("0xdeadbeef"))
+			receipts.Append(nil)
+		}
 		block := backend.chain.GetBlockByNumber(i)
 		hashes = append(hashes, block.Hash())
 		br := backend.chain.GetReceiptsByHash(block.Hash())

--- a/eth/protocols/eth/handlers.go
+++ b/eth/protocols/eth/handlers.go
@@ -281,15 +281,18 @@ func ServiceGetReceiptsQuery69(chain *core.BlockChain, query GetReceiptsRequest)
 		// Retrieve the requested block's receipts
 		results := chain.GetReceiptsRLP(hash)
 		if results == nil {
-			continue // Can't retrieve the receipts, so we just skip this block.
+			receipts.Append(nil)
+			continue
 		}
 		body := chain.GetBodyRLP(hash)
 		if body == nil {
-			continue // The block body is missing, we also have to skip.
+			receipts.Append(nil)
+			continue
 		}
 		results, _, err := blockReceiptsToNetwork(results, body, receiptQueryParams{})
 		if err != nil {
 			log.Error("Error in block receipts conversion", "hash", hash, "err", err)
+			receipts.Append(nil)
 			continue
 		}
 		receipts.AppendRaw(results)
@@ -313,11 +316,13 @@ func serviceGetReceiptsQuery70(chain *core.BlockChain, query GetReceiptsRequest,
 		}
 		results := chain.GetReceiptsRLP(hash)
 		if results == nil {
-			continue // Can't retrieve the receipts, so we just skip this block.
+			receipts.Append(nil)
+			continue
 		}
 		body := chain.GetBodyRLP(hash)
 		if body == nil {
-			continue // The block body is missing, we also have to skip.
+			receipts.Append(nil)
+			continue
 		}
 		q := receiptQueryParams{sizeLimit: uint64(maxPacketSize - bytes)}
 		if i == 0 {
@@ -326,6 +331,7 @@ func serviceGetReceiptsQuery70(chain *core.BlockChain, query GetReceiptsRequest,
 		results, incomplete, err := blockReceiptsToNetwork(results, body, q)
 		if err != nil {
 			log.Error("Error in block receipts conversion", "hash", hash, "err", err)
+			receipts.Append(nil)
 			continue
 		}
 		if results == nil {

--- a/eth/protocols/eth/handlers.go
+++ b/eth/protocols/eth/handlers.go
@@ -241,6 +241,9 @@ func ServiceGetBlockBodiesQuery(chain *core.BlockChain, query GetBlockBodiesRequ
 		if data := chain.GetBodyRLP(hash); len(data) != 0 {
 			bodies = append(bodies, data)
 			bytes += len(data)
+		} else {
+			// Append an empty body [[], []] as placeholder for missing block
+			bodies = append(bodies, []byte{0xc2, 0xc0, 0xc0})
 		}
 	}
 	return bodies
@@ -281,18 +284,18 @@ func ServiceGetReceiptsQuery69(chain *core.BlockChain, query GetReceiptsRequest)
 		// Retrieve the requested block's receipts
 		results := chain.GetReceiptsRLP(hash)
 		if results == nil {
-			receipts.Append(nil)
+			receipts.AppendRaw(rlp.EmptyList)
 			continue
 		}
 		body := chain.GetBodyRLP(hash)
 		if body == nil {
-			receipts.Append(nil)
+			receipts.AppendRaw(rlp.EmptyList)
 			continue
 		}
 		results, _, err := blockReceiptsToNetwork(results, body, receiptQueryParams{})
 		if err != nil {
 			log.Error("Error in block receipts conversion", "hash", hash, "err", err)
-			receipts.Append(nil)
+			receipts.AppendRaw(rlp.EmptyList)
 			continue
 		}
 		receipts.AppendRaw(results)
@@ -316,12 +319,12 @@ func serviceGetReceiptsQuery70(chain *core.BlockChain, query GetReceiptsRequest,
 		}
 		results := chain.GetReceiptsRLP(hash)
 		if results == nil {
-			receipts.Append(nil)
+			receipts.AppendRaw(rlp.EmptyList)
 			continue
 		}
 		body := chain.GetBodyRLP(hash)
 		if body == nil {
-			receipts.Append(nil)
+			receipts.AppendRaw(rlp.EmptyList)
 			continue
 		}
 		q := receiptQueryParams{sizeLimit: uint64(maxPacketSize - bytes)}
@@ -331,7 +334,7 @@ func serviceGetReceiptsQuery70(chain *core.BlockChain, query GetReceiptsRequest,
 		results, incomplete, err := blockReceiptsToNetwork(results, body, q)
 		if err != nil {
 			log.Error("Error in block receipts conversion", "hash", hash, "err", err)
-			receipts.Append(nil)
+			receipts.AppendRaw(rlp.EmptyList)
 			continue
 		}
 		if results == nil {


### PR DESCRIPTION
In the current implementation, the handler skips unavailable responses without inserting a placeholder. On the client side, skipped responses were not handled and all subsequent responses were discarded.

There are two possible approaches
- Stop appending responses when an unavailable response is found
- Append a placeholder for unavailable responses and handle them

This PR implements the second one