### PR TITLE
core/types: reject empty authorizationList in SetCodeTx

### DIFF
--- a/core/types/transaction_marshalling.go
+++ b/core/types/transaction_marshalling.go
@@ -477,6 +477,9 @@ func (tx *Transaction) UnmarshalJSON(input []byte) error {
 		if dec.AuthorizationList == nil {
 			return errors.New("missing required field 'authorizationList' in transaction")
 		}
+		if len(dec.AuthorizationList) == 0 {
+			return errors.New("'authorizationList' must contain at least one authorization")
+		}
 		itx.AuthList = dec.AuthorizationList
 
 		// signature R


### PR DESCRIPTION
UnmarshalJSON only checked AuthorizationList == nil, but EIP-7702 requires at least one authorization (state_transition.go:524 returns ErrEmptyAuthList). Reject empty lists at the JSON boundary so the error surfaces earlier.