### PR TITLE
log: share mutex in log handles with same writer and other fields

### DIFF
--- a/log/handler.go
+++ b/log/handler.go
@@ -37,7 +37,7 @@ func (h *discardHandler) WithAttrs(attrs []slog.Attr) slog.Handler {
 }
 
 type TerminalHandler struct {
-	mu       sync.Mutex
+	mu       *sync.Mutex
 	wr       io.Writer
 	lvl      slog.Level
 	useColor bool
@@ -66,6 +66,7 @@ func NewTerminalHandler(wr io.Writer, useColor bool) *TerminalHandler {
 // records which are less than or equal to the specified verbosity level.
 func NewTerminalHandlerWithLevel(wr io.Writer, lvl slog.Level, useColor bool) *TerminalHandler {
 	return &TerminalHandler{
+		mu:           &sync.Mutex{},
 		wr:           wr,
 		lvl:          lvl,
 		useColor:     useColor,
@@ -92,6 +93,7 @@ func (h *TerminalHandler) WithGroup(name string) slog.Handler {
 
 func (h *TerminalHandler) WithAttrs(attrs []slog.Attr) slog.Handler {
 	return &TerminalHandler{
+		mu:           h.mu,
 		wr:           h.wr,
 		lvl:          h.lvl,
 		useColor:     h.useColor,


### PR DESCRIPTION
In old code, mu is struct not pointer, it caused create new mutex event with same writer.
change to use pointer to sync.Mutex, so that the mutex is shared between handler with same writer.