### PR TITLE
miner: re-used basefee and big.Int in loop

### DIFF
--- a/miner/worker.go
+++ b/miner/worker.go
@@ -598,10 +598,14 @@ func (miner *Miner) fillTransactions(ctx context.Context, interrupt *atomic.Int3
 
 // totalFees computes total consumed miner fees in Wei. Block transactions and receipts have to have the same order.
 func totalFees(block *types.Block, receipts []*types.Receipt) *big.Int {
+	baseFee := block.BaseFee()
 	feesWei := new(big.Int)
+	var gasUsed, product big.Int
 	for i, tx := range block.Transactions() {
-		minerFee, _ := tx.EffectiveGasTip(block.BaseFee())
-		feesWei.Add(feesWei, new(big.Int).Mul(new(big.Int).SetUint64(receipts[i].GasUsed), minerFee))
+		minerFee, _ := tx.EffectiveGasTip(baseFee)
+		gasUsed.SetUint64(receipts[i].GasUsed)
+		product.Mul(&gasUsed, minerFee)
+		feesWei.Add(feesWei, &product)
 	}
 	return feesWei
 }


### PR DESCRIPTION
benchmark code:
```
// Copyright 2026 The go-ethereum Authors
// This file is part of the go-ethereum library.
//
// The go-ethereum library is free software: you can redistribute it and/or modify
// it under the terms of the GNU Lesser General Public License as published by
// the Free Software Foundation, either version 3 of the License, or
// (at your option) any later version.
//
// The go-ethereum library is distributed in the hope that it will be useful,
// but WITHOUT ANY WARRANTY; without even the implied warranty of
// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
// GNU Lesser General Public License for more details.
//
// You should have received a copy of the GNU Lesser General Public License
// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.

package miner

import (
	"fmt"
	"math/big"
	"testing"

	"github.com/ethereum/go-ethereum/common"
	"github.com/ethereum/go-ethereum/core/types"
	"github.com/ethereum/go-ethereum/crypto"
	"github.com/ethereum/go-ethereum/trie"
)

// buildTotalFeesFixture creates a block with `n` signed dynamic-fee transactions
// and corresponding receipts, suitable for benchmarking totalFees.
func buildTotalFeesFixture(n int) (*types.Block, []*types.Receipt) {
	baseFee := big.NewInt(1_000_000_000) // 1 gwei
	signer := types.LatestSignerForChainID(big.NewInt(1))

	key, _ := crypto.HexToECDSA("b71c71a67e1177ad4e901695e1b4b9ee17ae16c6668d313eac2f96dbcda3f291")

	txs := make(types.Transactions, n)
	receipts := make([]*types.Receipt, n)
	for i := 0; i < n; i++ {
		tx := types.NewTx(&types.DynamicFeeTx{
			ChainID:   big.NewInt(1),
			Nonce:     uint64(i),
			To:        &common.Address{},
			Value:     big.NewInt(0),
			Gas:       21000,
			GasFeeCap: big.NewInt(3_000_000_000),
			GasTipCap: big.NewInt(2_000_000_000),
			Data:      nil,
		})
		signed, err := types.SignTx(tx, signer, key)
		if err != nil {
			panic(err)
		}
		txs[i] = signed
		receipts[i] = &types.Receipt{GasUsed: 21000}
	}

	header := &types.Header{
		Number:     big.NewInt(1),
		GasLimit:   30_000_000,
		BaseFee:    baseFee,
		Difficulty: big.NewInt(1),
	}
	block := types.NewBlock(header, &types.Body{Transactions: txs}, receipts, trie.NewStackTrie(nil))
	return block, receipts
}

func BenchmarkTotalFees(b *testing.B) {
	for _, n := range []int{1, 50, 200} {
		block, receipts := buildTotalFeesFixture(n)
		b.Run(fmt.Sprintf("txs=%d", n), func(b *testing.B) {
			b.ReportAllocs()
			b.ResetTimer()
			for i := 0; i < b.N; i++ {
				_ = totalFees(block, receipts)
			}
		})
	}
}

```
benchmark result:  
```
goos: darwin
goarch: arm64
pkg: github.com/ethereum/go-ethereum/miner
cpu: Apple M4 Pro
                     │ miner/old.txt │            miner/new.txt            │
                     │    sec/op     │   sec/op     vs base                │
TotalFees/txs=1-14       85.64n ± 4%   87.57n ± 2%   +2.25% (p=0.024 n=10)
TotalFees/txs=50-14      3.517µ ± 2%   2.264µ ± 4%  -35.63% (p=0.000 n=10)
TotalFees/txs=200-14    14.801µ ± 2%   9.336µ ± 2%  -36.93% (p=0.000 n=10)
geomean                  1.646µ        1.228µ       -25.40%

                     │ miner/old.txt │             miner/new.txt              │
                     │     B/op      │     B/op      vs base                  │
TotalFees/txs=1-14        168.0 ± 0%     168.0 ± 0%        ~ (p=1.000 n=10) ¹
TotalFees/txs=50-14     6.336Ki ± 0%   3.273Ki ± 0%  -48.34% (p=0.000 n=10)
TotalFees/txs=200-14    25.09Ki ± 0%   12.65Ki ± 0%  -49.58% (p=0.000 n=10)
geomean                 2.965Ki        1.894Ki       -36.13%
¹ all samples are equal

                     │ miner/old.txt │            miner/new.txt             │
                     │   allocs/op   │ allocs/op   vs base                  │
TotalFees/txs=1-14        7.000 ± 0%   7.000 ± 0%        ~ (p=1.000 n=10) ¹
TotalFees/txs=50-14       253.0 ± 0%   106.0 ± 0%  -58.10% (p=0.000 n=10)
TotalFees/txs=200-14     1003.0 ± 0%   406.0 ± 0%  -59.52% (p=0.000 n=10)
geomean                   121.1        67.04       -44.65%
¹ all samples are equal
```