### PR TITLE
accounts/keystore: enable fsnotify watcher on linux/arm64

### DIFF
--- a/accounts/keystore/watch.go
+++ b/accounts/keystore/watch.go
@@ -14,8 +14,8 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
 
-//go:build (darwin && !ios && cgo) || freebsd || (linux && !arm64) || netbsd || solaris
-// +build darwin,!ios,cgo freebsd linux,!arm64 netbsd solaris
+//go:build (darwin && !ios && cgo) || freebsd || linux || netbsd || solaris
+// +build darwin,!ios,cgo freebsd linux netbsd solaris
 
 package keystore
 

--- a/accounts/keystore/watch_fallback.go
+++ b/accounts/keystore/watch_fallback.go
@@ -14,8 +14,8 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
 
-//go:build (darwin && !cgo) || ios || (linux && arm64) || windows || (!darwin && !freebsd && !linux && !netbsd && !solaris)
-// +build darwin,!cgo ios linux,arm64 windows !darwin,!freebsd,!linux,!netbsd,!solaris
+//go:build (darwin && !cgo) || ios || windows || (!darwin && !freebsd && !linux && !netbsd && !solaris)
+// +build darwin,!cgo ios windows !darwin,!freebsd,!linux,!netbsd,!solaris
 
 // This is the fallback implementation of directory watching.
 // It is used on unsupported platforms.


### PR DESCRIPTION
- drop `!arm64` from the build tags so linux/arm64 hits the real `fsnotify` watcher instead of the no-op fallback
- `inotify` is a kernel syscall and arch-independent; the 2016 carve-out has no technical basis
- without it, geth on linux/arm64 silently misses keystore changes and new keyfiles aren't picked up until restart