### PR TITLE
core/types: fix duplicated "the" in Authority doc-comment

### DIFF
--- a/core/types/tx_setcode.go
+++ b/core/types/tx_setcode.go
@@ -117,7 +117,7 @@ func (a *SetCodeAuthorization) SigHash() common.Hash {
 	})
 }
 
-// Authority recovers the the authorizing account of an authorization.
+// Authority recovers the authorizing account of an authorization.
 func (a *SetCodeAuthorization) Authority() (common.Address, error) {
 	sighash := a.SigHash()
 	if !crypto.ValidateSignatureValues(a.V, a.R.ToBig(), a.S.ToBig(), true) {


### PR DESCRIPTION
One-line typo fix in `core/types/tx_setcode.go`: "// Authority recovers the the authorizing account of an authorization." → "// Authority recovers the authorizing account of an authorization.". No code/behavior change.