### PR TITLE
account/abi: name idx should start with 1

### DIFF
--- a/accounts/abi/utils.go
+++ b/accounts/abi/utils.go
@@ -32,7 +32,7 @@ import "fmt"
 func ResolveNameConflict(rawName string, used func(string) bool) string {
 	name := rawName
 	ok := used(name)
-	for idx := 0; ok; idx++ {
+	for idx := 1; ok; idx++ {
 		name = fmt.Sprintf("%s%d", rawName, idx)
 		ok = used(name)
 	}


### PR DESCRIPTION
as desc in doc, if abi contains Methods "send" and "send1", ResolveNameConflict should return send1.
but currrent codebase return send0. So change to start with idx=1