### PR TITLE
core: drop tx-lookup entries during chain rewind (closes #33744)

### DIFF
--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -1078,6 +1078,13 @@ func (bc *BlockChain) setHeadBeyondRoot(head uint64, time uint64, root common.Ha
 	}
 	// Rewind the header chain, deleting all block bodies until then
 	delFn := func(db ethdb.KeyValueWriter, hash common.Hash, num uint64) {
+		// Read the body before deleting it so we can also drop the
+		// per-transaction tx-lookup entries for this block. ReadBody
+		// transparently handles both kv-store and ancient-store sources,
+		// so this works regardless of which branch handles body removal
+		// below. (#33744)
+		body := rawdb.ReadBody(bc.db, hash, num)
+
 		// Ignore the error here since light client won't hit this path
 		frozen, _ := bc.db.Ancients()
 		if num+1 <= frozen {
@@ -1094,7 +1101,19 @@ func (bc *BlockChain) setHeadBeyondRoot(head uint64, time uint64, root common.Ha
 			rawdb.DeleteBody(db, hash, num)
 			rawdb.DeleteReceipts(db, hash, num)
 		}
-		// Todo(rjl493456442) txlookup, log index, etc
+		// Drop the tx-lookup entries for every transaction this block
+		// contained. These live in the key-value store regardless of
+		// whether the block body itself moved to the ancient store, so
+		// without this step `eth_getTransactionByHash` (and friends) on
+		// a rewound chain would still resolve a hash to a ghost block
+		// position. (#33744)
+		if body != nil {
+			hashes := make([]common.Hash, len(body.Transactions))
+			for i, tx := range body.Transactions {
+				hashes[i] = tx.Hash()
+			}
+			rawdb.DeleteTxLookupEntries(db, hashes)
+		}
 	}
 	// If SetHead was only called as a chain reparation method, try to skip
 	// touching the header chain altogether, unless the freezer is broken

--- a/core/blockchain_setheadtxlookup_test.go
+++ b/core/blockchain_setheadtxlookup_test.go
@@ -1,0 +1,108 @@
+// Copyright 2025 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+
+package core
+
+import (
+	"math/big"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/consensus/ethash"
+	"github.com/ethereum/go-ethereum/core/rawdb"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/ethereum/go-ethereum/params"
+)
+
+// TestSetHeadCleansTxLookupEntries pins the contract added for #33744:
+// rewinding the chain past a block must delete every tx-lookup entry
+// the block contained. Before the fix delFn left those entries behind,
+// so a subsequent eth_getTransactionByHash resolved the hash to a
+// block position that no longer existed.
+func TestSetHeadCleansTxLookupEntries(t *testing.T) {
+	var (
+		key, _    = crypto.HexToECDSA("b71c71a67e1177ad4e901695e1b4b9ee17ae16c6668d313eac2f96dbcda3f291")
+		address   = crypto.PubkeyToAddress(key.PublicKey)
+		funds     = big.NewInt(1_000_000_000_000_000)
+		chainHead = uint64(10)
+		gspec     = &Genesis{
+			Config:  params.TestChainConfig,
+			Alloc:   types.GenesisAlloc{address: {Balance: funds}},
+			BaseFee: big.NewInt(params.InitialBaseFee),
+		}
+	)
+
+	// Build a chain where every block carries one signed transaction so we
+	// have a non-empty body for each height.
+	_, blocks, _ := GenerateChainWithGenesis(gspec, ethash.NewFaker(), int(chainHead), func(i int, gen *BlockGen) {
+		tx, err := types.SignTx(
+			types.NewTransaction(gen.TxNonce(address), common.Address{0x00}, big.NewInt(1000), params.TxGas, gen.BaseFee(), nil),
+			types.LatestSigner(gspec.Config), key,
+		)
+		if err != nil {
+			t.Fatalf("sign tx for block %d: %v", i, err)
+		}
+		gen.AddTx(tx)
+	})
+
+	db := rawdb.NewMemoryDatabase()
+	chain, err := NewBlockChain(db, gspec, ethash.NewFaker(), nil)
+	if err != nil {
+		t.Fatalf("new blockchain: %v", err)
+	}
+	defer chain.Stop()
+
+	if n, err := chain.InsertChain(blocks); err != nil {
+		t.Fatalf("insert chain (failed at block %d): %v", n, err)
+	}
+
+	// Sanity check: every block's tx-lookup entry is present pre-rewind.
+	for _, b := range blocks {
+		for _, tx := range b.Transactions() {
+			if rawdb.ReadTxLookupEntry(db, tx.Hash()) == nil {
+				t.Fatalf("missing tx-lookup entry pre-rewind for block %d tx %s",
+					b.NumberU64(), tx.Hash().Hex())
+			}
+		}
+	}
+
+	// Rewind past blocks 6..10. delFn must drop the tx-lookup entries for
+	// every transaction those blocks contained.
+	const rewindTo = uint64(5)
+	if err := chain.SetHead(rewindTo); err != nil {
+		t.Fatalf("SetHead(%d): %v", rewindTo, err)
+	}
+
+	// Lookups for kept blocks (1..rewindTo) must still resolve.
+	for _, b := range blocks[:rewindTo] {
+		for _, tx := range b.Transactions() {
+			if rawdb.ReadTxLookupEntry(db, tx.Hash()) == nil {
+				t.Fatalf("kept-block tx-lookup entry missing at height %d tx %s",
+					b.NumberU64(), tx.Hash().Hex())
+			}
+		}
+	}
+	// Lookups for rewound blocks (rewindTo+1..) must be gone.
+	for _, b := range blocks[rewindTo:] {
+		for _, tx := range b.Transactions() {
+			if lookup := rawdb.ReadTxLookupEntry(db, tx.Hash()); lookup != nil {
+				t.Fatalf("stale tx-lookup entry survived rewind at height %d tx %s (lookup→block %d)",
+					b.NumberU64(), tx.Hash().Hex(), *lookup)
+			}
+		}
+	}
+}


### PR DESCRIPTION
Closes #33744.

### Problem

`SetHead` rewinds the chain past a block by calling `delFn` for each removed height. The kv-store branch removes the block body and receipts, but the tx-lookup entries that point each transaction hash back to the now-removed block are left in place. The function even carried the long-standing TODO acknowledging the gap:

```go
} else {
    rawdb.DeleteBody(db, hash, num)
    rawdb.DeleteReceipts(db, hash, num)
}
// Todo(rjl493456442) txlookup, log index, etc
```

After the rewind, `eth_getTransactionByHash` (and any other path that calls `rawdb.ReadTxLookupEntry`) resolves the transaction hash to a ghost block position that no longer has a header / body / receipts behind it. This is exactly the inconsistency the issue describes.

### Fix

`delFn` now reads the body first, then deletes every per-transaction tx-lookup entry via `rawdb.DeleteTxLookupEntries`, into the same batch it already uses for the body / receipts deletions:

- `rawdb.ReadBody(bc.db, hash, num)` transparently handles both kv-store and ancient-store sources, so the lookup cleanup works regardless of which branch removes the body itself.
- Tx-lookup entries live in the key-value store only — they never migrate to the ancient store — so the same delete applies in both the frozen and unfrozen branches.
- Skipped when the body cannot be read (e.g. body already gone from a prior partial rewind), since there are no hashes to clean up.

### Regression test

New file `core/blockchain_setheadtxlookup_test.go`:

- Build a 10-block chain with one signed tx per block.
- Assert every block's `ReadTxLookupEntry` is non-nil pre-rewind.
- `chain.SetHead(5)` rewinds past blocks 6..10.
- Assert lookups for kept blocks (1..5) still resolve.
- Assert lookups for rewound blocks (6..10) are gone — message includes the stale block-number `lookup` value so the failure mode is debuggable.

### Local

- `go test ./core/ -run "TestSetHeadCleansTxLookupEntries|TestTxIndexer|TestBlockchain|TestSetHead"` — green.
- `go vet ./core/` — clean.
- `gofmt -l core/blockchain.go core/blockchain_setheadtxlookup_test.go` — clean.
