### PR TITLE
core: widen BAL index from uint16 to uint64 (EIP-7928)

### DIFF
--- a/core/types/bal/bal.go
+++ b/core/types/bal/bal.go
@@ -31,7 +31,7 @@ type ConstructionAccountAccess struct {
 	// StorageWrites is the post-state values of an account's storage slots
 	// that were modified in a block, keyed by the slot key and the tx index
 	// where the modification occurred.
-	StorageWrites map[common.Hash]map[uint16]common.Hash `json:"storageWrites,omitempty"`
+	StorageWrites map[common.Hash]map[uint64]common.Hash `json:"storageWrites,omitempty"`
 
 	// StorageReads is the set of slot keys that were accessed during block
 	// execution.
@@ -42,25 +42,25 @@ type ConstructionAccountAccess struct {
 
 	// BalanceChanges contains the post-transaction balances of an account,
 	// keyed by transaction indices where it was changed.
-	BalanceChanges map[uint16]*uint256.Int `json:"balanceChanges,omitempty"`
+	BalanceChanges map[uint64]*uint256.Int `json:"balanceChanges,omitempty"`
 
 	// NonceChanges contains the post-state nonce values of an account keyed
 	// by tx index.
-	NonceChanges map[uint16]uint64 `json:"nonceChanges,omitempty"`
+	NonceChanges map[uint64]uint64 `json:"nonceChanges,omitempty"`
 
 	// CodeChange contains the post-state contract code of an account keyed
 	// by tx index.
-	CodeChange map[uint16][]byte `json:"codeChange,omitempty"`
+	CodeChange map[uint64][]byte `json:"codeChange,omitempty"`
 }
 
 // NewConstructionAccountAccess initializes the account access object.
 func NewConstructionAccountAccess() *ConstructionAccountAccess {
 	return &ConstructionAccountAccess{
-		StorageWrites:  make(map[common.Hash]map[uint16]common.Hash),
+		StorageWrites:  make(map[common.Hash]map[uint64]common.Hash),
 		StorageReads:   make(map[common.Hash]struct{}),
-		BalanceChanges: make(map[uint16]*uint256.Int),
-		NonceChanges:   make(map[uint16]uint64),
-		CodeChange:     make(map[uint16][]byte),
+		BalanceChanges: make(map[uint64]*uint256.Int),
+		NonceChanges:   make(map[uint64]uint64),
+		CodeChange:     make(map[uint64][]byte),
 	}
 }
 
@@ -97,12 +97,12 @@ func (b *ConstructionBlockAccessList) StorageRead(address common.Address, key co
 
 // StorageWrite records the post-transaction value of a mutated storage slot.
 // The storage slot is removed from the list of read slots.
-func (b *ConstructionBlockAccessList) StorageWrite(txIdx uint16, address common.Address, key, value common.Hash) {
+func (b *ConstructionBlockAccessList) StorageWrite(txIdx uint64, address common.Address, key, value common.Hash) {
 	if _, ok := b.Accounts[address]; !ok {
 		b.Accounts[address] = NewConstructionAccountAccess()
 	}
 	if _, ok := b.Accounts[address].StorageWrites[key]; !ok {
-		b.Accounts[address].StorageWrites[key] = make(map[uint16]common.Hash)
+		b.Accounts[address].StorageWrites[key] = make(map[uint64]common.Hash)
 	}
 	b.Accounts[address].StorageWrites[key][txIdx] = value
 
@@ -110,7 +110,7 @@ func (b *ConstructionBlockAccessList) StorageWrite(txIdx uint16, address common.
 }
 
 // CodeChange records the code of a newly-created contract.
-func (b *ConstructionBlockAccessList) CodeChange(address common.Address, txIndex uint16, code []byte) {
+func (b *ConstructionBlockAccessList) CodeChange(address common.Address, txIndex uint64, code []byte) {
 	if _, ok := b.Accounts[address]; !ok {
 		b.Accounts[address] = NewConstructionAccountAccess()
 	}
@@ -120,7 +120,7 @@ func (b *ConstructionBlockAccessList) CodeChange(address common.Address, txIndex
 
 // NonceChange records tx post-state nonce of any contract-like accounts whose
 // nonce was incremented.
-func (b *ConstructionBlockAccessList) NonceChange(address common.Address, txIdx uint16, postNonce uint64) {
+func (b *ConstructionBlockAccessList) NonceChange(address common.Address, txIdx uint64, postNonce uint64) {
 	if _, ok := b.Accounts[address]; !ok {
 		b.Accounts[address] = NewConstructionAccountAccess()
 	}
@@ -129,7 +129,7 @@ func (b *ConstructionBlockAccessList) NonceChange(address common.Address, txIdx 
 
 // BalanceChange records the post-transaction balance of an account whose
 // balance changed.
-func (b *ConstructionBlockAccessList) BalanceChange(txIdx uint16, address common.Address, balance *uint256.Int) {
+func (b *ConstructionBlockAccessList) BalanceChange(txIdx uint64, address common.Address, balance *uint256.Int) {
 	if _, ok := b.Accounts[address]; !ok {
 		b.Accounts[address] = NewConstructionAccountAccess()
 	}
@@ -148,21 +148,21 @@ func (b *ConstructionBlockAccessList) Copy() *ConstructionBlockAccessList {
 	for addr, aa := range b.Accounts {
 		var aaCopy ConstructionAccountAccess
 
-		slotWrites := make(map[common.Hash]map[uint16]common.Hash, len(aa.StorageWrites))
+		slotWrites := make(map[common.Hash]map[uint64]common.Hash, len(aa.StorageWrites))
 		for key, m := range aa.StorageWrites {
 			slotWrites[key] = maps.Clone(m)
 		}
 		aaCopy.StorageWrites = slotWrites
 		aaCopy.StorageReads = maps.Clone(aa.StorageReads)
 
-		balances := make(map[uint16]*uint256.Int, len(aa.BalanceChanges))
+		balances := make(map[uint64]*uint256.Int, len(aa.BalanceChanges))
 		for index, balance := range aa.BalanceChanges {
 			balances[index] = balance.Clone()
 		}
 		aaCopy.BalanceChanges = balances
 		aaCopy.NonceChanges = maps.Clone(aa.NonceChanges)
 
-		codes := make(map[uint16][]byte, len(aa.CodeChange))
+		codes := make(map[uint64][]byte, len(aa.CodeChange))
 		for index, code := range aa.CodeChange {
 			codes[index] = bytes.Clone(code)
 		}

--- a/core/types/bal/bal_encoding.go
+++ b/core/types/bal/bal_encoding.go
@@ -86,19 +86,19 @@ func encodeBalance(val *uint256.Int) [16]byte {
 
 // encodingBalanceChange is the encoding format of BalanceChange.
 type encodingBalanceChange struct {
-	TxIdx   uint16   `ssz-size:"2"`
+	TxIdx   uint64   `ssz-size:"8"`
 	Balance [16]byte `ssz-size:"16"`
 }
 
 // encodingAccountNonce is the encoding format of NonceChange.
 type encodingAccountNonce struct {
-	TxIdx uint16 `ssz-size:"2"`
+	TxIdx uint64 `ssz-size:"8"`
 	Nonce uint64 `ssz-size:"8"`
 }
 
 // encodingStorageWrite is the encoding format of StorageWrites.
 type encodingStorageWrite struct {
-	TxIdx      uint16
+	TxIdx      uint64
 	ValueAfter [32]byte `ssz-size:"32"`
 }
 
@@ -112,7 +112,7 @@ type encodingSlotWrites struct {
 // working representation.
 func (e *encodingSlotWrites) validate() error {
 	if slices.IsSortedFunc(e.Accesses, func(a, b encodingStorageWrite) int {
-		return cmp.Compare[uint16](a.TxIdx, b.TxIdx)
+		return cmp.Compare[uint64](a.TxIdx, b.TxIdx)
 	}) {
 		return nil
 	}
@@ -122,7 +122,7 @@ func (e *encodingSlotWrites) validate() error {
 // encodingCodeChange contains the runtime bytecode deployed at an address
 // and the transaction index where the deployment took place.
 type encodingCodeChange struct {
-	TxIndex uint16 `ssz-size:"2"`
+	TxIndex uint64 `ssz-size:"8"`
 	Code    []byte `ssz-max:"300000"` // TODO(rjl493456442) shall we put the limit here? The limit will be increased gradually
 }
 
@@ -161,21 +161,21 @@ func (e *AccountAccess) validate() error {
 
 	// Check the balance changes are sorted in order
 	if !slices.IsSortedFunc(e.BalanceChanges, func(a, b encodingBalanceChange) int {
-		return cmp.Compare[uint16](a.TxIdx, b.TxIdx)
+		return cmp.Compare[uint64](a.TxIdx, b.TxIdx)
 	}) {
 		return errors.New("balance changes not in ascending order by tx index")
 	}
 
 	// Check the nonce changes are sorted in order
 	if !slices.IsSortedFunc(e.NonceChanges, func(a, b encodingAccountNonce) int {
-		return cmp.Compare[uint16](a.TxIdx, b.TxIdx)
+		return cmp.Compare[uint64](a.TxIdx, b.TxIdx)
 	}) {
 		return errors.New("nonce changes not in ascending order by tx index")
 	}
 
 	// Check the code changes are sorted in order
 	if !slices.IsSortedFunc(e.CodeChanges, func(a, b encodingCodeChange) int {
-		return cmp.Compare[uint16](a.TxIndex, b.TxIndex)
+		return cmp.Compare[uint64](a.TxIndex, b.TxIndex)
 	}) {
 		return errors.New("code changes not in ascending order by tx index")
 	}
@@ -244,7 +244,7 @@ func (a *ConstructionAccountAccess) toEncodingObj(addr common.Address) AccountAc
 		obj.Accesses = make([]encodingStorageWrite, 0, len(slotWrites))
 
 		indices := slices.Collect(maps.Keys(slotWrites))
-		slices.SortFunc(indices, cmp.Compare[uint16])
+		slices.SortFunc(indices, cmp.Compare[uint64])
 		for _, index := range indices {
 			obj.Accesses = append(obj.Accesses, encodingStorageWrite{
 				TxIdx:      index,
@@ -263,7 +263,7 @@ func (a *ConstructionAccountAccess) toEncodingObj(addr common.Address) AccountAc
 
 	// Convert balance changes
 	balanceIndices := slices.Collect(maps.Keys(a.BalanceChanges))
-	slices.SortFunc(balanceIndices, cmp.Compare[uint16])
+	slices.SortFunc(balanceIndices, cmp.Compare[uint64])
 	for _, idx := range balanceIndices {
 		res.BalanceChanges = append(res.BalanceChanges, encodingBalanceChange{
 			TxIdx:   idx,
@@ -273,7 +273,7 @@ func (a *ConstructionAccountAccess) toEncodingObj(addr common.Address) AccountAc
 
 	// Convert nonce changes
 	nonceIndices := slices.Collect(maps.Keys(a.NonceChanges))
-	slices.SortFunc(nonceIndices, cmp.Compare[uint16])
+	slices.SortFunc(nonceIndices, cmp.Compare[uint64])
 	for _, idx := range nonceIndices {
 		res.NonceChanges = append(res.NonceChanges, encodingAccountNonce{
 			TxIdx: idx,
@@ -283,7 +283,7 @@ func (a *ConstructionAccountAccess) toEncodingObj(addr common.Address) AccountAc
 
 	// Convert code change
 	codeIndices := slices.Collect(maps.Keys(a.CodeChange))
-	slices.SortFunc(codeIndices, cmp.Compare[uint16])
+	slices.SortFunc(codeIndices, cmp.Compare[uint64])
 	for _, idx := range codeIndices {
 		res.CodeChanges = append(res.CodeChanges, encodingCodeChange{
 			TxIndex: idx,

--- a/core/types/bal/bal_encoding_rlp_generated.go
+++ b/core/types/bal/bal_encoding_rlp_generated.go
@@ -115,7 +115,7 @@ func (obj *BlockAccessList) DecodeRLP(dec *rlp.Stream) error {
 									return err
 								}
 								// TxIdx:
-								_tmp9, err := dec.Uint16()
+								_tmp9, err := dec.Uint64()
 								if err != nil {
 									return err
 								}
@@ -174,7 +174,7 @@ func (obj *BlockAccessList) DecodeRLP(dec *rlp.Stream) error {
 							return err
 						}
 						// TxIdx:
-						_tmp15, err := dec.Uint16()
+						_tmp15, err := dec.Uint64()
 						if err != nil {
 							return err
 						}
@@ -207,7 +207,7 @@ func (obj *BlockAccessList) DecodeRLP(dec *rlp.Stream) error {
 							return err
 						}
 						// TxIdx:
-						_tmp19, err := dec.Uint16()
+						_tmp19, err := dec.Uint64()
 						if err != nil {
 							return err
 						}
@@ -240,7 +240,7 @@ func (obj *BlockAccessList) DecodeRLP(dec *rlp.Stream) error {
 							return err
 						}
 						// TxIndex:
-						_tmp23, err := dec.Uint16()
+						_tmp23, err := dec.Uint64()
 						if err != nil {
 							return err
 						}

--- a/core/types/bal/bal_encoding_rlp_generated.go
+++ b/core/types/bal/bal_encoding_rlp_generated.go
@@ -19,7 +19,7 @@ func (obj *BlockAccessList) EncodeRLP(_w io.Writer) error {
 			_tmp7 := w.List()
 			for _, _tmp8 := range _tmp5.Accesses {
 				_tmp9 := w.List()
-				w.WriteUint64(uint64(_tmp8.TxIdx))
+				w.WriteUint64(_tmp8.TxIdx)
 				w.WriteBytes(_tmp8.ValueAfter[:])
 				w.ListEnd(_tmp9)
 			}
@@ -35,7 +35,7 @@ func (obj *BlockAccessList) EncodeRLP(_w io.Writer) error {
 		_tmp12 := w.List()
 		for _, _tmp13 := range _tmp2.BalanceChanges {
 			_tmp14 := w.List()
-			w.WriteUint64(uint64(_tmp13.TxIdx))
+			w.WriteUint64(_tmp13.TxIdx)
 			w.WriteBytes(_tmp13.Balance[:])
 			w.ListEnd(_tmp14)
 		}
@@ -43,7 +43,7 @@ func (obj *BlockAccessList) EncodeRLP(_w io.Writer) error {
 		_tmp15 := w.List()
 		for _, _tmp16 := range _tmp2.NonceChanges {
 			_tmp17 := w.List()
-			w.WriteUint64(uint64(_tmp16.TxIdx))
+			w.WriteUint64(_tmp16.TxIdx)
 			w.WriteUint64(_tmp16.Nonce)
 			w.ListEnd(_tmp17)
 		}
@@ -51,7 +51,7 @@ func (obj *BlockAccessList) EncodeRLP(_w io.Writer) error {
 		_tmp18 := w.List()
 		for _, _tmp19 := range _tmp2.CodeChanges {
 			_tmp20 := w.List()
-			w.WriteUint64(uint64(_tmp19.TxIndex))
+			w.WriteUint64(_tmp19.TxIndex)
 			w.WriteBytes(_tmp19.Code)
 			w.ListEnd(_tmp20)
 		}

--- a/core/types/bal/bal_test.go
+++ b/core/types/bal/bal_test.go
@@ -40,7 +40,7 @@ func makeTestConstructionBAL() *ConstructionBlockAccessList {
 	return &ConstructionBlockAccessList{
 		map[common.Address]*ConstructionAccountAccess{
 			common.BytesToAddress([]byte{0xff, 0xff}): {
-				StorageWrites: map[common.Hash]map[uint16]common.Hash{
+				StorageWrites: map[common.Hash]map[uint64]common.Hash{
 					common.BytesToHash([]byte{0x01}): {
 						1: common.BytesToHash([]byte{1, 2, 3, 4}),
 						2: common.BytesToHash([]byte{1, 2, 3, 4, 5, 6}),
@@ -52,20 +52,20 @@ func makeTestConstructionBAL() *ConstructionBlockAccessList {
 				StorageReads: map[common.Hash]struct{}{
 					common.BytesToHash([]byte{1, 2, 3, 4, 5, 6, 7}): {},
 				},
-				BalanceChanges: map[uint16]*uint256.Int{
+				BalanceChanges: map[uint64]*uint256.Int{
 					1: uint256.NewInt(100),
 					2: uint256.NewInt(500),
 				},
-				NonceChanges: map[uint16]uint64{
+				NonceChanges: map[uint64]uint64{
 					1: 2,
 					2: 6,
 				},
-				CodeChange: map[uint16][]byte{
+				CodeChange: map[uint64][]byte{
 					0: common.Hex2Bytes("deadbeef"),
 				},
 			},
 			common.BytesToAddress([]byte{0xff, 0xff, 0xff}): {
-				StorageWrites: map[common.Hash]map[uint16]common.Hash{
+				StorageWrites: map[common.Hash]map[uint64]common.Hash{
 					common.BytesToHash([]byte{0x01}): {
 						2: common.BytesToHash([]byte{1, 2, 3, 4, 5, 6}),
 						3: common.BytesToHash([]byte{1, 2, 3, 4, 5, 6, 7, 8}),
@@ -77,14 +77,14 @@ func makeTestConstructionBAL() *ConstructionBlockAccessList {
 				StorageReads: map[common.Hash]struct{}{
 					common.BytesToHash([]byte{1, 2, 3, 4, 5, 6, 7, 8}): {},
 				},
-				BalanceChanges: map[uint16]*uint256.Int{
+				BalanceChanges: map[uint64]*uint256.Int{
 					2: uint256.NewInt(100),
 					3: uint256.NewInt(500),
 				},
-				NonceChanges: map[uint16]uint64{
+				NonceChanges: map[uint64]uint64{
 					1: 2,
 				},
-				CodeChange: map[uint16][]byte{
+				CodeChange: map[uint64][]byte{
 					0: common.Hex2Bytes("deadbeef"),
 				},
 			},
@@ -125,13 +125,13 @@ func makeTestAccountAccess(sort bool) AccountAccess {
 		}
 		for j := 0; j < 3; j++ {
 			slot.Accesses = append(slot.Accesses, encodingStorageWrite{
-				TxIdx:      uint16(2 * j),
+				TxIdx:      uint64(2 * j),
 				ValueAfter: testrand.Hash(),
 			})
 		}
 		if sort {
 			slices.SortFunc(slot.Accesses, func(a, b encodingStorageWrite) int {
-				return cmp.Compare[uint16](a.TxIdx, b.TxIdx)
+				return cmp.Compare[uint64](a.TxIdx, b.TxIdx)
 			})
 		}
 		storageWrites = append(storageWrites, slot)
@@ -153,25 +153,25 @@ func makeTestAccountAccess(sort bool) AccountAccess {
 
 	for i := 0; i < 5; i++ {
 		balances = append(balances, encodingBalanceChange{
-			TxIdx:   uint16(2 * i),
+			TxIdx:   uint64(2 * i),
 			Balance: [16]byte(testrand.Bytes(16)),
 		})
 	}
 	if sort {
 		slices.SortFunc(balances, func(a, b encodingBalanceChange) int {
-			return cmp.Compare[uint16](a.TxIdx, b.TxIdx)
+			return cmp.Compare[uint64](a.TxIdx, b.TxIdx)
 		})
 	}
 
 	for i := 0; i < 5; i++ {
 		nonces = append(nonces, encodingAccountNonce{
-			TxIdx: uint16(2 * i),
+			TxIdx: uint64(2 * i),
 			Nonce: uint64(i + 100),
 		})
 	}
 	if sort {
 		slices.SortFunc(nonces, func(a, b encodingAccountNonce) int {
-			return cmp.Compare[uint16](a.TxIdx, b.TxIdx)
+			return cmp.Compare[uint64](a.TxIdx, b.TxIdx)
 		})
 	}
 
@@ -187,6 +187,38 @@ func makeTestAccountAccess(sort bool) AccountAccess {
 				Code:    testrand.Bytes(256),
 			},
 		},
+	}
+}
+
+func TestBALEncodingLargeTxIndex(t *testing.T) {
+	var buf bytes.Buffer
+	bal := NewConstructionBlockAccessList()
+	addr := common.BytesToAddress([]byte{0xaa})
+	largeIdx := uint64(1 << 16)
+	bal.StorageWrite(largeIdx, addr, common.BytesToHash([]byte{0x01}), common.BytesToHash([]byte{0x02}))
+	bal.BalanceChange(largeIdx, addr, uint256.NewInt(1))
+	bal.NonceChange(addr, largeIdx, 2)
+	bal.CodeChange(addr, largeIdx, common.Hex2Bytes("deadbeef"))
+
+	if err := bal.EncodeRLP(&buf); err != nil {
+		t.Fatalf("encoding failed: %v", err)
+	}
+	var dec BlockAccessList
+	if err := dec.DecodeRLP(rlp.NewStream(bytes.NewReader(buf.Bytes()), 0)); err != nil {
+		t.Fatalf("decoding failed: %v", err)
+	}
+	got := dec.Accesses[0]
+	if got.StorageWrites[0].Accesses[0].TxIdx != largeIdx {
+		t.Fatalf("storage write tx index mismatch: got %d want %d", got.StorageWrites[0].Accesses[0].TxIdx, largeIdx)
+	}
+	if got.BalanceChanges[0].TxIdx != largeIdx {
+		t.Fatalf("balance change tx index mismatch: got %d want %d", got.BalanceChanges[0].TxIdx, largeIdx)
+	}
+	if got.NonceChanges[0].TxIdx != largeIdx {
+		t.Fatalf("nonce change tx index mismatch: got %d want %d", got.NonceChanges[0].TxIdx, largeIdx)
+	}
+	if got.CodeChanges[0].TxIndex != largeIdx {
+		t.Fatalf("code change tx index mismatch: got %d want %d", got.CodeChanges[0].TxIndex, largeIdx)
 	}
 }
 


### PR DESCRIPTION
Updates the Block Access List index type from `uint16` to `uint64` across the entire stack to future-proof the BAL for higher gas limits (`300M+`) and `EIP-2780` compatibility. The current uint16 index caps out at `65,535` entries per block, which is insufficient once gas limits scale beyond current levels. Widening to `uint64` eliminates this ceiling entirely, ensuring the BAL remains viable without further type migrations as the protocol evolves.

Spec Change Refrence: https://github.com/ethereum/execution-specs/pull/2713
EIP Change Refrence: https://github.com/ethereum/EIPs/pull/11535

