### PR TITLE
graphql: limit request body size

### DIFF
--- a/graphql/graphql_test.go
+++ b/graphql/graphql_test.go
@@ -23,6 +23,7 @@ import (
 	"io"
 	"math/big"
 	"net/http"
+	"net/http/httptest"
 	"strings"
 	"testing"
 	"time"
@@ -132,7 +133,7 @@ func TestGraphQLBlockSerialization(t *testing.T) {
 			code: 400,
 		},
 		{
-			body: `{"query": "{bleh{number}}","variables": null}"`,
+			body: `{"query": "{bleh{number}}","variables": null}`,
 			want: `{"errors":[{"message":"Cannot query field \"bleh\" on type \"Query\".","locations":[{"line":1,"column":2}]}]}`,
 			code: 400,
 		},
@@ -172,6 +173,35 @@ func TestGraphQLBlockSerialization(t *testing.T) {
 		if ctype := resp.Header.Get("Content-Type"); ctype != "application/json" {
 			t.Errorf("testcase %d \nwrong Content-Type, have: %v, want: %v", i, ctype, "application/json")
 		}
+	}
+}
+
+func TestGraphQLHTTPBodyLimit(t *testing.T) {
+	tests := []struct {
+		name string
+		body string
+	}{
+		{
+			name: "should reject oversized request body if query field exceeds limit",
+			body: `{"query":"` + strings.Repeat("a", maxRequestBodySize) + `"}`,
+		},
+		{
+			name: "should reject oversized request body if trailing data exceeds limit",
+			body: `{"query":"{block{number}}"}` + strings.Repeat(" ", maxRequestBodySize),
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodPost, "/graphql", strings.NewReader(test.body))
+			w := httptest.NewRecorder()
+
+			handler{}.ServeHTTP(w, req)
+
+			if w.Code != http.StatusRequestEntityTooLarge {
+				t.Fatalf("got status %d, want %d", w.Code, http.StatusRequestEntityTooLarge)
+			}
+		})
 	}
 }
 

--- a/graphql/service.go
+++ b/graphql/service.go
@@ -19,6 +19,8 @@ package graphql
 import (
 	"context"
 	"encoding/json"
+	"errors"
+	"io"
 	"net/http"
 	"strconv"
 	"sync"
@@ -35,18 +37,31 @@ import (
 // maxQueryDepth limits the maximum field nesting depth allowed in GraphQL queries.
 const maxQueryDepth = 20
 
+// maxRequestBodySize limits the size of incoming GraphQL request bodies.
+const maxRequestBodySize = 5 * 1024 * 1024
+
 type handler struct {
 	Schema *graphql.Schema
 }
 
 func (h handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	r.Body = http.MaxBytesReader(w, r.Body, maxRequestBodySize)
+
 	var params struct {
 		Query         string                 `json:"query"`
 		OperationName string                 `json:"operationName"`
 		Variables     map[string]interface{} `json:"variables"`
 	}
-	if err := json.NewDecoder(r.Body).Decode(&params); err != nil {
-		http.Error(w, err.Error(), http.StatusBadRequest)
+	dec := json.NewDecoder(r.Body)
+	if err := dec.Decode(&params); err != nil {
+		writeRequestError(w, err)
+		return
+	}
+	if err := dec.Decode(&struct{}{}); err != io.EOF {
+		if err == nil {
+			err = errors.New("unexpected content after JSON value")
+		}
+		writeRequestError(w, err)
 		return
 	}
 
@@ -106,6 +121,15 @@ func (h handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		}
 		w.Write(responseJSON)
 	})
+}
+
+func writeRequestError(w http.ResponseWriter, err error) {
+	var maxBytesErr *http.MaxBytesError
+	if errors.As(err, &maxBytesErr) {
+		http.Error(w, err.Error(), http.StatusRequestEntityTooLarge)
+		return
+	}
+	http.Error(w, err.Error(), http.StatusBadRequest)
 }
 
 // New constructs a new GraphQL service instance.


### PR DESCRIPTION
Fixes #35033

## Problem

The GraphQL HTTP handler decoded request bodies directly before executing the query. Unlike the JSON-RPC HTTP path, `/graphql` did not have an explicit request body limit before JSON decoding.

A single `Decode` also stops after the first JSON value, so the handler now requires EOF after the GraphQL request object to ensure oversized trailing request data is not ignored.

## Changes

- Limit GraphQL request bodies to 5 MiB, matching the existing JSON-RPC default body limit.
- Return `413 Request Entity Too Large` when the limit is exceeded.
- Require EOF after the request JSON object.
- Add regression coverage for oversized query bodies and oversized trailing request data.
- Fix an existing GraphQL test fixture that had an unintended trailing quote after the JSON object.

## Validation

- `gofmt -w graphql/service.go graphql/graphql_test.go`
- `go run golang.org/x/tools/cmd/goimports@latest -w graphql/service.go graphql/graphql_test.go`
- `go test ./graphql -run TestGraphQLHTTPBodyLimit -count=1`
- `go test ./graphql -count=1`