### PR TITLE
node, cmd/clef, graphql: disable gzip on engine API

### DIFF
--- a/cmd/clef/main.go
+++ b/cmd/clef/main.go
@@ -739,7 +739,7 @@ func signer(c *cli.Context) error {
 		if err != nil {
 			utils.Fatalf("Could not register API: %w", err)
 		}
-		handler := node.NewHTTPHandlerStack(srv, cors, vhosts, nil)
+		handler := node.NewHTTPHandlerStack(srv, cors, vhosts, nil, false)
 
 		// set port
 		port := c.Int(rpcPortFlag.Name)

--- a/graphql/service.go
+++ b/graphql/service.go
@@ -148,7 +148,7 @@ func newHandler(stack *node.Node, backend ethapi.Backend, filterSystem *filters.
 		return nil, err
 	}
 	h := handler{Schema: s}
-	handler := node.NewHTTPHandlerStack(h, cors, vhosts, nil)
+	handler := node.NewHTTPHandlerStack(h, cors, vhosts, nil, false)
 
 	stack.RegisterHandler("GraphQL UI", "/graphql/ui", GraphiQL{})
 	stack.RegisterHandler("GraphQL UI", "/graphql/ui/", GraphiQL{})

--- a/node/node.go
+++ b/node/node.go
@@ -445,6 +445,7 @@ func (n *Node) startRPC() error {
 			Vhosts:             n.config.AuthVirtualHosts,
 			Modules:            DefaultAuthModules,
 			prefix:             DefaultAuthPrefix,
+			disableGzip:        true,
 			rpcEndpointConfig:  sharedConfig,
 		})
 		if err != nil {

--- a/node/rpcstack.go
+++ b/node/rpcstack.go
@@ -42,6 +42,7 @@ type httpConfig struct {
 	CorsAllowedOrigins []string
 	Vhosts             []string
 	prefix             string // path prefix on which to mount http handler
+	disableGzip        bool
 	rpcEndpointConfig
 }
 
@@ -320,7 +321,7 @@ func (h *httpServer) enableRPC(apis []rpc.API, config httpConfig) error {
 	}
 	h.httpConfig = config
 	h.httpHandler.Store(&rpcHandler{
-		Handler: NewHTTPHandlerStack(srv, config.CorsAllowedOrigins, config.Vhosts, config.jwtSecret),
+		Handler: NewHTTPHandlerStack(srv, config.CorsAllowedOrigins, config.Vhosts, config.jwtSecret, config.disableGzip),
 		prefix:  config.prefix,
 		server:  srv,
 	})
@@ -402,12 +403,15 @@ func isWebsocket(r *http.Request) bool {
 }
 
 // NewHTTPHandlerStack returns wrapped http-related handlers
-func NewHTTPHandlerStack(srv http.Handler, cors []string, vhosts []string, jwtSecret []byte) http.Handler {
+func NewHTTPHandlerStack(srv http.Handler, cors []string, vhosts []string, jwtSecret []byte, disableGzip bool) http.Handler {
 	// Wrap the CORS-handler within a host-handler
 	handler := newCorsHandler(srv, cors)
 	handler = newVHostHandler(vhosts, handler)
 	if len(jwtSecret) != 0 {
 		handler = newJWTHandler(jwtSecret, handler)
+	}
+	if disableGzip {
+		return handler
 	}
 	return newGzipHandler(handler)
 }


### PR DESCRIPTION
Add a disableGzip parameter to NewHTTPHandlerStack and httpConfig. initAuth sets it true so compression is disabled in the engine api. Public HTTP RPC behavior is unchanged.