### PR TITLE
accounts/external, signer/core: support setcode txs

### DIFF
--- a/accounts/external/backend.go
+++ b/accounts/external/backend.go
@@ -236,6 +236,7 @@ func (api *ExternalSigner) SignTx(account accounts.Account, tx *types.Transactio
 		args.AccessList = &accessList
 	}
 	if tx.Type() == types.BlobTxType {
+		args.BlobFeeCap = (*hexutil.Big)(tx.BlobGasFeeCap())
 		args.BlobHashes = tx.BlobHashes()
 		sidecar := tx.BlobTxSidecar()
 		if sidecar == nil {
@@ -244,6 +245,12 @@ func (api *ExternalSigner) SignTx(account accounts.Account, tx *types.Transactio
 		args.Blobs = sidecar.Blobs
 		args.Commitments = sidecar.Commitments
 		args.Proofs = sidecar.Proofs
+	}
+	if tx.Type() == types.SetCodeTxType {
+		args.AuthorizationList = tx.SetCodeAuthorizations()
+		if args.AuthorizationList == nil {
+			args.AuthorizationList = []types.SetCodeAuthorization{}
+		}
 	}
 
 	var res signTransactionResult

--- a/signer/core/apitypes/types.go
+++ b/signer/core/apitypes/types.go
@@ -112,6 +112,9 @@ type SendTxArgs struct {
 	Blobs       []kzg4844.Blob       `json:"blobs,omitempty"`
 	Commitments []kzg4844.Commitment `json:"commitments,omitempty"`
 	Proofs      []kzg4844.Proof      `json:"proofs,omitempty"`
+
+	// For SetCodeTxType
+	AuthorizationList []types.SetCodeAuthorization `json:"authorizationList"`
 }
 
 func (args SendTxArgs) String() string {
@@ -146,6 +149,27 @@ func (args *SendTxArgs) ToTransaction() (*types.Transaction, error) {
 	}
 	var data types.TxData
 	switch {
+	case args.AuthorizationList != nil:
+		al := types.AccessList{}
+		if args.AccessList != nil {
+			al = *args.AccessList
+		}
+		if to == nil {
+			return nil, errors.New("transaction recipient must be set for setcode transactions")
+		}
+		data = &types.SetCodeTx{
+			To:         *to,
+			ChainID:    uint256.MustFromBig((*big.Int)(args.ChainID)),
+			Nonce:      uint64(args.Nonce),
+			Gas:        uint64(args.Gas),
+			GasFeeCap:  uint256.MustFromBig((*big.Int)(args.MaxFeePerGas)),
+			GasTipCap:  uint256.MustFromBig((*big.Int)(args.MaxPriorityFeePerGas)),
+			Value:      uint256.MustFromBig((*big.Int)(&args.Value)),
+			Data:       args.data(),
+			AccessList: al,
+			AuthList:   args.AuthorizationList,
+		}
+
 	case args.BlobHashes != nil:
 		al := types.AccessList{}
 		if args.AccessList != nil {

--- a/signer/core/apitypes/types_test.go
+++ b/signer/core/apitypes/types_test.go
@@ -20,9 +20,11 @@ import (
 	"crypto/rand"
 	"crypto/sha256"
 	"encoding/json"
+	"math/big"
 	"testing"
 
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/crypto/kzg4844"
 	"github.com/holiman/uint256"
@@ -138,6 +140,63 @@ func TestBlobTxs(t *testing.T) {
 		t.Fatal(err)
 	}
 	t.Logf("tx %v", string(data))
+}
+
+func TestSetCodeTxArgs(t *testing.T) {
+	t.Parallel()
+
+	to := common.NewMixedcaseAddress(common.HexToAddress("0x0000000000000000000000000000000000000001"))
+	input := hexutil.Bytes{0x01}
+	value := hexutil.Big(*big.NewInt(7))
+	auth := types.SetCodeAuthorization{
+		ChainID: *uint256.NewInt(1),
+		Address: common.HexToAddress("0x0000000000000000000000000000000000000002"),
+		Nonce:   3,
+		V:       1,
+		R:       *uint256.NewInt(4),
+		S:       *uint256.NewInt(5),
+	}
+	args := SendTxArgs{
+		From:                 common.NewMixedcaseAddress(common.HexToAddress("0x0000000000000000000000000000000000000003")),
+		To:                   &to,
+		Gas:                  hexutil.Uint64(21000),
+		MaxFeePerGas:         (*hexutil.Big)(big.NewInt(11)),
+		MaxPriorityFeePerGas: (*hexutil.Big)(big.NewInt(2)),
+		Value:                value,
+		Nonce:                hexutil.Uint64(1),
+		Input:                &input,
+		ChainID:              (*hexutil.Big)(big.NewInt(1)),
+		AuthorizationList:    []types.SetCodeAuthorization{auth},
+	}
+	tx, err := args.ToTransaction()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if have := tx.Type(); have != types.SetCodeTxType {
+		t.Fatalf("have type %d, want %d", have, types.SetCodeTxType)
+	}
+	auths := tx.SetCodeAuthorizations()
+	if len(auths) != 1 || auths[0] != auth {
+		t.Fatalf("have authorizations %#v, want %#v", auths, []types.SetCodeAuthorization{auth})
+	}
+
+	blobHashes := []common.Hash{{0x01}}
+	args.BlobHashes = blobHashes
+	roundtrip, err := json.Marshal(args)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var decoded SendTxArgs
+	if err := json.Unmarshal(roundtrip, &decoded); err != nil {
+		t.Fatal(err)
+	}
+	tx, err = decoded.ToTransaction()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if have := tx.Type(); have != types.SetCodeTxType {
+		t.Fatalf("after JSON roundtrip have type %d, want %d", have, types.SetCodeTxType)
+	}
 }
 
 func TestType_IsArray(t *testing.T) {


### PR DESCRIPTION
Completes the external signer transaction arguments for typed transactions.

Blob transactions now forward `maxFeePerBlobGas` to clef, and set-code transactions include `authorizationList` so clef reconstructs the request as `SetCodeTxType` instead of a dynamic fee transaction.
