### PR TITLE
core/txpool/locals: protect journal.writer with a dedicated mutex (closes #34983)

### DIFF
--- a/core/txpool/locals/journal.go
+++ b/core/txpool/locals/journal.go
@@ -21,6 +21,7 @@ import (
 	"io"
 	"io/fs"
 	"os"
+	"sync"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
@@ -43,9 +44,39 @@ func (*devNull) Close() error                      { return nil }
 
 // journal is a rotating log of transactions with the aim of storing locally
 // created transactions to allow non-executed ones to survive node restarts.
+//
+// writer is shared between the tracker loop goroutine (load / setupWriter /
+// rotate / close) and any goroutine that calls TxTracker.Track / TrackAll
+// (which reaches journal.insert). TxTracker.mu does not cover loop-side
+// writer mutations — see #34983 for the race report from `go test -race`.
+// A small dedicated mutex guards every read / write of the writer pointer.
+// We deliberately drop the lock before doing the actual rlp.Encode in
+// insert so that a concurrent close / rotate is not blocked by an in-flight
+// write — Write on a closed file simply returns an error, which insert
+// propagates back to the caller (already ignored at the call site in
+// TrackAll).
 type journal struct {
-	path   string         // Filesystem path to store the transactions at
+	path string // Filesystem path to store the transactions at
+
+	mu     sync.Mutex
 	writer io.WriteCloser // Output stream to write new transactions into
+}
+
+// getWriter returns the current journal writer under the writer mutex.
+func (journal *journal) getWriter() io.WriteCloser {
+	journal.mu.Lock()
+	defer journal.mu.Unlock()
+	return journal.writer
+}
+
+// setWriter atomically swaps the writer pointer and returns the previous
+// value so the caller can close it after releasing the lock.
+func (journal *journal) setWriter(w io.WriteCloser) io.WriteCloser {
+	journal.mu.Lock()
+	defer journal.mu.Unlock()
+	prev := journal.writer
+	journal.writer = w
+	return prev
 }
 
 // newTxJournal creates a new transaction journal to
@@ -69,9 +100,12 @@ func (journal *journal) load(add func([]*types.Transaction) []error) error {
 	}
 	defer input.Close()
 
-	// Temporarily discard any journal additions (don't double add on load)
-	journal.writer = new(devNull)
-	defer func() { journal.writer = nil }()
+	// Temporarily discard any journal additions (don't double add on load).
+	// The add callback below dispatches to TxTracker.TrackAll → insert, which
+	// reads journal.writer under journal.mu; setWriter publishes the devNull
+	// atomically so those reads observe a consistent value.
+	journal.setWriter(new(devNull))
+	defer journal.setWriter(nil)
 
 	// Inject all transactions from the journal into the pool
 	stream := rlp.NewStream(input, 0)
@@ -118,44 +152,47 @@ func (journal *journal) load(add func([]*types.Transaction) []error) error {
 }
 
 func (journal *journal) setupWriter() error {
-	if journal.writer != nil {
-		if err := journal.writer.Close(); err != nil {
+	// Close any previously-installed writer; clear the slot first so concurrent
+	// inserts can see the transition without racing on the close.
+	if prev := journal.setWriter(nil); prev != nil {
+		if err := prev.Close(); err != nil {
 			return err
 		}
-		journal.writer = nil
 	}
 
-	// Re-open the journal file for appending
-	// Use O_APPEND to ensure we always write to the end of the file
+	// Re-open the journal file for appending.
+	// Use O_APPEND to ensure we always write to the end of the file.
 	sink, err := os.OpenFile(journal.path, os.O_WRONLY|os.O_CREATE|os.O_APPEND, 0644)
 	if err != nil {
 		return err
 	}
-	journal.writer = sink
+	journal.setWriter(sink)
 
 	return nil
 }
 
 // insert adds the specified transaction to the local disk journal.
 func (journal *journal) insert(tx *types.Transaction) error {
-	if journal.writer == nil {
+	// Snapshot the writer under the mutex, then release before doing the
+	// actual rlp.Encode so a concurrent close / rotate is not blocked by an
+	// in-flight write. Write on a closed file returns an error which we
+	// propagate; the existing call site in TrackAll already ignores it.
+	w := journal.getWriter()
+	if w == nil {
 		return errNoActiveJournal
 	}
-	if err := rlp.Encode(journal.writer, tx); err != nil {
-		return err
-	}
-	return nil
+	return rlp.Encode(w, tx)
 }
 
 // rotate regenerates the transaction journal based on the current contents of
 // the transaction pool.
 func (journal *journal) rotate(all map[common.Address]types.Transactions) error {
-	// Close the current journal (if any is open)
-	if journal.writer != nil {
-		if err := journal.writer.Close(); err != nil {
+	// Close the current journal (if any is open). Clear the slot first so
+	// concurrent inserts observe the transition before the file is closed.
+	if prev := journal.setWriter(nil); prev != nil {
+		if err := prev.Close(); err != nil {
 			return err
 		}
-		journal.writer = nil
 	}
 	// Generate a new journal with the contents of the current pool
 	replacement, err := os.OpenFile(journal.path+".new", os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0644)
@@ -182,7 +219,7 @@ func (journal *journal) rotate(all map[common.Address]types.Transactions) error 
 	if err != nil {
 		return err
 	}
-	journal.writer = sink
+	journal.setWriter(sink)
 
 	logger := log.Info
 	if len(all) == 0 {
@@ -195,10 +232,8 @@ func (journal *journal) rotate(all map[common.Address]types.Transactions) error 
 
 // close flushes the transaction journal contents to disk and closes the file.
 func (journal *journal) close() error {
-	var err error
-	if journal.writer != nil {
-		err = journal.writer.Close()
-		journal.writer = nil
+	if prev := journal.setWriter(nil); prev != nil {
+		return prev.Close()
 	}
-	return err
+	return nil
 }

--- a/core/txpool/locals/tx_tracker_test.go
+++ b/core/txpool/locals/tx_tracker_test.go
@@ -170,6 +170,63 @@ func TestResubmit(t *testing.T) {
 	}
 }
 
+// TestJournalSetupAndInsertRace exercises the race fixed in #34983: the
+// tracker loop goroutine calls journal.setupWriter() (writing the writer
+// pointer) while caller goroutines reach journal.insert() through TrackAll
+// (reading the writer pointer). Pre-fix the writer field had no
+// synchronisation and `go test -race ./core/txpool/locals/` flagged this as
+// "DATA RACE". Run under `-race` for the assertion to bite.
+func TestJournalSetupAndInsertRace(t *testing.T) {
+	journalPath := filepath.Join(t.TempDir(), fmt.Sprintf("%d", rand.Int63()))
+	env := newTestEnv(t, 10, 0, journalPath)
+	defer env.close()
+
+	env.tracker.Start()
+	defer env.tracker.Stop()
+
+	// Pump TrackAll from multiple goroutines while the loop goroutine is
+	// still calling setupWriter() / rotating the journal. The race detector
+	// will trip on writer reads / writes if synchronisation regresses.
+	const goroutines = 8
+	txs := env.makeTxs(64)
+	done := make(chan struct{})
+	for i := 0; i < goroutines; i++ {
+		go func(start int) {
+			for j := 0; j < 64; j++ {
+				env.tracker.Track(txs[(start+j)%len(txs)])
+			}
+			done <- struct{}{}
+		}(i)
+	}
+	for i := 0; i < goroutines; i++ {
+		<-done
+	}
+}
+
+// TestJournalSetupWriterReplacesWriter exercises the second half of the
+// #34983 contract: setupWriter() must clear the writer slot before closing
+// the previous writer so a concurrent insert never holds a freed pointer.
+// We assert that repeated setupWriter calls return cleanly and the final
+// writer is usable by a follow-up insert.
+func TestJournalSetupWriterReplacesWriter(t *testing.T) {
+	journalPath := filepath.Join(t.TempDir(), fmt.Sprintf("%d", rand.Int63()))
+	j := newTxJournal(journalPath)
+	for i := 0; i < 8; i++ {
+		if err := j.setupWriter(); err != nil {
+			t.Fatalf("setupWriter iteration %d: %v", i, err)
+		}
+		if w := j.getWriter(); w == nil {
+			t.Fatalf("writer should be non-nil after setupWriter (iter %d)", i)
+		}
+	}
+	if err := j.close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+	if w := j.getWriter(); w != nil {
+		t.Fatalf("writer should be nil after close, got %T", w)
+	}
+}
+
 func TestJournal(t *testing.T) {
 	journalPath := filepath.Join(t.TempDir(), fmt.Sprintf("%d", rand.Int63()))
 	env := newTestEnv(t, 10, 0, journalPath)


### PR DESCRIPTION
Closes #34983.

### Race report

`go test -race ./core/txpool/locals/` on master trips 8 DATA RACE warnings on `journal.writer`:

- **Writer goroutine** — `tracker.loop()` → `journal.setupWriter()` at `journal.go:134` writes `journal.writer = sink` without any synchronization.
- **Reader goroutines** — caller-initiated `TxTracker.Track` / `TrackAll` → `journal.insert()` at `journal.go:142` reads `journal.writer` while holding `TxTracker.mu`.

`TxTracker.mu` does not cover the loop-side writer mutations, so the two ends race. `rotate()` and `close()` mutate `writer` too, both with the same hole.

### Fix

Adds a dedicated `mu sync.Mutex` on the `journal` struct that guards every read / write of the writer pointer:

- `setupWriter` / `rotate` / `close` clear the slot via `setWriter(nil)` first, then close the previous writer outside the lock. Concurrent inserts observe the transition cleanly.
- `insert` snapshots the writer with `getWriter()` under the mutex and releases the lock before doing the actual `rlp.Encode`, so a concurrent `close` / `rotate` is not blocked by an in-flight write. `Write` on a closed file simply returns an error, which `insert` propagates back — already ignored at the `TrackAll` call site (`tx_tracker.go:111`).
- `load` publishes the `devNull` shim through `setWriter` so the in-progress add-callback path (which re-enters `TrackAll` → `insert` on the same goroutine) sees a consistent value. No nesting of the new mutex.

### Tests

Two new cases under `core/txpool/locals/tx_tracker_test.go`:

- `TestJournalSetupAndInsertRace` — pumps `Track` from 8 goroutines while the loop goroutine is still inside `setupWriter()` / rotating the journal. Trips the race detector under `-race` pre-fix; clean post-fix.
- `TestJournalSetupWriterReplacesWriter` — pins the slot-clear-before-close contract: repeated `setupWriter` calls leave the writer populated, and `close` clears it back to nil.

### Local

- `go test -race ./core/txpool/locals/` — all green (`TestResubmit`, `TestJournalSetupAndInsertRace`, `TestJournalSetupWriterReplacesWriter`, `TestJournal`).
- `go vet ./core/txpool/locals/` — clean.
- `gofmt -l core/txpool/locals/` — clean.
