### PR TITLE
trie/bintrie: print todot path in binary

### DIFF
--- a/trie/bintrie/store_commit.go
+++ b/trie/bintrie/store_commit.go
@@ -279,10 +279,10 @@ func (s *nodeStore) toDot(ref nodeRef, parent, path string) string {
 			ret = fmt.Sprintf("%s %s -> %s\n", ret, parent, me)
 		}
 		if !node.left.IsEmpty() {
-			ret += s.toDot(node.left, me, fmt.Sprintf("%s%02x", path, 0))
+			ret += s.toDot(node.left, me, fmt.Sprintf("%s%b", path, 0))
 		}
 		if !node.right.IsEmpty() {
-			ret += s.toDot(node.right, me, fmt.Sprintf("%s%02x", path, 1))
+			ret += s.toDot(node.right, me, fmt.Sprintf("%s%b", path, 1))
 		}
 		return ret
 	case kindStem:


### PR DESCRIPTION
The nodes were named using the byte representation of the path, instead of the binary representation. This was confusing to other client devs trying to achieve interop.