### PR TITLE
core: skip tx gas cap after Amsterdam

### DIFF
--- a/cmd/evm/internal/t8ntool/transaction.go
+++ b/cmd/evm/internal/t8ntool/transaction.go
@@ -185,7 +185,9 @@ func Transaction(ctx *cli.Context) error {
 			}
 		}
 
-		if chainConfig.IsOsaka(new(big.Int), 0) && tx.Gas() > params.MaxTxGas {
+		isOsaka := chainConfig.IsOsaka(new(big.Int), 0)
+		isAmsterdam := chainConfig.IsAmsterdam(new(big.Int), 0)
+		if isOsaka && !isAmsterdam && tx.Gas() > params.MaxTxGas {
 			r.Error = errors.New("gas limit exceeds maximum")
 		}
 		results = append(results, r)

--- a/core/state_transition.go
+++ b/core/state_transition.go
@@ -344,9 +344,10 @@ func (st *stateTransition) preCheck() error {
 		}
 	}
 	isOsaka := st.evm.ChainConfig().IsOsaka(st.evm.Context.BlockNumber, st.evm.Context.Time)
+	isAmsterdam := st.evm.ChainConfig().IsAmsterdam(st.evm.Context.BlockNumber, st.evm.Context.Time)
 	if !msg.SkipTransactionChecks {
 		// Verify tx gas limit does not exceed EIP-7825 cap.
-		if isOsaka && msg.GasLimit > params.MaxTxGas {
+		if isOsaka && !isAmsterdam && msg.GasLimit > params.MaxTxGas {
 			return fmt.Errorf("%w (cap: %d, tx: %d)", ErrGasLimitTooHigh, params.MaxTxGas, msg.GasLimit)
 		}
 		// Make sure the sender is an EOA

--- a/core/txpool/legacypool/legacypool.go
+++ b/core/txpool/legacypool/legacypool.go
@@ -1223,7 +1223,9 @@ func (pool *LegacyPool) runReorg(done chan struct{}, reset *txpoolResetRequest, 
 	if reset != nil {
 		if reset.newHead != nil && reset.oldHead != nil {
 			// Discard the transactions with the gas limit higher than the cap.
-			if pool.chainconfig.IsOsaka(reset.newHead.Number, reset.newHead.Time) && !pool.chainconfig.IsOsaka(reset.oldHead.Number, reset.oldHead.Time) {
+			if pool.chainconfig.IsOsaka(reset.newHead.Number, reset.newHead.Time) &&
+				!pool.chainconfig.IsAmsterdam(reset.newHead.Number, reset.newHead.Time) &&
+				!pool.chainconfig.IsOsaka(reset.oldHead.Number, reset.oldHead.Time) {
 				var hashes []common.Hash
 				pool.all.Range(func(hash common.Hash, tx *types.Transaction) bool {
 					if tx.Gas() > params.MaxTxGas {

--- a/core/txpool/legacypool/legacypool.go
+++ b/core/txpool/legacypool/legacypool.go
@@ -1222,9 +1222,9 @@ func (pool *LegacyPool) runReorg(done chan struct{}, reset *txpoolResetRequest, 
 	pool.mu.Lock()
 	if reset != nil {
 		if reset.newHead != nil && reset.oldHead != nil {
-			// Discard the transactions with the gas limit higher than the cap.
+			// Discard the transactions with the gas limit higher than the cap at the
+			// Osaka fork boundary.
 			if pool.chainconfig.IsOsaka(reset.newHead.Number, reset.newHead.Time) &&
-				!pool.chainconfig.IsAmsterdam(reset.newHead.Number, reset.newHead.Time) &&
 				!pool.chainconfig.IsOsaka(reset.oldHead.Number, reset.oldHead.Time) {
 				var hashes []common.Hash
 				pool.all.Range(func(hash common.Hash, tx *types.Transaction) bool {

--- a/core/txpool/validation.go
+++ b/core/txpool/validation.go
@@ -92,7 +92,7 @@ func ValidateTransaction(tx *types.Transaction, head *types.Header, signer types
 			return err
 		}
 	}
-	if rules.IsOsaka && tx.Gas() > params.MaxTxGas {
+	if rules.IsOsaka && !rules.IsAmsterdam && tx.Gas() > params.MaxTxGas {
 		return fmt.Errorf("%w (cap: %d, tx: %d)", core.ErrGasLimitTooHigh, params.MaxTxGas, tx.Gas())
 	}
 	// Transactions can't be negative. This may never happen using RLP decoded

--- a/eth/gasestimator/gasestimator.go
+++ b/eth/gasestimator/gasestimator.go
@@ -63,10 +63,10 @@ func Estimate(ctx context.Context, call *core.Message, opts *Options, gasCap uin
 	}
 
 	// Cap the maximum gas allowance according to EIP-7825 if the estimation targets Osaka
-	if hi > params.MaxTxGas {
-		if opts.Config.IsOsaka(opts.Header.Number, opts.Header.Time) {
-			hi = params.MaxTxGas
-		}
+	isOsaka := opts.Config.IsOsaka(opts.Header.Number, opts.Header.Time)
+	isAmsterdam := opts.Config.IsAmsterdam(opts.Header.Number, opts.Header.Time)
+	if hi > params.MaxTxGas && isOsaka && !isAmsterdam {
+		hi = params.MaxTxGas
 	}
 
 	// Normalize the max fee per gas the call is willing to spend.

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -560,7 +560,7 @@ func (miner *Miner) fillTransactions(ctx context.Context, interrupt *atomic.Int3
 	if env.header.ExcessBlobGas != nil {
 		filter.BlobFee = uint256.MustFromBig(eip4844.CalcBlobFee(miner.chainConfig, env.header))
 	}
-	if miner.chainConfig.IsOsaka(env.header.Number, env.header.Time) {
+	if miner.chainConfig.IsOsaka(env.header.Number, env.header.Time) && !miner.chainConfig.IsAmsterdam(env.header.Number, env.header.Time) {
 		filter.GasLimitCap = params.MaxTxGas
 	}
 	filter.BlobTxs = false


### PR DESCRIPTION
EIP-7825 caps the transaction gas limit at `MaxTxGas`, but after Amsterdam/EIP-8037 the transaction gas limit can include state gas reservoir in addition to the regular gas dimension. Applying the Osaka cap to the full `tx.Gas()` rejects otherwise valid Amsterdam transactions that need more than `MaxTxGas` total gas because of state gas, while their regular gas use remains within the intended limit.

This changes geth to stop applying the full transaction gas cap once Amsterdam is active:

- txpool stateless validation no longer rejects `tx.Gas() > MaxTxGas` under Amsterdam
- legacy pool reorg cleanup does not purge high-total-gas transactions at the Osaka transition if Amsterdam is also active
- execution precheck mirrors the txpool behavior and does not reject high-total-gas messages under Amsterdam

The block gas limit check remains in place, so transactions still cannot request more total gas than the current block gas limit.

Validation run:

```
go test ./core/txpool ./core/txpool/legacypool
go test ./core -run TestStateProcessorErrors
```
