### PR TITLE
core/txpool/blobpool: reduce lock contention

### DIFF
--- a/core/txpool/blobpool/blobpool.go
+++ b/core/txpool/blobpool/blobpool.go
@@ -1590,19 +1590,30 @@ func (p *BlobPool) add(tx *types.Transaction) (err error) {
 	waitStart := time.Now()
 	p.lock.Lock()
 	addwaitHist.Update(time.Since(waitStart).Nanoseconds())
-	defer p.lock.Unlock()
-
 	defer func(start time.Time) {
 		addtimeHist.Update(time.Since(start).Nanoseconds())
 	}(time.Now())
 
-	return p.addLocked(tx, true)
+	toDelete, err := p.addLocked(tx, true)
+	p.lock.Unlock()
+
+	for _, id := range toDelete {
+		if err := p.store.Delete(id); err != nil {
+			log.Error("Failed to delete blob transaction", "id", id, "err", err)
+		}
+	}
+	if err == nil {
+		p.updateStorageMetrics()
+	}
+	return err
 }
 
 // addLocked inserts a new blob transaction into the pool if it passes validation (both
 // consensus validity and pool restrictions). It must be called with the pool lock held.
 // Only for internal use.
-func (p *BlobPool) addLocked(tx *types.Transaction, checkGapped bool) (err error) {
+//
+// Returns billy slot ids that the caller must delete after releasing the lock.
+func (p *BlobPool) addLocked(tx *types.Transaction, checkGapped bool) (toDelete []uint64, err error) {
 	// Ensure the transaction is valid from all perspectives
 	if err := p.validateTx(tx); err != nil {
 		log.Trace("Transaction validation failed", "hash", tx.Hash(), "err", err)
@@ -1622,7 +1633,7 @@ func (p *BlobPool) addLocked(tx *types.Transaction, checkGapped bool) (err error
 				p.gapped[from] = append(p.gapped[from], tx)
 				p.gappedSource[tx.Hash()] = from
 				log.Trace("added tx to gapped blob queue", "allowance", allowance, "hash", tx.Hash(), "from", from, "nonce", tx.Nonce(), "qlen", len(p.gapped[from]))
-				return nil
+				return nil, nil
 			} else {
 				// if maxGapped is reached, it is better to give time to gapped
 				// transactions by keeping the old and dropping this one.
@@ -1639,7 +1650,7 @@ func (p *BlobPool) addLocked(tx *types.Transaction, checkGapped bool) (err error
 		default:
 			addInvalidMeter.Mark(1)
 		}
-		return err
+		return nil, err
 	}
 	// If the address is not yet known, request exclusivity to track the account
 	// only by this subpool until all transactions are evicted
@@ -1647,7 +1658,7 @@ func (p *BlobPool) addLocked(tx *types.Transaction, checkGapped bool) (err error
 	if _, ok := p.index[from]; !ok {
 		if err := p.reserver.Hold(from); err != nil {
 			addNonExclusiveMeter.Mark(1)
-			return err
+			return nil, err
 		}
 		defer func() {
 			// If the transaction is rejected by some post-validation check, remove
@@ -1666,11 +1677,11 @@ func (p *BlobPool) addLocked(tx *types.Transaction, checkGapped bool) (err error
 	blob, err := rlp.EncodeToBytes(tx)
 	if err != nil {
 		log.Error("Failed to encode transaction for storage", "hash", tx.Hash(), "err", err)
-		return err
+		return nil, err
 	}
 	id, err := p.store.Put(blob)
 	if err != nil {
-		return err
+		return nil, err
 	}
 	meta := newBlobTxMeta(id, tx.Size(), p.store.Size(id), tx)
 
@@ -1689,10 +1700,7 @@ func (p *BlobPool) addLocked(tx *types.Transaction, checkGapped bool) (err error
 		dropReplacedMeter.Mark(1)
 
 		prev := p.index[from][offset]
-		if err := p.store.Delete(prev.id); err != nil {
-			// Shitty situation, but try to recover gracefully instead of going boom
-			log.Error("Failed to delete replaced transaction", "id", prev.id, "err", err)
-		}
+		toDelete = append(toDelete, prev.id)
 		// Update the transaction index
 		p.index[from][offset] = meta
 		p.spent[from] = new(uint256.Int).Sub(p.spent[from], prev.costCap)
@@ -1764,7 +1772,6 @@ func (p *BlobPool) addLocked(tx *types.Transaction, checkGapped bool) (err error
 	for p.stored > p.config.Datacap {
 		p.drop()
 	}
-	p.updateStorageMetrics()
 
 	addValidMeter.Mark(1)
 
@@ -1812,7 +1819,9 @@ func (p *BlobPool) addLocked(tx *types.Transaction, checkGapped bool) (err error
 				// If we hit the pending range, including the first gap, add it and continue to try to add more.
 				// We do not recurse here, but continue to loop instead.
 				// We are under lock, so we can add the transaction directly.
-				if err := p.addLocked(tx, false); err == nil {
+				subDelete, err := p.addLocked(tx, false)
+				toDelete = append(toDelete, subDelete...)
+				if err == nil {
 					log.Trace("Gapped blob transaction added to pool", "hash", tx.Hash(), "from", from, "nonce", tx.Nonce(), "qlen", len(p.gapped[from]))
 				} else {
 					log.Trace("Gapped blob transaction not accepted", "hash", tx.Hash(), "from", from, "nonce", tx.Nonce(), "err", err)
@@ -1825,7 +1834,7 @@ func (p *BlobPool) addLocked(tx *types.Transaction, checkGapped bool) (err error
 			p.gapped[from] = gtxs
 		}
 	}
-	return nil
+	return toDelete, nil
 }
 
 // drop removes the worst transaction from the pool. It is primarily used when a

--- a/core/txpool/blobpool/blobpool.go
+++ b/core/txpool/blobpool/blobpool.go
@@ -527,7 +527,10 @@ func (p *BlobPool) Init(gasTip uint64, head *types.Header, reserver txpool.Reser
 	// Since the user might have modified their pool's capacity, evict anything
 	// above the current allowance
 	for p.stored > p.config.Datacap {
-		p.drop()
+		id := p.drop()
+		if err := p.store.Delete(id); err != nil {
+			log.Error("Failed to drop evicted transaction", "id", id, "err", err)
+		}
 	}
 	// Update the metrics and return the constructed pool
 	datacapGauge.Update(int64(p.config.Datacap))
@@ -1770,7 +1773,7 @@ func (p *BlobPool) addLocked(tx *types.Transaction, checkGapped bool) (toDelete 
 	// If the pool went over the allowed data limit, evict transactions until
 	// we're again below the threshold
 	for p.stored > p.config.Datacap {
-		p.drop()
+		toDelete = append(toDelete, p.drop())
 	}
 
 	addValidMeter.Mark(1)
@@ -1841,7 +1844,9 @@ func (p *BlobPool) addLocked(tx *types.Transaction, checkGapped bool) (toDelete 
 // freshly added transaction overflows the pool and needs to evict something. The
 // method is also called on startup if the user resizes their storage, might be an
 // expensive run but it should be fine-ish.
-func (p *BlobPool) drop() {
+//
+// Returns the billy slot id that the caller must delete after releasing the lock.
+func (p *BlobPool) drop() uint64 {
 	// Peek at the account with the worse transaction set to evict from (Go's heap
 	// stores the minimum at index zero of the heap slice) and retrieve it's last
 	// transaction.
@@ -1882,13 +1887,10 @@ func (p *BlobPool) drop() {
 			heap.Fix(p.evict, 0)
 		}
 	}
-	// Remove the transaction from the data store
 	log.Debug("Evicting overflown blob transaction", "from", from, "evicted", drop.nonce, "id", drop.id)
 	dropOverflownMeter.Mark(1)
 
-	if err := p.store.Delete(drop.id); err != nil {
-		log.Error("Failed to drop evicted transaction", "id", drop.id, "err", err)
-	}
+	return drop.id
 }
 
 // Pending retrieves all currently processable transactions, grouped by origin

--- a/core/txpool/blobpool/blobpool.go
+++ b/core/txpool/blobpool/blobpool.go
@@ -1373,46 +1373,64 @@ func (p *BlobPool) Has(hash common.Hash) bool {
 	return poolHas || gapped
 }
 
-func (p *BlobPool) getRLP(hash common.Hash) []byte {
-	// Track the amount of time waiting to retrieve a fully resolved blob tx from
-	// the pool and the amount of time actually spent on pulling the data from disk.
+// getAndVerify resolves a hash to its on-disk payload with the pool lock
+// released across the disk read, retrying once if a concurrent reinject moved
+// the same hash to a new slot.
+func (p *BlobPool) getAndVerify(hash common.Hash) ([]byte, *types.Transaction) {
 	getStart := time.Now()
 	p.lock.RLock()
 	getwaitHist.Update(time.Since(getStart).Nanoseconds())
-	defer p.lock.RUnlock()
 
+	id, ok := p.lookup.storeidOfTx(hash)
+	p.lock.RUnlock()
+	if !ok {
+		return nil, nil
+	}
 	defer func(start time.Time) {
 		gettimeHist.Update(time.Since(start).Nanoseconds())
 	}(time.Now())
 
-	// Pull the blob from disk and return an assembled response
-	id, ok := p.lookup.storeidOfTx(hash)
-	if !ok {
-		return nil
+	for retry := 0; retry < 2; retry++ {
+		data, err := p.store.Get(id)
+		if err != nil {
+			log.Warn("Failed to read blob tx from store", "hash", hash, "id", id, "err", err)
+			return nil, nil
+		}
+		tx := new(types.Transaction)
+		if err := rlp.DecodeBytes(data, tx); err != nil {
+			log.Warn("Failed to decode blob tx from store", "hash", hash, "id", id, "err", err)
+			return nil, nil
+		}
+		p.lock.RLock()
+		currentID, stillTracked := p.lookup.storeidOfTx(hash)
+		p.lock.RUnlock()
+		if !stillTracked {
+			return nil, nil
+		}
+		if currentID == id && tx.Hash() == hash {
+			return data, tx
+		}
+		if tx.Hash() != hash {
+			log.Debug("Blob tx slot reused by concurrent writer", "hash", hash, "id", id, "got", tx.Hash())
+		}
+		if currentID == id {
+			return nil, nil
+		}
+		id = currentID
 	}
-	data, err := p.store.Get(id)
-	if err != nil {
-		log.Error("Tracked blob transaction missing from store", "hash", hash, "id", id, "err", err)
-		return nil
-	}
+	return nil, nil
+}
+
+// getRLP returns a RLP-encoded transaction if it is contained in the pool.
+func (p *BlobPool) getRLP(hash common.Hash) []byte {
+	data, _ := p.getAndVerify(hash)
 	return data
 }
 
 // Get returns a transaction if it is contained in the pool, or nil otherwise.
 func (p *BlobPool) Get(hash common.Hash) *types.Transaction {
-	data := p.getRLP(hash)
-	if len(data) == 0 {
-		return nil
-	}
-	item := new(types.Transaction)
-	if err := rlp.DecodeBytes(data, item); err != nil {
-		id, _ := p.lookup.storeidOfTx(hash)
-
-		log.Error("Blobs corrupted for traced transaction",
-			"hash", hash, "id", id, "err", err)
-		return nil
-	}
-	return item
+	_, tx := p.getAndVerify(hash)
+	return tx
 }
 
 // GetRLP returns a RLP-encoded transaction if it is contained in the pool.

--- a/core/txpool/blobpool/blobpool.go
+++ b/core/txpool/blobpool/blobpool.go
@@ -1165,8 +1165,9 @@ func (p *BlobPool) reinject(addr common.Address, txhash common.Hash) error {
 // SetGasTip implements txpool.SubPool, allowing the blob pool's gas requirements
 // to be kept in sync with the main transaction pool's gas requirements.
 func (p *BlobPool) SetGasTip(tip *big.Int) {
+	var dropped []uint64
+
 	p.lock.Lock()
-	defer p.lock.Unlock()
 
 	// Store the new minimum gas tip
 	old := p.gasTip.Load()
@@ -1209,15 +1210,10 @@ func (p *BlobPool) SetGasTip(tip *big.Int) {
 						heap.Remove(p.evict, p.evict.index[addr])
 						p.reserver.Release(addr)
 					}
-					// Clear out the transactions from the data store
 					log.Warn("Dropping underpriced blob transaction", "from", addr, "rejected", tx.nonce, "tip", tx.execTipCap, "want", tip, "drop", nonces, "ids", ids)
 					dropUnderpricedMeter.Mark(int64(len(ids)))
 
-					for _, id := range ids {
-						if err := p.store.Delete(id); err != nil {
-							log.Error("Failed to delete dropped transaction", "id", id, "err", err)
-						}
-					}
+					dropped = append(dropped, ids...)
 					break
 				}
 			}
@@ -1225,6 +1221,14 @@ func (p *BlobPool) SetGasTip(tip *big.Int) {
 	}
 	log.Debug("Blobpool tip threshold updated", "tip", tip)
 	pooltipGauge.Update(tip.Int64())
+	p.lock.Unlock()
+
+	// Flush the dropped transactions to disk without holding the pool lock.
+	for _, id := range dropped {
+		if err := p.store.Delete(id); err != nil {
+			log.Error("Failed to delete dropped transaction", "id", id, "err", err)
+		}
+	}
 	p.updateStorageMetrics()
 }
 

--- a/core/txpool/blobpool/blobpool_test.go
+++ b/core/txpool/blobpool/blobpool_test.go
@@ -2235,3 +2235,20 @@ func BenchmarkWriteUnderReaderLoad(b *testing.B) {
 	close(stop)
 	wg.Wait()
 }
+
+// BenchmarkSetGasTipDrop times a SetGasTip call that drops every tx in a
+// freshly populated pool of numTxs blob transactions whose tips fall below
+// the new threshold.
+func BenchmarkSetGasTipDrop(b *testing.B) {
+	const numTxs = 256
+
+	for i := 0; i < b.N; i++ {
+		b.StopTimer()
+		pool, _, _ := setupGetBenchPool(b, numTxs)
+		b.StartTimer()
+		// Any tip far above the per-tx execTipCap (10) drops everything.
+		pool.SetGasTip(big.NewInt(1_000_000_000))
+		b.StopTimer()
+		pool.Close()
+	}
+}

--- a/core/txpool/blobpool/blobpool_test.go
+++ b/core/txpool/blobpool/blobpool_test.go
@@ -31,6 +31,7 @@ import (
 	"slices"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/consensus/misc/eip1559"
@@ -2132,4 +2133,105 @@ func benchmarkPoolPending(b *testing.B, datacap uint64) {
 			b.Fatalf("have %d want %d", len(p), capacity)
 		}
 	}
+}
+
+// setupGetBenchPool provisions a blob pool with numTxs blob transactions and
+// returns it together with the inserted transaction hashes and the first sender.
+func setupGetBenchPool(b *testing.B, numTxs int) (*BlobPool, []common.Hash, common.Address) {
+	b.Helper()
+	var (
+		basefee    = uint64(1050)
+		blobfee    = uint64(105)
+		signer     = types.LatestSigner(params.MainnetChainConfig)
+		statedb, _ = state.New(types.EmptyRootHash, state.NewDatabaseForTesting())
+		chain      = &testBlockChain{
+			config:  params.MainnetChainConfig,
+			basefee: uint256.NewInt(basefee),
+			blobfee: uint256.NewInt(blobfee),
+			statedb: statedb,
+		}
+		pool = New(Config{Datadir: b.TempDir()}, chain, nil)
+	)
+	if err := pool.Init(1, chain.CurrentBlock(), newReserver()); err != nil {
+		b.Fatalf("failed to create blob pool: %v", err)
+	}
+	hashes := make([]common.Hash, 0, numTxs)
+	var firstAddr common.Address
+	for i := 0; i < numTxs; i++ {
+		blobtx := makeUnsignedTx(0, 10, basefee+10, blobfee)
+		blobtx.R = uint256.NewInt(1)
+		blobtx.S = uint256.NewInt(uint64(100 + i))
+		blobtx.V = uint256.NewInt(0)
+		tx := types.NewTx(blobtx)
+		addr, err := types.Sender(signer, tx)
+		if err != nil {
+			b.Fatal(err)
+		}
+		statedb.AddBalance(addr, uint256.NewInt(1_000_000_000), tracing.BalanceChangeUnspecified)
+		if err := pool.add(tx); err != nil {
+			b.Fatalf("add tx %d: %v", i, err)
+		}
+		hashes = append(hashes, tx.Hash())
+		if i == 0 {
+			firstAddr = addr
+		}
+	}
+	statedb.Commit(0, true, false)
+	return pool, hashes, firstAddr
+}
+
+// BenchmarkGetRLP measures the per-call cost of a successful GetRLP against
+// a real billy store (disk Get + RLP decode + hash verification).
+func BenchmarkGetRLP(b *testing.B) {
+	pool, hashes, _ := setupGetBenchPool(b, 1024)
+	defer pool.Close()
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if data := pool.GetRLP(hashes[i%len(hashes)]); data == nil {
+			b.Fatalf("GetRLP returned nil for known hash")
+		}
+	}
+}
+
+// BenchmarkWriteUnderReaderLoad measures the latency of a write-lock probe
+// (Nonce on a tracked address) while readerConcurrency goroutines are
+// calling GetRLP in a tight loop. The probe does near-zero in-lock work, so
+// the per-iter time is dominated by lock-acquisition wait.
+func BenchmarkWriteUnderReaderLoad(b *testing.B) {
+	pool, hashes, addr := setupGetBenchPool(b, 1024)
+	defer pool.Close()
+
+	const readerConcurrency = 4
+	var (
+		stop = make(chan struct{})
+		wg   sync.WaitGroup
+	)
+	for i := 0; i < readerConcurrency; i++ {
+		wg.Add(1)
+		go func(seed int) {
+			defer wg.Done()
+			r := rand.New(rand.NewSource(int64(seed)))
+			for {
+				select {
+				case <-stop:
+					return
+				default:
+					pool.GetRLP(hashes[r.Intn(len(hashes))])
+				}
+			}
+		}(i)
+	}
+	time.Sleep(100 * time.Millisecond)
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		pool.Nonce(addr)
+	}
+	b.StopTimer()
+
+	close(stop)
+	wg.Wait()
 }

--- a/core/txpool/blobpool/metrics.go
+++ b/core/txpool/blobpool/metrics.go
@@ -67,10 +67,11 @@ var (
 	// addwait/time, resetwait/time and getwait/time track the rough health of
 	// the pool and whether it's capable of keeping up with the load from the
 	// network.
-	addwaitHist   = metrics.NewRegisteredHistogram("blobpool/addwait", nil, metrics.NewExpDecaySample(1028, 0.015))
-	addtimeHist   = metrics.NewRegisteredHistogram("blobpool/addtime", nil, metrics.NewExpDecaySample(1028, 0.015))
-	getwaitHist   = metrics.NewRegisteredHistogram("blobpool/getwait", nil, metrics.NewExpDecaySample(1028, 0.015))
-	gettimeHist   = metrics.NewRegisteredHistogram("blobpool/gettime", nil, metrics.NewExpDecaySample(1028, 0.015))
+	addwaitHist = metrics.NewRegisteredHistogram("blobpool/addwait", nil, metrics.NewExpDecaySample(1028, 0.015))
+	addtimeHist = metrics.NewRegisteredHistogram("blobpool/addtime", nil, metrics.NewExpDecaySample(1028, 0.015))
+	getwaitHist = metrics.NewRegisteredHistogram("blobpool/getwait", nil, metrics.NewExpDecaySample(1028, 0.015))
+	gettimeHist = metrics.NewRegisteredHistogram("blobpool/gettime", nil, metrics.NewExpDecaySample(1028, 0.015))
+
 	pendwaitHist  = metrics.NewRegisteredHistogram("blobpool/pendwait", nil, metrics.NewExpDecaySample(1028, 0.015))
 	pendtimeHist  = metrics.NewRegisteredHistogram("blobpool/pendtime", nil, metrics.NewExpDecaySample(1028, 0.015))
 	resetwaitHist = metrics.NewRegisteredHistogram("blobpool/resetwait", nil, metrics.NewExpDecaySample(1028, 0.015))


### PR DESCRIPTION
`blobpool` guards almost all of its internal state with a single wide RWMutex (`p.lock`). `legacypool`, by contrast, already splits its locks by purpose — `pool.mu` for the main pool, a separate RWMutex on `pool.all` (the lookup), `reheapMu` on `pricedList`, and so on.

I think `blobpool` should move in the same direction. For example, the read paths `Get` / `GetRLP` / `GetMetadata` / `GetBlobs` / `AvailableBlobs` only really need to consult `lookup`, but today they contend on the same lock as `add()` / `SetGasTip` / `Reset`. Giving `lookup` its own RWMutex would let these read paths run essentially independently of the write paths — this is the same pattern `legacypool.pool.all` already uses, with the same motivation.

That said, splitting the lock is a substantial change and needs re-establishing which lock protects which state. Before going down that road, curious to hear @cskiraly's take on whether this direction makes sense.

In the meantime, here's an incremental step that addresses mutex contention without restructuring the lock. Four small commits:

1. **`getRLP` / `Get`** — Move the billy disk read out of the lock. To handle slot reuse and the case where the same hash gets moved to a new slot (reinject), re-check `lookup` after the read and retry once if needed.
2. **`SetGasTip`** — Collect the slot ids to drop under the lock; run `store.Delete` in a batch after the lock is released.
3. **`addLocked` replacement** — Return the replaced `prev.id` to the caller (`add`) and run the delete after the lock is released.
4. **`addLocked` overflow eviction** — Change `drop()`'s signature to `() uint64`. The eviction loop accumulates ids; the caller runs a batched delete after the lock is released.

## Measurements

5 runs per benchmark, compared with benchstat:

| Bench | master | this PR |
|---|---|---|
| `BenchmarkGetRLP` | 17.4 µs | 41.7 µs |
| `BenchmarkWriteUnderReaderLoad` (writer wait time under reader load) | 54.2 µs | 55 ns |
| `BenchmarkSetGasTipDrop` (256 tx batch drop, total) | 1.525 ms | 1.524 ms |
| `BenchmarkSetGasTipDrop` (256 tx batch drop, time under lock) | 1.525 ms | ~131 µs |

`GetRLP` is +24 µs, but it's only used to serve `GetPooledTransactions` peer requests and the response is bounded by `softResponseLimit` (2 MB), so the impact is limited.