### PR TITLE
accounts/external, signer/core: preserve setcode authlist

### DIFF
--- a/accounts/external/backend.go
+++ b/accounts/external/backend.go
@@ -235,6 +235,9 @@ func (api *ExternalSigner) SignTx(account accounts.Account, tx *types.Transactio
 		accessList := tx.AccessList()
 		args.AccessList = &accessList
 	}
+	if tx.Type() == types.SetCodeTxType {
+		args.AuthorizationList = tx.SetCodeAuthorizations()
+	}
 	if tx.Type() == types.BlobTxType {
 		args.BlobHashes = tx.BlobHashes()
 		sidecar := tx.BlobTxSidecar()

--- a/signer/core/apitypes/types.go
+++ b/signer/core/apitypes/types.go
@@ -103,6 +103,9 @@ type SendTxArgs struct {
 	AccessList *types.AccessList `json:"accessList,omitempty"`
 	ChainID    *hexutil.Big      `json:"chainId,omitempty"`
 
+	// For SetCodeTxType
+	AuthorizationList []types.SetCodeAuthorization `json:"authorizationList,omitempty"`
+
 	// For BlobTxType
 	BlobFeeCap *hexutil.Big  `json:"maxFeePerBlobGas,omitempty"`
 	BlobHashes []common.Hash `json:"blobVersionedHashes,omitempty"`
@@ -173,6 +176,24 @@ func (args *SendTxArgs) ToTransaction() (*types.Transaction, error) {
 				version = types.BlobSidecarVersion1
 			}
 			data.(*types.BlobTx).Sidecar = types.NewBlobTxSidecar(version, args.Blobs, args.Commitments, args.Proofs)
+		}
+
+	case args.AuthorizationList != nil:
+		al := types.AccessList{}
+		if args.AccessList != nil {
+			al = *args.AccessList
+		}
+		data = &types.SetCodeTx{
+			To:         *to,
+			ChainID:    uint256.MustFromBig((*big.Int)(args.ChainID)),
+			Nonce:      uint64(args.Nonce),
+			Gas:        uint64(args.Gas),
+			GasFeeCap:  uint256.MustFromBig((*big.Int)(args.MaxFeePerGas)),
+			GasTipCap:  uint256.MustFromBig((*big.Int)(args.MaxPriorityFeePerGas)),
+			Value:      uint256.MustFromBig((*big.Int)(&args.Value)),
+			Data:       args.data(),
+			AccessList: al,
+			AuthList:   args.AuthorizationList,
 		}
 
 	case args.MaxFeePerGas != nil:

--- a/signer/core/apitypes/types_test.go
+++ b/signer/core/apitypes/types_test.go
@@ -109,6 +109,27 @@ func TestTxArgs(t *testing.T) {
 	*/
 }
 
+func TestTxArgsSetCodeTx(t *testing.T) {
+	data := []byte(`{"from":"0x1b442286e32ddcaa6e2570ce9ed85f4b4fc87425","authorizationList":[{"chainId":"0x7","address":"0x0000000000000000000000000000000000000001","nonce":"0x1","yParity":"0x0","r":"0x1","s":"0x2"}],"accessList":[],"chainId":"0x7","gas":"0x124f8","input":"0x","maxFeePerGas":"0x6fc23ac00","maxPriorityFeePerGas":"0x3b9aca00","nonce":"0x0","to":"0x1b442286e32ddcaa6e2570ce9ed85f4b4fc87425","value":"0x0"}`)
+
+	var txArgs SendTxArgs
+	if err := json.Unmarshal(data, &txArgs); err != nil {
+		t.Fatal(err)
+	}
+	tx, err := txArgs.ToTransaction()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if have := tx.Type(); have != types.SetCodeTxType {
+		t.Fatalf("have tx type %d, want %d", have, types.SetCodeTxType)
+	}
+	if have := tx.SetCodeAuthorizations(); len(have) != 1 {
+		t.Fatalf("have %d authorizations, want 1", len(have))
+	} else if have[0] != txArgs.AuthorizationList[0] {
+		t.Fatalf("authorization mismatch: have %#v, want %#v", have[0], txArgs.AuthorizationList[0])
+	}
+}
+
 func TestBlobTxs(t *testing.T) {
 	blob := kzg4844.Blob{0x1}
 	commitment, err := kzg4844.BlobToCommitment(&blob)


### PR DESCRIPTION
Fixes #35092.

This preserves EIP-7702 set-code authorization lists when transactions are passed through the external signer/Clef path.

The external signer now forwards `SetCodeTx` authorizations into `SendTxArgs`, and Clef-side transaction argument conversion recognizes `authorizationList` as a set-code transaction instead of reconstructing it as a dynamic-fee transaction.

Validation:

- `gofmt -w accounts/external/backend.go signer/core/apitypes/types.go signer/core/apitypes/types_test.go`
- `GOCACHE=/private/tmp/go-ethereum-gocache go test ./signer/core/apitypes ./accounts/external`
- `GOCACHE=/private/tmp/go-ethereum-gocache go run ./build/ci.go test -short`

Note: `goimports` was not available on PATH in this environment.