### PR TITLE
core: set empty BlockAccessListHash on Amsterdam genesis

### DIFF
--- a/core/genesis.go
+++ b/core/genesis.go
@@ -557,6 +557,9 @@ func (g *Genesis) toBlockWithRoot(root common.Hash) *types.Block {
 			if head.SlotNumber == nil {
 				head.SlotNumber = new(uint64)
 			}
+			if head.BlockAccessListHash == nil {
+				head.BlockAccessListHash = &types.EmptyBlockAccessListHash
+			}
 		}
 	}
 	return types.NewBlock(head, &types.Body{Withdrawals: withdrawals}, nil, trie.NewStackTrie(nil))

--- a/core/types/hashes.go
+++ b/core/types/hashes.go
@@ -43,6 +43,10 @@ var (
 	// EmptyRequestsHash is the known hash of an empty request set, sha256("").
 	EmptyRequestsHash = common.HexToHash("e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855")
 
+	// EmptyBlockAccessListHash is the known hash of an empty block access list,
+	// keccak256(rlp(empty list)) = keccak256(0xc0).
+	EmptyBlockAccessListHash = common.HexToHash("1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347")
+
 	// EmptyVerkleHash is the known hash of an empty verkle trie.
 	EmptyVerkleHash = common.Hash{}
 


### PR DESCRIPTION
## Problem

When Amsterdam is active at genesis, `(*Genesis).toBlockWithRoot` sets `head.SlotNumber` but leaves `head.BlockAccessListHash` nil:

```go
if conf.IsAmsterdam(num, g.Timestamp) {
    head.SlotNumber = g.SlotNumber
    if head.SlotNumber == nil {
        head.SlotNumber = new(uint64)
    }
}
```

`BlockAccessListHash` and `SlotNumber` are both `rlp:"optional"` on `Header`, and `BlockAccessListHash` precedes `SlotNumber` in the struct. With an intermediate optional nil and a trailing optional set, RLP encodes an empty string (`0x80`) placeholder in the BAL-hash slot. On read-back, the decoder tries to parse that 0-byte string into a `common.Hash` and fails:

```
Invalid block header RLP hash=...  err="rlp: input string too short for
    common.Hash, decoding into (types.Header).BlockAccessListHash"
Fatal: Failed to register the Ethereum service: genesis not found in chain
```

Reproduced on `glamsterdam-devnet-0` against a devnet with `gloas_fork_epoch: 0` generated by `ethpandaops/ethereum-genesis-generator` — geth writes the genesis block successfully, then crashes on the subsequent self-read. A minimal RLP round-trip test against this branch's `types.Header` reproduces the error when `BlockAccessListHash == nil && SlotNumber != nil`, and succeeds when both are populated.

## Fix

Default `head.BlockAccessListHash` to the empty-BAL hash under the same Amsterdam fork gate, mirroring the existing Prague `RequestsHash = &types.EmptyRequestsHash` pattern. Adds an `EmptyBlockAccessListHash` constant (`keccak256(rlp(empty list)) = keccak256(0xc0) = 0x1dcc4de8…49347`) next to the other `Empty*Hash` constants in `core/types/hashes.go`.

Genesis headers now round-trip through RLP; the node starts cleanly against a gloas-at-genesis chain.

## Test plan

- [x] `go test ./core/ -run TestGenesis -count=1`
- [ ] Local kurtosis run with `gloas_fork_epoch: 0`, Prysm `v1.7.0-alpha.5`, geth built from this branch — blocks should import past genesis.

Computed constant independently:

```go
var b bal.BlockAccessList
fmt.Printf("0x%x\n", b.Hash())
// 0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347
```