### PR TITLE
p2p/discover: copy buffer before sending read errors to unhandled

### DIFF
--- a/p2p/discover/v4_udp.go
+++ b/p2p/discover/v4_udp.go
@@ -555,10 +555,8 @@ func (t *UDPv4) readLoop(unhandled chan<- ReadPacket) {
 		if err := t.handlePacket(from, buf[:nbytes]); err != nil && unhandled == nil {
 			t.log.Debug("Bad discv4 packet", "addr", from, "err", err)
 		} else if err != nil && unhandled != nil {
-			packet := make([]byte, nbytes)
-			copy(packet, buf[:nbytes])
-			select {
-			case unhandled <- ReadPacket{packet, from}:
+			p := ReadPacket{bytes.Clone(buf[:nbytes]), from}
+			case unhandled <- p:
 			default:
 			}
 		}

--- a/p2p/discover/v4_udp.go
+++ b/p2p/discover/v4_udp.go
@@ -556,6 +556,7 @@ func (t *UDPv4) readLoop(unhandled chan<- ReadPacket) {
 			t.log.Debug("Bad discv4 packet", "addr", from, "err", err)
 		} else if err != nil && unhandled != nil {
 			p := ReadPacket{bytes.Clone(buf[:nbytes]), from}
+			select {
 			case unhandled <- p:
 			default:
 			}

--- a/p2p/discover/v4_udp.go
+++ b/p2p/discover/v4_udp.go
@@ -555,8 +555,10 @@ func (t *UDPv4) readLoop(unhandled chan<- ReadPacket) {
 		if err := t.handlePacket(from, buf[:nbytes]); err != nil && unhandled == nil {
 			t.log.Debug("Bad discv4 packet", "addr", from, "err", err)
 		} else if err != nil && unhandled != nil {
+			packet := make([]byte, nbytes)
+			copy(packet, buf[:nbytes])
 			select {
-			case unhandled <- ReadPacket{buf[:nbytes], from}:
+			case unhandled <- ReadPacket{packet, from}:
 			default:
 			}
 		}


### PR DESCRIPTION
This fixes an issue where packets send to the `Unhandled` channel configured on discv4 could be corrupted when the packet buffer gets reused.