### PR TITLE
node: fix wrong status code in ws

### DIFF
--- a/node/rpcstack.go
+++ b/node/rpcstack.go
@@ -211,7 +211,7 @@ func (h *httpServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			ws.ServeHTTP(w, r)
 			return
 		}
-		http.Error(w, "404 not found", http.StatusNotFound)
+		http.Error(w, "not found", http.StatusNotFound)
 		return
 	}
 

--- a/node/rpcstack.go
+++ b/node/rpcstack.go
@@ -209,7 +209,9 @@ func (h *httpServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	if ws != nil && isWebsocket(r) {
 		if checkPath(r, ws.prefix) {
 			ws.ServeHTTP(w, r)
+			return
 		}
+		http.Error(w, "404 not found", http.StatusNotFound)
 		return
 	}
 


### PR DESCRIPTION
Fixes an issue where we would falsely return 400 when we should return 200 because the request was served successfully 