### PR TITLE
core/state: opt stateObject.GetState

### DIFF
--- a/core/state/state_object.go
+++ b/core/state/state_object.go
@@ -162,8 +162,12 @@ func (s *stateObject) getPrefetchedTrie() Trie {
 
 // GetState retrieves a value associated with the given storage key.
 func (s *stateObject) GetState(key common.Hash) common.Hash {
-	value, _ := s.getState(key)
-	return value
+	value, dirty := s.dirtyStorage[key]
+	if dirty {
+		return value
+	}
+	origin := s.GetCommittedState(key)
+	return origin
 }
 
 // getState retrieves a value associated with the given storage key, along with

--- a/core/state/state_object.go
+++ b/core/state/state_object.go
@@ -166,8 +166,7 @@ func (s *stateObject) GetState(key common.Hash) common.Hash {
 	if dirty {
 		return value
 	}
-	origin := s.GetCommittedState(key)
-	return origin
+	return s.GetCommittedState(key)
 }
 
 // getState retrieves a value associated with the given storage key, along with


### PR DESCRIPTION
benchmark code:  
```
// Copyright 2026 The go-ethereum Authors
// This file is part of the go-ethereum library.
//
// The go-ethereum library is free software: you can redistribute it and/or modify
// it under the terms of the GNU Lesser General Public License as published by
// the Free Software Foundation, either version 3 of the License, or
// (at your option) any later version.
//
// The go-ethereum library is distributed in the hope that it will be useful,
// but WITHOUT ANY WARRANTY; without even the implied warranty of
// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
// GNU Lesser General Public License for more details.
//
// You should have received a copy of the GNU Lesser General Public License
// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.

package state

import (
	"testing"

	"github.com/ethereum/go-ethereum/common"
	"github.com/ethereum/go-ethereum/core/rawdb"
	"github.com/ethereum/go-ethereum/core/tracing"
	"github.com/ethereum/go-ethereum/core/types"
	"github.com/ethereum/go-ethereum/crypto"
	"github.com/ethereum/go-ethereum/triedb"
	"github.com/holiman/uint256"
)

// newGetStateBenchObject builds a stateObject pre-populated with `n` dirty
// slots and returns the object together with the list of dirty keys.
func newGetStateBenchObject(b *testing.B, n int) (*stateObject, []common.Hash) {
	b.Helper()
	memdb := rawdb.NewMemoryDatabase()
	tdb := triedb.NewDatabase(memdb, nil)
	sdb := NewDatabase(tdb, nil)
	state, err := New(types.EmptyRootHash, sdb)
	if err != nil {
		b.Fatalf("failed to create statedb: %v", err)
	}
	addr := common.Address(crypto.Keccak256Hash([]byte("getstate_bench_addr")).Bytes()[12:])
	state.AddBalance(addr, uint256.NewInt(1), tracing.BalanceChangeUnspecified)

	keys := make([]common.Hash, n)
	for i := 0; i < n; i++ {
		keys[i] = crypto.Keccak256Hash([]byte("getstate_bench_key"), []byte{byte(i), byte(i >> 8)})
		v := crypto.Keccak256Hash([]byte("getstate_bench_val"), []byte{byte(i), byte(i >> 8)})
		state.SetState(addr, keys[i], v)
	}
	obj := state.getStateObject(addr)
	if obj == nil {
		b.Fatalf("state object missing for %x", addr)
	}
	if len(obj.dirtyStorage) != n {
		b.Fatalf("expected %d dirty slots, got %d", n, len(obj.dirtyStorage))
	}
	return obj, keys
}

// BenchmarkStateObjectGetStateDirtyHit measures the cost of GetState on a slot
// that lives in dirtyStorage. This is the path the short-circuit targets.
func BenchmarkStateObjectGetStateDirtyHit1(b *testing.B)    { benchGetStateDirtyHit(b, 1) }
func BenchmarkStateObjectGetStateDirtyHit8(b *testing.B)    { benchGetStateDirtyHit(b, 8) }
func BenchmarkStateObjectGetStateDirtyHit64(b *testing.B)   { benchGetStateDirtyHit(b, 64) }
func BenchmarkStateObjectGetStateDirtyHit512(b *testing.B)  { benchGetStateDirtyHit(b, 512) }
func BenchmarkStateObjectGetStateDirtyHit4096(b *testing.B) { benchGetStateDirtyHit(b, 4096) }

func benchGetStateDirtyHit(b *testing.B, n int) {
	obj, keys := newGetStateBenchObject(b, n)
	b.ResetTimer()
	b.ReportAllocs()
	for i := 0; i < b.N; i++ {
		obj.GetState(keys[i%n])
	}
}

// BenchmarkStateObjectGetStateOriginHit measures GetState on a slot that is
// only in originStorage (not dirty). Acts as a regression check that the
// short-circuit does not penalize the clean path.
func BenchmarkStateObjectGetStateOriginHit1(b *testing.B)    { benchGetStateOriginHit(b, 1) }
func BenchmarkStateObjectGetStateOriginHit8(b *testing.B)    { benchGetStateOriginHit(b, 8) }
func BenchmarkStateObjectGetStateOriginHit64(b *testing.B)   { benchGetStateOriginHit(b, 64) }
func BenchmarkStateObjectGetStateOriginHit512(b *testing.B)  { benchGetStateOriginHit(b, 512) }
func BenchmarkStateObjectGetStateOriginHit4096(b *testing.B) { benchGetStateOriginHit(b, 4096) }

func benchGetStateOriginHit(b *testing.B, n int) {
	obj, keys := newGetStateBenchObject(b, n)
	// Pre-populate originStorage with the same values; clear dirtyStorage so
	// the lookups go through the GetCommittedState/originStorage path.
	for k, v := range obj.dirtyStorage {
		obj.originStorage[k] = v
	}
	obj.dirtyStorage = make(Storage)
	b.ResetTimer()
	b.ReportAllocs()
	for i := 0; i < b.N; i++ {
		obj.GetState(keys[i%n])
	}
}

```

result in:  
```
goos: darwin
goarch: arm64
pkg: github.com/ethereum/go-ethereum/core/state
cpu: Apple M4 Pro
                                    │ getstate_old.txt │           getstate_new.txt           │
                                    │      sec/op      │    sec/op     vs base                │
StateObjectGetStateDirtyHit1-14          19.385n ±  2%   8.405n ±  2%  -56.64% (p=0.000 n=10)
StateObjectGetStateDirtyHit8-14          20.980n ± 10%   9.359n ± 22%  -55.39% (p=0.000 n=10)
StateObjectGetStateDirtyHit64-14         20.825n ±  3%   9.335n ±  3%  -55.17% (p=0.000 n=10)
StateObjectGetStateDirtyHit512-14        21.180n ±  3%   9.419n ±  1%  -55.53% (p=0.000 n=10)
StateObjectGetStateDirtyHit4096-14        27.62n ±  3%   11.95n ±  3%  -56.74% (p=0.000 n=10)
StateObjectGetStateOriginHit1-14          15.07n ±  2%   13.79n ±  3%   -8.52% (p=0.000 n=10)
StateObjectGetStateOriginHit8-14          15.89n ±  1%   14.53n ±  1%   -8.59% (p=0.001 n=10)
StateObjectGetStateOriginHit64-14         16.04n ±  2%   14.97n ±  2%   -6.64% (p=0.000 n=10)
StateObjectGetStateOriginHit512-14        16.25n ±  2%   14.96n ±  1%   -7.97% (p=0.000 n=10)
StateObjectGetStateOriginHit4096-14       21.12n ±  1%   19.30n ±  1%   -8.64% (p=0.000 n=10)
geomean                                   19.12n         12.17n        -36.33%

                                    │ getstate_old.txt │          getstate_new.txt           │
                                    │       B/op       │    B/op     vs base                 │
StateObjectGetStateDirtyHit1-14           0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
StateObjectGetStateDirtyHit8-14           0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
StateObjectGetStateDirtyHit64-14          0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
StateObjectGetStateDirtyHit512-14         0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
StateObjectGetStateDirtyHit4096-14        0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
StateObjectGetStateOriginHit1-14          0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
StateObjectGetStateOriginHit8-14          0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
StateObjectGetStateOriginHit64-14         0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
StateObjectGetStateOriginHit512-14        0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
StateObjectGetStateOriginHit4096-14       0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
geomean                                              ²               +0.00%                ²
¹ all samples are equal
² summaries must be >0 to compute geomean

                                    │ getstate_old.txt │          getstate_new.txt           │
                                    │    allocs/op     │ allocs/op   vs base                 │
StateObjectGetStateDirtyHit1-14           0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
StateObjectGetStateDirtyHit8-14           0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
StateObjectGetStateDirtyHit64-14          0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
StateObjectGetStateDirtyHit512-14         0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
StateObjectGetStateDirtyHit4096-14        0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
StateObjectGetStateOriginHit1-14          0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
StateObjectGetStateOriginHit8-14          0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
StateObjectGetStateOriginHit64-14         0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
StateObjectGetStateOriginHit512-14        0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
StateObjectGetStateOriginHit4096-14       0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
geomean                                              ²               +0.00%                ²
¹ all samples are equal
² summaries must be >0 to compute geomean
```