### PR TITLE
accounts/abi/bind: re-export event signature mismatch errors

### DIFF
--- a/accounts/abi/bind/old.go
+++ b/accounts/abi/bind/old.go
@@ -176,6 +176,14 @@ var (
 	// ErrNoCodeAfterDeploy is returned by WaitDeployed if contract creation leaves
 	// an empty contract behind.
 	ErrNoCodeAfterDeploy = bind2.ErrNoCodeAfterDeploy
+
+	// ErrNoEventSignature is returned when a log entry has no topics.
+	ErrNoEventSignature = bind2.ErrNoEventSignature
+
+	// ErrEventSignatureMismatch is returned when a log's topic[0] does not match
+	// the expected event signature. Callers can use errors.Is to distinguish a
+	// signature mismatch from other unpacking failures.
+	ErrEventSignatureMismatch = bind2.ErrEventSignatureMismatch
 )
 
 // ContractCaller defines the methods needed to allow operating with a contract on a read

--- a/accounts/abi/bind/old.go
+++ b/accounts/abi/bind/old.go
@@ -181,8 +181,7 @@ var (
 	ErrNoEventSignature = bind2.ErrNoEventSignature
 
 	// ErrEventSignatureMismatch is returned when a log's topic[0] does not match
-	// the expected event signature. Callers can use errors.Is to distinguish a
-	// signature mismatch from other unpacking failures.
+	// the expected event signature.
 	ErrEventSignatureMismatch = bind2.ErrEventSignatureMismatch
 )
 


### PR DESCRIPTION
The bind/v2 package already defines ErrEventSignatureMismatch and ErrNoEventSignature, and generated code references them correctly. However, callers importing the top-level bind package have no way to use errors.Is without also importing bind/v2 directly. This re-exports both sentinels through the compatibility shim in bind/old.go, following the same pattern used for ErrNoCode and friends.

Fixes #34075