### PR TITLE
rpc: tolerate Windows close-error in websocket read-limit test

### DIFF
--- a/rpc/server_test.go
+++ b/rpc/server_test.go
@@ -274,7 +274,8 @@ func TestServerWebsocketReadLimit(t *testing.T) {
 				} else if !errors.Is(err, websocket.ErrReadLimit) &&
 					!strings.Contains(strings.ToLower(err.Error()), "1009") &&
 					!strings.Contains(strings.ToLower(err.Error()), "message too big") &&
-					!strings.Contains(strings.ToLower(err.Error()), "connection reset by peer") {
+					!strings.Contains(strings.ToLower(err.Error()), "connection reset by peer") &&
+					!strings.Contains(strings.ToLower(err.Error()), "forcibly closed") {
 					// Not the error we expect from exceeding the message size limit.
 					t.Fatalf("unexpected error for read limit violation: %v", err)
 				}


### PR DESCRIPTION
On Windows the read-limit violation surfaces as "wsarecv: An existing connection was forcibly closed by the remote host" instead of "connection reset by peer", causing TestServerWebsocketReadLimit to flake. Accept "forcibly closed" as another expected error string.