### PR TITLE
internal/ethapi: return standardized error codes for transaction submission

### DIFF
--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -1645,7 +1645,7 @@ func SubmitTransaction(ctx context.Context, b Backend, tx *types.Transaction) (c
 		return common.Hash{}, errors.New("only replay-protected (EIP-155) transactions allowed over RPC")
 	}
 	if err := b.SendTx(ctx, tx); err != nil {
-		return common.Hash{}, err
+		return common.Hash{}, txSubmitError(err)
 	}
 	// Print a log with full tx details for manual investigations and interventions
 	head := b.CurrentBlock()

--- a/internal/ethapi/errors.go
+++ b/internal/ethapi/errors.go
@@ -24,6 +24,7 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/core"
+	"github.com/ethereum/go-ethereum/core/txpool"
 	"github.com/ethereum/go-ethereum/core/vm"
 )
 
@@ -149,6 +150,81 @@ func txValidationError(err error) *invalidTxError {
 		Message: err.Error(),
 		Code:    errCodeInternalError,
 	}
+}
+
+// Standardized JSON-RPC error codes for transaction submission, shared across
+// EVM clients via the execution-apis error-code catalog (src/error-groups):
+// ExecutionErrors (1-199), GasErrors (800-999) and TxPoolErrors (1000-1199).
+// See https://github.com/ethereum/execution-apis/tree/master/src/error-groups.
+const (
+	errCodeStdNonceTooLow          = 1
+	errCodeStdNonceTooHigh         = 2
+	errCodeStdIntrinsicGas         = 800
+	errCodeStdGasPriceTooLow       = 802
+	errCodeStdGasExceedsBlockLimit = 803
+	errCodeStdTipAboveFeeCap       = 804
+	errCodeStdGasUintOverflow      = 805
+	errCodeStdFeeCapTooLow         = 806
+	errCodeStdTipVeryHigh          = 807
+	errCodeStdFeeCapVeryHigh       = 808
+	errCodeStdInsufficientFunds    = 809
+	errCodeStdAlreadyKnown         = 1000
+	errCodeStdInvalidSender        = 1001
+	errCodeStdReplaceUnderpriced   = 1002
+)
+
+// txSubmitError maps an error returned while submitting a transaction to the
+// pool (eth_sendTransaction / eth_sendRawTransaction) to its standardized
+// execution-apis JSON-RPC error code, preserving the original error message.
+// Errors without a catalog code are returned unchanged, so they keep geth's
+// default behavior (the generic -32000 code).
+func txSubmitError(err error) error {
+	if err == nil {
+		return nil
+	}
+	if code, ok := txSubmitErrorCode(err); ok {
+		return &invalidTxError{Message: err.Error(), Code: code}
+	}
+	return err
+}
+
+// txSubmitErrorCode returns the standardized error code for a transaction
+// submission error, and whether a code is defined for it.
+func txSubmitErrorCode(err error) (int, bool) {
+	switch {
+	// TxPoolErrors (1000-1199)
+	case errors.Is(err, txpool.ErrAlreadyKnown):
+		return errCodeStdAlreadyKnown, true
+	case errors.Is(err, txpool.ErrInvalidSender):
+		return errCodeStdInvalidSender, true
+	case errors.Is(err, txpool.ErrReplaceUnderpriced):
+		return errCodeStdReplaceUnderpriced, true
+	// GasErrors (800-999)
+	case errors.Is(err, core.ErrIntrinsicGas):
+		return errCodeStdIntrinsicGas, true
+	case errors.Is(err, txpool.ErrTxGasPriceTooLow):
+		return errCodeStdGasPriceTooLow, true
+	case errors.Is(err, txpool.ErrGasLimit):
+		return errCodeStdGasExceedsBlockLimit, true
+	case errors.Is(err, core.ErrTipAboveFeeCap):
+		return errCodeStdTipAboveFeeCap, true
+	case errors.Is(err, core.ErrGasUintOverflow):
+		return errCodeStdGasUintOverflow, true
+	case errors.Is(err, core.ErrFeeCapTooLow):
+		return errCodeStdFeeCapTooLow, true
+	case errors.Is(err, core.ErrTipVeryHigh):
+		return errCodeStdTipVeryHigh, true
+	case errors.Is(err, core.ErrFeeCapVeryHigh):
+		return errCodeStdFeeCapVeryHigh, true
+	case errors.Is(err, core.ErrInsufficientFunds), errors.Is(err, core.ErrInsufficientFundsForTransfer):
+		return errCodeStdInsufficientFunds, true
+	// ExecutionErrors (1-199)
+	case errors.Is(err, core.ErrNonceTooLow):
+		return errCodeStdNonceTooLow, true
+	case errors.Is(err, core.ErrNonceTooHigh):
+		return errCodeStdNonceTooHigh, true
+	}
+	return 0, false
 }
 
 type invalidParamsError struct{ message string }

--- a/internal/ethapi/errors_test.go
+++ b/internal/ethapi/errors_test.go
@@ -1,0 +1,94 @@
+// Copyright 2026 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+
+package ethapi
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/core"
+	"github.com/ethereum/go-ethereum/core/txpool"
+)
+
+// rpcErrorCoder mirrors the rpc package's interface for errors that carry a
+// JSON-RPC error code.
+type rpcErrorCoder interface {
+	error
+	ErrorCode() int
+}
+
+// TestTxSubmitError verifies that transaction-submission errors are mapped to
+// the standardized execution-apis JSON-RPC error codes while preserving the
+// original error message, and that unmapped errors are returned unchanged.
+func TestTxSubmitError(t *testing.T) {
+	for _, tt := range []struct {
+		name string
+		err  error
+		code int
+	}{
+		{"nonce too low", core.ErrNonceTooLow, errCodeStdNonceTooLow},
+		{"nonce too high", core.ErrNonceTooHigh, errCodeStdNonceTooHigh},
+		{"intrinsic gas", core.ErrIntrinsicGas, errCodeStdIntrinsicGas},
+		{"gas price too low", txpool.ErrTxGasPriceTooLow, errCodeStdGasPriceTooLow},
+		{"exceeds block gas limit", txpool.ErrGasLimit, errCodeStdGasExceedsBlockLimit},
+		{"tip above fee cap", core.ErrTipAboveFeeCap, errCodeStdTipAboveFeeCap},
+		{"gas uint overflow", core.ErrGasUintOverflow, errCodeStdGasUintOverflow},
+		{"fee cap too low", core.ErrFeeCapTooLow, errCodeStdFeeCapTooLow},
+		{"tip very high", core.ErrTipVeryHigh, errCodeStdTipVeryHigh},
+		{"fee cap very high", core.ErrFeeCapVeryHigh, errCodeStdFeeCapVeryHigh},
+		{"insufficient funds", core.ErrInsufficientFunds, errCodeStdInsufficientFunds},
+		{"insufficient funds for transfer", core.ErrInsufficientFundsForTransfer, errCodeStdInsufficientFunds},
+		{"already known", txpool.ErrAlreadyKnown, errCodeStdAlreadyKnown},
+		{"invalid sender", txpool.ErrInvalidSender, errCodeStdInvalidSender},
+		{"replacement underpriced", txpool.ErrReplaceUnderpriced, errCodeStdReplaceUnderpriced},
+	} {
+		// The raw sentinel error and a wrapped variant (as the pool/state
+		// actually return them, e.g. "nonce too low: next nonce 5, tx nonce 0")
+		// must both map to the same code via errors.Is.
+		for _, err := range []error{tt.err, fmt.Errorf("%w: extra context", tt.err)} {
+			got := txSubmitError(err)
+			coder, ok := got.(rpcErrorCoder)
+			if !ok {
+				t.Fatalf("%s: txSubmitError(%q) = %T, want an error with ErrorCode()", tt.name, err, got)
+			}
+			if coder.ErrorCode() != tt.code {
+				t.Errorf("%s: code = %d, want %d", tt.name, coder.ErrorCode(), tt.code)
+			}
+			if got.Error() != err.Error() {
+				t.Errorf("%s: message = %q, want it preserved as %q", tt.name, got.Error(), err.Error())
+			}
+		}
+	}
+}
+
+// TestTxSubmitErrorPassthrough verifies that errors without a catalog code are
+// returned unchanged (so they keep geth's default -32000 behavior) and that a
+// nil error stays nil.
+func TestTxSubmitErrorPassthrough(t *testing.T) {
+	if got := txSubmitError(nil); got != nil {
+		t.Fatalf("txSubmitError(nil) = %v, want nil", got)
+	}
+	unmapped := errors.New("some unrelated failure")
+	got := txSubmitError(unmapped)
+	if got != unmapped {
+		t.Fatalf("txSubmitError(unmapped) = %v, want the original error returned unchanged", got)
+	}
+	if _, ok := got.(rpcErrorCoder); ok {
+		t.Fatalf("unmapped error should not carry an ErrorCode()")
+	}
+}


### PR DESCRIPTION
### Rationale

`eth_sendTransaction` and `eth_sendRawTransaction` currently return the generic `-32000` code for submission failures, so callers must string-match the error *message* to tell a nonce error from an underpriced replacement, insufficient funds, an over-limit gas, etc.

This wires the submission path to the standardized JSON-RPC error-code catalog that EVM clients agreed on in [ethereum/execution-apis](https://github.com/ethereum/execution-apis/tree/master/src/error-groups) (introduced in ethereum/execution-apis#650): `ExecutionErrors` (1–199), `GasErrors` (800–999), and `TxPoolErrors` (1000–1199). It mirrors the existing precedent of returning `3` for execution reverts.

### Changes

- `internal/ethapi/errors.go`: add the catalog codes and a `txSubmitError` mapper that maps `core`/`txpool` sentinel errors to their catalog code via `errors.Is`, **preserving the original error message**. Errors without a catalog code are returned unchanged (they keep the existing `-32000` default), so this is not a blanket behavior change.
- `internal/ethapi/api.go`: wrap the `SendTx` error in `SubmitTransaction` (shared by both submission methods).
- `internal/ethapi/errors_test.go`: table test covering each mapped error, a wrapped variant (proving `errors.Is` works through the pool/state message wrapping), and an unmapped passthrough.

| core / txpool error | code |
|---|---|
| `ErrNonceTooLow` / `ErrNonceTooHigh` | 1 / 2 |
| `ErrIntrinsicGas` | 800 |
| `txpool.ErrTxGasPriceTooLow` | 802 |
| `txpool.ErrGasLimit` | 803 |
| `ErrTipAboveFeeCap` | 804 |
| `ErrGasUintOverflow` | 805 |
| `ErrFeeCapTooLow` | 806 |
| `ErrTipVeryHigh` / `ErrFeeCapVeryHigh` | 807 / 808 |
| `ErrInsufficientFunds` / `ErrInsufficientFundsForTransfer` | 809 |
| `txpool.ErrAlreadyKnown` | 1000 |
| `txpool.ErrInvalidSender` | 1001 |
| `txpool.ErrReplaceUnderpriced` | 1002 |

### Validation

Beyond the unit tests, this was verified against the spec-conformance fixtures in ethereum/execution-apis#784: regenerating that PR's `eth_sendRawTransaction` error fixtures with this build — and the PR's temporary error-code-rewrite shim disabled — reproduces them byte-for-byte, and `speccheck` passes. That allows execution-apis#784 to drop its shim and use go-ethereum as the conformant reference for cross-client `rpc-compat` testing.

### Out of scope

`eth_simulateV1`'s per-call validation errors (`txValidationError`, currently in the `-38xxx` range) are intentionally left unchanged. Aligning those to the catalog is a natural follow-up, tied to the `execute.yaml` error-groups wiring proposed in execution-apis#784, and is kept separate to keep this change focused.
