### PR TITLE
node: match vhost allowlist case-insensitively

### DIFF
--- a/node/rpcstack.go
+++ b/node/rpcstack.go
@@ -473,7 +473,9 @@ func (h *virtualHostHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		h.next.ServeHTTP(w, r)
 		return
 	}
-	if _, exist := h.vhosts[host]; exist {
+	// Hostnames are case-insensitive per RFC 3986 section 3.2.2, and the
+	// configured allowlist is normalized to lower-case in newVHostHandler.
+	if _, exist := h.vhosts[strings.ToLower(host)]; exist {
 		h.next.ServeHTTP(w, r)
 		return
 	}

--- a/node/rpcstack_test.go
+++ b/node/rpcstack_test.go
@@ -62,6 +62,13 @@ func TestVhosts(t *testing.T) {
 
 	resp2 := rpcRequest(t, url, testMethod, "host", "bad")
 	assert.Equal(t, resp2.StatusCode, http.StatusForbidden)
+
+	// Hostnames are case-insensitive per RFC 3986; mixed-case Host headers
+	// must match a lower-cased allowlist entry. Regression for #34692.
+	for _, mixed := range []string{"TEST", "TeSt", "Test:1234"} {
+		resp := rpcRequest(t, url, testMethod, "host", mixed)
+		assert.Equal(t, http.StatusOK, resp.StatusCode, "host=%q should be accepted", mixed)
+	}
 }
 
 type originTest struct {


### PR DESCRIPTION
The vhost allowlist is normalised to lower-case in `newVHostHandler`, but the `Host` header on incoming requests was compared without lower-casing it first. As a result, a request with a mixed-case hostname such as `Host: TeSt:1234` is rejected with `403 Forbidden` even though `test` is in `--http.vhosts`.

Hostnames are case-insensitive per RFC 3986 section 3.2.2, so the comparison should be case-insensitive too. This patch lower-cases the parsed host before the map lookup.

### Reproduction

```sh
geth --http --http.addr 127.0.0.1 --http.port 8545 --http.api web3 --http.vhosts test
```

Before:
```sh
$ curl -i -H 'Host: TeSt:1234' --data '{"jsonrpc":"2.0","id":1,"method":"web3_clientVersion","params":[]}' http://127.0.0.1:8545
HTTP/1.1 403 Forbidden
invalid host specified
```

After: returns 200 with the normal JSON-RPC reply.

### Test

`TestVhosts` is extended with mixed-case host headers (`TEST`, `TeSt`, `Test:1234`) which all succeed against an allowlist of `["test"]`.

Fixes #34692