### PR TITLE
cmd/utils: avoid extra newlines when reading era checksums

### DIFF
--- a/cmd/utils/cmd.go
+++ b/cmd/utils/cmd.go
@@ -246,7 +246,7 @@ func readList(filename string) ([]string, error) {
 	if err != nil {
 		return nil, err
 	}
-	return strings.Split(string(b), "\n"), nil
+	return strings.Split(strings.TrimRight(string(b), "\n"), "\n"), nil
 }
 
 // ImportHistory imports Era1 files containing historical block information,

--- a/cmd/utils/cmd.go
+++ b/cmd/utils/cmd.go
@@ -242,11 +242,21 @@ func ImportChain(chain *core.BlockChain, fn string) error {
 }
 
 func readList(filename string) ([]string, error) {
-	b, err := os.ReadFile(filename)
+	f, err := os.Open(filename)
 	if err != nil {
 		return nil, err
 	}
-	return strings.Split(strings.TrimRight(string(b), "\n"), "\n"), nil
+	defer f.Close()
+
+	var lines []string
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		lines = append(lines, scanner.Text())
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, err
+	}
+	return lines, nil
 }
 
 // ImportHistory imports Era1 files containing historical block information,

--- a/cmd/utils/history_test.go
+++ b/cmd/utils/history_test.go
@@ -106,10 +106,14 @@ func TestHistoryImportAndExport(t *testing.T) {
 			}
 
 			// Read checksums.
-			b, err := os.ReadFile(filepath.Join(dir, "checksums.txt"))
+			checksumsFile := filepath.Join(dir, "checksums.txt")
+			b, err := os.ReadFile(checksumsFile)
 			if err != nil {
 				t.Fatalf("failed to read checksums: %v", err)
 			}
+
+			// Add a trailing newline to ensure checksum handling is defensive.
+			_ = os.WriteFile(checksumsFile, append(b, '\n'), 0644)
 			checksums := strings.Split(string(b), "\n")
 
 			// Verify each Era.


### PR DESCRIPTION
The checksum count during EraE import is off by one when `checksums.txt` ends its last line on a newline, as the pandaops file does. The current code would result in one empty string after the final `\n`, something like

```
[]string{
    "line1",
    "line2",
    "line3",
    "",
}
```

Trim off the final `\n`, if it exists: `return strings.Split(strings.TrimRight(string(b), "\n"), "\n"), nil`