### PR TITLE
core: log elapsed time when flushing trie state on shutdown

### DIFF
--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -1363,15 +1363,21 @@ func (bc *BlockChain) Stop() {
 					recent := bc.GetBlockByNumber(number - offset)
 
 					log.Info("Writing cached state to disk", "block", recent.Number(), "hash", recent.Hash(), "root", recent.Root())
+					start := time.Now()
 					if err := triedb.Commit(recent.Root(), true); err != nil {
 						log.Error("Failed to commit recent state trie", "err", err)
+					} else {
+						log.Info("Written cached state to disk", "block", recent.Number(), "root", recent.Root(), "elapsed", common.PrettyDuration(time.Since(start)))
 					}
 				}
 			}
 			if snapBase != (common.Hash{}) {
 				log.Info("Writing snapshot state to disk", "root", snapBase)
+				start := time.Now()
 				if err := triedb.Commit(snapBase, true); err != nil {
 					log.Error("Failed to commit recent state trie", "err", err)
+				} else {
+					log.Info("Written snapshot state to disk", "root", snapBase, "elapsed", common.PrettyDuration(time.Since(start)))
 				}
 			}
 			for !bc.triegc.Empty() {


### PR DESCRIPTION
- on hash-mode nodes, `triedb.Commit` during `Stop` can stall for tens of seconds while paging the in-memory trie to disk
- only the start was logged, so operators saw `Writing cached/snapshot state to disk` and assumed the process had hung — risking a forced kill mid-flush
- emit a `Written ... state to disk` line with `elapsed` after each successful `Commit`, using the existing `common.PrettyDuration(time.Since(start))` pattern; failure path is unchanged since `log.Error` already covers it