### PR TITLE
core/txpool/blobpool: fix garbled error for oversized sidecar version

### DIFF
--- a/core/txpool/blobpool/blobpool.go
+++ b/core/txpool/blobpool/blobpool.go
@@ -238,8 +238,11 @@ func encodeForNetwork(storedRLP []byte) ([]byte, error) {
 
 	// 2. Find the version of sidecar.
 	version, _, err := rlp.SplitUint64(elems[1])
-	if err != nil || version > 255 {
+	if err != nil {
 		return nil, fmt.Errorf("invalid version: %w", err)
+	}
+	if version > 255 {
+		return nil, fmt.Errorf("version %d exceeds byte range", version)
 	}
 	versionByte := byte(version)
 	// 3. Extract sidecar elements.


### PR DESCRIPTION
When the stored RLP version field decodes successfully but exceeds 255, the existing branch wraps a nil err with %w, producing the literal string "invalid version: %!w(<nil>)". Split the conditions so each failure mode returns its own descriptive error.