### PR TITLE
rpc: assign distinct error code to marshal failures (#35039)

### DIFF
--- a/rpc/errors.go
+++ b/rpc/errors.go
@@ -61,8 +61,8 @@ const (
 	errcodeDefault          = -32000
 	errcodeTimeout          = -32002
 	errcodeResponseTooLarge = -32003
+	errcodeMarshalError     = -32004
 	errcodePanic            = -32603
-	errcodeMarshalError     = -32603
 
 	legacyErrcodeNotificationsUnsupported = -32001
 )

--- a/rpc/testdata/internal-error.js
+++ b/rpc/testdata/internal-error.js
@@ -1,7 +1,7 @@
 // These tests trigger various 'internal error' conditions.
 
 --> {"jsonrpc":"2.0","id":1,"method":"test_marshalError","params": []}
-<-- {"jsonrpc":"2.0","id":1,"error":{"code":-32603,"message":"json: error calling MarshalText for type *rpc.MarshalErrObj: marshal error"}}
+<-- {"jsonrpc":"2.0","id":1,"error":{"code":-32004,"message":"json: error calling MarshalText for type *rpc.MarshalErrObj: marshal error"}}
 
 --> {"jsonrpc":"2.0","id":2,"method":"test_panic","params": []}
 <-- {"jsonrpc":"2.0","id":2,"error":{"code":-32603,"message":"method handler crashed"}}


### PR DESCRIPTION
Closes #35039.

`errcodeMarshalError` shared `-32603` with `errcodePanic` in `rpc/errors.go`. Both qualify as JSON-RPC "internal error" by spec, but a client receiving `-32603` cannot tell whether the method panicked or the server failed to encode the response — two conditions with different operational responses (retry vs. report and abandon).

Move marshal failures into the implementation-defined server-error range (`-32004`, the next free slot after `errcodeResponseTooLarge = -32003`). Panic stays at `-32603` because that is the spec's catch-all internal error.

Touched files:

- `rpc/errors.go` — change `errcodeMarshalError` from `-32603` to `-32004`, and reorder so the `-3260x` range is contiguous.
- `rpc/testdata/internal-error.js` — update the `test_marshalError` fixture to expect `-32004`. `test_panic` keeps `-32603`.

`go test ./rpc/` is clean.