### PR TITLE
core/types: reject empty authorizationList in setcode tx json

### DIFF
--- a/core/types/transaction_marshalling.go
+++ b/core/types/transaction_marshalling.go
@@ -477,6 +477,9 @@ func (tx *Transaction) UnmarshalJSON(input []byte) error {
 		if dec.AuthorizationList == nil {
 			return errors.New("missing required field 'authorizationList' in transaction")
 		}
+		if len(dec.AuthorizationList) == 0 {
+			return errors.New("'authorizationList' must contain at least one authorization")
+		}
 		itx.AuthList = dec.AuthorizationList
 
 		// signature R


### PR DESCRIPTION
while reading the blob tx json validation next to it I noticed UnmarshalJSON only rejects a nil authorizationList for setcode (EIP-7702) transactions, not an empty one, so a payload with "authorizationList": [] decodes into a tx whose auth list has zero length. that is invalid per EIP-7702 and the rest of the codebase already treats it as such (ErrEmptyAuthList in state_transition.go and txpool/validation.go), it just isn't caught at the json layer. this adds the len check right where the nil check is, matching the blobVersionedHashes handling a few cases above.