### PR TITLE
graphql: handle missing block body in Raw resolver

### DIFF
--- a/graphql/graphql.go
+++ b/graphql/graphql.go
@@ -929,7 +929,7 @@ func (b *Block) RawHeader(ctx context.Context) (hexutil.Bytes, error) {
 
 func (b *Block) Raw(ctx context.Context) (hexutil.Bytes, error) {
 	block, err := b.resolve(ctx)
-	if err != nil {
+	if err != nil || block == nil {
 		return hexutil.Bytes{}, err
 	}
 	return rlp.EncodeToBytes(block)


### PR DESCRIPTION
Return empty raw bytes when the GraphQL `Block.raw` resolver cannot load the block body. This matches the nil handling used by the other block-body-backed resolvers and avoids exposing RLP empty-list bytes as raw block data.