### PR TITLE
cmd, node, rpc: make HTTP body limit configurable

### DIFF
--- a/cmd/geth/main.go
+++ b/cmd/geth/main.go
@@ -193,6 +193,7 @@ var (
 		utils.AllowUnprotectedTxs,
 		utils.BatchRequestLimit,
 		utils.BatchResponseMaxSize,
+		utils.HTTPBodyLimitFlag,
 		utils.RPCTxSyncDefaultTimeoutFlag,
 		utils.RPCTxSyncMaxTimeoutFlag,
 		utils.RPCGlobalRangeLimitFlag,

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -850,6 +850,12 @@ var (
 		Value:    node.DefaultConfig.BatchResponseMaxSize,
 		Category: flags.APICategory,
 	}
+	HTTPBodyLimitFlag = &cli.IntFlag{
+		Name:     "http.bodylimit",
+		Usage:    "Maximum size of an HTTP RPC request body in bytes",
+		Value:    node.DefaultConfig.HTTPBodyLimit,
+		Category: flags.APICategory,
+	}
 
 	// Network Settings
 	MaxPeersFlag = &cli.IntFlag{
@@ -1349,6 +1355,10 @@ func setHTTP(ctx *cli.Context, cfg *node.Config) {
 
 	if ctx.IsSet(BatchResponseMaxSize.Name) {
 		cfg.BatchResponseMaxSize = ctx.Int(BatchResponseMaxSize.Name)
+	}
+
+	if ctx.IsSet(HTTPBodyLimitFlag.Name) {
+		cfg.HTTPBodyLimit = ctx.Int(HTTPBodyLimitFlag.Name)
 	}
 }
 

--- a/node/api.go
+++ b/node/api.go
@@ -181,6 +181,7 @@ func (api *adminAPI) StartHTTP(host *string, port *int, cors *string, apis *stri
 		rpcEndpointConfig: rpcEndpointConfig{
 			batchItemLimit:         api.node.config.BatchRequestLimit,
 			batchResponseSizeLimit: api.node.config.BatchResponseMaxSize,
+			httpBodyLimit:          api.node.config.HTTPBodyLimit,
 		},
 	}
 	if cors != nil {
@@ -259,6 +260,7 @@ func (api *adminAPI) StartWS(host *string, port *int, allowedOrigins *string, ap
 		rpcEndpointConfig: rpcEndpointConfig{
 			batchItemLimit:         api.node.config.BatchRequestLimit,
 			batchResponseSizeLimit: api.node.config.BatchResponseMaxSize,
+			httpBodyLimit:          api.node.config.HTTPBodyLimit,
 		},
 	}
 	if apis != nil {

--- a/node/config.go
+++ b/node/config.go
@@ -134,6 +134,9 @@ type Config struct {
 	// interface.
 	HTTPTimeouts rpc.HTTPTimeouts
 
+	// HTTPBodyLimit is the maximum size of an HTTP request body in bytes.
+	HTTPBodyLimit int `toml:",omitempty"`
+
 	// HTTPPathPrefix specifies a path prefix on which http-rpc is to be served.
 	HTTPPathPrefix string `toml:",omitempty"`
 

--- a/node/defaults.go
+++ b/node/defaults.go
@@ -63,6 +63,7 @@ var DefaultConfig = Config{
 	HTTPModules:          []string{"net", "web3"},
 	HTTPVirtualHosts:     []string{"localhost"},
 	HTTPTimeouts:         rpc.DefaultHTTPTimeouts,
+	HTTPBodyLimit:        rpc.DefaultHTTPBodyLimit,
 	WSPort:               DefaultWSPort,
 	WSModules:            []string{"net", "web3"},
 	BatchRequestLimit:    1000,

--- a/node/node.go
+++ b/node/node.go
@@ -395,6 +395,7 @@ func (n *Node) startRPC() error {
 	rpcConfig := rpcEndpointConfig{
 		batchItemLimit:         n.config.BatchRequestLimit,
 		batchResponseSizeLimit: n.config.BatchResponseMaxSize,
+		httpBodyLimit:          n.config.HTTPBodyLimit,
 	}
 
 	initHttp := func(server *httpServer, port int) error {

--- a/node/rpcstack_test.go
+++ b/node/rpcstack_test.go
@@ -324,6 +324,20 @@ func baseRpcRequest(t *testing.T, url, bodyStr string, extraHeaders ...string) *
 	return resp
 }
 
+func TestHTTPBodyLimit(t *testing.T) {
+	body := `{"jsonrpc":"2.0","id":1,"method":"rpc_modules","params":[]}`
+	cfg := &httpConfig{
+		rpcEndpointConfig: rpcEndpointConfig{
+			httpBodyLimit: len(body) - 1,
+		},
+	}
+	srv := createAndStartServer(t, cfg, false, &wsConfig{}, nil)
+	defer srv.stop()
+
+	resp := baseRpcRequest(t, "http://"+srv.listenAddr(), body)
+	assert.Equal(t, http.StatusRequestEntityTooLarge, resp.StatusCode)
+}
+
 type testClaim map[string]interface{}
 
 func (testClaim) Valid() error {

--- a/rpc/http.go
+++ b/rpc/http.go
@@ -36,8 +36,10 @@ import (
 )
 
 const (
-	defaultBodyLimit = 5 * 1024 * 1024
-	contentType      = "application/json"
+	// DefaultHTTPBodyLimit is the default maximum size of an HTTP request body.
+	DefaultHTTPBodyLimit = 5 * 1024 * 1024
+	defaultBodyLimit     = DefaultHTTPBodyLimit
+	contentType          = "application/json"
 )
 
 // https://www.jsonrpc.org/historical/json-rpc-over-http.html#id13


### PR DESCRIPTION
This exposes the existing HTTP RPC request body limit through node configuration and the `--http.bodylimit` flag.

The default remains 5MB. Operators that need to accept larger JSON-RPC request payloads in controlled environments, such as local development nodes or private RPC deployments, can now raise the limit without patching `rpc.Server` internals. The authenticated Engine API keeps its separate 128MB limit.

The setting is wired through normal node startup and admin-started HTTP/WS endpoints. A node RPC stack test covers rejection of a request larger than the configured limit.