### PR TITLE
eth/catalyst: count actually-available blobs in getBlobs

### DIFF
--- a/eth/catalyst/api.go
+++ b/eth/catalyst/api.go
@@ -630,7 +630,12 @@ func (api *ConsensusAPI) getBlobs(hashes []common.Hash, v2 bool) (engine.BlobAnd
 	if len(hashes) > 128 {
 		return nil, engine.TooLargeRequest.With(fmt.Errorf("requested blob count too large: %v", len(hashes)))
 	}
-	available := len(api.eth.BlobTxPool().AvailableBlobs(hashes))
+	available := 0
+	for _, ok := range api.eth.BlobTxPool().AvailableBlobs(hashes) {
+		if ok {
+			available++
+		}
+	}
 	getBlobsRequestedCounter.Inc(int64(len(hashes)))
 	getBlobsAvailableCounter.Inc(int64(available))
 


### PR DESCRIPTION
After AvailableBlobs was changed to return []bool, the caller used len() on the result, which always equals len(hashes). The available metric over-reports and the v2 short-circuit before the expensive disk read is dead. Count the true entries instead.