### PR TITLE
cmd/evm: respect --fuzz=false

### DIFF
--- a/cmd/evm/blockrunner.go
+++ b/cmd/evm/blockrunner.go
@@ -78,7 +78,7 @@ func blockTestCmd(ctx *cli.Context) error {
 			return err
 		}
 		// During fuzzing, we report the result after every block
-		if !ctx.IsSet(FuzzFlag.Name) {
+		if !ctx.Bool(FuzzFlag.Name) {
 			report(ctx, results)
 		}
 	}
@@ -101,7 +101,7 @@ func runBlockTest(ctx *cli.Context, fname string) ([]testResult, error) {
 	tracer := tracerFromFlags(ctx)
 
 	// Suppress INFO logs during fuzzing
-	if ctx.IsSet(FuzzFlag.Name) {
+	if ctx.Bool(FuzzFlag.Name) {
 		log.SetDefault(log.NewLogger(log.DiscardHandler()))
 	}
 
@@ -140,7 +140,7 @@ func runBlockTest(ctx *cli.Context, fname string) ([]testResult, error) {
 		}
 
 		// When fuzzing, write results after every block
-		if ctx.IsSet(FuzzFlag.Name) {
+		if ctx.Bool(FuzzFlag.Name) {
 			report(ctx, []testResult{*result})
 		}
 		results = append(results, *result)

--- a/cmd/geth/chaincmd.go
+++ b/cmd/geth/chaincmd.go
@@ -797,8 +797,8 @@ func downloadEra(ctx *cli.Context) error {
 	var network = "mainnet"
 	if utils.IsNetworkPreset(ctx) {
 		switch {
-		case ctx.IsSet(utils.MainnetFlag.Name):
-		case ctx.IsSet(utils.SepoliaFlag.Name):
+		case ctx.Bool(utils.MainnetFlag.Name):
+		case ctx.Bool(utils.SepoliaFlag.Name):
 			network = "sepolia"
 		default:
 			return errors.New("unsupported network, no known era1 checksums")
@@ -825,7 +825,7 @@ func downloadEra(ctx *cli.Context) error {
 		return err
 	}
 	switch {
-	case ctx.IsSet(eraAllFlag.Name):
+	case ctx.Bool(eraAllFlag.Name):
 		return l.DownloadAll(dir)
 
 	case ctx.IsSet(eraBlockFlag.Name):

--- a/cmd/geth/main.go
+++ b/cmd/geth/main.go
@@ -290,13 +290,13 @@ func main() {
 func prepare(ctx *cli.Context) {
 	// If we're running a known preset, log it for convenience.
 	switch {
-	case ctx.IsSet(utils.SepoliaFlag.Name):
+	case ctx.Bool(utils.SepoliaFlag.Name):
 		log.Info("Starting Geth on Sepolia testnet...")
 
-	case ctx.IsSet(utils.HoleskyFlag.Name):
+	case ctx.Bool(utils.HoleskyFlag.Name):
 		log.Info("Starting Geth on Holesky testnet...")
 
-	case ctx.IsSet(utils.HoodiFlag.Name):
+	case ctx.Bool(utils.HoodiFlag.Name):
 		log.Info("Starting Geth on Hoodi testnet...")
 
 	case !ctx.IsSet(utils.NetworkIdFlag.Name):

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -1905,7 +1905,7 @@ func SetEthConfig(ctx *cli.Context, stack *node.Node, cfg *ethconfig.Config) {
 	if ctx.IsSet(RPCGlobalTxFeeCapFlag.Name) {
 		cfg.RPCTxFeeCap = ctx.Float64(RPCGlobalTxFeeCapFlag.Name)
 	}
-	if ctx.IsSet(NoDiscoverFlag.Name) {
+	if ctx.Bool(NoDiscoverFlag.Name) {
 		cfg.EthDiscoveryURLs, cfg.SnapDiscoveryURLs = []string{}, []string{}
 	} else if ctx.IsSet(DNSDiscoveryFlag.Name) {
 		urls := ctx.String(DNSDiscoveryFlag.Name)
@@ -2343,7 +2343,7 @@ func tryMakeReadOnlyDatabase(ctx *cli.Context, stack *node.Node) ethdb.Database 
 func IsNetworkPreset(ctx *cli.Context) bool {
 	for _, flag := range NetworkFlags {
 		bFlag, _ := flag.(*cli.BoolFlag)
-		if ctx.IsSet(bFlag.Name) {
+		if ctx.Bool(bFlag.Name) {
 			return true
 		}
 	}

--- a/cmd/utils/flags_test.go
+++ b/cmd/utils/flags_test.go
@@ -18,8 +18,11 @@
 package utils
 
 import (
+	"flag"
 	"reflect"
 	"testing"
+
+	"github.com/urfave/cli/v2"
 )
 
 func Test_SplitTagsFlag(t *testing.T) {
@@ -65,4 +68,53 @@ func Test_SplitTagsFlag(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestIsNetworkPresetUsesFlagValue(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		args []string
+		want bool
+	}{
+		{
+			name: "unset",
+			want: false,
+		},
+		{
+			name: "enabled",
+			args: []string{"--sepolia"},
+			want: true,
+		},
+		{
+			name: "explicit false",
+			args: []string{"--sepolia=false"},
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			ctx := newTestContext(t, tt.args, NetworkFlags...)
+			if got := IsNetworkPreset(ctx); got != tt.want {
+				t.Fatalf("IsNetworkPreset() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func newTestContext(t *testing.T, args []string, flags ...cli.Flag) *cli.Context {
+	t.Helper()
+
+	set := flag.NewFlagSet("test", flag.ContinueOnError)
+	for _, f := range flags {
+		if err := f.Apply(set); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := set.Parse(args); err != nil {
+		t.Fatal(err)
+	}
+	return cli.NewContext(nil, set, nil)
 }

--- a/cmd/workload/testsuite.go
+++ b/cmd/workload/testsuite.go
@@ -122,7 +122,7 @@ func validateHistoryPruneErr(err error, blockNum uint64, historyPruneBlock *uint
 
 func testConfigFromCLI(ctx *cli.Context) (cfg testConfig) {
 	flags.CheckExclusive(ctx, testMainnetFlag, testSepoliaFlag)
-	if (ctx.IsSet(testMainnetFlag.Name) || ctx.IsSet(testSepoliaFlag.Name)) && ctx.IsSet(filterQueryFileFlag.Name) {
+	if (ctx.Bool(testMainnetFlag.Name) || ctx.Bool(testSepoliaFlag.Name)) && ctx.IsSet(filterQueryFileFlag.Name) {
 		exit(filterQueryFileFlag.Name + " cannot be used with " + testMainnetFlag.Name + " or " + testSepoliaFlag.Name)
 	}
 


### PR DESCRIPTION
Passing `--fuzz=false` currently still selects blocktest fuzz output mode because the command checks whether the flag was set.

This switches the blocktest fuzz-mode checks to use the boolean flag value, so explicit false keeps the normal output path while `--fuzz` still enables fuzz-oriented reporting.