### PR TITLE
cmd/evm: skip empty lines in stdin batch mode

### DIFF
--- a/cmd/evm/blockrunner.go
+++ b/cmd/evm/blockrunner.go
@@ -71,7 +71,7 @@ func blockTestCmd(ctx *cli.Context) error {
 	for scanner.Scan() {
 		fname := scanner.Text()
 		if len(fname) == 0 {
-			return nil
+			continue
 		}
 		results, err := runBlockTest(ctx, fname)
 		if err != nil {

--- a/cmd/evm/staterunner.go
+++ b/cmd/evm/staterunner.go
@@ -84,7 +84,7 @@ func stateTestCmd(ctx *cli.Context) error {
 	for scanner.Scan() {
 		fname := scanner.Text()
 		if len(fname) == 0 {
-			return nil
+			continue
 		}
 		results, err := runStateTest(ctx, fname)
 		if err != nil {


### PR DESCRIPTION
`blockrunner` and `staterunner` returned on the first empty stdin line, silently skipping the rest of the batch. Switch to `continue` so all filenames get processed, matching `cmd/rlpdump`.