### PR TITLE
internal/ethapi: validate explicit transaction type in TransactionArgs

### DIFF
--- a/internal/ethapi/transaction_args.go
+++ b/internal/ethapi/transaction_args.go
@@ -42,6 +42,7 @@ import (
 type TransactionArgs struct {
 	From                 *common.Address `json:"from"`
 	To                   *common.Address `json:"to"`
+	Type                 *hexutil.Uint64 `json:"type,omitempty"`
 	Gas                  *hexutil.Uint64 `json:"gas"`
 	GasPrice             *hexutil.Big    `json:"gasPrice"`
 	MaxFeePerGas         *hexutil.Big    `json:"maxFeePerGas"`
@@ -101,6 +102,9 @@ type sidecarConfig struct {
 
 // setDefaults fills in default values for unspecified tx fields.
 func (args *TransactionArgs) setDefaults(ctx context.Context, b Backend, config sidecarConfig) error {
+	if err := args.validateTxType(); err != nil {
+		return err
+	}
 	if err := args.setBlobTxSidecar(ctx, config); err != nil {
 		return err
 	}
@@ -390,6 +394,9 @@ func (args *TransactionArgs) setBlobTxSidecar(ctx context.Context, config sideca
 // CallDefaults sanitizes the transaction arguments, often filling in zero values,
 // for the purpose of eth_call class of RPC methods.
 func (args *TransactionArgs) CallDefaults(globalGasCap uint64, baseFee *big.Int, chainID *big.Int) error {
+	if err := args.validateTxType(); err != nil {
+		return err
+	}
 	// Reject invalid combinations of pre- and post-1559 fee styles
 	if args.GasPrice != nil && (args.MaxFeePerGas != nil || args.MaxPriorityFeePerGas != nil) {
 		return errors.New("both gasPrice and (maxFeePerGas or maxPriorityFeePerGas) specified")
@@ -438,6 +445,18 @@ func (args *TransactionArgs) CallDefaults(globalGasCap uint64, baseFee *big.Int,
 	}
 
 	return nil
+}
+
+func (args *TransactionArgs) validateTxType() error {
+	if args.Type == nil {
+		return nil
+	}
+	switch uint64(*args.Type) {
+	case types.LegacyTxType, types.AccessListTxType, types.DynamicFeeTxType, types.BlobTxType, types.SetCodeTxType:
+		return nil
+	default:
+		return fmt.Errorf("unsupported transaction type: %d", uint64(*args.Type))
+	}
 }
 
 // ToMessage converts the transaction arguments to the Message type used by the

--- a/internal/ethapi/transaction_args.go
+++ b/internal/ethapi/transaction_args.go
@@ -102,7 +102,7 @@ type sidecarConfig struct {
 
 // setDefaults fills in default values for unspecified tx fields.
 func (args *TransactionArgs) setDefaults(ctx context.Context, b Backend, config sidecarConfig) error {
-	if err := args.validateTxType(); err != nil {
+	if err := args.validateTxTypeSupported(); err != nil {
 		return err
 	}
 	if err := args.setBlobTxSidecar(ctx, config); err != nil {
@@ -179,6 +179,9 @@ func (args *TransactionArgs) setDefaults(ctx context.Context, b Backend, config 
 		}
 	} else {
 		args.ChainID = (*hexutil.Big)(want)
+	}
+	if err := args.validateTxTypeMatch(types.LegacyTxType); err != nil {
+		return err
 	}
 	return nil
 }
@@ -394,7 +397,7 @@ func (args *TransactionArgs) setBlobTxSidecar(ctx context.Context, config sideca
 // CallDefaults sanitizes the transaction arguments, often filling in zero values,
 // for the purpose of eth_call class of RPC methods.
 func (args *TransactionArgs) CallDefaults(globalGasCap uint64, baseFee *big.Int, chainID *big.Int) error {
-	if err := args.validateTxType(); err != nil {
+	if err := args.validateTxTypeSupported(); err != nil {
 		return err
 	}
 	// Reject invalid combinations of pre- and post-1559 fee styles
@@ -443,11 +446,14 @@ func (args *TransactionArgs) CallDefaults(globalGasCap uint64, baseFee *big.Int,
 	if args.BlobFeeCap == nil && args.BlobHashes != nil {
 		args.BlobFeeCap = new(hexutil.Big)
 	}
+	if err := args.validateTxTypeMatch(types.LegacyTxType); err != nil {
+		return err
+	}
 
 	return nil
 }
 
-func (args *TransactionArgs) validateTxType() error {
+func (args *TransactionArgs) validateTxTypeSupported() error {
 	if args.Type == nil {
 		return nil
 	}
@@ -457,6 +463,21 @@ func (args *TransactionArgs) validateTxType() error {
 	default:
 		return fmt.Errorf("unsupported transaction type: %d", uint64(*args.Type))
 	}
+}
+
+func (args *TransactionArgs) validateTxTypeMatch(defaultType int) error {
+	if args.Type == nil {
+		return nil
+	}
+	// Blob txs cannot be contract creations. ToTransaction assumes this invariant.
+	if args.BlobHashes != nil && args.To == nil {
+		return errors.New(`missing "to" in blob transaction`)
+	}
+	inferred := args.ToTransaction(defaultType).Type()
+	if uint64(*args.Type) != uint64(inferred) {
+		return fmt.Errorf("transaction type mismatch (requested=%d inferred=%d)", uint64(*args.Type), inferred)
+	}
+	return nil
 }
 
 // ToMessage converts the transaction arguments to the Message type used by the

--- a/internal/ethapi/transaction_args_test.go
+++ b/internal/ethapi/transaction_args_test.go
@@ -256,6 +256,40 @@ func TestSetFeeDefaults(t *testing.T) {
 	}
 }
 
+func TestTransactionArgsRejectUnsupportedTypeInCallDefaults(t *testing.T) {
+	t.Parallel()
+
+	badType := hexutil.Uint64(0x5)
+	args := &TransactionArgs{Type: &badType}
+	err := args.CallDefaults(0, big.NewInt(1), big.NewInt(1))
+	if err == nil {
+		t.Fatal("expected error for unsupported transaction type")
+	}
+	if err.Error() != "unsupported transaction type: 5" {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestTransactionArgsRejectUnsupportedTypeInSetDefaults(t *testing.T) {
+	t.Parallel()
+
+	badType := hexutil.Uint64(0x5)
+	gas := hexutil.Uint64(21000)
+	to := common.Address{0x1}
+	args := &TransactionArgs{
+		To:   &to,
+		Gas:  &gas,
+		Type: &badType,
+	}
+	err := args.setDefaults(context.Background(), newBackendMock(), sidecarConfig{})
+	if err == nil {
+		t.Fatal("expected error for unsupported transaction type")
+	}
+	if err.Error() != "unsupported transaction type: 5" {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
 type backendMock struct {
 	current *types.Header
 	config  *params.ChainConfig

--- a/internal/ethapi/transaction_args_test.go
+++ b/internal/ethapi/transaction_args_test.go
@@ -290,6 +290,45 @@ func TestTransactionArgsRejectUnsupportedTypeInSetDefaults(t *testing.T) {
 	}
 }
 
+func TestTransactionArgsRejectTypeMismatchInCallDefaults(t *testing.T) {
+	t.Parallel()
+
+	requestedLegacy := hexutil.Uint64(types.LegacyTxType)
+	args := &TransactionArgs{
+		Type:        &requestedLegacy,
+		MaxFeePerGas: (*hexutil.Big)(big.NewInt(2)),
+	}
+	err := args.CallDefaults(0, big.NewInt(1), big.NewInt(1))
+	if err == nil {
+		t.Fatal("expected type mismatch error")
+	}
+	if err.Error() != "transaction type mismatch (requested=0 inferred=2)" {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestTransactionArgsRejectTypeMismatchInSetDefaults(t *testing.T) {
+	t.Parallel()
+
+	requestedDynamic := hexutil.Uint64(types.DynamicFeeTxType)
+	gas := hexutil.Uint64(21000)
+	gasPrice := (*hexutil.Big)(big.NewInt(1))
+	to := common.Address{0x1}
+	args := &TransactionArgs{
+		To:       &to,
+		Gas:      &gas,
+		GasPrice: gasPrice,
+		Type:     &requestedDynamic,
+	}
+	err := args.setDefaults(context.Background(), newBackendMock(), sidecarConfig{})
+	if err == nil {
+		t.Fatal("expected type mismatch error")
+	}
+	if err.Error() != "transaction type mismatch (requested=2 inferred=0)" {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
 type backendMock struct {
 	current *types.Header
 	config  *params.ChainConfig


### PR DESCRIPTION
Fixes #33106.
This PR validates the optional `type` field in RPC `TransactionArgs` and rejects inconsistent requests early.
### What this changes
- Add `type` to `internal/ethapi.TransactionArgs` (`json:"type,omitempty"`).
- Validate that an explicitly requested type is one of the supported transaction types:
  - legacy (0), access-list (1), dynamic-fee (2), blob (3), set-code (4).
- Reuse existing transaction construction logic (`ToTransaction`) to determine the effective/inferred type, and return an error if it differs from the requested type.
- Apply the validation in both:
  - `setDefaults(...)`
  - `CallDefaults(...)`
### Why
`type` in RPC calls could previously be ignored, which allowed malformed/inconsistent requests (e.g. requesting one type while providing fields for another).  
This change makes `type` explicit and enforceable, returning clear errors instead of silently accepting mismatches.
### Behavior
- Unsupported type:
  - `unsupported transaction type: <n>`
- Requested vs inferred mismatch:
  - `transaction type mismatch (requested=<r> inferred=<i>)`
### Tests
Added/updated tests in `internal/ethapi/transaction_args_test.go`:
- `TestTransactionArgsRejectUnsupportedTypeInCallDefaults`
- `TestTransactionArgsRejectUnsupportedTypeInSetDefaults`
- `TestTransactionArgsRejectTypeMismatchInCallDefaults`
- `TestTransactionArgsRejectTypeMismatchInSetDefaults`
Ran:
```bash
go test ./internal/ethapi -count=1