### PR TITLE
triedb/pathdb: fix 32-bit overflow in history trie node decoding

### DIFF
--- a/triedb/pathdb/history_trienode.go
+++ b/triedb/pathdb/history_trienode.go
@@ -375,7 +375,7 @@ func decodeKeyEntry(keySection []byte, offset int) (uint64, uint64, []byte, int,
 	byteRead += nn
 
 	// Validate that the values can fit in an int to prevent overflow on 32-bit systems
-	if nShared > uint64(math.MaxUint32) || nUnshared > uint64(math.MaxUint32) || nValue > uint64(math.MaxUint32) {
+	if nShared > uint64(math.MaxInt) || nUnshared > uint64(math.MaxInt) || nValue > uint64(math.MaxInt) {
 		return 0, 0, nil, 0, errors.New("key/value size too large")
 	}
 

--- a/triedb/pathdb/history_trienode_test.go
+++ b/triedb/pathdb/history_trienode_test.go
@@ -20,8 +20,10 @@ import (
 	"bytes"
 	"encoding/binary"
 	"fmt"
+	"math"
 	"math/rand"
 	"reflect"
+	"strings"
 	"testing"
 
 	"github.com/ethereum/go-ethereum/common"
@@ -655,6 +657,40 @@ func TestDecodeSingleCorruptedData(t *testing.T) {
 	err = decodeSingle(corrupted, nil)
 	if err == nil {
 		t.Fatal("Expected error for invalid restart count")
+	}
+}
+
+// TestDecodeKeyEntryIntOverflow checks that varints exceeding int range are
+// rejected before the int() cast, which would wrap to a negative value on
+// 32-bit builds and panic in the slice expression.
+func TestDecodeKeyEntryIntOverflow(t *testing.T) {
+	oversize := uint64(math.MaxInt) + 1
+	tests := []struct {
+		name      string
+		nShared   uint64
+		nUnshared uint64
+		nValue    uint64
+	}{
+		{"oversize nShared", oversize, 0, 0},
+		{"oversize nUnshared", 0, oversize, 0},
+		{"oversize nValue", 0, 0, oversize},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			buf := make([]byte, 3*binary.MaxVarintLen64)
+			off := 0
+			off += binary.PutUvarint(buf[off:], tt.nShared)
+			off += binary.PutUvarint(buf[off:], tt.nUnshared)
+			off += binary.PutUvarint(buf[off:], tt.nValue)
+
+			_, _, _, _, err := decodeKeyEntry(buf[:off], 0)
+			if err == nil {
+				t.Fatal("expected error for varint exceeding int range, got nil")
+			}
+			if !strings.Contains(err.Error(), "too large") {
+				t.Fatalf("expected 'too large' error, got: %v", err)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
Use `math.MaxInt` instead of `math.MaxUint32` for size validation. On 32-bit systems, `int` is 32 bits, so values between `MaxInt32` and `MaxUint32` would pass the check but overflow to negative when cast to `int`, causing slice bounds panic.

also added a unit test