### PR TITLE
cmd, core, internal, miner: wrap pre/post-execution

### DIFF
--- a/cmd/evm/internal/t8ntool/execution.go
+++ b/cmd/evm/internal/t8ntool/execution.go
@@ -17,6 +17,7 @@
 package t8ntool
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	stdmath "math"
@@ -331,27 +332,14 @@ func (pre *Prestate) Apply(vmConfig vm.Config, chainConfig *params.ChainConfig, 
 	}
 
 	// Gather the execution-layer triggered requests.
-	var requests [][]byte
-	if chainConfig.IsPrague(vmContext.BlockNumber, vmContext.Time) {
-		requests = [][]byte{}
-		// EIP-6110
-		var allLogs []*types.Log
-		for _, receipt := range receipts {
-			allLogs = append(allLogs, receipt.Logs...)
-		}
-		if err := core.ParseDepositLogs(&requests, allLogs, chainConfig); err != nil {
-			return nil, nil, nil, NewError(ErrorEVM, fmt.Errorf("could not parse requests logs: %v", err))
-		}
-		// EIP-7002
-		if err := core.ProcessWithdrawalQueue(&requests, evm); err != nil {
-			return nil, nil, nil, NewError(ErrorEVM, fmt.Errorf("could not process withdrawal requests: %v", err))
-		}
-		// EIP-7251
-		if err := core.ProcessConsolidationQueue(&requests, evm); err != nil {
-			return nil, nil, nil, NewError(ErrorEVM, fmt.Errorf("could not process consolidation requests: %v", err))
-		}
+	var allLogs []*types.Log
+	for _, receipt := range receipts {
+		allLogs = append(allLogs, receipt.Logs...)
 	}
-
+	requests, err := core.PostExecution(context.Background(), chainConfig, vmContext.BlockNumber, vmContext.Time, allLogs, evm)
+	if err != nil {
+		return nil, nil, nil, NewError(ErrorEVM, fmt.Errorf("failed to process post-execution: %v", err))
+	}
 	// Commit block
 	root, err := statedb.Commit(vmContext.BlockNumber.Uint64(), chainConfig.IsEIP158(vmContext.BlockNumber), chainConfig.IsCancun(vmContext.BlockNumber, vmContext.Time))
 	if err != nil {

--- a/cmd/evm/internal/t8ntool/execution.go
+++ b/cmd/evm/internal/t8ntool/execution.go
@@ -230,16 +230,17 @@ func (pre *Prestate) Apply(vmConfig vm.Config, chainConfig *params.ChainConfig, 
 		misc.ApplyDAOHardFork(statedb)
 	}
 	evm := vm.NewEVM(vmContext, statedb, chainConfig, vmConfig)
-	if beaconRoot := pre.Env.ParentBeaconBlockRoot; beaconRoot != nil {
-		core.ProcessBeaconBlockRoot(*beaconRoot, evm)
-	}
+
+	var (
+		prevNumber uint64
+		prevHash   common.Hash
+	)
 	if pre.Env.BlockHashes != nil && chainConfig.IsPrague(new(big.Int).SetUint64(pre.Env.Number), pre.Env.Timestamp) {
-		var (
-			prevNumber = pre.Env.Number - 1
-			prevHash   = pre.Env.BlockHashes[math.HexOrDecimal64(prevNumber)]
-		)
-		core.ProcessParentBlockHash(prevHash, evm)
+		prevNumber = pre.Env.Number - 1
+		prevHash = pre.Env.BlockHashes[math.HexOrDecimal64(prevNumber)]
 	}
+	core.PreExecution(context.Background(), pre.Env.ParentBeaconBlockRoot, prevHash, chainConfig, evm, vmContext.BlockNumber, vmContext.Time)
+
 	for i := 0; txIt.Next(); i++ {
 		tx, err := txIt.Tx()
 		if err != nil {

--- a/cmd/evm/internal/t8ntool/execution.go
+++ b/cmd/evm/internal/t8ntool/execution.go
@@ -230,17 +230,16 @@ func (pre *Prestate) Apply(vmConfig vm.Config, chainConfig *params.ChainConfig, 
 		misc.ApplyDAOHardFork(statedb)
 	}
 	evm := vm.NewEVM(vmContext, statedb, chainConfig, vmConfig)
-
-	var (
-		prevNumber uint64
-		prevHash   common.Hash
-	)
-	if pre.Env.BlockHashes != nil && chainConfig.IsPrague(new(big.Int).SetUint64(pre.Env.Number), pre.Env.Timestamp) {
-		prevNumber = pre.Env.Number - 1
-		prevHash = pre.Env.BlockHashes[math.HexOrDecimal64(prevNumber)]
+	if beaconRoot := pre.Env.ParentBeaconBlockRoot; beaconRoot != nil {
+		core.ProcessBeaconBlockRoot(*beaconRoot, evm)
 	}
-	core.PreExecution(context.Background(), pre.Env.ParentBeaconBlockRoot, prevHash, chainConfig, evm, vmContext.BlockNumber, vmContext.Time)
-
+	if pre.Env.BlockHashes != nil && chainConfig.IsPrague(new(big.Int).SetUint64(pre.Env.Number), pre.Env.Timestamp) {
+		var (
+			prevNumber = pre.Env.Number - 1
+			prevHash   = pre.Env.BlockHashes[math.HexOrDecimal64(prevNumber)]
+		)
+		core.ProcessParentBlockHash(prevHash, evm)
+	}
 	for i := 0; txIt.Next(); i++ {
 		tx, err := txIt.Tx()
 		if err != nil {

--- a/core/chain_makers.go
+++ b/core/chain_makers.go
@@ -17,6 +17,7 @@
 package core
 
 import (
+	"context"
 	"fmt"
 	"math/big"
 
@@ -314,28 +315,18 @@ func (b *BlockGen) collectRequests(readonly bool) (requests [][]byte) {
 		// off the statedb before executing the system calls.
 		statedb = statedb.Copy()
 	}
-
-	if b.cm.config.IsPrague(b.header.Number, b.header.Time) {
-		requests = [][]byte{}
-		// EIP-6110 deposits
-		var blockLogs []*types.Log
-		for _, r := range b.receipts {
-			blockLogs = append(blockLogs, r.Logs...)
-		}
-		if err := ParseDepositLogs(&requests, blockLogs, b.cm.config); err != nil {
-			panic(fmt.Sprintf("failed to parse deposit log: %v", err))
-		}
-		// create EVM for system calls
-		blockContext := NewEVMBlockContext(b.header, b.cm, &b.header.Coinbase)
-		evm := vm.NewEVM(blockContext, statedb, b.cm.config, vm.Config{})
-		// EIP-7002
-		if err := ProcessWithdrawalQueue(&requests, evm); err != nil {
-			panic(fmt.Sprintf("could not process withdrawal requests: %v", err))
-		}
-		// EIP-7251
-		if err := ProcessConsolidationQueue(&requests, evm); err != nil {
-			panic(fmt.Sprintf("could not process consolidation requests: %v", err))
-		}
+	// EIP-6110 deposits
+	var blockLogs []*types.Log
+	for _, r := range b.receipts {
+		blockLogs = append(blockLogs, r.Logs...)
+	}
+	// TODO(rjl493456442) the EVM instance should be shared across the entire
+	// generation life cycle.
+	blockContext := NewEVMBlockContext(b.header, b.cm, &b.header.Coinbase)
+	evm := vm.NewEVM(blockContext, statedb, b.cm.config, vm.Config{})
+	requests, err := PostExecution(context.Background(), b.cm.config, b.header.Number, b.header.Time, blockLogs, evm)
+	if err != nil {
+		panic(fmt.Sprintf("failed to run post-execution: %v", err))
 	}
 	return requests
 }

--- a/core/chain_makers.go
+++ b/core/chain_makers.go
@@ -315,15 +315,14 @@ func (b *BlockGen) collectRequests(readonly bool) (requests [][]byte) {
 		// off the statedb before executing the system calls.
 		statedb = statedb.Copy()
 	}
-	// EIP-6110 deposits
 	var blockLogs []*types.Log
 	for _, r := range b.receipts {
 		blockLogs = append(blockLogs, r.Logs...)
 	}
-	// TODO(rjl493456442) the EVM instance should be shared across the entire
-	// generation life cycle.
+	// TODO use the shared EVM throughout the entire generation cycle
 	blockContext := NewEVMBlockContext(b.header, b.cm, &b.header.Coinbase)
 	evm := vm.NewEVM(blockContext, statedb, b.cm.config, vm.Config{})
+
 	requests, err := PostExecution(context.Background(), b.cm.config, b.header.Number, b.header.Time, blockLogs, evm)
 	if err != nil {
 		panic(fmt.Sprintf("failed to run post-execution: %v", err))

--- a/core/state_processor.go
+++ b/core/state_processor.go
@@ -81,21 +81,13 @@ func (p *StateProcessor) Process(ctx context.Context, block *types.Block, stated
 		misc.ApplyDAOHardFork(tracingStateDB)
 	}
 	var (
-		context vm.BlockContext
+		context = NewEVMBlockContext(header, p.chain, nil)
 		signer  = types.MakeSigner(config, header.Number, header.Time)
+		evm     = vm.NewEVM(context, tracingStateDB, config, cfg)
 	)
-
-	// Apply pre-execution system calls.
-	context = NewEVMBlockContext(header, p.chain, nil)
-	evm := vm.NewEVM(context, tracingStateDB, config, cfg)
 	defer evm.Release()
-
-	if beaconRoot := block.BeaconRoot(); beaconRoot != nil {
-		ProcessBeaconBlockRoot(*beaconRoot, evm)
-	}
-	if config.IsPrague(block.Number(), block.Time()) || config.IsUBT(block.Number(), block.Time()) {
-		ProcessParentBlockHash(block.ParentHash(), evm)
-	}
+	// Run the pre-execution system calls
+	PreExecution(ctx, block.BeaconRoot(), block.ParentHash(), config, evm, block.Number(), block.Time())
 
 	// Iterate over and process the individual transactions
 	for i, tx := range block.Transactions() {
@@ -118,6 +110,7 @@ func (p *StateProcessor) Process(ctx context.Context, block *types.Block, stated
 		allLogs = append(allLogs, receipt.Logs...)
 		spanEnd(nil)
 	}
+	// Run the post-execution system calls
 	requests, err := PostExecution(ctx, config, block.Number(), block.Time(), allLogs, evm)
 	if err != nil {
 		return nil, err
@@ -131,6 +124,19 @@ func (p *StateProcessor) Process(ctx context.Context, block *types.Block, stated
 		Logs:     allLogs,
 		GasUsed:  gp.Used(),
 	}, nil
+}
+
+// PreExecution processes pre-execution system calls.
+func PreExecution(ctx context.Context, beaconRoot *common.Hash, parent common.Hash, config *params.ChainConfig, evm *vm.EVM, number *big.Int, time uint64) {
+	_, _, spanEnd := telemetry.StartSpan(ctx, "core.preExecution")
+	defer spanEnd(nil)
+
+	if beaconRoot != nil {
+		ProcessBeaconBlockRoot(*beaconRoot, evm)
+	}
+	if config.IsPrague(number, time) || config.IsUBT(number, time) {
+		ProcessParentBlockHash(parent, evm)
+	}
 }
 
 // PostExecution processes post-execution system calls when Prague is enabled.

--- a/core/state_processor.go
+++ b/core/state_processor.go
@@ -132,7 +132,6 @@ func PreExecution(ctx context.Context, beaconRoot *common.Hash, parent common.Ha
 	defer spanEnd(nil)
 
 	// EIP-4788
-	// TODO(rjl) it should be enforced if cancun is enabled
 	if beaconRoot != nil {
 		ProcessBeaconBlockRoot(*beaconRoot, evm)
 	}

--- a/core/state_processor.go
+++ b/core/state_processor.go
@@ -86,9 +86,7 @@ func (p *StateProcessor) Process(ctx context.Context, block *types.Block, stated
 	)
 	defer evm.Release()
 	// Run the pre-execution system calls
-	if err := PreExecution(ctx, block.BeaconRoot(), block.ParentHash(), config, evm, block.Number(), block.Time()); err != nil {
-		return nil, err
-	}
+	PreExecution(ctx, block.BeaconRoot(), block.ParentHash(), config, evm, block.Number(), block.Time())
 	// Iterate over and process the individual transactions
 	for i, tx := range block.Transactions() {
 		msg, err := TransactionToMessage(tx, signer, header.BaseFee)
@@ -127,7 +125,7 @@ func (p *StateProcessor) Process(ctx context.Context, block *types.Block, stated
 }
 
 // PreExecution processes pre-execution system calls.
-func PreExecution(ctx context.Context, beaconRoot *common.Hash, parent common.Hash, config *params.ChainConfig, evm *vm.EVM, number *big.Int, time uint64) error {
+func PreExecution(ctx context.Context, beaconRoot *common.Hash, parent common.Hash, config *params.ChainConfig, evm *vm.EVM, number *big.Int, time uint64) {
 	_, _, spanEnd := telemetry.StartSpan(ctx, "core.preExecution")
 	defer spanEnd(nil)
 
@@ -139,7 +137,6 @@ func PreExecution(ctx context.Context, beaconRoot *common.Hash, parent common.Ha
 	if config.IsPrague(number, time) || config.IsUBT(number, time) {
 		ProcessParentBlockHash(parent, evm)
 	}
-	return nil
 }
 
 // PostExecution processes post-execution system calls when Prague is enabled.

--- a/core/state_processor.go
+++ b/core/state_processor.go
@@ -75,7 +75,6 @@ func (p *StateProcessor) Process(ctx context.Context, block *types.Block, stated
 	if hooks := cfg.Tracer; hooks != nil {
 		tracingStateDB = state.NewHookedState(statedb, hooks)
 	}
-
 	// Mutate the block and state according to any hard-fork specs
 	if config.DAOForkSupport && config.DAOForkBlock != nil && config.DAOForkBlock.Cmp(block.Number()) == 0 {
 		misc.ApplyDAOHardFork(tracingStateDB)
@@ -87,8 +86,9 @@ func (p *StateProcessor) Process(ctx context.Context, block *types.Block, stated
 	)
 	defer evm.Release()
 	// Run the pre-execution system calls
-	PreExecution(ctx, block.BeaconRoot(), block.ParentHash(), config, evm, block.Number(), block.Time())
-
+	if err := PreExecution(ctx, block.BeaconRoot(), block.ParentHash(), config, evm, block.Number(), block.Time()); err != nil {
+		return nil, err
+	}
 	// Iterate over and process the individual transactions
 	for i, tx := range block.Transactions() {
 		msg, err := TransactionToMessage(tx, signer, header.BaseFee)
@@ -127,16 +127,20 @@ func (p *StateProcessor) Process(ctx context.Context, block *types.Block, stated
 }
 
 // PreExecution processes pre-execution system calls.
-func PreExecution(ctx context.Context, beaconRoot *common.Hash, parent common.Hash, config *params.ChainConfig, evm *vm.EVM, number *big.Int, time uint64) {
+func PreExecution(ctx context.Context, beaconRoot *common.Hash, parent common.Hash, config *params.ChainConfig, evm *vm.EVM, number *big.Int, time uint64) error {
 	_, _, spanEnd := telemetry.StartSpan(ctx, "core.preExecution")
 	defer spanEnd(nil)
 
+	// EIP-4788
+	// TODO(rjl) it should be enforced if cancun is enabled
 	if beaconRoot != nil {
 		ProcessBeaconBlockRoot(*beaconRoot, evm)
 	}
+	// EIP-2935
 	if config.IsPrague(number, time) || config.IsUBT(number, time) {
 		ProcessParentBlockHash(parent, evm)
 	}
+	return nil
 }
 
 // PostExecution processes post-execution system calls when Prague is enabled.

--- a/core/state_processor.go
+++ b/core/state_processor.go
@@ -118,11 +118,10 @@ func (p *StateProcessor) Process(ctx context.Context, block *types.Block, stated
 		allLogs = append(allLogs, receipt.Logs...)
 		spanEnd(nil)
 	}
-	requests, err := postExecution(ctx, config, block, allLogs, evm)
+	requests, err := PostExecution(ctx, config, block.Number(), block.Time(), allLogs, evm)
 	if err != nil {
 		return nil, err
 	}
-
 	// Finalize the block, applying any consensus engine specific extras (e.g. block rewards)
 	p.chain.Engine().Finalize(p.chain, header, tracingStateDB, block.Body())
 
@@ -134,28 +133,29 @@ func (p *StateProcessor) Process(ctx context.Context, block *types.Block, stated
 	}, nil
 }
 
-// postExecution processes the post-execution system calls if Prague is enabled.
-func postExecution(ctx context.Context, config *params.ChainConfig, block *types.Block, allLogs []*types.Log, evm *vm.EVM) (requests [][]byte, err error) {
+// PostExecution processes post-execution system calls when Prague is enabled.
+// If Prague is not activated, it returns null requests to differentiate from
+// empty requests.
+func PostExecution(ctx context.Context, config *params.ChainConfig, number *big.Int, time uint64, allLogs []*types.Log, evm *vm.EVM) (requests [][]byte, err error) {
 	_, _, spanEnd := telemetry.StartSpan(ctx, "core.postExecution")
 	defer spanEnd(&err)
 
 	// Read requests if Prague is enabled.
-	if config.IsPrague(block.Number(), block.Time()) {
+	if config.IsPrague(number, time) {
 		requests = [][]byte{}
 		// EIP-6110
 		if err := ParseDepositLogs(&requests, allLogs, config); err != nil {
-			return requests, fmt.Errorf("failed to parse deposit logs: %w", err)
+			return nil, fmt.Errorf("failed to parse deposit logs: %w", err)
 		}
 		// EIP-7002
 		if err := ProcessWithdrawalQueue(&requests, evm); err != nil {
-			return requests, fmt.Errorf("failed to process withdrawal queue: %w", err)
+			return nil, fmt.Errorf("failed to process withdrawal queue: %w", err)
 		}
 		// EIP-7251
 		if err := ProcessConsolidationQueue(&requests, evm); err != nil {
-			return requests, fmt.Errorf("failed to process consolidation queue: %w", err)
+			return nil, fmt.Errorf("failed to process consolidation queue: %w", err)
 		}
 	}
-
 	return requests, nil
 }
 

--- a/eth/state_accessor.go
+++ b/eth/state_accessor.go
@@ -248,13 +248,10 @@ func (eth *Ethereum) stateAtTransaction(ctx context.Context, block *types.Block,
 	context := core.NewEVMBlockContext(block.Header(), eth.blockchain, nil)
 	evm := vm.NewEVM(context, statedb, eth.blockchain.Config(), vm.Config{})
 	defer evm.Release()
-	if beaconRoot := block.BeaconRoot(); beaconRoot != nil {
-		core.ProcessBeaconBlockRoot(*beaconRoot, evm)
-	}
-	// If prague hardfork, insert parent block hash in the state as per EIP-2935.
-	if eth.blockchain.Config().IsPrague(block.Number(), block.Time()) {
-		core.ProcessParentBlockHash(block.ParentHash(), evm)
-	}
+
+	// Run pre-execution system calls
+	core.PreExecution(ctx, block.BeaconRoot(), block.ParentHash(), eth.blockchain.Config(), evm, block.Number(), block.Time())
+
 	if txIndex == 0 && len(block.Transactions()) == 0 {
 		return nil, context, statedb, release, nil
 	}

--- a/eth/state_accessor.go
+++ b/eth/state_accessor.go
@@ -250,9 +250,8 @@ func (eth *Ethereum) stateAtTransaction(ctx context.Context, block *types.Block,
 	defer evm.Release()
 
 	// Run pre-execution system calls
-	if err := core.PreExecution(ctx, block.BeaconRoot(), block.ParentHash(), eth.blockchain.Config(), evm, block.Number(), block.Time()); err != nil {
-		return nil, vm.BlockContext{}, nil, nil, err
-	}
+	core.PreExecution(ctx, block.BeaconRoot(), block.ParentHash(), eth.blockchain.Config(), evm, block.Number(), block.Time())
+
 	if txIndex == 0 && len(block.Transactions()) == 0 {
 		return nil, context, statedb, release, nil
 	}

--- a/eth/state_accessor.go
+++ b/eth/state_accessor.go
@@ -250,8 +250,10 @@ func (eth *Ethereum) stateAtTransaction(ctx context.Context, block *types.Block,
 	defer evm.Release()
 
 	// Run pre-execution system calls
-	core.PreExecution(ctx, block.BeaconRoot(), block.ParentHash(), eth.blockchain.Config(), evm, block.Number(), block.Time())
+	if err := core.PreExecution(ctx, block.BeaconRoot(), block.ParentHash(), eth.blockchain.Config(), evm, block.Number(), block.Time()); err != nil {
+		return nil, vm.BlockContext{}, nil, nil, err
 
+	}
 	if txIndex == 0 && len(block.Transactions()) == 0 {
 		return nil, context, statedb, release, nil
 	}

--- a/eth/state_accessor.go
+++ b/eth/state_accessor.go
@@ -252,7 +252,6 @@ func (eth *Ethereum) stateAtTransaction(ctx context.Context, block *types.Block,
 	// Run pre-execution system calls
 	if err := core.PreExecution(ctx, block.BeaconRoot(), block.ParentHash(), eth.blockchain.Config(), evm, block.Number(), block.Time()); err != nil {
 		return nil, vm.BlockContext{}, nil, nil, err
-
 	}
 	if txIndex == 0 && len(block.Transactions()) == 0 {
 		return nil, context, statedb, release, nil

--- a/eth/tracers/api.go
+++ b/eth/tracers/api.go
@@ -520,7 +520,6 @@ func (api *API) IntermediateRoots(ctx context.Context, hash common.Hash, config 
 		vmctx              = core.NewEVMBlockContext(block.Header(), api.chainContext(ctx), nil)
 		deleteEmptyObjects = chainConfig.IsEIP158(block.Number())
 		evm                = vm.NewEVM(vmctx, statedb, chainConfig, vm.Config{})
-		logs               []*types.Log
 	)
 	defer evm.Release()
 	// Run pre-execution system calls
@@ -545,7 +544,6 @@ func (api *API) IntermediateRoots(ctx context.Context, hash common.Hash, config 
 		// Calling IntermediateRoot will internally call Finalize on the state
 		// so any modifications are written to the trie
 		roots = append(roots, statedb.IntermediateRoot(deleteEmptyObjects))
-		logs = append(logs, statedb.GetLogs(tx.Hash(), block.NumberU64(), block.Hash(), block.Time())...)
 	}
 	return roots, nil
 }

--- a/eth/tracers/api.go
+++ b/eth/tracers/api.go
@@ -551,10 +551,6 @@ func (api *API) IntermediateRoots(ctx context.Context, hash common.Hash, config 
 		roots = append(roots, statedb.IntermediateRoot(deleteEmptyObjects))
 		logs = append(logs, statedb.GetLogs(tx.Hash(), block.NumberU64(), block.Hash(), block.Time())...)
 	}
-	// TODO(rjl) it's a behavioral change, need to discuss with team
-	// Run post-execution system calls
-	// core.PostExecution(ctx, chainConfig, block.Number(), block.Time(), logs, evm)
-	// roots = append(roots, statedb.IntermediateRoot(deleteEmptyObjects))
 	return roots, nil
 }
 

--- a/eth/tracers/api.go
+++ b/eth/tracers/api.go
@@ -372,6 +372,7 @@ func (api *API) traceChain(start, end *types.Block, config *TraceConfig, closed 
 			// as per EIP-4788.
 			context := core.NewEVMBlockContext(next.Header(), api.chainContext(ctx), nil)
 			evm := vm.NewEVM(context, statedb, api.backend.ChainConfig(), vm.Config{})
+
 			if beaconRoot := next.BeaconRoot(); beaconRoot != nil {
 				core.ProcessBeaconBlockRoot(*beaconRoot, evm)
 			}

--- a/eth/tracers/api.go
+++ b/eth/tracers/api.go
@@ -372,12 +372,9 @@ func (api *API) traceChain(start, end *types.Block, config *TraceConfig, closed 
 			// as per EIP-4788.
 			context := core.NewEVMBlockContext(next.Header(), api.chainContext(ctx), nil)
 			evm := vm.NewEVM(context, statedb, api.backend.ChainConfig(), vm.Config{})
+			defer evm.Release()
 
-			if err := core.PreExecution(ctx, next.BeaconRoot(), next.ParentHash(), api.backend.ChainConfig(), evm, next.Number(), next.Time()); err != nil {
-				failed = err
-				break
-			}
-			evm.Release()
+			core.PreExecution(ctx, next.BeaconRoot(), next.ParentHash(), api.backend.ChainConfig(), evm, next.Number(), next.Time())
 			// Clean out any pending release functions of trace state. Note this
 			// step must be done after constructing tracing state, because the
 			// tracing state of block next depends on the parent state and construction
@@ -527,9 +524,8 @@ func (api *API) IntermediateRoots(ctx context.Context, hash common.Hash, config 
 	)
 	defer evm.Release()
 	// Run pre-execution system calls
-	if err := core.PreExecution(ctx, block.BeaconRoot(), block.ParentHash(), chainConfig, evm, block.Number(), block.Time()); err != nil {
-		return nil, err
-	}
+	core.PreExecution(ctx, block.BeaconRoot(), block.ParentHash(), chainConfig, evm, block.Number(), block.Time())
+
 	for i, tx := range block.Transactions() {
 		if err := ctx.Err(); err != nil {
 			return nil, err
@@ -588,9 +584,8 @@ func (api *API) traceBlock(ctx context.Context, block *types.Block, config *Trac
 	defer evm.Release()
 
 	// Run pre-execution system calls
-	if err := core.PreExecution(ctx, block.BeaconRoot(), block.ParentHash(), api.backend.ChainConfig(), evm, block.Number(), block.Time()); err != nil {
-		return nil, err
-	}
+	core.PreExecution(ctx, block.BeaconRoot(), block.ParentHash(), api.backend.ChainConfig(), evm, block.Number(), block.Time())
+
 	// JS tracers have high overhead. In this case run a parallel
 	// process that generates states in one thread and traces txes
 	// in separate worker threads.
@@ -761,9 +756,8 @@ func (api *API) standardTraceBlockToFile(ctx context.Context, block *types.Block
 	defer evm.Release()
 
 	// Run pre-execution system calls
-	if err := core.PreExecution(ctx, block.BeaconRoot(), block.ParentHash(), chainConfig, evm, block.Number(), block.Time()); err != nil {
-		return nil, err
-	}
+	core.PreExecution(ctx, block.BeaconRoot(), block.ParentHash(), chainConfig, evm, block.Number(), block.Time())
+
 	for i, tx := range block.Transactions() {
 		// Prepare the transaction for un-traced execution
 		msg, _ := core.TransactionToMessage(tx, signer, block.BaseFee())

--- a/eth/tracers/api.go
+++ b/eth/tracers/api.go
@@ -373,12 +373,9 @@ func (api *API) traceChain(start, end *types.Block, config *TraceConfig, closed 
 			context := core.NewEVMBlockContext(next.Header(), api.chainContext(ctx), nil)
 			evm := vm.NewEVM(context, statedb, api.backend.ChainConfig(), vm.Config{})
 
-			if beaconRoot := next.BeaconRoot(); beaconRoot != nil {
-				core.ProcessBeaconBlockRoot(*beaconRoot, evm)
-			}
-			// Insert parent hash in history contract.
-			if api.backend.ChainConfig().IsPrague(next.Number(), next.Time()) {
-				core.ProcessParentBlockHash(next.ParentHash(), evm)
+			if err := core.PreExecution(ctx, next.BeaconRoot(), next.ParentHash(), api.backend.ChainConfig(), evm, next.Number(), next.Time()); err != nil {
+				failed = err
+				break
 			}
 			evm.Release()
 			// Clean out any pending release functions of trace state. Note this
@@ -495,8 +492,8 @@ func (api *API) StandardTraceBlockToFile(ctx context.Context, hash common.Hash, 
 	return api.standardTraceBlockToFile(ctx, block, config)
 }
 
-// IntermediateRoots executes a block (bad- or canon- or side-), and returns a list
-// of intermediate roots: the stateroot after each transaction.
+// IntermediateRoots executes a block, and returns a list of intermediate roots:
+// the stateroot after each transaction.
 func (api *API) IntermediateRoots(ctx context.Context, hash common.Hash, config *TraceConfig) ([]common.Hash, error) {
 	block, _ := api.blockByHash(ctx, hash)
 	if block == nil {
@@ -518,20 +515,20 @@ func (api *API) IntermediateRoots(ctx context.Context, hash common.Hash, config 
 		return nil, err
 	}
 	defer release()
+
 	var (
 		roots              []common.Hash
 		signer             = types.MakeSigner(api.backend.ChainConfig(), block.Number(), block.Time())
 		chainConfig        = api.backend.ChainConfig()
 		vmctx              = core.NewEVMBlockContext(block.Header(), api.chainContext(ctx), nil)
 		deleteEmptyObjects = chainConfig.IsEIP158(block.Number())
+		evm                = vm.NewEVM(vmctx, statedb, chainConfig, vm.Config{})
+		logs               []*types.Log
 	)
-	evm := vm.NewEVM(vmctx, statedb, chainConfig, vm.Config{})
 	defer evm.Release()
-	if beaconRoot := block.BeaconRoot(); beaconRoot != nil {
-		core.ProcessBeaconBlockRoot(*beaconRoot, evm)
-	}
-	if chainConfig.IsPrague(block.Number(), block.Time()) {
-		core.ProcessParentBlockHash(block.ParentHash(), evm)
+	// Run pre-execution system calls
+	if err := core.PreExecution(ctx, block.BeaconRoot(), block.ParentHash(), chainConfig, evm, block.Number(), block.Time()); err != nil {
+		return nil, err
 	}
 	for i, tx := range block.Transactions() {
 		if err := ctx.Err(); err != nil {
@@ -549,10 +546,15 @@ func (api *API) IntermediateRoots(ctx context.Context, hash common.Hash, config 
 			// N.B: This should never happen while tracing canon blocks, only when tracing bad blocks.
 			return roots, nil
 		}
-		// calling IntermediateRoot will internally call Finalize on the state
+		// Calling IntermediateRoot will internally call Finalize on the state
 		// so any modifications are written to the trie
 		roots = append(roots, statedb.IntermediateRoot(deleteEmptyObjects))
+		logs = append(logs, statedb.GetLogs(tx.Hash(), block.NumberU64(), block.Hash(), block.Time())...)
 	}
+	// TODO(rjl) it's a behavioral change, need to discuss with team
+	// Run post-execution system calls
+	// core.PostExecution(ctx, chainConfig, block.Number(), block.Time(), logs, evm)
+	// roots = append(roots, statedb.IntermediateRoot(deleteEmptyObjects))
 	return roots, nil
 }
 
@@ -588,13 +590,11 @@ func (api *API) traceBlock(ctx context.Context, block *types.Block, config *Trac
 	blockCtx := core.NewEVMBlockContext(block.Header(), api.chainContext(ctx), nil)
 	evm := vm.NewEVM(blockCtx, statedb, api.backend.ChainConfig(), vm.Config{})
 	defer evm.Release()
-	if beaconRoot := block.BeaconRoot(); beaconRoot != nil {
-		core.ProcessBeaconBlockRoot(*beaconRoot, evm)
-	}
-	if api.backend.ChainConfig().IsPrague(block.Number(), block.Time()) {
-		core.ProcessParentBlockHash(block.ParentHash(), evm)
-	}
 
+	// Run pre-execution system calls
+	if err := core.PreExecution(ctx, block.BeaconRoot(), block.ParentHash(), api.backend.ChainConfig(), evm, block.Number(), block.Time()); err != nil {
+		return nil, err
+	}
 	// JS tracers have high overhead. In this case run a parallel
 	// process that generates states in one thread and traces txes
 	// in separate worker threads.
@@ -761,14 +761,12 @@ func (api *API) standardTraceBlockToFile(ctx context.Context, block *types.Block
 		// Note: This copies the config, to not screw up the main config
 		chainConfig, canon = overrideConfig(chainConfig, config.Overrides)
 	}
-
 	evm := vm.NewEVM(vmctx, statedb, chainConfig, vm.Config{})
 	defer evm.Release()
-	if beaconRoot := block.BeaconRoot(); beaconRoot != nil {
-		core.ProcessBeaconBlockRoot(*beaconRoot, evm)
-	}
-	if chainConfig.IsPrague(block.Number(), block.Time()) {
-		core.ProcessParentBlockHash(block.ParentHash(), evm)
+
+	// Run pre-execution system calls
+	if err := core.PreExecution(ctx, block.BeaconRoot(), block.ParentHash(), chainConfig, evm, block.Number(), block.Time()); err != nil {
+		return nil, err
 	}
 	for i, tx := range block.Transactions() {
 		// Prepare the transaction for un-traced execution
@@ -796,6 +794,7 @@ func (api *API) standardTraceBlockToFile(ctx context.Context, block *types.Block
 			return nil, err
 		}
 		dumps = append(dumps, dump.Name())
+
 		// Set up the tracer and EVM for the transaction.
 		var (
 			writer = bufio.NewWriter(dump)

--- a/eth/tracers/api.go
+++ b/eth/tracers/api.go
@@ -372,9 +372,9 @@ func (api *API) traceChain(start, end *types.Block, config *TraceConfig, closed 
 			// as per EIP-4788.
 			context := core.NewEVMBlockContext(next.Header(), api.chainContext(ctx), nil)
 			evm := vm.NewEVM(context, statedb, api.backend.ChainConfig(), vm.Config{})
-			defer evm.Release()
 
 			core.PreExecution(ctx, next.BeaconRoot(), next.ParentHash(), api.backend.ChainConfig(), evm, next.Number(), next.Time())
+			evm.Release()
 			// Clean out any pending release functions of trace state. Note this
 			// step must be done after constructing tracing state, because the
 			// tracing state of block next depends on the parent state and construction

--- a/internal/ethapi/simulate.go
+++ b/internal/ethapi/simulate.go
@@ -319,8 +319,9 @@ func (sim *simulator) processBlock(ctx context.Context, block *simBlock, header,
 		evm.SetPrecompiles(precompiles)
 	}
 	// Run pre-execution system calls
-	core.PreExecution(ctx, header.ParentBeaconRoot, header.ParentHash, sim.chainConfig, evm, header.Number, header.Time)
-
+	if err := core.PreExecution(ctx, header.ParentBeaconRoot, header.ParentHash, sim.chainConfig, evm, header.Number, header.Time); err != nil {
+		return nil, nil, nil, err
+	}
 	var allLogs []*types.Log
 	for i, call := range block.Calls {
 		// Terminate if the context is cancelled

--- a/internal/ethapi/simulate.go
+++ b/internal/ethapi/simulate.go
@@ -318,12 +318,9 @@ func (sim *simulator) processBlock(ctx context.Context, block *simBlock, header,
 	if precompiles != nil {
 		evm.SetPrecompiles(precompiles)
 	}
-	if sim.chainConfig.IsPrague(header.Number, header.Time) || sim.chainConfig.IsUBT(header.Number, header.Time) {
-		core.ProcessParentBlockHash(header.ParentHash, evm)
-	}
-	if header.ParentBeaconRoot != nil {
-		core.ProcessBeaconBlockRoot(*header.ParentBeaconRoot, evm)
-	}
+	// Run pre-execution system calls
+	core.PreExecution(ctx, header.ParentBeaconRoot, header.ParentHash, sim.chainConfig, evm, header.Number, header.Time)
+
 	var allLogs []*types.Log
 	for i, call := range block.Calls {
 		// Terminate if the context is cancelled
@@ -393,7 +390,7 @@ func (sim *simulator) processBlock(ctx context.Context, block *simBlock, header,
 		header.BlobGasUsed = &blobGasUsed
 	}
 
-	// Process EIP-7685 requests
+	// Run post-execution system calls
 	requests, err := core.PostExecution(ctx, sim.chainConfig, header.Number, header.Time, allLogs, evm)
 	if err != nil {
 		return nil, nil, nil, err

--- a/internal/ethapi/simulate.go
+++ b/internal/ethapi/simulate.go
@@ -394,21 +394,9 @@ func (sim *simulator) processBlock(ctx context.Context, block *simBlock, header,
 	}
 
 	// Process EIP-7685 requests
-	var requests [][]byte
-	if sim.chainConfig.IsPrague(header.Number, header.Time) {
-		requests = [][]byte{}
-		// EIP-6110
-		if err := core.ParseDepositLogs(&requests, allLogs, sim.chainConfig); err != nil {
-			return nil, nil, nil, err
-		}
-		// EIP-7002
-		if err := core.ProcessWithdrawalQueue(&requests, evm); err != nil {
-			return nil, nil, nil, err
-		}
-		// EIP-7251
-		if err := core.ProcessConsolidationQueue(&requests, evm); err != nil {
-			return nil, nil, nil, err
-		}
+	requests, err := core.PostExecution(ctx, sim.chainConfig, header.Number, header.Time, allLogs, evm)
+	if err != nil {
+		return nil, nil, nil, err
 	}
 	if requests != nil {
 		reqHash := types.CalcRequestsHash(requests)

--- a/internal/ethapi/simulate.go
+++ b/internal/ethapi/simulate.go
@@ -319,9 +319,8 @@ func (sim *simulator) processBlock(ctx context.Context, block *simBlock, header,
 		evm.SetPrecompiles(precompiles)
 	}
 	// Run pre-execution system calls
-	if err := core.PreExecution(ctx, header.ParentBeaconRoot, header.ParentHash, sim.chainConfig, evm, header.Number, header.Time); err != nil {
-		return nil, nil, nil, err
-	}
+	core.PreExecution(ctx, header.ParentBeaconRoot, header.ParentHash, sim.chainConfig, evm, header.Number, header.Time)
+
 	var allLogs []*types.Log
 	for i, call := range block.Calls {
 		// Terminate if the context is cancelled

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -317,12 +317,8 @@ func (miner *Miner) prepareWork(ctx context.Context, genParams *generateParams, 
 		log.Error("Failed to create sealing context", "err", err)
 		return nil, err
 	}
-	if header.ParentBeaconRoot != nil {
-		core.ProcessBeaconBlockRoot(*header.ParentBeaconRoot, env.evm)
-	}
-	if miner.chainConfig.IsPrague(header.Number, header.Time) {
-		core.ProcessParentBlockHash(header.ParentHash, env.evm)
-	}
+	// Run pre-execution system calls
+	core.PreExecution(ctx, header.ParentBeaconRoot, header.ParentHash, miner.chainConfig, env.evm, header.Number, header.Time)
 	return env, nil
 }
 

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -318,7 +318,9 @@ func (miner *Miner) prepareWork(ctx context.Context, genParams *generateParams, 
 		return nil, err
 	}
 	// Run pre-execution system calls
-	core.PreExecution(ctx, header.ParentBeaconRoot, header.ParentHash, miner.chainConfig, env.evm, header.Number, header.Time)
+	if err := core.PreExecution(ctx, header.ParentBeaconRoot, header.ParentHash, miner.chainConfig, env.evm, header.Number, header.Time); err != nil {
+		return nil, err
+	}
 	return env, nil
 }
 

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -208,21 +208,9 @@ func (miner *Miner) generateWork(ctx context.Context, genParam *generateParams, 
 	}
 
 	// Collect consensus-layer requests if Prague is enabled.
-	var requests [][]byte
-	if miner.chainConfig.IsPrague(work.header.Number, work.header.Time) {
-		requests = [][]byte{}
-		// EIP-6110 deposits
-		if err := core.ParseDepositLogs(&requests, allLogs, miner.chainConfig); err != nil {
-			return &newPayloadResult{err: err}
-		}
-		// EIP-7002
-		if err := core.ProcessWithdrawalQueue(&requests, work.evm); err != nil {
-			return &newPayloadResult{err: err}
-		}
-		// EIP-7251 consolidations
-		if err := core.ProcessConsolidationQueue(&requests, work.evm); err != nil {
-			return &newPayloadResult{err: err}
-		}
+	requests, err := core.PostExecution(ctx, miner.chainConfig, work.header.Number, work.header.Time, allLogs, work.evm)
+	if err != nil {
+		return &newPayloadResult{err: err}
 	}
 	if requests != nil {
 		reqHash := types.CalcRequestsHash(requests)

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -318,9 +318,7 @@ func (miner *Miner) prepareWork(ctx context.Context, genParams *generateParams, 
 		return nil, err
 	}
 	// Run pre-execution system calls
-	if err := core.PreExecution(ctx, header.ParentBeaconRoot, header.ParentHash, miner.chainConfig, env.evm, header.Number, header.Time); err != nil {
-		return nil, err
-	}
+	core.PreExecution(ctx, header.ParentBeaconRoot, header.ParentHash, miner.chainConfig, env.evm, header.Number, header.Time)
 	return env, nil
 }
 


### PR DESCRIPTION
This is a refactoring PR to wrap all pre/post-execution system calls as the exported functions, eliminating the duplicated system calls across the codebase.

There are a few things unchanged but worths highlight:

- ChainMaker is left as unchanged, a significant rewrite is required
- BeaconRoot in header should be non-nil if Cancun is enabled