### PR TITLE
core/state/snapshot: make diskLayer.stopGeneration idempotent

### DIFF
--- a/core/state/snapshot/disklayer.go
+++ b/core/state/snapshot/disklayer.go
@@ -41,6 +41,7 @@ type diskLayer struct {
 	genMarker  []byte                    // Marker for the state that's indexed during initial layer generation
 	genPending chan struct{}             // Notification channel when generation is done (test synchronicity)
 	genAbort   chan chan *generatorStats // Notification channel to abort generating the snapshot in this layer
+	genStop    sync.Once                 // Guards stopGeneration so it can be called multiple times safely
 
 	lock sync.RWMutex
 }
@@ -184,17 +185,24 @@ func (dl *diskLayer) Update(blockHash common.Hash, accounts map[common.Hash][]by
 	return newDiffLayer(dl, blockHash, accounts, storage)
 }
 
-// stopGeneration aborts the state snapshot generation if it is currently running.
+// stopGeneration aborts the state snapshot generation if it is currently
+// running. It is safe to call multiple times: only the first call dispatches
+// an abort signal to the generator; subsequent calls are no-ops. Tree.Disable
+// and Tree.Rebuild both invoke this on every disk layer, so a layer that is
+// reached through both paths must not deadlock on the second send to the
+// unbuffered genAbort channel.
 func (dl *diskLayer) stopGeneration() {
-	dl.lock.RLock()
-	generating := dl.genMarker != nil
-	dl.lock.RUnlock()
-	if !generating {
-		return
-	}
-	if dl.genAbort != nil {
-		abort := make(chan *generatorStats)
-		dl.genAbort <- abort
-		<-abort
-	}
+	dl.genStop.Do(func() {
+		dl.lock.RLock()
+		generating := dl.genMarker != nil
+		dl.lock.RUnlock()
+		if !generating {
+			return
+		}
+		if dl.genAbort != nil {
+			abort := make(chan *generatorStats)
+			dl.genAbort <- abort
+			<-abort
+		}
+	})
 }

--- a/core/state/snapshot/disklayer_test.go
+++ b/core/state/snapshot/disklayer_test.go
@@ -19,6 +19,7 @@ package snapshot
 import (
 	"bytes"
 	"testing"
+	"time"
 
 	"github.com/VictoriaMetrics/fastcache"
 	"github.com/ethereum/go-ethereum/common"
@@ -584,5 +585,55 @@ func TestDiskSeek(t *testing.T) {
 				t.Fatalf("test %d, item %d, value wrong, got %v exp %v", i, count, v, k)
 			}
 		}
+	}
+}
+
+// TestStopGenerationIdempotent verifies that stopGeneration can be invoked
+// multiple times on the same disk layer without deadlocking. Tree.Disable and
+// Tree.Rebuild both walk every disk layer and call this, so a layer that is
+// reachable from both paths must not hang on the second call's send to the
+// unbuffered genAbort channel after the generator goroutine has already exited.
+// Regression test for issue #33233.
+func TestStopGenerationIdempotent(t *testing.T) {
+	t.Parallel()
+
+	abortCh := make(chan chan *generatorStats)
+	dl := &diskLayer{
+		diskdb:    rawdb.NewMemoryDatabase(),
+		genMarker: []byte{}, // non-nil signals generation in progress
+		genAbort:  abortCh,
+	}
+
+	// Stand in for the generator goroutine: receive on genAbort exactly once,
+	// then exit. A second send by stopGeneration would deadlock the test.
+	generatorExited := make(chan struct{})
+	go func() {
+		defer close(generatorExited)
+		ack := <-abortCh
+		ack <- &generatorStats{}
+	}()
+
+	// First call drives the abort handshake.
+	dl.stopGeneration()
+
+	// Generator must have observed the first abort and exited.
+	select {
+	case <-generatorExited:
+	case <-time.After(5 * time.Second):
+		t.Fatal("first stopGeneration never delivered abort to generator")
+	}
+
+	// Second call must return immediately. Run in a goroutine so the test
+	// fails with a clear message on regression instead of hanging until the
+	// outer test timeout fires.
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		dl.stopGeneration()
+	}()
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("second stopGeneration deadlocked sending to genAbort after the generator had exited")
 	}
 }

--- a/core/state/snapshot/snapshot.go
+++ b/core/state/snapshot/snapshot.go
@@ -258,8 +258,6 @@ func (t *Tree) Disable() {
 	for _, layer := range t.layers {
 		switch layer := layer.(type) {
 		case *diskLayer:
-			// TODO this function will hang if it's called twice. Will
-			// fix it in the following PRs.
 			layer.stopGeneration()
 			layer.markStale()
 			layer.Release()
@@ -702,8 +700,6 @@ func (t *Tree) Rebuild(root common.Hash) {
 	for _, layer := range t.layers {
 		switch layer := layer.(type) {
 		case *diskLayer:
-			// TODO this function will hang if it's called twice. Will
-			// fix it in the following PRs.
 			layer.stopGeneration()
 			layer.markStale()
 			layer.Release()


### PR DESCRIPTION
## Summary

Fixes #33233.

Both `Tree.Disable` and `Tree.Rebuild` walk every layer in the tree and call `stopGeneration()` on each disk layer. Both call sites carry the same TODO since the function was introduced:

```go
// TODO this function will hang if it's called twice. Will
// fix it in the following PRs.
layer.stopGeneration()
```

## What hangs

\`stopGeneration\` sends on the unbuffered \`genAbort\` channel whenever \`genMarker\` is non-nil:

```go
if dl.genMarker != nil {
    abort := make(chan *generatorStats)
    dl.genAbort <- abort
    <-abort
}
```

After the first abort handshake the generator goroutine exits, but \`genMarker\` is only cleared on the **successful-completion** path in \`generate()\` (line 700) — not on the **aborted-mid-flight** path that returns at line 678/691. A second \`stopGeneration\` therefore observes \`generating == true\`, sends on \`genAbort\` with no receiver, and blocks forever.

The reported reproducer in #33233 also lands at \`generate.go:705\`, where the goroutine waits on \`genAbort\` after a successful run. Wrapping \`stopGeneration\` in a \`sync.Once\` covers both paths cleanly: only the first call drives the abort handshake, subsequent calls are no-ops.

## Approach

- Add \`genStop sync.Once\` to \`diskLayer\`.
- Wrap the existing handshake body in \`dl.genStop.Do(...)\`.
- Drop both TODO comments in \`snapshot.go\`.

The first-call semantics are unchanged — same lock acquisition, same \`generating\` check, same send + ack on \`genAbort\`. Only the second-call behavior changes (no-op instead of deadlock), which is the documented goal.

## Test

\`TestStopGenerationIdempotent\` stands up a mock generator goroutine that receives on \`genAbort\` exactly once and exits, then calls \`stopGeneration\` twice. The second call is dispatched in its own goroutine with a 5s deadline so a regression fails with an explicit message instead of hanging the test runner.

Running against \`master\` (without this fix) hits the \`time.After(5*time.Second)\` branch on the second call:

```
--- FAIL: TestStopGenerationIdempotent (5.00s)
    disklayer_test.go:638: second stopGeneration deadlocked sending to genAbort after the generator had exited
```

With the fix:

```
$ go test -count=1 -run TestStopGenerationIdempotent ./core/state/snapshot/...
ok  	github.com/ethereum/go-ethereum/core/state/snapshot	0.5s
```

## Validation

- \`go build ./core/state/snapshot/...\` — clean
- \`go test -count=1 -timeout 10m ./core/state/snapshot/...\` — ok (full package, 6.778s)