### PR TITLE
triedb/pathdb: fix layer 5 key range in storage iterator traversal test

### DIFF
--- a/triedb/pathdb/iterator_test.go
+++ b/triedb/pathdb/iterator_test.go
@@ -489,7 +489,7 @@ func TestStorageIteratorTraversalValues(t *testing.T) {
 		if i%8 == 0 {
 			e[common.Hash{i}] = fmt.Appendf(nil, "layer-%d, key %d", 4, i)
 		}
-		if i > 50 || i < 85 {
+		if i > 50 && i < 85 {
 			f[common.Hash{i}] = fmt.Appendf(nil, "layer-%d, key %d", 5, i)
 		}
 		if i%64 == 0 {


### PR DESCRIPTION
Mirror the account-iterator test fix from #34639 into the sibling storage-iterator test in the same file. The layer-5 diff condition used `i > 50 || i < 85`, which is true for every byte in the 0..255 loop since the two ranges cover the full byte space between them.

Switch to `i > 50 && i < 85` so layer 5 only covers the intended band (51..84), consistent with the fix already applied to TestAccountIteratorTraversalValues in #34639 and to both variants of TestAccountIteratorTraversalValues / TestStorageIteratorTraversalValues in core/state/snapshot/iterator_test.go from #34638.