### PR TITLE
internal/ethapi: fix SetCode transaction argument handling

### DIFF
--- a/internal/ethapi/transaction_args.go
+++ b/internal/ethapi/transaction_args.go
@@ -138,6 +138,9 @@ func (args *TransactionArgs) setDefaults(ctx context.Context, b Backend, config 
 		if len(args.data()) == 0 {
 			return errors.New(`contract creation without any data provided`)
 		}
+		if len(args.AuthorizationList) > 0 {
+			return errors.New(`authorizationList provided for contract creation, but "to" field is missing`)
+		}
 	}
 
 	if args.Gas == nil {

--- a/internal/ethapi/transaction_args.go
+++ b/internal/ethapi/transaction_args.go
@@ -526,7 +526,7 @@ func (args *TransactionArgs) ToTransaction(defaultType int) *types.Transaction {
 		if args.AccessList != nil {
 			al = *args.AccessList
 		}
-		authList := []types.SetCodeAuthorization{}
+		var authList []types.SetCodeAuthorization
 		if args.AuthorizationList != nil {
 			authList = args.AuthorizationList
 		}


### PR DESCRIPTION
## Summary
- Reject `authorizationList` when building a contract-creation transaction without a `to` field.
- Use a nil authorization slice in `ToTransaction` when no `authorizationList` was provided, instead of an empty slice.

## Test plan
- [ ] `go test ./internal/ethapi/... -short`
- [ ] Manual RPC check: SetCode tx with and without `authorizationList` encodes as expected