### PR TITLE
node: default OpenTelemetry SampleRatio to 1.0

### DIFF
--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -1104,7 +1104,7 @@ Please note that --` + MetricsHTTPFlag.Name + ` must be set to start the server.
 	RPCTelemetrySampleRatioFlag = &cli.Float64Flag{
 		Name:     "rpc.telemetry.sample-ratio",
 		Usage:    "Defines the sampling ratio for RPC telemetry (0.0 to 1.0)",
-		Value:    1.0,
+		Value:    node.DefaultConfig.OpenTelemetry.SampleRatio,
 		Category: flags.APICategory,
 	}
 	// Era flags are a group of flags related to the era archive format.

--- a/node/defaults.go
+++ b/node/defaults.go
@@ -76,6 +76,9 @@ var DefaultConfig = Config{
 		DiscoveryV5: true,
 	},
 	DBEngine: "", // Use whatever exists, will default to Pebble if non-existent and supported
+	OpenTelemetry: OpenTelemetryConfig{
+		SampleRatio: 1.0,
+	},
 }
 
 // DefaultDataDir is the default data directory to use for the databases and other


### PR DESCRIPTION
## Summary

The `--rpc.telemetry.sample-ratio` flag declares `Value: 1.0` and `geth --help` advertises `(default: 1)`. In practice, however, omitting the flag produces a sample ratio of `0`, causing `sdktrace.TraceIDRatioBased(0)` to drop 100% of spans. Users who enable `--rpc.telemetry` see the `OpenTelemetry trace export enabled` log line and a clean startup, but no traces ever leave the process.

The root cause is the interaction between two pieces of code:

1. `cmd/utils/flags.go:setOpenTelemetry` (added in #34062) only copies the flag value when `ctx.IsSet(...)` returns true:

   ```go
   if ctx.IsSet(RPCTelemetrySampleRatioFlag.Name) {
       tcfg.SampleRatio = ctx.Float64(RPCTelemetrySampleRatioFlag.Name)
   }
   ```

   That is the right pattern for "don't clobber a config-file value with the CLI default," but it implies that something else must initialise the field when neither source sets it.

2. `node/defaults.go:DefaultConfig` never initialises `OpenTelemetry.SampleRatio`, leaving it at the float64 zero value.

The result for the common CLI-only user (no TOML config) is `SampleRatio = 0` → every span is silently dropped, despite the documented default of 1.

## Change

Seed `OpenTelemetry: OpenTelemetryConfig{SampleRatio: 1.0}` in `node.DefaultConfig` so the documented default matches runtime behavior and the `ctx.IsSet` guard in `setOpenTelemetry` continues to do what it was designed to do.

## Test plan

- [x] Build geth from this branch and run with `--rpc.telemetry --rpc.telemetry.endpoint=grpc://collector:4317` (no `--rpc.telemetry.sample-ratio` flag). Confirmed an OTLP gRPC connection is established and spans arrive at an OpenTelemetry collector.
- [x] Re-tested with `http://...:4318` to confirm both transports work without the explicit flag.
- [x] Reproduced the broken behavior on plain `master` (no flag → no spans), and confirmed the fix restores expected behavior.
- [ ] Unit-test coverage in `cmd/utils` for the default-value path (not included; happy to add if reviewers prefer).