### PR TITLE
cmd/abigen: respect --v2=false

### DIFF
--- a/cmd/abigen/main.go
+++ b/cmd/abigen/main.go
@@ -215,7 +215,7 @@ func generate(c *cli.Context) error {
 		code string
 		err  error
 	)
-	if c.IsSet(v2Flag.Name) {
+	if c.Bool(v2Flag.Name) {
 		code, err = abigen.BindV2(types, abis, bins, c.String(pkgFlag.Name), libs, aliases)
 	} else {
 		code, err = abigen.Bind(types, abis, bins, sigs, c.String(pkgFlag.Name), libs, aliases)


### PR DESCRIPTION
Passing `--v2=false` currently still selects the v2 binding generator because the command checks whether the flag was set.

This switches generation to use the boolean flag value, so explicit false continues to generate legacy bindings while `--v2` keeps selecting v2.