### PR TITLE
core/state/pruner: handle batch write errors in pruning

### DIFF
--- a/core/state/pruner/pruner.go
+++ b/core/state/pruner/pruner.go
@@ -171,7 +171,10 @@ func prune(snaptree *snapshot.Tree, root common.Hash, maindb ethdb.Database, sta
 			// Recreate the iterator after every batch commit in order
 			// to allow the underlying compactor to delete the entries.
 			if batch.ValueSize() >= ethdb.IdealBatchSize {
-				batch.Write()
+				if err := batch.Write(); err != nil {
+					iter.Release()
+					return err
+				}
 				batch.Reset()
 
 				iter.Release()
@@ -180,7 +183,10 @@ func prune(snaptree *snapshot.Tree, root common.Hash, maindb ethdb.Database, sta
 		}
 	}
 	if batch.ValueSize() > 0 {
-		batch.Write()
+		if err := batch.Write(); err != nil {
+			iter.Release()
+			return err
+		}
 		batch.Reset()
 	}
 	iter.Release()


### PR DESCRIPTION
Handle batch write failures during state pruning, returning immediately to prevent partial destructive pruning state.