### PR TITLE
cmd/evm/internal/t8ntool: Amsterdam t8n updates; adds BAL and slotNum

### DIFF
--- a/cmd/evm/internal/t8ntool/execution.go
+++ b/cmd/evm/internal/t8ntool/execution.go
@@ -77,8 +77,8 @@ type ExecutionResult struct {
 	RequestsHash         *common.Hash          `json:"requestsHash,omitempty"`
 	Requests             [][]byte              `json:"requests"`
 
-	BlockAccessList     *bal.BlockAccessList `json:"blockAccessList,omitempty"`
-	BlockAccessListHash *common.Hash         `json:"blockAccessListHash,omitempty"`
+	BlockAccessList     hexutil.Bytes `json:"blockAccessList,omitempty"`
+	BlockAccessListHash *common.Hash  `json:"blockAccessListHash,omitempty"`
 }
 
 type executionResultMarshaling struct {
@@ -191,6 +191,9 @@ func (pre *Prestate) Apply(vmConfig vm.Config, chainConfig *params.ChainConfig, 
 		Difficulty:  pre.Env.Difficulty,
 		GasLimit:    pre.Env.GasLimit,
 		GetHash:     getHash,
+	}
+	if pre.Env.SlotNumber != nil {
+		vmContext.SlotNum = *pre.Env.SlotNumber
 	}
 	// If currentBaseFee is defined, add it to the vmContext.
 	if pre.Env.BaseFee != nil {
@@ -396,10 +399,14 @@ func (pre *Prestate) Apply(vmConfig vm.Config, chainConfig *params.ChainConfig, 
 		execRs.Requests = requests
 	}
 	if isAmsterdam {
-		bal := blockAccessList.ToEncodingObj()
-		balHash := bal.Hash()
+		encoded := blockAccessList.ToEncodingObj()
+		balRLP, err := rlp.EncodeToBytes(encoded)
+		if err != nil {
+			return nil, nil, nil, NewError(ErrorEVM, fmt.Errorf("could not encode BAL: %v", err))
+		}
+		balHash := encoded.Hash()
 		execRs.BlockAccessListHash = &balHash
-		execRs.BlockAccessList = bal
+		execRs.BlockAccessList = balRLP
 	}
 
 	// Re-create statedb instance with new root for MPT mode

--- a/cmd/evm/internal/t8ntool/gen_execresult.go
+++ b/cmd/evm/internal/t8ntool/gen_execresult.go
@@ -10,7 +10,6 @@ import (
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/common/math"
 	"github.com/ethereum/go-ethereum/core/types"
-	"github.com/ethereum/go-ethereum/core/types/bal"
 )
 
 var _ = (*executionResultMarshaling)(nil)
@@ -33,7 +32,7 @@ func (e ExecutionResult) MarshalJSON() ([]byte, error) {
 		CurrentBlobGasUsed   *math.HexOrDecimal64  `json:"blobGasUsed,omitempty"`
 		RequestsHash         *common.Hash          `json:"requestsHash,omitempty"`
 		Requests             []hexutil.Bytes       `json:"requests"`
-		BlockAccessList      *bal.BlockAccessList  `json:"blockAccessList,omitempty"`
+		BlockAccessList      hexutil.Bytes         `json:"blockAccessList,omitempty"`
 		BlockAccessListHash  *common.Hash          `json:"blockAccessListHash,omitempty"`
 	}
 	var enc ExecutionResult
@@ -80,7 +79,7 @@ func (e *ExecutionResult) UnmarshalJSON(input []byte) error {
 		CurrentBlobGasUsed   *math.HexOrDecimal64  `json:"blobGasUsed,omitempty"`
 		RequestsHash         *common.Hash          `json:"requestsHash,omitempty"`
 		Requests             []hexutil.Bytes       `json:"requests"`
-		BlockAccessList      *bal.BlockAccessList  `json:"blockAccessList,omitempty"`
+		BlockAccessList      *hexutil.Bytes        `json:"blockAccessList,omitempty"`
 		BlockAccessListHash  *common.Hash          `json:"blockAccessListHash,omitempty"`
 	}
 	var dec ExecutionResult
@@ -138,7 +137,7 @@ func (e *ExecutionResult) UnmarshalJSON(input []byte) error {
 		}
 	}
 	if dec.BlockAccessList != nil {
-		e.BlockAccessList = dec.BlockAccessList
+		e.BlockAccessList = *dec.BlockAccessList
 	}
 	if dec.BlockAccessListHash != nil {
 		e.BlockAccessListHash = dec.BlockAccessListHash


### PR DESCRIPTION
The changes here enable us to fill tests with Amsterdam using geth EVM bin.

This will be useful for block builder tests using `testing_buildBlockV1` endpoint and for filling benchmarking compute and stateful tests as Python is too slow for benchmark tests.

Tested in [ethereum/execution-specs](https://github.com/ethereum/execution-specs) with:

```
uv run fill --clean --fork=Amsterdam tests/amsterdam/eip7928_block_level_access_lists/test_block_access_lists.py --evm-bin=$GETH_EVM_PATH
```