### PR TITLE
p2p/discover: fix deadlock in waitForNodes by buffering subscriber channel

### DIFF
--- a/p2p/discover/table.go
+++ b/p2p/discover/table.go
@@ -769,7 +769,7 @@ func (tab *Table) waitForNodes(ctx context.Context, n int) error {
 		}
 		if ch == nil {
 			// Init subscription.
-			ch = make(chan *enode.Node)
+			ch = make(chan *enode.Node, 1)
 			sub := tab.nodeFeed.Subscribe(ch)
 			defer sub.Unsubscribe()
 		}


### PR DESCRIPTION
## Summary

Fixes a deadlock between `loadSeedNodes` and `waitForNodes` in the discv5 discovery table (issue #34881).

## Root Cause

`loadSeedNodes` holds `tab.mutex` while calling `handleAddNode` → `nodeAdded` → `tab.nodeFeed.Send(n.Node)`. `FeedOf.Send` is synchronous — it blocks until every subscriber receives the value on their channel.

`waitForNodes` is the subscriber. After receiving a node on `ch`, it loops back to acquire `tab.mutex` to re-check the node count. There is a brief window where it's blocked on `tab.mutex.Lock()` rather than reading from `ch`.

If `loadSeedNodes` processes its next seed during this window and calls `Send` while holding the mutex, the result is a circular wait:

- `loadSeedNodes`: holds `tab.mutex`, blocked in `Send` (no reader on `ch`)
- `waitForNodes`: blocked on `tab.mutex.Lock()`, not reading `ch`
- `Table.loop` (`handleTrackRequest`): also blocked on `tab.mutex.Lock()`

This deadlock was latent but became near-certain after PR #32912 added `slowdown()` pacing to lookup creation, which increased the time iterators spend inside `lookupFailed → waitForNodes`.

## Fix

Change the subscriber channel in `waitForNodes` from unbuffered to buffered with capacity 1:

```go
// Before:
ch = make(chan *enode.Node)

// After:
ch = make(chan *enode.Node, 1)
```

A buffered channel allows `FeedOf.Send` to deliver a value without blocking, even when `waitForNodes` is momentarily between receiving on `ch` and re-acquiring the mutex. The value sits in the buffer until `waitForNodes` re-enters its select, at which point it's consumed and the actual bucket count is re-checked.

A buffer of 1 is sufficient because `FeedOf.sendLock` serializes sends — only one `Send` can execute at a time, and the subscriber drains the buffer on each select iteration.

## Test Plan

- [x] `go test ./p2p/discover/...` passes
- [x] `go test -race ./p2p/discover/...` passes
- [x] Deadlock reproduction test confirmed
  - With unbuffered channel: `waitForNodes` blocks on `tab.mutex.Lock()` while `FeedOf.Send` blocks in `reflect.Select` — deadlock
  - With buffered channel: both operations complete immediately

## Reproducer

The deadlock is reproducible by:
1. Running a beacon node that uses `RandomNodes()` for peer discovery
2. Cutting the host's external network connectivity
3. Waiting until the local routing table empties enough that lookups return empty and iterators enter `lookupFailed`

Goroutine dumps from the deadlock show three goroutines all stalled for 11+ minutes:
- `loadSeedNodes` in `FeedOf.Send` (holding `tab.mutex`)
- `waitForNodes` in `tab.mutex.Lock`
- `Table.loop` / `handleTrackRequest` in `tab.mutex.Lock`

Fixes: #34881