### PR TITLE
miner: supply a slot number when synthesising pending block post-Amsterdam

### DIFF
--- a/miner/miner.go
+++ b/miner/miner.go
@@ -151,11 +151,23 @@ func (miner *Miner) getPending() *newPayloadResult {
 		return cached
 	}
 	var (
-		timestamp  = uint64(time.Now().Unix())
-		withdrawal types.Withdrawals
+		timestamp   = uint64(time.Now().Unix())
+		childNumber = new(big.Int).Add(header.Number, big.NewInt(1))
+		withdrawal  types.Withdrawals
+		slotNum     *uint64
 	)
-	if miner.chainConfig.IsShanghai(new(big.Int).Add(header.Number, big.NewInt(1)), timestamp) {
+	if miner.chainConfig.IsShanghai(childNumber, timestamp) {
 		withdrawal = []*types.Withdrawal{}
+	}
+	// Post-Amsterdam, prepareWork requires a slot number (EIP-7843). The pending
+	// block is synthetic and has no canonical slot, so derive one from the parent
+	// when available and fall back to zero otherwise.
+	if miner.chainConfig.IsAmsterdam(childNumber, timestamp) {
+		var n uint64
+		if header.SlotNumber != nil {
+			n = *header.SlotNumber + 1
+		}
+		slotNum = &n
 	}
 	ret := miner.generateWork(context.Background(),
 		&generateParams{
@@ -166,6 +178,7 @@ func (miner *Miner) getPending() *newPayloadResult {
 			random:      common.Hash{},
 			withdrawals: withdrawal,
 			beaconRoot:  nil,
+			slotNum:     slotNum,
 			noTxs:       false,
 		}, false) // we will never make a witness for a pending block
 	if ret.err != nil {


### PR DESCRIPTION

<img width="1373" height="350" alt="Screenshot 2026-04-22 at 14 13 45" src="https://github.com/user-attachments/assets/f956d09f-f1b5-4573-8409-5fde96175d09" />

## Summary

`miner.getPending()` builds the pending block on demand via `generateWork`, but after EIP-7843 (#33589) `prepareWork` rejects the call unless `generateParams.slotNum` is non-nil once Amsterdam is active:

```go
if miner.chainConfig.IsAmsterdam(header.Number, header.Time) {
    if genParams.slotNum == nil {
        return nil, errors.New("no slot number set post-amsterdam")
    }
    header.SlotNumber = genParams.slotNum
}
```

`getPending` never populated `slotNum`, so on any Amsterdam-activated chain the RPC paths that resolve through pending state fail:

```
eth_getBalance(addr, "pending")   -> -32000 "pending state is not available"
```

This breaks faucets, nonce trackers, and anything else that polls `pending`.

## Fix

Synthesise a slot number from the parent header when Amsterdam is active — one block ahead of `header.SlotNumber`, falling back to `0` when the parent has no slot set. Mirrors how the Shanghai branch above already conditionally populates `withdrawals`. The pending block is empty post-merge so the exact slot value is not user-visible; it just has to satisfy `prepareWork`'s invariant.

## Reproduction

Observed on a `bal-devnet-3` Geth build (commit `c30c846c`). Every `eth_getBalance(…, "pending")` against the bootnode returned `-32000 "pending state is not available"`. Other ELs on the same chain (Nethermind, Besu, Reth, Erigon, Ethrex) serve `pending` without issue:

| EL | `eth_getBalance(…,"pending")` |
|---|---|
| Geth `v1.17.3-unstable-c30c846c` | ❌ `-32000 "pending state is not available"` |
| Nethermind `v1.37.0-unstable` | ✅ ok |
| Besu `v26.4-develop` | ✅ ok |
| Reth `v1.11.3` | ✅ ok |
| Erigon `3.5.0` | ✅ ok |
| Ethrex `v9.0.0-HEAD` | ✅ ok |

## Test plan

- [x] `go build ./miner/...`
- [x] `go test ./miner/...` (existing suite passes)
- [ ] Redeploy bootnode with this patch and verify faucet resumes polling

Note: same fix is needed on master (`getPending` on master also omits `slotNum`, same `IsAmsterdam` guard in `prepareWork`) and on `glamsterdam-devnet-0` — separate PRs follow.