### PR TITLE
internal/download: don't discard `dst.Close` error

### DIFF
--- a/internal/download/download.go
+++ b/internal/download/download.go
@@ -210,7 +210,9 @@ func (db *ChecksumDB) DownloadFile(url, dstPath string) error {
 		dst = newDownloadWriter(fd, resp.ContentLength)
 	}
 	_, err = io.Copy(dst, resp.Body)
-	dst.Close()
+	if closeErr := dst.Close(); err == nil {
+		err = closeErr
+	}
 	if err != nil {
 		os.Remove(tmpfile)
 		return err

--- a/internal/download/download.go
+++ b/internal/download/download.go
@@ -209,11 +209,11 @@ func (db *ChecksumDB) DownloadFile(url, dstPath string) error {
 	if resp.ContentLength > 0 {
 		dst = newDownloadWriter(fd, resp.ContentLength)
 	}
-	_, err = io.Copy(dst, resp.Body)
-	if closeErr := dst.Close(); err == nil {
-		err = closeErr
+	if _, err = io.Copy(dst, resp.Body); err != nil {
+		os.Remove(tmpfile)
+		return err
 	}
-	if err != nil {
+	if err = dst.Close(); err != nil {
 		os.Remove(tmpfile)
 		return err
 	}


### PR DESCRIPTION
When `io.Copy` succeeds but the buffered `Close` fails (e.g. disk full on `Flush`), the error was swallowed and verification reported a misleading hash mismatch instead of the real I/O failure. Keep the `Close` error when `io.Copy` didn't already produce one.