### PR TITLE
.github/workflows: add a typo checker

### DIFF
--- a/.github/workflows/typos.yml
+++ b/.github/workflows/typos.yml
@@ -1,0 +1,22 @@
+name: Typos
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+  workflow_dispatch:
+
+jobs:
+  typos:
+    name: Spell Check
+    runs-on: [self-hosted-ghr, size-s-x64]
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: false
+
+      - name: Check for typos
+        uses: crates-ci/typos@v1.29.4


### PR DESCRIPTION
This is something that came up while discussing with reth members on how they stem slop PRs. One good way to ensure you don't get many of them, is to make sure that they don't make it to the repo in the first place.