### PR TITLE
ethstats: ethstats pong reply mangles any ping substring in the nonce

### DIFF
--- a/ethstats/ethstats.go
+++ b/ethstats/ethstats.go
@@ -388,7 +388,7 @@ func (s *Service) readLoop(conn *connWrapper) {
 		// If the network packet is a system ping, respond to it directly
 		var ping string
 		if err := json.Unmarshal(blob, &ping); err == nil && strings.HasPrefix(ping, "primus::ping::") {
-			if err := conn.WriteJSON(strings.ReplaceAll(ping, "ping", "pong")); err != nil {
+			if err := conn.WriteJSON(strings.Replace(ping, "primus::ping::", "primus::pong::", 1)); err != nil {
 				log.Warn("Failed to respond to system ping message", "err", err)
 				return
 			}


### PR DESCRIPTION
if a ping payload's nonce contain ping, the pong is malformed