### PR TITLE
accounts/abi, core, metrics, miner, rlp, signer, triedb: fix all incorrect variable usages in error strings

### DIFF
--- a/accounts/abi/bind/v2/lib_test.go
+++ b/accounts/abi/bind/v2/lib_test.go
@@ -310,7 +310,7 @@ done:
 		t.Fatalf("expected e1Count of 2 from filter call.  got %d", e1Count)
 	}
 	if e2Count != 1 {
-		t.Fatalf("expected e2Count of 1 from filter call.  got %d", e1Count)
+		t.Fatalf("expected e2Count of 1 from filter call.  got %d", e2Count)
 	}
 }
 

--- a/core/genesis_test.go
+++ b/core/genesis_test.go
@@ -196,7 +196,7 @@ func TestGenesisHashes(t *testing.T) {
 		}
 		// Test via ToBlock
 		if have := c.genesis.ToBlock().Hash(); have != c.want {
-			t.Errorf("case: %d a), want: %s, got: %s", i, c.want.Hex(), have.Hex())
+			t.Errorf("case: %d b), want: %s, got: %s", i, c.want.Hex(), have.Hex())
 		}
 	}
 }

--- a/metrics/registry_test.go
+++ b/metrics/registry_test.go
@@ -182,7 +182,7 @@ func TestRegistryUnregister(t *testing.T) {
 	r.Unregister("bar")
 	r.Unregister("baz")
 	if len(arbiter.meters) != l {
-		t.Errorf("arbiter.meters: %d != %d\n", l+2, len(arbiter.meters))
+		t.Errorf("arbiter.meters: %d != %d\n", l, len(arbiter.meters))
 	}
 }
 

--- a/miner/ordering_test.go
+++ b/miner/ordering_test.go
@@ -119,7 +119,7 @@ func testTransactionPriceNonceSort(t *testing.T, baseFee *big.Int) {
 		for j, txj := range txs[i+1:] {
 			fromj, _ := types.Sender(signer, txj)
 			if fromi == fromj && txi.Nonce() > txj.Nonce() {
-				t.Errorf("invalid nonce ordering: tx #%d (A=%x N=%v) < tx #%d (A=%x N=%v)", i, fromi[:4], txi.Nonce(), i+j, fromj[:4], txj.Nonce())
+				t.Errorf("invalid nonce ordering: tx #%d (A=%x N=%v) < tx #%d (A=%x N=%v)", i, fromi[:4], txi.Nonce(), i+1+j, fromj[:4], txj.Nonce())
 			}
 		}
 		// If the next tx has different from account, the price must be lower than the current one

--- a/rlp/iterator_test.go
+++ b/rlp/iterator_test.go
@@ -66,7 +66,7 @@ func TestIterator(t *testing.T) {
 		i++
 	}
 	if exp := 2; i != exp {
-		t.Errorf("count wrong, expected %d got %d", i, exp)
+		t.Errorf("count wrong, expected %d got %d", exp, i)
 	}
 }
 

--- a/signer/core/apitypes/types_test.go
+++ b/signer/core/apitypes/types_test.go
@@ -216,7 +216,7 @@ func TestType_TypeName(t *testing.T) {
 		},
 	} {
 		if tc.Input.typeName() != tc.Expected {
-			t.Errorf("test %d: expected typeName value of '%v' but got '%v'", i, tc.Expected, tc.Input)
+			t.Errorf("test %d: expected typeName value of '%v' but got '%v'", i, tc.Expected, tc.Input.typeName())
 		}
 	}
 }

--- a/signer/storage/aes_gcm_storage_test.go
+++ b/signer/storage/aes_gcm_storage_test.go
@@ -48,7 +48,7 @@ func TestEncryption(t *testing.T) {
 	}
 	t.Logf("Plaintext %v\n", string(p))
 	if !bytes.Equal(plaintext, p) {
-		t.Errorf("Failed: expected plaintext recovery, got %v expected %v", string(plaintext), string(p))
+		t.Errorf("Failed: expected plaintext recovery, got %v expected %v", string(p), string(plaintext))
 	}
 }
 

--- a/triedb/pathdb/history_index_test.go
+++ b/triedb/pathdb/history_index_test.go
@@ -239,7 +239,7 @@ func testIndexDeleterBasic(t *testing.T, bitmapSize int) {
 			t.Fatalf("Unexpected error for element popping, %v", err)
 		}
 		if id.lastID != uint64(i-1) {
-			t.Fatalf("Unexpected lastID, want: %d, got: %d", uint64(i-1), iw.lastID)
+			t.Fatalf("Unexpected lastID, want: %d, got: %d", uint64(i-1), id.lastID)
 		}
 	}
 }


### PR DESCRIPTION
This PR is trying to stem further slop PRs by going over all incorrect strings and fixing them.