### PR TITLE
cmd/geth: respect --graphql=false

### DIFF
--- a/cmd/geth/config.go
+++ b/cmd/geth/config.go
@@ -270,7 +270,7 @@ func makeFullNode(ctx *cli.Context) *node.Node {
 	filterSystem := utils.RegisterFilterAPI(stack, backend, &cfg.Eth)
 
 	// Configure GraphQL if requested.
-	if ctx.IsSet(utils.GraphQLEnabledFlag.Name) {
+	if ctx.Bool(utils.GraphQLEnabledFlag.Name) {
 		utils.RegisterGraphQLService(stack, backend, filterSystem, &cfg.Node)
 	}
 	// Add the Ethereum Stats daemon if requested.


### PR DESCRIPTION
Passing `--graphql=false` currently still registers the GraphQL handler because the startup path checks whether the flag was set, not its boolean value.

This switches the registration condition to use `ctx.Bool`, so explicit false disables GraphQL while the default behavior remains unchanged.