### PR TITLE
add ux improvement changes

### DIFF
--- a/core/rawdb/chain_iterator.go
+++ b/core/rawdb/chain_iterator.go
@@ -298,9 +298,10 @@ func unindexTransactions(db ethdb.Database, from uint64, to uint64, interrupt ch
 
 		// we expect the first number to come in to be [from]. Therefore, setting
 		// nextNum to from means that the queue gap-evaluation will work correctly
-		nextNum     = from
-		queue       = prque.New[int64, *blockTxHashes](nil)
-		blocks, txs = 0, 0 // for stats reporting
+		nextNum          = from
+		queue            = prque.New[int64, *blockTxHashes](nil)
+		blocks, txs      = 0, 0 // for stats reporting
+		loggedFirstBanner = false
 	)
 	// Otherwise spin up the concurrent iterator and unindexer
 	for delivery := range hashesCh {
@@ -338,7 +339,12 @@ func unindexTransactions(db ethdb.Database, from uint64, to uint64, interrupt ch
 			}
 			// If we've spent too much time already, notify the user of what we're doing
 			if time.Since(logged) > 8*time.Second {
-				log.Info("Unindexing transactions", "blocks", blocks, "txs", txs, "total", to-from, "elapsed", common.PrettyDuration(time.Since(start)))
+				if !loggedFirstBanner {
+					log.Info("Unindexing transactions — this is normal maintenance and does not indicate data loss", "blocks", blocks, "txs", txs, "total", to-from, "elapsed", common.PrettyDuration(time.Since(start)))
+					loggedFirstBanner = true
+				} else {
+					log.Debug("Unindexing transactions", "blocks", blocks, "txs", txs, "total", to-from, "elapsed", common.PrettyDuration(time.Since(start)))
+				}
 				logged = time.Now()
 			}
 		}

--- a/core/rawdb/chain_iterator.go
+++ b/core/rawdb/chain_iterator.go
@@ -340,7 +340,7 @@ func unindexTransactions(db ethdb.Database, from uint64, to uint64, interrupt ch
 			// If we've spent too much time already, notify the user of what we're doing
 			if time.Since(logged) > 8*time.Second {
 				if !loggedFirstBanner {
-					log.Info("Unindexing transactions — this is normal maintenance and does not indicate data loss", "blocks", blocks, "txs", txs, "total", to-from, "elapsed", common.PrettyDuration(time.Since(start)))
+					log.Info("Removing old transaction ids from transaction lookup index", "blocks", blocks, "txs", txs, "total", to-from, "elapsed", common.PrettyDuration(time.Since(start)))
 					loggedFirstBanner = true
 				} else {
 					log.Debug("Unindexing transactions", "blocks", blocks, "txs", txs, "total", to-from, "elapsed", common.PrettyDuration(time.Since(start)))

--- a/core/rawdb/database.go
+++ b/core/rawdb/database.go
@@ -719,7 +719,7 @@ func ReadChainMetadata(db ethdb.KeyValueStore) [][]string {
 	// more actionable message instead of the generic "<nil>".
 	ppDatabaseVersion := func(val *uint64) string {
 		if val == nil {
-			return "not set (new or uninitialized database)"
+			return "<nil>, database not initialized"
 		}
 		return fmt.Sprintf("%d (%#x)", *val, *val)
 	}

--- a/core/rawdb/database.go
+++ b/core/rawdb/database.go
@@ -714,8 +714,18 @@ func ReadChainMetadata(db ethdb.KeyValueStore) [][]string {
 		return fmt.Sprintf("%d (%#x)", *val, *val)
 	}
 
+	// databaseVersion is special-cased: when nil, it means the database is
+	// uninitialized (rather than an optional/empty field), so we surface a
+	// more actionable message instead of the generic "<nil>".
+	ppDatabaseVersion := func(val *uint64) string {
+		if val == nil {
+			return "not set (new or uninitialized database)"
+		}
+		return fmt.Sprintf("%d (%#x)", *val, *val)
+	}
+
 	data := [][]string{
-		{"databaseVersion", pp(ReadDatabaseVersion(db))},
+		{"databaseVersion", ppDatabaseVersion(ReadDatabaseVersion(db))},
 		{"headBlockHash", fmt.Sprintf("%v", ReadHeadBlockHash(db))},
 		{"headFastBlockHash", fmt.Sprintf("%v", ReadHeadFastBlockHash(db))},
 		{"headHeaderHash", fmt.Sprintf("%v", ReadHeadHeaderHash(db))},

--- a/core/state/pruner/pruner.go
+++ b/core/state/pruner/pruner.go
@@ -68,8 +68,8 @@ type Config struct {
 //   - iterate the database, delete all other state entries which
 //     don't belong to the target state and the genesis state
 //
-// It can take several hours(around 2 hours for mainnet) to finish
-// the whole pruning work. It's recommended to run this offline tool
+// It can take several hours to several days, depending on chain size and
+// disk speed, to finish the whole pruning work. It's recommended to run this offline tool
 // periodically in order to release the disk usage and improve the
 // disk read performance to some extent.
 type Pruner struct {


### PR DESCRIPTION
## Summary

Three small UX improvements found from analyzing the Arbitrum node operator support channels — these are recurring sources of confusion for our users, but the underlying issues aren't Arbitrum-specific. They affect any geth user running a node with a large database or doing a fresh setup, so we think landing them upstream is worthwhile rather than carrying them as a downstream patch. No behavior changes.

## Changes

**1. `core/rawdb/database.go`** — uninitialized DB shows `databaseVersion: <nil>` which leaves users guessing. Now displays `not set (new or uninitialized database)`. Special-cased only for `databaseVersion`; other nil-able fields keep `<nil>` since they can legitimately be nil on a healthy node.

**2. `core/rawdb/chain_iterator.go`** — `unindexTransactions` logs INFO every 8s for hours/days on large chains, leading users to think the node is stuck or losing data. First occurrence stays INFO with explicit context (`"normal maintenance and does not indicate data loss"`); subsequent lines downgraded to DEBUG.

**3. `core/state/pruner/pruner.go`** — comment-only. Updates the "around 2 hours for mainnet" estimate (no longer accurate) to "several hours to several days, depending on chain size and disk speed".

Happy to split into separate PRs if preferred.