### PR TITLE
cmd/workload: surface JSON encode errors when writing test files

### DIFF
--- a/cmd/workload/filtertestgen.go
+++ b/cmd/workload/filtertestgen.go
@@ -355,7 +355,9 @@ func (s *filterTestGen) writeQueries() {
 		exit(fmt.Errorf("Error creating filter test query file %s: %v", s.queryFile, err))
 		return
 	}
-	json.NewEncoder(file).Encode(&s.queries)
+	if err := json.NewEncoder(file).Encode(&s.queries); err != nil {
+		exit(fmt.Errorf("Error writing filter test query file %s: %v", s.queryFile, err))
+	}
 	file.Close()
 }
 

--- a/cmd/workload/filtertestperf.go
+++ b/cmd/workload/filtertestperf.go
@@ -160,5 +160,7 @@ func writeErrors(errorFile string, errors []*filterQuery) {
 		return
 	}
 	defer file.Close()
-	json.NewEncoder(file).Encode(errors)
+	if err := json.NewEncoder(file).Encode(errors); err != nil {
+		exit(fmt.Errorf("Error writing filter error file %s: %v", errorFile, err))
+	}
 }

--- a/cmd/workload/historytestgen.go
+++ b/cmd/workload/historytestgen.go
@@ -150,5 +150,7 @@ func writeJSON(fileName string, value any) {
 	}
 	defer file.Close()
 
-	json.NewEncoder(file).Encode(value)
+	if err := json.NewEncoder(file).Encode(value); err != nil {
+		exit(fmt.Errorf("error writing %s: %v", fileName, err))
+	}
 }


### PR DESCRIPTION
The three `json.NewEncoder(file).Encode(...)` calls in `filtertestgen.go`, `historytestgen.go`, and `filtertestperf.go` discarded their return values, so encode failures left empty/truncated JSON files while the process exited 0. Now each call routes the error through `exit()`, matching the surrounding pattern used for `os.Create` failures.