### PR TITLE
eth/filters: reject GetLogs range with begin > 0 and end == 0

### DIFF
--- a/eth/filters/api.go
+++ b/eth/filters/api.go
@@ -478,7 +478,7 @@ func (api *FilterAPI) GetLogs(ctx context.Context, crit FilterCriteria) ([]*type
 			end = crit.ToBlock.Int64()
 		}
 		// Block numbers below 0 are special cases.
-		if begin > 0 && end > 0 && begin > end {
+		if begin >= 0 && end >= 0 && begin > end {
 			return nil, errInvalidBlockRange
 		}
 		if begin >= 0 && begin < int64(api.events.backend.HistoryPruningCutoff()) {


### PR DESCRIPTION
The `begin > 0 && end > 0` guard skips validation when toBlock == 0 (genesis); switch both bounds to `>= 0` so the API rejects ranges like fromBlock=5, toBlock=0 directly instead of relying on the deeper rangeLogs check.