### PR TITLE
cmd/evm/t8ntool: gate ProcessParentBlockHash on IsPrague || IsUBT

### DIFF
--- a/cmd/evm/internal/t8ntool/execution.go
+++ b/cmd/evm/internal/t8ntool/execution.go
@@ -233,7 +233,7 @@ func (pre *Prestate) Apply(vmConfig vm.Config, chainConfig *params.ChainConfig, 
 	if beaconRoot := pre.Env.ParentBeaconBlockRoot; beaconRoot != nil {
 		core.ProcessBeaconBlockRoot(*beaconRoot, evm)
 	}
-	if pre.Env.BlockHashes != nil && chainConfig.IsPrague(new(big.Int).SetUint64(pre.Env.Number), pre.Env.Timestamp) {
+	if pre.Env.BlockHashes != nil && (chainConfig.IsPrague(new(big.Int).SetUint64(pre.Env.Number), pre.Env.Timestamp) || chainConfig.IsUBT(new(big.Int).SetUint64(pre.Env.Number), pre.Env.Timestamp)) {
 		var (
 			prevNumber = pre.Env.Number - 1
 			prevHash   = pre.Env.BlockHashes[math.HexOrDecimal64(prevNumber)]


### PR DESCRIPTION
Mirror the IsPrague || IsUBT check used by core.PreExecution and the other refactored sites in #34812. UBT activates EIP-2935 too, so a UBT-only test config (e.g. tests/init.go Forks["Verkle"]) was silently skipping ProcessParentBlockHash here.