### PR TITLE
accounts/abi/abigen: add ABI method to v2 bindings

### DIFF
--- a/accounts/abi/abigen/source2.go.tpl
+++ b/accounts/abi/abigen/source2.go.tpl
@@ -68,6 +68,13 @@ var (
 		return &{{.Type}}{abi: *parsed}
 	}
 
+	// ABI returns the parsed ABI of the contract. The returned value shares
+	// its internal maps (Methods, Events, Errors) with the binding, so callers
+	// must not mutate it.
+	func (c *{{.Type}}) ABI() abi.ABI {
+		return c.abi
+	}
+
 	// Instance creates a wrapper for a deployed contract instance at the given address.
 	// Use this to create the instance object passed to abigen v2 library functions Call, Transact, etc.
 	func (c *{{.Type}}) Instance(backend bind.ContractBackend, addr common.Address) *bind.BoundContract {

--- a/accounts/abi/abigen/testdata/v2/callbackparam.go.txt
+++ b/accounts/abi/abigen/testdata/v2/callbackparam.go.txt
@@ -45,6 +45,13 @@ func NewCallbackParam() *CallbackParam {
 	return &CallbackParam{abi: *parsed}
 }
 
+// ABI returns the parsed ABI of the contract. The returned value shares
+// its internal maps (Methods, Events, Errors) with the binding, so callers
+// must not mutate it.
+func (c *CallbackParam) ABI() abi.ABI {
+	return c.abi
+}
+
 // Instance creates a wrapper for a deployed contract instance at the given address.
 // Use this to create the instance object passed to abigen v2 library functions Call, Transact, etc.
 func (c *CallbackParam) Instance(backend bind.ContractBackend, addr common.Address) *bind.BoundContract {

--- a/accounts/abi/abigen/testdata/v2/crowdsale.go.txt
+++ b/accounts/abi/abigen/testdata/v2/crowdsale.go.txt
@@ -45,6 +45,13 @@ func NewCrowdsale() *Crowdsale {
 	return &Crowdsale{abi: *parsed}
 }
 
+// ABI returns the parsed ABI of the contract. The returned value shares
+// its internal maps (Methods, Events, Errors) with the binding, so callers
+// must not mutate it.
+func (c *Crowdsale) ABI() abi.ABI {
+	return c.abi
+}
+
 // Instance creates a wrapper for a deployed contract instance at the given address.
 // Use this to create the instance object passed to abigen v2 library functions Call, Transact, etc.
 func (c *Crowdsale) Instance(backend bind.ContractBackend, addr common.Address) *bind.BoundContract {

--- a/accounts/abi/abigen/testdata/v2/dao.go.txt
+++ b/accounts/abi/abigen/testdata/v2/dao.go.txt
@@ -45,6 +45,13 @@ func NewDAO() *DAO {
 	return &DAO{abi: *parsed}
 }
 
+// ABI returns the parsed ABI of the contract. The returned value shares
+// its internal maps (Methods, Events, Errors) with the binding, so callers
+// must not mutate it.
+func (c *DAO) ABI() abi.ABI {
+	return c.abi
+}
+
 // Instance creates a wrapper for a deployed contract instance at the given address.
 // Use this to create the instance object passed to abigen v2 library functions Call, Transact, etc.
 func (c *DAO) Instance(backend bind.ContractBackend, addr common.Address) *bind.BoundContract {

--- a/accounts/abi/abigen/testdata/v2/deeplynestedarray.go.txt
+++ b/accounts/abi/abigen/testdata/v2/deeplynestedarray.go.txt
@@ -45,6 +45,13 @@ func NewDeeplyNestedArray() *DeeplyNestedArray {
 	return &DeeplyNestedArray{abi: *parsed}
 }
 
+// ABI returns the parsed ABI of the contract. The returned value shares
+// its internal maps (Methods, Events, Errors) with the binding, so callers
+// must not mutate it.
+func (c *DeeplyNestedArray) ABI() abi.ABI {
+	return c.abi
+}
+
 // Instance creates a wrapper for a deployed contract instance at the given address.
 // Use this to create the instance object passed to abigen v2 library functions Call, Transact, etc.
 func (c *DeeplyNestedArray) Instance(backend bind.ContractBackend, addr common.Address) *bind.BoundContract {

--- a/accounts/abi/abigen/testdata/v2/empty.go.txt
+++ b/accounts/abi/abigen/testdata/v2/empty.go.txt
@@ -45,6 +45,13 @@ func NewEmpty() *Empty {
 	return &Empty{abi: *parsed}
 }
 
+// ABI returns the parsed ABI of the contract. The returned value shares
+// its internal maps (Methods, Events, Errors) with the binding, so callers
+// must not mutate it.
+func (c *Empty) ABI() abi.ABI {
+	return c.abi
+}
+
 // Instance creates a wrapper for a deployed contract instance at the given address.
 // Use this to create the instance object passed to abigen v2 library functions Call, Transact, etc.
 func (c *Empty) Instance(backend bind.ContractBackend, addr common.Address) *bind.BoundContract {

--- a/accounts/abi/abigen/testdata/v2/eventchecker.go.txt
+++ b/accounts/abi/abigen/testdata/v2/eventchecker.go.txt
@@ -44,6 +44,13 @@ func NewEventChecker() *EventChecker {
 	return &EventChecker{abi: *parsed}
 }
 
+// ABI returns the parsed ABI of the contract. The returned value shares
+// its internal maps (Methods, Events, Errors) with the binding, so callers
+// must not mutate it.
+func (c *EventChecker) ABI() abi.ABI {
+	return c.abi
+}
+
 // Instance creates a wrapper for a deployed contract instance at the given address.
 // Use this to create the instance object passed to abigen v2 library functions Call, Transact, etc.
 func (c *EventChecker) Instance(backend bind.ContractBackend, addr common.Address) *bind.BoundContract {

--- a/accounts/abi/abigen/testdata/v2/getter.go.txt
+++ b/accounts/abi/abigen/testdata/v2/getter.go.txt
@@ -45,6 +45,13 @@ func NewGetter() *Getter {
 	return &Getter{abi: *parsed}
 }
 
+// ABI returns the parsed ABI of the contract. The returned value shares
+// its internal maps (Methods, Events, Errors) with the binding, so callers
+// must not mutate it.
+func (c *Getter) ABI() abi.ABI {
+	return c.abi
+}
+
 // Instance creates a wrapper for a deployed contract instance at the given address.
 // Use this to create the instance object passed to abigen v2 library functions Call, Transact, etc.
 func (c *Getter) Instance(backend bind.ContractBackend, addr common.Address) *bind.BoundContract {

--- a/accounts/abi/abigen/testdata/v2/identifiercollision.go.txt
+++ b/accounts/abi/abigen/testdata/v2/identifiercollision.go.txt
@@ -45,6 +45,13 @@ func NewIdentifierCollision() *IdentifierCollision {
 	return &IdentifierCollision{abi: *parsed}
 }
 
+// ABI returns the parsed ABI of the contract. The returned value shares
+// its internal maps (Methods, Events, Errors) with the binding, so callers
+// must not mutate it.
+func (c *IdentifierCollision) ABI() abi.ABI {
+	return c.abi
+}
+
 // Instance creates a wrapper for a deployed contract instance at the given address.
 // Use this to create the instance object passed to abigen v2 library functions Call, Transact, etc.
 func (c *IdentifierCollision) Instance(backend bind.ContractBackend, addr common.Address) *bind.BoundContract {

--- a/accounts/abi/abigen/testdata/v2/inputchecker.go.txt
+++ b/accounts/abi/abigen/testdata/v2/inputchecker.go.txt
@@ -44,6 +44,13 @@ func NewInputChecker() *InputChecker {
 	return &InputChecker{abi: *parsed}
 }
 
+// ABI returns the parsed ABI of the contract. The returned value shares
+// its internal maps (Methods, Events, Errors) with the binding, so callers
+// must not mutate it.
+func (c *InputChecker) ABI() abi.ABI {
+	return c.abi
+}
+
 // Instance creates a wrapper for a deployed contract instance at the given address.
 // Use this to create the instance object passed to abigen v2 library functions Call, Transact, etc.
 func (c *InputChecker) Instance(backend bind.ContractBackend, addr common.Address) *bind.BoundContract {

--- a/accounts/abi/abigen/testdata/v2/interactor.go.txt
+++ b/accounts/abi/abigen/testdata/v2/interactor.go.txt
@@ -45,6 +45,13 @@ func NewInteractor() *Interactor {
 	return &Interactor{abi: *parsed}
 }
 
+// ABI returns the parsed ABI of the contract. The returned value shares
+// its internal maps (Methods, Events, Errors) with the binding, so callers
+// must not mutate it.
+func (c *Interactor) ABI() abi.ABI {
+	return c.abi
+}
+
 // Instance creates a wrapper for a deployed contract instance at the given address.
 // Use this to create the instance object passed to abigen v2 library functions Call, Transact, etc.
 func (c *Interactor) Instance(backend bind.ContractBackend, addr common.Address) *bind.BoundContract {

--- a/accounts/abi/abigen/testdata/v2/nameconflict.go.txt
+++ b/accounts/abi/abigen/testdata/v2/nameconflict.go.txt
@@ -51,6 +51,13 @@ func NewNameConflict() *NameConflict {
 	return &NameConflict{abi: *parsed}
 }
 
+// ABI returns the parsed ABI of the contract. The returned value shares
+// its internal maps (Methods, Events, Errors) with the binding, so callers
+// must not mutate it.
+func (c *NameConflict) ABI() abi.ABI {
+	return c.abi
+}
+
 // Instance creates a wrapper for a deployed contract instance at the given address.
 // Use this to create the instance object passed to abigen v2 library functions Call, Transact, etc.
 func (c *NameConflict) Instance(backend bind.ContractBackend, addr common.Address) *bind.BoundContract {

--- a/accounts/abi/abigen/testdata/v2/numericmethodname.go.txt
+++ b/accounts/abi/abigen/testdata/v2/numericmethodname.go.txt
@@ -45,6 +45,13 @@ func NewNumericMethodName() *NumericMethodName {
 	return &NumericMethodName{abi: *parsed}
 }
 
+// ABI returns the parsed ABI of the contract. The returned value shares
+// its internal maps (Methods, Events, Errors) with the binding, so callers
+// must not mutate it.
+func (c *NumericMethodName) ABI() abi.ABI {
+	return c.abi
+}
+
 // Instance creates a wrapper for a deployed contract instance at the given address.
 // Use this to create the instance object passed to abigen v2 library functions Call, Transact, etc.
 func (c *NumericMethodName) Instance(backend bind.ContractBackend, addr common.Address) *bind.BoundContract {

--- a/accounts/abi/abigen/testdata/v2/outputchecker.go.txt
+++ b/accounts/abi/abigen/testdata/v2/outputchecker.go.txt
@@ -44,6 +44,13 @@ func NewOutputChecker() *OutputChecker {
 	return &OutputChecker{abi: *parsed}
 }
 
+// ABI returns the parsed ABI of the contract. The returned value shares
+// its internal maps (Methods, Events, Errors) with the binding, so callers
+// must not mutate it.
+func (c *OutputChecker) ABI() abi.ABI {
+	return c.abi
+}
+
 // Instance creates a wrapper for a deployed contract instance at the given address.
 // Use this to create the instance object passed to abigen v2 library functions Call, Transact, etc.
 func (c *OutputChecker) Instance(backend bind.ContractBackend, addr common.Address) *bind.BoundContract {

--- a/accounts/abi/abigen/testdata/v2/overload.go.txt
+++ b/accounts/abi/abigen/testdata/v2/overload.go.txt
@@ -45,6 +45,13 @@ func NewOverload() *Overload {
 	return &Overload{abi: *parsed}
 }
 
+// ABI returns the parsed ABI of the contract. The returned value shares
+// its internal maps (Methods, Events, Errors) with the binding, so callers
+// must not mutate it.
+func (c *Overload) ABI() abi.ABI {
+	return c.abi
+}
+
 // Instance creates a wrapper for a deployed contract instance at the given address.
 // Use this to create the instance object passed to abigen v2 library functions Call, Transact, etc.
 func (c *Overload) Instance(backend bind.ContractBackend, addr common.Address) *bind.BoundContract {

--- a/accounts/abi/abigen/testdata/v2/rangekeyword.go.txt
+++ b/accounts/abi/abigen/testdata/v2/rangekeyword.go.txt
@@ -45,6 +45,13 @@ func NewRangeKeyword() *RangeKeyword {
 	return &RangeKeyword{abi: *parsed}
 }
 
+// ABI returns the parsed ABI of the contract. The returned value shares
+// its internal maps (Methods, Events, Errors) with the binding, so callers
+// must not mutate it.
+func (c *RangeKeyword) ABI() abi.ABI {
+	return c.abi
+}
+
 // Instance creates a wrapper for a deployed contract instance at the given address.
 // Use this to create the instance object passed to abigen v2 library functions Call, Transact, etc.
 func (c *RangeKeyword) Instance(backend bind.ContractBackend, addr common.Address) *bind.BoundContract {

--- a/accounts/abi/abigen/testdata/v2/slicer.go.txt
+++ b/accounts/abi/abigen/testdata/v2/slicer.go.txt
@@ -45,6 +45,13 @@ func NewSlicer() *Slicer {
 	return &Slicer{abi: *parsed}
 }
 
+// ABI returns the parsed ABI of the contract. The returned value shares
+// its internal maps (Methods, Events, Errors) with the binding, so callers
+// must not mutate it.
+func (c *Slicer) ABI() abi.ABI {
+	return c.abi
+}
+
 // Instance creates a wrapper for a deployed contract instance at the given address.
 // Use this to create the instance object passed to abigen v2 library functions Call, Transact, etc.
 func (c *Slicer) Instance(backend bind.ContractBackend, addr common.Address) *bind.BoundContract {

--- a/accounts/abi/abigen/testdata/v2/structs.go.txt
+++ b/accounts/abi/abigen/testdata/v2/structs.go.txt
@@ -50,6 +50,13 @@ func NewStructs() *Structs {
 	return &Structs{abi: *parsed}
 }
 
+// ABI returns the parsed ABI of the contract. The returned value shares
+// its internal maps (Methods, Events, Errors) with the binding, so callers
+// must not mutate it.
+func (c *Structs) ABI() abi.ABI {
+	return c.abi
+}
+
 // Instance creates a wrapper for a deployed contract instance at the given address.
 // Use this to create the instance object passed to abigen v2 library functions Call, Transact, etc.
 func (c *Structs) Instance(backend bind.ContractBackend, addr common.Address) *bind.BoundContract {

--- a/accounts/abi/abigen/testdata/v2/token.go.txt
+++ b/accounts/abi/abigen/testdata/v2/token.go.txt
@@ -45,6 +45,13 @@ func NewToken() *Token {
 	return &Token{abi: *parsed}
 }
 
+// ABI returns the parsed ABI of the contract. The returned value shares
+// its internal maps (Methods, Events, Errors) with the binding, so callers
+// must not mutate it.
+func (c *Token) ABI() abi.ABI {
+	return c.abi
+}
+
 // Instance creates a wrapper for a deployed contract instance at the given address.
 // Use this to create the instance object passed to abigen v2 library functions Call, Transact, etc.
 func (c *Token) Instance(backend bind.ContractBackend, addr common.Address) *bind.BoundContract {

--- a/accounts/abi/abigen/testdata/v2/tuple.go.txt
+++ b/accounts/abi/abigen/testdata/v2/tuple.go.txt
@@ -70,6 +70,13 @@ func NewTuple() *Tuple {
 	return &Tuple{abi: *parsed}
 }
 
+// ABI returns the parsed ABI of the contract. The returned value shares
+// its internal maps (Methods, Events, Errors) with the binding, so callers
+// must not mutate it.
+func (c *Tuple) ABI() abi.ABI {
+	return c.abi
+}
+
 // Instance creates a wrapper for a deployed contract instance at the given address.
 // Use this to create the instance object passed to abigen v2 library functions Call, Transact, etc.
 func (c *Tuple) Instance(backend bind.ContractBackend, addr common.Address) *bind.BoundContract {

--- a/accounts/abi/abigen/testdata/v2/tupler.go.txt
+++ b/accounts/abi/abigen/testdata/v2/tupler.go.txt
@@ -45,6 +45,13 @@ func NewTupler() *Tupler {
 	return &Tupler{abi: *parsed}
 }
 
+// ABI returns the parsed ABI of the contract. The returned value shares
+// its internal maps (Methods, Events, Errors) with the binding, so callers
+// must not mutate it.
+func (c *Tupler) ABI() abi.ABI {
+	return c.abi
+}
+
 // Instance creates a wrapper for a deployed contract instance at the given address.
 // Use this to create the instance object passed to abigen v2 library functions Call, Transact, etc.
 func (c *Tupler) Instance(backend bind.ContractBackend, addr common.Address) *bind.BoundContract {

--- a/accounts/abi/abigen/testdata/v2/underscorer.go.txt
+++ b/accounts/abi/abigen/testdata/v2/underscorer.go.txt
@@ -45,6 +45,13 @@ func NewUnderscorer() *Underscorer {
 	return &Underscorer{abi: *parsed}
 }
 
+// ABI returns the parsed ABI of the contract. The returned value shares
+// its internal maps (Methods, Events, Errors) with the binding, so callers
+// must not mutate it.
+func (c *Underscorer) ABI() abi.ABI {
+	return c.abi
+}
+
 // Instance creates a wrapper for a deployed contract instance at the given address.
 // Use this to create the instance object passed to abigen v2 library functions Call, Transact, etc.
 func (c *Underscorer) Instance(backend bind.ContractBackend, addr common.Address) *bind.BoundContract {

--- a/accounts/abi/bind/v2/internal/contracts/db/bindings.go
+++ b/accounts/abi/bind/v2/internal/contracts/db/bindings.go
@@ -52,6 +52,13 @@ func NewDB() *DB {
 	return &DB{abi: *parsed}
 }
 
+// ABI returns the parsed ABI of the contract. The returned value shares
+// its internal maps (Methods, Events, Errors) with the binding, so callers
+// must not mutate it.
+func (c *DB) ABI() abi.ABI {
+	return c.abi
+}
+
 // Instance creates a wrapper for a deployed contract instance at the given address.
 // Use this to create the instance object passed to abigen v2 library functions Call, Transact, etc.
 func (c *DB) Instance(backend bind.ContractBackend, addr common.Address) *bind.BoundContract {

--- a/accounts/abi/bind/v2/internal/contracts/events/bindings.go
+++ b/accounts/abi/bind/v2/internal/contracts/events/bindings.go
@@ -45,6 +45,13 @@ func NewC() *C {
 	return &C{abi: *parsed}
 }
 
+// ABI returns the parsed ABI of the contract. The returned value shares
+// its internal maps (Methods, Events, Errors) with the binding, so callers
+// must not mutate it.
+func (c *C) ABI() abi.ABI {
+	return c.abi
+}
+
 // Instance creates a wrapper for a deployed contract instance at the given address.
 // Use this to create the instance object passed to abigen v2 library functions Call, Transact, etc.
 func (c *C) Instance(backend bind.ContractBackend, addr common.Address) *bind.BoundContract {

--- a/accounts/abi/bind/v2/internal/contracts/nested_libraries/bindings.go
+++ b/accounts/abi/bind/v2/internal/contracts/nested_libraries/bindings.go
@@ -49,6 +49,13 @@ func NewC1() *C1 {
 	return &C1{abi: *parsed}
 }
 
+// ABI returns the parsed ABI of the contract. The returned value shares
+// its internal maps (Methods, Events, Errors) with the binding, so callers
+// must not mutate it.
+func (c *C1) ABI() abi.ABI {
+	return c.abi
+}
+
 // Instance creates a wrapper for a deployed contract instance at the given address.
 // Use this to create the instance object passed to abigen v2 library functions Call, Transact, etc.
 func (c *C1) Instance(backend bind.ContractBackend, addr common.Address) *bind.BoundContract {
@@ -127,6 +134,13 @@ func NewC2() *C2 {
 	return &C2{abi: *parsed}
 }
 
+// ABI returns the parsed ABI of the contract. The returned value shares
+// its internal maps (Methods, Events, Errors) with the binding, so callers
+// must not mutate it.
+func (c *C2) ABI() abi.ABI {
+	return c.abi
+}
+
 // Instance creates a wrapper for a deployed contract instance at the given address.
 // Use this to create the instance object passed to abigen v2 library functions Call, Transact, etc.
 func (c *C2) Instance(backend bind.ContractBackend, addr common.Address) *bind.BoundContract {
@@ -201,6 +215,13 @@ func NewL1() *L1 {
 	return &L1{abi: *parsed}
 }
 
+// ABI returns the parsed ABI of the contract. The returned value shares
+// its internal maps (Methods, Events, Errors) with the binding, so callers
+// must not mutate it.
+func (c *L1) ABI() abi.ABI {
+	return c.abi
+}
+
 // Instance creates a wrapper for a deployed contract instance at the given address.
 // Use this to create the instance object passed to abigen v2 library functions Call, Transact, etc.
 func (c *L1) Instance(backend bind.ContractBackend, addr common.Address) *bind.BoundContract {
@@ -264,6 +285,13 @@ func NewL2() *L2 {
 		panic(errors.New("invalid ABI: " + err.Error()))
 	}
 	return &L2{abi: *parsed}
+}
+
+// ABI returns the parsed ABI of the contract. The returned value shares
+// its internal maps (Methods, Events, Errors) with the binding, so callers
+// must not mutate it.
+func (c *L2) ABI() abi.ABI {
+	return c.abi
 }
 
 // Instance creates a wrapper for a deployed contract instance at the given address.
@@ -331,6 +359,13 @@ func NewL2b() *L2b {
 	return &L2b{abi: *parsed}
 }
 
+// ABI returns the parsed ABI of the contract. The returned value shares
+// its internal maps (Methods, Events, Errors) with the binding, so callers
+// must not mutate it.
+func (c *L2b) ABI() abi.ABI {
+	return c.abi
+}
+
 // Instance creates a wrapper for a deployed contract instance at the given address.
 // Use this to create the instance object passed to abigen v2 library functions Call, Transact, etc.
 func (c *L2b) Instance(backend bind.ContractBackend, addr common.Address) *bind.BoundContract {
@@ -391,6 +426,13 @@ func NewL3() *L3 {
 		panic(errors.New("invalid ABI: " + err.Error()))
 	}
 	return &L3{abi: *parsed}
+}
+
+// ABI returns the parsed ABI of the contract. The returned value shares
+// its internal maps (Methods, Events, Errors) with the binding, so callers
+// must not mutate it.
+func (c *L3) ABI() abi.ABI {
+	return c.abi
 }
 
 // Instance creates a wrapper for a deployed contract instance at the given address.
@@ -459,6 +501,13 @@ func NewL4() *L4 {
 	return &L4{abi: *parsed}
 }
 
+// ABI returns the parsed ABI of the contract. The returned value shares
+// its internal maps (Methods, Events, Errors) with the binding, so callers
+// must not mutate it.
+func (c *L4) ABI() abi.ABI {
+	return c.abi
+}
+
 // Instance creates a wrapper for a deployed contract instance at the given address.
 // Use this to create the instance object passed to abigen v2 library functions Call, Transact, etc.
 func (c *L4) Instance(backend bind.ContractBackend, addr common.Address) *bind.BoundContract {
@@ -522,6 +571,13 @@ func NewL4b() *L4b {
 		panic(errors.New("invalid ABI: " + err.Error()))
 	}
 	return &L4b{abi: *parsed}
+}
+
+// ABI returns the parsed ABI of the contract. The returned value shares
+// its internal maps (Methods, Events, Errors) with the binding, so callers
+// must not mutate it.
+func (c *L4b) ABI() abi.ABI {
+	return c.abi
 }
 
 // Instance creates a wrapper for a deployed contract instance at the given address.

--- a/accounts/abi/bind/v2/internal/contracts/solc_errors/bindings.go
+++ b/accounts/abi/bind/v2/internal/contracts/solc_errors/bindings.go
@@ -45,6 +45,13 @@ func NewC() *C {
 	return &C{abi: *parsed}
 }
 
+// ABI returns the parsed ABI of the contract. The returned value shares
+// its internal maps (Methods, Events, Errors) with the binding, so callers
+// must not mutate it.
+func (c *C) ABI() abi.ABI {
+	return c.abi
+}
+
 // Instance creates a wrapper for a deployed contract instance at the given address.
 // Use this to create the instance object passed to abigen v2 library functions Call, Transact, etc.
 func (c *C) Instance(backend bind.ContractBackend, addr common.Address) *bind.BoundContract {
@@ -180,6 +187,13 @@ func NewC2() *C2 {
 		panic(errors.New("invalid ABI: " + err.Error()))
 	}
 	return &C2{abi: *parsed}
+}
+
+// ABI returns the parsed ABI of the contract. The returned value shares
+// its internal maps (Methods, Events, Errors) with the binding, so callers
+// must not mutate it.
+func (c *C2) ABI() abi.ABI {
+	return c.abi
 }
 
 // Instance creates a wrapper for a deployed contract instance at the given address.

--- a/accounts/abi/bind/v2/internal/contracts/uint256arrayreturn/bindings.go
+++ b/accounts/abi/bind/v2/internal/contracts/uint256arrayreturn/bindings.go
@@ -45,6 +45,13 @@ func NewMyContract() *MyContract {
 	return &MyContract{abi: *parsed}
 }
 
+// ABI returns the parsed ABI of the contract. The returned value shares
+// its internal maps (Methods, Events, Errors) with the binding, so callers
+// must not mutate it.
+func (c *MyContract) ABI() abi.ABI {
+	return c.abi
+}
+
 // Instance creates a wrapper for a deployed contract instance at the given address.
 // Use this to create the instance object passed to abigen v2 library functions Call, Transact, etc.
 func (c *MyContract) Instance(backend bind.ContractBackend, addr common.Address) *bind.BoundContract {


### PR DESCRIPTION
## Summary

This adds an exported `ABI()` method on every v2 contract binding generated by abigen. The method returns the parsed `abi.ABI` held by the binding so callers can access event, error, and method metadata without re-parsing via `ContractMetaData.ParseABI()`.

A common use case is building a `FilterQuery` whose `Topics` span multiple contracts:

```go
contractA := ContractA.NewContractA()
contractB := ContractB.NewContractB()

fq := ethereum.FilterQuery{
    Topics: [][]common.Hash{{
        contractA.ABI().Events[ContractA.ContractAFooEventName].ID,
        contractB.ABI().Events[ContractB.ContractBBarEventName].ID,
    }},
}
```

## Naming

The issue proposed `GetABI()`. I went with `ABI()` to follow the Go getter naming convention used elsewhere in this repository and in the standard library, where getters typically drop the `Get` prefix (`Header.Number()`, `Block.Transactions()`, `abi.Method.Sig`, etc.). Happy to rename back to `GetABI()` if maintainers prefer; it is a one-line template edit plus a regeneration pass.

## Aliasing note

`abi.ABI` is a struct containing map fields (`Methods`, `Events`, `Errors`). Returning it by value copies the struct header while the maps remain shared with the binding. The doc comment warns callers against mutating the returned value. A deep copy would require round-tripping through JSON and was avoided given the read-only access pattern the issue describes.

## Changes

- Add the `ABI()` method to `accounts/abi/abigen/source2.go.tpl`.
- Regenerate the v2 test goldens under `accounts/abi/abigen/testdata/v2/`.
- Regenerate the `go generate`-managed test bindings under `accounts/abi/bind/v2/internal/contracts/`.

## Testing

- `make all`
- `go test ./accounts/abi/...` (passes)
- `go run ./build/ci.go lint` (0 issues)
- `go run ./build/ci.go check_generate` (clean)
- `go run ./build/ci.go check_baddeps` (clean)

Full suite (`go run ./build/ci.go test`) was not run locally; relying on CI.

Closes #34705.
