### PR TITLE
params: remove named hardforks from bpo schedule

### DIFF
--- a/consensus/misc/eip4844/eip4844.go
+++ b/consensus/misc/eip4844/eip4844.go
@@ -73,8 +73,6 @@ func latestBlobConfig(cfg *params.ChainConfig, time uint64) (BlobConfig, error) 
 		bc = s.BPO2
 	case cfg.IsBPO1(london, time) && s.BPO1 != nil:
 		bc = s.BPO1
-	case cfg.IsOsaka(london, time) && s.Osaka != nil:
-		bc = s.Osaka
 	case cfg.IsPrague(london, time) && s.Prague != nil:
 		bc = s.Prague
 	case cfg.IsCancun(london, time) && s.Cancun != nil:

--- a/consensus/misc/eip4844/eip4844_test.go
+++ b/consensus/misc/eip4844/eip4844_test.go
@@ -120,7 +120,6 @@ func TestCalcBlobFeePostOsaka(t *testing.T) {
 			BlobScheduleConfig: &params.BlobScheduleConfig{
 				Cancun: params.DefaultCancunBlobConfig,
 				Prague: params.DefaultPragueBlobConfig,
-				Osaka:  params.DefaultOsakaBlobConfig,
 				BPO1: &params.BlobConfig{
 					Target:         9,
 					Max:            14,
@@ -191,7 +190,7 @@ func TestFakeExponential(t *testing.T) {
 func TestCalcExcessBlobGasEIP7918(t *testing.T) {
 	var (
 		cfg           = params.MergedTestChainConfig
-		targetBlobs   = cfg.BlobScheduleConfig.Osaka.Target
+		targetBlobs   = cfg.BlobScheduleConfig.Prague.Target
 		blobGasTarget = uint64(targetBlobs) * params.BlobTxBlobGasPerBlob
 	)
 

--- a/core/bal_test.go
+++ b/core/bal_test.go
@@ -42,9 +42,6 @@ import (
 func balChainConfig() *params.ChainConfig {
 	cfg := *params.MergedTestChainConfig
 	cfg.AmsterdamTime = new(uint64)
-	blob := *cfg.BlobScheduleConfig
-	blob.Amsterdam = blob.Osaka
-	cfg.BlobScheduleConfig = &blob
 	return &cfg
 }
 

--- a/core/bintrie_witness_test.go
+++ b/core/bintrie_witness_test.go
@@ -55,8 +55,9 @@ var (
 		UBTTime:                 u64(0),
 		TerminalTotalDifficulty: common.Big0,
 		EnableUBTAtGenesis:      true,
+		// UBT inherits its blob schedule; nothing to declare here.
 		BlobScheduleConfig: &params.BlobScheduleConfig{
-			UBT: params.DefaultPragueBlobConfig,
+			Prague: params.DefaultPragueBlobConfig,
 		},
 	}
 )

--- a/core/eth_transfer_logs_test.go
+++ b/core/eth_transfer_logs_test.go
@@ -78,11 +78,7 @@ func testEthTransferLogs(t *testing.T, value uint64) {
 		engine     = beacon.New(ethash.NewFaker())
 	)
 
-	//TODO remove this hacky config initialization when final Amsterdam config is available
 	config.AmsterdamTime = new(uint64)
-	blobConfig := *config.BlobScheduleConfig
-	blobConfig.Amsterdam = blobConfig.Osaka
-	config.BlobScheduleConfig = &blobConfig
 
 	gspec := &Genesis{
 		Config: &config,

--- a/core/genesis_test.go
+++ b/core/genesis_test.go
@@ -293,8 +293,6 @@ func TestBinaryGenesisCommit(t *testing.T) {
 		BlobScheduleConfig: &params.BlobScheduleConfig{
 			Cancun: params.DefaultCancunBlobConfig,
 			Prague: params.DefaultPragueBlobConfig,
-			Osaka:  params.DefaultOsakaBlobConfig,
-			UBT:    params.DefaultPragueBlobConfig,
 		},
 	}
 

--- a/core/txpool/blobpool/blobpool_test.go
+++ b/core/txpool/blobpool/blobpool_test.go
@@ -1241,11 +1241,6 @@ func TestBillyMigration(t *testing.T) {
 					Max:            maxBlobs,
 					UpdateFraction: params.DefaultCancunBlobConfig.UpdateFraction,
 				},
-				Osaka: &params.BlobConfig{
-					Target:         maxBlobs / 2,
-					Max:            maxBlobs,
-					UpdateFraction: params.DefaultCancunBlobConfig.UpdateFraction,
-				},
 			},
 		}
 		chain := &testBlockChain{

--- a/core/txpool/blobpool/cache_test.go
+++ b/core/txpool/blobpool/cache_test.go
@@ -94,7 +94,7 @@ func newTestCache(t *testing.T, txConfig []txSpec) *testCache {
 		CancunTime:  &cancunTime,
 		OsakaTime:   &cancunTime,
 		BlobScheduleConfig: &params.BlobScheduleConfig{
-			Osaka: &params.BlobConfig{
+			Cancun: &params.BlobConfig{
 				Target:         1,
 				Max:            1,
 				UpdateFraction: params.DefaultCancunBlobConfig.UpdateFraction,

--- a/eth/catalyst/api_benchmark_test.go
+++ b/eth/catalyst/api_benchmark_test.go
@@ -197,7 +197,6 @@ func newBenchmarkBlobEnv(b *testing.B, blobCount int, version byte, fork benchFo
 	config.BlobScheduleConfig = &params.BlobScheduleConfig{
 		Cancun: &params.BlobConfig{Target: 6, Max: 128, UpdateFraction: 3338477},
 		Prague: &params.BlobConfig{Target: 6, Max: 128, UpdateFraction: 5007716},
-		Osaka:  &params.BlobConfig{Target: 6, Max: 128, UpdateFraction: 5007716},
 	}
 	// Configure fork times based on requested fork
 	switch fork {

--- a/miner/stress/main.go
+++ b/miner/stress/main.go
@@ -138,7 +138,10 @@ func makeGenesis(faucets []*ecdsa.PrivateKey) *core.Genesis {
 
 	blockZero := uint64(0)
 	config.AmsterdamTime = &blockZero
-	config.BlobScheduleConfig.Amsterdam = &params.BlobConfig{
+	// Amsterdam inherits its blob schedule from the most recent BPO; activate BPO1
+	// at the same time with the target/max we want exercised by the stress harness.
+	config.BPO1Time = &blockZero
+	config.BlobScheduleConfig.BPO1 = &params.BlobConfig{
 		Target:         14,
 		Max:            21,
 		UpdateFraction: 13739630,

--- a/params/config.go
+++ b/params/config.go
@@ -17,12 +17,14 @@
 package params
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 	"math"
 	"math/big"
 
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/params/forks"
 )
 
@@ -69,7 +71,6 @@ var (
 		BlobScheduleConfig: &BlobScheduleConfig{
 			Cancun: DefaultCancunBlobConfig,
 			Prague: DefaultPragueBlobConfig,
-			Osaka:  DefaultOsakaBlobConfig,
 			BPO1:   DefaultBPO1BlobConfig,
 			BPO2:   DefaultBPO2BlobConfig,
 		},
@@ -105,7 +106,6 @@ var (
 		BlobScheduleConfig: &BlobScheduleConfig{
 			Cancun: DefaultCancunBlobConfig,
 			Prague: DefaultPragueBlobConfig,
-			Osaka:  DefaultOsakaBlobConfig,
 			BPO1:   DefaultBPO1BlobConfig,
 			BPO2:   DefaultBPO2BlobConfig,
 		},
@@ -141,7 +141,6 @@ var (
 		BlobScheduleConfig: &BlobScheduleConfig{
 			Cancun: DefaultCancunBlobConfig,
 			Prague: DefaultPragueBlobConfig,
-			Osaka:  DefaultOsakaBlobConfig,
 			BPO1:   DefaultBPO1BlobConfig,
 			BPO2:   DefaultBPO2BlobConfig,
 		},
@@ -177,7 +176,6 @@ var (
 		BlobScheduleConfig: &BlobScheduleConfig{
 			Cancun: DefaultCancunBlobConfig,
 			Prague: DefaultPragueBlobConfig,
-			Osaka:  DefaultOsakaBlobConfig,
 			BPO1:   DefaultBPO1BlobConfig,
 			BPO2:   DefaultBPO2BlobConfig,
 		},
@@ -235,7 +233,6 @@ var (
 		BlobScheduleConfig: &BlobScheduleConfig{
 			Cancun: DefaultCancunBlobConfig,
 			Prague: DefaultPragueBlobConfig,
-			Osaka:  DefaultOsakaBlobConfig,
 		},
 	}
 
@@ -330,7 +327,6 @@ var (
 		BlobScheduleConfig: &BlobScheduleConfig{
 			Cancun: DefaultCancunBlobConfig,
 			Prague: DefaultPragueBlobConfig,
-			Osaka:  DefaultOsakaBlobConfig,
 		},
 	}
 
@@ -379,12 +375,6 @@ var (
 		Max:            9,
 		UpdateFraction: 5007716,
 	}
-	// DefaultOsakaBlobConfig is the default blob configuration for the Osaka fork.
-	DefaultOsakaBlobConfig = &BlobConfig{
-		Target:         6,
-		Max:            9,
-		UpdateFraction: 5007716,
-	}
 	// DefaultBPO1BlobConfig is the default blob configuration for the BPO1 fork.
 	DefaultBPO1BlobConfig = &BlobConfig{
 		Target:         10,
@@ -413,7 +403,6 @@ var (
 	DefaultBlobSchedule = &BlobScheduleConfig{
 		Cancun: DefaultCancunBlobConfig,
 		Prague: DefaultPragueBlobConfig,
-		Osaka:  DefaultOsakaBlobConfig,
 	}
 )
 
@@ -670,7 +659,7 @@ func (c *ChainConfig) Description() string {
 		banner += fmt.Sprintf(" - Prague:                      @%-10v blob: (%s)\n", *c.PragueTime, c.BlobScheduleConfig.Prague)
 	}
 	if c.OsakaTime != nil {
-		banner += fmt.Sprintf(" - Osaka:                       @%-10v blob: (%s)\n", *c.OsakaTime, c.BlobScheduleConfig.Osaka)
+		banner += fmt.Sprintf(" - Osaka:                       @%-10v\n", *c.OsakaTime)
 	}
 	if c.BPO1Time != nil {
 		banner += fmt.Sprintf(" - BPO1:                        @%-10v blob: (%s)\n", *c.BPO1Time, c.BlobScheduleConfig.BPO1)
@@ -688,10 +677,10 @@ func (c *ChainConfig) Description() string {
 		banner += fmt.Sprintf(" - BPO5:                        @%-10v blob: (%s)\n", *c.BPO5Time, c.BlobScheduleConfig.BPO5)
 	}
 	if c.AmsterdamTime != nil {
-		banner += fmt.Sprintf(" - Amsterdam:									 @%-10v blob: (%s)\n", *c.AmsterdamTime, c.BlobScheduleConfig.Amsterdam)
+		banner += fmt.Sprintf(" - Amsterdam:                   @%-10v\n", *c.AmsterdamTime)
 	}
 	if c.UBTTime != nil {
-		banner += fmt.Sprintf(" - UBT:                         @%-10v blob: (%s)\n", *c.UBTTime, c.BlobScheduleConfig.UBT)
+		banner += fmt.Sprintf(" - UBT:                         @%-10v\n", *c.UBTTime)
 	}
 	banner += fmt.Sprintf("\nAll fork specifications can be found at https://ethereum.github.io/execution-specs/src/ethereum/forks/\n")
 	return banner
@@ -713,17 +702,45 @@ func (bc *BlobConfig) String() string {
 }
 
 // BlobScheduleConfig determines target and max number of blobs allow per fork.
+//
+// From Prague onward, the blob schedule is updated only at BPO (Blob Parameter-Only)
+// forks. Named forks such as Osaka or Amsterdam inherit the most recently configured
+// BPO entry and must not declare their own BlobConfig. Re-declared named-fork keys
+// in JSON (osaka, amsterdam, ubt) are loudly warned about and ignored.
 type BlobScheduleConfig struct {
-	Cancun    *BlobConfig `json:"cancun,omitempty"`
-	Prague    *BlobConfig `json:"prague,omitempty"`
-	Osaka     *BlobConfig `json:"osaka,omitempty"`
-	BPO1      *BlobConfig `json:"bpo1,omitempty"`
-	BPO2      *BlobConfig `json:"bpo2,omitempty"`
-	BPO3      *BlobConfig `json:"bpo3,omitempty"`
-	BPO4      *BlobConfig `json:"bpo4,omitempty"`
-	BPO5      *BlobConfig `json:"bpo5,omitempty"`
-	Amsterdam *BlobConfig `json:"amsterdam,omitempty"`
-	UBT       *BlobConfig `json:"ubt,omitempty"`
+	Cancun *BlobConfig `json:"cancun,omitempty"`
+	Prague *BlobConfig `json:"prague,omitempty"`
+	BPO1   *BlobConfig `json:"bpo1,omitempty"`
+	BPO2   *BlobConfig `json:"bpo2,omitempty"`
+	BPO3   *BlobConfig `json:"bpo3,omitempty"`
+	BPO4   *BlobConfig `json:"bpo4,omitempty"`
+	BPO5   *BlobConfig `json:"bpo5,omitempty"`
+}
+
+// deprecatedBlobScheduleKeys lists named-fork keys that used to be valid blob
+// schedule entries. They are accepted but ignored at unmarshal time.
+var deprecatedBlobScheduleKeys = []string{"osaka", "amsterdam", "ubt"}
+
+// UnmarshalJSON implements json.Unmarshaler. Unknown keys named after forks
+// that no longer carry their own blob schedule (osaka, amsterdam, ubt) trigger
+// a loud warning but do not abort loading — the blob schedule for those forks
+// inherits from the most recent preceding BPO entry.
+func (b *BlobScheduleConfig) UnmarshalJSON(data []byte) error {
+	type plain BlobScheduleConfig
+	if err := json.Unmarshal(data, (*plain)(b)); err != nil {
+		return err
+	}
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return err
+	}
+	for _, k := range deprecatedBlobScheduleKeys {
+		if _, ok := raw[k]; ok {
+			log.Warn("ignoring blobSchedule entry for named fork; inherit from prior BPO",
+				"fork", k)
+		}
+	}
+	return nil
 }
 
 // IsHomestead returns whether num is either equal to the homestead block or greater.
@@ -1000,13 +1017,11 @@ func (c *ChainConfig) CheckConfigForkOrder() error {
 	}{
 		{name: "cancun", timestamp: c.CancunTime, config: bsc.Cancun},
 		{name: "prague", timestamp: c.PragueTime, config: bsc.Prague},
-		{name: "osaka", timestamp: c.OsakaTime, config: bsc.Osaka},
 		{name: "bpo1", timestamp: c.BPO1Time, config: bsc.BPO1},
 		{name: "bpo2", timestamp: c.BPO2Time, config: bsc.BPO2},
 		{name: "bpo3", timestamp: c.BPO3Time, config: bsc.BPO3},
 		{name: "bpo4", timestamp: c.BPO4Time, config: bsc.BPO4},
 		{name: "bpo5", timestamp: c.BPO5Time, config: bsc.BPO5},
-		{name: "amsterdam", timestamp: c.AmsterdamTime, config: bsc.Amsterdam},
 	} {
 		if cur.config != nil {
 			if err := cur.config.validate(); err != nil {
@@ -1169,28 +1184,33 @@ func (c *ChainConfig) LatestFork(time uint64) forks.Fork {
 	}
 }
 
-// BlobConfig returns the blob config associated with the provided fork.
+// BlobConfig returns the blob config active at the provided fork. Since named
+// forks (Osaka, Amsterdam, ...) no longer carry their own blob schedule, the
+// lookup walks down from fork through the BPO chain to Prague/Cancun and returns
+// the first non-nil entry.
 func (c *ChainConfig) BlobConfig(fork forks.Fork) *BlobConfig {
-	switch fork {
-	case forks.BPO5:
-		return c.BlobScheduleConfig.BPO5
-	case forks.BPO4:
-		return c.BlobScheduleConfig.BPO4
-	case forks.BPO3:
-		return c.BlobScheduleConfig.BPO3
-	case forks.BPO2:
-		return c.BlobScheduleConfig.BPO2
-	case forks.BPO1:
-		return c.BlobScheduleConfig.BPO1
-	case forks.Osaka:
-		return c.BlobScheduleConfig.Osaka
-	case forks.Prague:
-		return c.BlobScheduleConfig.Prague
-	case forks.Cancun:
-		return c.BlobScheduleConfig.Cancun
-	default:
+	if c.BlobScheduleConfig == nil {
 		return nil
 	}
+	bsc := c.BlobScheduleConfig
+	chain := []struct {
+		at  forks.Fork
+		cfg *BlobConfig
+	}{
+		{forks.BPO5, bsc.BPO5},
+		{forks.BPO4, bsc.BPO4},
+		{forks.BPO3, bsc.BPO3},
+		{forks.BPO2, bsc.BPO2},
+		{forks.BPO1, bsc.BPO1},
+		{forks.Prague, bsc.Prague},
+		{forks.Cancun, bsc.Cancun},
+	}
+	for _, e := range chain {
+		if e.at <= fork && e.cfg != nil {
+			return e.cfg
+		}
+	}
+	return nil
 }
 
 // ActiveSystemContracts returns the currently active system contracts at the

--- a/params/config.go
+++ b/params/config.go
@@ -17,14 +17,12 @@
 package params
 
 import (
-	"encoding/json"
 	"errors"
 	"fmt"
 	"math"
 	"math/big"
 
 	"github.com/ethereum/go-ethereum/common"
-	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/params/forks"
 )
 
@@ -705,8 +703,7 @@ func (bc *BlobConfig) String() string {
 //
 // From Prague onward, the blob schedule is updated only at BPO (Blob Parameter-Only)
 // forks. Named forks such as Osaka or Amsterdam inherit the most recently configured
-// BPO entry and must not declare their own BlobConfig. Re-declared named-fork keys
-// in JSON (osaka, amsterdam, ubt) are loudly warned about and ignored.
+// BPO entry and must not declare their own BlobConfig.
 type BlobScheduleConfig struct {
 	Cancun *BlobConfig `json:"cancun,omitempty"`
 	Prague *BlobConfig `json:"prague,omitempty"`
@@ -715,32 +712,6 @@ type BlobScheduleConfig struct {
 	BPO3   *BlobConfig `json:"bpo3,omitempty"`
 	BPO4   *BlobConfig `json:"bpo4,omitempty"`
 	BPO5   *BlobConfig `json:"bpo5,omitempty"`
-}
-
-// deprecatedBlobScheduleKeys lists named-fork keys that used to be valid blob
-// schedule entries. They are accepted but ignored at unmarshal time.
-var deprecatedBlobScheduleKeys = []string{"osaka", "amsterdam", "ubt"}
-
-// UnmarshalJSON implements json.Unmarshaler. Unknown keys named after forks
-// that no longer carry their own blob schedule (osaka, amsterdam, ubt) trigger
-// a loud warning but do not abort loading — the blob schedule for those forks
-// inherits from the most recent preceding BPO entry.
-func (b *BlobScheduleConfig) UnmarshalJSON(data []byte) error {
-	type plain BlobScheduleConfig
-	if err := json.Unmarshal(data, (*plain)(b)); err != nil {
-		return err
-	}
-	var raw map[string]json.RawMessage
-	if err := json.Unmarshal(data, &raw); err != nil {
-		return err
-	}
-	for _, k := range deprecatedBlobScheduleKeys {
-		if _, ok := raw[k]; ok {
-			log.Warn("ignoring blobSchedule entry for named fork; inherit from prior BPO",
-				"fork", k)
-		}
-	}
-	return nil
 }
 
 // IsHomestead returns whether num is either equal to the homestead block or greater.

--- a/tests/init.go
+++ b/tests/init.go
@@ -434,7 +434,6 @@ var Forks = map[string]*params.ChainConfig{
 		BlobScheduleConfig: &params.BlobScheduleConfig{
 			Cancun: params.DefaultCancunBlobConfig,
 			Prague: params.DefaultPragueBlobConfig,
-			Osaka:  params.DefaultOsakaBlobConfig,
 		},
 	},
 	"PragueToOsakaAtTime15k": {
@@ -461,7 +460,6 @@ var Forks = map[string]*params.ChainConfig{
 		BlobScheduleConfig: &params.BlobScheduleConfig{
 			Cancun: params.DefaultCancunBlobConfig,
 			Prague: params.DefaultPragueBlobConfig,
-			Osaka:  params.DefaultOsakaBlobConfig,
 		},
 	},
 	"BPO1": {
@@ -489,8 +487,7 @@ var Forks = map[string]*params.ChainConfig{
 		BlobScheduleConfig: &params.BlobScheduleConfig{
 			Cancun: params.DefaultCancunBlobConfig,
 			Prague: params.DefaultPragueBlobConfig,
-			Osaka:  params.DefaultOsakaBlobConfig,
-			BPO1:   bpo1BlobConfig,
+			BPO1:   params.DefaultBPO1BlobConfig,
 		},
 	},
 	"OsakaToBPO1AtTime15k": {
@@ -518,8 +515,7 @@ var Forks = map[string]*params.ChainConfig{
 		BlobScheduleConfig: &params.BlobScheduleConfig{
 			Cancun: params.DefaultCancunBlobConfig,
 			Prague: params.DefaultPragueBlobConfig,
-			Osaka:  params.DefaultOsakaBlobConfig,
-			BPO1:   bpo1BlobConfig,
+			BPO1:   params.DefaultBPO1BlobConfig,
 		},
 	},
 	"BPO2": {
@@ -548,9 +544,8 @@ var Forks = map[string]*params.ChainConfig{
 		BlobScheduleConfig: &params.BlobScheduleConfig{
 			Cancun: params.DefaultCancunBlobConfig,
 			Prague: params.DefaultPragueBlobConfig,
-			Osaka:  params.DefaultOsakaBlobConfig,
-			BPO1:   bpo1BlobConfig,
-			BPO2:   bpo2BlobConfig,
+			BPO1:   params.DefaultBPO1BlobConfig,
+			BPO2:   params.DefaultBPO2BlobConfig,
 		},
 	},
 	"BPO1ToBPO2AtTime15k": {
@@ -579,9 +574,8 @@ var Forks = map[string]*params.ChainConfig{
 		BlobScheduleConfig: &params.BlobScheduleConfig{
 			Cancun: params.DefaultCancunBlobConfig,
 			Prague: params.DefaultPragueBlobConfig,
-			Osaka:  params.DefaultOsakaBlobConfig,
-			BPO1:   bpo1BlobConfig,
-			BPO2:   bpo2BlobConfig,
+			BPO1:   params.DefaultBPO1BlobConfig,
+			BPO2:   params.DefaultBPO2BlobConfig,
 		},
 	},
 	"BPO3": {
@@ -611,9 +605,8 @@ var Forks = map[string]*params.ChainConfig{
 		BlobScheduleConfig: &params.BlobScheduleConfig{
 			Cancun: params.DefaultCancunBlobConfig,
 			Prague: params.DefaultPragueBlobConfig,
-			Osaka:  params.DefaultOsakaBlobConfig,
-			BPO1:   bpo1BlobConfig,
-			BPO2:   bpo2BlobConfig,
+			BPO1:   params.DefaultBPO1BlobConfig,
+			BPO2:   params.DefaultBPO2BlobConfig,
 			BPO3:   params.DefaultBPO3BlobConfig,
 		},
 	},
@@ -644,9 +637,8 @@ var Forks = map[string]*params.ChainConfig{
 		BlobScheduleConfig: &params.BlobScheduleConfig{
 			Cancun: params.DefaultCancunBlobConfig,
 			Prague: params.DefaultPragueBlobConfig,
-			Osaka:  params.DefaultOsakaBlobConfig,
-			BPO1:   bpo1BlobConfig,
-			BPO2:   bpo2BlobConfig,
+			BPO1:   params.DefaultBPO1BlobConfig,
+			BPO2:   params.DefaultBPO2BlobConfig,
 			BPO3:   params.DefaultBPO3BlobConfig,
 		},
 	},
@@ -678,9 +670,8 @@ var Forks = map[string]*params.ChainConfig{
 		BlobScheduleConfig: &params.BlobScheduleConfig{
 			Cancun: params.DefaultCancunBlobConfig,
 			Prague: params.DefaultPragueBlobConfig,
-			Osaka:  params.DefaultOsakaBlobConfig,
-			BPO1:   bpo1BlobConfig,
-			BPO2:   bpo2BlobConfig,
+			BPO1:   params.DefaultBPO1BlobConfig,
+			BPO2:   params.DefaultBPO2BlobConfig,
 			BPO3:   params.DefaultBPO3BlobConfig,
 			BPO4:   params.DefaultBPO4BlobConfig,
 		},
@@ -713,9 +704,8 @@ var Forks = map[string]*params.ChainConfig{
 		BlobScheduleConfig: &params.BlobScheduleConfig{
 			Cancun: params.DefaultCancunBlobConfig,
 			Prague: params.DefaultPragueBlobConfig,
-			Osaka:  params.DefaultOsakaBlobConfig,
-			BPO1:   bpo1BlobConfig,
-			BPO2:   bpo2BlobConfig,
+			BPO1:   params.DefaultBPO1BlobConfig,
+			BPO2:   params.DefaultBPO2BlobConfig,
 			BPO3:   params.DefaultBPO3BlobConfig,
 			BPO4:   params.DefaultBPO4BlobConfig,
 		},
@@ -747,14 +737,12 @@ var Forks = map[string]*params.ChainConfig{
 		AmsterdamTime:           u64(0),
 		DepositContractAddress:  params.MainnetChainConfig.DepositContractAddress,
 		BlobScheduleConfig: &params.BlobScheduleConfig{
-			Cancun:    params.DefaultCancunBlobConfig,
-			Prague:    params.DefaultPragueBlobConfig,
-			Osaka:     params.DefaultOsakaBlobConfig,
-			BPO1:      bpo1BlobConfig,
-			BPO2:      bpo2BlobConfig,
-			BPO3:      params.DefaultBPO3BlobConfig,
-			BPO4:      params.DefaultBPO4BlobConfig,
-			Amsterdam: params.DefaultBPO4BlobConfig, // TODO update when defined
+			Cancun: params.DefaultCancunBlobConfig,
+			Prague: params.DefaultPragueBlobConfig,
+			BPO1:   params.DefaultBPO1BlobConfig,
+			BPO2:   params.DefaultBPO2BlobConfig,
+			BPO3:   params.DefaultBPO3BlobConfig,
+			BPO4:   params.DefaultBPO4BlobConfig,
 		},
 	},
 	"Verkle": {
@@ -804,18 +792,6 @@ var Forks = map[string]*params.ChainConfig{
 			Osaka:  params.DefaultOsakaBlobConfig,
 		},
 	},
-}
-
-var bpo1BlobConfig = &params.BlobConfig{
-	Target:         9,
-	Max:            14,
-	UpdateFraction: 8832827,
-}
-
-var bpo2BlobConfig = &params.BlobConfig{
-	Target:         14,
-	Max:            21,
-	UpdateFraction: 13739630,
 }
 
 // AvailableForks returns the set of defined fork names

--- a/tests/init.go
+++ b/tests/init.go
@@ -789,7 +789,6 @@ var Forks = map[string]*params.ChainConfig{
 		BlobScheduleConfig: &params.BlobScheduleConfig{
 			Cancun: params.DefaultCancunBlobConfig,
 			Prague: params.DefaultPragueBlobConfig,
-			Osaka:  params.DefaultOsakaBlobConfig,
 		},
 	},
 }

--- a/tests/init.go
+++ b/tests/init.go
@@ -487,7 +487,7 @@ var Forks = map[string]*params.ChainConfig{
 		BlobScheduleConfig: &params.BlobScheduleConfig{
 			Cancun: params.DefaultCancunBlobConfig,
 			Prague: params.DefaultPragueBlobConfig,
-			BPO1:   params.DefaultBPO1BlobConfig,
+			BPO1:   bpo1BlobConfig,
 		},
 	},
 	"OsakaToBPO1AtTime15k": {
@@ -515,7 +515,7 @@ var Forks = map[string]*params.ChainConfig{
 		BlobScheduleConfig: &params.BlobScheduleConfig{
 			Cancun: params.DefaultCancunBlobConfig,
 			Prague: params.DefaultPragueBlobConfig,
-			BPO1:   params.DefaultBPO1BlobConfig,
+			BPO1:   bpo1BlobConfig,
 		},
 	},
 	"BPO2": {
@@ -544,8 +544,8 @@ var Forks = map[string]*params.ChainConfig{
 		BlobScheduleConfig: &params.BlobScheduleConfig{
 			Cancun: params.DefaultCancunBlobConfig,
 			Prague: params.DefaultPragueBlobConfig,
-			BPO1:   params.DefaultBPO1BlobConfig,
-			BPO2:   params.DefaultBPO2BlobConfig,
+			BPO1:   bpo1BlobConfig,
+			BPO2:   bpo2BlobConfig,
 		},
 	},
 	"BPO1ToBPO2AtTime15k": {
@@ -574,8 +574,8 @@ var Forks = map[string]*params.ChainConfig{
 		BlobScheduleConfig: &params.BlobScheduleConfig{
 			Cancun: params.DefaultCancunBlobConfig,
 			Prague: params.DefaultPragueBlobConfig,
-			BPO1:   params.DefaultBPO1BlobConfig,
-			BPO2:   params.DefaultBPO2BlobConfig,
+			BPO1:   bpo1BlobConfig,
+			BPO2:   bpo2BlobConfig,
 		},
 	},
 	"BPO3": {
@@ -605,8 +605,8 @@ var Forks = map[string]*params.ChainConfig{
 		BlobScheduleConfig: &params.BlobScheduleConfig{
 			Cancun: params.DefaultCancunBlobConfig,
 			Prague: params.DefaultPragueBlobConfig,
-			BPO1:   params.DefaultBPO1BlobConfig,
-			BPO2:   params.DefaultBPO2BlobConfig,
+			BPO1:   bpo1BlobConfig,
+			BPO2:   bpo2BlobConfig,
 			BPO3:   params.DefaultBPO3BlobConfig,
 		},
 	},
@@ -637,8 +637,8 @@ var Forks = map[string]*params.ChainConfig{
 		BlobScheduleConfig: &params.BlobScheduleConfig{
 			Cancun: params.DefaultCancunBlobConfig,
 			Prague: params.DefaultPragueBlobConfig,
-			BPO1:   params.DefaultBPO1BlobConfig,
-			BPO2:   params.DefaultBPO2BlobConfig,
+			BPO1:   bpo1BlobConfig,
+			BPO2:   bpo2BlobConfig,
 			BPO3:   params.DefaultBPO3BlobConfig,
 		},
 	},
@@ -670,8 +670,8 @@ var Forks = map[string]*params.ChainConfig{
 		BlobScheduleConfig: &params.BlobScheduleConfig{
 			Cancun: params.DefaultCancunBlobConfig,
 			Prague: params.DefaultPragueBlobConfig,
-			BPO1:   params.DefaultBPO1BlobConfig,
-			BPO2:   params.DefaultBPO2BlobConfig,
+			BPO1:   bpo1BlobConfig,
+			BPO2:   bpo2BlobConfig,
 			BPO3:   params.DefaultBPO3BlobConfig,
 			BPO4:   params.DefaultBPO4BlobConfig,
 		},
@@ -704,8 +704,8 @@ var Forks = map[string]*params.ChainConfig{
 		BlobScheduleConfig: &params.BlobScheduleConfig{
 			Cancun: params.DefaultCancunBlobConfig,
 			Prague: params.DefaultPragueBlobConfig,
-			BPO1:   params.DefaultBPO1BlobConfig,
-			BPO2:   params.DefaultBPO2BlobConfig,
+			BPO1:   bpo1BlobConfig,
+			BPO2:   bpo2BlobConfig,
 			BPO3:   params.DefaultBPO3BlobConfig,
 			BPO4:   params.DefaultBPO4BlobConfig,
 		},
@@ -739,8 +739,8 @@ var Forks = map[string]*params.ChainConfig{
 		BlobScheduleConfig: &params.BlobScheduleConfig{
 			Cancun: params.DefaultCancunBlobConfig,
 			Prague: params.DefaultPragueBlobConfig,
-			BPO1:   params.DefaultBPO1BlobConfig,
-			BPO2:   params.DefaultBPO2BlobConfig,
+			BPO1:   bpo1BlobConfig,
+			BPO2:   bpo2BlobConfig,
 			BPO3:   params.DefaultBPO3BlobConfig,
 			BPO4:   params.DefaultBPO4BlobConfig,
 		},
@@ -792,6 +792,18 @@ var Forks = map[string]*params.ChainConfig{
 			Osaka:  params.DefaultOsakaBlobConfig,
 		},
 	},
+}
+
+var bpo1BlobConfig = &params.BlobConfig{
+	Target:         9,
+	Max:            14,
+	UpdateFraction: 8832827,
+}
+
+var bpo2BlobConfig = &params.BlobConfig{
+	Target:         14,
+	Max:            21,
+	UpdateFraction: 13739630,
 }
 
 // AvailableForks returns the set of defined fork names


### PR DESCRIPTION
Turns
```
    "blobSchedule": {
      "cancun": {
        "target": 3,
        "max": 6,
        "baseFeeUpdateFraction": 3338477
      },
      "prague": {
        "target": 6,
        "max": 9,
        "baseFeeUpdateFraction": 5007716
      },
      "osaka": {
        "target": 6,
        "max": 9,
        "baseFeeUpdateFraction": 5007716
      },
      "bpo1": {
        "target": 10,
        "max": 15,
        "baseFeeUpdateFraction": 8346193
      },
      "amsterdam": {
        "target": 10,
        "max": 15,
        "baseFeeUpdateFraction": 8346193
      }
    },
    "osakaTime": 0,
    "bpo1Time": 0,
    "amsterdamTime": 1779434285
```
into

```
    "blobSchedule": {
      "cancun": {
        "target": 3,
        "max": 6,
        "baseFeeUpdateFraction": 3338477
      },
      "prague": {
        "target": 6,
        "max": 9,
        "baseFeeUpdateFraction": 5007716
      },
      "bpo1": {
        "target": 10,
        "max": 15,
        "baseFeeUpdateFraction": 8346193
      },
    },
    "osakaTime": 0,
    "bpo1Time": 0,
    "amsterdamTime": 1779434285
    ```