### PR TITLE
p2p/nat: server list contains IPv6 servers

### DIFF
--- a/p2p/nat/nat_test.go
+++ b/p2p/nat/nat_test.go
@@ -73,6 +73,7 @@ func TestParseStun(t *testing.T) {
 	}{
 		{"stun", &stun{serverList: strings.Split(stunDefaultServers, "\n")}},
 		{"stun:1.2.3.4:1234", &stun{serverList: []string{"1.2.3.4:1234"}}},
+		{"stun:[2001:db8::1]:3478", &stun{serverList: []string{"[2001:db8::1]:3478"}}},
 	}
 
 	for _, tc := range testcases {

--- a/p2p/nat/stun.go
+++ b/p2p/nat/stun.go
@@ -45,7 +45,7 @@ func newSTUN(serverAddr string) (Interface, error) {
 	if serverAddr == "" {
 		s.serverList = strings.Split(stunDefaultServers, "\n")
 	} else {
-		_, err := net.ResolveUDPAddr("udp4", serverAddr)
+		_, err := net.ResolveUDPAddr("udp", serverAddr)
 		if err != nil {
 			return nil, err
 		}
@@ -111,7 +111,7 @@ func (s *stun) externalIP(server string) (net.IP, error) {
 	}
 
 	log.Trace("Attempting STUN binding request", "server", server)
-	conn, err := stunV3.Dial("udp4", server)
+	conn, err := stunV3.Dial("udp", server)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
stun-list.txt includes 10 bracketd IPv6 server, but the dial network is fixed to "udp4"