### PR TITLE
eth/protocols/snap: validate trie node path length

### DIFF
--- a/eth/protocols/snap/handler.go
+++ b/eth/protocols/snap/handler.go
@@ -55,11 +55,13 @@ const (
 
 	// maxTrieNodePathLength is the longest a compact-encoded trie path can be
 	// while still addressing a node in any Ethereum state trie. Trie keys are
-	// Keccak256 hashes (32 bytes = 64 nibbles), and the compact encoding adds
-	// at most one prefix byte, giving 32+1 = 33 bytes. Anything longer is
-	// structurally invalid and cannot match a node, so the handler skips it
-	// without performing a trie traversal.
-	maxTrieNodePathLength = 33
+	// Keccak256 hashes (32 bytes = 64 nibbles). The theoretical compact-encoded
+	// upper bound is 33 bytes (64 nibbles + 1 prefix byte), but in an MPT the
+	// value node is always embedded in its parent and is never addressed as a
+	// standalone node, so the hexary path length is at most 63 nibbles and the
+	// compact encoding never exceeds 32 bytes. Anything longer is structurally
+	// invalid and the handler skips it without performing a trie traversal.
+	maxTrieNodePathLength = 32
 )
 
 // Handler is a callback to invoke from an outside runner after the boilerplate

--- a/eth/protocols/snap/handler.go
+++ b/eth/protocols/snap/handler.go
@@ -52,6 +52,14 @@ const (
 	// If we spend too much time, then it's a fairly high chance of timing out
 	// at the remote side, which means all the work is in vain.
 	maxTrieNodeTimeSpent = 5 * time.Second
+
+	// maxTrieNodePathLength is the longest a compact-encoded trie path can be
+	// while still addressing a node in any Ethereum state trie. Trie keys are
+	// Keccak256 hashes (32 bytes = 64 nibbles), and the compact encoding adds
+	// at most one prefix byte, giving 32+1 = 33 bytes. Anything longer is
+	// structurally invalid and cannot match a node, so the handler skips it
+	// without performing a trie traversal.
+	maxTrieNodePathLength = 33
 )
 
 // Handler is a callback to invoke from an outside runner after the boilerplate

--- a/eth/protocols/snap/handler_test.go
+++ b/eth/protocols/snap/handler_test.go
@@ -220,6 +220,71 @@ func TestServiceGetAccessListsQueryByteLimit(t *testing.T) {
 	}
 }
 
+// TestServiceGetTrieNodesQueryPathLength verifies that ServiceGetTrieNodesQuery
+// rejects structurally invalid (over-length) compact-encoded paths without
+// allocating in compactToHex or walking the trie. Trie keys are Keccak256
+// hashes, so the longest valid compact-encoded path is 33 bytes; anything
+// longer cannot match a node in any state trie. A peer sending such a path
+// (up to the 10MB request size cap) would otherwise force the server to
+// allocate 2*len(path)+1 nibbles per entry and start a doomed traversal.
+func TestServiceGetTrieNodesQueryPathLength(t *testing.T) {
+	t.Parallel()
+
+	bc, _, _ := getChainWithBALs(1, 100)
+	defer bc.Stop()
+
+	root := bc.CurrentBlock().Root
+
+	// One byte beyond the spec-aligned cap (33 bytes).
+	overlong := make([]byte, maxTrieNodePathLength+1)
+	for i := range overlong {
+		overlong[i] = byte(i)
+	}
+	// Far over the cap, exercising the worst-case allocation path.
+	gigantic := make([]byte, 1024)
+	for i := range gigantic {
+		gigantic[i] = byte(i)
+	}
+
+	tests := []struct {
+		name  string
+		paths []TrieNodePathSet
+	}{
+		{
+			name:  "account path one byte over limit",
+			paths: []TrieNodePathSet{{overlong}},
+		},
+		{
+			name:  "account path far over limit",
+			paths: []TrieNodePathSet{{gigantic}},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			encPaths, err := rlp.EncodeToRawList(tt.paths)
+			if err != nil {
+				t.Fatalf("encode paths: %v", err)
+			}
+			req := &GetTrieNodesPacket{
+				ID:    1,
+				Root:  root,
+				Paths: encPaths,
+				Bytes: softResponseLimit,
+			}
+			nodes, err := ServiceGetTrieNodesQuery(bc, req)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if len(nodes) != 1 {
+				t.Fatalf("expected 1 placeholder node, got %d", len(nodes))
+			}
+			if len(nodes[0]) != 0 {
+				t.Errorf("expected nil placeholder for oversized path, got %x", nodes[0])
+			}
+		})
+	}
+}
+
 // TestGetAccessListResponseDecoding verifies that an AccessListsPacket
 // round-trips through RLP encode/decode, preserving positional
 // correspondence and correctly representing absent BALs as empty strings.

--- a/eth/protocols/snap/handler_test.go
+++ b/eth/protocols/snap/handler_test.go
@@ -223,10 +223,12 @@ func TestServiceGetAccessListsQueryByteLimit(t *testing.T) {
 // TestServiceGetTrieNodesQueryPathLength verifies that ServiceGetTrieNodesQuery
 // rejects structurally invalid (over-length) compact-encoded paths without
 // allocating in compactToHex or walking the trie. Trie keys are Keccak256
-// hashes, so the longest valid compact-encoded path is 33 bytes; anything
-// longer cannot match a node in any state trie. A peer sending such a path
-// (up to the 10MB request size cap) would otherwise force the server to
-// allocate 2*len(path)+1 nibbles per entry and start a doomed traversal.
+// hashes; value nodes are always embedded in their parent and are never
+// addressed as standalone nodes, so the longest compact-encoded path that can
+// match a node is 32 bytes. Anything longer cannot match a node in any state
+// trie. A peer sending such a path (up to the 10MB request size cap) would
+// otherwise force the server to allocate 2*len(path)+1 nibbles per entry and
+// start a doomed traversal.
 func TestServiceGetTrieNodesQueryPathLength(t *testing.T) {
 	t.Parallel()
 

--- a/eth/protocols/snap/handlers.go
+++ b/eth/protocols/snap/handlers.go
@@ -476,15 +476,15 @@ func ServiceGetTrieNodesQuery(chain *core.BlockChain, req *GetTrieNodesPacket) (
 			// the request, matching the existing behavior for non-existent nodes.
 			if len(accKey) > maxTrieNodePathLength {
 				nodes = append(nodes, nil)
-				break
+			} else {
+				blob, resolved, err := accTrie.GetNode(accKey)
+				loads += resolved // always account database reads, even for failures
+				if err != nil {
+					break
+				}
+				nodes = append(nodes, blob)
+				bytes += uint64(len(blob))
 			}
-			blob, resolved, err := accTrie.GetNode(accKey)
-			loads += resolved // always account database reads, even for failures
-			if err != nil {
-				break
-			}
-			nodes = append(nodes, blob)
-			bytes += uint64(len(blob))
 
 		default:
 			// Storage slots requested, open the storage trie and retrieve from there
@@ -528,18 +528,15 @@ func ServiceGetTrieNodesQuery(chain *core.BlockChain, req *GetTrieNodesPacket) (
 				// the response stays positionally aligned with the request.
 				if len(path) > maxTrieNodePathLength {
 					nodes = append(nodes, nil)
-					if bytes > req.Bytes || loads > maxTrieNodeLookups || time.Since(start) > maxTrieNodeTimeSpent {
+				} else {
+					blob, resolved, err := stTrie.GetNode(path)
+					loads += resolved // always account database reads, even for failures
+					if err != nil {
 						break
 					}
-					continue
+					nodes = append(nodes, blob)
+					bytes += uint64(len(blob))
 				}
-				blob, resolved, err := stTrie.GetNode(path)
-				loads += resolved // always account database reads, even for failures
-				if err != nil {
-					break
-				}
-				nodes = append(nodes, blob)
-				bytes += uint64(len(blob))
 
 				// Sanity check limits to avoid DoS on the store trie loads
 				if bytes > req.Bytes || loads > maxTrieNodeLookups || time.Since(start) > maxTrieNodeTimeSpent {

--- a/eth/protocols/snap/handlers.go
+++ b/eth/protocols/snap/handlers.go
@@ -469,6 +469,15 @@ func ServiceGetTrieNodesQuery(chain *core.BlockChain, req *GetTrieNodesPacket) (
 			if accKey == nil {
 				return nodes, fmt.Errorf("%w: invalid account node request", errBadRequest)
 			}
+			// Skip structurally invalid paths (longer than maxTrieNodePathLength)
+			// without traversing the trie. compactToHex would otherwise allocate
+			// 2*len(accKey)+1 bytes for a key that cannot possibly match any node.
+			// A nil placeholder is appended to preserve positional alignment with
+			// the request, matching the existing behavior for non-existent nodes.
+			if len(accKey) > maxTrieNodePathLength {
+				nodes = append(nodes, nil)
+				break
+			}
 			blob, resolved, err := accTrie.GetNode(accKey)
 			loads += resolved // always account database reads, even for failures
 			if err != nil {
@@ -512,6 +521,17 @@ func ServiceGetTrieNodesQuery(chain *core.BlockChain, req *GetTrieNodesPacket) (
 				path, _, err := rlp.SplitString(innerIt.Value())
 				if err != nil {
 					return nil, fmt.Errorf("%w: invalid storage key: %v", errBadRequest, err)
+				}
+				// Skip structurally invalid paths (longer than maxTrieNodePathLength)
+				// without traversing the storage trie. See the account-path branch
+				// above for the rationale; we still append a nil placeholder so
+				// the response stays positionally aligned with the request.
+				if len(path) > maxTrieNodePathLength {
+					nodes = append(nodes, nil)
+					if bytes > req.Bytes || loads > maxTrieNodeLookups || time.Since(start) > maxTrieNodeTimeSpent {
+						break
+					}
+					continue
 				}
 				blob, resolved, err := stTrie.GetNode(path)
 				loads += resolved // always account database reads, even for failures


### PR DESCRIPTION
## Description

Fixes #34853.

`ServiceGetTrieNodesQuery` in `eth/protocols/snap/handlers.go` passes peer-supplied paths straight to `accTrie.GetNode` / `stTrie.GetNode`, which call `compactToHex(path)` and walk the trie. The handler currently performs no length check on the incoming path.

State trie keys are Keccak256 hashes (32 bytes = 64 nibbles), so the longest valid compact-encoded path is **33 bytes** (64 nibbles + 1 prefix byte). Any path longer than that is structurally invalid and cannot address a node in any Ethereum state trie.

Two consequences of the missing check:

1. **Resource amplification.** A peer can pack a `GetTrieNodes` request (up to the 10 MB message limit) with arbitrary-length paths. For each, geth allocates `2*len(path)+1` nibbles in `compactToHex` and starts a doomed trie traversal. Cheap to send, expensive to serve.
2. **Cross-client compliance.** The devp2p snap-test suite (`cmd/devp2p/internal/ethtest/snap.go`, "very long trie node path") expects geth's accept-and-empty-respond behavior. Clients that reject overlong paths at the protocol layer (the spec-aligned behavior) fail this test.

## Fix

Add `maxTrieNodePathLength = 33` in `eth/protocols/snap/handler.go` and guard both the account-path and storage-path branches in `ServiceGetTrieNodesQuery`. When a path exceeds the limit, append a `nil` placeholder and skip the trie walk:

```go
if len(accKey) > maxTrieNodePathLength {
    nodes = append(nodes, nil)
    break
}
```

The `nil` placeholder preserves positional alignment with the request and matches the existing wire behavior for paths that resolve to a non-existent node. **Wire-observable behavior is unchanged** — peers see the same response shape as before. Only the server-side cost goes away.

Happy to follow up with a stricter behavior (skip-and-omit, or peer disconnect via `errBadRequest`) if maintainers prefer that direction; that would be a deliberate protocol change and may want spec-side discussion first.

## Tests

`TestServiceGetTrieNodesQueryPathLength` in `eth/protocols/snap/handler_test.go` covers:
- account path one byte over the limit
- account path far over the limit (1024 bytes)

The storage-path branch uses the identical guard, but exercising it on the wire requires a chain with existing accounts and a populated storage trie; left as a follow-up.

```
$ go test -count=1 ./eth/protocols/snap/...
ok      github.com/ethereum/go-ethereum/eth/protocols/snap      22.289s

$ go test -count=1 ./eth/downloader/...
ok      github.com/ethereum/go-ethereum/eth/downloader  9.416s
```

## Notes for reviewers

- Diff is +93 / -0 across 3 files. No code paths removed.
- The issue suggests possible follow-ups (peer disconnect, devp2p test update). This PR intentionally takes the smallest correct step; happy to extend in a follow-up once reviewers weigh in on protocol semantics.