### PR TITLE
miner: supply a slot number when synthesising pending block post-Amsterdam

### DIFF
--- a/miner/miner.go
+++ b/miner/miner.go
@@ -151,11 +151,23 @@ func (miner *Miner) getPending() *newPayloadResult {
 		return cached
 	}
 	var (
-		timestamp  = uint64(time.Now().Unix())
-		withdrawal types.Withdrawals
+		timestamp   = uint64(time.Now().Unix())
+		childNumber = new(big.Int).Add(header.Number, big.NewInt(1))
+		withdrawal  types.Withdrawals
+		slotNum     *uint64
 	)
-	if miner.chainConfig.IsShanghai(new(big.Int).Add(header.Number, big.NewInt(1)), timestamp) {
+	if miner.chainConfig.IsShanghai(childNumber, timestamp) {
 		withdrawal = []*types.Withdrawal{}
+	}
+	// Post-Amsterdam, prepareWork requires a slot number (EIP-7843). The pending
+	// block is synthetic and has no canonical slot, so derive one from the parent
+	// when available and fall back to zero otherwise.
+	if miner.chainConfig.IsAmsterdam(childNumber, timestamp) {
+		var n uint64
+		if header.SlotNumber != nil {
+			n = *header.SlotNumber + 1
+		}
+		slotNum = &n
 	}
 	ret := miner.generateWork(context.Background(),
 		&generateParams{
@@ -166,6 +178,7 @@ func (miner *Miner) getPending() *newPayloadResult {
 			random:      common.Hash{},
 			withdrawals: withdrawal,
 			beaconRoot:  nil,
+			slotNum:     slotNum,
 			noTxs:       false,
 		}, false) // we will never make a witness for a pending block
 	if ret.err != nil {


### PR DESCRIPTION
## Summary

Same fix as #34790, cherry-picked onto `glamsterdam-devnet-0`. The `getPending`/`prepareWork` code paths are identical on both branches, so this branch has the same latent bug: `eth_getBalance(addr, "pending")` returns `-32000 "pending state is not available"` once Amsterdam is active because `getPending` never supplies `generateParams.slotNum`.

## Fix

Synthesise a slot number from the parent header (`header.SlotNumber + 1`, falling back to `0` when unset) when `IsAmsterdam(childNumber, timestamp)`. Mirrors the existing Shanghai/withdrawals branch above it. No behavioural change pre-Amsterdam.

## Test plan

- [x] `go build ./miner/...`
- [x] `go test ./miner/...` (existing suite passes)

See #34790 for repro details (observed on bal-devnet-3 with faucet breakage, other ELs unaffected).