### PR TITLE
rpc: get error code/data from wrapped error

### DIFF
--- a/rpc/json.go
+++ b/rpc/json.go
@@ -126,12 +126,12 @@ func errorMessage(err error) *jsonrpcMessage {
 		Code:    errcodeDefault,
 		Message: err.Error(),
 	}}
-	ec, ok := err.(Error)
-	if ok {
+	var ec Error
+	if errors.As(err, &ec) {
 		msg.Error.Code = ec.ErrorCode()
 	}
-	de, ok := err.(DataError)
-	if ok {
+	var de DataError
+	if errors.As(err, &de) {
 		msg.Error.Data = de.ErrorData()
 	}
 	return msg

--- a/rpc/json.go
+++ b/rpc/json.go
@@ -126,12 +126,13 @@ func errorMessage(err error) *jsonrpcMessage {
 		Code:    errcodeDefault,
 		Message: err.Error(),
 	}}
-	var ec Error
-	if errors.As(err, &ec) {
-		msg.Error.Code = ec.ErrorCode()
+	var rpcError Error
+	if errors.As(err, &rpcError) {
+		msg.Error.Code = rpcError.ErrorCode()
 	}
-	var de DataError
-	if errors.As(err, &de) {
+	// Type assert on rpcError to ensure that both code and data come from the same error object.
+	de, ok := rpcError.(DataError)
+	if ok {
 		msg.Error.Data = de.ErrorData()
 	}
 	return msg


### PR DESCRIPTION
`errorMessage` previously cast err directly to `rpc.Error`/`DataError`, which missed errors wrapped with `fmt.Errorf("%w", ...)`. Switch to `errors.As` so the code and data are extracted correctly from wrapped errors. This turns out to be very useful in client-server communication based on the geth's `rpc` package (see e.g. https://github.com/OffchainLabs/nitro/pull/4629).