### PR TITLE
cmd/utils: tune GOGC for large cache values

### DIFF
--- a/cmd/geth/main.go
+++ b/cmd/geth/main.go
@@ -101,6 +101,7 @@ var (
 		utils.CachePreimagesFlag,
 		utils.CacheLogSizeFlag,
 		utils.FDLimitFlag,
+		utils.MemoryLimitFlag,
 		utils.CryptoKZGFlag,
 		utils.ListenPortFlag,
 		utils.DiscoveryPortFlag,

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -1771,32 +1771,23 @@ func SetEthConfig(ctx *cli.Context, stack *node.Node, cfg *ethconfig.Config) {
 	// burned ~20% of CPU on `runtime.scanobject`/`gcDrain`/`findObject`
 	// (confirmed by CPU profile of newPayload).
 	//
-	// Modern Go (1.19+) supports SetMemoryLimit, which lets the runtime
-	// keep GOGC at the default 100 (fewer/larger collections) while still
-	// guaranteeing memory stays below a soft cap. We size the cap so it's
-	// large enough that GOGC=100 governs steady-state behavior, but the
-	// limit kicks in if real memory pressure appears.
-	cache := ctx.Int(CacheFlag.Name)
-	var memLimit int64
-	if mem, memErr := gopsutil.VirtualMemory(); memErr == nil && mem.Total > 0 {
-		// Leave half the host memory for the OS / page cache / other
-		// processes; cap the rest at roughly 4× the configured DB cache
-		// to avoid runaway growth on machines with lots of RAM but a
-		// modest --cache.
-		halfHost := int64(mem.Total / 2)
-		fourCache := int64(cache) * 4 * 1024 * 1024
-		memLimit = min(halfHost, fourCache)
-	} else {
-		// Fallback when the host's total memory isn't reportable.
-		memLimit = int64(cache) * 4 * 1024 * 1024
+	// Modern Go (1.19+) supports SetMemoryLimit, which lets the runtime keep
+	// GOGC at the default 100 (fewer/larger collections) while still keeping
+	// memory below a soft cap. We size the cap from the same cgroup-aware
+	// limit used for the cache sanitizer above (total), so it's large enough
+	// that GOGC=100 governs steady state but the limit engages under real
+	// memory pressure. When the effective limit can't be determined, leave
+	// Go's defaults untouched.
+	if total > 0 {
+		cache := int64(ctx.Int(CacheFlag.Name)) * 1024 * 1024
+		// Target ~4× the cache so GOGC=100 governs steady state, but cap at
+		// half of memory. The rest is for the OS, page cache, and off-heap
+		// caches like Pebble that SetMemoryLimit doesn't count.
+		memLimit := min(int64(total)/2, cache*4)
+		log.Debug("Setting Go memory limit", "MB", memLimit/1024/1024, "source", source)
+		godebug.SetMemoryLimit(memLimit)
+		godebug.SetGCPercent(100)
 	}
-	if memLimit < int64(cache)*1024*1024*2 {
-		// Always allow at least 2× the cache so the cache itself fits.
-		memLimit = int64(cache) * 1024 * 1024 * 2
-	}
-	log.Debug("Setting Go memory limit", "MB", memLimit/1024/1024)
-	godebug.SetMemoryLimit(memLimit)
-	godebug.SetGCPercent(100)
 
 	if ctx.IsSet(SyncTargetFlag.Name) {
 		cfg.SyncMode = ethconfig.FullSync // dev sync target forces full sync

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -556,7 +556,7 @@ var (
 	}
 	MemoryLimitFlag = &cli.IntFlag{
 		Name:     "memorylimit",
-		Usage:    "Soft memory limit for the Go runtime in megabytes (default = derived from --cache and available memory)",
+		Usage:    "Soft memory limit for the Go runtime in megabytes (default = no limit)",
 		Category: flags.PerfCategory,
 	}
 	CryptoKZGFlag = &cli.StringFlag{
@@ -1767,36 +1767,12 @@ func SetEthConfig(ctx *cli.Context, stack *node.Node, cfg *ethconfig.Config) {
 			ctx.Set(CacheFlag.Name, strconv.Itoa(allowance))
 		}
 	}
-	// Tune Go's GC to balance throughput against the database cache.
-	//
-	// The historical formula here was:
-	//   gogc = max(20, min(100, 100/(cache_GB)))
-	// which drove GOGC down to 20 at --cache >= 8 GiB. With GOGC=20, the GC
-	// fires every ~20% heap growth — and during block processing that
-	// burned ~20% of CPU on `runtime.scanobject`/`gcDrain`/`findObject`
-	// (confirmed by CPU profile of newPayload).
-	//
-	// Modern Go (1.19+) supports SetMemoryLimit, which lets the runtime keep
-	// GOGC at the default 100 (fewer/larger collections) while still keeping
-	// memory below a soft cap. We size the cap from the same cgroup-aware
-	// limit used for the cache sanitizer above (total), so it's large enough
-	// that GOGC=100 governs steady state but the limit engages under real
-	// memory pressure. An explicit --memorylimit overrides this and when neither
-	// is available, Go's defaults are left untouched.
+
+	godebug.SetGCPercent(100)
 	if ctx.IsSet(MemoryLimitFlag.Name) {
 		memLimit := int64(ctx.Int(MemoryLimitFlag.Name)) * 1024 * 1024
-		log.Debug("Setting Go memory limit", "MB", memLimit/1024/1024, "source", "flag")
+		log.Debug("Setting Go memory limit", "MB", memLimit/1024/1024)
 		godebug.SetMemoryLimit(memLimit)
-		godebug.SetGCPercent(100)
-	} else if total > 0 {
-		cache := int64(ctx.Int(CacheFlag.Name)) * 1024 * 1024
-		// Target ~4x the cache so GOGC=100 governs steady state, but cap at
-		// half of memory. The rest is for the OS, page cache, and off-heap
-		// caches like Pebble that SetMemoryLimit doesn't count.
-		memLimit := min(int64(total)/2, cache*4)
-		log.Debug("Setting Go memory limit", "MB", memLimit/1024/1024, "source", source)
-		godebug.SetMemoryLimit(memLimit)
-		godebug.SetGCPercent(100)
 	}
 
 	if ctx.IsSet(SyncTargetFlag.Name) {

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -554,6 +554,11 @@ var (
 		Usage:    "Raise the open file descriptor resource limit (default = system fd limit)",
 		Category: flags.PerfCategory,
 	}
+	MemoryLimitFlag = &cli.IntFlag{
+		Name:     "memorylimit",
+		Usage:    "Soft memory limit for the Go runtime in megabytes (default = derived from --cache and available memory)",
+		Category: flags.PerfCategory,
+	}
 	CryptoKZGFlag = &cli.StringFlag{
 		Name:     "crypto.kzg",
 		Usage:    "KZG library implementation to use; gokzg (recommended) or ckzg",
@@ -1776,11 +1781,16 @@ func SetEthConfig(ctx *cli.Context, stack *node.Node, cfg *ethconfig.Config) {
 	// memory below a soft cap. We size the cap from the same cgroup-aware
 	// limit used for the cache sanitizer above (total), so it's large enough
 	// that GOGC=100 governs steady state but the limit engages under real
-	// memory pressure. When the effective limit can't be determined, leave
-	// Go's defaults untouched.
-	if total > 0 {
+	// memory pressure. An explicit --memorylimit overrides this and when neither
+	// is available, Go's defaults are left untouched.
+	if ctx.IsSet(MemoryLimitFlag.Name) {
+		memLimit := int64(ctx.Int(MemoryLimitFlag.Name)) * 1024 * 1024
+		log.Debug("Setting Go memory limit", "MB", memLimit/1024/1024, "source", "flag")
+		godebug.SetMemoryLimit(memLimit)
+		godebug.SetGCPercent(100)
+	} else if total > 0 {
 		cache := int64(ctx.Int(CacheFlag.Name)) * 1024 * 1024
-		// Target ~4× the cache so GOGC=100 governs steady state, but cap at
+		// Target ~4x the cache so GOGC=100 governs steady state, but cap at
 		// half of memory. The rest is for the OS, page cache, and off-heap
 		// caches like Pebble that SetMemoryLimit doesn't count.
 		memLimit := min(int64(total)/2, cache*4)

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -1762,12 +1762,41 @@ func SetEthConfig(ctx *cli.Context, stack *node.Node, cfg *ethconfig.Config) {
 			ctx.Set(CacheFlag.Name, strconv.Itoa(allowance))
 		}
 	}
-	// Ensure Go's GC ignores the database cache for trigger percentage
+	// Tune Go's GC to balance throughput against the database cache.
+	//
+	// The historical formula here was:
+	//   gogc = max(20, min(100, 100/(cache_GB)))
+	// which drove GOGC down to 20 at --cache >= 8 GiB. With GOGC=20, the GC
+	// fires every ~20% heap growth — and during block processing that
+	// burned ~20% of CPU on `runtime.scanobject`/`gcDrain`/`findObject`
+	// (confirmed by CPU profile of newPayload).
+	//
+	// Modern Go (1.19+) supports SetMemoryLimit, which lets the runtime
+	// keep GOGC at the default 100 (fewer/larger collections) while still
+	// guaranteeing memory stays below a soft cap. We size the cap so it's
+	// large enough that GOGC=100 governs steady-state behavior, but the
+	// limit kicks in if real memory pressure appears.
 	cache := ctx.Int(CacheFlag.Name)
-	gogc := max(20, min(100, 100/(float64(cache)/1024)))
-
-	log.Debug("Sanitizing Go's GC trigger", "percent", int(gogc))
-	godebug.SetGCPercent(int(gogc))
+	var memLimit int64
+	if mem, memErr := gopsutil.VirtualMemory(); memErr == nil && mem.Total > 0 {
+		// Leave half the host memory for the OS / page cache / other
+		// processes; cap the rest at roughly 4× the configured DB cache
+		// to avoid runaway growth on machines with lots of RAM but a
+		// modest --cache.
+		halfHost := int64(mem.Total / 2)
+		fourCache := int64(cache) * 4 * 1024 * 1024
+		memLimit = min(halfHost, fourCache)
+	} else {
+		// Fallback when the host's total memory isn't reportable.
+		memLimit = int64(cache) * 4 * 1024 * 1024
+	}
+	if memLimit < int64(cache)*1024*1024*2 {
+		// Always allow at least 2× the cache so the cache itself fits.
+		memLimit = int64(cache) * 1024 * 1024 * 2
+	}
+	log.Debug("Setting Go memory limit", "MB", memLimit/1024/1024)
+	godebug.SetMemoryLimit(memLimit)
+	godebug.SetGCPercent(100)
 
 	if ctx.IsSet(SyncTargetFlag.Name) {
 		cfg.SyncMode = ethconfig.FullSync // dev sync target forces full sync


### PR DESCRIPTION
Needs bench with different cache values.

```
● GC Memory-Limit Retune - engine_newPayload benchmark
  ===========================================================
  Commit before: a06558042 (master)
  Commit after:  feea0dab1 (cmd/utils: tune GOGC for large cache values)
  Blocks: 1k mainnet (24950066 → 24951065)
  Runs: 3 baseline / 2 hawk, clean ZFS clone per run

                  Before (avg)    With Hawk (avg)     Δ
  Throughput      176.0 MGas/s    184.7 MGas/s        +4.9%
  Mean NP         172.3ms         164.2ms             -4.7%
  p50             162.8ms         156.7ms             -3.8%
  p95             282.4ms         270.4ms             -4.3%
  p99             391.0ms         373.8ms             -4.4%

  Machine: Intel Ultra 7 255H, 62GB DDR5, NVMe (ZFS), governor=performance, turbo=off

```