### PR TITLE
log: return TerminalHandler write errors from Handle

### DIFF
--- a/log/handler.go
+++ b/log/handler.go
@@ -77,9 +77,9 @@ func (h *TerminalHandler) Handle(_ context.Context, r slog.Record) error {
 	h.mu.Lock()
 	defer h.mu.Unlock()
 	buf := h.format(h.buf, r, h.useColor)
-	h.wr.Write(buf)
+	_, err := h.wr.Write(buf)
 	h.buf = buf[:0]
-	return nil
+	return err
 }
 
 func (h *TerminalHandler) Enabled(_ context.Context, level slog.Level) bool {


### PR DESCRIPTION
Propagate slog Handle failures when the underlying io.Writer rejects output.