### PR TITLE
eth/protocols/snap: downgrade log levels for storage retrieval messages

### DIFF
--- a/eth/protocols/snap/sync.go
+++ b/eth/protocols/snap/sync.go
@@ -1998,15 +1998,13 @@ func (s *Syncer) processAccountResponse(res *accountResponse) {
 		// The hash of last delivered account in the response
 		last := res.hashes[len(res.hashes)-1]
 		for hash := range res.task.SubTasks {
-			// TODO(rjl493456442) degrade the log level before merging.
 			if hash.Cmp(last) > 0 {
-				log.Info("Keeping suspended storage retrieval", "account", hash)
+				log.Debug("Keeping suspended storage retrieval", "account", hash)
 				continue
 			}
-			// TODO(rjl493456442) degrade the log level before merging.
 			// It should never happen in ethereum.
 			if _, ok := resumed[hash]; !ok {
-				log.Error("Aborting suspended storage retrieval", "account", hash)
+				log.Warn("Aborting suspended storage retrieval", "account", hash)
 				delete(res.task.SubTasks, hash)
 				largeStorageDiscardGauge.Inc(1)
 			}


### PR DESCRIPTION
Downgrade `log.Info` to `log.Debug` and `log.Error` to `log.Warn` for suspended storage retrieval logs in snap sync, as marked by the TODO comments