### PR TITLE
core/txpool/locals: fix data race

### DIFF
--- a/core/txpool/locals/tx_tracker.go
+++ b/core/txpool/locals/tx_tracker.go
@@ -173,6 +173,17 @@ func (tracker *TxTracker) recheck(journalCheck bool) []*types.Transaction {
 // Start is called after all services have been constructed and the networking
 // layer was also initialized to spawn any goroutines required by the service.
 func (tracker *TxTracker) Start() error {
+	if tracker.journal != nil {
+		tracker.journal.load(func(transactions []*types.Transaction) []error {
+			tracker.TrackAll(transactions)
+			return nil
+		})
+		// Setup the writer for the upcoming transactions
+		if err := tracker.journal.setupWriter(); err != nil {
+			log.Error("Failed to setup the journal writer", "err", err)
+			return err
+		}
+	}
 	tracker.wg.Add(1)
 	go tracker.loop()
 	return nil
@@ -184,25 +195,19 @@ func (tracker *TxTracker) Start() error {
 func (tracker *TxTracker) Stop() error {
 	close(tracker.shutdownCh)
 	tracker.wg.Wait()
-	return nil
+
+	tracker.mu.Lock()
+	var err error
+	if tracker.journal != nil {
+		err = tracker.journal.close()
+	}
+	tracker.mu.Unlock()
+	return err
 }
 
 func (tracker *TxTracker) loop() {
 	defer tracker.wg.Done()
 
-	if tracker.journal != nil {
-		tracker.journal.load(func(transactions []*types.Transaction) []error {
-			tracker.TrackAll(transactions)
-			return nil
-		})
-
-		// Setup the writer for the upcoming transactions
-		if err := tracker.journal.setupWriter(); err != nil {
-			log.Error("Failed to setup the journal writer", "err", err)
-			return
-		}
-		defer tracker.journal.close()
-	}
 	var (
 		lastJournal = time.Now()
 		timer       = time.NewTimer(10 * time.Second) // Do initial check after 10 seconds, do rechecks more seldom.


### PR DESCRIPTION
Supersedes #35060

```
go test -race ./core/txpool/locals/
ok      github.com/ethereum/go-ethereum/core/txpool/locals      1.782s
```