### PR TITLE
Add QuarkChain history compatible config

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,6 +4,7 @@
 
 - **Keep changes minimal and focused.** Only modify code directly related to the task at hand. Do not refactor unrelated code, rename existing variables or functions for style, or bundle unrelated fixes into the same commit or PR.
 - **Do not add, remove, or update dependencies** unless the task explicitly requires it.
+- **Use the QuarkChain copyright header for new code files.** When adding a new code file, put `// Copyright 2026-2027, QuarkChain.` on the first line instead of copying go-ethereum's copyright header.
 
 ## Pre-Commit Checklist
 

--- a/core/evm.go
+++ b/core/evm.go
@@ -60,7 +60,7 @@ func NewEVMBlockContext(header *types.Header, chain ChainContext, author *common
 	if header.ExcessBlobGas != nil {
 		blobBaseFee = eip4844.CalcBlobFee(chain.Config(), header)
 	}
-	if header.Difficulty.Sign() == 0 {
+	if header.Difficulty.Sign() == 0 && (chain == nil || chain.Config().IsPostMerge(header.Number.Uint64(), header.Time)) {
 		random = &header.MixDigest
 	}
 	if header.SlotNumber != nil {

--- a/core/evm_test.go
+++ b/core/evm_test.go
@@ -1,18 +1,4 @@
-// Copyright 2026 The go-ethereum Authors
-// This file is part of the go-ethereum library.
-//
-// The go-ethereum library is free software: you can redistribute it and/or modify
-// it under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// The go-ethereum library is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+// Copyright 2026-2027, QuarkChain.
 
 package core
 

--- a/core/evm_test.go
+++ b/core/evm_test.go
@@ -1,0 +1,56 @@
+// Copyright 2026 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+
+package core
+
+import (
+	"math/big"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/consensus"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/params"
+	"github.com/stretchr/testify/require"
+)
+
+type evmBlockContextChain struct {
+	config *params.ChainConfig
+}
+
+func (c evmBlockContextChain) Config() *params.ChainConfig                 { return c.config }
+func (c evmBlockContextChain) CurrentHeader() *types.Header                { return nil }
+func (c evmBlockContextChain) GetHeader(common.Hash, uint64) *types.Header { return nil }
+func (c evmBlockContextChain) GetHeaderByNumber(uint64) *types.Header      { return nil }
+func (c evmBlockContextChain) GetHeaderByHash(common.Hash) *types.Header   { return nil }
+func (c evmBlockContextChain) Engine() consensus.Engine                    { return nil }
+
+func TestNewEVMBlockContextRandomRequiresPostMerge(t *testing.T) {
+	author := common.HexToAddress("0x1")
+	random := common.HexToHash("0x1234")
+	header := &types.Header{
+		Number:     big.NewInt(1),
+		Difficulty: big.NewInt(0),
+		MixDigest:  random,
+	}
+
+	legacy := NewEVMBlockContext(header, evmBlockContextChain{config: params.QuarkChainHistoryChainConfig}, &author)
+	require.Nil(t, legacy.Random)
+
+	merged := NewEVMBlockContext(header, evmBlockContextChain{config: params.MergedTestChainConfig}, &author)
+	require.NotNil(t, merged.Random)
+	require.Equal(t, random, *merged.Random)
+}

--- a/core/vm/evm.go
+++ b/core/vm/evm.go
@@ -148,6 +148,8 @@ func NewEVM(blockCtx BlockContext, statedb StateDB, chainConfig *params.ChainCon
 	evm.precompiles = activePrecompiledContracts(evm.chainRules)
 
 	switch {
+	case evm.chainRules.IsQuarkChainHistory:
+		evm.table = &quarkChainHistoryInstructionSet
 	case evm.chainRules.IsAmsterdam:
 		evm.table = &amsterdamInstructionSet
 	case evm.chainRules.IsOsaka:

--- a/core/vm/gas_table.go
+++ b/core/vm/gas_table.go
@@ -167,6 +167,25 @@ func gasSStore(evm *EVM, contract *Contract, stack *Stack, mem *Memory, memorySi
 	return GasCosts{RegularGas: params.NetSstoreDirtyGas}, nil
 }
 
+func gasSStoreQuarkChainHistory(evm *EVM, contract *Contract, stack *Stack, mem *Memory, memorySize uint64) (GasCosts, error) {
+	if evm.readOnly {
+		return GasCosts{}, ErrWriteProtection
+	}
+	var (
+		y, x    = stack.back(1), stack.back(0)
+		current = evm.StateDB.GetState(contract.Address(), x.Bytes32())
+	)
+	switch {
+	case current == (common.Hash{}) && y.Sign() != 0:
+		return GasCosts{RegularGas: params.SstoreSetGas}, nil
+	case current != (common.Hash{}) && y.Sign() == 0:
+		evm.StateDB.AddRefund(params.SstoreRefundGas)
+		return GasCosts{RegularGas: params.SstoreClearGas}, nil
+	default:
+		return GasCosts{RegularGas: params.SstoreResetGas}, nil
+	}
+}
+
 // Here come the EIP2200 rules:
 //
 //	(0.) If *gasleft* is less than or equal to 2300, fail the current call.

--- a/core/vm/gas_table_test.go
+++ b/core/vm/gas_table_test.go
@@ -31,6 +31,7 @@ import (
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/params"
 	"github.com/holiman/uint256"
+	"github.com/stretchr/testify/require"
 )
 
 func TestMemoryGasCost(t *testing.T) {
@@ -109,6 +110,30 @@ func TestEIP2200(t *testing.T) {
 			t.Errorf("test %d: gas refund mismatch: have %v, want %v", i, refund, tt.refund)
 		}
 	}
+}
+
+func TestQuarkChainHistorySStoreGas(t *testing.T) {
+	address := common.BytesToAddress([]byte("contract"))
+
+	statedb, _ := state.New(types.EmptyRootHash, state.NewDatabaseForTesting())
+	statedb.CreateAccount(address)
+	statedb.SetCode(address, hexutil.MustDecode("0x60016000556000600055"), tracing.CodeChangeUnspecified)
+	statedb.Finalise(true)
+
+	vmctx := BlockContext{
+		CanTransfer: func(StateDB, common.Address, *uint256.Int) bool { return true },
+		Transfer:    func(StateDB, common.Address, common.Address, *uint256.Int, *params.Rules) {},
+		BlockNumber: big.NewInt(0),
+		Difficulty:  big.NewInt(1),
+	}
+	evm := NewEVM(vmctx, statedb, params.QuarkChainHistoryChainConfig, Config{})
+	defer evm.Release()
+
+	initialGas := NewGasBudget(math.MaxUint64)
+	_, leftOver, err := evm.Call(common.Address{}, address, nil, initialGas.Copy(), new(uint256.Int))
+	require.NoError(t, err)
+	require.Equal(t, uint64(25012), leftOver.Used(initialGas))
+	require.Equal(t, uint64(15000), evm.StateDB.GetRefund())
 }
 
 var createGasTests = []struct {

--- a/core/vm/jump_table.go
+++ b/core/vm/jump_table.go
@@ -48,22 +48,23 @@ type operation struct {
 }
 
 var (
-	frontierInstructionSet         = newFrontierInstructionSet()
-	homesteadInstructionSet        = newHomesteadInstructionSet()
-	tangerineWhistleInstructionSet = newTangerineWhistleInstructionSet()
-	spuriousDragonInstructionSet   = newSpuriousDragonInstructionSet()
-	byzantiumInstructionSet        = newByzantiumInstructionSet()
-	constantinopleInstructionSet   = newConstantinopleInstructionSet()
-	istanbulInstructionSet         = newIstanbulInstructionSet()
-	berlinInstructionSet           = newBerlinInstructionSet()
-	londonInstructionSet           = newLondonInstructionSet()
-	mergeInstructionSet            = newMergeInstructionSet()
-	shanghaiInstructionSet         = newShanghaiInstructionSet()
-	cancunInstructionSet           = newCancunInstructionSet()
-	verkleInstructionSet           = newVerkleInstructionSet()
-	pragueInstructionSet           = newPragueInstructionSet()
-	osakaInstructionSet            = newOsakaInstructionSet()
-	amsterdamInstructionSet        = newAmsterdamInstructionSet()
+	frontierInstructionSet          = newFrontierInstructionSet()
+	homesteadInstructionSet         = newHomesteadInstructionSet()
+	tangerineWhistleInstructionSet  = newTangerineWhistleInstructionSet()
+	spuriousDragonInstructionSet    = newSpuriousDragonInstructionSet()
+	byzantiumInstructionSet         = newByzantiumInstructionSet()
+	constantinopleInstructionSet    = newConstantinopleInstructionSet()
+	quarkChainHistoryInstructionSet = newQuarkChainHistoryInstructionSet()
+	istanbulInstructionSet          = newIstanbulInstructionSet()
+	berlinInstructionSet            = newBerlinInstructionSet()
+	londonInstructionSet            = newLondonInstructionSet()
+	mergeInstructionSet             = newMergeInstructionSet()
+	shanghaiInstructionSet          = newShanghaiInstructionSet()
+	cancunInstructionSet            = newCancunInstructionSet()
+	verkleInstructionSet            = newVerkleInstructionSet()
+	pragueInstructionSet            = newPragueInstructionSet()
+	osakaInstructionSet             = newOsakaInstructionSet()
+	amsterdamInstructionSet         = newAmsterdamInstructionSet()
 )
 
 // JumpTable contains the EVM opcodes supported at a given fork.
@@ -206,6 +207,15 @@ func newConstantinopleInstructionSet() JumpTable {
 		maxStack:    maxStack(4, 1),
 		memorySize:  memoryCreate2,
 	}
+	return validate(instructionSet)
+}
+
+// newQuarkChainHistoryInstructionSet returns the old goquarkchain historical
+// EVM instruction set: Constantinople opcodes with goquarkchain's legacy SSTORE
+// gas accounting.
+func newQuarkChainHistoryInstructionSet() JumpTable {
+	instructionSet := newConstantinopleInstructionSet()
+	instructionSet[SSTORE].dynamicGas = gasSStoreQuarkChainHistory
 	return validate(instructionSet)
 }
 

--- a/core/vm/jump_table_export.go
+++ b/core/vm/jump_table_export.go
@@ -26,6 +26,8 @@ import (
 // the rules.
 func LookupInstructionSet(rules params.Rules) (JumpTable, error) {
 	switch {
+	case rules.IsQuarkChainHistory:
+		return newQuarkChainHistoryInstructionSet(), nil
 	case rules.IsUBT:
 		return newCancunInstructionSet(), errors.New("verkle-fork not defined yet")
 	case rules.IsAmsterdam:

--- a/core/vm/jump_table_test.go
+++ b/core/vm/jump_table_test.go
@@ -17,8 +17,11 @@
 package vm
 
 import (
+	"math/big"
 	"testing"
 
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/params"
 	"github.com/stretchr/testify/require"
 )
 
@@ -32,4 +35,26 @@ func TestJumpTableCopy(t *testing.T) {
 	deepCopy[SLOAD].constantGas = 100
 	require.Equal(t, uint64(100), deepCopy[SLOAD].constantGas)
 	require.Equal(t, uint64(0), tbl[SLOAD].constantGas)
+}
+
+func TestQuarkChainHistoryInstructionSet(t *testing.T) {
+	random := common.HexToHash("0xffff")
+	evm := NewEVM(BlockContext{
+		BlockNumber: big.NewInt(0),
+		Difficulty:  big.NewInt(7),
+		Random:      &random,
+	}, nil, params.QuarkChainHistoryChainConfig, Config{})
+	defer evm.Release()
+
+	require.True(t, evm.chainRules.IsQuarkChainHistory)
+	require.False(t, evm.chainRules.IsMerge)
+	require.True(t, evm.table[CHAINID].undefined)
+	require.True(t, evm.table[PUSH0].undefined)
+
+	stack := newStackForTesting()
+	pc := uint64(0)
+	_, err := evm.table[DIFFICULTY].execute(&pc, evm, &ScopeContext{Stack: stack})
+	require.NoError(t, err)
+	actual := stack.pop()
+	require.Equal(t, uint64(7), actual.Uint64())
 }

--- a/docs/quarkchain/evm-opcode-compatibility.md
+++ b/docs/quarkchain/evm-opcode-compatibility.md
@@ -1,0 +1,84 @@
+# EVM Opcode Compatibility Differences: goquarkchain vs geth 1.17.3
+
+## Background and replay risk
+
+`goquarkchain` embeds an EVM derived from an old geth line. Its module file depends on `github.com/ethereum/go-ethereum v1.8.20`, and its default EVM chain config enables the pre-Istanbul fork set up to Constantinople at block zero. In contrast, `geth 1.17.3` contains fork-specific jump tables and EIP activators through later protocol changes, including Istanbul, Berlin, London, Merge, Shanghai, Cancun, Prague, Osaka, and Amsterdam-era logic.
+
+This matters for historical replay. If historical `goquarkchain` blocks are executed under `geth 1.17.3` latest rules without a compatibility layer, the same bytecode can observe different opcode availability, different gas costs, different refunds, and different opcode semantics. Those differences can change transaction success, gasleft-dependent control flow, account/storage writes, and ultimately state roots.
+
+Primary source anchors:
+
+- `goquarkchain` default Constantinople-style config: [params/evm_params.go](https://github.com/QuarkChain/goquarkchain/blob/8534eaf6f0e64374c81a939901058d84ec285661/params/evm_params.go#L36-L44)
+- `goquarkchain` old geth dependency: [go.mod](https://github.com/QuarkChain/goquarkchain/blob/8534eaf6f0e64374c81a939901058d84ec285661/go.mod#L1-L12)
+- `goquarkchain` jump tables: [core/vm/jump_table.go](https://github.com/QuarkChain/goquarkchain/blob/8534eaf6f0e64374c81a939901058d84ec285661/core/vm/jump_table.go#L53-L90)
+- `geth 1.17.3` forked jump tables: [core/vm/jump_table.go](https://github.com/ethereum/go-ethereum/blob/v1.17.3/core/vm/jump_table.go#L96-L170)
+- `geth 1.17.3` opcode constants: [core/vm/opcodes.go](https://github.com/ethereum/go-ethereum/blob/v1.17.3/core/vm/opcodes.go#L49-L125)
+- `geth 1.17.3` EIP activators: [core/vm/eips.go](https://github.com/ethereum/go-ethereum/blob/v1.17.3/core/vm/eips.go#L73-L190), [core/vm/eips.go](https://github.com/ethereum/go-ethereum/blob/v1.17.3/core/vm/eips.go#L226-L342)
+
+## Baseline fork model comparison
+
+| Area | `goquarkchain` | `geth 1.17.3` | Replay implication |
+| --- | --- | --- | --- |
+| Default EVM fork baseline | `DefaultConstantinople` sets Homestead, EIP-150, EIP-155, EIP-158, DAO, Byzantium, and Constantinople at block zero. | Fork-specific jump tables exist from Frontier through Amsterdam-era rules. | A replay engine must not blindly select the newest geth table for old goquarkchain blocks. |
+| Jump table coverage | Frontier, Homestead, Byzantium, Constantinople. | Frontier, Homestead, Tangerine Whistle, Spurious Dragon, Byzantium, Constantinople, Istanbul, Berlin, London, Merge, Shanghai, Cancun, Verkle/UBT, Prague, Osaka, Amsterdam. | Later geth tables introduce both new opcodes and repriced existing opcodes. |
+| Merge handling | No `PREVRANDAO` alias or Merge jump table. `0x44` remains `DIFFICULTY`. | Merge table remaps `0x44` to `PREVRANDAO`/randomness when Merge rules are active. | Contracts reading `0x44` can see different values. |
+| State access model | No EIP-2929 cold/warm access-list gas model in the inspected EVM. | Berlin rules apply cold/warm accounting for SLOAD, account access, call-family opcodes, and selfdestruct. | Gasleft and out-of-gas behavior can diverge even when opcode semantics look similar. |
+
+## Opcode set differences
+
+The following opcodes are present in `geth 1.17.3` source but absent from the inspected `goquarkchain` opcode set. Some are activated by specific fork tables; others are defined in the opcode namespace and only become executable when the corresponding feature table enables them.
+
+| Opcode | Name | Introduced/associated rule in `geth 1.17.3` | `goquarkchain` behavior | Replay risk |
+| --- | --- | --- | --- | --- |
+| `0x1e` | `CLZ` | Osaka/EIP-7939 | Undefined opcode | Bytecode using it is invalid in goquarkchain but executable in geth when enabled. |
+| `0x46` | `CHAINID` | Istanbul/EIP-1344 | Undefined opcode | Environment value becomes observable in geth. |
+| `0x47` | `SELFBALANCE` | Istanbul/EIP-1884 | Undefined opcode | Contract self-balance becomes directly readable in geth. |
+| `0x48` | `BASEFEE` | London/EIP-3198 | Undefined opcode | Base fee becomes observable in geth. |
+| `0x49` | `BLOBHASH` | Cancun/EIP-4844 | Undefined opcode | Blob transaction context becomes observable in geth. |
+| `0x4a` | `BLOBBASEFEE` | Cancun/EIP-7516 | Undefined opcode | Blob base fee becomes observable in geth. |
+| `0x4b` | `SLOTNUM` | Amsterdam/EIP-7843 | Undefined opcode | Slot number becomes observable in geth. |
+| `0x5c` | `TLOAD` | Cancun/EIP-1153 | Undefined opcode | Transient storage reads become executable in geth. |
+| `0x5d` | `TSTORE` | Cancun/EIP-1153 | Undefined opcode | Transient storage writes become executable in geth. |
+| `0x5e` | `MCOPY` | Cancun/EIP-5656 | Undefined opcode | Memory copy behavior becomes executable in geth. |
+| `0x5f` | `PUSH0` | Shanghai/EIP-3855 | Undefined opcode | Common compiler output using `PUSH0` fails in goquarkchain but succeeds in geth. |
+| `0xd0`-`0xd3` | `DATALOAD`, `DATALOADN`, `DATASIZE`, `DATACOPY` | EOF-related namespace | Undefined opcode | Must remain disabled for goquarkchain historical replay. |
+| `0xe0`-`0xe8` | `RJUMP`, `RJUMPI`, `RJUMPV`, `CALLF`, `RETF`, `JUMPF`, `DUPN`, `SWAPN`, `EXCHANGE` | EOF/Amsterdam-era namespace; `DUPN`, `SWAPN`, `EXCHANGE` are enabled by EIP-8024 | Undefined opcode | Control-flow and stack behavior can diverge if enabled. |
+| `0xec`, `0xee` | `EOFCREATE`, `RETURNCONTRACT` | EOF-related namespace | Undefined opcode | Contract creation semantics must not leak into historical replay. |
+| `0xf7`-`0xfb` | `RETURNDATALOAD`, `EXTCALL`, `EXTDELEGATECALL`, `EXTSTATICCALL` | New return-data/call-family namespace | Undefined opcode | Call semantics can diverge if enabled. |
+| `0xfe` | `INVALID` | Explicit constant in geth | No explicit named constant in the inspected opcode list | Usually equivalent invalid behavior, but traces/names can differ. |
+
+`0x20` is a naming difference rather than a semantic difference: `goquarkchain` names it `SHA3`; `geth 1.17.3` names it `KECCAK256`.
+
+## Same-opcode semantic differences
+
+| Opcode | `goquarkchain` behavior | `geth 1.17.3` behavior | Replay risk |
+| --- | --- | --- | --- |
+| `0x44 DIFFICULTY` / `PREVRANDAO` | Always pushes the block difficulty from `interpreter.evm.Difficulty`: [instructions.go](https://github.com/QuarkChain/goquarkchain/blob/8534eaf6f0e64374c81a939901058d84ec285661/core/vm/instructions.go#L591-L593). | Pre-Merge `opDifficulty` pushes difficulty; Merge rules replace the jump table entry with `opRandom`, which pushes `prevRandao`/randomness: [instructions.go](https://github.com/ethereum/go-ethereum/blob/v1.17.3/core/vm/instructions.go#L467-L474). | High. Any contract using `0x44` can compute different values and write different state. |
+| `SELFDESTRUCT` | Transfers balance to the beneficiary and marks the contract as suicided: [instructions.go](https://github.com/QuarkChain/goquarkchain/blob/8534eaf6f0e64374c81a939901058d84ec285661/core/vm/instructions.go#L889-L894). | Pre-Cancun `opSelfdestruct` deletes the account; Cancun/EIP-6780 `opSelfdestruct6780` deletes only newly created contracts in the same transaction and otherwise mostly transfers balance: [instructions.go](https://github.com/ethereum/go-ethereum/blob/v1.17.3/core/vm/instructions.go#L878-L930). | High. Account deletion, code/storage persistence, balance movement, and refunds can diverge. |
+| `CREATE` / `CREATE2` | Constantinople-era behavior without EIP-3860 initcode metering or size limit. | Shanghai/EIP-3860 meters initcode by word and checks maximum initcode size: [gas_table.go](https://github.com/ethereum/go-ethereum/blob/v1.17.3/core/vm/gas_table.go#L315-L350). | Medium to high. Large initcode or tight gas can succeed in one engine and fail in the other. |
+| `CALL`, `CALLCODE`, `DELEGATECALL`, `STATICCALL` | EIP-150/EIP-158-era gas model, plus QuarkChain-specific token/balance behavior in its EVM context. | Berlin/EIP-2929 adds cold/warm account access costs; Prague/EIP-7702 changes call gas handling for delegation designators: [operations_acl.go](https://github.com/ethereum/go-ethereum/blob/v1.17.3/core/vm/operations_acl.go#L159-L203), [operations_acl.go](https://github.com/ethereum/go-ethereum/blob/v1.17.3/core/vm/operations_acl.go#L267-L292). | High. Gas forwarding and gasleft-sensitive code can diverge. |
+| `SSTORE` | The inspected code forces legacy metering through `if true`, using current-state-based 20,000/5,000 gas and 15,000 refund paths: [gas_table.go](https://github.com/QuarkChain/goquarkchain/blob/8534eaf6f0e64374c81a939901058d84ec285661/core/vm/gas_table.go#L118-L141). | geth 1.17.3 contains EIP-2200, EIP-2929, and EIP-3529 variants, selected by fork rules: [gas_table.go](https://github.com/ethereum/go-ethereum/blob/v1.17.3/core/vm/gas_table.go#L185-L227), [operations_acl.go](https://github.com/ethereum/go-ethereum/blob/v1.17.3/core/vm/operations_acl.go#L208-L224). | Very high. Storage writes, refunds, and out-of-gas behavior are core state-root inputs. |
+
+## Gas metering and refund differences
+
+| Area | `goquarkchain` | `geth 1.17.3` | Compatibility note |
+| --- | --- | --- | --- |
+| `SLOAD` | Uses the older gas table selected by the old chain rules. | Istanbul reprices SLOAD, and Berlin changes it to cold/warm storage access charging: [operations_acl.go](https://github.com/ethereum/go-ethereum/blob/v1.17.3/core/vm/operations_acl.go#L96-L112). | Historical replay should use the old fixed-cost model unless the chain explicitly migrated. |
+| Account access opcodes | `BALANCE`, `EXTCODESIZE`, `EXTCODEHASH`, and `EXTCODECOPY` use old fixed-style gas table behavior. | Istanbul reprices `BALANCE`, `EXTCODEHASH`, and `SLOAD`; Berlin adds cold/warm access checks for account reads and extcode operations: [eips.go](https://github.com/ethereum/go-ethereum/blob/v1.17.3/core/vm/eips.go#L73-L90), [operations_acl.go](https://github.com/ethereum/go-ethereum/blob/v1.17.3/core/vm/operations_acl.go#L114-L157). | Cold/warm access accounting can change whether later opcodes have enough gas. |
+| Call-family gas | Old call gas model using the selected `GasTable`. | EIP-2929 charges cold account access; EIP-7702 adds delegation-related call gas handling. | Replay should not enable EIP-2929/EIP-7702 for historical goquarkchain blocks unless intentionally forked. |
+| `SSTORE` refund | Legacy clear refund is 15,000 in the inspected path. | EIP-3529 lowers clear refund behavior and changes refund cap assumptions. | Refund differences affect effective gas used and can affect block validity/accounting. |
+| `SELFDESTRUCT` refund | Adds suicide refund when the account has not suicided before: [gas_table.go](https://github.com/QuarkChain/goquarkchain/blob/8534eaf6f0e64374c81a939901058d84ec285661/core/vm/gas_table.go#L460-L483). | EIP-3529 removes selfdestruct refunds in the London table path: [operations_acl.go](https://github.com/ethereum/go-ethereum/blob/v1.17.3/core/vm/operations_acl.go#L199-L206). | Must preserve old refund behavior for old blocks. |
+| Initcode metering | No EIP-3860 metering in the inspected old EVM. | Shanghai adds initcode size checks and per-word gas: [gas_table.go](https://github.com/ethereum/go-ethereum/blob/v1.17.3/core/vm/gas_table.go#L315-L350). | Historical contract creation must not be rejected by newer initcode limits. |
+| Memory copy | No `MCOPY`. | Cancun adds `MCOPY` with memory expansion plus copy-word gas: [eips.go](https://github.com/ethereum/go-ethereum/blob/v1.17.3/core/vm/eips.go#L250-L274). | Treat `0x5e` as invalid for old blocks. |
+
+## Recommended compatibility strategy
+
+For historical `goquarkchain` replay, do not execute old blocks with the latest `geth 1.17.3` jump table. Instead, introduce an explicit compatibility ruleset that preserves the old execution surface:
+
+1. Select a `goquarkchain`/Constantinople-compatible jump table for historical blocks.
+2. Keep `0x44` mapped to block difficulty, not `PREVRANDAO`.
+3. Treat post-Constantinople opcodes such as `CHAINID`, `BASEFEE`, `PUSH0`, `TLOAD`, `TSTORE`, `MCOPY`, blob opcodes, EOF opcodes, and new call-family opcodes as invalid unless a QuarkChain-specific migration height enables them.
+4. Preserve old `SLOAD`, `SSTORE`, call-family, and `SELFDESTRUCT` gas/refund behavior for historical blocks.
+5. Add replay tests around contracts that exercise `0x44`, `SSTORE`, `SELFDESTRUCT`, `PUSH0`, `BASEFEE`, `TLOAD/TSTORE`, `MCOPY`, and cold/warm access-sensitive calls.
+
+The safest migration model is height-gated execution: old blocks use a pinned `goquarkchain` compatibility EVM, and only blocks after an explicit protocol upgrade height use newer `geth 1.17.3` semantics.

--- a/params/config.go
+++ b/params/config.go
@@ -269,6 +269,22 @@ var (
 		Clique:                  &CliqueConfig{Period: 0, Epoch: 30000},
 	}
 
+	// QuarkChainHistoryChainConfig matches goquarkchain's historical EVM baseline.
+	// It is an execution compatibility mode only; it does not implement
+	// goquarkchain's shard consensus, transaction envelope, or multi-token state.
+	QuarkChainHistoryChainConfig = &ChainConfig{
+		ChainID:             big.NewInt(1),
+		HomesteadBlock:      big.NewInt(0),
+		DAOForkBlock:        big.NewInt(0),
+		DAOForkSupport:      false,
+		EIP150Block:         big.NewInt(0),
+		EIP155Block:         big.NewInt(0),
+		EIP158Block:         big.NewInt(0),
+		ByzantiumBlock:      big.NewInt(0),
+		ConstantinopleBlock: big.NewInt(0),
+		QuarkChainHistory:   true,
+	}
+
 	// TestChainConfig contains every protocol change (EIPs) introduced
 	// and accepted by the Ethereum core developers for testing purposes.
 	TestChainConfig = &ChainConfig{
@@ -487,6 +503,11 @@ type ChainConfig struct {
 	// those cases.
 	EnableUBTAtGenesis bool `json:"enableUBTAtGenesis,omitempty"`
 
+	// QuarkChainHistory enables the goquarkchain historical EVM compatibility
+	// mode. It pins execution to goquarkchain's old Constantinople-era opcode
+	// semantics and must not be used for Ethereum mainnet-compatible chains.
+	QuarkChainHistory bool `json:"quarkChainHistory,omitempty"`
+
 	// Various consensus engines
 	Ethash             *EthashConfig       `json:"ethash,omitempty"`
 	Clique             *CliqueConfig       `json:"clique,omitempty"`
@@ -563,6 +584,9 @@ func (c *ChainConfig) String() string {
 	if c.MergeNetsplitBlock != nil {
 		result += fmt.Sprintf(", MergeNetsplitBlock: %v", c.MergeNetsplitBlock)
 	}
+	if c.QuarkChainHistory {
+		result += ", QuarkChainHistory: true"
+	}
 
 	// Add timestamp-based forks
 	if c.ShanghaiTime != nil {
@@ -613,6 +637,8 @@ func (c *ChainConfig) Description() string {
 	}
 	banner += fmt.Sprintf("Chain ID:  %v (%s)\n", c.ChainID, network)
 	switch {
+	case c.QuarkChainHistory:
+		banner += "Consensus: QuarkChain history compatibility (EVM only)\n"
 	case c.Ethash != nil:
 		banner += "Consensus: Beacon (proof-of-stake), merged from Ethash (proof-of-work)\n"
 	case c.Clique != nil:
@@ -770,6 +796,9 @@ func (c *ChainConfig) IsMuirGlacier(num *big.Int) bool {
 // - equal to or greater than the PetersburgBlock fork block,
 // - OR is nil, and Constantinople is active
 func (c *ChainConfig) IsPetersburg(num *big.Int) bool {
+	if c.QuarkChainHistory {
+		return false
+	}
 	return isBlockForked(c.PetersburgBlock, num) || c.PetersburgBlock == nil && isBlockForked(c.ConstantinopleBlock, num)
 }
 
@@ -810,6 +839,9 @@ func (c *ChainConfig) IsTerminalPoWBlock(parentTotalDiff *big.Int, totalDiff *bi
 // Here we check the MergeNetsplitBlock to allow configuring networks with a PoW or
 // PoA chain for unit testing purposes.
 func (c *ChainConfig) IsPostMerge(blockNum uint64, timestamp uint64) bool {
+	if c.QuarkChainHistory {
+		return false
+	}
 	mergedAtGenesis := c.TerminalTotalDifficulty != nil && c.TerminalTotalDifficulty.Sign() == 0
 	return mergedAtGenesis ||
 		c.MergeNetsplitBlock != nil && blockNum >= c.MergeNetsplitBlock.Uint64() ||
@@ -1381,10 +1413,22 @@ type Rules struct {
 	IsBerlin, IsLondon                                      bool
 	IsMerge, IsShanghai, IsCancun, IsPrague, IsOsaka        bool
 	IsAmsterdam, IsUBT                                      bool
+	IsQuarkChainHistory                                     bool
 }
 
 // Rules ensures c's ChainID is not nil.
 func (c *ChainConfig) Rules(num *big.Int, isMerge bool, timestamp uint64) Rules {
+	if c.QuarkChainHistory {
+		return Rules{
+			IsHomestead:         c.IsHomestead(num),
+			IsEIP150:            c.IsEIP150(num),
+			IsEIP155:            c.IsEIP155(num),
+			IsEIP158:            c.IsEIP158(num),
+			IsByzantium:         c.IsByzantium(num),
+			IsConstantinople:    c.IsConstantinople(num),
+			IsQuarkChainHistory: true,
+		}
+	}
 	// disallow setting Merge out of order
 	isMerge = isMerge && c.IsLondon(num)
 	isUBT := isMerge && c.IsUBT(num, timestamp)

--- a/params/config.go
+++ b/params/config.go
@@ -270,8 +270,6 @@ var (
 	}
 
 	// QuarkChainHistoryChainConfig matches goquarkchain's historical EVM baseline.
-	// It is an execution compatibility mode only; it does not implement
-	// goquarkchain's shard consensus, transaction envelope, or multi-token state.
 	QuarkChainHistoryChainConfig = &ChainConfig{
 		ChainID:             big.NewInt(1),
 		HomesteadBlock:      big.NewInt(0),
@@ -282,6 +280,7 @@ var (
 		EIP158Block:         big.NewInt(0),
 		ByzantiumBlock:      big.NewInt(0),
 		ConstantinopleBlock: big.NewInt(0),
+		PetersburgBlock:     big.NewInt(0),
 		QuarkChainHistory:   true,
 	}
 
@@ -796,9 +795,6 @@ func (c *ChainConfig) IsMuirGlacier(num *big.Int) bool {
 // - equal to or greater than the PetersburgBlock fork block,
 // - OR is nil, and Constantinople is active
 func (c *ChainConfig) IsPetersburg(num *big.Int) bool {
-	if c.QuarkChainHistory {
-		return false
-	}
 	return isBlockForked(c.PetersburgBlock, num) || c.PetersburgBlock == nil && isBlockForked(c.ConstantinopleBlock, num)
 }
 
@@ -1426,6 +1422,7 @@ func (c *ChainConfig) Rules(num *big.Int, isMerge bool, timestamp uint64) Rules 
 			IsEIP158:            c.IsEIP158(num),
 			IsByzantium:         c.IsByzantium(num),
 			IsConstantinople:    c.IsConstantinople(num),
+			IsPetersburg:        c.IsPetersburg(num),
 			IsQuarkChainHistory: true,
 		}
 	}

--- a/params/config_test.go
+++ b/params/config_test.go
@@ -139,6 +139,34 @@ func TestConfigRules(t *testing.T) {
 	}
 }
 
+func TestQuarkChainHistoryRules(t *testing.T) {
+	rules := QuarkChainHistoryChainConfig.Rules(big.NewInt(0), true, math.MaxUint64)
+	require.True(t, rules.IsQuarkChainHistory)
+	require.True(t, rules.IsHomestead)
+	require.True(t, rules.IsEIP150)
+	require.True(t, rules.IsEIP155)
+	require.True(t, rules.IsEIP158)
+	require.True(t, rules.IsByzantium)
+	require.True(t, rules.IsConstantinople)
+
+	require.False(t, rules.IsPetersburg)
+	require.False(t, rules.IsIstanbul)
+	require.False(t, rules.IsBerlin)
+	require.False(t, rules.IsLondon)
+	require.False(t, rules.IsMerge)
+	require.False(t, rules.IsShanghai)
+	require.False(t, rules.IsCancun)
+	require.False(t, rules.IsPrague)
+	require.False(t, rules.IsOsaka)
+	require.False(t, rules.IsAmsterdam)
+	require.False(t, rules.IsUBT)
+	require.False(t, rules.IsEIP2929)
+	require.False(t, rules.IsEIP4762)
+
+	require.False(t, QuarkChainHistoryChainConfig.IsPetersburg(big.NewInt(0)))
+	require.False(t, QuarkChainHistoryChainConfig.IsPostMerge(0, math.MaxUint64))
+}
+
 func TestTimestampCompatError(t *testing.T) {
 	require.Equal(t, new(ConfigCompatError).Error(), "")
 

--- a/params/config_test.go
+++ b/params/config_test.go
@@ -149,7 +149,7 @@ func TestQuarkChainHistoryRules(t *testing.T) {
 	require.True(t, rules.IsByzantium)
 	require.True(t, rules.IsConstantinople)
 
-	require.False(t, rules.IsPetersburg)
+	require.True(t, rules.IsPetersburg)
 	require.False(t, rules.IsIstanbul)
 	require.False(t, rules.IsBerlin)
 	require.False(t, rules.IsLondon)
@@ -163,7 +163,7 @@ func TestQuarkChainHistoryRules(t *testing.T) {
 	require.False(t, rules.IsEIP2929)
 	require.False(t, rules.IsEIP4762)
 
-	require.False(t, QuarkChainHistoryChainConfig.IsPetersburg(big.NewInt(0)))
+	require.True(t, QuarkChainHistoryChainConfig.IsPetersburg(big.NewInt(0)))
 	require.False(t, QuarkChainHistoryChainConfig.IsPostMerge(0, math.MaxUint64))
 }
 


### PR DESCRIPTION
## Summary

Addressing https://github.com/QuarkChain/goshard/issues/6, this PR adds a minimal QuarkChain historical EVM compatibility mode.

This introduces `params.QuarkChainHistoryChainConfig` and a `QuarkChainHistory` config flag. In this mode, EVM rules are fixed to the goquarkchain Constantinople/Petersburg-era rule set while later forks remain disabled.

## Changes

- Add QuarkChain history chain config and rules gating.
- Prevent `difficulty == 0` from enabling `PREVRANDAO` unless the chain is actually post-merge.
- Add a QuarkChain history jump table where `0x44` remains `DIFFICULTY`.
- Keep newer opcodes such as `PUSH0` and `CHAINID` disabled in QuarkChain history mode.
- Restore goquarkchain-style legacy `SSTORE` gas/refund behavior.
- A document comparing goquarkchain against geth 1.17.3 for EVM opcode compatibility.

## Tests

Passed:

```sh
go test ./...
```
## Notes

For the reviewers' convenience, this PR only includes the EVM opcode/gas compatibility layer. It does not yet support full QuarkChain historical replay, which includes shard consensus, the QuarkChain transaction envelope, multi-token StateDB, and the 514b native-token precompile. Which would be added later, step by step.
