### PR TITLE
core/types: copy optional block hash accessors

### DIFF
--- a/core/types/block.go
+++ b/core/types/block.go
@@ -413,8 +413,21 @@ func (b *Block) BaseFee() *big.Int {
 	return new(big.Int).Set(b.header.BaseFee)
 }
 
-func (b *Block) BeaconRoot() *common.Hash   { return b.header.ParentBeaconRoot }
-func (b *Block) RequestsHash() *common.Hash { return b.header.RequestsHash }
+func (b *Block) BeaconRoot() *common.Hash {
+	if b.header.ParentBeaconRoot == nil {
+		return nil
+	}
+	root := *b.header.ParentBeaconRoot
+	return &root
+}
+
+func (b *Block) RequestsHash() *common.Hash {
+	if b.header.RequestsHash == nil {
+		return nil
+	}
+	hash := *b.header.RequestsHash
+	return &hash
+}
 
 func (b *Block) ExcessBlobGas() *uint64 {
 	var excessBlobGas *uint64

--- a/core/types/block_test.go
+++ b/core/types/block_test.go
@@ -70,6 +70,36 @@ func TestBlockEncoding(t *testing.T) {
 	}
 }
 
+func TestBlockHashAccessorsReturnCopies(t *testing.T) {
+	beaconRoot := common.HexToHash("0x01")
+	requestsHash := common.HexToHash("0x02")
+	block := NewBlockWithHeader(&Header{
+		Difficulty:       big.NewInt(1),
+		Number:           big.NewInt(1),
+		ParentBeaconRoot: &beaconRoot,
+		RequestsHash:     &requestsHash,
+	})
+
+	gotBeaconRoot := block.BeaconRoot()
+	if gotBeaconRoot == nil || *gotBeaconRoot != beaconRoot {
+		t.Fatalf("unexpected beacon root: got %v, want %v", gotBeaconRoot, beaconRoot)
+	}
+	gotRequestsHash := block.RequestsHash()
+	if gotRequestsHash == nil || *gotRequestsHash != requestsHash {
+		t.Fatalf("unexpected requests hash: got %v, want %v", gotRequestsHash, requestsHash)
+	}
+	*gotBeaconRoot = common.HexToHash("0x03")
+	*gotRequestsHash = common.HexToHash("0x04")
+
+	header := block.Header()
+	if *header.ParentBeaconRoot != beaconRoot {
+		t.Fatalf("beacon root accessor mutated block header: got %v, want %v", *header.ParentBeaconRoot, beaconRoot)
+	}
+	if *header.RequestsHash != requestsHash {
+		t.Fatalf("requests hash accessor mutated block header: got %v, want %v", *header.RequestsHash, requestsHash)
+	}
+}
+
 func TestEIP1559BlockEncoding(t *testing.T) {
 	blockEnc := common.FromHex("f9030bf901fea083cafc574e1f51ba9dc0568fc617a08ea2429fb384059c972f13b19fa1c8dd55a01dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347948888f1f195afa192cfee860698584c030f4c9db1a0ef1552a40b7165c3cd773806b9e0c165b75356e0314bf0706f279c729f51e017a05fe50b260da6308036625b850b5d6ced6d0a9f814c0688bc91ffb7b7a3a54b67a0bc37d79753ad738a6dac4921e57392f145d8887476de3f783dfa7edae9283e52b90100000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000008302000001832fefd8825208845506eb0780a0bd4472abb6659ebe3ee06ee4d7b72a00a9f4d001caca51342001075469aff49888a13a5a8c8f2bb1c4843b9aca00f90106f85f800a82c35094095e7baea6a6c7c4c2dfeb977efac326af552d870a801ba09bea4c4daac7c7c52e093e6a4c35dbbcf8856f1af7b059ba20253e70848d094fa08a8fae537ce25ed8cb5af9adac3f141af69bd515bd2ba031522df09b97dd72b1b8a302f8a0018080843b9aca008301e24194095e7baea6a6c7c4c2dfeb977efac326af552d878080f838f7940000000000000000000000000000000000000001e1a0000000000000000000000000000000000000000000000000000000000000000080a0fe38ca4e44a30002ac54af7cf922a6ac2ba11b7d22f548e8ecb3f51f41cb31b0a06de6a5cbae13c0c856e33acf021b51819636cfc009d39eafb9f606d546e305a8c0")
 	var block Block


### PR DESCRIPTION
Block header accessors are expected to copy header data because mutating returned header fields can invalidate the block's cached hash and size.

This makes `BeaconRoot` and `RequestsHash` return copies of their optional hash values, matching the other optional header accessors and preserving the block immutability guarantee.