### PR TITLE
.github: cancel CI run for stale PR commits

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -7,6 +7,7 @@ on:
       - master
   workflow_dispatch:
 
+# Free runner capacity by cancelling superseded PR runs.
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -7,6 +7,10 @@ on:
       - master
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   lint:
     name: Lint


### PR DESCRIPTION
Each commit on a PR kicks off a CI run. Those CI jobs run to the finish regardless, even when new commits have been pushed which make them stale and useless. This change attempts to cancel any previously running job for the same PR.