### PR TITLE
rpc: count error responses against batch response size limit

### DIFF
--- a/rpc/handler.go
+++ b/rpc/handler.go
@@ -237,7 +237,13 @@ func (h *handler) handleBatch(msgs []*jsonrpcMessage) {
 			resp := h.handleCallMsg(cp, msg)
 			callBuffer.pushResponse(resp)
 			if resp != nil && h.batchResponseMaxSize != 0 {
-				responseBytes += len(resp.Result)
+				// Account for both successful results and error payloads so
+				// that responses carrying large error.data (e.g. revert
+				// reasons returned via rpc.DataError) are subject to the
+				// same cap as oversized successful results. Pre-fix, only
+				// len(resp.Result) was counted and error responses with
+				// large Data could push the batch well past the limit.
+				responseBytes += responseSize(resp)
 				if responseBytes > h.batchResponseMaxSize {
 					err := &internalServerError{errcodeResponseTooLarge, errMsgResponseTooLarge}
 					callBuffer.respondWithError(cp.ctx, h.conn, err)
@@ -255,6 +261,28 @@ func (h *handler) handleBatch(msgs []*jsonrpcMessage) {
 			n.activate()
 		}
 	})
+}
+
+// responseSize returns the number of bytes that should be charged against the
+// batch response size limit for a single response. Successful responses
+// contribute len(resp.Result); error responses contribute the marshalled size
+// of the error object (including any error.Data) so that large rpc.DataError
+// payloads cannot bypass the cap.
+func responseSize(resp *jsonrpcMessage) int {
+	if resp == nil {
+		return 0
+	}
+	if resp.Error == nil {
+		return len(resp.Result)
+	}
+	encoded, err := json.Marshal(resp.Error)
+	if err != nil {
+		// Marshalling jsonError cannot realistically fail, but if it ever
+		// does, fall back to a conservative non-zero estimate so the
+		// counter still advances and the limit is eventually tripped.
+		return len(resp.Error.Message)
+	}
+	return len(encoded)
 }
 
 func (h *handler) respondWithBatchTooLarge(cp *callProc, batch []*jsonrpcMessage) {

--- a/rpc/server_test.go
+++ b/rpc/server_test.go
@@ -208,6 +208,56 @@ func TestServerBatchResponseSizeLimit(t *testing.T) {
 	}
 }
 
+// TestServerBatchResponseSizeLimitErrors is the regression test for #33814:
+// the batch response size counter previously only accounted for len(resp.Result),
+// so error responses (which set resp.Error and leave resp.Result nil) could be
+// returned without bound. Large rpc.DataError payloads in particular could blow
+// past the configured limit.
+//
+// The testService.ReturnError method returns an Error with code 444 and
+// "testError data" as Data, which marshals to roughly 60 bytes per response.
+// With a 100-byte cap, the first error is accepted but every subsequent error
+// must trip the response-too-large path.
+func TestServerBatchResponseSizeLimitErrors(t *testing.T) {
+	t.Parallel()
+
+	server := newTestServer()
+	defer server.Stop()
+	// Tight cap: a single marshalled testError is ~56 bytes, so the first
+	// response is accepted but every subsequent response must trip the cap.
+	server.SetBatchLimits(100, 50)
+
+	client := DialInProc(server)
+	defer client.Close()
+
+	var batch []BatchElem
+	for i := 0; i < 5; i++ {
+		batch = append(batch, BatchElem{
+			Method: "test_returnError",
+			Args:   []any{},
+			Result: new(any),
+		})
+	}
+	if err := client.BatchCall(batch); err != nil {
+		t.Fatal("error sending batch:", err)
+	}
+
+	// The first response is the genuine testError; the rest must be the
+	// internal response-too-large error.
+	if batch[0].Error == nil {
+		t.Fatalf("batch elem 0 expected testError, got nil")
+	}
+	for i := 1; i < len(batch); i++ {
+		re, ok := batch[i].Error.(Error)
+		if !ok {
+			t.Fatalf("batch elem %d expected Error, got %v (%T)", i, batch[i].Error, batch[i].Error)
+		}
+		if re.ErrorCode() != errcodeResponseTooLarge {
+			t.Errorf("batch elem %d wrong error code, have %d want %d", i, re.ErrorCode(), errcodeResponseTooLarge)
+		}
+	}
+}
+
 func TestServerWebsocketReadLimit(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
### Problem

In `(*handler).handleBatch`, the cumulative batch response size was tracked as:

```go
responseBytes += len(resp.Result)
```

`resp.Result` is `json.RawMessage`, so this only counts the size of successful results. Error responses populate `resp.Error` (with `resp.Result == nil`) and contribute zero bytes to the running total. As a consequence, a batch made up of many error responses - particularly ones carrying large payloads on `error.data` via `rpc.DataError` - can blow well past `BatchResponseMaxSize` without ever returning ``-32003 (response too large)``.

### Fix

Introduce a `responseSize` helper:

- Successful response: return `len(resp.Result)` (unchanged from before).
- Error response: return `len(json.Marshal(resp.Error))`, which captures both the message and any `Data` field.
- Fallback: if the (theoretically impossible) `json.Marshal` of `*jsonError` fails, return `len(resp.Error.Message)` so the counter still advances and the limit is eventually tripped.

The handler now adds `responseSize(resp)` per iteration instead of `len(resp.Result)`.

### Test

`TestServerBatchResponseSizeLimitErrors` configures `SetBatchLimits(100, 50)`, sends a batch of five `test_returnError` calls (each yielding an Error with code 444 and ``\"testError data\"`` payload, marshalling to ~56 bytes), and asserts:

- batch[0] receives the genuine test error (already pushed when the limit trips), and
- batch[1..4] all receive code ``-32003 (errcodeResponseTooLarge)``.

The test reliably fails on master (all five elements come back as the original test error) and passes with this patch.

Fixes #33814