### PR TITLE
eth/fetcher: lazy-allocate hashes slice in scheduleFetches

### DIFF
--- a/eth/fetcher/tx_fetcher.go
+++ b/eth/fetcher/tx_fetcher.go
@@ -991,8 +991,10 @@ func (f *TxFetcher) scheduleFetches(timer *mclock.Timer, timeout chan struct{}, 
 		if len(f.announces[peer]) == 0 {
 			return // continue in the for-each
 		}
+		// hashes is allocated lazily: peers that collect no new hashes
+		// (all announces already being fetched) skip the 8KB allocation.
 		var (
-			hashes = make([]common.Hash, 0, maxTxRetrievals)
+			hashes []common.Hash
 			bytes  uint64
 		)
 		f.forEachAnnounce(f.announces[peer], func(hash common.Hash, meta txMetadata) bool {
@@ -1009,6 +1011,9 @@ func (f *TxFetcher) scheduleFetches(timer *mclock.Timer, timeout chan struct{}, 
 			f.alternates[hash] = f.announced[hash]
 			delete(f.announced, hash)
 
+			if hashes == nil {
+				hashes = make([]common.Hash, 0, maxTxRetrievals)
+			}
 			// Accumulate the hash and stop if the limit was reached
 			hashes = append(hashes, hash)
 			if len(hashes) >= maxTxRetrievals {

--- a/eth/fetcher/tx_fetcher.go
+++ b/eth/fetcher/tx_fetcher.go
@@ -991,8 +991,6 @@ func (f *TxFetcher) scheduleFetches(timer *mclock.Timer, timeout chan struct{}, 
 		if len(f.announces[peer]) == 0 {
 			return // continue in the for-each
 		}
-		// hashes is allocated lazily: peers that collect no new hashes
-		// (all announces already being fetched) skip the 8KB allocation.
 		var (
 			hashes []common.Hash
 			bytes  uint64


### PR DESCRIPTION
scheduleFetches.func1 is the biggest allocator in the long-duration profile of my node (11% of total alloc_space). Each peer-iteration pre-allocated `make([]common.Hash, 0, maxTxRetrievals)`, even for peers that end up collecting no new hashes (all their announces were already being fetched by someone else).

Defer the slice allocation to the first append. Peers that collect zero hashes now pay zero allocation, which is the common case on the timeoutTrigger path where all peers with any announces are iterated.

This will yield decent gains because the zero hashes case is the norm:

```
func1    cum alloc_space: 291.94 GB   ← entire closure (mostly hashes slice)
func1.2  cum alloc_space:   2.22 GB   ← the `go func(){fetchTxs}` goroutine
                                           — only launched when len(hashes) > 0
```