### PR TITLE
cmd/utils: respect --state.size-tracking=false

### DIFF
--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -1936,8 +1936,8 @@ func SetEthConfig(ctx *cli.Context, stack *node.Node, cfg *ethconfig.Config) {
 			cfg.EthDiscoveryURLs = SplitAndTrim(urls)
 		}
 	}
-	if ctx.Bool(StateSizeTrackingFlag.Name) {
-		cfg.EnableStateSizeTracking = true
+	if ctx.IsSet(StateSizeTrackingFlag.Name) {
+		cfg.EnableStateSizeTracking = ctx.Bool(StateSizeTrackingFlag.Name)
 	}
 	// Override any default configs for hard coded networks.
 	switch {

--- a/cmd/utils/flags_test.go
+++ b/cmd/utils/flags_test.go
@@ -18,8 +18,12 @@
 package utils
 
 import (
+	"flag"
 	"reflect"
 	"testing"
+
+	"github.com/ethereum/go-ethereum/eth/ethconfig"
+	"github.com/urfave/cli/v2"
 )
 
 func Test_SplitTagsFlag(t *testing.T) {
@@ -63,4 +67,42 @@ func Test_SplitTagsFlag(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestSetEthConfigAllowsDisablingStateSizeTracking(t *testing.T) {
+	ctx := newTestFlagContext(t, []cli.Flag{
+		CacheFlag,
+		CacheDatabaseFlag,
+		CacheGCFlag,
+		CacheSnapshotFlag,
+		CacheTrieFlag,
+		CryptoKZGFlag,
+		FDLimitFlag,
+		GCModeFlag,
+		SnapshotFlag,
+		StateSizeTrackingFlag,
+	}, "--state.size-tracking=false")
+
+	cfg := ethconfig.Defaults
+	cfg.EnableStateSizeTracking = true
+	SetEthConfig(ctx, nil, &cfg)
+
+	if cfg.EnableStateSizeTracking {
+		t.Fatal("state size tracking should be disabled by explicit CLI flag")
+	}
+}
+
+func newTestFlagContext(t *testing.T, flags []cli.Flag, args ...string) *cli.Context {
+	t.Helper()
+
+	set := flag.NewFlagSet(t.Name(), flag.ContinueOnError)
+	for _, flag := range flags {
+		if err := flag.Apply(set); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := set.Parse(args); err != nil {
+		t.Fatal(err)
+	}
+	return cli.NewContext(cli.NewApp(), set, nil)
 }

--- a/cmd/utils/flags_test.go
+++ b/cmd/utils/flags_test.go
@@ -18,12 +18,8 @@
 package utils
 
 import (
-	"flag"
 	"reflect"
 	"testing"
-
-	"github.com/ethereum/go-ethereum/eth/ethconfig"
-	"github.com/urfave/cli/v2"
 )
 
 func Test_SplitTagsFlag(t *testing.T) {
@@ -67,42 +63,4 @@ func Test_SplitTagsFlag(t *testing.T) {
 			}
 		})
 	}
-}
-
-func TestSetEthConfigAllowsDisablingStateSizeTracking(t *testing.T) {
-	ctx := newTestFlagContext(t, []cli.Flag{
-		CacheFlag,
-		CacheDatabaseFlag,
-		CacheGCFlag,
-		CacheSnapshotFlag,
-		CacheTrieFlag,
-		CryptoKZGFlag,
-		FDLimitFlag,
-		GCModeFlag,
-		SnapshotFlag,
-		StateSizeTrackingFlag,
-	}, "--state.size-tracking=false")
-
-	cfg := ethconfig.Defaults
-	cfg.EnableStateSizeTracking = true
-	SetEthConfig(ctx, nil, &cfg)
-
-	if cfg.EnableStateSizeTracking {
-		t.Fatal("state size tracking should be disabled by explicit CLI flag")
-	}
-}
-
-func newTestFlagContext(t *testing.T, flags []cli.Flag, args ...string) *cli.Context {
-	t.Helper()
-
-	set := flag.NewFlagSet(t.Name(), flag.ContinueOnError)
-	for _, flag := range flags {
-		if err := flag.Apply(set); err != nil {
-			t.Fatal(err)
-		}
-	}
-	if err := set.Parse(args); err != nil {
-		t.Fatal(err)
-	}
-	return cli.NewContext(cli.NewApp(), set, nil)
 }


### PR DESCRIPTION
Passing `--state.size-tracking=false` currently cannot disable state size tracking when it was enabled by the config file because the CLI path only turns the config value on.