### PR TITLE
cmd/utils: improve documentation for SplitAndTrim

### DIFF
--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -1278,8 +1278,8 @@ func setNAT(ctx *cli.Context, cfg *p2p.Config) {
 	}
 }
 
-// SplitAndTrim splits input separated by a comma
-// and trims excessive white space from the substrings.
+// SplitAndTrim splits a comma-separated string into substrings,
+// trims surrounding whitespace, and returns only non-empty strings.
 func SplitAndTrim(input string) (ret []string) {
 	l := strings.Split(input, ",")
 	for _, r := range l {


### PR DESCRIPTION
### Changes
- Improved documentation comment for the SplitAndTrim helper function

### Motivation
Enhance clarity by making the return type more explicit and improving overall readability