### PR TITLE
cmd/blsync: use default jwt secret path when datadir is set

### DIFF
--- a/cmd/blsync/main.go
+++ b/cmd/blsync/main.go
@@ -45,6 +45,7 @@ func main() {
 		utils.BeaconCheckpointFlag,
 		utils.BeaconCheckpointFileFlag,
 		utils.DataDirFlag,
+		//TODO datadir for optional permanent database
 		utils.MainnetFlag,
 		utils.SepoliaFlag,
 		utils.HoleskyFlag,

--- a/cmd/blsync/main.go
+++ b/cmd/blsync/main.go
@@ -44,7 +44,7 @@ func main() {
 		utils.BeaconGenesisTimeFlag,
 		utils.BeaconCheckpointFlag,
 		utils.BeaconCheckpointFileFlag,
-		//TODO datadir for optional permanent database
+		utils.DataDirFlag,
 		utils.MainnetFlag,
 		utils.SepoliaFlag,
 		utils.HoleskyFlag,
@@ -87,11 +87,15 @@ func makeRPCClient(ctx *cli.Context) *rpc.Client {
 		log.Warn("No engine API target specified, performing a dry run")
 		return nil
 	}
-	if !ctx.IsSet(utils.BlsyncJWTSecretFlag.Name) {
-		utils.Fatalf("JWT secret parameter missing") //TODO use default if datadir is specified
+	jwtFileName := ctx.String(utils.BlsyncJWTSecretFlag.Name)
+	if jwtFileName == "" && ctx.IsSet(utils.DataDirFlag.Name) {
+		jwtFileName = (&node.Config{Name: "geth", DataDir: ctx.String(utils.DataDirFlag.Name)}).ResolvePath("jwtsecret")
+	}
+	if jwtFileName == "" {
+		utils.Fatalf("JWT secret parameter missing")
 	}
 
-	engineApiUrl, jwtFileName := ctx.String(utils.BlsyncApiFlag.Name), ctx.String(utils.BlsyncJWTSecretFlag.Name)
+	engineApiUrl := ctx.String(utils.BlsyncApiFlag.Name)
 	var jwtSecret [32]byte
 	if jwt, err := node.ObtainJWTSecret(jwtFileName); err == nil {
 		copy(jwtSecret[:], jwt)


### PR DESCRIPTION
## Summary
- add `--datadir` support to `cmd/blsync`
- fall back to the default geth JWT secret path when `--blsync.jwtsecret` is unset
- preserve the separate TODO for future permanent database support

## Why
`cmd/blsync` previously required `--blsync.jwtsecret` whenever an engine API target was configured, even when a datadir was already available and geth's default JWT secret path could be derived from it.

## Validation
- not run in this environment because the Go toolchain (`go`, `gofmt`, `goimports`) was not available on `PATH`
