### PR TITLE
core/state/snapshot: reduce storage snapshot cache key allocations

### DIFF
--- a/core/state/snapshot/disklayer.go
+++ b/core/state/snapshot/disklayer.go
@@ -29,6 +29,13 @@ import (
 	"github.com/ethereum/go-ethereum/triedb"
 )
 
+func storageCacheKey(accountHash, storageHash common.Hash) [2 * common.HashLength]byte {
+	var key [2 * common.HashLength]byte
+	copy(key[:common.HashLength], accountHash[:])
+	copy(key[common.HashLength:], storageHash[:])
+	return key
+}
+
 // diskLayer is a low level persistent snapshot built on top of a key-value store.
 type diskLayer struct {
 	diskdb ethdb.KeyValueStore // Key-value store containing the base snapshot
@@ -148,25 +155,25 @@ func (dl *diskLayer) Storage(accountHash, storageHash common.Hash) ([]byte, erro
 	if dl.stale {
 		return nil, ErrSnapshotStale
 	}
-	key := append(accountHash[:], storageHash[:]...)
+	key := storageCacheKey(accountHash, storageHash)
 
 	// If the layer is being generated, ensure the requested hash has already been
 	// covered by the generator.
-	if dl.genMarker != nil && bytes.Compare(key, dl.genMarker) > 0 {
+	if dl.genMarker != nil && bytes.Compare(key[:], dl.genMarker) > 0 {
 		return nil, ErrNotCoveredYet
 	}
 	// If we're in the disk layer, all diff layers missed
 	snapshotDirtyStorageMissMeter.Mark(1)
 
 	// Try to retrieve the storage slot from the memory cache
-	if blob, found := dl.cache.HasGet(nil, key); found {
+	if blob, found := dl.cache.HasGet(nil, key[:]); found {
 		snapshotCleanStorageHitMeter.Mark(1)
 		snapshotCleanStorageReadMeter.Mark(int64(len(blob)))
 		return blob, nil
 	}
 	// Cache doesn't contain storage slot, pull from disk and cache for later
 	blob := rawdb.ReadStorageSnapshot(dl.diskdb, accountHash, storageHash)
-	dl.cache.Set(key, blob)
+	dl.cache.Set(key[:], blob)
 
 	snapshotCleanStorageMissMeter.Mark(1)
 	if n := len(blob); n > 0 {

--- a/core/state/snapshot/snapshot.go
+++ b/core/state/snapshot/snapshot.go
@@ -581,13 +581,14 @@ func diffToDisk(bottom *diffLayer) *diskLayer {
 			if midAccount && bytes.Compare(storageHash[:], base.genMarker[common.HashLength:]) > 0 {
 				continue
 			}
+			cacheKey := storageCacheKey(accountHash, storageHash)
 			if len(data) > 0 {
 				rawdb.WriteStorageSnapshot(batch, accountHash, storageHash, data)
-				base.cache.Set(append(accountHash[:], storageHash[:]...), data)
+				base.cache.Set(cacheKey[:], data)
 				snapshotCleanStorageWriteMeter.Mark(int64(len(data)))
 			} else {
 				rawdb.DeleteStorageSnapshot(batch, accountHash, storageHash)
-				base.cache.Set(append(accountHash[:], storageHash[:]...), nil)
+				base.cache.Set(cacheKey[:], nil)
 			}
 			snapshotFlushStorageItemMeter.Mark(1)
 			snapshotFlushStorageSizeMeter.Mark(int64(len(data)))


### PR DESCRIPTION
This change updates the storage snapshot cache path in core/state/snapshot to build the (accountHash, storageHash) cache key with a fixed-size stack-backed buffer instead of concatenating slices on each access. The same key construction is used consistently in both lookup and snapshot flush paths, which keeps the code straightforward and avoids repeated temporary allocations in a hot part of the package.

```
goos: linux
goarch: amd64
pkg: github.com/ethereum/go-ethereum/core/state/snapshot
cpu: Intel(R) Core(TM) i7-8565U CPU @ 1.80GHz
           │ old_bench.txt │            new_bench.txt            │
           │    sec/op     │   sec/op     vs base                │
SearchSlot     142.1n ± 3%   116.8n ± 5%  -17.81% (p=0.000 n=10)

           │ old_bench.txt │           new_bench.txt            │
           │     B/op      │   B/op     vs base                 │
SearchSlot      64.00 ± 0%   0.00 ± 0%  -100.00% (p=0.000 n=10)

           │ old_bench.txt │            new_bench.txt            │
           │   allocs/op   │ allocs/op   vs base                 │
SearchSlot      1.000 ± 0%   0.000 ± 0%  -100.00% (p=0.000 n=10)
```