### PR TITLE
core: add code cache hit/miss meters

### DIFF
--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -84,6 +84,8 @@ var (
 	accountCacheMissMeter = metrics.NewRegisteredMeter("chain/account/reads/cache/process/miss", nil)
 	storageCacheHitMeter  = metrics.NewRegisteredMeter("chain/storage/reads/cache/process/hit", nil)
 	storageCacheMissMeter = metrics.NewRegisteredMeter("chain/storage/reads/cache/process/miss", nil)
+	codeCacheHitMeter     = metrics.NewRegisteredMeter("chain/code/reads/cache/process/hit", nil)
+	codeCacheMissMeter    = metrics.NewRegisteredMeter("chain/code/reads/cache/process/miss", nil)
 
 	accountCacheHitPrefetchMeter  = metrics.NewRegisteredMeter("chain/account/reads/cache/prefetch/hit", nil)
 	accountCacheMissPrefetchMeter = metrics.NewRegisteredMeter("chain/account/reads/cache/prefetch/miss", nil)

--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -91,6 +91,8 @@ var (
 	accountCacheMissPrefetchMeter = metrics.NewRegisteredMeter("chain/account/reads/cache/prefetch/miss", nil)
 	storageCacheHitPrefetchMeter  = metrics.NewRegisteredMeter("chain/storage/reads/cache/prefetch/hit", nil)
 	storageCacheMissPrefetchMeter = metrics.NewRegisteredMeter("chain/storage/reads/cache/prefetch/miss", nil)
+	codeCacheHitPrefetchMeter     = metrics.NewRegisteredMeter("chain/code/reads/cache/prefetch/hit", nil)
+	codeCacheMissPrefetchMeter    = metrics.NewRegisteredMeter("chain/code/reads/cache/prefetch/miss", nil)
 
 	accountReadSingleTimer = metrics.NewRegisteredResettingTimer("chain/account/single/reads", nil)
 	storageReadSingleTimer = metrics.NewRegisteredResettingTimer("chain/storage/single/reads", nil)

--- a/core/blockchain_stats.go
+++ b/core/blockchain_stats.go
@@ -96,6 +96,8 @@ func (s *ExecuteStats) reportMetrics() {
 	accountCacheMissPrefetchMeter.Mark(s.StatePrefetchCacheStats.StateStats.AccountCacheMiss)
 	storageCacheHitPrefetchMeter.Mark(s.StatePrefetchCacheStats.StateStats.StorageCacheHit)
 	storageCacheMissPrefetchMeter.Mark(s.StatePrefetchCacheStats.StateStats.StorageCacheMiss)
+	codeCacheHitPrefetchMeter.Mark(s.StatePrefetchCacheStats.CodeStats.CacheHit)
+	codeCacheMissPrefetchMeter.Mark(s.StatePrefetchCacheStats.CodeStats.CacheMiss)
 
 	accountCacheHitMeter.Mark(s.StateReadCacheStats.StateStats.AccountCacheHit)
 	accountCacheMissMeter.Mark(s.StateReadCacheStats.StateStats.AccountCacheMiss)

--- a/core/blockchain_stats.go
+++ b/core/blockchain_stats.go
@@ -101,6 +101,8 @@ func (s *ExecuteStats) reportMetrics() {
 	accountCacheMissMeter.Mark(s.StateReadCacheStats.StateStats.AccountCacheMiss)
 	storageCacheHitMeter.Mark(s.StateReadCacheStats.StateStats.StorageCacheHit)
 	storageCacheMissMeter.Mark(s.StateReadCacheStats.StateStats.StorageCacheMiss)
+	codeCacheHitMeter.Mark(s.StateReadCacheStats.CodeStats.CacheHit)
+	codeCacheMissMeter.Mark(s.StateReadCacheStats.CodeStats.CacheMiss)
 }
 
 // slowBlockLog represents the JSON structure for slow block logging.


### PR DESCRIPTION
- register `codeCacheHitMeter` / `codeCacheMissMeter` under `chain/code/reads/cache/process/{hit,miss}`, mirroring the account/storage pair
- wire them from `StateReadCacheStats.CodeStats` in `reportMetrics()` so the data already exposed in the slow-block JSON is also scrapable from Prometheus
- code cache efficiency matters — bytecode misses can be tens of KB each, so operators need a live meter, not just slow-block postmortems