### PR TITLE
core/types: reject blob tx sidecar in JSON

### DIFF
--- a/core/types/transaction_marshalling.go
+++ b/core/types/transaction_marshalling.go
@@ -58,6 +58,28 @@ type txJSON struct {
 	Hash common.Hash `json:"hash"`
 }
 
+var errBlobTxSidecarInJSON = errors.New("blob transaction sidecar fields are not supported in JSON")
+
+func (tx *txJSON) UnmarshalJSON(input []byte) error {
+	type txJSONNoMethod txJSON
+	dec := struct {
+		*txJSONNoMethod
+		Version     json.RawMessage `json:"version,omitempty"`
+		Blobs       json.RawMessage `json:"blobs,omitempty"`
+		Commitments json.RawMessage `json:"commitments,omitempty"`
+		Proofs      json.RawMessage `json:"proofs,omitempty"`
+	}{
+		txJSONNoMethod: (*txJSONNoMethod)(tx),
+	}
+	if err := json.Unmarshal(input, &dec); err != nil {
+		return err
+	}
+	if dec.Version != nil || dec.Blobs != nil || dec.Commitments != nil || dec.Proofs != nil {
+		return errBlobTxSidecarInJSON
+	}
+	return nil
+}
+
 // yParityValue returns the YParity value from JSON. For backwards-compatibility reasons,
 // this can be given in the 'v' field or the 'yParity' field. If both exist, they must match.
 func (tx *txJSON) yParityValue() (*big.Int, error) {

--- a/core/types/tx_blob_test.go
+++ b/core/types/tx_blob_test.go
@@ -18,6 +18,7 @@ package types
 
 import (
 	"crypto/ecdsa"
+	"encoding/json"
 	"testing"
 
 	"github.com/ethereum/go-ethereum/common"
@@ -71,6 +72,51 @@ func TestBlobTxSize(t *testing.T) {
 	}
 	if sz := withBlobsStripped.Size(); sz != sizeNoBlobs {
 		t.Fatal("wrong size on tx after WithoutBlobTxSidecar:", sz)
+	}
+}
+
+func TestBlobTxJSONRejectsSidecar(t *testing.T) {
+	key, _ := crypto.GenerateKey()
+	withBlobs := createEmptyBlobTx(key, true)
+	withBlobsJSON, err := withBlobs.MarshalJSON()
+	if err != nil {
+		t.Fatal(err)
+	}
+	var decoded Transaction
+	if err := decoded.UnmarshalJSON(withBlobsJSON); err != errBlobTxSidecarInJSON {
+		t.Fatalf("wrong error: got %v, want %v", err, errBlobTxSidecarInJSON)
+	}
+
+	withoutBlobsJSON, err := withBlobs.WithoutBlobTxSidecar().MarshalJSON()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := decoded.UnmarshalJSON(withoutBlobsJSON); err != nil {
+		t.Fatalf("failed to unmarshal tx without sidecar: %v", err)
+	}
+
+	var blobtx map[string]any
+	if err := json.Unmarshal(withoutBlobsJSON, &blobtx); err != nil {
+		t.Fatal(err)
+	}
+	for _, tc := range []struct {
+		field string
+		value any
+	}{
+		{field: "version", value: "0x0"},
+		{field: "blobs", value: []any{}},
+		{field: "commitments", value: []any{}},
+		{field: "proofs", value: []any{}},
+	} {
+		blobtx[tc.field] = tc.value
+		payload, err := json.Marshal(blobtx)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := decoded.UnmarshalJSON(payload); err != errBlobTxSidecarInJSON {
+			t.Fatalf("field %q: wrong error: got %v, want %v", tc.field, err, errBlobTxSidecarInJSON)
+		}
+		delete(blobtx, tc.field)
 	}
 }
 


### PR DESCRIPTION
## Summary
- Reject blob transaction sidecar fields (`version`, `blobs`, `commitments`, `proofs`) during transaction JSON unmarshalling.
- Keep the JSON decoder from importing blob sidecar payloads while preserving existing transaction JSON decoding behavior.

## Test plan
- `go test ./core/types -run TestBlobTxJSONRejectsSidecar`
- `go test ./core/types`