### PR TITLE
ethclient: add maxUsedGas to simulate call results

### DIFF
--- a/ethclient/ethclient.go
+++ b/ethclient/ethclient.go
@@ -914,6 +914,7 @@ type SimulateCallResult struct {
 	ReturnValue []byte       `json:"returnData"`
 	Logs        []*types.Log `json:"logs"`
 	GasUsed     uint64       `json:"gasUsed"`
+	MaxUsedGas  uint64       `json:"maxUsedGas"`
 	Status      uint64       `json:"status"`
 	Error       *CallError   `json:"error,omitempty"`
 }
@@ -921,6 +922,7 @@ type SimulateCallResult struct {
 type simulateCallResultMarshaling struct {
 	ReturnValue hexutil.Bytes
 	GasUsed     hexutil.Uint64
+	MaxUsedGas  hexutil.Uint64
 	Status      hexutil.Uint64
 }
 

--- a/ethclient/ethclient_test.go
+++ b/ethclient/ethclient_test.go
@@ -861,6 +861,12 @@ func TestSimulateV1(t *testing.T) {
 	if results[0].Calls[0].Error != nil {
 		t.Errorf("expected no error, got %v", results[0].Calls[0].Error)
 	}
+	if results[0].Calls[0].MaxUsedGas == 0 {
+		t.Error("expected maxUsedGas to be set")
+	}
+	if results[0].Calls[0].MaxUsedGas < results[0].Calls[0].GasUsed {
+		t.Errorf("expected maxUsedGas >= gasUsed, got %d < %d", results[0].Calls[0].MaxUsedGas, results[0].Calls[0].GasUsed)
+	}
 }
 
 func TestSimulateV1WithBlockOverrides(t *testing.T) {

--- a/ethclient/gen_simulate_call_result.go
+++ b/ethclient/gen_simulate_call_result.go
@@ -17,6 +17,7 @@ func (s SimulateCallResult) MarshalJSON() ([]byte, error) {
 		ReturnValue hexutil.Bytes  `json:"returnData"`
 		Logs        []*types.Log   `json:"logs"`
 		GasUsed     hexutil.Uint64 `json:"gasUsed"`
+		MaxUsedGas  hexutil.Uint64 `json:"maxUsedGas"`
 		Status      hexutil.Uint64 `json:"status"`
 		Error       *CallError     `json:"error,omitempty"`
 	}
@@ -24,6 +25,7 @@ func (s SimulateCallResult) MarshalJSON() ([]byte, error) {
 	enc.ReturnValue = s.ReturnValue
 	enc.Logs = s.Logs
 	enc.GasUsed = hexutil.Uint64(s.GasUsed)
+	enc.MaxUsedGas = hexutil.Uint64(s.MaxUsedGas)
 	enc.Status = hexutil.Uint64(s.Status)
 	enc.Error = s.Error
 	return json.Marshal(&enc)
@@ -35,6 +37,7 @@ func (s *SimulateCallResult) UnmarshalJSON(input []byte) error {
 		ReturnValue *hexutil.Bytes  `json:"returnData"`
 		Logs        []*types.Log    `json:"logs"`
 		GasUsed     *hexutil.Uint64 `json:"gasUsed"`
+		MaxUsedGas  *hexutil.Uint64 `json:"maxUsedGas"`
 		Status      *hexutil.Uint64 `json:"status"`
 		Error       *CallError      `json:"error,omitempty"`
 	}
@@ -50,6 +53,9 @@ func (s *SimulateCallResult) UnmarshalJSON(input []byte) error {
 	}
 	if dec.GasUsed != nil {
 		s.GasUsed = uint64(*dec.GasUsed)
+	}
+	if dec.MaxUsedGas != nil {
+		s.MaxUsedGas = uint64(*dec.MaxUsedGas)
 	}
 	if dec.Status != nil {
 		s.Status = uint64(*dec.Status)


### PR DESCRIPTION
This updates the typed `ethclient` model for `eth_simulateV1` call results to include `maxUsedGas`, matching the field already returned by the server-side RPC response.

The generated JSON codec now marshals and unmarshals `maxUsedGas` as a hex quantity, and `TestSimulateV1` checks that the field is populated through the client path.

Follow-up to #32789.