### PR TITLE
event: make nil available

### DIFF
--- a/event/feedof.go
+++ b/event/feedof.go
@@ -88,7 +88,12 @@ func (f *FeedOf[T]) remove(sub *feedOfSub[T]) {
 // Send delivers to all subscribed channels simultaneously.
 // It returns the number of subscribers that the value was sent to.
 func (f *FeedOf[T]) Send(value T) (nsent int) {
-	rvalue := reflect.ValueOf(value)
+	var rvalue reflect.Value
+	if reflect.TypeFor[T]().Kind() == reflect.Interface {
+		rvalue = reflect.ValueOf(&value).Elem()
+	} else {
+		rvalue = reflect.ValueOf(value)
+	}
 
 	f.once.Do(f.init)
 	<-f.sendLock

--- a/event/feedof_test.go
+++ b/event/feedof_test.go
@@ -70,6 +70,28 @@ func TestFeedOf(t *testing.T) {
 	done.Wait()
 }
 
+// TestFeedOfSendNilAnySucceeds is a regression check: FeedOf[any].Send(nil) used to fail
+// (panic from Invalid reflect.Value on reflect.SelectCase, or silent non-delivery from
+// TrySend) because nil stored in interface{} does not satisfy reflect.ValueOf(value).Valid().
+// Send must succeed and deliver nil to every subscriber.
+func TestFeedOfSendNilAnySucceeds(t *testing.T) {
+	var feed FeedOf[any]
+	ch1 := make(chan any, 1)
+	ch2 := make(chan any, 1)
+	defer feed.Subscribe(ch1).Unsubscribe()
+	defer feed.Subscribe(ch2).Unsubscribe()
+
+	if nsent := feed.Send(nil); nsent != 2 {
+		t.Fatalf("Send(nil) nsent=%d, want 2 (failed delivery before reflect fix)", nsent)
+	}
+	for i, ch := range []chan any{ch1, ch2} {
+		got := <-ch
+		if got != nil {
+			t.Fatalf("subscriber %d: got %#v, want nil", i, got)
+		}
+	}
+}
+
 func TestFeedOfSubscribeSameChannel(t *testing.T) {
 	var (
 		feed FeedOf[int]


### PR DESCRIPTION
Description
Problem

When FeedOf is instantiated with an interface-shaped type argument (notably any / interface{}) and callers use Send(nil), the logical value is nil carried inside an interface box. Taking reflect.ValueOf(value) in that situation yields an invalid reflect.Value, because the boxed value does not expose a concrete type the way reflect expects.

That invalidated value was then plugged into reflective send helpers (reflect.SelectCase, reflect.Value.TrySend). The old behaviour was wrong in practice: Send(nil) could panic or fail to deliver, instead of broadcasting nil to subscribers like any other payload.

Fix

Build the reflect.Value used for sending from reflect.ValueOf(&value).Elem(), so the holder of T is reflected correctly and the send path sees a valid value (including “nil interface” cases).

Testing

Add TestFeedOfSendNilAnySucceeds, which subscribes two buffered channels on a FeedOf[any], calls Send(nil), and asserts nsent == 2 and that both subscribers receive nil. This locks in the fixed behaviour and documents the previous failure mode.