### PR TITLE
cmd/devp2p,p2p/enode: validate fallback UDP port range

### DIFF
--- a/cmd/devp2p/discv4cmd.go
+++ b/cmd/devp2p/discv4cmd.go
@@ -336,7 +336,7 @@ func parseExtAddr(spec string) (ip net.IP, port int, ok bool) {
 		return nil, 0, false
 	}
 	port, err = strconv.Atoi(portstr)
-	if err != nil {
+	if err != nil || port < 0 || port > 65535 {
 		return nil, 0, false
 	}
 	return ip, port, true

--- a/cmd/devp2p/discv4cmd_test.go
+++ b/cmd/devp2p/discv4cmd_test.go
@@ -1,0 +1,43 @@
+// Copyright 2026 The go-ethereum Authors
+// This file is part of go-ethereum.
+//
+// go-ethereum is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// go-ethereum is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with go-ethereum. If not, see <http://www.gnu.org/licenses/>.
+
+package main
+
+import "testing"
+
+func TestParseExtAddrPortRange(t *testing.T) {
+	tests := []struct {
+		input string
+		ok    bool
+		port  int
+	}{
+		{input: "127.0.0.1", ok: true, port: 0},
+		{input: "127.0.0.1:30303", ok: true, port: 30303},
+		{input: "127.0.0.1:65535", ok: true, port: 65535},
+		{input: "127.0.0.1:65536", ok: false},
+		{input: "127.0.0.1:-1", ok: false},
+		{input: "[2001:db8::1]:30303", ok: true, port: 30303},
+	}
+	for _, tc := range tests {
+		_, port, ok := parseExtAddr(tc.input)
+		if ok != tc.ok {
+			t.Fatalf("parseExtAddr(%q) ok=%v, want %v", tc.input, ok, tc.ok)
+		}
+		if ok && port != tc.port {
+			t.Fatalf("parseExtAddr(%q) port=%d, want %d", tc.input, port, tc.port)
+		}
+	}
+}

--- a/p2p/enode/localnode.go
+++ b/p2p/enode/localnode.go
@@ -205,6 +205,9 @@ func (ln *LocalNode) SetFallbackIP(ip net.IP) {
 // SetFallbackUDP sets the last-resort UDP-on-IPv4 port. This port is used
 // if no endpoint prediction can be made.
 func (ln *LocalNode) SetFallbackUDP(port int) {
+	if port < 0 || port > 65535 {
+		return
+	}
 	ln.mu.Lock()
 	defer ln.mu.Unlock()
 

--- a/p2p/enode/localnode_test.go
+++ b/p2p/enode/localnode_test.go
@@ -136,3 +136,22 @@ func TestLocalNodeEndpoint(t *testing.T) {
 	assert.Equal(t, fallback.Port, ln.Node().UDP())
 	assert.Equal(t, initialSeq+3, ln.Node().Seq())
 }
+
+func TestSetFallbackUDPRejectsOutOfRange(t *testing.T) {
+	ln, db := newLocalNodeForTesting()
+	defer db.Close()
+
+	initialSeq := ln.Node().Seq()
+	ln.SetFallbackUDP(30303)
+	assert.Equal(t, 30303, ln.Node().UDP())
+	assert.Equal(t, initialSeq+1, ln.Node().Seq())
+
+	seqAfterValid := ln.Node().Seq()
+	ln.SetFallbackUDP(65536)
+	assert.Equal(t, 30303, ln.Node().UDP())
+	assert.Equal(t, seqAfterValid, ln.Node().Seq())
+
+	ln.SetFallbackUDP(-1)
+	assert.Equal(t, 30303, ln.Node().UDP())
+	assert.Equal(t, seqAfterValid, ln.Node().Seq())
+}


### PR DESCRIPTION
Validate extaddr UDP port bounds and guard LocalNode fallback updates, preventing uint16 truncation from invalid input.