### PR TITLE
p2p/discover: waitForNodes hangs on RespCount=0 from peer

### DIFF
--- a/p2p/discover/v5_udp.go
+++ b/p2p/discover/v5_udp.go
@@ -464,7 +464,7 @@ func (t *UDPv5) waitForNodes(c *callV5, distances []uint) ([]*enode.Node, error)
 			if total == -1 {
 				total = min(int(response.RespCount), totalNodesResponseLimit)
 			}
-			if received++; received == total {
+			if received++; received >= total {
 				return nodes, nil
 			}
 		case err := <-c.err:


### PR DESCRIPTION
The first NODES response sets total = min(int(response.RespCount), totalNodesResponseLimit), With RespCount=0, total=0 but receive become 1; receive == count is never satisfied.