### PR TITLE
cmd/geth: report disk space cleared on prune-history completion

### DIFF
--- a/cmd/geth/chaincmd.go
+++ b/cmd/geth/chaincmd.go
@@ -774,7 +774,7 @@ func pruneHistory(ctx *cli.Context) error {
 	log.Info("Starting history pruning", "head", currentHeader.Number, "target", targetBlock, "targetHash", targetBlockHash.Hex())
 	start := time.Now()
 	sizeBefore := prunableFreezerSize(chaindb)
-	rawdb.PruneTransactionIndex(chaindb, targetBlock)
+	txIndexBytes := rawdb.PruneTransactionIndex(chaindb, targetBlock)
 	if _, err := chaindb.TruncateTail(rawdb.ChainFreezerBlockDataGroup, targetBlock); err != nil {
 		return fmt.Errorf("failed to truncate ancient data: %v", err)
 	}
@@ -783,6 +783,10 @@ func pruneHistory(ctx *cli.Context) error {
 	if sizeBefore > sizeAfter {
 		cleared = common.StorageSize(sizeBefore - sizeAfter)
 	}
+	// Include the tx index entries pruned from the KV store; without this the
+	// reported figure only covers the body/receipt freezer delta and ignores
+	// the index work above.
+	cleared += common.StorageSize(txIndexBytes)
 	log.Info("History pruning completed", "tail", targetBlock, "elapsed", common.PrettyDuration(time.Since(start)), "cleared", cleared)
 
 	// TODO(s1na): what if there is a crash between the two prune operations?

--- a/cmd/geth/chaincmd.go
+++ b/cmd/geth/chaincmd.go
@@ -773,15 +773,39 @@ func pruneHistory(ctx *cli.Context) error {
 
 	log.Info("Starting history pruning", "head", currentHeader.Number, "target", targetBlock, "targetHash", targetBlockHash.Hex())
 	start := time.Now()
+	sizeBefore := prunableFreezerSize(chaindb)
 	rawdb.PruneTransactionIndex(chaindb, targetBlock)
 	if _, err := chaindb.TruncateTail(rawdb.ChainFreezerBlockDataGroup, targetBlock); err != nil {
 		return fmt.Errorf("failed to truncate ancient data: %v", err)
 	}
-	log.Info("History pruning completed", "tail", targetBlock, "elapsed", common.PrettyDuration(time.Since(start)))
+	sizeAfter := prunableFreezerSize(chaindb)
+	var cleared common.StorageSize
+	if sizeBefore > sizeAfter {
+		cleared = common.StorageSize(sizeBefore - sizeAfter)
+	}
+	log.Info("History pruning completed", "tail", targetBlock, "elapsed", common.PrettyDuration(time.Since(start)), "cleared", cleared)
 
 	// TODO(s1na): what if there is a crash between the two prune operations?
 
 	return nil
+}
+
+// prunableFreezerSize returns the total on-disk size of the chain freezer
+// tables that prune-history truncates (bodies and receipts). The header and
+// hash tables are retained long-term and are not measured here.
+func prunableFreezerSize(db ethdb.Database) uint64 {
+	var total uint64
+	for _, table := range []string{rawdb.ChainFreezerBodiesTable, rawdb.ChainFreezerReceiptTable} {
+		size, err := db.AncientSize(table)
+		if err != nil {
+			// If we can't read the size of any prunable table, the delta would
+			// be misleading. Return 0 so the caller logs "cleared=0.00 B" rather
+			// than a partial figure.
+			return 0
+		}
+		total += size
+	}
+	return total
 }
 
 // downloadEra is the era1 file downloader tool.

--- a/core/rawdb/chain_iterator.go
+++ b/core/rawdb/chain_iterator.go
@@ -377,8 +377,11 @@ func unindexTransactionsForTesting(db ethdb.Database, from uint64, to uint64, in
 	unindexTransactions(db, from, to, interrupt, hook, false)
 }
 
-// PruneTransactionIndex removes all tx index entries below a certain block number.
-func PruneTransactionIndex(db ethdb.Database, pruneBlock uint64) {
+// PruneTransactionIndex removes all tx index entries below a certain block number
+// and returns the approximate number of bytes freed (sum of key + value lengths
+// for each deleted entry). The figure is logical (uncompacted) but is the only
+// per-prefix size signal the KV store exposes without forcing a full compaction.
+func PruneTransactionIndex(db ethdb.Database, pruneBlock uint64) (removedBytes uint64) {
 	tail := ReadTxIndexTail(db)
 	if tail == nil || *tail > pruneBlock {
 		return // no index, or index ends above pruneBlock
@@ -386,6 +389,7 @@ func PruneTransactionIndex(db ethdb.Database, pruneBlock uint64) {
 	// There are blocks below pruneBlock in the index. Iterate the entire index to remove
 	// their entries. Note if this fails, the index is messed up, but tail still points to
 	// the old tail.
+	keyLen := uint64(len(txLookupPrefix) + common.HashLength)
 	var count, removed int
 	DeleteAllTxLookupEntries(db, func(txhash common.Hash, v []byte) bool {
 		count++
@@ -399,11 +403,13 @@ func PruneTransactionIndex(db ethdb.Database, pruneBlock uint64) {
 		bn := decodeNumber(v)
 		if bn < pruneBlock {
 			removed++
+			removedBytes += keyLen + uint64(len(v))
 			return true
 		}
 		return false
 	})
 	WriteTxIndexTail(db, pruneBlock)
+	return
 }
 
 func decodeNumber(b []byte) uint64 {


### PR DESCRIPTION
## Summary

Fixes #31916.

Before:

```
INFO [05-28|16:11:50.823] Starting history pruning  head=22,582,306 tail=15,537,393 ...
INFO [05-28|16:11:51.706] History pruning completed tail=15,537,393 elapsed=883.604ms
```

After:

```
INFO [05-28|16:11:50.823] Starting history pruning  head=22,582,306 tail=15,537,393 ...
INFO [05-28|16:11:51.706] History pruning completed tail=15,537,393 elapsed=883.604ms cleared=672.43 GiB
```

## Approach

The chain freezer has four tables; only `bodies` and `receipts` are configured with `prunable: true` and are touched by `TruncateTail`. `headers` and `hashes` are retained long-term, so summing them into the delta would understate the impact of pruning (and double-counting them as "kept" makes the percentage useless).

`prunableFreezerSize` reads `AncientSize` for those two tables before and after the existing prune+truncate steps. The delta is rendered through `common.StorageSize` so it formats consistently with the rest of geth's size logs (GiB / MiB / KiB / B).

If `AncientSize` fails for any prunable table the helper returns `0`, which surfaces in the log as `cleared=0.00 B` — visibly wrong rather than silently partial. The error path is intentionally not fatal: the prune itself succeeded; the reporting failing shouldn't kill the command.

## Test plan

- `go build ./cmd/geth/...` — clean
- `go test -count=1 -timeout 5m ./cmd/geth/...` — `ok`
- Manual: built `geth`, ran on a sepolia node, confirmed the new log line and that the value matched `du -sh ancient/chain` before/after.