### PR TITLE
core/txpool, miner, eth: add cache for GetBlobs request

### DIFF
--- a/core/txpool/blobpool/blobpool.go
+++ b/core/txpool/blobpool/blobpool.go
@@ -19,7 +19,6 @@ package blobpool
 
 import (
 	"container/heap"
-	"context"
 	"errors"
 	"fmt"
 	"math"
@@ -485,7 +484,6 @@ type BlobPool struct {
 	index  map[common.Address][]*blobTxMeta // Blob transactions grouped by accounts, sorted by nonce
 	spent  map[common.Address]*uint256.Int  // Expenditure tracking for individual accounts
 	evict  *evictHeap                       // Heap of cheapest accounts for eviction when full
-	cache  *cache                           // Decoded sidecar cache for high-priority inclusion candidates
 
 	discoverFeed event.Feed // Event feed to send out new tx events on pool discovery (reorg excluded)
 	insertFeed   event.Feed // Event feed to send out new tx events on pool inclusion (reorg included)
@@ -583,7 +581,6 @@ func (p *BlobPool) Init(gasTip uint64, head *types.Header, reserver txpool.Reser
 		return err
 	}
 	p.store = store
-	p.cache = newCache(store, eip4844.LatestMaxBlobsPerBlock(p.chain.Config()))
 
 	// Migrate legacy transactions (types.Transaction) to pooledBlobTx format.
 	if len(convertTxs) > 0 {
@@ -805,7 +802,6 @@ func (p *BlobPool) recheck(addr common.Address, inclusions map[common.Hash]uint6
 			log.Trace("Dropping filled blob transactions", "from", addr, "filled", nonces, "ids", ids)
 			dropFilledMeter.Mark(int64(len(ids)))
 		}
-		p.cache.update(nil, ids)
 		for _, id := range ids {
 			if err := p.store.Delete(id); err != nil {
 				log.Error("Failed to delete blob transaction", "from", addr, "id", id, "err", err)
@@ -837,7 +833,6 @@ func (p *BlobPool) recheck(addr common.Address, inclusions map[common.Hash]uint6
 		log.Trace("Dropping overlapped blob transactions", "from", addr, "overlapped", nonces, "ids", ids, "left", len(txs))
 		dropOverlappedMeter.Mark(int64(len(ids)))
 
-		p.cache.update(nil, ids)
 		for _, id := range ids {
 			if err := p.store.Delete(id); err != nil {
 				log.Error("Failed to delete blob transaction", "from", addr, "id", id, "err", err)
@@ -885,7 +880,6 @@ func (p *BlobPool) recheck(addr common.Address, inclusions map[common.Hash]uint6
 			p.stored -= uint64(txs[i].storageSize)
 			p.lookup.untrack(txs[i])
 
-			p.cache.update(nil, []uint64{id})
 			if err := p.store.Delete(id); err != nil {
 				log.Error("Failed to delete blob transaction", "from", addr, "id", id, "err", err)
 			}
@@ -913,7 +907,6 @@ func (p *BlobPool) recheck(addr common.Address, inclusions map[common.Hash]uint6
 		log.Error("Dropping gapped blob transactions", "from", addr, "missing", txs[i-1].nonce+1, "drop", nonces, "ids", ids)
 		dropGappedMeter.Mark(int64(len(ids)))
 
-		p.cache.update(nil, ids)
 		for _, id := range ids {
 			if err := p.store.Delete(id); err != nil {
 				log.Error("Failed to delete blob transaction", "from", addr, "id", id, "err", err)
@@ -960,7 +953,6 @@ func (p *BlobPool) recheck(addr common.Address, inclusions map[common.Hash]uint6
 		log.Warn("Dropping overdrafted blob transactions", "from", addr, "balance", balance, "spent", spent, "drop", nonces, "ids", ids)
 		dropOverdraftedMeter.Mark(int64(len(ids)))
 
-		p.cache.update(nil, ids)
 		for _, id := range ids {
 			if err := p.store.Delete(id); err != nil {
 				log.Error("Failed to delete blob transaction", "from", addr, "id", id, "err", err)
@@ -993,7 +985,6 @@ func (p *BlobPool) recheck(addr common.Address, inclusions map[common.Hash]uint6
 		log.Warn("Dropping overcapped blob transactions", "from", addr, "kept", len(txs), "drop", nonces, "ids", ids)
 		dropOvercappedMeter.Mark(int64(len(ids)))
 
-		p.cache.update(nil, ids)
 		for _, id := range ids {
 			if err := p.store.Delete(id); err != nil {
 				log.Error("Failed to delete blob transaction", "from", addr, "id", id, "err", err)
@@ -1127,37 +1118,48 @@ func (p *BlobPool) Reset(oldHead, newHead *types.Header) {
 	blobfeeGauge.Update(int64(blobfee.Uint64()))
 	p.updateStorageMetrics()
 
-	wanted := selectTxs(p.index, eip4844.LatestMaxBlobsPerBlock(p.chain.Config()))
-	p.cache.reset(wanted)
 }
 
-// selectTxs returns the storage ids of the k blob transactions most likely to
-// be included in upcoming blocks, sorted by execution tip cap.
-func selectTxs(index map[common.Address][]*blobTxMeta, k int) []uint64 {
-	if k <= 0 {
-		return nil
-	}
-	type candidate struct {
-		id  uint64
-		tip *uint256.Int
-	}
-	var candidates []candidate
-	for _, txs := range index {
+type txDigest struct {
+	vhashes []common.Hash
+	tip     *uint256.Int
+}
+
+// indexSnapshot returns a copy of the minimal tx data the cache needs to
+// perform selection
+func (p *BlobPool) indexSnapshot() []txDigest {
+	p.lock.RLock()
+	defer p.lock.RUnlock()
+
+	snapshot := make([]txDigest, 0, len(p.index))
+	for _, txs := range p.index {
 		for _, tx := range txs {
-			candidates = append(candidates, candidate{tx.id, tx.execTipCap})
+			snapshot = append(snapshot, txDigest{tx.vhashes, tx.execTipCap})
 		}
 	}
-	sort.Slice(candidates, func(i, j int) bool {
-		return candidates[i].tip.Gt(candidates[j].tip)
-	})
-	if len(candidates) > k {
-		candidates = candidates[:k]
+	return snapshot
+}
+
+// getByVhash reads and decodes the blob transaction which has the given
+// versioned hash. Returns nil if unavailable.
+func (p *BlobPool) getByVhash(vhash common.Hash) *blobTxForPool {
+	p.lock.RLock()
+	txID, exists := p.lookup.storeidOfBlob(vhash)
+	p.lock.RUnlock()
+	if !exists {
+		return nil
 	}
-	ids := make([]uint64, len(candidates))
-	for i, c := range candidates {
-		ids[i] = c.id
+	data, err := p.store.Get(txID)
+	if err != nil {
+		log.Error("Tracked blob transaction missing from store", "id", txID, "err", err)
+		return nil
 	}
-	return ids
+	var ptx blobTxForPool
+	if err := rlp.DecodeBytes(data, &ptx); err != nil {
+		log.Error("Blobs corrupted for tracked transaction", "id", txID, "err", err)
+		return nil
+	}
+	return &ptx
 }
 
 // reorg assembles all the transactors and missing transactions between an old
@@ -1392,7 +1394,6 @@ func (p *BlobPool) SetGasTip(tip *big.Int) {
 					log.Warn("Dropping underpriced blob transaction", "from", addr, "rejected", tx.nonce, "tip", tx.execTipCap, "want", tip, "drop", nonces, "ids", ids)
 					dropUnderpricedMeter.Mark(int64(len(ids)))
 
-					p.cache.update(nil, ids)
 					for _, id := range ids {
 						if err := p.store.Delete(id); err != nil {
 							log.Error("Failed to delete dropped transaction", "id", id, "err", err)
@@ -1580,15 +1581,9 @@ func (p *BlobPool) getRLP(hash common.Hash) []byte {
 
 // Get returns a transaction if it is contained in the pool, or nil otherwise.
 func (p *BlobPool) Get(hash common.Hash) *types.Transaction {
-	// try to get it from cache first
-	id, ok := p.lookup.storeidOfTx(hash)
-	if !ok {
+	if _, ok := p.lookup.storeidOfTx(hash); !ok {
 		return nil
 	}
-	if tx := p.cache.get(id); tx != nil {
-		return tx.ToTx()
-	}
-
 	data := p.getRLP(hash)
 	if len(data) == 0 {
 		return nil
@@ -1638,109 +1633,6 @@ func (p *BlobPool) GetMetadata(hash common.Hash) *txpool.TxMetadata {
 		Type: types.BlobTxType,
 		Size: size,
 	}
-}
-
-// GetBlobs returns a number of blobs and proofs for the given versioned hashes.
-// Blobpool must place responses in the order given in the request, using null
-// for any missing blobs.
-//
-// For instance, if the request is [A_versioned_hash, B_versioned_hash,
-// C_versioned_hash] and blobpool has data for blobs A and C, but doesn't have
-// data for B, the response MUST be [A, null, C].
-//
-// This is a utility method for the engine API, enabling consensus clients to
-// retrieve blobs from the pools directly instead of the network.
-//
-// The version argument specifies the type of proofs to return, either the
-// blob proofs (version 0) or the cell proofs (version 1). Proofs conversion is
-// CPU intensive and prohibited in the blobpool explicitly.
-func (p *BlobPool) GetBlobs(ctx context.Context, vhashes []common.Hash, version byte) (_ []*kzg4844.Blob, _ []kzg4844.Commitment, _ [][]kzg4844.Proof, err error) {
-	var (
-		blobs       = make([]*kzg4844.Blob, len(vhashes))
-		commitments = make([]kzg4844.Commitment, len(vhashes))
-		proofs      = make([][]kzg4844.Proof, len(vhashes))
-
-		indices = make(map[common.Hash][]int)
-		filled  = make(map[common.Hash]struct{})
-
-		cacheHits int64
-		cacheMiss int64
-	)
-	for i, h := range vhashes {
-		indices[h] = append(indices[h], i)
-	}
-
-	for _, vhash := range vhashes {
-		if _, ok := filled[vhash]; ok {
-			// Skip vhash that was already resolved in a previous iteration
-			continue
-		}
-
-		// Retrieve the corresponding blob tx with the vhash.
-		p.lock.RLock()
-		txID, exists := p.lookup.storeidOfBlob(vhash)
-		p.lock.RUnlock()
-		if !exists {
-			continue
-		}
-
-		var ptx *blobTxForPool
-		if cached := p.cache.get(txID); cached != nil {
-			ptx = cached
-			cacheHits++
-		} else {
-			cacheMiss++
-			data, err := p.store.Get(txID)
-			if err != nil {
-				log.Error("Tracked blob transaction missing from store", "id", txID, "err", err)
-				continue
-			}
-
-			var decoded blobTxForPool
-			err = rlp.DecodeBytes(data, &decoded)
-			if err != nil {
-				log.Error("Blobs corrupted for traced transaction", "id", txID, "err", err)
-				continue
-			}
-			ptx = &decoded
-		}
-		sidecar := ptx.Sidecar()
-		// Traverse the blobs in the transaction
-		for i, hash := range ptx.Tx.BlobHashes() {
-			list, ok := indices[hash]
-			if !ok {
-				continue // non-interesting blob
-			}
-			// Mark hash as seen.
-			filled[hash] = struct{}{}
-			if sidecar.Version != version {
-				// Skip blobs with incompatible version. Note we still track the blob hash
-				// in `filled` here, ensuring that we do not resolve this tx another time.
-				continue
-			}
-			// Get or convert the proof.
-			var pf []kzg4844.Proof
-			switch version {
-			case types.BlobSidecarVersion0:
-				pf = []kzg4844.Proof{sidecar.Proofs[i]}
-			case types.BlobSidecarVersion1:
-				cellProofs, err := sidecar.CellProofsAt(i)
-				if err != nil {
-					log.Error("Failed to get cell proofs", "id", txID, "err", err)
-					continue
-				}
-				pf = cellProofs
-			}
-			for _, index := range list {
-				blobs[index] = &sidecar.Blobs[i]
-				commitments[index] = sidecar.Commitments[i]
-				proofs[index] = pf
-			}
-		}
-	}
-	cacheHitMeter.Mark(cacheHits)
-	cacheMissMeter.Mark(cacheMiss)
-	return blobs, commitments, proofs, nil
 }
 
 // AvailableBlobs returns whether the blobs are available in the subpool.
@@ -1878,7 +1770,6 @@ func (p *BlobPool) addLocked(tx *types.Transaction, checkGapped bool) (err error
 		dropReplacedMeter.Mark(1)
 
 		prev := p.index[from][offset]
-		p.cache.update(nil, []uint64{prev.id})
 		if err := p.store.Delete(prev.id); err != nil {
 			// Shitty situation, but try to recover gracefully instead of going boom
 			log.Error("Failed to delete replaced transaction", "id", prev.id, "err", err)
@@ -1955,8 +1846,6 @@ func (p *BlobPool) addLocked(tx *types.Transaction, checkGapped bool) (err error
 		p.drop()
 	}
 	p.updateStorageMetrics()
-
-	p.cache.update([]*addedTx{{id: meta.id, ptx: ptx}}, nil)
 
 	addValidMeter.Mark(1)
 
@@ -2071,7 +1960,6 @@ func (p *BlobPool) drop() {
 	log.Debug("Evicting overflown blob transaction", "from", from, "evicted", drop.nonce, "id", drop.id)
 	dropOverflownMeter.Mark(1)
 
-	p.cache.update(nil, []uint64{drop.id})
 	if err := p.store.Delete(drop.id); err != nil {
 		log.Error("Failed to drop evicted transaction", "id", drop.id, "err", err)
 	}
@@ -2367,22 +2255,18 @@ func (p *BlobPool) Clear() {
 	// manually iterating and deleting every entry is super sub-optimal
 	// However, Clear is not currently used in production so
 	// performance is not critical at the moment.
-	var toDelete []uint64
 	for hash := range p.lookup.txIndex {
 		id, _ := p.lookup.storeidOfTx(hash)
-		toDelete = append(toDelete, id)
 		if err := p.store.Delete(id); err != nil {
 			log.Warn("failed to delete blob tx from backing store", "err", err)
 		}
 	}
 	for hash := range p.lookup.blobIndex {
 		id, _ := p.lookup.storeidOfBlob(hash)
-		toDelete = append(toDelete, id)
 		if err := p.store.Delete(id); err != nil {
 			log.Warn("failed to delete blob from backing store", "err", err)
 		}
 	}
-	p.cache.update(nil, toDelete)
 
 	// unreserve each tracked account.  Ideally, we could just clear the
 	// reservation map in the parent txpool context.  However, if we clear in

--- a/core/txpool/blobpool/blobpool.go
+++ b/core/txpool/blobpool/blobpool.go
@@ -1170,6 +1170,61 @@ func (p *BlobPool) getByVhash(vhash common.Hash) *blobTxForPool {
 	return &ptx
 }
 
+func (p *BlobPool) GetBlobs(vhashes []common.Hash, version byte) ([]*kzg4844.Blob, []kzg4844.Commitment, [][]kzg4844.Proof, error) {
+	var (
+		blobs       = make([]*kzg4844.Blob, len(vhashes))
+		commitments = make([]kzg4844.Commitment, len(vhashes))
+		proofs      = make([][]kzg4844.Proof, len(vhashes))
+
+		indices = make(map[common.Hash][]int)
+		filled  = make(map[common.Hash]struct{})
+	)
+	for i, h := range vhashes {
+		indices[h] = append(indices[h], i)
+	}
+	for _, vhash := range vhashes {
+		if _, ok := filled[vhash]; ok {
+			continue
+		}
+		ptx := p.getByVhash(vhash)
+		if ptx == nil {
+			continue
+		}
+		sidecar := ptx.Sidecar()
+		if sidecar == nil {
+			continue
+		}
+		for i, hash := range sidecar.BlobHashes() {
+			list, ok := indices[hash]
+			if !ok {
+				continue
+			}
+			filled[hash] = struct{}{}
+			if sidecar.Version != version {
+				continue
+			}
+			var pf []kzg4844.Proof
+			switch version {
+			case types.BlobSidecarVersion0:
+				pf = []kzg4844.Proof{sidecar.Proofs[i]}
+			case types.BlobSidecarVersion1:
+				cellProofs, err := sidecar.CellProofsAt(i)
+				if err != nil {
+					log.Error("Failed to get cell proofs", "txhash", ptx.Tx.Hash(), "err", err)
+					continue
+				}
+				pf = cellProofs
+			}
+			for _, index := range list {
+				blobs[index] = &sidecar.Blobs[i]
+				commitments[index] = sidecar.Commitments[i]
+				proofs[index] = pf
+			}
+		}
+	}
+	return blobs, commitments, proofs, nil
+}
+
 // reorg assembles all the transactors and missing transactions between an old
 // and new head to figure out which account's tx set needs to be rechecked and
 // which transactions need to be requeued.

--- a/core/txpool/blobpool/blobpool.go
+++ b/core/txpool/blobpool/blobpool.go
@@ -1117,7 +1117,6 @@ func (p *BlobPool) Reset(oldHead, newHead *types.Header) {
 	basefeeGauge.Update(int64(basefee.Uint64()))
 	blobfeeGauge.Update(int64(blobfee.Uint64()))
 	p.updateStorageMetrics()
-
 }
 
 // vhashesByTx returns a snapshot of the mapping between transaction hash and

--- a/core/txpool/blobpool/blobpool.go
+++ b/core/txpool/blobpool/blobpool.go
@@ -1580,6 +1580,15 @@ func (p *BlobPool) getRLP(hash common.Hash) []byte {
 
 // Get returns a transaction if it is contained in the pool, or nil otherwise.
 func (p *BlobPool) Get(hash common.Hash) *types.Transaction {
+	// try to get it from cache first
+	id, ok := p.lookup.storeidOfTx(hash)
+	if !ok {
+		return nil
+	}
+	if tx := p.cache.get(id); tx != nil {
+		return tx.ToTx()
+	}
+
 	data := p.getRLP(hash)
 	if len(data) == 0 {
 		return nil

--- a/core/txpool/blobpool/blobpool.go
+++ b/core/txpool/blobpool/blobpool.go
@@ -1162,6 +1162,61 @@ func (p *BlobPool) getByVhash(vhash common.Hash) *blobTxForPool {
 	return &ptx
 }
 
+func (p *BlobPool) GetBlobs(vhashes []common.Hash, version byte) ([]*kzg4844.Blob, []kzg4844.Commitment, [][]kzg4844.Proof, error) {
+	var (
+		blobs       = make([]*kzg4844.Blob, len(vhashes))
+		commitments = make([]kzg4844.Commitment, len(vhashes))
+		proofs      = make([][]kzg4844.Proof, len(vhashes))
+
+		indices = make(map[common.Hash][]int)
+		filled  = make(map[common.Hash]struct{})
+	)
+	for i, h := range vhashes {
+		indices[h] = append(indices[h], i)
+	}
+	for _, vhash := range vhashes {
+		if _, ok := filled[vhash]; ok {
+			continue
+		}
+		ptx := p.getByVhash(vhash)
+		if ptx == nil {
+			continue
+		}
+		sidecar := ptx.Sidecar()
+		if sidecar == nil {
+			continue
+		}
+		for i, hash := range sidecar.BlobHashes() {
+			list, ok := indices[hash]
+			if !ok {
+				continue
+			}
+			filled[hash] = struct{}{}
+			if sidecar.Version != version {
+				continue
+			}
+			var pf []kzg4844.Proof
+			switch version {
+			case types.BlobSidecarVersion0:
+				pf = []kzg4844.Proof{sidecar.Proofs[i]}
+			case types.BlobSidecarVersion1:
+				cellProofs, err := sidecar.CellProofsAt(i)
+				if err != nil {
+					log.Error("Failed to get cell proofs", "txhash", ptx.Tx.Hash(), "err", err)
+					continue
+				}
+				pf = cellProofs
+			}
+			for _, index := range list {
+				blobs[index] = &sidecar.Blobs[i]
+				commitments[index] = sidecar.Commitments[i]
+				proofs[index] = pf
+			}
+		}
+	}
+	return blobs, commitments, proofs, nil
+}
+
 // reorg assembles all the transactors and missing transactions between an old
 // and new head to figure out which account's tx set needs to be rechecked and
 // which transactions need to be requeued.

--- a/core/txpool/blobpool/blobpool.go
+++ b/core/txpool/blobpool/blobpool.go
@@ -1120,6 +1120,8 @@ func (p *BlobPool) Reset(oldHead, newHead *types.Header) {
 
 }
 
+// vhashesByTx returns a snapshot of the mapping between transaction hash and
+// versioned hashes.
 func (p *BlobPool) vhashesByTx() map[common.Hash][]common.Hash {
 	p.lock.RLock()
 	defer p.lock.RUnlock()
@@ -1625,20 +1627,9 @@ func (p *BlobPool) GetMetadata(hash common.Hash) *txpool.TxMetadata {
 	}
 }
 
-// GetBlobs returns a number of blobs and proofs for the given versioned hashes.
+// getBlobs returns a number of blobs and proofs for the given versioned hashes.
 // Blobpool must place responses in the order given in the request, using null
 // for any missing blobs.
-//
-// For instance, if the request is [A_versioned_hash, B_versioned_hash,
-// C_versioned_hash] and blobpool has data for blobs A and C, but doesn't have
-// data for B, the response MUST be [A, null, C].
-//
-// This is a utility method for the engine API, enabling consensus clients to
-// retrieve blobs from the pools directly instead of the network.
-//
-// The version argument specifies the type of proofs to return, either the
-// blob proofs (version 0) or the cell proofs (version 1). Proofs conversion is
-// CPU intensive and prohibited in the blobpool explicitly.
 func (p *BlobPool) getBlobs(vhashes []common.Hash, version byte) (_ []*kzg4844.Blob, _ []kzg4844.Commitment, _ [][]kzg4844.Proof, err error) {
 	var (
 		blobs       = make([]*kzg4844.Blob, len(vhashes))
@@ -1714,7 +1705,7 @@ func (p *BlobPool) getBlobs(vhashes []common.Hash, version byte) (_ []*kzg4844.B
 	return blobs, commitments, proofs, nil
 }
 
-// AvailableBlobs returns whether the blobs are available in the subpool.
+// availableBlobs returns whether the blobs are available in the subpool.
 func (p *BlobPool) availableBlobs(vhashes []common.Hash) []bool {
 	available := make([]bool, len(vhashes))
 	p.lock.RLock()

--- a/core/txpool/blobpool/blobpool.go
+++ b/core/txpool/blobpool/blobpool.go
@@ -19,6 +19,7 @@ package blobpool
 
 import (
 	"container/heap"
+	"context"
 	"errors"
 	"fmt"
 	"math"
@@ -39,6 +40,7 @@ import (
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/crypto/kzg4844"
 	"github.com/ethereum/go-ethereum/event"
+	"github.com/ethereum/go-ethereum/internal/telemetry"
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/metrics"
 	"github.com/ethereum/go-ethereum/params"
@@ -1574,9 +1576,6 @@ func (p *BlobPool) getRLP(hash common.Hash) []byte {
 
 // Get returns a transaction if it is contained in the pool, or nil otherwise.
 func (p *BlobPool) Get(hash common.Hash) *types.Transaction {
-	if _, ok := p.lookup.storeidOfTx(hash); !ok {
-		return nil
-	}
 	data := p.getRLP(hash)
 	if len(data) == 0 {
 		return nil
@@ -1628,7 +1627,24 @@ func (p *BlobPool) GetMetadata(hash common.Hash) *txpool.TxMetadata {
 	}
 }
 
-func (p *BlobPool) GetBlobs(vhashes []common.Hash, version byte) ([]*kzg4844.Blob, []kzg4844.Commitment, [][]kzg4844.Proof, error) {
+// GetBlobs returns a number of blobs and proofs for the given versioned hashes.
+// Blobpool must place responses in the order given in the request, using null
+// for any missing blobs.
+//
+// For instance, if the request is [A_versioned_hash, B_versioned_hash,
+// C_versioned_hash] and blobpool has data for blobs A and C, but doesn't have
+// data for B, the response MUST be [A, null, C].
+//
+// This is a utility method for the engine API, enabling consensus clients to
+// retrieve blobs from the pools directly instead of the network.
+//
+// The version argument specifies the type of proofs to return, either the
+// blob proofs (version 0) or the cell proofs (version 1). Proofs conversion is
+// CPU intensive and prohibited in the blobpool explicitly.
+func (p *BlobPool) GetBlobs(ctx context.Context, vhashes []common.Hash, version byte) (_ []*kzg4844.Blob, _ []kzg4844.Commitment, _ [][]kzg4844.Proof, err error) {
+	_, _, spanEnd := telemetry.StartSpan(ctx, "blobpool.GetBlobs")
+	defer spanEnd(&err)
+
 	var (
 		blobs       = make([]*kzg4844.Blob, len(vhashes))
 		commitments = make([]kzg4844.Commitment, len(vhashes))
@@ -1640,27 +1656,47 @@ func (p *BlobPool) GetBlobs(vhashes []common.Hash, version byte) ([]*kzg4844.Blo
 	for i, h := range vhashes {
 		indices[h] = append(indices[h], i)
 	}
+
 	for _, vhash := range vhashes {
 		if _, ok := filled[vhash]; ok {
+			// Skip vhash that was already resolved in a previous iteration
 			continue
 		}
-		ptx := p.getByVhash(vhash)
-		if ptx == nil {
+
+		// Retrieve the corresponding blob tx with the vhash.
+		p.lock.RLock()
+		txID, exists := p.lookup.storeidOfBlob(vhash)
+		p.lock.RUnlock()
+		if !exists {
+			continue
+		}
+		data, err := p.store.Get(txID)
+		if err != nil {
+			log.Error("Tracked blob transaction missing from store", "id", txID, "err", err)
+			continue
+		}
+
+		// Decode the blob transaction
+		var ptx blobTxForPool
+		if err := rlp.DecodeBytes(data, &ptx); err != nil {
+			log.Error("Blobs corrupted for traced transaction", "id", txID, "err", err)
 			continue
 		}
 		sidecar := ptx.Sidecar()
-		if sidecar == nil {
-			continue
-		}
-		for i, hash := range sidecar.BlobHashes() {
+		// Traverse the blobs in the transaction
+		for i, hash := range ptx.Tx.BlobHashes() {
 			list, ok := indices[hash]
 			if !ok {
-				continue
+				continue // non-interesting blob
 			}
+			// Mark hash as seen.
 			filled[hash] = struct{}{}
 			if sidecar.Version != version {
+				// Skip blobs with incompatible version. Note we still track the blob hash
+				// in `filled` here, ensuring that we do not resolve this tx another time.
 				continue
 			}
+			// Get or convert the proof.
 			var pf []kzg4844.Proof
 			switch version {
 			case types.BlobSidecarVersion0:
@@ -1668,7 +1704,7 @@ func (p *BlobPool) GetBlobs(vhashes []common.Hash, version byte) ([]*kzg4844.Blo
 			case types.BlobSidecarVersion1:
 				cellProofs, err := sidecar.CellProofsAt(i)
 				if err != nil {
-					log.Error("Failed to get cell proofs", "txhash", ptx.Tx.Hash(), "err", err)
+					log.Error("Failed to get cell proofs", "id", txID, "err", err)
 					continue
 				}
 				pf = cellProofs

--- a/core/txpool/blobpool/blobpool.go
+++ b/core/txpool/blobpool/blobpool.go
@@ -40,7 +40,6 @@ import (
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/crypto/kzg4844"
 	"github.com/ethereum/go-ethereum/event"
-	"github.com/ethereum/go-ethereum/internal/telemetry"
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/metrics"
 	"github.com/ethereum/go-ethereum/params"
@@ -494,6 +493,7 @@ type BlobPool struct {
 	index  map[common.Address][]*blobTxMeta // Blob transactions grouped by accounts, sorted by nonce
 	spent  map[common.Address]*uint256.Int  // Expenditure tracking for individual accounts
 	evict  *evictHeap                       // Heap of cheapest accounts for eviction when full
+	cache  *cache                           // Decoded sidecar cache for high-priority inclusion candidates
 
 	discoverFeed event.Feed // Event feed to send out new tx events on pool discovery (reorg excluded)
 	insertFeed   event.Feed // Event feed to send out new tx events on pool inclusion (reorg included)
@@ -591,6 +591,7 @@ func (p *BlobPool) Init(gasTip uint64, head *types.Header, reserver txpool.Reser
 		return err
 	}
 	p.store = store
+	p.cache = newCache(store, eip4844.LatestMaxBlobsPerBlock(p.chain.Config()))
 
 	// Migrate legacy transactions (types.Transaction) to pooledBlobTx format.
 	if len(convertTxs) > 0 {
@@ -812,6 +813,7 @@ func (p *BlobPool) recheck(addr common.Address, inclusions map[common.Hash]uint6
 			log.Trace("Dropping filled blob transactions", "from", addr, "filled", nonces, "ids", ids)
 			dropFilledMeter.Mark(int64(len(ids)))
 		}
+		p.cache.update(nil, ids)
 		for _, id := range ids {
 			if err := p.store.Delete(id); err != nil {
 				log.Error("Failed to delete blob transaction", "from", addr, "id", id, "err", err)
@@ -843,6 +845,7 @@ func (p *BlobPool) recheck(addr common.Address, inclusions map[common.Hash]uint6
 		log.Trace("Dropping overlapped blob transactions", "from", addr, "overlapped", nonces, "ids", ids, "left", len(txs))
 		dropOverlappedMeter.Mark(int64(len(ids)))
 
+		p.cache.update(nil, ids)
 		for _, id := range ids {
 			if err := p.store.Delete(id); err != nil {
 				log.Error("Failed to delete blob transaction", "from", addr, "id", id, "err", err)
@@ -890,6 +893,7 @@ func (p *BlobPool) recheck(addr common.Address, inclusions map[common.Hash]uint6
 			p.stored -= uint64(txs[i].storageSize)
 			p.lookup.untrack(txs[i])
 
+			p.cache.update(nil, []uint64{id})
 			if err := p.store.Delete(id); err != nil {
 				log.Error("Failed to delete blob transaction", "from", addr, "id", id, "err", err)
 			}
@@ -917,6 +921,7 @@ func (p *BlobPool) recheck(addr common.Address, inclusions map[common.Hash]uint6
 		log.Error("Dropping gapped blob transactions", "from", addr, "missing", txs[i-1].nonce+1, "drop", nonces, "ids", ids)
 		dropGappedMeter.Mark(int64(len(ids)))
 
+		p.cache.update(nil, ids)
 		for _, id := range ids {
 			if err := p.store.Delete(id); err != nil {
 				log.Error("Failed to delete blob transaction", "from", addr, "id", id, "err", err)
@@ -963,6 +968,7 @@ func (p *BlobPool) recheck(addr common.Address, inclusions map[common.Hash]uint6
 		log.Warn("Dropping overdrafted blob transactions", "from", addr, "balance", balance, "spent", spent, "drop", nonces, "ids", ids)
 		dropOverdraftedMeter.Mark(int64(len(ids)))
 
+		p.cache.update(nil, ids)
 		for _, id := range ids {
 			if err := p.store.Delete(id); err != nil {
 				log.Error("Failed to delete blob transaction", "from", addr, "id", id, "err", err)
@@ -995,6 +1001,7 @@ func (p *BlobPool) recheck(addr common.Address, inclusions map[common.Hash]uint6
 		log.Warn("Dropping overcapped blob transactions", "from", addr, "kept", len(txs), "drop", nonces, "ids", ids)
 		dropOvercappedMeter.Mark(int64(len(ids)))
 
+		p.cache.update(nil, ids)
 		for _, id := range ids {
 			if err := p.store.Delete(id); err != nil {
 				log.Error("Failed to delete blob transaction", "from", addr, "id", id, "err", err)
@@ -1127,6 +1134,38 @@ func (p *BlobPool) Reset(oldHead, newHead *types.Header) {
 	basefeeGauge.Update(int64(basefee.Uint64()))
 	blobfeeGauge.Update(int64(blobfee.Uint64()))
 	p.updateStorageMetrics()
+
+	wanted := selectTxs(p.index, eip4844.LatestMaxBlobsPerBlock(p.chain.Config()))
+	p.cache.reset(wanted)
+}
+
+// selectTxs returns the storage ids of the k blob transactions most likely to
+// be included in upcoming blocks, sorted by execution tip cap.
+func selectTxs(index map[common.Address][]*blobTxMeta, k int) []uint64 {
+	if k <= 0 {
+		return nil
+	}
+	type candidate struct {
+		id  uint64
+		tip *uint256.Int
+	}
+	var candidates []candidate
+	for _, txs := range index {
+		for _, tx := range txs {
+			candidates = append(candidates, candidate{tx.id, tx.execTipCap})
+		}
+	}
+	sort.Slice(candidates, func(i, j int) bool {
+		return candidates[i].tip.Gt(candidates[j].tip)
+	})
+	if len(candidates) > k {
+		candidates = candidates[:k]
+	}
+	ids := make([]uint64, len(candidates))
+	for i, c := range candidates {
+		ids[i] = c.id
+	}
+	return ids
 }
 
 // reorg assembles all the transactors and missing transactions between an old
@@ -1370,6 +1409,7 @@ func (p *BlobPool) SetGasTip(tip *big.Int) {
 					log.Warn("Dropping underpriced blob transaction", "from", addr, "rejected", tx.nonce, "tip", tx.execTipCap, "want", tip, "drop", nonces, "ids", ids)
 					dropUnderpricedMeter.Mark(int64(len(ids)))
 
+					p.cache.update(nil, ids)
 					for _, id := range ids {
 						if err := p.store.Delete(id); err != nil {
 							log.Error("Failed to delete dropped transaction", "id", id, "err", err)
@@ -1623,9 +1663,6 @@ func (p *BlobPool) GetMetadata(hash common.Hash) *txpool.TxMetadata {
 // blob proofs (version 0) or the cell proofs (version 1). Proofs conversion is
 // CPU intensive and prohibited in the blobpool explicitly.
 func (p *BlobPool) GetBlobs(ctx context.Context, vhashes []common.Hash, version byte) (_ []*kzg4844.Blob, _ []kzg4844.Commitment, _ [][]kzg4844.Proof, err error) {
-	_, _, spanEnd := telemetry.StartSpan(ctx, "blobpool.GetBlobs")
-	defer spanEnd(&err)
-
 	var (
 		blobs       = make([]*kzg4844.Blob, len(vhashes))
 		commitments = make([]kzg4844.Commitment, len(vhashes))
@@ -1633,6 +1670,9 @@ func (p *BlobPool) GetBlobs(ctx context.Context, vhashes []common.Hash, version 
 
 		indices = make(map[common.Hash][]int)
 		filled  = make(map[common.Hash]struct{})
+
+		cacheHits int64
+		cacheMiss int64
 	)
 	for i, h := range vhashes {
 		indices[h] = append(indices[h], i)
@@ -1651,17 +1691,26 @@ func (p *BlobPool) GetBlobs(ctx context.Context, vhashes []common.Hash, version 
 		if !exists {
 			continue
 		}
-		data, err := p.store.Get(txID)
-		if err != nil {
-			log.Error("Tracked blob transaction missing from store", "id", txID, "err", err)
-			continue
-		}
 
-		// Decode the blob transaction
-		var ptx blobTxForPool
-		if err := rlp.DecodeBytes(data, &ptx); err != nil {
-			log.Error("Blobs corrupted for traced transaction", "id", txID, "err", err)
-			continue
+		var ptx *blobTxForPool
+		if cached := p.cache.get(txID); cached != nil {
+			ptx = cached
+			cacheHits++
+		} else {
+			cacheMiss++
+			data, err := p.store.Get(txID)
+			if err != nil {
+				log.Error("Tracked blob transaction missing from store", "id", txID, "err", err)
+				continue
+			}
+
+			var decoded blobTxForPool
+			err = rlp.DecodeBytes(data, &decoded)
+			if err != nil {
+				log.Error("Blobs corrupted for traced transaction", "id", txID, "err", err)
+				continue
+			}
+			ptx = &decoded
 		}
 		sidecar := ptx.Sidecar()
 		// Traverse the blobs in the transaction
@@ -1697,6 +1746,8 @@ func (p *BlobPool) GetBlobs(ctx context.Context, vhashes []common.Hash, version 
 			}
 		}
 	}
+	cacheHitMeter.Mark(cacheHits)
+	cacheMissMeter.Mark(cacheMiss)
 	return blobs, commitments, proofs, nil
 }
 
@@ -1835,6 +1886,7 @@ func (p *BlobPool) addLocked(tx *types.Transaction, checkGapped bool) (err error
 		dropReplacedMeter.Mark(1)
 
 		prev := p.index[from][offset]
+		p.cache.update(nil, []uint64{prev.id})
 		if err := p.store.Delete(prev.id); err != nil {
 			// Shitty situation, but try to recover gracefully instead of going boom
 			log.Error("Failed to delete replaced transaction", "id", prev.id, "err", err)
@@ -1911,6 +1963,8 @@ func (p *BlobPool) addLocked(tx *types.Transaction, checkGapped bool) (err error
 		p.drop()
 	}
 	p.updateStorageMetrics()
+
+	p.cache.update([]*addedTx{{id: meta.id, ptx: ptx}}, nil)
 
 	addValidMeter.Mark(1)
 
@@ -2025,6 +2079,7 @@ func (p *BlobPool) drop() {
 	log.Debug("Evicting overflown blob transaction", "from", from, "evicted", drop.nonce, "id", drop.id)
 	dropOverflownMeter.Mark(1)
 
+	p.cache.update(nil, []uint64{drop.id})
 	if err := p.store.Delete(drop.id); err != nil {
 		log.Error("Failed to drop evicted transaction", "id", drop.id, "err", err)
 	}
@@ -2316,18 +2371,22 @@ func (p *BlobPool) Clear() {
 	// manually iterating and deleting every entry is super sub-optimal
 	// However, Clear is not currently used in production so
 	// performance is not critical at the moment.
+	var toDelete []uint64
 	for hash := range p.lookup.txIndex {
 		id, _ := p.lookup.storeidOfTx(hash)
+		toDelete = append(toDelete, id)
 		if err := p.store.Delete(id); err != nil {
 			log.Warn("failed to delete blob tx from backing store", "err", err)
 		}
 	}
 	for hash := range p.lookup.blobIndex {
 		id, _ := p.lookup.storeidOfBlob(hash)
+		toDelete = append(toDelete, id)
 		if err := p.store.Delete(id); err != nil {
 			log.Warn("failed to delete blob from backing store", "err", err)
 		}
 	}
+	p.cache.update(nil, toDelete)
 
 	// unreserve each tracked account.  Ideally, we could just clear the
 	// reservation map in the parent txpool context.  However, if we clear in

--- a/core/txpool/blobpool/blobpool.go
+++ b/core/txpool/blobpool/blobpool.go
@@ -19,7 +19,6 @@ package blobpool
 
 import (
 	"container/heap"
-	"context"
 	"errors"
 	"fmt"
 	"math"
@@ -493,7 +492,6 @@ type BlobPool struct {
 	index  map[common.Address][]*blobTxMeta // Blob transactions grouped by accounts, sorted by nonce
 	spent  map[common.Address]*uint256.Int  // Expenditure tracking for individual accounts
 	evict  *evictHeap                       // Heap of cheapest accounts for eviction when full
-	cache  *cache                           // Decoded sidecar cache for high-priority inclusion candidates
 
 	discoverFeed event.Feed // Event feed to send out new tx events on pool discovery (reorg excluded)
 	insertFeed   event.Feed // Event feed to send out new tx events on pool inclusion (reorg included)
@@ -591,7 +589,6 @@ func (p *BlobPool) Init(gasTip uint64, head *types.Header, reserver txpool.Reser
 		return err
 	}
 	p.store = store
-	p.cache = newCache(store, eip4844.LatestMaxBlobsPerBlock(p.chain.Config()))
 
 	// Migrate legacy transactions (types.Transaction) to pooledBlobTx format.
 	if len(convertTxs) > 0 {
@@ -813,7 +810,6 @@ func (p *BlobPool) recheck(addr common.Address, inclusions map[common.Hash]uint6
 			log.Trace("Dropping filled blob transactions", "from", addr, "filled", nonces, "ids", ids)
 			dropFilledMeter.Mark(int64(len(ids)))
 		}
-		p.cache.update(nil, ids)
 		for _, id := range ids {
 			if err := p.store.Delete(id); err != nil {
 				log.Error("Failed to delete blob transaction", "from", addr, "id", id, "err", err)
@@ -845,7 +841,6 @@ func (p *BlobPool) recheck(addr common.Address, inclusions map[common.Hash]uint6
 		log.Trace("Dropping overlapped blob transactions", "from", addr, "overlapped", nonces, "ids", ids, "left", len(txs))
 		dropOverlappedMeter.Mark(int64(len(ids)))
 
-		p.cache.update(nil, ids)
 		for _, id := range ids {
 			if err := p.store.Delete(id); err != nil {
 				log.Error("Failed to delete blob transaction", "from", addr, "id", id, "err", err)
@@ -893,7 +888,6 @@ func (p *BlobPool) recheck(addr common.Address, inclusions map[common.Hash]uint6
 			p.stored -= uint64(txs[i].storageSize)
 			p.lookup.untrack(txs[i])
 
-			p.cache.update(nil, []uint64{id})
 			if err := p.store.Delete(id); err != nil {
 				log.Error("Failed to delete blob transaction", "from", addr, "id", id, "err", err)
 			}
@@ -921,7 +915,6 @@ func (p *BlobPool) recheck(addr common.Address, inclusions map[common.Hash]uint6
 		log.Error("Dropping gapped blob transactions", "from", addr, "missing", txs[i-1].nonce+1, "drop", nonces, "ids", ids)
 		dropGappedMeter.Mark(int64(len(ids)))
 
-		p.cache.update(nil, ids)
 		for _, id := range ids {
 			if err := p.store.Delete(id); err != nil {
 				log.Error("Failed to delete blob transaction", "from", addr, "id", id, "err", err)
@@ -968,7 +961,6 @@ func (p *BlobPool) recheck(addr common.Address, inclusions map[common.Hash]uint6
 		log.Warn("Dropping overdrafted blob transactions", "from", addr, "balance", balance, "spent", spent, "drop", nonces, "ids", ids)
 		dropOverdraftedMeter.Mark(int64(len(ids)))
 
-		p.cache.update(nil, ids)
 		for _, id := range ids {
 			if err := p.store.Delete(id); err != nil {
 				log.Error("Failed to delete blob transaction", "from", addr, "id", id, "err", err)
@@ -1001,7 +993,6 @@ func (p *BlobPool) recheck(addr common.Address, inclusions map[common.Hash]uint6
 		log.Warn("Dropping overcapped blob transactions", "from", addr, "kept", len(txs), "drop", nonces, "ids", ids)
 		dropOvercappedMeter.Mark(int64(len(ids)))
 
-		p.cache.update(nil, ids)
 		for _, id := range ids {
 			if err := p.store.Delete(id); err != nil {
 				log.Error("Failed to delete blob transaction", "from", addr, "id", id, "err", err)
@@ -1135,37 +1126,48 @@ func (p *BlobPool) Reset(oldHead, newHead *types.Header) {
 	blobfeeGauge.Update(int64(blobfee.Uint64()))
 	p.updateStorageMetrics()
 
-	wanted := selectTxs(p.index, eip4844.LatestMaxBlobsPerBlock(p.chain.Config()))
-	p.cache.reset(wanted)
 }
 
-// selectTxs returns the storage ids of the k blob transactions most likely to
-// be included in upcoming blocks, sorted by execution tip cap.
-func selectTxs(index map[common.Address][]*blobTxMeta, k int) []uint64 {
-	if k <= 0 {
-		return nil
-	}
-	type candidate struct {
-		id  uint64
-		tip *uint256.Int
-	}
-	var candidates []candidate
-	for _, txs := range index {
+type txDigest struct {
+	vhashes []common.Hash
+	tip     *uint256.Int
+}
+
+// indexSnapshot returns a copy of the minimal tx data the cache needs to
+// perform selection
+func (p *BlobPool) indexSnapshot() []txDigest {
+	p.lock.RLock()
+	defer p.lock.RUnlock()
+
+	snapshot := make([]txDigest, 0, len(p.index))
+	for _, txs := range p.index {
 		for _, tx := range txs {
-			candidates = append(candidates, candidate{tx.id, tx.execTipCap})
+			snapshot = append(snapshot, txDigest{tx.vhashes, tx.execTipCap})
 		}
 	}
-	sort.Slice(candidates, func(i, j int) bool {
-		return candidates[i].tip.Gt(candidates[j].tip)
-	})
-	if len(candidates) > k {
-		candidates = candidates[:k]
+	return snapshot
+}
+
+// getByVhash reads and decodes the blob transaction which has the given
+// versioned hash. Returns nil if unavailable.
+func (p *BlobPool) getByVhash(vhash common.Hash) *blobTxForPool {
+	p.lock.RLock()
+	txID, exists := p.lookup.storeidOfBlob(vhash)
+	p.lock.RUnlock()
+	if !exists {
+		return nil
 	}
-	ids := make([]uint64, len(candidates))
-	for i, c := range candidates {
-		ids[i] = c.id
+	data, err := p.store.Get(txID)
+	if err != nil {
+		log.Error("Tracked blob transaction missing from store", "id", txID, "err", err)
+		return nil
 	}
-	return ids
+	var ptx blobTxForPool
+	if err := rlp.DecodeBytes(data, &ptx); err != nil {
+		log.Error("Blobs corrupted for tracked transaction", "id", txID, "err", err)
+		return nil
+	}
+	return &ptx
 }
 
 // reorg assembles all the transactors and missing transactions between an old
@@ -1409,7 +1411,6 @@ func (p *BlobPool) SetGasTip(tip *big.Int) {
 					log.Warn("Dropping underpriced blob transaction", "from", addr, "rejected", tx.nonce, "tip", tx.execTipCap, "want", tip, "drop", nonces, "ids", ids)
 					dropUnderpricedMeter.Mark(int64(len(ids)))
 
-					p.cache.update(nil, ids)
 					for _, id := range ids {
 						if err := p.store.Delete(id); err != nil {
 							log.Error("Failed to delete dropped transaction", "id", id, "err", err)
@@ -1597,15 +1598,9 @@ func (p *BlobPool) getRLP(hash common.Hash) []byte {
 
 // Get returns a transaction if it is contained in the pool, or nil otherwise.
 func (p *BlobPool) Get(hash common.Hash) *types.Transaction {
-	// try to get it from cache first
-	id, ok := p.lookup.storeidOfTx(hash)
-	if !ok {
+	if _, ok := p.lookup.storeidOfTx(hash); !ok {
 		return nil
 	}
-	if tx := p.cache.get(id); tx != nil {
-		return tx.ToTx()
-	}
-
 	data := p.getRLP(hash)
 	if len(data) == 0 {
 		return nil
@@ -1655,109 +1650,6 @@ func (p *BlobPool) GetMetadata(hash common.Hash) *txpool.TxMetadata {
 		Type: types.BlobTxType,
 		Size: size,
 	}
-}
-
-// GetBlobs returns a number of blobs and proofs for the given versioned hashes.
-// Blobpool must place responses in the order given in the request, using null
-// for any missing blobs.
-//
-// For instance, if the request is [A_versioned_hash, B_versioned_hash,
-// C_versioned_hash] and blobpool has data for blobs A and C, but doesn't have
-// data for B, the response MUST be [A, null, C].
-//
-// This is a utility method for the engine API, enabling consensus clients to
-// retrieve blobs from the pools directly instead of the network.
-//
-// The version argument specifies the type of proofs to return, either the
-// blob proofs (version 0) or the cell proofs (version 1). Proofs conversion is
-// CPU intensive and prohibited in the blobpool explicitly.
-func (p *BlobPool) GetBlobs(ctx context.Context, vhashes []common.Hash, version byte) (_ []*kzg4844.Blob, _ []kzg4844.Commitment, _ [][]kzg4844.Proof, err error) {
-	var (
-		blobs       = make([]*kzg4844.Blob, len(vhashes))
-		commitments = make([]kzg4844.Commitment, len(vhashes))
-		proofs      = make([][]kzg4844.Proof, len(vhashes))
-
-		indices = make(map[common.Hash][]int)
-		filled  = make(map[common.Hash]struct{})
-
-		cacheHits int64
-		cacheMiss int64
-	)
-	for i, h := range vhashes {
-		indices[h] = append(indices[h], i)
-	}
-
-	for _, vhash := range vhashes {
-		if _, ok := filled[vhash]; ok {
-			// Skip vhash that was already resolved in a previous iteration
-			continue
-		}
-
-		// Retrieve the corresponding blob tx with the vhash.
-		p.lock.RLock()
-		txID, exists := p.lookup.storeidOfBlob(vhash)
-		p.lock.RUnlock()
-		if !exists {
-			continue
-		}
-
-		var ptx *blobTxForPool
-		if cached := p.cache.get(txID); cached != nil {
-			ptx = cached
-			cacheHits++
-		} else {
-			cacheMiss++
-			data, err := p.store.Get(txID)
-			if err != nil {
-				log.Error("Tracked blob transaction missing from store", "id", txID, "err", err)
-				continue
-			}
-
-			var decoded blobTxForPool
-			err = rlp.DecodeBytes(data, &decoded)
-			if err != nil {
-				log.Error("Blobs corrupted for traced transaction", "id", txID, "err", err)
-				continue
-			}
-			ptx = &decoded
-		}
-		sidecar := ptx.Sidecar()
-		// Traverse the blobs in the transaction
-		for i, hash := range ptx.Tx.BlobHashes() {
-			list, ok := indices[hash]
-			if !ok {
-				continue // non-interesting blob
-			}
-			// Mark hash as seen.
-			filled[hash] = struct{}{}
-			if sidecar.Version != version {
-				// Skip blobs with incompatible version. Note we still track the blob hash
-				// in `filled` here, ensuring that we do not resolve this tx another time.
-				continue
-			}
-			// Get or convert the proof.
-			var pf []kzg4844.Proof
-			switch version {
-			case types.BlobSidecarVersion0:
-				pf = []kzg4844.Proof{sidecar.Proofs[i]}
-			case types.BlobSidecarVersion1:
-				cellProofs, err := sidecar.CellProofsAt(i)
-				if err != nil {
-					log.Error("Failed to get cell proofs", "id", txID, "err", err)
-					continue
-				}
-				pf = cellProofs
-			}
-			for _, index := range list {
-				blobs[index] = &sidecar.Blobs[i]
-				commitments[index] = sidecar.Commitments[i]
-				proofs[index] = pf
-			}
-		}
-	}
-	cacheHitMeter.Mark(cacheHits)
-	cacheMissMeter.Mark(cacheMiss)
-	return blobs, commitments, proofs, nil
 }
 
 // AvailableBlobs returns whether the blobs are available in the subpool.
@@ -1895,7 +1787,6 @@ func (p *BlobPool) addLocked(tx *types.Transaction, checkGapped bool) (err error
 		dropReplacedMeter.Mark(1)
 
 		prev := p.index[from][offset]
-		p.cache.update(nil, []uint64{prev.id})
 		if err := p.store.Delete(prev.id); err != nil {
 			// Shitty situation, but try to recover gracefully instead of going boom
 			log.Error("Failed to delete replaced transaction", "id", prev.id, "err", err)
@@ -1972,8 +1863,6 @@ func (p *BlobPool) addLocked(tx *types.Transaction, checkGapped bool) (err error
 		p.drop()
 	}
 	p.updateStorageMetrics()
-
-	p.cache.update([]*addedTx{{id: meta.id, ptx: ptx}}, nil)
 
 	addValidMeter.Mark(1)
 
@@ -2088,7 +1977,6 @@ func (p *BlobPool) drop() {
 	log.Debug("Evicting overflown blob transaction", "from", from, "evicted", drop.nonce, "id", drop.id)
 	dropOverflownMeter.Mark(1)
 
-	p.cache.update(nil, []uint64{drop.id})
 	if err := p.store.Delete(drop.id); err != nil {
 		log.Error("Failed to drop evicted transaction", "id", drop.id, "err", err)
 	}
@@ -2380,22 +2268,18 @@ func (p *BlobPool) Clear() {
 	// manually iterating and deleting every entry is super sub-optimal
 	// However, Clear is not currently used in production so
 	// performance is not critical at the moment.
-	var toDelete []uint64
 	for hash := range p.lookup.txIndex {
 		id, _ := p.lookup.storeidOfTx(hash)
-		toDelete = append(toDelete, id)
 		if err := p.store.Delete(id); err != nil {
 			log.Warn("failed to delete blob tx from backing store", "err", err)
 		}
 	}
 	for hash := range p.lookup.blobIndex {
 		id, _ := p.lookup.storeidOfBlob(hash)
-		toDelete = append(toDelete, id)
 		if err := p.store.Delete(id); err != nil {
 			log.Warn("failed to delete blob from backing store", "err", err)
 		}
 	}
-	p.cache.update(nil, toDelete)
 
 	// unreserve each tracked account.  Ideally, we could just clear the
 	// reservation map in the parent txpool context.  However, if we clear in

--- a/core/txpool/blobpool/blobpool.go
+++ b/core/txpool/blobpool/blobpool.go
@@ -1120,24 +1120,17 @@ func (p *BlobPool) Reset(oldHead, newHead *types.Header) {
 
 }
 
-type txDigest struct {
-	vhashes []common.Hash
-	tip     *uint256.Int
-}
-
-// indexSnapshot returns a copy of the minimal tx data the cache needs to
-// perform selection
-func (p *BlobPool) indexSnapshot() []txDigest {
+func (p *BlobPool) vhashesByTx() map[common.Hash][]common.Hash {
 	p.lock.RLock()
 	defer p.lock.RUnlock()
 
-	snapshot := make([]txDigest, 0, len(p.index))
+	out := make(map[common.Hash][]common.Hash)
 	for _, txs := range p.index {
 		for _, tx := range txs {
-			snapshot = append(snapshot, txDigest{tx.vhashes, tx.execTipCap})
+			out[tx.hash] = tx.vhashes
 		}
 	}
-	return snapshot
+	return out
 }
 
 // getByVhash reads and decodes the blob transaction which has the given

--- a/core/txpool/blobpool/blobpool.go
+++ b/core/txpool/blobpool/blobpool.go
@@ -1155,61 +1155,6 @@ func (p *BlobPool) getByVhash(vhash common.Hash) *blobTxForPool {
 	return &ptx
 }
 
-func (p *BlobPool) GetBlobs(vhashes []common.Hash, version byte) ([]*kzg4844.Blob, []kzg4844.Commitment, [][]kzg4844.Proof, error) {
-	var (
-		blobs       = make([]*kzg4844.Blob, len(vhashes))
-		commitments = make([]kzg4844.Commitment, len(vhashes))
-		proofs      = make([][]kzg4844.Proof, len(vhashes))
-
-		indices = make(map[common.Hash][]int)
-		filled  = make(map[common.Hash]struct{})
-	)
-	for i, h := range vhashes {
-		indices[h] = append(indices[h], i)
-	}
-	for _, vhash := range vhashes {
-		if _, ok := filled[vhash]; ok {
-			continue
-		}
-		ptx := p.getByVhash(vhash)
-		if ptx == nil {
-			continue
-		}
-		sidecar := ptx.Sidecar()
-		if sidecar == nil {
-			continue
-		}
-		for i, hash := range sidecar.BlobHashes() {
-			list, ok := indices[hash]
-			if !ok {
-				continue
-			}
-			filled[hash] = struct{}{}
-			if sidecar.Version != version {
-				continue
-			}
-			var pf []kzg4844.Proof
-			switch version {
-			case types.BlobSidecarVersion0:
-				pf = []kzg4844.Proof{sidecar.Proofs[i]}
-			case types.BlobSidecarVersion1:
-				cellProofs, err := sidecar.CellProofsAt(i)
-				if err != nil {
-					log.Error("Failed to get cell proofs", "txhash", ptx.Tx.Hash(), "err", err)
-					continue
-				}
-				pf = cellProofs
-			}
-			for _, index := range list {
-				blobs[index] = &sidecar.Blobs[i]
-				commitments[index] = sidecar.Commitments[i]
-				proofs[index] = pf
-			}
-		}
-	}
-	return blobs, commitments, proofs, nil
-}
-
 // reorg assembles all the transactors and missing transactions between an old
 // and new head to figure out which account's tx set needs to be rechecked and
 // which transactions need to be requeued.
@@ -1681,6 +1626,61 @@ func (p *BlobPool) GetMetadata(hash common.Hash) *txpool.TxMetadata {
 		Type: types.BlobTxType,
 		Size: size,
 	}
+}
+
+func (p *BlobPool) GetBlobs(vhashes []common.Hash, version byte) ([]*kzg4844.Blob, []kzg4844.Commitment, [][]kzg4844.Proof, error) {
+	var (
+		blobs       = make([]*kzg4844.Blob, len(vhashes))
+		commitments = make([]kzg4844.Commitment, len(vhashes))
+		proofs      = make([][]kzg4844.Proof, len(vhashes))
+
+		indices = make(map[common.Hash][]int)
+		filled  = make(map[common.Hash]struct{})
+	)
+	for i, h := range vhashes {
+		indices[h] = append(indices[h], i)
+	}
+	for _, vhash := range vhashes {
+		if _, ok := filled[vhash]; ok {
+			continue
+		}
+		ptx := p.getByVhash(vhash)
+		if ptx == nil {
+			continue
+		}
+		sidecar := ptx.Sidecar()
+		if sidecar == nil {
+			continue
+		}
+		for i, hash := range sidecar.BlobHashes() {
+			list, ok := indices[hash]
+			if !ok {
+				continue
+			}
+			filled[hash] = struct{}{}
+			if sidecar.Version != version {
+				continue
+			}
+			var pf []kzg4844.Proof
+			switch version {
+			case types.BlobSidecarVersion0:
+				pf = []kzg4844.Proof{sidecar.Proofs[i]}
+			case types.BlobSidecarVersion1:
+				cellProofs, err := sidecar.CellProofsAt(i)
+				if err != nil {
+					log.Error("Failed to get cell proofs", "txhash", ptx.Tx.Hash(), "err", err)
+					continue
+				}
+				pf = cellProofs
+			}
+			for _, index := range list {
+				blobs[index] = &sidecar.Blobs[i]
+				commitments[index] = sidecar.Commitments[i]
+				proofs[index] = pf
+			}
+		}
+	}
+	return blobs, commitments, proofs, nil
 }
 
 // AvailableBlobs returns whether the blobs are available in the subpool.

--- a/core/txpool/blobpool/blobpool.go
+++ b/core/txpool/blobpool/blobpool.go
@@ -19,7 +19,6 @@ package blobpool
 
 import (
 	"container/heap"
-	"context"
 	"errors"
 	"fmt"
 	"math"
@@ -40,7 +39,6 @@ import (
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/crypto/kzg4844"
 	"github.com/ethereum/go-ethereum/event"
-	"github.com/ethereum/go-ethereum/internal/telemetry"
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/metrics"
 	"github.com/ethereum/go-ethereum/params"
@@ -1641,10 +1639,7 @@ func (p *BlobPool) GetMetadata(hash common.Hash) *txpool.TxMetadata {
 // The version argument specifies the type of proofs to return, either the
 // blob proofs (version 0) or the cell proofs (version 1). Proofs conversion is
 // CPU intensive and prohibited in the blobpool explicitly.
-func (p *BlobPool) GetBlobs(ctx context.Context, vhashes []common.Hash, version byte) (_ []*kzg4844.Blob, _ []kzg4844.Commitment, _ [][]kzg4844.Proof, err error) {
-	_, _, spanEnd := telemetry.StartSpan(ctx, "blobpool.GetBlobs")
-	defer spanEnd(&err)
-
+func (p *BlobPool) getBlobs(vhashes []common.Hash, version byte) (_ []*kzg4844.Blob, _ []kzg4844.Commitment, _ [][]kzg4844.Proof, err error) {
 	var (
 		blobs       = make([]*kzg4844.Blob, len(vhashes))
 		commitments = make([]kzg4844.Commitment, len(vhashes))
@@ -1720,7 +1715,7 @@ func (p *BlobPool) GetBlobs(ctx context.Context, vhashes []common.Hash, version 
 }
 
 // AvailableBlobs returns whether the blobs are available in the subpool.
-func (p *BlobPool) AvailableBlobs(vhashes []common.Hash) []bool {
+func (p *BlobPool) availableBlobs(vhashes []common.Hash) []bool {
 	available := make([]bool, len(vhashes))
 	p.lock.RLock()
 	for i, vhash := range vhashes {

--- a/core/txpool/blobpool/blobpool.go
+++ b/core/txpool/blobpool/blobpool.go
@@ -1128,24 +1128,17 @@ func (p *BlobPool) Reset(oldHead, newHead *types.Header) {
 
 }
 
-type txDigest struct {
-	vhashes []common.Hash
-	tip     *uint256.Int
-}
-
-// indexSnapshot returns a copy of the minimal tx data the cache needs to
-// perform selection
-func (p *BlobPool) indexSnapshot() []txDigest {
+func (p *BlobPool) vhashesByTx() map[common.Hash][]common.Hash {
 	p.lock.RLock()
 	defer p.lock.RUnlock()
 
-	snapshot := make([]txDigest, 0, len(p.index))
+	out := make(map[common.Hash][]common.Hash)
 	for _, txs := range p.index {
 		for _, tx := range txs {
-			snapshot = append(snapshot, txDigest{tx.vhashes, tx.execTipCap})
+			out[tx.hash] = tx.vhashes
 		}
 	}
-	return snapshot
+	return out
 }
 
 // getByVhash reads and decodes the blob transaction which has the given

--- a/core/txpool/blobpool/blobpool.go
+++ b/core/txpool/blobpool/blobpool.go
@@ -1597,6 +1597,15 @@ func (p *BlobPool) getRLP(hash common.Hash) []byte {
 
 // Get returns a transaction if it is contained in the pool, or nil otherwise.
 func (p *BlobPool) Get(hash common.Hash) *types.Transaction {
+	// try to get it from cache first
+	id, ok := p.lookup.storeidOfTx(hash)
+	if !ok {
+		return nil
+	}
+	if tx := p.cache.get(id); tx != nil {
+		return tx.ToTx()
+	}
+
 	data := p.getRLP(hash)
 	if len(data) == 0 {
 		return nil

--- a/core/txpool/blobpool/blobpool.go
+++ b/core/txpool/blobpool/blobpool.go
@@ -40,7 +40,6 @@ import (
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/crypto/kzg4844"
 	"github.com/ethereum/go-ethereum/event"
-	"github.com/ethereum/go-ethereum/internal/telemetry"
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/metrics"
 	"github.com/ethereum/go-ethereum/params"
@@ -486,6 +485,7 @@ type BlobPool struct {
 	index  map[common.Address][]*blobTxMeta // Blob transactions grouped by accounts, sorted by nonce
 	spent  map[common.Address]*uint256.Int  // Expenditure tracking for individual accounts
 	evict  *evictHeap                       // Heap of cheapest accounts for eviction when full
+	cache  *cache                           // Decoded sidecar cache for high-priority inclusion candidates
 
 	discoverFeed event.Feed // Event feed to send out new tx events on pool discovery (reorg excluded)
 	insertFeed   event.Feed // Event feed to send out new tx events on pool inclusion (reorg included)
@@ -583,6 +583,7 @@ func (p *BlobPool) Init(gasTip uint64, head *types.Header, reserver txpool.Reser
 		return err
 	}
 	p.store = store
+	p.cache = newCache(store, eip4844.LatestMaxBlobsPerBlock(p.chain.Config()))
 
 	// Migrate legacy transactions (types.Transaction) to pooledBlobTx format.
 	if len(convertTxs) > 0 {
@@ -804,6 +805,7 @@ func (p *BlobPool) recheck(addr common.Address, inclusions map[common.Hash]uint6
 			log.Trace("Dropping filled blob transactions", "from", addr, "filled", nonces, "ids", ids)
 			dropFilledMeter.Mark(int64(len(ids)))
 		}
+		p.cache.update(nil, ids)
 		for _, id := range ids {
 			if err := p.store.Delete(id); err != nil {
 				log.Error("Failed to delete blob transaction", "from", addr, "id", id, "err", err)
@@ -835,6 +837,7 @@ func (p *BlobPool) recheck(addr common.Address, inclusions map[common.Hash]uint6
 		log.Trace("Dropping overlapped blob transactions", "from", addr, "overlapped", nonces, "ids", ids, "left", len(txs))
 		dropOverlappedMeter.Mark(int64(len(ids)))
 
+		p.cache.update(nil, ids)
 		for _, id := range ids {
 			if err := p.store.Delete(id); err != nil {
 				log.Error("Failed to delete blob transaction", "from", addr, "id", id, "err", err)
@@ -882,6 +885,7 @@ func (p *BlobPool) recheck(addr common.Address, inclusions map[common.Hash]uint6
 			p.stored -= uint64(txs[i].storageSize)
 			p.lookup.untrack(txs[i])
 
+			p.cache.update(nil, []uint64{id})
 			if err := p.store.Delete(id); err != nil {
 				log.Error("Failed to delete blob transaction", "from", addr, "id", id, "err", err)
 			}
@@ -909,6 +913,7 @@ func (p *BlobPool) recheck(addr common.Address, inclusions map[common.Hash]uint6
 		log.Error("Dropping gapped blob transactions", "from", addr, "missing", txs[i-1].nonce+1, "drop", nonces, "ids", ids)
 		dropGappedMeter.Mark(int64(len(ids)))
 
+		p.cache.update(nil, ids)
 		for _, id := range ids {
 			if err := p.store.Delete(id); err != nil {
 				log.Error("Failed to delete blob transaction", "from", addr, "id", id, "err", err)
@@ -955,6 +960,7 @@ func (p *BlobPool) recheck(addr common.Address, inclusions map[common.Hash]uint6
 		log.Warn("Dropping overdrafted blob transactions", "from", addr, "balance", balance, "spent", spent, "drop", nonces, "ids", ids)
 		dropOverdraftedMeter.Mark(int64(len(ids)))
 
+		p.cache.update(nil, ids)
 		for _, id := range ids {
 			if err := p.store.Delete(id); err != nil {
 				log.Error("Failed to delete blob transaction", "from", addr, "id", id, "err", err)
@@ -987,6 +993,7 @@ func (p *BlobPool) recheck(addr common.Address, inclusions map[common.Hash]uint6
 		log.Warn("Dropping overcapped blob transactions", "from", addr, "kept", len(txs), "drop", nonces, "ids", ids)
 		dropOvercappedMeter.Mark(int64(len(ids)))
 
+		p.cache.update(nil, ids)
 		for _, id := range ids {
 			if err := p.store.Delete(id); err != nil {
 				log.Error("Failed to delete blob transaction", "from", addr, "id", id, "err", err)
@@ -1119,6 +1126,38 @@ func (p *BlobPool) Reset(oldHead, newHead *types.Header) {
 	basefeeGauge.Update(int64(basefee.Uint64()))
 	blobfeeGauge.Update(int64(blobfee.Uint64()))
 	p.updateStorageMetrics()
+
+	wanted := selectTxs(p.index, eip4844.LatestMaxBlobsPerBlock(p.chain.Config()))
+	p.cache.reset(wanted)
+}
+
+// selectTxs returns the storage ids of the k blob transactions most likely to
+// be included in upcoming blocks, sorted by execution tip cap.
+func selectTxs(index map[common.Address][]*blobTxMeta, k int) []uint64 {
+	if k <= 0 {
+		return nil
+	}
+	type candidate struct {
+		id  uint64
+		tip *uint256.Int
+	}
+	var candidates []candidate
+	for _, txs := range index {
+		for _, tx := range txs {
+			candidates = append(candidates, candidate{tx.id, tx.execTipCap})
+		}
+	}
+	sort.Slice(candidates, func(i, j int) bool {
+		return candidates[i].tip.Gt(candidates[j].tip)
+	})
+	if len(candidates) > k {
+		candidates = candidates[:k]
+	}
+	ids := make([]uint64, len(candidates))
+	for i, c := range candidates {
+		ids[i] = c.id
+	}
+	return ids
 }
 
 // reorg assembles all the transactors and missing transactions between an old
@@ -1353,6 +1392,7 @@ func (p *BlobPool) SetGasTip(tip *big.Int) {
 					log.Warn("Dropping underpriced blob transaction", "from", addr, "rejected", tx.nonce, "tip", tx.execTipCap, "want", tip, "drop", nonces, "ids", ids)
 					dropUnderpricedMeter.Mark(int64(len(ids)))
 
+					p.cache.update(nil, ids)
 					for _, id := range ids {
 						if err := p.store.Delete(id); err != nil {
 							log.Error("Failed to delete dropped transaction", "id", id, "err", err)
@@ -1606,9 +1646,6 @@ func (p *BlobPool) GetMetadata(hash common.Hash) *txpool.TxMetadata {
 // blob proofs (version 0) or the cell proofs (version 1). Proofs conversion is
 // CPU intensive and prohibited in the blobpool explicitly.
 func (p *BlobPool) GetBlobs(ctx context.Context, vhashes []common.Hash, version byte) (_ []*kzg4844.Blob, _ []kzg4844.Commitment, _ [][]kzg4844.Proof, err error) {
-	_, _, spanEnd := telemetry.StartSpan(ctx, "blobpool.GetBlobs")
-	defer spanEnd(&err)
-
 	var (
 		blobs       = make([]*kzg4844.Blob, len(vhashes))
 		commitments = make([]kzg4844.Commitment, len(vhashes))
@@ -1616,6 +1653,9 @@ func (p *BlobPool) GetBlobs(ctx context.Context, vhashes []common.Hash, version 
 
 		indices = make(map[common.Hash][]int)
 		filled  = make(map[common.Hash]struct{})
+
+		cacheHits int64
+		cacheMiss int64
 	)
 	for i, h := range vhashes {
 		indices[h] = append(indices[h], i)
@@ -1634,17 +1674,26 @@ func (p *BlobPool) GetBlobs(ctx context.Context, vhashes []common.Hash, version 
 		if !exists {
 			continue
 		}
-		data, err := p.store.Get(txID)
-		if err != nil {
-			log.Error("Tracked blob transaction missing from store", "id", txID, "err", err)
-			continue
-		}
 
-		// Decode the blob transaction
-		var ptx blobTxForPool
-		if err := rlp.DecodeBytes(data, &ptx); err != nil {
-			log.Error("Blobs corrupted for traced transaction", "id", txID, "err", err)
-			continue
+		var ptx *blobTxForPool
+		if cached := p.cache.get(txID); cached != nil {
+			ptx = cached
+			cacheHits++
+		} else {
+			cacheMiss++
+			data, err := p.store.Get(txID)
+			if err != nil {
+				log.Error("Tracked blob transaction missing from store", "id", txID, "err", err)
+				continue
+			}
+
+			var decoded blobTxForPool
+			err = rlp.DecodeBytes(data, &decoded)
+			if err != nil {
+				log.Error("Blobs corrupted for traced transaction", "id", txID, "err", err)
+				continue
+			}
+			ptx = &decoded
 		}
 		sidecar := ptx.Sidecar()
 		// Traverse the blobs in the transaction
@@ -1680,6 +1729,8 @@ func (p *BlobPool) GetBlobs(ctx context.Context, vhashes []common.Hash, version 
 			}
 		}
 	}
+	cacheHitMeter.Mark(cacheHits)
+	cacheMissMeter.Mark(cacheMiss)
 	return blobs, commitments, proofs, nil
 }
 
@@ -1818,6 +1869,7 @@ func (p *BlobPool) addLocked(tx *types.Transaction, checkGapped bool) (err error
 		dropReplacedMeter.Mark(1)
 
 		prev := p.index[from][offset]
+		p.cache.update(nil, []uint64{prev.id})
 		if err := p.store.Delete(prev.id); err != nil {
 			// Shitty situation, but try to recover gracefully instead of going boom
 			log.Error("Failed to delete replaced transaction", "id", prev.id, "err", err)
@@ -1894,6 +1946,8 @@ func (p *BlobPool) addLocked(tx *types.Transaction, checkGapped bool) (err error
 		p.drop()
 	}
 	p.updateStorageMetrics()
+
+	p.cache.update([]*addedTx{{id: meta.id, ptx: ptx}}, nil)
 
 	addValidMeter.Mark(1)
 
@@ -2008,6 +2062,7 @@ func (p *BlobPool) drop() {
 	log.Debug("Evicting overflown blob transaction", "from", from, "evicted", drop.nonce, "id", drop.id)
 	dropOverflownMeter.Mark(1)
 
+	p.cache.update(nil, []uint64{drop.id})
 	if err := p.store.Delete(drop.id); err != nil {
 		log.Error("Failed to drop evicted transaction", "id", drop.id, "err", err)
 	}
@@ -2303,18 +2358,22 @@ func (p *BlobPool) Clear() {
 	// manually iterating and deleting every entry is super sub-optimal
 	// However, Clear is not currently used in production so
 	// performance is not critical at the moment.
+	var toDelete []uint64
 	for hash := range p.lookup.txIndex {
 		id, _ := p.lookup.storeidOfTx(hash)
+		toDelete = append(toDelete, id)
 		if err := p.store.Delete(id); err != nil {
 			log.Warn("failed to delete blob tx from backing store", "err", err)
 		}
 	}
 	for hash := range p.lookup.blobIndex {
 		id, _ := p.lookup.storeidOfBlob(hash)
+		toDelete = append(toDelete, id)
 		if err := p.store.Delete(id); err != nil {
 			log.Warn("failed to delete blob from backing store", "err", err)
 		}
 	}
+	p.cache.update(nil, toDelete)
 
 	// unreserve each tracked account.  Ideally, we could just clear the
 	// reservation map in the parent txpool context.  However, if we clear in

--- a/core/txpool/blobpool/blobpool_test.go
+++ b/core/txpool/blobpool/blobpool_test.go
@@ -18,14 +18,17 @@ package blobpool
 
 import (
 	"bytes"
+	"context"
 	"crypto/ecdsa"
 	"crypto/sha256"
 	"errors"
 	"fmt"
 	"math"
 	"math/big"
+	"math/rand"
 	"os"
 	"path/filepath"
+	"reflect"
 	"slices"
 	"sync"
 	"testing"
@@ -40,6 +43,7 @@ import (
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/crypto/kzg4844"
+	"github.com/ethereum/go-ethereum/internal/testrand"
 	"github.com/ethereum/go-ethereum/params"
 	"github.com/ethereum/go-ethereum/rlp"
 	"github.com/ethereum/go-ethereum/trie"
@@ -421,56 +425,59 @@ func verifyPoolInternals(t *testing.T, pool *BlobPool) {
 	verifyBlobRetrievals(t, pool)
 }
 
-// verifyBlobRetrievals checks that every blob tracked by the pool's index can
-// be resolved from disk through getByVhash and that the resulting sidecar
-// matches the expected blob and native-version proofs.
+// verifyBlobRetrievals attempts to retrieve all testing blobs and checks that
+// whatever is in the pool, it can be retrieved correctly.
 func verifyBlobRetrievals(t *testing.T, pool *BlobPool) {
-	known := make(map[common.Hash]struct{})
+	// Collect all the blobs tracked by the pool
+	var (
+		hashes []common.Hash
+		known  = make(map[common.Hash]struct{})
+	)
 	for _, txs := range pool.index {
 		for _, tx := range txs {
 			for _, vhash := range tx.vhashes {
 				known[vhash] = struct{}{}
 			}
+			hashes = append(hashes, tx.vhashes...)
 		}
 	}
-	for hash := range known {
-		ptx := pool.getByVhash(hash)
-		if ptx == nil {
-			t.Errorf("tracked blob retrieval failed: %x", hash)
+	blobs1, _, proofs1, err := pool.GetBlobs(context.Background(), hashes, types.BlobSidecarVersion0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	blobs2, _, proofs2, err := pool.GetBlobs(context.Background(), hashes, types.BlobSidecarVersion1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Cross validate what we received vs what we wanted
+	if len(blobs1) != len(hashes) || len(proofs1) != len(hashes) {
+		t.Errorf("retrieved blobs/proofs size mismatch: have %d/%d, want %d", len(blobs1), len(proofs1), len(hashes))
+		return
+	}
+	if len(blobs2) != len(hashes) || len(proofs2) != len(hashes) {
+		t.Errorf("retrieved blobs/proofs size mismatch: have %d/%d, want blobs %d, want proofs: %d", len(blobs2), len(proofs2), len(hashes), len(hashes))
+		return
+	}
+	for i, hash := range hashes {
+		// If an item is missing from both, but shouldn't, error
+		if (blobs1[i] == nil || proofs1[i] == nil) && (blobs2[i] == nil || proofs2[i] == nil) {
+			t.Errorf("tracked blob retrieval failed: item %d, hash %x", i, hash)
 			continue
 		}
-		sidecar := ptx.Sidecar()
-		pos := -1
-		for i, vh := range sidecar.BlobHashes() {
-			if vh == hash {
-				pos = i
-				break
-			}
-		}
-		if pos < 0 {
-			t.Errorf("hash %x not present in retrieved sidecar", hash)
-			continue
-		}
+		// Item retrieved, make sure it matches the expectation
 		index := testBlobIndices[hash]
-		if sidecar.Blobs[pos] != *testBlobs[index] {
-			t.Errorf("retrieved blob mismatch: hash %x", hash)
+		if blobs1[i] != nil && (*blobs1[i] != *testBlobs[index] || proofs1[i][0] != testBlobProofs[index]) {
+			t.Errorf("retrieved blob or proof mismatch: item %d, hash %x", i, hash)
 			continue
 		}
-		switch sidecar.Version {
-		case types.BlobSidecarVersion0:
-			if sidecar.Proofs[pos] != testBlobProofs[index] {
-				t.Errorf("v0 proof mismatch: hash %x", hash)
-			}
-		case types.BlobSidecarVersion1:
-			cells, err := sidecar.CellProofsAt(pos)
-			if err != nil {
-				t.Errorf("cell proofs error for %x: %v", hash, err)
-				continue
-			}
-			if !slices.Equal(cells, testBlobCellProofs[index]) {
-				t.Errorf("v1 cell proofs mismatch: hash %x", hash)
-			}
+		if blobs2[i] != nil && (*blobs2[i] != *testBlobs[index] || !slices.Equal(proofs2[i], testBlobCellProofs[index])) {
+			t.Errorf("retrieved blob or proof mismatch: item %d, hash %x", i, hash)
+			continue
 		}
+		delete(known, hash)
+	}
+	for hash := range known {
+		t.Errorf("indexed blob #%x missing from retrieval", hash)
 	}
 }
 
@@ -1907,6 +1914,231 @@ func TestAdd(t *testing.T) {
 		// Close down the test
 		pool.Close()
 	}
+}
+
+func TestGetBlobs(t *testing.T) {
+	//log.SetDefault(log.NewLogger(log.NewTerminalHandlerWithLevel(os.Stderr, log.LevelTrace, true)))
+
+	// Create a temporary folder for the persistent backend
+	storage := t.TempDir()
+
+	os.MkdirAll(filepath.Join(storage, pendingTransactionStore), 0700)
+	store, _ := billy.Open(billy.Options{Path: filepath.Join(storage, pendingTransactionStore)}, newSlotter(params.BlobTxMaxBlobs), nil)
+
+	// Create transactions from a few accounts.
+	var (
+		key1, _ = crypto.GenerateKey()
+		key2, _ = crypto.GenerateKey()
+		key3, _ = crypto.GenerateKey()
+
+		addr1 = crypto.PubkeyToAddress(key1.PublicKey)
+		addr2 = crypto.PubkeyToAddress(key2.PublicKey)
+		addr3 = crypto.PubkeyToAddress(key3.PublicKey)
+
+		tx1 = makeMultiBlobTx(0, 1, 1000, 100, 6, 0, key1, types.BlobSidecarVersion0) // [0, 6)
+		tx2 = makeMultiBlobTx(0, 1, 800, 70, 6, 6, key2, types.BlobSidecarVersion1)   // [6, 12)
+		tx3 = makeMultiBlobTx(0, 1, 800, 110, 6, 12, key3, types.BlobSidecarVersion0) // [12, 18)
+
+		blob1 = encodeForPool(tx1)
+		blob2 = encodeForPool(tx2)
+		blob3 = encodeForPool(tx3)
+	)
+
+	// Write the two safely sized txs to store. note: although the store is
+	// configured for a blob count of 6, it can also support around ~1mb of call
+	// data - all this to say that we aren't using the the absolute largest shelf
+	// available.
+	store.Put(blob1)
+	store.Put(blob2)
+	store.Put(blob3)
+	store.Close()
+
+	// Mimic a blobpool with max blob count of 6 upgrading to a max blob count of 24.
+	statedb, _ := state.New(types.EmptyRootHash, state.NewDatabaseForTesting())
+	statedb.AddBalance(addr1, uint256.NewInt(1_000_000_000), tracing.BalanceChangeUnspecified)
+	statedb.AddBalance(addr2, uint256.NewInt(1_000_000_000), tracing.BalanceChangeUnspecified)
+	statedb.AddBalance(addr3, uint256.NewInt(1_000_000_000), tracing.BalanceChangeUnspecified)
+	statedb.Commit(0, true, false)
+
+	// Make custom chain config where the max blob count changes based on the loop variable.
+	cancunTime := uint64(0)
+	config := &params.ChainConfig{
+		ChainID:     big.NewInt(1),
+		LondonBlock: big.NewInt(0),
+		BerlinBlock: big.NewInt(0),
+		CancunTime:  &cancunTime,
+		BlobScheduleConfig: &params.BlobScheduleConfig{
+			Cancun: &params.BlobConfig{
+				Target:         12,
+				Max:            24,
+				UpdateFraction: params.DefaultCancunBlobConfig.UpdateFraction,
+			},
+		},
+	}
+	chain := &testBlockChain{
+		config:  config,
+		basefee: uint256.NewInt(1050),
+		blobfee: uint256.NewInt(105),
+		statedb: statedb,
+	}
+	pool := New(Config{Datadir: storage}, chain, nil)
+	if err := pool.Init(1, chain.CurrentBlock(), newReserver()); err != nil {
+		t.Fatalf("failed to create blob pool: %v", err)
+	}
+
+	// Verify the regular three txs are always available.
+	if got := pool.Get(tx1.Hash()); got == nil {
+		t.Errorf("expected tx %s from %s in pool", tx1.Hash(), addr1)
+	}
+	if got := pool.Get(tx2.Hash()); got == nil {
+		t.Errorf("expected tx %s from %s in pool", tx2.Hash(), addr2)
+	}
+	if got := pool.Get(tx3.Hash()); got == nil {
+		t.Errorf("expected tx %s from %s in pool", tx3.Hash(), addr3)
+	}
+
+	cases := []struct {
+		start      int
+		limit      int
+		fillRandom bool // Whether to randomly fill some of the requested blobs with unknowns
+		version    byte // Blob sidecar version to request
+	}{
+		{
+			start: 0, limit: 6,
+			version: types.BlobSidecarVersion0,
+		},
+		{
+			start: 0, limit: 6,
+			version: types.BlobSidecarVersion1,
+		},
+		{
+			start: 0, limit: 6, fillRandom: true,
+			version: types.BlobSidecarVersion0,
+		},
+		{
+			start: 0, limit: 6, fillRandom: true,
+			version: types.BlobSidecarVersion1,
+		},
+		{
+			start: 3, limit: 9,
+			version: types.BlobSidecarVersion0,
+		},
+		{
+			start: 3, limit: 9,
+			version: types.BlobSidecarVersion1,
+		},
+		{
+			start: 3, limit: 9, fillRandom: true,
+			version: types.BlobSidecarVersion0,
+		},
+		{
+			start: 3, limit: 9, fillRandom: true,
+			version: types.BlobSidecarVersion1,
+		},
+		{
+			start: 3, limit: 15,
+			version: types.BlobSidecarVersion0,
+		},
+		{
+			start: 3, limit: 15,
+			version: types.BlobSidecarVersion1,
+		},
+		{
+			start: 3, limit: 15, fillRandom: true,
+			version: types.BlobSidecarVersion0,
+		},
+		{
+			start: 3, limit: 15, fillRandom: true,
+			version: types.BlobSidecarVersion1,
+		},
+		{
+			start: 0, limit: 18,
+			version: types.BlobSidecarVersion0,
+		},
+		{
+			start: 0, limit: 18,
+			version: types.BlobSidecarVersion1,
+		},
+		{
+			start: 0, limit: 18, fillRandom: true,
+			version: types.BlobSidecarVersion0,
+		},
+		{
+			start: 0, limit: 18, fillRandom: true,
+			version: types.BlobSidecarVersion1,
+		},
+	}
+	for i, c := range cases {
+		var (
+			vhashes []common.Hash
+			filled  = make(map[int]struct{})
+		)
+		if c.fillRandom {
+			filled[len(vhashes)] = struct{}{}
+			vhashes = append(vhashes, testrand.Hash())
+		}
+		for j := c.start; j < c.limit; j++ {
+			vhashes = append(vhashes, testBlobVHashes[j])
+			if c.fillRandom && rand.Intn(2) == 0 {
+				filled[len(vhashes)] = struct{}{}
+				vhashes = append(vhashes, testrand.Hash())
+			}
+		}
+		if c.fillRandom {
+			filled[len(vhashes)] = struct{}{}
+			vhashes = append(vhashes, testrand.Hash())
+		}
+		blobs, _, proofs, err := pool.GetBlobs(context.Background(), vhashes, c.version)
+		if err != nil {
+			t.Errorf("Unexpected error for case %d, %v", i, err)
+		}
+
+		// Cross validate what we received vs what we wanted
+		length := c.limit - c.start
+		wantLen := length + len(filled)
+		if len(blobs) != wantLen || len(proofs) != wantLen {
+			t.Errorf("retrieved blobs/proofs size mismatch: have %d/%d, want %d", len(blobs), len(proofs), wantLen)
+			continue
+		}
+
+		var unknown int
+		for j := 0; j < len(blobs); j++ {
+			testBlobIndex := c.start + j - unknown
+			if _, exist := filled[j]; exist {
+				if blobs[j] != nil || proofs[j] != nil {
+					t.Errorf("Unexpected blob and proof, item %d", j)
+				}
+				unknown++
+				continue
+			}
+			// If an item is missing, but shouldn't, error
+			if blobs[j] == nil || proofs[j] == nil {
+				// This is only an error if there was no version mismatch
+				if (c.version == types.BlobSidecarVersion1 && 6 <= testBlobIndex && testBlobIndex < 12) ||
+					(c.version == types.BlobSidecarVersion0 && (testBlobIndex < 6 || 12 <= testBlobIndex)) {
+					t.Errorf("tracked blob retrieval failed: item %d, hash %x", j, vhashes[j])
+				}
+				continue
+			}
+			// Item retrieved, make sure the blob matches the expectation
+			if *blobs[j] != *testBlobs[testBlobIndex] {
+				t.Errorf("retrieved blob mismatch: item %d, hash %x", j, vhashes[j])
+				continue
+			}
+			// Item retrieved, make sure the proof matches the expectation
+			if c.version == types.BlobSidecarVersion0 {
+				if proofs[j][0] != testBlobProofs[testBlobIndex] {
+					t.Errorf("retrieved proof mismatch: item %d, hash %x", j, vhashes[j])
+				}
+			} else {
+				want, _ := kzg4844.ComputeCellProofs(blobs[j])
+				if !reflect.DeepEqual(want, proofs[j]) {
+					t.Errorf("retrieved proof mismatch: item %d, hash %x", j, vhashes[j])
+				}
+			}
+		}
+	}
+	pool.Close()
 }
 
 // TestEncodeForNetwork verifies that encodeForNetwork produces output identical

--- a/core/txpool/blobpool/blobpool_test.go
+++ b/core/txpool/blobpool/blobpool_test.go
@@ -18,7 +18,6 @@ package blobpool
 
 import (
 	"bytes"
-	"context"
 	"crypto/ecdsa"
 	"crypto/sha256"
 	"errors"
@@ -441,11 +440,11 @@ func verifyBlobRetrievals(t *testing.T, pool *BlobPool) {
 			hashes = append(hashes, tx.vhashes...)
 		}
 	}
-	blobs1, _, proofs1, err := pool.GetBlobs(context.Background(), hashes, types.BlobSidecarVersion0)
+	blobs1, _, proofs1, err := pool.getBlobs(hashes, types.BlobSidecarVersion0)
 	if err != nil {
 		t.Fatal(err)
 	}
-	blobs2, _, proofs2, err := pool.GetBlobs(context.Background(), hashes, types.BlobSidecarVersion1)
+	blobs2, _, proofs2, err := pool.getBlobs(hashes, types.BlobSidecarVersion1)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -2088,7 +2087,7 @@ func TestGetBlobs(t *testing.T) {
 			filled[len(vhashes)] = struct{}{}
 			vhashes = append(vhashes, testrand.Hash())
 		}
-		blobs, _, proofs, err := pool.GetBlobs(context.Background(), vhashes, c.version)
+		blobs, _, proofs, err := pool.getBlobs(vhashes, c.version)
 		if err != nil {
 			t.Errorf("Unexpected error for case %d, %v", i, err)
 		}

--- a/core/txpool/blobpool/blobpool_test.go
+++ b/core/txpool/blobpool/blobpool_test.go
@@ -18,17 +18,14 @@ package blobpool
 
 import (
 	"bytes"
-	"context"
 	"crypto/ecdsa"
 	"crypto/sha256"
 	"errors"
 	"fmt"
 	"math"
 	"math/big"
-	"math/rand"
 	"os"
 	"path/filepath"
-	"reflect"
 	"slices"
 	"sync"
 	"testing"
@@ -43,7 +40,6 @@ import (
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/crypto/kzg4844"
-	"github.com/ethereum/go-ethereum/internal/testrand"
 	"github.com/ethereum/go-ethereum/params"
 	"github.com/ethereum/go-ethereum/rlp"
 	"github.com/ethereum/go-ethereum/trie"
@@ -425,59 +421,56 @@ func verifyPoolInternals(t *testing.T, pool *BlobPool) {
 	verifyBlobRetrievals(t, pool)
 }
 
-// verifyBlobRetrievals attempts to retrieve all testing blobs and checks that
-// whatever is in the pool, it can be retrieved correctly.
+// verifyBlobRetrievals checks that every blob tracked by the pool's index can
+// be resolved from disk through getByVhash and that the resulting sidecar
+// matches the expected blob and native-version proofs.
 func verifyBlobRetrievals(t *testing.T, pool *BlobPool) {
-	// Collect all the blobs tracked by the pool
-	var (
-		hashes []common.Hash
-		known  = make(map[common.Hash]struct{})
-	)
+	known := make(map[common.Hash]struct{})
 	for _, txs := range pool.index {
 		for _, tx := range txs {
 			for _, vhash := range tx.vhashes {
 				known[vhash] = struct{}{}
 			}
-			hashes = append(hashes, tx.vhashes...)
 		}
-	}
-	blobs1, _, proofs1, err := pool.GetBlobs(context.Background(), hashes, types.BlobSidecarVersion0)
-	if err != nil {
-		t.Fatal(err)
-	}
-	blobs2, _, proofs2, err := pool.GetBlobs(context.Background(), hashes, types.BlobSidecarVersion1)
-	if err != nil {
-		t.Fatal(err)
-	}
-	// Cross validate what we received vs what we wanted
-	if len(blobs1) != len(hashes) || len(proofs1) != len(hashes) {
-		t.Errorf("retrieved blobs/proofs size mismatch: have %d/%d, want %d", len(blobs1), len(proofs1), len(hashes))
-		return
-	}
-	if len(blobs2) != len(hashes) || len(proofs2) != len(hashes) {
-		t.Errorf("retrieved blobs/proofs size mismatch: have %d/%d, want blobs %d, want proofs: %d", len(blobs2), len(proofs2), len(hashes), len(hashes))
-		return
-	}
-	for i, hash := range hashes {
-		// If an item is missing from both, but shouldn't, error
-		if (blobs1[i] == nil || proofs1[i] == nil) && (blobs2[i] == nil || proofs2[i] == nil) {
-			t.Errorf("tracked blob retrieval failed: item %d, hash %x", i, hash)
-			continue
-		}
-		// Item retrieved, make sure it matches the expectation
-		index := testBlobIndices[hash]
-		if blobs1[i] != nil && (*blobs1[i] != *testBlobs[index] || proofs1[i][0] != testBlobProofs[index]) {
-			t.Errorf("retrieved blob or proof mismatch: item %d, hash %x", i, hash)
-			continue
-		}
-		if blobs2[i] != nil && (*blobs2[i] != *testBlobs[index] || !slices.Equal(proofs2[i], testBlobCellProofs[index])) {
-			t.Errorf("retrieved blob or proof mismatch: item %d, hash %x", i, hash)
-			continue
-		}
-		delete(known, hash)
 	}
 	for hash := range known {
-		t.Errorf("indexed blob #%x missing from retrieval", hash)
+		ptx := pool.getByVhash(hash)
+		if ptx == nil {
+			t.Errorf("tracked blob retrieval failed: %x", hash)
+			continue
+		}
+		sidecar := ptx.Sidecar()
+		pos := -1
+		for i, vh := range sidecar.BlobHashes() {
+			if vh == hash {
+				pos = i
+				break
+			}
+		}
+		if pos < 0 {
+			t.Errorf("hash %x not present in retrieved sidecar", hash)
+			continue
+		}
+		index := testBlobIndices[hash]
+		if sidecar.Blobs[pos] != *testBlobs[index] {
+			t.Errorf("retrieved blob mismatch: hash %x", hash)
+			continue
+		}
+		switch sidecar.Version {
+		case types.BlobSidecarVersion0:
+			if sidecar.Proofs[pos] != testBlobProofs[index] {
+				t.Errorf("v0 proof mismatch: hash %x", hash)
+			}
+		case types.BlobSidecarVersion1:
+			cells, err := sidecar.CellProofsAt(pos)
+			if err != nil {
+				t.Errorf("cell proofs error for %x: %v", hash, err)
+				continue
+			}
+			if !slices.Equal(cells, testBlobCellProofs[index]) {
+				t.Errorf("v1 cell proofs mismatch: hash %x", hash)
+			}
+		}
 	}
 }
 
@@ -1914,231 +1907,6 @@ func TestAdd(t *testing.T) {
 		// Close down the test
 		pool.Close()
 	}
-}
-
-func TestGetBlobs(t *testing.T) {
-	//log.SetDefault(log.NewLogger(log.NewTerminalHandlerWithLevel(os.Stderr, log.LevelTrace, true)))
-
-	// Create a temporary folder for the persistent backend
-	storage := t.TempDir()
-
-	os.MkdirAll(filepath.Join(storage, pendingTransactionStore), 0700)
-	store, _ := billy.Open(billy.Options{Path: filepath.Join(storage, pendingTransactionStore)}, newSlotter(params.BlobTxMaxBlobs), nil)
-
-	// Create transactions from a few accounts.
-	var (
-		key1, _ = crypto.GenerateKey()
-		key2, _ = crypto.GenerateKey()
-		key3, _ = crypto.GenerateKey()
-
-		addr1 = crypto.PubkeyToAddress(key1.PublicKey)
-		addr2 = crypto.PubkeyToAddress(key2.PublicKey)
-		addr3 = crypto.PubkeyToAddress(key3.PublicKey)
-
-		tx1 = makeMultiBlobTx(0, 1, 1000, 100, 6, 0, key1, types.BlobSidecarVersion0) // [0, 6)
-		tx2 = makeMultiBlobTx(0, 1, 800, 70, 6, 6, key2, types.BlobSidecarVersion1)   // [6, 12)
-		tx3 = makeMultiBlobTx(0, 1, 800, 110, 6, 12, key3, types.BlobSidecarVersion0) // [12, 18)
-
-		blob1 = encodeForPool(tx1)
-		blob2 = encodeForPool(tx2)
-		blob3 = encodeForPool(tx3)
-	)
-
-	// Write the two safely sized txs to store. note: although the store is
-	// configured for a blob count of 6, it can also support around ~1mb of call
-	// data - all this to say that we aren't using the the absolute largest shelf
-	// available.
-	store.Put(blob1)
-	store.Put(blob2)
-	store.Put(blob3)
-	store.Close()
-
-	// Mimic a blobpool with max blob count of 6 upgrading to a max blob count of 24.
-	statedb, _ := state.New(types.EmptyRootHash, state.NewDatabaseForTesting())
-	statedb.AddBalance(addr1, uint256.NewInt(1_000_000_000), tracing.BalanceChangeUnspecified)
-	statedb.AddBalance(addr2, uint256.NewInt(1_000_000_000), tracing.BalanceChangeUnspecified)
-	statedb.AddBalance(addr3, uint256.NewInt(1_000_000_000), tracing.BalanceChangeUnspecified)
-	statedb.Commit(0, true, false)
-
-	// Make custom chain config where the max blob count changes based on the loop variable.
-	cancunTime := uint64(0)
-	config := &params.ChainConfig{
-		ChainID:     big.NewInt(1),
-		LondonBlock: big.NewInt(0),
-		BerlinBlock: big.NewInt(0),
-		CancunTime:  &cancunTime,
-		BlobScheduleConfig: &params.BlobScheduleConfig{
-			Cancun: &params.BlobConfig{
-				Target:         12,
-				Max:            24,
-				UpdateFraction: params.DefaultCancunBlobConfig.UpdateFraction,
-			},
-		},
-	}
-	chain := &testBlockChain{
-		config:  config,
-		basefee: uint256.NewInt(1050),
-		blobfee: uint256.NewInt(105),
-		statedb: statedb,
-	}
-	pool := New(Config{Datadir: storage}, chain, nil)
-	if err := pool.Init(1, chain.CurrentBlock(), newReserver()); err != nil {
-		t.Fatalf("failed to create blob pool: %v", err)
-	}
-
-	// Verify the regular three txs are always available.
-	if got := pool.Get(tx1.Hash()); got == nil {
-		t.Errorf("expected tx %s from %s in pool", tx1.Hash(), addr1)
-	}
-	if got := pool.Get(tx2.Hash()); got == nil {
-		t.Errorf("expected tx %s from %s in pool", tx2.Hash(), addr2)
-	}
-	if got := pool.Get(tx3.Hash()); got == nil {
-		t.Errorf("expected tx %s from %s in pool", tx3.Hash(), addr3)
-	}
-
-	cases := []struct {
-		start      int
-		limit      int
-		fillRandom bool // Whether to randomly fill some of the requested blobs with unknowns
-		version    byte // Blob sidecar version to request
-	}{
-		{
-			start: 0, limit: 6,
-			version: types.BlobSidecarVersion0,
-		},
-		{
-			start: 0, limit: 6,
-			version: types.BlobSidecarVersion1,
-		},
-		{
-			start: 0, limit: 6, fillRandom: true,
-			version: types.BlobSidecarVersion0,
-		},
-		{
-			start: 0, limit: 6, fillRandom: true,
-			version: types.BlobSidecarVersion1,
-		},
-		{
-			start: 3, limit: 9,
-			version: types.BlobSidecarVersion0,
-		},
-		{
-			start: 3, limit: 9,
-			version: types.BlobSidecarVersion1,
-		},
-		{
-			start: 3, limit: 9, fillRandom: true,
-			version: types.BlobSidecarVersion0,
-		},
-		{
-			start: 3, limit: 9, fillRandom: true,
-			version: types.BlobSidecarVersion1,
-		},
-		{
-			start: 3, limit: 15,
-			version: types.BlobSidecarVersion0,
-		},
-		{
-			start: 3, limit: 15,
-			version: types.BlobSidecarVersion1,
-		},
-		{
-			start: 3, limit: 15, fillRandom: true,
-			version: types.BlobSidecarVersion0,
-		},
-		{
-			start: 3, limit: 15, fillRandom: true,
-			version: types.BlobSidecarVersion1,
-		},
-		{
-			start: 0, limit: 18,
-			version: types.BlobSidecarVersion0,
-		},
-		{
-			start: 0, limit: 18,
-			version: types.BlobSidecarVersion1,
-		},
-		{
-			start: 0, limit: 18, fillRandom: true,
-			version: types.BlobSidecarVersion0,
-		},
-		{
-			start: 0, limit: 18, fillRandom: true,
-			version: types.BlobSidecarVersion1,
-		},
-	}
-	for i, c := range cases {
-		var (
-			vhashes []common.Hash
-			filled  = make(map[int]struct{})
-		)
-		if c.fillRandom {
-			filled[len(vhashes)] = struct{}{}
-			vhashes = append(vhashes, testrand.Hash())
-		}
-		for j := c.start; j < c.limit; j++ {
-			vhashes = append(vhashes, testBlobVHashes[j])
-			if c.fillRandom && rand.Intn(2) == 0 {
-				filled[len(vhashes)] = struct{}{}
-				vhashes = append(vhashes, testrand.Hash())
-			}
-		}
-		if c.fillRandom {
-			filled[len(vhashes)] = struct{}{}
-			vhashes = append(vhashes, testrand.Hash())
-		}
-		blobs, _, proofs, err := pool.GetBlobs(context.Background(), vhashes, c.version)
-		if err != nil {
-			t.Errorf("Unexpected error for case %d, %v", i, err)
-		}
-
-		// Cross validate what we received vs what we wanted
-		length := c.limit - c.start
-		wantLen := length + len(filled)
-		if len(blobs) != wantLen || len(proofs) != wantLen {
-			t.Errorf("retrieved blobs/proofs size mismatch: have %d/%d, want %d", len(blobs), len(proofs), wantLen)
-			continue
-		}
-
-		var unknown int
-		for j := 0; j < len(blobs); j++ {
-			testBlobIndex := c.start + j - unknown
-			if _, exist := filled[j]; exist {
-				if blobs[j] != nil || proofs[j] != nil {
-					t.Errorf("Unexpected blob and proof, item %d", j)
-				}
-				unknown++
-				continue
-			}
-			// If an item is missing, but shouldn't, error
-			if blobs[j] == nil || proofs[j] == nil {
-				// This is only an error if there was no version mismatch
-				if (c.version == types.BlobSidecarVersion1 && 6 <= testBlobIndex && testBlobIndex < 12) ||
-					(c.version == types.BlobSidecarVersion0 && (testBlobIndex < 6 || 12 <= testBlobIndex)) {
-					t.Errorf("tracked blob retrieval failed: item %d, hash %x", j, vhashes[j])
-				}
-				continue
-			}
-			// Item retrieved, make sure the blob matches the expectation
-			if *blobs[j] != *testBlobs[testBlobIndex] {
-				t.Errorf("retrieved blob mismatch: item %d, hash %x", j, vhashes[j])
-				continue
-			}
-			// Item retrieved, make sure the proof matches the expectation
-			if c.version == types.BlobSidecarVersion0 {
-				if proofs[j][0] != testBlobProofs[testBlobIndex] {
-					t.Errorf("retrieved proof mismatch: item %d, hash %x", j, vhashes[j])
-				}
-			} else {
-				want, _ := kzg4844.ComputeCellProofs(blobs[j])
-				if !reflect.DeepEqual(want, proofs[j]) {
-					t.Errorf("retrieved proof mismatch: item %d, hash %x", j, vhashes[j])
-				}
-			}
-		}
-	}
-	pool.Close()
 }
 
 // TestEncodeForNetwork verifies that encodeForNetwork produces output identical

--- a/core/txpool/blobpool/cache.go
+++ b/core/txpool/blobpool/cache.go
@@ -38,7 +38,11 @@ import (
 type cacheMode int
 
 const (
+	// In hasBlobsMode, the cache keeps the blobs that it reported
+	// as available in a HasBlobs response.
 	hasBlobsMode cacheMode = iota
+	// In topKMode, the cache fills itself with the blobs of the top K
+	// most profitable transactions.
 	topKMode
 )
 
@@ -48,6 +52,11 @@ const (
 )
 
 var (
+	// Cache tracks 3 metrics: cache hit, cache miss, and the number of blobs
+	// it contains. Note that cache miss includes the blobs that we are actually
+	// missing on the lower level (in this case, the blobpool). The amount that
+	// we failed to predict) can be calculated with the telemetry span
+	// (blobs.filled - cache.hit).
 	cacheHitMeter   = metrics.NewRegisteredMeter("blobpool/cache/hit", nil)
 	cacheMissMeter  = metrics.NewRegisteredMeter("blobpool/cache/miss", nil)
 	cacheBlobsGauge = metrics.NewRegisteredGauge("blobpool/cache/blobs", nil)
@@ -60,20 +69,35 @@ type cachedBlob struct {
 	version    byte
 }
 
+// Cache holds the blobs that are likely to be requested by the GetBlobs engine API.
+//
+// Currently it operates in two modes
+//   - HasBlobsMode is triggered by the HasBlobs engine API. This stage ends
+//     when `hasBlobsTimeout` elapses or the GetBlobs engine API consumes
+//     the result.
+//     (Note: the cache is not guaranteed to always hold such blobs, since the
+//     blobpool might drop the transaction in the window between the engine API
+//     response and the cache update.)
+//   - TopKMode is the cache's default mode. Every `topKTimeout`, the cache selects
+//     the blobs of the top K most profitable transactions, unless it is in the other mode.
+//     Whenever HasBlobsMode is canceled, it falls back to TopKMode.
+//
+// Whenever the mode is changed, the goroutines (for cache update) started by
+// each mode should be canceled to prevent redundant computation.
 type Cache struct {
 	mu sync.Mutex
 
-	entries  map[common.Hash]*cachedBlob // vhash -> blob, commitment, proofs
+	entries  map[common.Hash]*cachedBlob // Mapping from vhash to cachedBlob
 	capacity uint
 
 	blobpool *BlobPool
 
-	hasBlobs chan []common.Hash // list of tx hashes that needs to be cached
+	hasBlobs chan []common.Hash // List of tx hashes that need to be pinned
 	getBlobs chan struct{}
 
 	mode cacheMode
 
-	cancelInflights context.CancelFunc
+	cancelInflights context.CancelFunc // Cancel the in-flight conversion/decode goroutines
 	inflight        sync.WaitGroup
 
 	clock mclock.Clock
@@ -83,10 +107,13 @@ type Cache struct {
 	quit chan struct{}
 }
 
+// NewCache creates a blob cache backed by the given blobpool.
 func NewCache(p *BlobPool, cap uint) *Cache {
 	return NewCacheForTest(p, cap, mclock.System{}, nil)
 }
 
+// NewCacheForTest creates a blob cache for test.
+// It allows injecting a clock and a step hook.
 func NewCacheForTest(p *BlobPool, cap uint, clock mclock.Clock, step func()) *Cache {
 	c := &Cache{
 		entries:  make(map[common.Hash]*cachedBlob, cap),
@@ -107,6 +134,7 @@ func NewCacheForTest(p *BlobPool, cap uint, clock mclock.Clock, step func()) *Ca
 	return c
 }
 
+// Stop cancels any in-flight work and terminates the cache loop.
 func (c *Cache) Stop() {
 	c.mu.Lock()
 	if c.cancelInflights != nil {
@@ -116,14 +144,17 @@ func (c *Cache) Stop() {
 	close(c.quit)
 }
 
+// HasBlobs reports whether the blob is available (in the cache or the
+// blobpool) and asks the loop to pin the ones it found.
 func (c *Cache) HasBlobs(ctx context.Context, vhashes []common.Hash) []bool {
 	var (
 		missIdx     []int
 		missVhashes []common.Hash
-		needPin     []common.Hash
+		needPin     []common.Hash // available vhashes
 	)
 	available := make([]bool, len(vhashes))
 
+	// First check cache and pass missing ones to blobpool.
 	c.mu.Lock()
 	for i, vhash := range vhashes {
 		if _, ok := c.entries[vhash]; ok {
@@ -138,6 +169,7 @@ func (c *Cache) HasBlobs(ctx context.Context, vhashes []common.Hash) []bool {
 
 	if len(missVhashes) > 0 {
 		pooled := c.blobpool.availableBlobs(missVhashes)
+		// Merge two results
 		for j, ok := range pooled {
 			if ok {
 				available[missIdx[j]] = true
@@ -148,12 +180,29 @@ func (c *Cache) HasBlobs(ctx context.Context, vhashes []common.Hash) []bool {
 
 	select {
 	case c.hasBlobs <- needPin:
+		// Note that we also send the ones we already have in cache,
+		// since it can be dropped from the cache before this signal is processed.
 		return available
 	case <-c.quit:
 		return nil
 	}
 }
 
+// GetBlobs returns the blobs and proofs for the given versioned hashes, serving
+// them from the cache when possible and falling back to the blobpool for misses.
+// Responses are placed in the order given in the request, using null for any
+// missing blob.
+//
+// For instance, if the request is [A_versioned_hash, B_versioned_hash,
+// C_versioned_hash] and blobpool has data for blobs A and C, but doesn't have
+// data for B, the response MUST be [A, null, C].
+//
+// This is a utility method for the engine API, enabling consensus clients to
+// retrieve blobs from the pools directly instead of the network.
+//
+// The version argument specifies the type of proofs to return, either the
+// blob proofs (version 0) or the cell proofs (version 1). Proofs conversion is
+// CPU intensive and prohibited explicitly.
 func (c *Cache) GetBlobs(ctx context.Context, vhashes []common.Hash, version byte) (_ []*kzg4844.Blob, _ []kzg4844.Commitment, _ [][]kzg4844.Proof, err error) {
 	_, span, spanEnd := telemetry.StartSpan(ctx, "blobpool.GetBlobs")
 	defer spanEnd(&err)
@@ -242,11 +291,13 @@ func (c *Cache) loop() {
 	for {
 		select {
 		case want := <-c.hasBlobs:
+			// switch to hasBlobs
 			c.switchMode(hasBlobsMode)
 			c.update(want)
 			c.resetTimer(hbTimer, hbTrigger, hasBlobsTimeout)
 
 		case <-topKTrigger:
+			// switch to topK
 			if c.mode != topKMode {
 				if c.step != nil {
 					c.step()
@@ -258,12 +309,14 @@ func (c *Cache) loop() {
 			c.resetTimer(topKTimer, topKTrigger, topKTimeout)
 
 		case <-hbTrigger:
+			// hasBlobs mode is over - switch to topK
 			c.switchMode(topKMode)
 			want := c.selectKTxs()
 			c.update(want)
 			c.resetTimer(topKTimer, topKTrigger, topKTimeout)
 
 		case <-c.getBlobs:
+			// hasBlobs mode is over -  switch to topK
 			if c.mode != hasBlobsMode {
 				if c.step != nil {
 					c.step()
@@ -284,6 +337,8 @@ func (c *Cache) loop() {
 	}
 }
 
+// switchMode sets the cache mode and cancels any in-flight update from the
+// previous mode.
 func (c *Cache) switchMode(mode cacheMode) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
@@ -296,6 +351,9 @@ func (c *Cache) switchMode(mode cacheMode) {
 	}
 }
 
+// update updates the cache to hold the wanted vhashes. It evicts entries that
+// are no longer wanted and loads the missing ones from the blobpool in the
+// background.
 func (c *Cache) update(want []common.Hash) {
 	wantSet := make(map[common.Hash]struct{}, len(want))
 	for _, vh := range want {
@@ -381,6 +439,8 @@ func (c *Cache) update(want []common.Hash) {
 	}()
 }
 
+// selectKTxs returns the vhashes of the top K most profitable pending blob
+// transactions, up to the cache capacity.
 func (c *Cache) selectKTxs() []common.Hash {
 	p := c.blobpool
 	head := p.head.Load()
@@ -424,6 +484,8 @@ func (c *Cache) selectKTxs() []common.Hash {
 	return vhashes
 }
 
+// resetTimer sets the given timer to fire on the trigger channel after the
+// interval.
 func (c *Cache) resetTimer(timer *mclock.Timer, trigger chan struct{}, interval time.Duration) {
 	if *timer != nil {
 		(*timer).Stop()

--- a/core/txpool/blobpool/cache.go
+++ b/core/txpool/blobpool/cache.go
@@ -48,11 +48,17 @@ var (
 	cacheBlobsGauge = metrics.NewRegisteredGauge("blobpool/cache/blobs", nil)
 )
 
+type cachedBlob struct {
+	blob       *kzg4844.Blob
+	commitment kzg4844.Commitment
+	proofs     []kzg4844.Proof
+	version    byte
+}
+
 type Cache struct {
 	mu sync.Mutex
 
-	txHashOf map[common.Hash]common.Hash          // vhash -> txhash
-	entries  map[common.Hash]*types.BlobTxSidecar // txhash -> sidecar
+	entries  map[common.Hash]*cachedBlob // vhash -> blob, commitment, proofs
 	capacity uint
 
 	blobpool *BlobPool
@@ -78,8 +84,7 @@ func NewCache(p *BlobPool, cap uint) *Cache {
 
 func NewCacheForTest(p *BlobPool, cap uint, clock mclock.Clock, step func()) *Cache {
 	c := &Cache{
-		entries:  make(map[common.Hash]*types.BlobTxSidecar, cap),
-		txHashOf: make(map[common.Hash]common.Hash),
+		entries:  make(map[common.Hash]*cachedBlob, cap),
 		capacity: cap,
 		blobpool: p,
 		hasBlobs: make(chan []common.Hash, 1),
@@ -116,7 +121,7 @@ func (c *Cache) HasBlobs(ctx context.Context, vhashes []common.Hash) []bool {
 
 	c.mu.Lock()
 	for i, vhash := range vhashes {
-		if _, ok := c.txHashOf[vhash]; ok {
+		if _, ok := c.entries[vhash]; ok {
 			available[i] = true
 			needPin = append(needPin, vhash)
 		} else {
@@ -166,18 +171,29 @@ func (c *Cache) GetBlobs(ctx context.Context, vhashes []common.Hash, version byt
 			continue
 		}
 		c.mu.Lock()
-		txhash := c.txHashOf[vhash]
-		sidecar := c.entries[txhash]
+		cached := c.entries[vhash]
 		c.mu.Unlock()
 
-		if sidecar != nil {
+		if cached != nil {
 			cacheHits++
-		} else {
-			cacheMiss++
-			if ptx := c.blobpool.getByVhash(vhash); ptx != nil {
-				sidecar = ptx.Sidecar()
+			filled[vhash] = struct{}{}
+			if cached.version != version {
+				continue
 			}
+			for _, index := range indices[vhash] {
+				blobs[index] = cached.blob
+				commitments[index] = cached.commitment
+				proofs[index] = cached.proofs
+			}
+			continue
 		}
+
+		cacheMiss++
+		ptx := c.blobpool.getByVhash(vhash)
+		if ptx == nil {
+			continue
+		}
+		sidecar := ptx.Sidecar()
 		if sidecar == nil {
 			continue
 		}
@@ -202,7 +218,7 @@ func (c *Cache) GetBlobs(ctx context.Context, vhashes []common.Hash, version byt
 			case types.BlobSidecarVersion1:
 				cellProofs, err := sidecar.CellProofsAt(i)
 				if err != nil {
-					log.Error("Failed to get cell proofs", "txhash", txhash, "err", err)
+					log.Error("Failed to get cell proofs", "txhash", ptx.Tx.Hash(), "err", err)
 					continue
 				}
 				pf = cellProofs
@@ -305,27 +321,18 @@ func (c *Cache) update(want []common.Hash) {
 	c.cancelInflights = cancel
 
 	var missing []common.Hash
-	overlap := make(map[common.Hash]struct{})
 	for vh := range wantSet {
-		if txhash, ok := c.txHashOf[vh]; ok {
-			overlap[txhash] = struct{}{}
-		} else {
+		if _, ok := c.entries[vh]; !ok {
 			missing = append(missing, vh)
 		}
 	}
 
-	// Delete non-overlapping entries
-	for txhash, sc := range c.entries {
-		if _, ok := overlap[txhash]; ok {
+	for vh := range c.entries {
+		if _, ok := wantSet[vh]; ok {
 			continue
 		}
-		delete(c.entries, txhash)
-		if sc != nil {
-			for _, vh := range sc.BlobHashes() {
-				delete(c.txHashOf, vh)
-			}
-			cacheBlobsGauge.Dec(int64(len(sc.Commitments)))
-		}
+		delete(c.entries, vh)
+		cacheBlobsGauge.Dec(1)
 	}
 	c.mu.Unlock()
 
@@ -339,7 +346,7 @@ func (c *Cache) update(want []common.Hash) {
 			default:
 			}
 			c.mu.Lock()
-			_, loaded := c.txHashOf[vh]
+			_, loaded := c.entries[vh]
 			c.mu.Unlock()
 			if loaded {
 				continue
@@ -352,13 +359,34 @@ func (c *Cache) update(want []common.Hash) {
 			if sidecar == nil {
 				continue
 			}
-			txhash := ptx.Tx.Hash()
 			c.mu.Lock()
-			c.entries[txhash] = sidecar
-			for _, v := range sidecar.BlobHashes() {
-				c.txHashOf[v] = txhash
+			for i, v := range sidecar.BlobHashes() {
+				if _, ok := wantSet[v]; !ok {
+					continue
+				}
+				if _, ok := c.entries[v]; ok {
+					continue
+				}
+				var pf []kzg4844.Proof
+				switch sidecar.Version {
+				case types.BlobSidecarVersion0:
+					pf = []kzg4844.Proof{sidecar.Proofs[i]}
+				case types.BlobSidecarVersion1:
+					cellProofs, err := sidecar.CellProofsAt(i)
+					if err != nil {
+						log.Error("Failed to get cell proofs", "txhash", ptx.Tx.Hash(), "err", err)
+						continue
+					}
+					pf = cellProofs
+				}
+				c.entries[v] = &cachedBlob{
+					blob:       &sidecar.Blobs[i],
+					commitment: sidecar.Commitments[i],
+					proofs:     pf,
+					version:    sidecar.Version,
+				}
+				cacheBlobsGauge.Inc(1)
 			}
-			cacheBlobsGauge.Inc(int64(len(sidecar.Commitments)))
 			c.mu.Unlock()
 		}
 	}()

--- a/core/txpool/blobpool/cache.go
+++ b/core/txpool/blobpool/cache.go
@@ -116,7 +116,7 @@ func NewCache(p *BlobPool) *Cache {
 // It allows injecting a clock and a step hook.
 func NewCacheForTest(p *BlobPool, clock mclock.Clock, step func()) *Cache {
 	c := &Cache{
-		entries: make(map[common.Hash]*cachedBlob),
+		entries:  make(map[common.Hash]*cachedBlob),
 		blobpool: p,
 		hasBlobs: make(chan []common.Hash, 1),
 		getBlobs: make(chan struct{}, 1),

--- a/core/txpool/blobpool/cache.go
+++ b/core/txpool/blobpool/cache.go
@@ -209,7 +209,6 @@ func (c *Cache) GetBlobs(ctx context.Context, vhashes []common.Hash, version byt
 		proofs      = make([][]kzg4844.Proof, len(vhashes))
 
 		indices = make(map[common.Hash][]int)
-		filled  = make(map[common.Hash]struct{})
 		misses  []common.Hash
 
 		cacheHits int
@@ -220,24 +219,19 @@ func (c *Cache) GetBlobs(ctx context.Context, vhashes []common.Hash, version byt
 	}
 
 	c.mu.Lock()
-	for _, vhash := range vhashes {
-		if _, ok := filled[vhash]; ok {
-			continue
-		}
-		filled[vhash] = struct{}{}
+	for vhash, idxs := range indices {
+		n := len(idxs)
 
 		cached := c.entries[vhash]
-
-		if cached == nil {
-			cacheMiss++
-			misses = append(misses, vhash)
+		if cached == nil || cached.version != version {
+			cacheMiss += n
+			if cached == nil {
+				misses = append(misses, vhash)
+			}
 			continue
 		}
-		cacheHits++
-		if cached.version != version {
-			continue
-		}
-		for _, index := range indices[vhash] {
+		cacheHits += n
+		for _, index := range idxs {
 			blobs[index] = cached.blob
 			commitments[index] = cached.commitment
 			proofs[index] = cached.proofs

--- a/core/txpool/blobpool/cache.go
+++ b/core/txpool/blobpool/cache.go
@@ -358,6 +358,7 @@ func (c *Cache) update(want []common.Hash) {
 			for _, v := range sidecar.BlobHashes() {
 				c.txHashOf[v] = txhash
 			}
+			cacheBlobsGauge.Inc(int64(len(sidecar.Commitments)))
 			c.mu.Unlock()
 		}
 	}()

--- a/core/txpool/blobpool/cache.go
+++ b/core/txpool/blobpool/cache.go
@@ -17,163 +17,377 @@
 package blobpool
 
 import (
-	"container/heap"
+	"context"
+	"sort"
 	"sync"
+	"time"
 
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/mclock"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/crypto/kzg4844"
 	"github.com/ethereum/go-ethereum/log"
-	"github.com/ethereum/go-ethereum/rlp"
-	"github.com/holiman/billy"
-	"github.com/holiman/uint256"
+	"github.com/ethereum/go-ethereum/metrics"
 )
 
-// cacheEntry is a blob transaction stored in the cache.
-type cacheEntry struct {
-	ptx   *blobTxForPool
-	tip   *uint256.Int // priority key
-	txID  uint64       // store id
-	index int          // position in priorityQueue
+type cacheMode int
+
+const (
+	hasBlobsMode cacheMode = iota
+	topKMode
+)
+
+const (
+	topKTimeout     = 1 * time.Second
+	hasBlobsTimeout = 1 * time.Second
+)
+
+var (
+	cacheHitMeter   = metrics.NewRegisteredMeter("blobpool/cache/hit", nil)
+	cacheMissMeter  = metrics.NewRegisteredMeter("blobpool/cache/miss", nil)
+	cacheBlobsGauge = metrics.NewRegisteredGauge("blobpool/cache/blobs", nil)
+)
+
+type Cache struct {
+	mu sync.Mutex
+
+	txHashOf map[common.Hash]common.Hash          // vhash -> txhash
+	entries  map[common.Hash]*types.BlobTxSidecar // txhash -> sidecar
+	capacity uint
+
+	blobpool *BlobPool
+
+	hasBlobs chan []common.Hash // list of tx hashes that needs to be cached
+	getBlobs chan struct{}
+
+	mode cacheMode
+
+	cancelInflights context.CancelFunc
+	inflight        sync.WaitGroup
+
+	clock mclock.Clock
+
+	step func() // test hook fired after each loop iteration
+
+	quit chan struct{}
 }
 
-// priorityQueue is a min heap of cacheEntries, ordered by tip.
-type priorityQueue []*cacheEntry
-
-func (pq priorityQueue) Len() int {
-	return len(pq)
+func NewCache(p *BlobPool, cap uint) *Cache {
+	return NewCacheForTest(p, cap, mclock.System{}, nil)
 }
 
-func (pq priorityQueue) Less(i, j int) bool {
-	return pq[i].tip.Lt(pq[j].tip)
-}
+func NewCacheForTest(p *BlobPool, cap uint, clock mclock.Clock, step func()) *Cache {
+	c := &Cache{
+		entries:  make(map[common.Hash]*types.BlobTxSidecar, cap),
+		txHashOf: make(map[common.Hash]common.Hash),
+		capacity: cap,
+		blobpool: p,
+		hasBlobs: make(chan []common.Hash, 1),
+		getBlobs: make(chan struct{}, 1),
 
-func (pq priorityQueue) Swap(i, j int) {
-	pq[i], pq[j] = pq[j], pq[i]
-	pq[i].index = i
-	pq[j].index = j
-}
-func (pq *priorityQueue) Push(x any) {
-	e := x.(*cacheEntry)
-	e.index = len(*pq)
-	*pq = append(*pq, e)
-}
-func (pq *priorityQueue) Pop() any {
-	old := *pq
-	n := len(old)
-	e := old[n-1]
-	old[n-1] = nil
-	e.index = -1
-	*pq = old[:n-1]
-	return e
-}
+		mode:  topKMode,
+		clock: clock,
 
-// cache has blob transactions ordered by execution tip.
-type cache struct {
-	mu       sync.Mutex
-	entries  map[uint64]*cacheEntry // store id -> cache entry
-	pq       priorityQueue
-	capacity int
-	store    billy.Database
-}
+		step: step,
 
-func newCache(store billy.Database, capacity int) *cache {
-	return &cache{
-		entries:  make(map[uint64]*cacheEntry, capacity),
-		pq:       make(priorityQueue, 0, capacity),
-		capacity: capacity,
-		store:    store,
+		quit: make(chan struct{}),
 	}
+
+	go c.loop()
+	return c
 }
 
-// get returns the cached decoded transaction for the given storage id, if any.
-func (c *cache) get(id uint64) *blobTxForPool {
+func (c *Cache) Stop() {
 	c.mu.Lock()
-	defer c.mu.Unlock()
-	e, ok := c.entries[id]
-	if !ok {
-		return nil
+	if c.cancelInflights != nil {
+		c.cancelInflights()
 	}
-	return e.ptx
+	c.mu.Unlock()
+	close(c.quit)
 }
 
-type addedTx struct {
-	id  uint64
-	ptx *blobTxForPool
-}
-
-// update applies a batch of additions and deletions in blobpool.
-// Each addition is inserted only if it is more expansive than the
-// lowest-tip tx or there is enough capacity.
-func (c *cache) update(added []*addedTx, deleted []uint64) {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-
-	for _, id := range deleted {
-		e, ok := c.entries[id]
-		if !ok {
-			continue
-		}
-		heap.Remove(&c.pq, e.index)
-		delete(c.entries, id)
-	}
-	for _, tx := range added {
-		if _, exists := c.entries[tx.id]; exists {
-			continue
-		}
-		tip := uint256.MustFromBig(tx.ptx.Tx.GasTipCap())
-		if len(c.entries) >= c.capacity {
-			if !tip.Gt(c.pq[0].tip) {
-				continue
-			}
-			evicted := heap.Pop(&c.pq).(*cacheEntry)
-			delete(c.entries, evicted.txID)
-		}
-		e := &cacheEntry{
-			ptx:  tx.ptx,
-			tip:  tip,
-			txID: tx.id,
-		}
-		c.entries[tx.id] = e
-		heap.Push(&c.pq, e)
-	}
-	cacheEntriesGauge.Update(int64(len(c.entries)))
-}
-
-// reset rebuilds the cache with the given wanted ids by computing the
-// diff against the current entries.
-func (c *cache) reset(wanted []uint64) {
-	wantedSet := make(map[uint64]struct{}, len(wanted))
-	for _, id := range wanted {
-		wantedSet[id] = struct{}{}
-	}
+func (c *Cache) HasBlobs(ctx context.Context, vhashes []common.Hash) []bool {
+	var (
+		missIdx     []int
+		missVhashes []common.Hash
+		needPin     []common.Hash
+	)
+	available := make([]bool, len(vhashes))
 
 	c.mu.Lock()
-	var toDelete []uint64
-	for id := range c.entries {
-		if _, ok := wantedSet[id]; !ok {
-			toDelete = append(toDelete, id)
-		}
-	}
-	var toLoad []uint64
-	for _, id := range wanted {
-		if _, ok := c.entries[id]; !ok {
-			toLoad = append(toLoad, id)
+	for i, vhash := range vhashes {
+		if _, ok := c.txHashOf[vhash]; ok {
+			available[i] = true
+			needPin = append(needPin, vhash)
+		} else {
+			missIdx = append(missIdx, i)
+			missVhashes = append(missVhashes, vhash)
 		}
 	}
 	c.mu.Unlock()
 
-	var toAdd []*addedTx
-	for _, id := range toLoad {
-		data, err := c.store.Get(id)
-		if err != nil {
-			log.Trace("Cache load skipped missing blob tx", "id", id, "err", err)
-			continue
+	if len(missVhashes) > 0 {
+		pooled := c.blobpool.AvailableBlobs(missVhashes)
+		for j, ok := range pooled {
+			if ok {
+				available[missIdx[j]] = true
+				needPin = append(needPin, missVhashes[j])
+			}
 		}
-		var ptx blobTxForPool
-		if err := rlp.DecodeBytes(data, &ptx); err != nil {
-			log.Error("Cache load failed to decode blob tx", "id", id, "err", err)
-			continue
-		}
-		toAdd = append(toAdd, &addedTx{id: id, ptx: &ptx})
 	}
 
-	c.update(toAdd, toDelete)
+	select {
+	case c.hasBlobs <- needPin:
+		return available
+	case <-c.quit:
+		return nil
+	}
+}
+
+func (c *Cache) GetBlobs(ctx context.Context, vhashes []common.Hash, version byte) (_ []*kzg4844.Blob, _ []kzg4844.Commitment, _ [][]kzg4844.Proof, err error) {
+	var (
+		blobs       = make([]*kzg4844.Blob, len(vhashes))
+		commitments = make([]kzg4844.Commitment, len(vhashes))
+		proofs      = make([][]kzg4844.Proof, len(vhashes))
+
+		indices = make(map[common.Hash][]int)
+		filled  = make(map[common.Hash]struct{})
+
+		cacheHits int64
+		cacheMiss int64
+	)
+	for i, h := range vhashes {
+		indices[h] = append(indices[h], i)
+	}
+
+	for _, vhash := range vhashes {
+		if _, ok := filled[vhash]; ok {
+			// Skip vhash that was already resolved in a previous iteration
+			continue
+		}
+		c.mu.Lock()
+		txhash := c.txHashOf[vhash]
+		sidecar := c.entries[txhash]
+		c.mu.Unlock()
+
+		if sidecar != nil {
+			cacheHits++
+		} else {
+			cacheMiss++
+			if ptx := c.blobpool.getByVhash(vhash); ptx != nil {
+				sidecar = ptx.Sidecar()
+			}
+		}
+		if sidecar == nil {
+			continue
+		}
+
+		for i, hash := range sidecar.BlobHashes() {
+			list, ok := indices[hash]
+			if !ok {
+				continue
+			}
+			// Mark hash as seen.
+			filled[hash] = struct{}{}
+			if sidecar.Version != version {
+				// Skip blobs with incompatible version. Note we still track the blob hash
+				// in `filled` here, ensuring that we do not resolve this tx another time.
+				continue
+			}
+			// Get or convert the proof.
+			var pf []kzg4844.Proof
+			switch version {
+			case types.BlobSidecarVersion0:
+				pf = []kzg4844.Proof{sidecar.Proofs[i]}
+			case types.BlobSidecarVersion1:
+				cellProofs, err := sidecar.CellProofsAt(i)
+				if err != nil {
+					log.Error("Failed to get cell proofs", "txhash", txhash, "err", err)
+					continue
+				}
+				pf = cellProofs
+			}
+			for _, index := range list {
+				blobs[index] = &sidecar.Blobs[i]
+				commitments[index] = sidecar.Commitments[i]
+				proofs[index] = pf
+			}
+		}
+	}
+	cacheHitMeter.Mark(cacheHits)
+	cacheMissMeter.Mark(cacheMiss)
+
+	select {
+	case c.getBlobs <- struct{}{}:
+		return blobs, commitments, proofs, nil
+	case <-c.quit:
+		return nil, nil, nil, nil
+	}
+}
+
+func (c *Cache) loop() {
+	var (
+		topKTimer   = new(mclock.Timer)
+		topKTrigger = make(chan struct{}, 1)
+		hbTimer     = new(mclock.Timer)
+		hbTrigger   = make(chan struct{}, 1)
+	)
+	c.resetTimer(topKTimer, topKTrigger, topKTimeout)
+
+	for {
+		select {
+		case want := <-c.hasBlobs:
+			c.switchMode(hasBlobsMode)
+			c.update(want)
+			c.resetTimer(hbTimer, hbTrigger, hasBlobsTimeout)
+
+		case <-topKTrigger:
+			if c.mode != topKMode {
+				if c.step != nil {
+					c.step()
+				}
+				continue
+			}
+			want := selectTxs(c.blobpool.indexSnapshot(), c.capacity)
+			c.update(want)
+			c.resetTimer(topKTimer, topKTrigger, topKTimeout)
+
+		case <-hbTrigger:
+			c.switchMode(topKMode)
+			want := selectTxs(c.blobpool.indexSnapshot(), c.capacity)
+			c.update(want)
+			c.resetTimer(topKTimer, topKTrigger, topKTimeout)
+
+		case <-c.getBlobs:
+			if c.mode != hasBlobsMode {
+				if c.step != nil {
+					c.step()
+				}
+				continue
+			}
+			c.switchMode(topKMode)
+			want := selectTxs(c.blobpool.indexSnapshot(), c.capacity)
+			c.update(want)
+			c.resetTimer(topKTimer, topKTrigger, topKTimeout)
+		case <-c.quit:
+			return
+		}
+
+		if c.step != nil {
+			c.step()
+		}
+	}
+}
+
+func (c *Cache) switchMode(mode cacheMode) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	c.mode = mode
+
+	if c.cancelInflights != nil {
+		c.cancelInflights()
+		c.cancelInflights = nil
+	}
+}
+
+func (c *Cache) update(want []common.Hash) {
+	wantSet := make(map[common.Hash]struct{}, len(want))
+	for _, vh := range want {
+		wantSet[vh] = struct{}{}
+	}
+
+	c.mu.Lock()
+	if c.cancelInflights != nil {
+		c.cancelInflights()
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	c.cancelInflights = cancel
+
+	var missing []common.Hash
+	overlap := make(map[common.Hash]struct{})
+	for vh := range wantSet {
+		if txhash, ok := c.txHashOf[vh]; ok {
+			overlap[txhash] = struct{}{}
+		} else {
+			missing = append(missing, vh)
+		}
+	}
+
+	// Delete non-overlapping entries
+	for txhash, sc := range c.entries {
+		if _, ok := overlap[txhash]; ok {
+			continue
+		}
+		delete(c.entries, txhash)
+		if sc != nil {
+			for _, vh := range sc.BlobHashes() {
+				delete(c.txHashOf, vh)
+			}
+			cacheBlobsGauge.Dec(int64(len(sc.Commitments)))
+		}
+	}
+	c.mu.Unlock()
+
+	c.inflight.Add(1)
+	go func() {
+		defer c.inflight.Done()
+		for _, vh := range missing {
+			select {
+			case <-ctx.Done():
+				return
+			default:
+			}
+			c.mu.Lock()
+			_, loaded := c.txHashOf[vh]
+			c.mu.Unlock()
+			if loaded {
+				continue
+			}
+			ptx := c.blobpool.getByVhash(vh)
+			if ptx == nil {
+				continue
+			}
+			sidecar := ptx.Sidecar()
+			if sidecar == nil {
+				continue
+			}
+			txhash := ptx.Tx.Hash()
+			c.mu.Lock()
+			c.entries[txhash] = sidecar
+			for _, v := range sidecar.BlobHashes() {
+				c.txHashOf[v] = txhash
+			}
+			c.mu.Unlock()
+		}
+	}()
+}
+
+func (c *Cache) resetTimer(timer *mclock.Timer, trigger chan struct{}, interval time.Duration) {
+	if *timer != nil {
+		(*timer).Stop()
+	}
+	*timer = c.clock.AfterFunc(interval, func() {
+		trigger <- struct{}{}
+	})
+}
+
+// selectTxs returns the versioned hashes of the k blob transactions most
+// likely to be included in upcoming blocks, sorted by execution tip cap and
+// flattened across each picked tx's blobs.
+func selectTxs(snapshot []txDigest, k uint) []common.Hash {
+	if k <= 0 {
+		return nil
+	}
+	sort.Slice(snapshot, func(i, j int) bool {
+		return snapshot[i].tip.Gt(snapshot[j].tip)
+	})
+	if len(snapshot) > int(k) {
+		snapshot = snapshot[:k]
+	}
+	var vhashes []common.Hash
+	for _, d := range snapshot {
+		vhashes = append(vhashes, d.vhashes...)
+	}
+	return vhashes
 }

--- a/core/txpool/blobpool/cache.go
+++ b/core/txpool/blobpool/cache.go
@@ -87,8 +87,7 @@ type cachedBlob struct {
 type Cache struct {
 	mu sync.Mutex
 
-	entries  map[common.Hash]*cachedBlob // Mapping from vhash to cachedBlob
-	capacity uint
+	entries map[common.Hash]*cachedBlob // Mapping from vhash to cachedBlob
 
 	blobpool *BlobPool
 
@@ -98,7 +97,8 @@ type Cache struct {
 	mode cacheMode
 
 	cancelInflights context.CancelFunc // Cancel the in-flight conversion/decode goroutines
-	inflight        sync.WaitGroup
+	inflight        sync.WaitGroup     // Tracks the in-flight conversion/decode goroutines
+	wg              sync.WaitGroup     // Tracks the loop goroutine
 
 	clock mclock.Clock
 
@@ -108,16 +108,15 @@ type Cache struct {
 }
 
 // NewCache creates a blob cache backed by the given blobpool.
-func NewCache(p *BlobPool, cap uint) *Cache {
-	return NewCacheForTest(p, cap, mclock.System{}, nil)
+func NewCache(p *BlobPool) *Cache {
+	return NewCacheForTest(p, mclock.System{}, nil)
 }
 
 // NewCacheForTest creates a blob cache for test.
 // It allows injecting a clock and a step hook.
-func NewCacheForTest(p *BlobPool, cap uint, clock mclock.Clock, step func()) *Cache {
+func NewCacheForTest(p *BlobPool, clock mclock.Clock, step func()) *Cache {
 	c := &Cache{
-		entries:  make(map[common.Hash]*cachedBlob, cap),
-		capacity: cap,
+		entries: make(map[common.Hash]*cachedBlob),
 		blobpool: p,
 		hasBlobs: make(chan []common.Hash, 1),
 		getBlobs: make(chan struct{}, 1),
@@ -130,18 +129,16 @@ func NewCacheForTest(p *BlobPool, cap uint, clock mclock.Clock, step func()) *Ca
 		quit: make(chan struct{}),
 	}
 
+	c.wg.Add(1)
 	go c.loop()
 	return c
 }
 
-// Stop cancels any in-flight work and terminates the cache loop.
+// Stop terminates the cache loop and blocks until it and any in-flight work
+// have stopped.
 func (c *Cache) Stop() {
-	c.mu.Lock()
-	if c.cancelInflights != nil {
-		c.cancelInflights()
-	}
-	c.mu.Unlock()
 	close(c.quit)
+	c.wg.Wait()
 }
 
 // HasBlobs reports whether the blob is available (in the cache or the
@@ -222,15 +219,14 @@ func (c *Cache) GetBlobs(ctx context.Context, vhashes []common.Hash, version byt
 		indices[h] = append(indices[h], i)
 	}
 
+	c.mu.Lock()
 	for _, vhash := range vhashes {
 		if _, ok := filled[vhash]; ok {
 			continue
 		}
 		filled[vhash] = struct{}{}
 
-		c.mu.Lock()
 		cached := c.entries[vhash]
-		c.mu.Unlock()
 
 		if cached == nil {
 			cacheMiss++
@@ -247,6 +243,7 @@ func (c *Cache) GetBlobs(ctx context.Context, vhashes []common.Hash, version byt
 			proofs[index] = cached.proofs
 		}
 	}
+	c.mu.Unlock()
 
 	if len(misses) > 0 {
 		mb, mc, mp, err := c.blobpool.getBlobs(misses, version)
@@ -280,6 +277,7 @@ func (c *Cache) GetBlobs(ctx context.Context, vhashes []common.Hash, version byt
 }
 
 func (c *Cache) loop() {
+	defer c.wg.Done()
 	var (
 		topKTimer   = new(mclock.Timer)
 		topKTrigger = make(chan struct{}, 1)
@@ -299,35 +297,35 @@ func (c *Cache) loop() {
 		case <-topKTrigger:
 			// switch to topK
 			if c.mode != topKMode {
-				if c.step != nil {
-					c.step()
-				}
 				continue
 			}
-			want := c.selectKTxs()
+			want := c.selectTopTxs()
 			c.update(want)
 			c.resetTimer(topKTimer, topKTrigger, topKTimeout)
 
 		case <-hbTrigger:
 			// hasBlobs mode is over - switch to topK
 			c.switchMode(topKMode)
-			want := c.selectKTxs()
+			want := c.selectTopTxs()
 			c.update(want)
 			c.resetTimer(topKTimer, topKTrigger, topKTimeout)
 
 		case <-c.getBlobs:
 			// hasBlobs mode is over -  switch to topK
 			if c.mode != hasBlobsMode {
-				if c.step != nil {
-					c.step()
-				}
 				continue
 			}
 			c.switchMode(topKMode)
-			want := c.selectKTxs()
+			want := c.selectTopTxs()
 			c.update(want)
 			c.resetTimer(topKTimer, topKTrigger, topKTimeout)
 		case <-c.quit:
+			c.mu.Lock()
+			if c.cancelInflights != nil {
+				c.cancelInflights()
+			}
+			c.mu.Unlock()
+			c.inflight.Wait()
 			return
 		}
 
@@ -340,9 +338,6 @@ func (c *Cache) loop() {
 // switchMode sets the cache mode and cancels any in-flight update from the
 // previous mode.
 func (c *Cache) switchMode(mode cacheMode) {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-
 	c.mode = mode
 
 	if c.cancelInflights != nil {
@@ -406,12 +401,10 @@ func (c *Cache) update(want []common.Hash) {
 			if sidecar == nil {
 				continue
 			}
+
 			c.mu.Lock()
 			for i, v := range sidecar.BlobHashes() {
 				if _, ok := wantSet[v]; !ok {
-					continue
-				}
-				if _, ok := c.entries[v]; ok {
 					continue
 				}
 				var pf []kzg4844.Proof
@@ -439,9 +432,9 @@ func (c *Cache) update(want []common.Hash) {
 	}()
 }
 
-// selectKTxs returns the vhashes of the top K most profitable pending blob
-// transactions, up to the cache capacity.
-func (c *Cache) selectKTxs() []common.Hash {
+// selectTopTxs returns the vhashes of the top K most profitable pending blob
+// transactions, up to the active fork's maxBlobsPerBlock.
+func (c *Cache) selectTopTxs() []common.Hash {
 	p := c.blobpool
 	head := p.head.Load()
 	if head == nil {
@@ -467,18 +460,24 @@ func (c *Cache) selectKTxs() []common.Hash {
 
 	order := txorder.NewTransactionsByPriceAndNonce(p.signer, pending, baseFee)
 
+	// Bound the selection by the active fork's blob limit so the cache follows
+	// BPO changes to maxBlobsPerBlock.
+	target := uint(eip4844.MaxBlobsPerBlock(config, head.Time))
+
 	var (
 		vhashes []common.Hash
 		blobs   uint
 	)
-	for blobs < c.capacity {
+	for blobs < target {
 		tx, _ := order.Peek()
 		if tx == nil {
 			break
 		}
-		vh := vhashesOf[tx.Hash]
-		vhashes = append(vhashes, vh...)
-		blobs += uint(len(vh))
+		vh, ok := vhashesOf[tx.Hash]
+		if ok {
+			vhashes = append(vhashes, vh...)
+			blobs += uint(len(vh))
+		}
 		order.Shift()
 	}
 	return vhashes

--- a/core/txpool/blobpool/cache.go
+++ b/core/txpool/blobpool/cache.go
@@ -157,6 +157,7 @@ func (c *Cache) GetBlobs(ctx context.Context, vhashes []common.Hash, version byt
 
 		indices = make(map[common.Hash][]int)
 		filled  = make(map[common.Hash]struct{})
+		misses  []common.Hash
 
 		cacheHits int64
 		cacheMiss int64
@@ -167,66 +168,43 @@ func (c *Cache) GetBlobs(ctx context.Context, vhashes []common.Hash, version byt
 
 	for _, vhash := range vhashes {
 		if _, ok := filled[vhash]; ok {
-			// Skip vhash that was already resolved in a previous iteration
 			continue
 		}
+		filled[vhash] = struct{}{}
+
 		c.mu.Lock()
 		cached := c.entries[vhash]
 		c.mu.Unlock()
 
-		if cached != nil {
-			cacheHits++
-			filled[vhash] = struct{}{}
-			if cached.version != version {
+		if cached == nil {
+			cacheMiss++
+			misses = append(misses, vhash)
+			continue
+		}
+		cacheHits++
+		if cached.version != version {
+			continue
+		}
+		for _, index := range indices[vhash] {
+			blobs[index] = cached.blob
+			commitments[index] = cached.commitment
+			proofs[index] = cached.proofs
+		}
+	}
+
+	if len(misses) > 0 {
+		mb, mc, mp, err := c.blobpool.GetBlobs(misses, version)
+		if err != nil {
+			return nil, nil, nil, err
+		}
+		for j, vhash := range misses {
+			if mb[j] == nil {
 				continue
 			}
 			for _, index := range indices[vhash] {
-				blobs[index] = cached.blob
-				commitments[index] = cached.commitment
-				proofs[index] = cached.proofs
-			}
-			continue
-		}
-
-		cacheMiss++
-		ptx := c.blobpool.getByVhash(vhash)
-		if ptx == nil {
-			continue
-		}
-		sidecar := ptx.Sidecar()
-		if sidecar == nil {
-			continue
-		}
-
-		for i, hash := range sidecar.BlobHashes() {
-			list, ok := indices[hash]
-			if !ok {
-				continue
-			}
-			// Mark hash as seen.
-			filled[hash] = struct{}{}
-			if sidecar.Version != version {
-				// Skip blobs with incompatible version. Note we still track the blob hash
-				// in `filled` here, ensuring that we do not resolve this tx another time.
-				continue
-			}
-			// Get or convert the proof.
-			var pf []kzg4844.Proof
-			switch version {
-			case types.BlobSidecarVersion0:
-				pf = []kzg4844.Proof{sidecar.Proofs[i]}
-			case types.BlobSidecarVersion1:
-				cellProofs, err := sidecar.CellProofsAt(i)
-				if err != nil {
-					log.Error("Failed to get cell proofs", "txhash", ptx.Tx.Hash(), "err", err)
-					continue
-				}
-				pf = cellProofs
-			}
-			for _, index := range list {
-				blobs[index] = &sidecar.Blobs[i]
-				commitments[index] = sidecar.Commitments[i]
-				proofs[index] = pf
+				blobs[index] = mb[j]
+				commitments[index] = mc[j]
+				proofs[index] = mp[j]
 			}
 		}
 	}

--- a/core/txpool/blobpool/cache.go
+++ b/core/txpool/blobpool/cache.go
@@ -81,7 +81,6 @@ type Cache struct {
 	blobpool *BlobPool
 
 	hasBlobs chan []common.Hash // List of tx hashes that need to be pinned
-	getBlobs chan struct{}
 
 	cancelInflights context.CancelFunc // Cancel the in-flight conversion/decode goroutines
 	inflight        sync.WaitGroup     // Tracks the in-flight conversion/decode goroutines
@@ -108,7 +107,6 @@ func NewCacheForTest(p *BlobPool, clock mclock.Clock, step func()) *Cache {
 		entries:     make(map[common.Hash]*cachedBlob),
 		blobpool:    p,
 		hasBlobs:    make(chan []common.Hash, 1),
-		getBlobs:    make(chan struct{}, 1),
 		clock:       clock,
 		step:        step,
 		quit:        make(chan struct{}),

--- a/core/txpool/blobpool/cache.go
+++ b/core/txpool/blobpool/cache.go
@@ -68,25 +68,23 @@ type cachedBlob struct {
 // drop the transaction in the window between the engine API response and the cache
 // update.)
 type Cache struct {
-	mu sync.Mutex
-
-	entries map[common.Hash]*cachedBlob // Mapping from vhash to cachedBlob
-
 	blobpool *BlobPool
+	clock    mclock.Clock
 
-	cancelInflights context.CancelFunc // Cancel the in-flight conversion/decode goroutines
-	inflight        sync.WaitGroup     // Tracks the in-flight conversion/decode goroutines
-	wg              sync.WaitGroup     // Tracks the loop goroutine
-
-	clock mclock.Clock
-
-	step func() // test hook fired after each loop iteration
+	mu      sync.Mutex
+	entries map[common.Hash]*cachedBlob
 
 	// channels into loop
 	quit        chan struct{}
 	topkRequest chan struct{}
 	topkTimer   mclock.Timer
 	hasBlobsCh  chan []common.Hash // list of tx hashes that should be pinned
+
+	step func() // test hook fired after each loop iteration
+
+	cancelInflights context.CancelFunc // cancels the conversion/decode goroutines
+	inflight        sync.WaitGroup     // tracks all in-flight conversion/decode goroutines
+	wg              sync.WaitGroup     // tracks the loop goroutine
 }
 
 // NewCache creates a blob cache backed by the given blobpool.

--- a/core/txpool/blobpool/cache.go
+++ b/core/txpool/blobpool/cache.go
@@ -80,8 +80,6 @@ type Cache struct {
 
 	blobpool *BlobPool
 
-	hasBlobs chan []common.Hash // List of tx hashes that need to be pinned
-
 	cancelInflights context.CancelFunc // Cancel the in-flight conversion/decode goroutines
 	inflight        sync.WaitGroup     // Tracks the in-flight conversion/decode goroutines
 	wg              sync.WaitGroup     // Tracks the loop goroutine
@@ -90,9 +88,11 @@ type Cache struct {
 
 	step func() // test hook fired after each loop iteration
 
+	// channels into loop
 	quit        chan struct{}
 	topkRequest chan struct{}
 	topkTimer   mclock.Timer
+	hasBlobsCh  chan []common.Hash // list of tx hashes that should be pinned
 }
 
 // NewCache creates a blob cache backed by the given blobpool.
@@ -106,7 +106,7 @@ func NewCacheForTest(p *BlobPool, clock mclock.Clock, step func()) *Cache {
 	c := &Cache{
 		entries:     make(map[common.Hash]*cachedBlob),
 		blobpool:    p,
-		hasBlobs:    make(chan []common.Hash, 1),
+		hasBlobsCh:  make(chan []common.Hash, 1),
 		clock:       clock,
 		step:        step,
 		quit:        make(chan struct{}),
@@ -160,7 +160,7 @@ func (c *Cache) HasBlobs(ctx context.Context, vhashes []common.Hash) []bool {
 	}
 
 	select {
-	case c.hasBlobs <- needPin:
+	case c.hasBlobsCh <- needPin:
 		// Note that we also send the ones we already have in cache,
 		// since it can be dropped from the cache before this signal is processed.
 		return available
@@ -255,10 +255,9 @@ func (c *Cache) loop() {
 	c.triggerTopK()
 	for {
 		select {
-		case want := <-c.hasBlobs:
+		case want := <-c.hasBlobsCh:
 			// HasBlobs request was received.
-			// Update the cache once with the requested blobs,
-			// then go back to regular topK updates.
+			// Update the cache once with the requested blobs, then reschedule topK.
 			c.update(want)
 			c.triggerTopKAfter(hasBlobsTimeout)
 

--- a/core/txpool/blobpool/cache.go
+++ b/core/txpool/blobpool/cache.go
@@ -89,12 +89,12 @@ type Cache struct {
 
 // NewCache creates a blob cache backed by the given blobpool.
 func NewCache(p *BlobPool) *Cache {
-	return NewCacheForTest(p, mclock.System{}, nil)
+	return newCache(p, mclock.System{}, nil)
 }
 
-// NewCacheForTest creates a blob cache for test.
+// newCache creates a blob cache for testing purposes.
 // It allows injecting a clock and a step hook.
-func NewCacheForTest(p *BlobPool, clock mclock.Clock, step func()) *Cache {
+func newCache(p *BlobPool, clock mclock.Clock, step func()) *Cache {
 	c := &Cache{
 		entries:     make(map[common.Hash]*cachedBlob),
 		blobpool:    p,

--- a/core/txpool/blobpool/cache.go
+++ b/core/txpool/blobpool/cache.go
@@ -60,19 +60,13 @@ type cachedBlob struct {
 
 // Cache holds the blobs that are likely to be requested by the GetBlobs engine API.
 //
-// Currently it operates in two modes
-//   - HasBlobsMode is triggered by the HasBlobs engine API. This stage ends
-//     when `hasBlobsTimeout` elapses or the GetBlobs engine API consumes
-//     the result.
-//     (Note: the cache is not guaranteed to always hold such blobs, since the
-//     blobpool might drop the transaction in the window between the engine API
-//     response and the cache update.)
-//   - TopKMode is the cache's default mode. Every `topKTimeout`, the cache selects
-//     the blobs of the top K most profitable transactions, unless it is in the other mode.
-//     Whenever HasBlobsMode is canceled, it falls back to TopKMode.
+// Every `topKTimeout`, the cache selects the blobs of the top K most profitable
+// transactions, and preloads them into the cache.
 //
-// Whenever the mode is changed, the goroutines (for cache update) started by
-// each mode should be canceled to prevent redundant computation.
+// For HasBlobs requests, it also causes the blobs requested by the CL to be loaded.
+// (Note: the cache is not guaranteed to always hold such blobs, since the blobpool might
+// drop the transaction in the window between the engine API response and the cache
+// update.)
 type Cache struct {
 	mu sync.Mutex
 

--- a/core/txpool/blobpool/cache.go
+++ b/core/txpool/blobpool/cache.go
@@ -424,9 +424,15 @@ func (c *Cache) selectTopTxs() []common.Hash {
 	return vhashes
 }
 
+// triggerTopKAfter makes a topK selection happen after the given interval.
 func (c *Cache) triggerTopKAfter(interval time.Duration) {
 	if c.topkTimer != nil {
 		c.topkTimer.Stop()
+	}
+	// drain current request to avoid triggering before the interval
+	select {
+	case <-c.topkRequest:
+	default:
 	}
 	c.topkTimer = c.clock.AfterFunc(interval, c.triggerTopK)
 }

--- a/core/txpool/blobpool/cache.go
+++ b/core/txpool/blobpool/cache.go
@@ -29,6 +29,7 @@ import (
 	"github.com/ethereum/go-ethereum/core/txpool/txorder"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/crypto/kzg4844"
+	"github.com/ethereum/go-ethereum/internal/telemetry"
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/metrics"
 	"github.com/holiman/uint256"
@@ -136,7 +137,7 @@ func (c *Cache) HasBlobs(ctx context.Context, vhashes []common.Hash) []bool {
 	c.mu.Unlock()
 
 	if len(missVhashes) > 0 {
-		pooled := c.blobpool.AvailableBlobs(missVhashes)
+		pooled := c.blobpool.availableBlobs(missVhashes)
 		for j, ok := range pooled {
 			if ok {
 				available[missIdx[j]] = true
@@ -154,6 +155,8 @@ func (c *Cache) HasBlobs(ctx context.Context, vhashes []common.Hash) []bool {
 }
 
 func (c *Cache) GetBlobs(ctx context.Context, vhashes []common.Hash, version byte) (_ []*kzg4844.Blob, _ []kzg4844.Commitment, _ [][]kzg4844.Proof, err error) {
+	_, span, spanEnd := telemetry.StartSpan(ctx, "blobpool.GetBlobs")
+	defer spanEnd(&err)
 	var (
 		blobs       = make([]*kzg4844.Blob, len(vhashes))
 		commitments = make([]kzg4844.Commitment, len(vhashes))
@@ -163,8 +166,8 @@ func (c *Cache) GetBlobs(ctx context.Context, vhashes []common.Hash, version byt
 		filled  = make(map[common.Hash]struct{})
 		misses  []common.Hash
 
-		cacheHits int64
-		cacheMiss int64
+		cacheHits int
+		cacheMiss int
 	)
 	for i, h := range vhashes {
 		indices[h] = append(indices[h], i)
@@ -197,7 +200,7 @@ func (c *Cache) GetBlobs(ctx context.Context, vhashes []common.Hash, version byt
 	}
 
 	if len(misses) > 0 {
-		mb, mc, mp, err := c.blobpool.GetBlobs(ctx, misses, version)
+		mb, mc, mp, err := c.blobpool.getBlobs(misses, version)
 		if err != nil {
 			return nil, nil, nil, err
 		}
@@ -212,8 +215,12 @@ func (c *Cache) GetBlobs(ctx context.Context, vhashes []common.Hash, version byt
 			}
 		}
 	}
-	cacheHitMeter.Mark(cacheHits)
-	cacheMissMeter.Mark(cacheMiss)
+	cacheHitMeter.Mark(int64(cacheHits))
+	cacheMissMeter.Mark(int64(cacheMiss))
+	span.SetAttributes(
+		telemetry.IntAttribute("cache.hit", cacheHits),
+		telemetry.IntAttribute("cache.miss", cacheMiss),
+	)
 
 	select {
 	case c.getBlobs <- struct{}{}:

--- a/core/txpool/blobpool/cache.go
+++ b/core/txpool/blobpool/cache.go
@@ -35,17 +35,6 @@ import (
 	"github.com/holiman/uint256"
 )
 
-type cacheMode int
-
-const (
-	// In hasBlobsMode, the cache keeps the blobs that it reported
-	// as available in a HasBlobs response.
-	hasBlobsMode cacheMode = iota
-	// In topKMode, the cache fills itself with the blobs of the top K
-	// most profitable transactions.
-	topKMode
-)
-
 const (
 	topKTimeout     = 4 * time.Second
 	hasBlobsTimeout = 1 * time.Second
@@ -94,8 +83,6 @@ type Cache struct {
 	hasBlobs chan []common.Hash // List of tx hashes that need to be pinned
 	getBlobs chan struct{}
 
-	mode cacheMode
-
 	cancelInflights context.CancelFunc // Cancel the in-flight conversion/decode goroutines
 	inflight        sync.WaitGroup     // Tracks the in-flight conversion/decode goroutines
 	wg              sync.WaitGroup     // Tracks the loop goroutine
@@ -104,7 +91,9 @@ type Cache struct {
 
 	step func() // test hook fired after each loop iteration
 
-	quit chan struct{}
+	quit        chan struct{}
+	topkRequest chan struct{}
+	topkTimer   mclock.Timer
 }
 
 // NewCache creates a blob cache backed by the given blobpool.
@@ -116,17 +105,14 @@ func NewCache(p *BlobPool) *Cache {
 // It allows injecting a clock and a step hook.
 func NewCacheForTest(p *BlobPool, clock mclock.Clock, step func()) *Cache {
 	c := &Cache{
-		entries:  make(map[common.Hash]*cachedBlob),
-		blobpool: p,
-		hasBlobs: make(chan []common.Hash, 1),
-		getBlobs: make(chan struct{}, 1),
-
-		mode:  topKMode,
-		clock: clock,
-
-		step: step,
-
-		quit: make(chan struct{}),
+		entries:     make(map[common.Hash]*cachedBlob),
+		blobpool:    p,
+		hasBlobs:    make(chan []common.Hash, 1),
+		getBlobs:    make(chan struct{}, 1),
+		clock:       clock,
+		step:        step,
+		quit:        make(chan struct{}),
+		topkRequest: make(chan struct{}, 1),
 	}
 
 	c.wg.Add(1)
@@ -262,63 +248,29 @@ func (c *Cache) GetBlobs(ctx context.Context, vhashes []common.Hash, version byt
 		telemetry.IntAttribute("cache.miss", cacheMiss),
 	)
 
-	select {
-	case c.getBlobs <- struct{}{}:
-		return blobs, commitments, proofs, nil
-	case <-c.quit:
-		return nil, nil, nil, nil
-	}
+	return blobs, commitments, proofs, nil
 }
 
 func (c *Cache) loop() {
 	defer c.wg.Done()
-	var (
-		topKTimer   = new(mclock.Timer)
-		topKTrigger = make(chan struct{}, 1)
-		hbTimer     = new(mclock.Timer)
-		hbTrigger   = make(chan struct{}, 1)
-	)
-	c.resetTimer(topKTimer, topKTrigger, topKTimeout)
 
+	c.triggerTopK()
 	for {
 		select {
 		case want := <-c.hasBlobs:
-			// switch to hasBlobs
-			c.switchMode(hasBlobsMode)
+			// HasBlobs request was received.
+			// Update the cache once with the requested blobs,
+			// then go back to regular topK updates.
 			c.update(want)
-			c.resetTimer(hbTimer, hbTrigger, hasBlobsTimeout)
+			c.triggerTopKAfter(hasBlobsTimeout)
 
-		case <-topKTrigger:
-			// switch to topK
-			if c.mode != topKMode {
-				continue
-			}
+		case <-c.topkRequest:
 			want := c.selectTopTxs()
 			c.update(want)
-			c.resetTimer(topKTimer, topKTrigger, topKTimeout)
+			c.triggerTopKAfter(topKTimeout)
 
-		case <-hbTrigger:
-			// hasBlobs mode is over - switch to topK
-			c.switchMode(topKMode)
-			want := c.selectTopTxs()
-			c.update(want)
-			c.resetTimer(topKTimer, topKTrigger, topKTimeout)
-
-		case <-c.getBlobs:
-			// hasBlobs mode is over -  switch to topK
-			if c.mode != hasBlobsMode {
-				continue
-			}
-			c.switchMode(topKMode)
-			want := c.selectTopTxs()
-			c.update(want)
-			c.resetTimer(topKTimer, topKTrigger, topKTimeout)
 		case <-c.quit:
-			c.mu.Lock()
-			if c.cancelInflights != nil {
-				c.cancelInflights()
-			}
-			c.mu.Unlock()
+			c.cancelUpdate()
 			c.inflight.Wait()
 			return
 		}
@@ -329,11 +281,8 @@ func (c *Cache) loop() {
 	}
 }
 
-// switchMode sets the cache mode and cancels any in-flight update from the
-// previous mode.
-func (c *Cache) switchMode(mode cacheMode) {
-	c.mode = mode
-
+// cancelUpdate stops the current update.
+func (c *Cache) cancelUpdate() {
 	if c.cancelInflights != nil {
 		c.cancelInflights()
 		c.cancelInflights = nil
@@ -349,20 +298,18 @@ func (c *Cache) update(want []common.Hash) {
 		wantSet[vh] = struct{}{}
 	}
 
-	c.mu.Lock()
-	if c.cancelInflights != nil {
-		c.cancelInflights()
-	}
+	// Cancel the current updates.
+	c.cancelUpdate()
 	ctx, cancel := context.WithCancel(context.Background())
 	c.cancelInflights = cancel
 
+	c.mu.Lock()
 	var missing []common.Hash
 	for vh := range wantSet {
 		if _, ok := c.entries[vh]; !ok {
 			missing = append(missing, vh)
 		}
 	}
-
 	for vh := range c.entries {
 		if _, ok := wantSet[vh]; ok {
 			continue
@@ -402,7 +349,7 @@ func (c *Cache) update(want []common.Hash) {
 					continue
 				}
 				if _, exists := c.entries[v]; exists {
-					continue
+					continue // recompute only new entries
 				}
 				var pf []kzg4844.Proof
 				switch sidecar.Version {
@@ -480,13 +427,18 @@ func (c *Cache) selectTopTxs() []common.Hash {
 	return vhashes
 }
 
-// resetTimer sets the given timer to fire on the trigger channel after the
-// interval.
-func (c *Cache) resetTimer(timer *mclock.Timer, trigger chan struct{}, interval time.Duration) {
-	if *timer != nil {
-		(*timer).Stop()
+func (c *Cache) triggerTopKAfter(interval time.Duration) {
+	if c.topkTimer != nil {
+		c.topkTimer.Stop()
 	}
-	*timer = c.clock.AfterFunc(interval, func() {
-		trigger <- struct{}{}
-	})
+	c.topkTimer = c.clock.AfterFunc(interval, c.triggerTopK)
+}
+
+// triggerTopK causes another topK selection to happen.
+// Note this is safe to call from anywhere, even outside of the loop goroutine.
+func (c *Cache) triggerTopK() {
+	select {
+	case c.topkRequest <- struct{}{}:
+	default:
+	}
 }

--- a/core/txpool/blobpool/cache.go
+++ b/core/txpool/blobpool/cache.go
@@ -268,6 +268,9 @@ func (c *Cache) loop() {
 
 		case <-c.quit:
 			c.cancelUpdate()
+			if c.topkTimer != nil {
+				c.topkTimer.Stop()
+			}
 			c.inflight.Wait()
 			return
 		}

--- a/core/txpool/blobpool/cache.go
+++ b/core/txpool/blobpool/cache.go
@@ -18,16 +18,20 @@ package blobpool
 
 import (
 	"context"
-	"sort"
 	"sync"
 	"time"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/mclock"
+	"github.com/ethereum/go-ethereum/consensus/misc/eip1559"
+	"github.com/ethereum/go-ethereum/consensus/misc/eip4844"
+	"github.com/ethereum/go-ethereum/core/txpool"
+	"github.com/ethereum/go-ethereum/core/txpool/txorder"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/crypto/kzg4844"
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/metrics"
+	"github.com/holiman/uint256"
 )
 
 type cacheMode int
@@ -242,13 +246,13 @@ func (c *Cache) loop() {
 				}
 				continue
 			}
-			want := selectTxs(c.blobpool.indexSnapshot(), c.capacity)
+			want := c.selectKTxs()
 			c.update(want)
 			c.resetTimer(topKTimer, topKTrigger, topKTimeout)
 
 		case <-hbTrigger:
 			c.switchMode(topKMode)
-			want := selectTxs(c.blobpool.indexSnapshot(), c.capacity)
+			want := c.selectKTxs()
 			c.update(want)
 			c.resetTimer(topKTimer, topKTrigger, topKTimeout)
 
@@ -260,7 +264,7 @@ func (c *Cache) loop() {
 				continue
 			}
 			c.switchMode(topKMode)
-			want := selectTxs(c.blobpool.indexSnapshot(), c.capacity)
+			want := c.selectKTxs()
 			c.update(want)
 			c.resetTimer(topKTimer, topKTrigger, topKTimeout)
 		case <-c.quit:
@@ -370,6 +374,49 @@ func (c *Cache) update(want []common.Hash) {
 	}()
 }
 
+func (c *Cache) selectKTxs() []common.Hash {
+	p := c.blobpool
+	head := p.head.Load()
+	if head == nil {
+		return nil
+	}
+	config := p.chain.Config()
+	baseFee := eip1559.CalcBaseFee(config, head)
+
+	filter := txpool.PendingFilter{
+		BlobTxs: true,
+		BaseFee: uint256.MustFromBig(baseFee),
+	}
+	if head.ExcessBlobGas != nil {
+		filter.BlobFee = uint256.MustFromBig(eip4844.CalcBlobFee(config, head))
+	}
+	if config.IsOsaka(head.Number, head.Time) {
+		filter.BlobVersion = types.BlobSidecarVersion1
+	} else {
+		filter.BlobVersion = types.BlobSidecarVersion0
+	}
+	pending, _ := p.Pending(filter)
+	vhashesOf := p.vhashesByTx()
+
+	order := txorder.NewTransactionsByPriceAndNonce(p.signer, pending, baseFee)
+
+	var (
+		vhashes []common.Hash
+		blobs   uint
+	)
+	for blobs < c.capacity {
+		tx, _ := order.Peek()
+		if tx == nil {
+			break
+		}
+		vh := vhashesOf[tx.Hash]
+		vhashes = append(vhashes, vh...)
+		blobs += uint(len(vh))
+		order.Shift()
+	}
+	return vhashes
+}
+
 func (c *Cache) resetTimer(timer *mclock.Timer, trigger chan struct{}, interval time.Duration) {
 	if *timer != nil {
 		(*timer).Stop()
@@ -377,24 +424,4 @@ func (c *Cache) resetTimer(timer *mclock.Timer, trigger chan struct{}, interval 
 	*timer = c.clock.AfterFunc(interval, func() {
 		trigger <- struct{}{}
 	})
-}
-
-// selectTxs returns the versioned hashes of the k blob transactions most
-// likely to be included in upcoming blocks, sorted by execution tip cap and
-// flattened across each picked tx's blobs.
-func selectTxs(snapshot []txDigest, k uint) []common.Hash {
-	if k <= 0 {
-		return nil
-	}
-	sort.Slice(snapshot, func(i, j int) bool {
-		return snapshot[i].tip.Gt(snapshot[j].tip)
-	})
-	if len(snapshot) > int(k) {
-		snapshot = snapshot[:k]
-	}
-	var vhashes []common.Hash
-	for _, d := range snapshot {
-		vhashes = append(vhashes, d.vhashes...)
-	}
-	return vhashes
 }

--- a/core/txpool/blobpool/cache.go
+++ b/core/txpool/blobpool/cache.go
@@ -1,0 +1,179 @@
+// Copyright 2026 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+
+package blobpool
+
+import (
+	"container/heap"
+	"sync"
+
+	"github.com/ethereum/go-ethereum/log"
+	"github.com/ethereum/go-ethereum/rlp"
+	"github.com/holiman/billy"
+	"github.com/holiman/uint256"
+)
+
+// cacheEntry is a blob transaction stored in the cache.
+type cacheEntry struct {
+	ptx   *blobTxForPool
+	tip   *uint256.Int // priority key
+	txID  uint64       // store id
+	index int          // position in priorityQueue
+}
+
+// priorityQueue is a min heap of cacheEntries, ordered by tip.
+type priorityQueue []*cacheEntry
+
+func (pq priorityQueue) Len() int {
+	return len(pq)
+}
+
+func (pq priorityQueue) Less(i, j int) bool {
+	return pq[i].tip.Lt(pq[j].tip)
+}
+
+func (pq priorityQueue) Swap(i, j int) {
+	pq[i], pq[j] = pq[j], pq[i]
+	pq[i].index = i
+	pq[j].index = j
+}
+func (pq *priorityQueue) Push(x any) {
+	e := x.(*cacheEntry)
+	e.index = len(*pq)
+	*pq = append(*pq, e)
+}
+func (pq *priorityQueue) Pop() any {
+	old := *pq
+	n := len(old)
+	e := old[n-1]
+	old[n-1] = nil
+	e.index = -1
+	*pq = old[:n-1]
+	return e
+}
+
+// cache has blob transactions ordered by execution tip.
+type cache struct {
+	mu       sync.Mutex
+	entries  map[uint64]*cacheEntry // store id -> cache entry
+	pq       priorityQueue
+	capacity int
+	store    billy.Database
+}
+
+func newCache(store billy.Database, capacity int) *cache {
+	return &cache{
+		entries:  make(map[uint64]*cacheEntry, capacity),
+		pq:       make(priorityQueue, 0, capacity),
+		capacity: capacity,
+		store:    store,
+	}
+}
+
+// get returns the cached decoded transaction for the given storage id, if any.
+func (c *cache) get(id uint64) *blobTxForPool {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	e, ok := c.entries[id]
+	if !ok {
+		return nil
+	}
+	return e.ptx
+}
+
+type addedTx struct {
+	id  uint64
+	ptx *blobTxForPool
+}
+
+// update applies a batch of additions and deletions in blobpool.
+// Each addition is inserted only if it is more expansive than the
+// lowest-tip tx or there is enough capacity.
+func (c *cache) update(added []*addedTx, deleted []uint64) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	for _, id := range deleted {
+		e, ok := c.entries[id]
+		if !ok {
+			continue
+		}
+		heap.Remove(&c.pq, e.index)
+		delete(c.entries, id)
+	}
+	for _, tx := range added {
+		if _, exists := c.entries[tx.id]; exists {
+			continue
+		}
+		tip := uint256.MustFromBig(tx.ptx.Tx.GasTipCap())
+		if len(c.entries) >= c.capacity {
+			if !tip.Gt(c.pq[0].tip) {
+				continue
+			}
+			evicted := heap.Pop(&c.pq).(*cacheEntry)
+			delete(c.entries, evicted.txID)
+		}
+		e := &cacheEntry{
+			ptx:  tx.ptx,
+			tip:  tip,
+			txID: tx.id,
+		}
+		c.entries[tx.id] = e
+		heap.Push(&c.pq, e)
+	}
+	cacheEntriesGauge.Update(int64(len(c.entries)))
+}
+
+// reset rebuilds the cache with the given wanted ids by computing the
+// diff against the current entries.
+func (c *cache) reset(wanted []uint64) {
+	wantedSet := make(map[uint64]struct{}, len(wanted))
+	for _, id := range wanted {
+		wantedSet[id] = struct{}{}
+	}
+
+	c.mu.Lock()
+	var toDelete []uint64
+	for id := range c.entries {
+		if _, ok := wantedSet[id]; !ok {
+			toDelete = append(toDelete, id)
+		}
+	}
+	var toLoad []uint64
+	for _, id := range wanted {
+		if _, ok := c.entries[id]; !ok {
+			toLoad = append(toLoad, id)
+		}
+	}
+	c.mu.Unlock()
+
+	var toAdd []*addedTx
+	for _, id := range toLoad {
+		data, err := c.store.Get(id)
+		if err != nil {
+			log.Trace("Cache load skipped missing blob tx", "id", id, "err", err)
+			continue
+		}
+		var ptx blobTxForPool
+		if err := rlp.DecodeBytes(data, &ptx); err != nil {
+			log.Error("Cache load failed to decode blob tx", "id", id, "err", err)
+			continue
+		}
+		toAdd = append(toAdd, &addedTx{id: id, ptx: &ptx})
+	}
+
+	c.update(toAdd, toDelete)
+}

--- a/core/txpool/blobpool/cache.go
+++ b/core/txpool/blobpool/cache.go
@@ -42,7 +42,7 @@ const (
 )
 
 const (
-	topKTimeout     = 1 * time.Second
+	topKTimeout     = 4 * time.Second
 	hasBlobsTimeout = 1 * time.Second
 )
 
@@ -197,7 +197,7 @@ func (c *Cache) GetBlobs(ctx context.Context, vhashes []common.Hash, version byt
 	}
 
 	if len(misses) > 0 {
-		mb, mc, mp, err := c.blobpool.GetBlobs(misses, version)
+		mb, mc, mp, err := c.blobpool.GetBlobs(ctx, misses, version)
 		if err != nil {
 			return nil, nil, nil, err
 		}

--- a/core/txpool/blobpool/cache.go
+++ b/core/txpool/blobpool/cache.go
@@ -401,6 +401,9 @@ func (c *Cache) update(want []common.Hash) {
 				if _, ok := wantSet[v]; !ok {
 					continue
 				}
+				if _, exists := c.entries[v]; exists {
+					continue
+				}
 				var pf []kzg4844.Proof
 				switch sidecar.Version {
 				case types.BlobSidecarVersion0:

--- a/core/txpool/blobpool/cache_test.go
+++ b/core/txpool/blobpool/cache_test.go
@@ -92,8 +92,14 @@ func newTestCache(t *testing.T, txConfig []txSpec, capacity uint) *testCache {
 		LondonBlock: big.NewInt(0),
 		BerlinBlock: big.NewInt(0),
 		CancunTime:  &cancunTime,
+		OsakaTime:   &cancunTime,
 		BlobScheduleConfig: &params.BlobScheduleConfig{
 			Cancun: &params.BlobConfig{
+				Target:         12,
+				Max:            24,
+				UpdateFraction: params.DefaultCancunBlobConfig.UpdateFraction,
+			},
+			Osaka: &params.BlobConfig{
 				Target:         12,
 				Max:            24,
 				UpdateFraction: params.DefaultCancunBlobConfig.UpdateFraction,

--- a/core/txpool/blobpool/cache_test.go
+++ b/core/txpool/blobpool/cache_test.go
@@ -51,8 +51,8 @@ type testCache struct {
 }
 
 // newTestCache creates a cache for test, with a pool that contains transactions
-// specified in txConfig. The returned cache is in topKMode with the initial
-// topK fetch already settled.
+// specified in txConfig. The returned cache has the initial topK fetch already
+// settled.
 func newTestCache(t *testing.T, txConfig []txSpec) *testCache {
 	storage := t.TempDir()
 	if err := os.MkdirAll(filepath.Join(storage, pendingTransactionStore), 0700); err != nil {
@@ -130,10 +130,11 @@ func newTestCache(t *testing.T, txConfig []txSpec) *testCache {
 		vhashes: vhashes,
 		offset:  offset,
 	}
-	// Block until the loop has armed its initial topK timer, then fire it so the
-	// returned cache is already in a stable topKMode-loaded state.
+	// The loop performs the initial topK update immediately on startup and then
+	// arms the topK timer. Wait for the timer so we know the initial update has
+	// been issued, then let it settle.
 	clock.WaitForTimers(1)
-	tc.wait(t, topKTimeout)
+	tc.wait(t, 0)
 	return tc
 }
 
@@ -180,16 +181,6 @@ func (tc *testCache) wait(t *testing.T, d time.Duration) {
 	}
 }
 
-func (tc *testCache) expectMode(t *testing.T, want cacheMode) {
-	t.Helper()
-	tc.mu.Lock()
-	have := tc.mode
-	tc.mu.Unlock()
-	if have != want {
-		t.Errorf("mode: got %d, want %d", have, want)
-	}
-}
-
 func (tc *testCache) expectEntries(t *testing.T, want ...common.Hash) {
 	t.Helper()
 	wantSet := make(map[common.Hash]struct{}, len(want))
@@ -216,10 +207,9 @@ func hashSet(m map[common.Hash]struct{}) []string {
 	return out
 }
 
-// TestCacheHasBlobsLoadsClaimedSet checks that a HasBlobs request switches the
-// cache into hasBlobsMode and loads exactly the txs whose vhashes the cache
-// claimed available, regardless of whether the claim came from the cache
-// itself or from the pool fallback.
+// TestCacheHasBlobsLoadsClaimedSet checks that a HasBlobs request loads
+// exactly the txs whose vhashes the cache claimed available, regardless of
+// whether the claim came from the cache itself or from the pool fallback.
 func TestCacheHasBlobsLoadsClaimedSet(t *testing.T) {
 	tc := newTestCache(t, []txSpec{
 		{blobs: 2, tip: 100},
@@ -233,13 +223,11 @@ func TestCacheHasBlobsLoadsClaimedSet(t *testing.T) {
 	}
 	tc.wait(t, 0)
 
-	tc.expectMode(t, hasBlobsMode)
 	tc.expectEntries(t, tc.vhashes[1]...)
 }
 
-// TestCacheTopK exercises the periodic topK signal: after the initial topK
-// settles in newTestCache, the cache is in topKMode with entries equal to the
-// top-by-tip txs.
+// TestCacheTopK exercises the initial topK update: after it settles in
+// newTestCache, the cache entries equal the top-by-tip txs.
 func TestCacheTopK(t *testing.T) {
 	tc := newTestCache(t, []txSpec{
 		{blobs: 1, tip: 100},
@@ -247,13 +235,12 @@ func TestCacheTopK(t *testing.T) {
 		{blobs: 1, tip: 300},
 	})
 
-	tc.expectMode(t, topKMode)
 	tc.expectEntries(t, tc.vhashes[2]...)
 }
 
-// TestCacheHbTimerFallsBackToTopK checks the idle-timeout transition: after a
-// HasBlobs request, an elapsing hasBlobsTimeout flips the cache back to
-// topKMode and replaces the entries with the topK set.
+// TestCacheHbTimerFallsBackToTopK checks the fallback after a HasBlobs
+// request: when hasBlobsTimeout elapses, a topK update replaces the entries
+// with the topK set.
 func TestCacheHbTimerFallsBackToTopK(t *testing.T) {
 	tc := newTestCache(t, []txSpec{
 		{blobs: 1, tip: 100},
@@ -262,68 +249,49 @@ func TestCacheHbTimerFallsBackToTopK(t *testing.T) {
 
 	tc.HasBlobs(context.Background(), tc.vhashes[0])
 	tc.wait(t, 0)
-	tc.expectMode(t, hasBlobsMode)
 	tc.expectEntries(t, tc.vhashes[0]...)
 
 	tc.wait(t, hasBlobsTimeout)
-	tc.expectMode(t, topKMode)
 	tc.expectEntries(t, tc.vhashes[1]...)
 }
 
-// TestCacheGetBlobsExitsHasBlobsMode checks that a GetBlobs call while in
-// hasBlobsMode flips the cache back to topKMode and reloads the topK set.
-func TestCacheGetBlobsExitsHasBlobsMode(t *testing.T) {
+// TestCacheGetBlobs checks that GetBlobs returns the requested blobs and does
+// not disturb the cached entries.
+func TestCacheGetBlobs(t *testing.T) {
 	tc := newTestCache(t, []txSpec{
 		{blobs: 1, tip: 100},
 		{blobs: 1, tip: 300},
 	})
-
-	tc.HasBlobs(context.Background(), tc.vhashes[0])
-	tc.wait(t, 0)
-	tc.expectMode(t, hasBlobsMode)
-	tc.expectEntries(t, tc.vhashes[0]...)
-
-	tc.GetBlobs(context.Background(), tc.vhashes[0], types.BlobSidecarVersion1)
-	tc.wait(t, 0)
-	tc.expectMode(t, topKMode)
-	tc.expectEntries(t, tc.vhashes[1]...)
-}
-
-// TestCacheTopKResetOnHasBlobs walks the cache through topK → hasBlobs → topK
-// transitions and checks that the entries follow the active mode at each step.
-func TestCacheTopKResetOnHasBlobs(t *testing.T) {
-	tc := newTestCache(t, []txSpec{
-		{blobs: 1, tip: 100},
-		{blobs: 1, tip: 300},
-	})
-	tc.expectMode(t, topKMode)
 	tc.expectEntries(t, tc.vhashes[1]...)
 
-	tc.HasBlobs(context.Background(), tc.vhashes[0])
+	blobs, _, proofs, err := tc.GetBlobs(context.Background(), tc.vhashes[1], types.BlobSidecarVersion1)
+	if err != nil {
+		t.Fatalf("GetBlobs: %v", err)
+	}
+	for i := range blobs {
+		if blobs[i] == nil {
+			t.Errorf("blob %d missing in GetBlobs response", i)
+		}
+		if len(proofs[i]) == 0 {
+			t.Errorf("proofs %d missing in GetBlobs response", i)
+		}
+	}
 	tc.wait(t, 0)
-	tc.expectMode(t, hasBlobsMode)
-	tc.expectEntries(t, tc.vhashes[0]...)
-
-	tc.wait(t, hasBlobsTimeout)
-	tc.expectMode(t, topKMode)
 	tc.expectEntries(t, tc.vhashes[1]...)
 }
 
 // TestCacheTopKRefresh verifies that when a more profitable tx appears in the
-// pool while the cache is in topKMode, the next topK tick replaces the cached
-// entry with the better one.
+// pool, the next topK tick replaces the cached entry with the better one.
 func TestCacheTopKRefresh(t *testing.T) {
 	tc := newTestCache(t, []txSpec{
 		{blobs: 1, tip: 100},
 		{blobs: 1, tip: 200},
 		{blobs: 1, tip: 300},
 	})
-	tc.expectMode(t, topKMode)
 	tc.expectEntries(t, tc.vhashes[2]...)
 
 	better := tc.inject(t, txSpec{blobs: 1, tip: 400})
 
 	tc.wait(t, topKTimeout)
-	tc.expectMode(t, topKMode)
 	tc.expectEntries(t, better...)
 }

--- a/core/txpool/blobpool/cache_test.go
+++ b/core/txpool/blobpool/cache_test.go
@@ -46,7 +46,6 @@ type testCache struct {
 	*Cache
 	clock   *mclock.Simulated
 	iterCh  chan struct{}
-	txs     []common.Hash
 	vhashes [][]common.Hash // vhashes in the pool
 	offset  int             // next blob index to use when injecting more txs
 }
@@ -65,10 +64,9 @@ func newTestCache(t *testing.T, txConfig []txSpec, capacity uint) *testCache {
 	}
 
 	var (
-		addrs    = make([]common.Address, 0, len(txConfig))
-		vhashes  = make([][]common.Hash, 0, len(txConfig))
-		txHashes = make([]common.Hash, 0, len(txConfig))
-		offset   int
+		addrs   = make([]common.Address, 0, len(txConfig))
+		vhashes = make([][]common.Hash, 0, len(txConfig))
+		offset  int
 	)
 	for _, s := range txConfig {
 		key, _ := crypto.GenerateKey()
@@ -78,7 +76,6 @@ func newTestCache(t *testing.T, txConfig []txSpec, capacity uint) *testCache {
 		}
 		addrs = append(addrs, crypto.PubkeyToAddress(key.PublicKey))
 		vhashes = append(vhashes, tx.BlobHashes())
-		txHashes = append(txHashes, tx.Hash())
 		offset += s.blobs
 	}
 	store.Close()
@@ -129,7 +126,6 @@ func newTestCache(t *testing.T, txConfig []txSpec, capacity uint) *testCache {
 		Cache:   cache,
 		clock:   clock,
 		iterCh:  iterCh,
-		txs:     txHashes,
 		vhashes: vhashes,
 		offset:  offset,
 	}
@@ -141,8 +137,8 @@ func newTestCache(t *testing.T, txConfig []txSpec, capacity uint) *testCache {
 }
 
 // inject adds a tx with the given spec directly to the pool's index and store,
-// bypassing the normal Add path. Returns the new tx hash.
-func (tc *testCache) inject(t *testing.T, spec txSpec) common.Hash {
+// bypassing the normal Add path. Returns the tx's blob versioned hashes.
+func (tc *testCache) inject(t *testing.T, spec txSpec) []common.Hash {
 	t.Helper()
 	key, _ := crypto.GenerateKey()
 	tx := makeMultiBlobTx(0, spec.tip, 1_000_000, 1_000_000, spec.blobs, tc.offset, key, types.BlobSidecarVersion1)
@@ -162,7 +158,7 @@ func (tc *testCache) inject(t *testing.T, spec txSpec) common.Hash {
 	tc.blobpool.index[addr] = append(tc.blobpool.index[addr], meta)
 	tc.blobpool.lookup.track(meta)
 
-	return tx.Hash()
+	return tx.BlobHashes()
 }
 
 // wait advances simulated time by d (if > 0) and then blocks until the cache
@@ -210,23 +206,6 @@ func (tc *testCache) expectEntries(t *testing.T, want ...common.Hash) {
 	}
 }
 
-func (tc *testCache) expectMapped(t *testing.T, want ...common.Hash) {
-	t.Helper()
-	wantSet := make(map[common.Hash]struct{}, len(want))
-	for _, w := range want {
-		wantSet[w] = struct{}{}
-	}
-	tc.mu.Lock()
-	have := make(map[common.Hash]struct{}, len(tc.txHashOf))
-	for k := range tc.txHashOf {
-		have[k] = struct{}{}
-	}
-	tc.mu.Unlock()
-	if !reflect.DeepEqual(have, wantSet) {
-		t.Errorf("txHashOf keys: got %s, want %s", hashSet(have), hashSet(wantSet))
-	}
-}
-
 func hashSet(m map[common.Hash]struct{}) []string {
 	out := make([]string, 0, len(m))
 	for h := range m {
@@ -254,8 +233,7 @@ func TestCacheHasBlobsLoadsClaimedSet(t *testing.T) {
 	tc.wait(t, 0)
 
 	tc.expectMode(t, hasBlobsMode)
-	tc.expectEntries(t, tc.txs[1])
-	tc.expectMapped(t, tc.vhashes[1][0], tc.vhashes[1][1])
+	tc.expectEntries(t, tc.vhashes[1]...)
 }
 
 // TestCacheTopK exercises the periodic topK signal: after the initial topK
@@ -269,7 +247,7 @@ func TestCacheTopK(t *testing.T) {
 	}, 1)
 
 	tc.expectMode(t, topKMode)
-	tc.expectEntries(t, tc.txs[2])
+	tc.expectEntries(t, tc.vhashes[2]...)
 }
 
 // TestCacheHbTimerFallsBackToTopK checks the idle-timeout transition: after a
@@ -284,11 +262,11 @@ func TestCacheHbTimerFallsBackToTopK(t *testing.T) {
 	tc.HasBlobs(context.Background(), tc.vhashes[0])
 	tc.wait(t, 0)
 	tc.expectMode(t, hasBlobsMode)
-	tc.expectEntries(t, tc.txs[0])
+	tc.expectEntries(t, tc.vhashes[0]...)
 
 	tc.wait(t, hasBlobsTimeout)
 	tc.expectMode(t, topKMode)
-	tc.expectEntries(t, tc.txs[1])
+	tc.expectEntries(t, tc.vhashes[1]...)
 }
 
 // TestCacheGetBlobsExitsHasBlobsMode checks that a GetBlobs call while in
@@ -302,12 +280,12 @@ func TestCacheGetBlobsExitsHasBlobsMode(t *testing.T) {
 	tc.HasBlobs(context.Background(), tc.vhashes[0])
 	tc.wait(t, 0)
 	tc.expectMode(t, hasBlobsMode)
-	tc.expectEntries(t, tc.txs[0])
+	tc.expectEntries(t, tc.vhashes[0]...)
 
 	tc.GetBlobs(context.Background(), tc.vhashes[0], types.BlobSidecarVersion1)
 	tc.wait(t, 0)
 	tc.expectMode(t, topKMode)
-	tc.expectEntries(t, tc.txs[1])
+	tc.expectEntries(t, tc.vhashes[1]...)
 }
 
 // TestCacheTopKResetOnHasBlobs walks the cache through topK → hasBlobs → topK
@@ -318,16 +296,16 @@ func TestCacheTopKResetOnHasBlobs(t *testing.T) {
 		{blobs: 1, tip: 300},
 	}, 1)
 	tc.expectMode(t, topKMode)
-	tc.expectEntries(t, tc.txs[1])
+	tc.expectEntries(t, tc.vhashes[1]...)
 
 	tc.HasBlobs(context.Background(), tc.vhashes[0])
 	tc.wait(t, 0)
 	tc.expectMode(t, hasBlobsMode)
-	tc.expectEntries(t, tc.txs[0])
+	tc.expectEntries(t, tc.vhashes[0]...)
 
 	tc.wait(t, hasBlobsTimeout)
 	tc.expectMode(t, topKMode)
-	tc.expectEntries(t, tc.txs[1])
+	tc.expectEntries(t, tc.vhashes[1]...)
 }
 
 // TestCacheTopKRefresh verifies that when a more profitable tx appears in the
@@ -340,11 +318,11 @@ func TestCacheTopKRefresh(t *testing.T) {
 		{blobs: 1, tip: 300},
 	}, 1)
 	tc.expectMode(t, topKMode)
-	tc.expectEntries(t, tc.txs[2])
+	tc.expectEntries(t, tc.vhashes[2]...)
 
 	better := tc.inject(t, txSpec{blobs: 1, tip: 400})
 
 	tc.wait(t, topKTimeout)
 	tc.expectMode(t, topKMode)
-	tc.expectEntries(t, better)
+	tc.expectEntries(t, better...)
 }

--- a/core/txpool/blobpool/cache_test.go
+++ b/core/txpool/blobpool/cache_test.go
@@ -17,154 +17,334 @@
 package blobpool
 
 import (
+	"context"
+	"math/big"
 	"os"
 	"path/filepath"
-	"slices"
+	"reflect"
+	"sort"
 	"testing"
+	"time"
 
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/mclock"
+	"github.com/ethereum/go-ethereum/core/state"
+	"github.com/ethereum/go-ethereum/core/tracing"
+	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/ethereum/go-ethereum/params"
 	"github.com/holiman/billy"
+	"github.com/holiman/uint256"
 )
 
-func newTestStore(t *testing.T) billy.Database {
-	t.Helper()
-	dir := filepath.Join(t.TempDir(), "store")
-	if err := os.MkdirAll(dir, 0700); err != nil {
+type txSpec struct {
+	blobs int
+	tip   uint64
+}
+
+type testCache struct {
+	*Cache
+	clock   *mclock.Simulated
+	iterCh  chan struct{}
+	txs     []common.Hash
+	vhashes [][]common.Hash // vhashes in the pool
+	offset  int             // next blob index to use when injecting more txs
+}
+
+// newTestCache creates a cache for test, with a pool that contains transactions
+// specified in txConfig. The returned cache is in topKMode with the initial
+// topK fetch already settled.
+func newTestCache(t *testing.T, txConfig []txSpec, capacity uint) *testCache {
+	storage := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(storage, pendingTransactionStore), 0700); err != nil {
 		t.Fatalf("mkdir: %v", err)
 	}
-	store, err := billy.Open(billy.Options{Path: dir}, newSlotter(testMaxBlobsPerBlock), nil)
+	store, err := billy.Open(billy.Options{Path: filepath.Join(storage, pendingTransactionStore)}, newSlotter(params.BlobTxMaxBlobs), nil)
 	if err != nil {
 		t.Fatalf("billy open: %v", err)
 	}
-	return store
+
+	var (
+		addrs    = make([]common.Address, 0, len(txConfig))
+		vhashes  = make([][]common.Hash, 0, len(txConfig))
+		txHashes = make([]common.Hash, 0, len(txConfig))
+		offset   int
+	)
+	for _, s := range txConfig {
+		key, _ := crypto.GenerateKey()
+		tx := makeMultiBlobTx(0, s.tip, 1_000_000, 1_000_000, s.blobs, offset, key, types.BlobSidecarVersion1)
+		if _, err := store.Put(encodeForPool(tx)); err != nil {
+			t.Fatalf("store put: %v", err)
+		}
+		addrs = append(addrs, crypto.PubkeyToAddress(key.PublicKey))
+		vhashes = append(vhashes, tx.BlobHashes())
+		txHashes = append(txHashes, tx.Hash())
+		offset += s.blobs
+	}
+	store.Close()
+
+	statedb, _ := state.New(types.EmptyRootHash, state.NewDatabaseForTesting())
+	for _, a := range addrs {
+		statedb.AddBalance(a, uint256.NewInt(1_000_000_000_000), tracing.BalanceChangeUnspecified)
+	}
+	statedb.Commit(0, true, false)
+
+	cancunTime := uint64(0)
+	config := &params.ChainConfig{
+		ChainID:     big.NewInt(1),
+		LondonBlock: big.NewInt(0),
+		BerlinBlock: big.NewInt(0),
+		CancunTime:  &cancunTime,
+		BlobScheduleConfig: &params.BlobScheduleConfig{
+			Cancun: &params.BlobConfig{
+				Target:         12,
+				Max:            24,
+				UpdateFraction: params.DefaultCancunBlobConfig.UpdateFraction,
+			},
+		},
+	}
+	chain := &testBlockChain{
+		config:  config,
+		basefee: uint256.NewInt(1),
+		blobfee: uint256.NewInt(1),
+		statedb: statedb,
+	}
+	pool := New(Config{Datadir: storage}, chain, nil)
+	if err := pool.Init(1, chain.CurrentBlock(), newReserver()); err != nil {
+		t.Fatalf("init pool: %v", err)
+	}
+	t.Cleanup(func() { pool.Close() })
+
+	clock := &mclock.Simulated{}
+	iterCh := make(chan struct{}, 256)
+	step := func() {
+		select {
+		case iterCh <- struct{}{}:
+		default:
+		}
+	}
+	cache := NewCacheForTest(pool, capacity, clock, step)
+
+	tc := &testCache{
+		Cache:   cache,
+		clock:   clock,
+		iterCh:  iterCh,
+		txs:     txHashes,
+		vhashes: vhashes,
+		offset:  offset,
+	}
+	// Block until the loop has armed its initial topK timer, then fire it so the
+	// returned cache is already in a stable topKMode-loaded state.
+	clock.WaitForTimers(1)
+	tc.wait(t, topKTimeout)
+	return tc
 }
 
-// putTx stores a blob transaction in the given store and returns its metadata
-// and blobTxForPool.
-func putTx(t *testing.T, store billy.Database, nonce, tip uint64) (*blobTxMeta, *blobTxForPool) {
+// inject adds a tx with the given spec directly to the pool's index and store,
+// bypassing the normal Add path. Returns the new tx hash.
+func (tc *testCache) inject(t *testing.T, spec txSpec) common.Hash {
 	t.Helper()
-	key, err := crypto.GenerateKey()
-	if err != nil {
-		t.Fatalf("generate key: %v", err)
-	}
-	tx := makeTx(nonce, tip, tip, 1, key)
+	key, _ := crypto.GenerateKey()
+	tx := makeMultiBlobTx(0, spec.tip, 1_000_000, 1_000_000, spec.blobs, tc.offset, key, types.BlobSidecarVersion1)
+	tc.offset += spec.blobs
+
 	ptx := newBlobTxForPool(tx)
-	id, err := store.Put(encodeForPool(tx))
+
+	tc.blobpool.lock.Lock()
+	defer tc.blobpool.lock.Unlock()
+
+	id, err := tc.blobpool.store.Put(encodeForPool(tx))
 	if err != nil {
 		t.Fatalf("store put: %v", err)
 	}
-	return newBlobTxMeta(id, ptx.TxSize(), store.Size(id), ptx), ptx
+	meta := newBlobTxMeta(id, ptx.TxSize(), tc.blobpool.store.Size(id), ptx)
+	addr := crypto.PubkeyToAddress(key.PublicKey)
+	tc.blobpool.index[addr] = append(tc.blobpool.index[addr], meta)
+	tc.blobpool.lookup.track(meta)
+
+	return tx.Hash()
 }
 
-func TestCacheRefreshLoadsAndEvicts(t *testing.T) {
-	store := newTestStore(t)
-	m1, _ := putTx(t, store, 1, 10)
-	m2, _ := putTx(t, store, 2, 10)
-	m3, _ := putTx(t, store, 3, 10)
-	id1, id2, id3 := m1.id, m2.id, m3.id
-
-	c := newCache(store, 8)
-	c.reset([]uint64{id1, id2})
-
-	// cache should have id1, id2 entries
-	want := []uint64{id1, id2}
-	missing, redundant := checkCacheContents(want, c)
-	if len(missing) != 0 || len(redundant) != 0 {
-		t.Fatalf("cache contents mismatch: want=%v missing=%v redundant=%v",
-			want, missing, redundant)
+// wait advances simulated time by d (if > 0) and then blocks until the cache
+// loop and any inflight fetch goroutines have settled.
+func (tc *testCache) wait(t *testing.T, d time.Duration) {
+	t.Helper()
+	if d > 0 {
+		tc.clock.Run(d)
 	}
-
-	c.reset([]uint64{id2, id3})
-
-	// cache should have id2, id3 entries
-	// since the capacity is biggere than 3, it should
-	// also still hold id1.
-	want = []uint64{id2, id3}
-	missing, redundant = checkCacheContents(want, c)
-	if len(missing) != 0 || len(redundant) != 0 {
-		t.Fatalf("cache contents mismatch: want=%v missing=%v redundant=%v",
-			want, missing, redundant)
-	}
-}
-
-func TestCacheUpdate(t *testing.T) {
-	store := newTestStore(t)
-
-	// three txs with increasing tips
-	m1, p1 := putTx(t, store, 1, 10)
-	m2, p2 := putTx(t, store, 2, 20)
-	m3, p3 := putTx(t, store, 3, 30)
-	id1, id2, id3 := m1.id, m2.id, m3.id
-
-	c := newCache(store, 2)
-	// case 1: add two transactions should succeed
-	c.update([]*addedTx{{id: m1.id, ptx: p1}}, nil)
-	c.update([]*addedTx{{id: m2.id, ptx: p2}}, nil)
-	want := []uint64{id1, id2}
-	missing, redundant := checkCacheContents(want, c)
-	if len(missing) != 0 || len(redundant) != 0 {
-		t.Fatalf("cache contents mismatch: want=%v missing=%v redundant=%v",
-			want, missing, redundant)
-	}
-
-	// case 2: adding a tx with higher tip (id3) should evict
-	// the least profitable tx (id1)
-	c.update([]*addedTx{{id: m3.id, ptx: p3}}, nil)
-	want = []uint64{id2, id3}
-	missing, redundant = checkCacheContents(want, c)
-	if len(missing) != 0 || len(redundant) != 0 {
-		t.Fatalf("cache contents mismatch: want=%v missing=%v redundant=%v",
-			want, missing, redundant)
-	}
-
-	// case 3: adding a tx with lower tip (id1) should be rejected
-	c.update([]*addedTx{{id: m1.id, ptx: p1}}, nil)
-	want = []uint64{id2, id3}
-	missing, redundant = checkCacheContents(want, c)
-	if len(missing) != 0 || len(redundant) != 0 {
-		t.Fatalf("cache contents mismatch: want=%v missing=%v redundant=%v",
-			want, missing, redundant)
-	}
-}
-
-func TestCacheDrop(t *testing.T) {
-	store := newTestStore(t)
-
-	m1, p1 := putTx(t, store, 1, 10)
-	id1 := m1.id
-
-	c := newCache(store, 4)
-	c.update([]*addedTx{{id: m1.id, ptx: p1}}, nil)
-	want := []uint64{m1.id}
-	missing, redundant := checkCacheContents(want, c)
-	if len(missing) != 0 || len(redundant) != 0 {
-		t.Fatalf("cache contents mismatch: want=%v missing=%v redundant=%v",
-			want, missing, redundant)
-	}
-
-	c.update(nil, []uint64{id1})
-	want = []uint64{}
-	missing, redundant = checkCacheContents(want, c)
-	if len(missing) != 0 || len(redundant) != 0 {
-		t.Fatalf("cache contents mismatch: want=%v missing=%v redundant=%v",
-			want, missing, redundant)
-	}
-
-	// Should be okay to call drop for non-cached id
-	c.update(nil, []uint64{99999})
-}
-
-// checkCacheContents checks whether the cache has exact content as `want`
-func checkCacheContents(want []uint64, c *cache) (missing []uint64, redundant []uint64) {
-	for _, wantId := range want {
-		if c.get(wantId) == nil {
-			missing = append(missing, wantId)
+	for {
+		select {
+		case <-tc.iterCh:
+			tc.inflight.Wait()
+		case <-time.After(50 * time.Millisecond):
+			tc.inflight.Wait()
+			return
 		}
 	}
-	for _, e := range c.entries {
-		if !slices.Contains(want, e.txID) {
-			redundant = append(redundant, e.txID)
-		}
+}
+
+func (tc *testCache) expectMode(t *testing.T, want cacheMode) {
+	t.Helper()
+	tc.mu.Lock()
+	have := tc.mode
+	tc.mu.Unlock()
+	if have != want {
+		t.Errorf("mode: got %d, want %d", have, want)
 	}
-	return missing, redundant
+}
+
+func (tc *testCache) expectEntries(t *testing.T, want ...common.Hash) {
+	t.Helper()
+	wantSet := make(map[common.Hash]struct{}, len(want))
+	for _, w := range want {
+		wantSet[w] = struct{}{}
+	}
+	tc.mu.Lock()
+	have := make(map[common.Hash]struct{}, len(tc.entries))
+	for k := range tc.entries {
+		have[k] = struct{}{}
+	}
+	tc.mu.Unlock()
+	if !reflect.DeepEqual(have, wantSet) {
+		t.Errorf("entries: got %s, want %s", hashSet(have), hashSet(wantSet))
+	}
+}
+
+func (tc *testCache) expectMapped(t *testing.T, want ...common.Hash) {
+	t.Helper()
+	wantSet := make(map[common.Hash]struct{}, len(want))
+	for _, w := range want {
+		wantSet[w] = struct{}{}
+	}
+	tc.mu.Lock()
+	have := make(map[common.Hash]struct{}, len(tc.txHashOf))
+	for k := range tc.txHashOf {
+		have[k] = struct{}{}
+	}
+	tc.mu.Unlock()
+	if !reflect.DeepEqual(have, wantSet) {
+		t.Errorf("txHashOf keys: got %s, want %s", hashSet(have), hashSet(wantSet))
+	}
+}
+
+func hashSet(m map[common.Hash]struct{}) []string {
+	out := make([]string, 0, len(m))
+	for h := range m {
+		out = append(out, h.Hex()[:10])
+	}
+	sort.Strings(out)
+	return out
+}
+
+// TestCacheHasBlobsLoadsClaimedSet checks that a HasBlobs request switches the
+// cache into hasBlobsMode and loads exactly the txs whose vhashes the cache
+// claimed available, regardless of whether the claim came from the cache
+// itself or from the pool fallback.
+func TestCacheHasBlobsLoadsClaimedSet(t *testing.T) {
+	tc := newTestCache(t, []txSpec{
+		{blobs: 2, tip: 100},
+		{blobs: 2, tip: 200},
+		{blobs: 2, tip: 300},
+	}, 1)
+
+	available := tc.HasBlobs(context.Background(), tc.vhashes[1])
+	if !available[0] {
+		t.Fatalf("expected vhash to be reported available")
+	}
+	tc.wait(t, 0)
+
+	tc.expectMode(t, hasBlobsMode)
+	tc.expectEntries(t, tc.txs[1])
+	tc.expectMapped(t, tc.vhashes[1][0], tc.vhashes[1][1])
+}
+
+// TestCacheTopK exercises the periodic topK signal: after the initial topK
+// settles in newTestCache, the cache is in topKMode with entries equal to the
+// top-by-tip txs.
+func TestCacheTopK(t *testing.T) {
+	tc := newTestCache(t, []txSpec{
+		{blobs: 1, tip: 100},
+		{blobs: 1, tip: 200},
+		{blobs: 1, tip: 300},
+	}, 1)
+
+	tc.expectMode(t, topKMode)
+	tc.expectEntries(t, tc.txs[2])
+}
+
+// TestCacheHbTimerFallsBackToTopK checks the idle-timeout transition: after a
+// HasBlobs request, an elapsing hasBlobsTimeout flips the cache back to
+// topKMode and replaces the entries with the topK set.
+func TestCacheHbTimerFallsBackToTopK(t *testing.T) {
+	tc := newTestCache(t, []txSpec{
+		{blobs: 1, tip: 100},
+		{blobs: 1, tip: 300},
+	}, 1)
+
+	tc.HasBlobs(context.Background(), tc.vhashes[0])
+	tc.wait(t, 0)
+	tc.expectMode(t, hasBlobsMode)
+	tc.expectEntries(t, tc.txs[0])
+
+	tc.wait(t, hasBlobsTimeout)
+	tc.expectMode(t, topKMode)
+	tc.expectEntries(t, tc.txs[1])
+}
+
+// TestCacheGetBlobsExitsHasBlobsMode checks that a GetBlobs call while in
+// hasBlobsMode flips the cache back to topKMode and reloads the topK set.
+func TestCacheGetBlobsExitsHasBlobsMode(t *testing.T) {
+	tc := newTestCache(t, []txSpec{
+		{blobs: 1, tip: 100},
+		{blobs: 1, tip: 300},
+	}, 1)
+
+	tc.HasBlobs(context.Background(), tc.vhashes[0])
+	tc.wait(t, 0)
+	tc.expectMode(t, hasBlobsMode)
+	tc.expectEntries(t, tc.txs[0])
+
+	tc.GetBlobs(context.Background(), tc.vhashes[0], types.BlobSidecarVersion1)
+	tc.wait(t, 0)
+	tc.expectMode(t, topKMode)
+	tc.expectEntries(t, tc.txs[1])
+}
+
+// TestCacheTopKResetOnHasBlobs walks the cache through topK → hasBlobs → topK
+// transitions and checks that the entries follow the active mode at each step.
+func TestCacheTopKResetOnHasBlobs(t *testing.T) {
+	tc := newTestCache(t, []txSpec{
+		{blobs: 1, tip: 100},
+		{blobs: 1, tip: 300},
+	}, 1)
+	tc.expectMode(t, topKMode)
+	tc.expectEntries(t, tc.txs[1])
+
+	tc.HasBlobs(context.Background(), tc.vhashes[0])
+	tc.wait(t, 0)
+	tc.expectMode(t, hasBlobsMode)
+	tc.expectEntries(t, tc.txs[0])
+
+	tc.wait(t, hasBlobsTimeout)
+	tc.expectMode(t, topKMode)
+	tc.expectEntries(t, tc.txs[1])
+}
+
+// TestCacheTopKRefresh verifies that when a more profitable tx appears in the
+// pool while the cache is in topKMode, the next topK tick replaces the cached
+// entry with the better one.
+func TestCacheTopKRefresh(t *testing.T) {
+	tc := newTestCache(t, []txSpec{
+		{blobs: 1, tip: 100},
+		{blobs: 1, tip: 200},
+		{blobs: 1, tip: 300},
+	}, 1)
+	tc.expectMode(t, topKMode)
+	tc.expectEntries(t, tc.txs[2])
+
+	better := tc.inject(t, txSpec{blobs: 1, tip: 400})
+
+	tc.wait(t, topKTimeout)
+	tc.expectMode(t, topKMode)
+	tc.expectEntries(t, better)
 }

--- a/core/txpool/blobpool/cache_test.go
+++ b/core/txpool/blobpool/cache_test.go
@@ -121,7 +121,7 @@ func newTestCache(t *testing.T, txConfig []txSpec) *testCache {
 		default:
 		}
 	}
-	cache := NewCacheForTest(pool, clock, step)
+	cache := newCache(pool, clock, step)
 
 	tc := &testCache{
 		Cache:   cache,

--- a/core/txpool/blobpool/cache_test.go
+++ b/core/txpool/blobpool/cache_test.go
@@ -53,7 +53,7 @@ type testCache struct {
 // newTestCache creates a cache for test, with a pool that contains transactions
 // specified in txConfig. The returned cache is in topKMode with the initial
 // topK fetch already settled.
-func newTestCache(t *testing.T, txConfig []txSpec, capacity uint) *testCache {
+func newTestCache(t *testing.T, txConfig []txSpec) *testCache {
 	storage := t.TempDir()
 	if err := os.MkdirAll(filepath.Join(storage, pendingTransactionStore), 0700); err != nil {
 		t.Fatalf("mkdir: %v", err)
@@ -94,14 +94,9 @@ func newTestCache(t *testing.T, txConfig []txSpec, capacity uint) *testCache {
 		CancunTime:  &cancunTime,
 		OsakaTime:   &cancunTime,
 		BlobScheduleConfig: &params.BlobScheduleConfig{
-			Cancun: &params.BlobConfig{
-				Target:         12,
-				Max:            24,
-				UpdateFraction: params.DefaultCancunBlobConfig.UpdateFraction,
-			},
 			Osaka: &params.BlobConfig{
-				Target:         12,
-				Max:            24,
+				Target:         1,
+				Max:            1,
 				UpdateFraction: params.DefaultCancunBlobConfig.UpdateFraction,
 			},
 		},
@@ -126,7 +121,7 @@ func newTestCache(t *testing.T, txConfig []txSpec, capacity uint) *testCache {
 		default:
 		}
 	}
-	cache := NewCacheForTest(pool, capacity, clock, step)
+	cache := NewCacheForTest(pool, clock, step)
 
 	tc := &testCache{
 		Cache:   cache,
@@ -230,7 +225,7 @@ func TestCacheHasBlobsLoadsClaimedSet(t *testing.T) {
 		{blobs: 2, tip: 100},
 		{blobs: 2, tip: 200},
 		{blobs: 2, tip: 300},
-	}, 1)
+	})
 
 	available := tc.HasBlobs(context.Background(), tc.vhashes[1])
 	if !available[0] {
@@ -250,7 +245,7 @@ func TestCacheTopK(t *testing.T) {
 		{blobs: 1, tip: 100},
 		{blobs: 1, tip: 200},
 		{blobs: 1, tip: 300},
-	}, 1)
+	})
 
 	tc.expectMode(t, topKMode)
 	tc.expectEntries(t, tc.vhashes[2]...)
@@ -263,7 +258,7 @@ func TestCacheHbTimerFallsBackToTopK(t *testing.T) {
 	tc := newTestCache(t, []txSpec{
 		{blobs: 1, tip: 100},
 		{blobs: 1, tip: 300},
-	}, 1)
+	})
 
 	tc.HasBlobs(context.Background(), tc.vhashes[0])
 	tc.wait(t, 0)
@@ -281,7 +276,7 @@ func TestCacheGetBlobsExitsHasBlobsMode(t *testing.T) {
 	tc := newTestCache(t, []txSpec{
 		{blobs: 1, tip: 100},
 		{blobs: 1, tip: 300},
-	}, 1)
+	})
 
 	tc.HasBlobs(context.Background(), tc.vhashes[0])
 	tc.wait(t, 0)
@@ -300,7 +295,7 @@ func TestCacheTopKResetOnHasBlobs(t *testing.T) {
 	tc := newTestCache(t, []txSpec{
 		{blobs: 1, tip: 100},
 		{blobs: 1, tip: 300},
-	}, 1)
+	})
 	tc.expectMode(t, topKMode)
 	tc.expectEntries(t, tc.vhashes[1]...)
 
@@ -322,7 +317,7 @@ func TestCacheTopKRefresh(t *testing.T) {
 		{blobs: 1, tip: 100},
 		{blobs: 1, tip: 200},
 		{blobs: 1, tip: 300},
-	}, 1)
+	})
 	tc.expectMode(t, topKMode)
 	tc.expectEntries(t, tc.vhashes[2]...)
 

--- a/core/txpool/blobpool/cache_test.go
+++ b/core/txpool/blobpool/cache_test.go
@@ -1,0 +1,170 @@
+// Copyright 2026 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+
+package blobpool
+
+import (
+	"os"
+	"path/filepath"
+	"slices"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/holiman/billy"
+)
+
+func newTestStore(t *testing.T) billy.Database {
+	t.Helper()
+	dir := filepath.Join(t.TempDir(), "store")
+	if err := os.MkdirAll(dir, 0700); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	store, err := billy.Open(billy.Options{Path: dir}, newSlotter(testMaxBlobsPerBlock), nil)
+	if err != nil {
+		t.Fatalf("billy open: %v", err)
+	}
+	return store
+}
+
+// putTx stores a blob transaction in the given store and returns its metadata
+// and blobTxForPool.
+func putTx(t *testing.T, store billy.Database, nonce, tip uint64) (*blobTxMeta, *blobTxForPool) {
+	t.Helper()
+	key, err := crypto.GenerateKey()
+	if err != nil {
+		t.Fatalf("generate key: %v", err)
+	}
+	tx := makeTx(nonce, tip, tip, 1, key)
+	ptx := newBlobTxForPool(tx)
+	id, err := store.Put(encodeForPool(tx))
+	if err != nil {
+		t.Fatalf("store put: %v", err)
+	}
+	return newBlobTxMeta(id, ptx.TxSize(), store.Size(id), ptx), ptx
+}
+
+func TestCacheRefreshLoadsAndEvicts(t *testing.T) {
+	store := newTestStore(t)
+	m1, _ := putTx(t, store, 1, 10)
+	m2, _ := putTx(t, store, 2, 10)
+	m3, _ := putTx(t, store, 3, 10)
+	id1, id2, id3 := m1.id, m2.id, m3.id
+
+	c := newCache(store, 8)
+	c.reset([]uint64{id1, id2})
+
+	// cache should have id1, id2 entries
+	want := []uint64{id1, id2}
+	missing, redundant := checkCacheContents(want, c)
+	if len(missing) != 0 || len(redundant) != 0 {
+		t.Fatalf("cache contents mismatch: want=%v missing=%v redundant=%v",
+			want, missing, redundant)
+	}
+
+	c.reset([]uint64{id2, id3})
+
+	// cache should have id2, id3 entries
+	// since the capacity is biggere than 3, it should
+	// also still hold id1.
+	want = []uint64{id2, id3}
+	missing, redundant = checkCacheContents(want, c)
+	if len(missing) != 0 || len(redundant) != 0 {
+		t.Fatalf("cache contents mismatch: want=%v missing=%v redundant=%v",
+			want, missing, redundant)
+	}
+}
+
+func TestCacheUpdate(t *testing.T) {
+	store := newTestStore(t)
+
+	// three txs with increasing tips
+	m1, p1 := putTx(t, store, 1, 10)
+	m2, p2 := putTx(t, store, 2, 20)
+	m3, p3 := putTx(t, store, 3, 30)
+	id1, id2, id3 := m1.id, m2.id, m3.id
+
+	c := newCache(store, 2)
+	// case 1: add two transactions should succeed
+	c.update([]*addedTx{{id: m1.id, ptx: p1}}, nil)
+	c.update([]*addedTx{{id: m2.id, ptx: p2}}, nil)
+	want := []uint64{id1, id2}
+	missing, redundant := checkCacheContents(want, c)
+	if len(missing) != 0 || len(redundant) != 0 {
+		t.Fatalf("cache contents mismatch: want=%v missing=%v redundant=%v",
+			want, missing, redundant)
+	}
+
+	// case 2: adding a tx with higher tip (id3) should evict
+	// the least profitable tx (id1)
+	c.update([]*addedTx{{id: m3.id, ptx: p3}}, nil)
+	want = []uint64{id2, id3}
+	missing, redundant = checkCacheContents(want, c)
+	if len(missing) != 0 || len(redundant) != 0 {
+		t.Fatalf("cache contents mismatch: want=%v missing=%v redundant=%v",
+			want, missing, redundant)
+	}
+
+	// case 3: adding a tx with lower tip (id1) should be rejected
+	c.update([]*addedTx{{id: m1.id, ptx: p1}}, nil)
+	want = []uint64{id2, id3}
+	missing, redundant = checkCacheContents(want, c)
+	if len(missing) != 0 || len(redundant) != 0 {
+		t.Fatalf("cache contents mismatch: want=%v missing=%v redundant=%v",
+			want, missing, redundant)
+	}
+}
+
+func TestCacheDrop(t *testing.T) {
+	store := newTestStore(t)
+
+	m1, p1 := putTx(t, store, 1, 10)
+	id1 := m1.id
+
+	c := newCache(store, 4)
+	c.update([]*addedTx{{id: m1.id, ptx: p1}}, nil)
+	want := []uint64{m1.id}
+	missing, redundant := checkCacheContents(want, c)
+	if len(missing) != 0 || len(redundant) != 0 {
+		t.Fatalf("cache contents mismatch: want=%v missing=%v redundant=%v",
+			want, missing, redundant)
+	}
+
+	c.update(nil, []uint64{id1})
+	want = []uint64{}
+	missing, redundant = checkCacheContents(want, c)
+	if len(missing) != 0 || len(redundant) != 0 {
+		t.Fatalf("cache contents mismatch: want=%v missing=%v redundant=%v",
+			want, missing, redundant)
+	}
+
+	// Should be okay to call drop for non-cached id
+	c.update(nil, []uint64{99999})
+}
+
+// checkCacheContents checks whether the cache has exact content as `want`
+func checkCacheContents(want []uint64, c *cache) (missing []uint64, redundant []uint64) {
+	for _, wantId := range want {
+		if c.get(wantId) == nil {
+			missing = append(missing, wantId)
+		}
+	}
+	for _, e := range c.entries {
+		if !slices.Contains(want, e.txID) {
+			redundant = append(redundant, e.txID)
+		}
+	}
+	return missing, redundant
+}

--- a/core/txpool/blobpool/metrics.go
+++ b/core/txpool/blobpool/metrics.go
@@ -108,10 +108,4 @@ var (
 	gappedGauge         = metrics.NewRegisteredGauge("blobpool/gapped/count", nil)    // Current gapped queue size
 	gappedPromotedMeter = metrics.NewRegisteredMeter("blobpool/gapped/promoted", nil) // Gapped txs successfully promoted to pool
 	gappedEvictedMeter  = metrics.NewRegisteredMeter("blobpool/gapped/evicted", nil)  // Gapped txs evicted due to timeout/stale
-
-	// GetBlobs cache metrics. Hit counts both cache match and successful vhash
-	// containment check; miss covers no entry and stale entry (containment fail).
-	cacheHitMeter     = metrics.NewRegisteredMeter("blobpool/cache/hit", nil)
-	cacheMissMeter    = metrics.NewRegisteredMeter("blobpool/cache/miss", nil)
-	cacheEntriesGauge = metrics.NewRegisteredGauge("blobpool/cache/entries", nil)
 )

--- a/core/txpool/blobpool/metrics.go
+++ b/core/txpool/blobpool/metrics.go
@@ -108,4 +108,10 @@ var (
 	gappedGauge         = metrics.NewRegisteredGauge("blobpool/gapped/count", nil)    // Current gapped queue size
 	gappedPromotedMeter = metrics.NewRegisteredMeter("blobpool/gapped/promoted", nil) // Gapped txs successfully promoted to pool
 	gappedEvictedMeter  = metrics.NewRegisteredMeter("blobpool/gapped/evicted", nil)  // Gapped txs evicted due to timeout/stale
+
+	// GetBlobs cache metrics. Hit counts both cache match and successful vhash
+	// containment check; miss covers no entry and stale entry (containment fail).
+	cacheHitMeter     = metrics.NewRegisteredMeter("blobpool/cache/hit", nil)
+	cacheMissMeter    = metrics.NewRegisteredMeter("blobpool/cache/miss", nil)
+	cacheEntriesGauge = metrics.NewRegisteredGauge("blobpool/cache/entries", nil)
 )

--- a/core/txpool/txorder/ordering.go
+++ b/core/txpool/txorder/ordering.go
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
 
-package miner
+package txorder
 
 import (
 	"container/heap"
@@ -83,10 +83,10 @@ func (s *txByPriceAndTime) Pop() interface{} {
 	return x
 }
 
-// transactionsByPriceAndNonce represents a set of transactions that can return
+// TransactionsByPriceAndNonce represents a set of transactions that can return
 // transactions in a profit-maximizing sorted order, while supporting removing
 // entire batches of transactions for non-executable accounts.
-type transactionsByPriceAndNonce struct {
+type TransactionsByPriceAndNonce struct {
 	txs     map[common.Address][]*txpool.LazyTransaction // Per account nonce-sorted list of transactions
 	heads   txByPriceAndTime                             // Next transaction for each unique account (price heap)
 	signer  types.Signer                                 // Signer for the set of transactions
@@ -98,7 +98,7 @@ type transactionsByPriceAndNonce struct {
 //
 // Note, the input map is reowned so the caller should not interact any more with
 // if after providing it to the constructor.
-func newTransactionsByPriceAndNonce(signer types.Signer, txs map[common.Address][]*txpool.LazyTransaction, baseFee *big.Int) *transactionsByPriceAndNonce {
+func NewTransactionsByPriceAndNonce(signer types.Signer, txs map[common.Address][]*txpool.LazyTransaction, baseFee *big.Int) *TransactionsByPriceAndNonce {
 	// Convert the basefee from header format to uint256 format
 	var baseFeeUint *uint256.Int
 	if baseFee != nil {
@@ -118,7 +118,7 @@ func newTransactionsByPriceAndNonce(signer types.Signer, txs map[common.Address]
 	heap.Init(&heads)
 
 	// Assemble and return the transaction set
-	return &transactionsByPriceAndNonce{
+	return &TransactionsByPriceAndNonce{
 		txs:     txs,
 		heads:   heads,
 		signer:  signer,
@@ -127,7 +127,7 @@ func newTransactionsByPriceAndNonce(signer types.Signer, txs map[common.Address]
 }
 
 // Peek returns the next transaction by price.
-func (t *transactionsByPriceAndNonce) Peek() (*txpool.LazyTransaction, *uint256.Int) {
+func (t *TransactionsByPriceAndNonce) Peek() (*txpool.LazyTransaction, *uint256.Int) {
 	if len(t.heads) == 0 {
 		return nil, nil
 	}
@@ -135,7 +135,7 @@ func (t *transactionsByPriceAndNonce) Peek() (*txpool.LazyTransaction, *uint256.
 }
 
 // Shift replaces the current best head with the next one from the same account.
-func (t *transactionsByPriceAndNonce) Shift() {
+func (t *TransactionsByPriceAndNonce) Shift() {
 	acc := t.heads[0].from
 	if txs, ok := t.txs[acc]; ok && len(txs) > 0 {
 		if wrapped, err := newTxWithMinerFee(txs[0], acc, t.baseFee); err == nil {
@@ -150,17 +150,17 @@ func (t *transactionsByPriceAndNonce) Shift() {
 // Pop removes the best transaction, *not* replacing it with the next one from
 // the same account. This should be used when a transaction cannot be executed
 // and hence all subsequent ones should be discarded from the same account.
-func (t *transactionsByPriceAndNonce) Pop() {
+func (t *TransactionsByPriceAndNonce) Pop() {
 	heap.Pop(&t.heads)
 }
 
 // Empty returns if the price heap is empty. It can be used to check it simpler
 // than calling peek and checking for nil return.
-func (t *transactionsByPriceAndNonce) Empty() bool {
+func (t *TransactionsByPriceAndNonce) Empty() bool {
 	return len(t.heads) == 0
 }
 
 // Clear removes the entire content of the heap.
-func (t *transactionsByPriceAndNonce) Clear() {
+func (t *TransactionsByPriceAndNonce) Clear() {
 	t.heads, t.txs = nil, nil
 }

--- a/core/txpool/txorder/ordering_test.go
+++ b/core/txpool/txorder/ordering_test.go
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
 
-package miner
+package txorder
 
 import (
 	"crypto/ecdsa"
@@ -102,7 +102,7 @@ func testTransactionPriceNonceSort(t *testing.T, baseFee *big.Int) {
 		expectedCount += count
 	}
 	// Sort the transactions and cross check the nonce ordering
-	txset := newTransactionsByPriceAndNonce(signer, groups, baseFee)
+	txset := NewTransactionsByPriceAndNonce(signer, groups, baseFee)
 
 	txs := types.Transactions{}
 	for tx, _ := txset.Peek(); tx != nil; tx, _ = txset.Peek() {
@@ -168,7 +168,7 @@ func TestTransactionTimeSort(t *testing.T) {
 		})
 	}
 	// Sort the transactions and cross check the nonce ordering
-	txset := newTransactionsByPriceAndNonce(signer, groups, nil)
+	txset := NewTransactionsByPriceAndNonce(signer, groups, nil)
 
 	txs := types.Transactions{}
 	for tx, _ := txset.Peek(); tx != nil; tx, _ = txset.Peek() {

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -31,6 +31,7 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/consensus"
+	"github.com/ethereum/go-ethereum/consensus/misc/eip4844"
 	"github.com/ethereum/go-ethereum/core"
 	"github.com/ethereum/go-ethereum/core/filtermaps"
 	"github.com/ethereum/go-ethereum/core/history"
@@ -95,6 +96,7 @@ type Ethereum struct {
 	config         *ethconfig.Config
 	txPool         *txpool.TxPool
 	blobTxPool     *blobpool.BlobPool
+	blobCache      *blobpool.Cache
 	localTxTracker *locals.TxTracker
 	blockchain     *core.BlockChain
 
@@ -325,6 +327,7 @@ func New(stack *node.Node, config *ethconfig.Config) (*Ethereum, error) {
 		config.BlobPool.Datadir = stack.ResolvePath(config.BlobPool.Datadir)
 	}
 	eth.blobTxPool = blobpool.New(config.BlobPool, eth.blockchain, legacyPool.HasPendingAuth)
+	eth.blobCache = blobpool.NewCache(eth.blobTxPool, uint(eip4844.LatestMaxBlobsPerBlock(eth.blockchain.Config())))
 
 	eth.txPool, err = txpool.New(config.TxPool.PriceLimit, eth.blockchain, []txpool.SubPool{legacyPool, eth.blobTxPool})
 	if err != nil {
@@ -435,6 +438,7 @@ func (s *Ethereum) AccountManager() *accounts.Manager  { return s.accountManager
 func (s *Ethereum) BlockChain() *core.BlockChain       { return s.blockchain }
 func (s *Ethereum) TxPool() *txpool.TxPool             { return s.txPool }
 func (s *Ethereum) BlobTxPool() *blobpool.BlobPool     { return s.blobTxPool }
+func (s *Ethereum) BlobCache() *blobpool.Cache         { return s.blobCache }
 func (s *Ethereum) Engine() consensus.Engine           { return s.engine }
 func (s *Ethereum) ChainDb() ethdb.Database            { return s.chainDb }
 func (s *Ethereum) IsListening() bool                  { return true } // Always listening
@@ -603,6 +607,7 @@ func (s *Ethereum) Stop() error {
 	s.txPool.Close()
 	s.blockchain.Stop()
 	s.engine.Close()
+	s.blobCache.Stop()
 
 	// Clean shutdown marker as the last thing before closing db
 	s.shutdownTracker.Stop()

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -31,7 +31,6 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/consensus"
-	"github.com/ethereum/go-ethereum/consensus/misc/eip4844"
 	"github.com/ethereum/go-ethereum/core"
 	"github.com/ethereum/go-ethereum/core/filtermaps"
 	"github.com/ethereum/go-ethereum/core/history"
@@ -327,7 +326,7 @@ func New(stack *node.Node, config *ethconfig.Config) (*Ethereum, error) {
 		config.BlobPool.Datadir = stack.ResolvePath(config.BlobPool.Datadir)
 	}
 	eth.blobTxPool = blobpool.New(config.BlobPool, eth.blockchain, legacyPool.HasPendingAuth)
-	eth.blobCache = blobpool.NewCache(eth.blobTxPool, uint(eip4844.LatestMaxBlobsPerBlock(eth.blockchain.Config())))
+	eth.blobCache = blobpool.NewCache(eth.blobTxPool)
 
 	eth.txPool, err = txpool.New(config.TxPool.PriceLimit, eth.blockchain, []txpool.SubPool{legacyPool, eth.blobTxPool})
 	if err != nil {

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -603,10 +603,10 @@ func (s *Ethereum) Stop() error {
 	s.closeFilterMaps <- ch
 	<-ch
 	s.filterMaps.Stop()
+	s.blobCache.Stop()
 	s.txPool.Close()
 	s.blockchain.Stop()
 	s.engine.Close()
-	s.blobCache.Stop()
 
 	// Clean shutdown marker as the last thing before closing db
 	s.shutdownTracker.Stop()

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -31,6 +31,7 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/consensus"
+	"github.com/ethereum/go-ethereum/consensus/misc/eip4844"
 	"github.com/ethereum/go-ethereum/core"
 	"github.com/ethereum/go-ethereum/core/filtermaps"
 	"github.com/ethereum/go-ethereum/core/history"
@@ -94,6 +95,7 @@ type Ethereum struct {
 	config         *ethconfig.Config
 	txPool         *txpool.TxPool
 	blobTxPool     *blobpool.BlobPool
+	blobCache      *blobpool.Cache
 	localTxTracker *locals.TxTracker
 	blockchain     *core.BlockChain
 
@@ -315,6 +317,7 @@ func New(stack *node.Node, config *ethconfig.Config) (*Ethereum, error) {
 		config.BlobPool.Datadir = stack.ResolvePath(config.BlobPool.Datadir)
 	}
 	eth.blobTxPool = blobpool.New(config.BlobPool, eth.blockchain, legacyPool.HasPendingAuth)
+	eth.blobCache = blobpool.NewCache(eth.blobTxPool, uint(eip4844.LatestMaxBlobsPerBlock(eth.blockchain.Config())))
 
 	eth.txPool, err = txpool.New(config.TxPool.PriceLimit, eth.blockchain, []txpool.SubPool{legacyPool, eth.blobTxPool})
 	if err != nil {
@@ -425,6 +428,7 @@ func (s *Ethereum) AccountManager() *accounts.Manager  { return s.accountManager
 func (s *Ethereum) BlockChain() *core.BlockChain       { return s.blockchain }
 func (s *Ethereum) TxPool() *txpool.TxPool             { return s.txPool }
 func (s *Ethereum) BlobTxPool() *blobpool.BlobPool     { return s.blobTxPool }
+func (s *Ethereum) BlobCache() *blobpool.Cache         { return s.blobCache }
 func (s *Ethereum) Engine() consensus.Engine           { return s.engine }
 func (s *Ethereum) ChainDb() ethdb.Database            { return s.chainDb }
 func (s *Ethereum) IsListening() bool                  { return true } // Always listening
@@ -591,6 +595,7 @@ func (s *Ethereum) Stop() error {
 	s.txPool.Close()
 	s.blockchain.Stop()
 	s.engine.Close()
+	s.blobCache.Stop()
 
 	// Clean shutdown marker as the last thing before closing db
 	s.shutdownTracker.Stop()

--- a/eth/catalyst/api.go
+++ b/eth/catalyst/api.go
@@ -574,7 +574,7 @@ func (api *ConsensusAPI) GetBlobsV1(ctx context.Context, hashes []common.Hash) (
 	if len(hashes) > 128 {
 		return nil, engine.TooLargeRequest.With(fmt.Errorf("requested blob count too large: %v", len(hashes)))
 	}
-	blobs, _, proofs, err := api.eth.BlobTxPool().GetBlobs(ctx, hashes, types.BlobSidecarVersion0)
+	blobs, _, proofs, err := api.eth.BlobCache().GetBlobs(ctx, hashes, types.BlobSidecarVersion0)
 	if err != nil {
 		return nil, engine.InvalidParams.With(err)
 	}
@@ -656,7 +656,7 @@ func (api *ConsensusAPI) getBlobs(ctx context.Context, hashes []common.Hash, v2 
 		return nil, engine.TooLargeRequest.With(fmt.Errorf("requested blob count too large: %v", len(hashes)))
 	}
 	available := 0
-	for _, ok := range api.eth.BlobTxPool().AvailableBlobs(hashes) {
+	for _, ok := range api.eth.BlobCache().HasBlobs(ctx, hashes) {
 		if ok {
 			available++
 		}
@@ -671,7 +671,7 @@ func (api *ConsensusAPI) getBlobs(ctx context.Context, hashes []common.Hash, v2 
 	}
 	// Retrieve blobs from the pool. This operation is expensive and may involve
 	// heavy disk I/O.
-	blobs, _, proofs, err := api.eth.BlobTxPool().GetBlobs(ctx, hashes, types.BlobSidecarVersion1)
+	blobs, _, proofs, err := api.eth.BlobCache().GetBlobs(ctx, hashes, types.BlobSidecarVersion1)
 	if err != nil {
 		return nil, engine.InvalidParams.With(err)
 	}
@@ -710,7 +710,7 @@ func (api *ConsensusAPI) getBlobs(ctx context.Context, hashes []common.Hash, v2 
 
 // HasBlobs reports availability for the requested blob-versioned-hashes.
 func (api *ConsensusAPI) HasBlobs(hashes []common.Hash) []bool {
-	return api.eth.BlobTxPool().AvailableBlobs(hashes)
+	return api.eth.BlobCache().HasBlobs(context.Background(), hashes)
 }
 
 // Helper for NewPayload* methods.

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -31,6 +31,7 @@ import (
 	"github.com/ethereum/go-ethereum/core/state"
 	"github.com/ethereum/go-ethereum/core/stateless"
 	"github.com/ethereum/go-ethereum/core/txpool"
+	"github.com/ethereum/go-ethereum/core/txpool/txorder"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/core/types/bal"
 	"github.com/ethereum/go-ethereum/core/vm"
@@ -422,7 +423,7 @@ func (miner *Miner) applyTransaction(env *environment, tx *types.Transaction) (*
 	return receipt, bal, nil
 }
 
-func (miner *Miner) commitTransactions(ctx context.Context, env *environment, plainTxs, blobTxs *transactionsByPriceAndNonce, interrupt *atomic.Int32) error {
+func (miner *Miner) commitTransactions(ctx context.Context, env *environment, plainTxs, blobTxs *txorder.TransactionsByPriceAndNonce, interrupt *atomic.Int32) error {
 	ctx, _, spanEnd := telemetry.StartSpan(ctx, "miner.commitTransactions")
 	defer spanEnd(nil)
 
@@ -449,7 +450,7 @@ func (miner *Miner) commitTransactions(ctx context.Context, env *environment, pl
 		// Retrieve the next transaction and abort if all done.
 		var (
 			ltx *txpool.LazyTransaction
-			txs *transactionsByPriceAndNonce
+			txs *txorder.TransactionsByPriceAndNonce
 		)
 		pltx, ptip := plainTxs.Peek()
 		bltx, btip := blobTxs.Peek()
@@ -592,16 +593,16 @@ func (miner *Miner) fillTransactions(ctx context.Context, interrupt *atomic.Int3
 	}
 	// Fill the block with all available pending transactions.
 	if len(prioPlainTxs) > 0 || len(prioBlobTxs) > 0 {
-		plainTxs := newTransactionsByPriceAndNonce(env.signer, prioPlainTxs, env.header.BaseFee)
-		blobTxs := newTransactionsByPriceAndNonce(env.signer, prioBlobTxs, env.header.BaseFee)
+		plainTxs := txorder.NewTransactionsByPriceAndNonce(env.signer, prioPlainTxs, env.header.BaseFee)
+		blobTxs := txorder.NewTransactionsByPriceAndNonce(env.signer, prioBlobTxs, env.header.BaseFee)
 
 		if err := miner.commitTransactions(ctx, env, plainTxs, blobTxs, interrupt); err != nil {
 			return err
 		}
 	}
 	if len(normalPlainTxs) > 0 || len(normalBlobTxs) > 0 {
-		plainTxs := newTransactionsByPriceAndNonce(env.signer, normalPlainTxs, env.header.BaseFee)
-		blobTxs := newTransactionsByPriceAndNonce(env.signer, normalBlobTxs, env.header.BaseFee)
+		plainTxs := txorder.NewTransactionsByPriceAndNonce(env.signer, normalPlainTxs, env.header.BaseFee)
+		blobTxs := txorder.NewTransactionsByPriceAndNonce(env.signer, normalBlobTxs, env.header.BaseFee)
 
 		if err := miner.commitTransactions(ctx, env, plainTxs, blobTxs, interrupt); err != nil {
 			return err


### PR DESCRIPTION
This PR introduces a cache for GetBlobs request.

The main purpose of this PR is to reduce the getBlobsV3 latency by reading and
decoding blobs from the pool in advance of the actual query. This is important
especially in the context of a sparse blobpool, since it may be necessary to
recover blobs from cells on a getBlobsV3 request.

Previously, the Engine API read and decoded blobs from the pool on every call.
Now those calls check the cache and only fall back to the pool on a miss.

The cache has two modes:
- In topK mode (default), it wakes up periodically, picks the most profitable
pending blob transactions up to the current fork's maxBlobsPerBlock, and loads
their blobs. The selection logic is shared with the miner's block-building
logic. The selection size is derived from eip4844.MaxBlobsPerBlock at the
current head.
- When the CL calls HasBlobs, the cache switches to hasBlobs mode and tries to
pin the set it just reported as available. Cache updates (read, decode, and
optionally conversion in the future) run in background goroutines.