### PR TITLE
core/types: fix duplicated "the" in Authority doc-comment

### DIFF
--- a/core/types/tx_setcode.go
+++ b/core/types/tx_setcode.go
@@ -117,7 +117,7 @@ func (a *SetCodeAuthorization) SigHash() common.Hash {
 	})
 }
 
-// Authority recovers the the authorizing account of an authorization.
+// Authority recovers the authorizing account of an authorization.
 func (a *SetCodeAuthorization) Authority() (common.Address, error) {
 	sighash := a.SigHash()
 	if !crypto.ValidateSignatureValues(a.V, a.R.ToBig(), a.S.ToBig(), true) {


### PR DESCRIPTION
Signed-off-by: Noa Levi <275430404+lphuc2250gma@users.noreply.github.com>