### PR TITLE
core/txpool/blobpool: continue on cell proof error in `GetBlobs`

### DIFF
--- a/core/txpool/blobpool/blobpool.go
+++ b/core/txpool/blobpool/blobpool.go
@@ -1517,7 +1517,8 @@ func (p *BlobPool) GetBlobs(vhashes []common.Hash, version byte) ([]*kzg4844.Blo
 			case types.BlobSidecarVersion1:
 				cellProofs, err := sidecar.CellProofsAt(i)
 				if err != nil {
-					return nil, nil, nil, err
+					log.Error("Failed to get cell proofs", "id", txID, "err", err)
+					continue
 				}
 				pf = cellProofs
 			}


### PR DESCRIPTION
`GetBlobs` returned early when `CellProofsAt` reported corrupted/out-of-bounds proofs, dropping every blob already collected and aborting the remaining hashes — a single bad sidecar killed the whole Engine API batch for consensus clients. Replaced the `return nil, nil, nil, err` with `log.Error + continue` so the slot stays `nil` per the sparse-array contract, matching the store/RLP/nil-sidecar branches a few lines above.