### PR TITLE
triedb/pathdb: fix swapped want/got args in journal-root mismatch error

### DIFF
--- a/triedb/pathdb/journal.go
+++ b/triedb/pathdb/journal.go
@@ -92,7 +92,7 @@ func (db *Database) loadJournal(diskRoot common.Hash) (layer, error) {
 	// The journal is not matched with persistent state, discard them.
 	// It can happen that geth crashes without persisting the journal.
 	if !bytes.Equal(root.Bytes(), diskRoot.Bytes()) {
-		return nil, fmt.Errorf("%w want %x got %x", errUnmatchedJournal, root, diskRoot)
+		return nil, fmt.Errorf("%w want %x got %x", errUnmatchedJournal, diskRoot, root)
 	}
 	// Load the disk layer from the journal
 	base, err := db.loadDiskLayer(r)


### PR DESCRIPTION
`loadJournal(diskRoot)` decodes a root out of the journal stream into `root`, then checks it against the persistent on-disk root the caller passed in.

```go
if !bytes.Equal(root.Bytes(), diskRoot.Bytes()) {
    return nil, fmt.Errorf("%w want %x got %x", errUnmatchedJournal, root, diskRoot)
}
```

The arguments are swapped. The function's contract is "the journal must declare `diskRoot`", so the operator reading the log expects:

- `want` = `diskRoot` (what the disk insists on)
- `got` = `root` (what the journal actually contains)

Today the message reports the opposite, which sends anyone investigating a journal/disk-state mismatch down the wrong root for several minutes.

Swap the args so the message lines up with the call site contract. Fixture inversion only, no behavioural change.

`go build ./triedb/pathdb/` and `go test ./triedb/pathdb/` are clean.