### PR TITLE
rpc: reject empty batch in BatchCallContext

### DIFF
--- a/rpc/client.go
+++ b/rpc/client.go
@@ -397,6 +397,9 @@ func (c *Client) BatchCall(b []BatchElem) error {
 //
 // Note that batch calls may not be executed atomically on the server side.
 func (c *Client) BatchCallContext(ctx context.Context, b []BatchElem) error {
+	if len(b) == 0 {
+		return &invalidRequestError{"empty batch"}
+	}
 	var (
 		msgs = make([]*jsonrpcMessage, len(b))
 		byID = make(map[string]int, len(b))


### PR DESCRIPTION
The server already rejects empty batches with -32600. On the client side, calling BatchCallContext with a zero-length slice on inproc/WS/IPC transports registers no request IDs but the server still replies with an error message whose id is null. The dispatch loop has no requestOp to match it to, so op.resp is never written and op.wait blocks until ctx deadline.

Short-circuit on len(b) == 0 with the same invalidRequestError the server uses, so all transports return immediately with -32600.