### PR TITLE
qkc/serialize: port QuarkChain binary serialization (byte-compatible)

### DIFF
--- a/qkc/serialize/bytebuffer.go
+++ b/qkc/serialize/bytebuffer.go
@@ -1,0 +1,107 @@
+// Ported verbatim from github.com/QuarkChain/goquarkchain/serialize (byte-compatible).
+
+package serialize
+
+import (
+	"encoding/binary"
+	"fmt"
+)
+
+type ByteBuffer struct {
+	data     *[]byte
+	position int
+	size     int
+}
+
+func NewByteBuffer(bytes []byte) *ByteBuffer {
+	bb := ByteBuffer{&bytes, 0, len(bytes)}
+	return &bb
+}
+
+func (bb *ByteBuffer) GetOffset() int {
+	return bb.position
+}
+
+func (bb *ByteBuffer) getBytes(size int) ([]byte, error) {
+	if size > bb.size-bb.position {
+		return nil, fmt.Errorf("deser: buffer is shorter than expected")
+	}
+
+	bytes := (*bb.data)[bb.position : bb.position+size]
+	bb.position += size
+	return bytes, nil
+}
+
+func (bb *ByteBuffer) GetUInt8() (uint8, error) {
+	bytes, err := bb.getBytes(1)
+	if err != nil {
+		return 0, err
+	}
+
+	return uint8(bytes[0]), nil
+}
+
+func (bb *ByteBuffer) GetUInt16() (uint16, error) {
+	bytes, err := bb.getBytes(2)
+	if err != nil {
+		return 0, err
+	}
+
+	return binary.BigEndian.Uint16(bytes), nil
+}
+
+func (bb *ByteBuffer) GetUInt32() (uint32, error) {
+	bytes, err := bb.getBytes(4)
+	if err != nil {
+		return 0, err
+	}
+
+	return binary.BigEndian.Uint32(bytes), nil
+}
+
+func (bb *ByteBuffer) GetUInt64() (uint64, error) {
+	bytes, err := bb.getBytes(8)
+	if err != nil {
+		return 0, err
+	}
+
+	return binary.BigEndian.Uint64(bytes), nil
+}
+
+func (bb *ByteBuffer) getLen(byteSize int) (int, error) {
+	if byteSize < 1 {
+		return 0, fmt.Errorf("deser: bytesize in GetVarBytes should larger than 0")
+	}
+
+	b, err := bb.getBytes(byteSize)
+	if err != nil {
+		return 0, err
+	}
+
+	var size int = 0
+	for i := 0; i < byteSize; i++ {
+		size = (size << 8) | int(b[i])
+	}
+
+	return size, nil
+}
+
+func (bb *ByteBuffer) GetVarBytes(byteSizeOfSliceLen int) ([]byte, error) {
+	size, err := bb.getLen(byteSizeOfSliceLen)
+	if err != nil {
+		return nil, err
+	}
+
+	bs, err := bb.getBytes(size)
+	if err != nil {
+		return nil, err
+	}
+
+	bytes := make([]byte, size, size)
+	copy(bytes, bs)
+	return bytes, nil
+}
+
+func (bb *ByteBuffer) Remaining() int {
+	return bb.size - bb.position
+}

--- a/qkc/serialize/deserializer.go
+++ b/qkc/serialize/deserializer.go
@@ -1,0 +1,267 @@
+// Ported verbatim from github.com/QuarkChain/goquarkchain/serialize (byte-compatible).
+
+package serialize
+
+import (
+	"errors"
+	"fmt"
+	"math/big"
+	"reflect"
+)
+
+var (
+	errNoPointer          = errors.New("deser: interface given to Deserialize must be a pointer")
+	errDeserializeIntoNil = errors.New("deser: pointer given to Deserialize must not be nil")
+)
+
+func Deserialize(bb *ByteBuffer, val interface{}) error {
+	return DeserializeWithTags(bb, val, Tags{ByteSizeOfSliceLen: 1})
+}
+
+func DeserializeWithTags(bb *ByteBuffer, val interface{}, ts Tags) error {
+	if val == nil {
+		return errDeserializeIntoNil
+	}
+
+	rval := reflect.ValueOf(val)
+	rtyp := rval.Type()
+	if rtyp.Kind() != reflect.Ptr {
+		return errNoPointer
+	}
+	if rval.IsNil() {
+		return errDeserializeIntoNil
+	}
+
+	info, err := cachedTypeInfo(rtyp.Elem())
+	if err != nil {
+		return err
+	}
+
+	err = info.deserializer(bb, rval.Elem(), ts)
+	return err
+}
+
+func DeserializeFromBytes(b []byte, val interface{}) error {
+	return Deserialize(NewByteBuffer(b), val)
+}
+
+func makeDeserializer(typ reflect.Type) (deserializer, error) {
+	kind := typ.Kind()
+	switch {
+	//check Ptr first and add optional byte output if ts is nilok,
+	//then get serializer for typ.Elem() which is not a ptr
+	case kind == reflect.Ptr:
+		return deserializePtr, nil
+	case kind != reflect.Ptr && reflect.PtrTo(typ).Implements(serializableInterface):
+		return deserializeSerializableInterface, nil
+	case typ.AssignableTo(bigInt):
+		return deserializeBigIntNoPtr, nil
+	case isUint(kind):
+		return deserializeUint, nil
+	case kind == reflect.Bool:
+		return deserializeBool, nil
+	case kind == reflect.String:
+		return deserializeString, nil
+	case kind == reflect.Slice && isByte(typ.Elem()):
+		return deserializeByteSlice, nil
+	case kind == reflect.Array && isByte(typ.Elem()):
+		return deserializeByteArray, nil
+	case kind == reflect.Slice || kind == reflect.Array:
+		return deserializeList, nil
+	case kind == reflect.Struct:
+		return deserializeStruct, nil
+	default:
+		return nil, fmt.Errorf("type %v is not serializable", typ)
+	}
+}
+
+func deserializeSerializableInterface(bb *ByteBuffer, val reflect.Value, ts Tags) error {
+	return val.Addr().Interface().(Serializable).Deserialize(bb)
+}
+
+func deserializeUint(bb *ByteBuffer, val reflect.Value, ts Tags) error {
+	kind := val.Type().Kind()
+	var bytes []byte
+	var err error
+	switch {
+	case kind > reflect.Uint && kind <= reflect.Uintptr:
+		bytes, err = bb.getBytes(val.Type().Bits() / 8)
+		break
+	case kind == reflect.Uint:
+		bytes, err = bb.GetVarBytes(1)
+		break
+	default:
+		err = fmt.Errorf("deser: invalid Uint type: %s", val.Type().Name())
+		break
+	}
+
+	if err == nil {
+		var ui uint64 = 0
+		for i := 0; i < len(bytes); i++ {
+			ui = ui<<8 | uint64(bytes[i])
+		}
+		val.SetUint(ui)
+	}
+
+	return err
+}
+
+func deserializeFixSizeBigUint(bb *ByteBuffer, val *big.Int, size int) error {
+	bytes, err := bb.getBytes(size)
+	if err == nil {
+		val.SetBytes(bytes)
+	}
+
+	return err
+}
+
+func deserializeBigIntNoPtr(bb *ByteBuffer, val reflect.Value, ts Tags) error {
+	return deserializeBigInt(bb, val.Addr())
+}
+
+func deserializeBigInt(bb *ByteBuffer, val reflect.Value) error {
+	bytes, err := bb.GetVarBytes(1)
+	if err != nil {
+		return err
+	}
+
+	i := val.Interface().(*big.Int)
+	if i == nil {
+		i = new(big.Int)
+		val.Set(reflect.ValueOf(i))
+	}
+
+	i.SetBytes(bytes)
+	return nil
+}
+
+func deserializeBool(bb *ByteBuffer, val reflect.Value, ts Tags) error {
+	b, err := bb.getBytes(1)
+	if err == nil {
+		switch b[0] {
+		case 0x00:
+			val.SetBool(false)
+		case 0x01:
+			val.SetBool(true)
+		default:
+			err = fmt.Errorf("deser: invalid boolean value: %d", b[0])
+		}
+	}
+
+	return err
+}
+
+// FixedSizeBytes
+func deserializeByteArray(bb *ByteBuffer, val reflect.Value, ts Tags) error {
+	if val.Kind() != reflect.Array {
+		return fmt.Errorf("deser: invalid byte array type: %s", val.Kind())
+	}
+	if val.Type().Elem().Kind() != reflect.Uint8 {
+		return fmt.Errorf("deser: invalid byte array type: [%d]%s", val.Len(), val.Kind())
+	}
+
+	bytes, err := bb.getBytes(val.Len())
+	if err == nil {
+		reflect.Copy(val, reflect.ValueOf(bytes))
+	}
+
+	return err
+}
+
+// deserializePrependedSizeBytes
+func deserializeByteSlice(bb *ByteBuffer, val reflect.Value, ts Tags) error {
+	bytes, err := bb.GetVarBytes(ts.ByteSizeOfSliceLen)
+	if err == nil {
+		val.SetBytes(bytes)
+	}
+
+	return err
+}
+
+func deserializeList(bb *ByteBuffer, val reflect.Value, ts Tags) error {
+	typeinfo, err := cachedTypeInfo(val.Type().Elem())
+	if err != nil {
+		return err
+	}
+
+	var vlen int = 0
+	if val.Kind() == reflect.Slice {
+		vlen, err = bb.getLen(ts.ByteSizeOfSliceLen)
+		if err != nil {
+			return err
+		}
+
+		newv := reflect.MakeSlice(val.Type(), vlen, vlen)
+		reflect.Copy(newv, val)
+		val.Set(newv)
+	} else if val.Kind() == reflect.Array {
+		vlen = val.Len()
+	}
+
+	for i := 0; i < vlen; i++ {
+		if err := typeinfo.deserializer(bb, val.Index(i), Tags{ByteSizeOfSliceLen: 1}); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func deserializeStruct(bb *ByteBuffer, val reflect.Value, ts Tags) error {
+	fields, err := structFields(val.Type())
+	if err != nil {
+		return err
+	}
+
+	for _, f := range fields {
+		err := f.info.deserializer(bb, val.Field(f.index), f.tags)
+		if err != nil {
+			return fmt.Errorf("%s for %v%s", err.Error(), val.Type(), "."+val.Type().Field(f.index).Name)
+		}
+	}
+
+	return nil
+}
+
+func deserializeString(bb *ByteBuffer, val reflect.Value, ts Tags) error {
+	b, err := bb.GetVarBytes(4)
+	if err != nil {
+		return err
+	}
+
+	val.SetString(string(b))
+	return nil
+}
+
+func deserializePtr(bb *ByteBuffer, val reflect.Value, ts Tags) error {
+	typ := val.Type()
+	typeinfo, err := cachedTypeInfo(typ.Elem())
+	if err != nil {
+		return err
+	}
+
+	if ts.NilOK {
+		b, err := bb.GetUInt8()
+		if err != nil {
+			return err
+		}
+
+		if b == 0 {
+			// set the pointer to nil.
+			val.Set(reflect.Zero(typ))
+			return nil
+		}
+	}
+
+	newval := val
+	if val.IsNil() {
+		newval = reflect.New(typ.Elem())
+	}
+
+	err = typeinfo.deserializer(bb, newval.Elem(), ts)
+	if err == nil {
+		val.Set(newval)
+	}
+
+	return err
+}

--- a/qkc/serialize/deserializer_test.go
+++ b/qkc/serialize/deserializer_test.go
@@ -1,0 +1,298 @@
+// Ported verbatim from github.com/QuarkChain/goquarkchain/serialize (byte-compatible).
+
+package serialize
+
+import (
+	"encoding/hex"
+	"fmt"
+	"math/big"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+type testDataForDeserialize struct {
+	input string
+	ptr   interface{}
+	value interface{}
+	error string
+}
+
+type simplestruct struct {
+	A uint
+	B string
+}
+
+var (
+	veryBigInt = big.NewInt(0).Add(
+		big.NewInt(0).Lsh(big.NewInt(0xFFFFFFFFFFFFFF), 16),
+		big.NewInt(0xFFFF),
+	)
+)
+
+type hasIgnoredField struct {
+	A uint
+	B uint `ser:"-"`
+	C uint32
+}
+
+var deserdata = []testDataForDeserialize{
+	// booleans
+	{input: "01", ptr: new(bool), value: true},
+	{input: "00", ptr: new(bool), value: false},
+	{input: "02", ptr: new(bool), error: "deser: invalid boolean value: 2"},
+
+	// integers
+
+	{input: "00", ptr: new(uint8), value: uint8(0)},
+	{input: "05", ptr: new(uint8), value: uint8(5)},
+	{input: "0000", ptr: new(uint16), value: uint16(0)},
+	{input: "0005", ptr: new(uint16), value: uint16(5)},
+	{input: "05", ptr: new(uint16), error: "deser: buffer is shorter than expected"},
+	{input: "00000000", ptr: new(uint32), value: uint32(0)},
+	{input: "00000505", ptr: new(uint32), value: uint32(0x0505)},
+	{input: "05050505", ptr: new(uint32), value: uint32(0x05050505)},
+	{input: "0000000000000000", ptr: new(uint64), value: uint64(0)},
+	{input: "0000000000000505", ptr: new(uint64), value: uint64(0x0505)},
+	{input: "0505050505050505", ptr: new(uint64), value: uint64(0x0505050505050505)},
+	{input: "0100", ptr: new(uint), value: uint(0)},
+	{input: "020505", ptr: new(uint), value: uint(0x0505)},
+	{input: "080505050505050505", ptr: new(uint), value: uint(0x0505050505050505)},
+
+	{input: "00000000000000000000000000000001", ptr: new(Uint128), value: *newUint128(1)},
+	{input: "00000000000000000000000000000080", ptr: new(Uint128), value: *newUint128(128)},
+	{input: "0000000000000000FFFFFFFFFFFFFFFF", ptr: new(Uint128), value: *newUint128(0xFFFFFFFFFFFFFFFF)},
+	{input: "05", ptr: new(Uint128), error: "deser: buffer is shorter than expected"},
+	{input: "0000000000000000000000000000000000000000000000000000000000000001", ptr: new(Uint256), value: *newUint256(1)},
+	{input: "0000000000000000000000000000000000000000000000000000000000000080", ptr: new(Uint256), value: *newUint256(128)},
+	{input: "000000000000000000000000000000000000000000000000FFFFFFFFFFFFFFFF", ptr: new(Uint256), value: *newUint256(0xFFFFFFFFFFFFFFFF)},
+	{input: "05", ptr: new(Uint256), error: "deser: buffer is shorter than expected"},
+
+	//uint slices
+	{input: "00", ptr: new([]uint), value: []uint{}},
+	{input: "080102030405060708", ptr: new([]uint8), value: []uint8{1, 2, 3, 4, 5, 6, 7, 8}},
+	{input: "080000000100000002000000030000000400000005000000060000000700000008", ptr: new([]uint32), value: []uint32{1, 2, 3, 4, 5, 6, 7, 8}},
+	{input: "050102", ptr: new([]uint8), error: "deser: buffer is shorter than expected"},
+
+	// arrays
+	{input: "0102030405", ptr: new([5]uint8), value: [5]uint8{1, 2, 3, 4, 5}},
+	{input: "0000000100000002000000030000000400000005", ptr: new([5]uint32), value: [5]uint32{1, 2, 3, 4, 5}},
+	{input: "", ptr: new([0]uint), value: [0]uint{}}, // zero sized arrays
+	{input: "0102", ptr: new([5]uint8), error: "deser: buffer is shorter than expected"},
+
+	// byte slices
+	{input: "0101", ptr: new([]byte), value: []byte{1}},
+	{input: "00", ptr: new([]byte), value: []byte{}},
+	{input: "0D6162636465666768696A6B6C6D", ptr: new([]byte), value: []byte("abcdefghijklm")},
+	{input: "0D0102", ptr: new([]byte), error: "deser: buffer is shorter than expected"},
+
+	// byte slices, strings
+	{input: "00", ptr: new([]byte), value: []byte{}},
+	{input: "017E", ptr: new([]byte), value: []byte{0x7E}},
+	{input: "0180", ptr: new([]byte), value: []byte{0x80}},
+	{input: "03010203", ptr: new([]byte), value: []byte{1, 2, 3}},
+	{input: "04010203", ptr: new([]byte), error: "deser: buffer is shorter than expected"},
+
+	//SerializableList interface
+	{input: "00000000", ptr: new(LargeBytes), value: LargeBytes{[]byte{}}},
+	{input: "000000017E", ptr: new(LargeBytes), value: LargeBytes{[]byte{0x7E}}},
+	{input: "0000000180", ptr: new(LargeBytes), value: LargeBytes{[]byte{0x80}}},
+	{input: "00000003010203", ptr: new(LargeBytes), value: LargeBytes{[]byte{1, 2, 3}}},
+	{input: "03010203", ptr: new(LargeBytes), error: "deser: buffer is shorter than expected for serialize.LargeBytes.Value"},
+
+	// byte arrays
+	{input: "00", ptr: new([0]byte), value: [0]byte{}},
+	{input: "02", ptr: new([1]byte), value: [1]byte{2}},
+	{input: "80", ptr: new([1]byte), value: [1]byte{128}},
+	{input: "0102030405", ptr: new([5]byte), value: [5]byte{1, 2, 3, 4, 5}},
+
+	// strings
+	{input: "0000000100", ptr: new(string), value: "\000"},
+	{input: "0000000D6162636465666768696A6B6C6D", ptr: new(string), value: "abcdefghijklm"},
+	{input: "0D6162636465666768696A6B6C6D", ptr: new(string), error: "deser: buffer is shorter than expected"},
+
+	// big ints
+	{input: "0101", ptr: new(*big.Int), value: big.NewInt(1)},
+	{input: "09FFFFFFFFFFFFFFFFFF", ptr: new(*big.Int), value: veryBigInt},
+	{input: "0110", ptr: new(big.Int), value: *big.NewInt(16)}, // non-pointer also works
+	{input: "0210", ptr: new(big.Int), error: "deser: buffer is shorter than expected"},
+
+	// structs
+	{input: "0301020300", ptr: new(structForTest), value: newStructForTest(&[]byte{1, 2, 3}, nil)},
+	{input: "030102030103040506", ptr: new(structForTest), value: newStructForTest(&[]byte{1, 2, 3}, &[]byte{4, 5, 6})},
+	{input: "0301020303040506", ptr: new(structForTest), error: "deser: buffer is shorter than expected for serialize.structForTest.To"},
+
+	// structs
+	{
+		input: "010500000003343434",
+		ptr:   new(simplestruct),
+		value: simplestruct{5, "444"},
+	},
+
+	// struct tag "-"
+	{
+		input: "010100000002",
+		ptr:   new(hasIgnoredField),
+		value: hasIgnoredField{A: 1, C: 2},
+	},
+
+	// pointers
+	{input: "0100", ptr: new(*[]byte), value: &[]byte{0}},
+	{input: "0100", ptr: new(*uint), value: uintp(0)},
+	{input: "0107", ptr: new(*uint), value: uintp(7)},
+	{input: "0180", ptr: new(*uint), value: uintp(0x80)},
+	{input: "010109", ptr: new(*[]uint), value: &[]uint{9}},
+	{input: "010403030303", ptr: new(*[][]byte), value: &[][]byte{{3, 3, 3, 3}}},
+
+	// do not support interface{}, need to know the real type
+	{input: "02", ptr: new(int), error: "type int is not serializable"},
+	{input: "00", ptr: new(interface{}), error: "type interface {} is not serializable"},
+}
+
+func uintp(i uint) *uint { return &i }
+
+func runTests(t *testing.T, deserialize func([]byte, interface{}) error) {
+	for i, test := range deserdata {
+		input, err := hex.DecodeString(test.input)
+		if err != nil {
+			t.Errorf("test %d: invalid hex input %q", i, test.input)
+			continue
+		}
+		err = deserialize(input, test.ptr)
+		if err != nil && test.error == "" {
+			t.Errorf("test %d: unexpected Deserialize error: %v\ndecoding into %T\ninput %q",
+				i, err, test.ptr, test.input)
+			continue
+		}
+		if test.error != "" && fmt.Sprint(err) != test.error {
+			t.Errorf("test %d: Deserialize error mismatch\ngot  %v\nwant %v\ndecoding into %T\ninput %q",
+				i, err, test.error, test.ptr, test.input)
+			continue
+		}
+		deref := reflect.ValueOf(test.ptr).Elem().Interface()
+		if err == nil && !reflect.DeepEqual(deref, test.value) {
+			t.Errorf("test %d: value mismatch\ngot  %#v\nwant %#v\ndecoding into %T\ninput %q",
+				i, deref, test.value, test.ptr, test.input)
+		}
+	}
+}
+
+func TestDeserialize(t *testing.T) {
+	runTests(t, func(input []byte, into interface{}) error {
+		return Deserialize(NewByteBuffer(input), into)
+	})
+}
+
+func ExampleDeserialize() {
+	input, _ := hex.DecodeString("010a0000001400000006666F6F626172")
+
+	type example struct {
+		A       uint
+		B       uint32
+		private uint // private fields are Ignored
+		String  string
+	}
+
+	var s example
+	err := Deserialize(NewByteBuffer(input), &s)
+	if err != nil {
+		fmt.Printf("Error: %v\n", err)
+	} else {
+		fmt.Printf("Deserialized value: %#v\n", s)
+	}
+	// Output:
+	// Deserialized value: serialize.example{A:0xa, B:0x14, private:0x0, String:"foobar"}
+}
+
+func ExampleDeserialize_structTagNilAndIgnore() {
+	// In this example, we'll use the "nil" struct tag to change
+	// how a pointer-typed field is deserialized. The input contains an RLP
+	// list of one element, an empty string.
+	input := []byte{0x00, 0x01, 0x03, 0x04, 0x05, 0x06}
+
+	s := new(structForTest)
+	Deserialize(NewByteBuffer(input), &s)
+	fmt.Printf("From = %v\n", *s.From)
+	fmt.Printf("To = %v\n", *s.To)
+
+	// Output:
+	// From = []
+	// To = [4 5 6]
+}
+
+func ExampleDeserialize_structTagNil() {
+	// In this example, we'll use the "nil" struct tag to change
+	// how a pointer-typed field is deserialized. The input contains an RLP
+	// list of one element, an empty string.
+	input := []byte{0x00}
+
+	// This type uses the normal rules.
+	// The empty input string is deserialized as a pointer to an empty Go string.
+	var normalRules struct {
+		String *[]byte
+	}
+	Deserialize(NewByteBuffer(input), &normalRules)
+	fmt.Printf("normal: String = %v\n", *normalRules.String)
+
+	// This type uses the struct tag.
+	// The empty input string is deserialized as a nil pointer.
+	var withEmptyOK struct {
+		String *[]byte `ser:"nil"`
+	}
+	Deserialize(NewByteBuffer(input), &withEmptyOK)
+	fmt.Printf("with nil tag: String = %v\n", withEmptyOK.String)
+
+	// Output:
+	// normal: String = []
+	// with nil tag: String = <nil>
+}
+
+func BenchmarkDeserialize(b *testing.B) {
+	enc := encodeTestSlice(90000)
+	b.SetBytes(int64(len(enc)))
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		var s []uint
+		bb := NewByteBuffer(enc)
+		if err := Deserialize(bb, &s); err != nil {
+			b.Fatalf("Deserialize error: %v", err)
+		}
+	}
+}
+
+func BenchmarkDeserializeIntSliceReuse(b *testing.B) {
+	enc := encodeTestSlice(100000)
+	b.SetBytes(int64(len(enc)))
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	var s []uint
+	for i := 0; i < b.N; i++ {
+		bb := NewByteBuffer(enc)
+		if err := Deserialize(bb, &s); err != nil {
+			b.Fatalf("Deserialize error: %v", err)
+		}
+	}
+}
+
+func encodeTestSlice(n uint) []byte {
+	s := make([]uint, n)
+	for i := uint(0); i < n; i++ {
+		s[i] = i
+	}
+	b, err := SerializeToBytes(s)
+	if err != nil {
+		panic(fmt.Sprintf("encode error: %v", err))
+	}
+	return b
+}
+
+func unhex(str string) []byte {
+	b, err := hex.DecodeString(strings.Replace(str, " ", "", -1))
+	if err != nil {
+		panic(fmt.Sprintf("invalid hex string: %q", str))
+	}
+	return b
+}

--- a/qkc/serialize/serializer.go
+++ b/qkc/serialize/serializer.go
@@ -1,0 +1,294 @@
+// Ported verbatim from github.com/QuarkChain/goquarkchain/serialize (byte-compatible).
+
+package serialize
+
+import (
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"math/big"
+	"reflect"
+)
+
+func Serialize(w *[]byte, val interface{}) error {
+	return SerializeWithTags(w, val, Tags{ByteSizeOfSliceLen: 1})
+}
+
+func SerializeWithTags(w *[]byte, val interface{}, ts Tags) error {
+	rval := reflect.ValueOf(val)
+	ti, err := cachedTypeInfo(rval.Type())
+	if err != nil {
+		return err
+	}
+
+	return ti.serializer(rval, w, ts)
+}
+
+// SerializeToBytes returns the serialize result of val.
+func SerializeToBytes(val interface{}) ([]byte, error) {
+	w := make([]byte, 0, 512)
+	if err := Serialize(&w, val); err != nil {
+		return nil, err
+	}
+
+	return w, nil
+}
+
+func makeSerializer(typ reflect.Type) (serializer, error) {
+	kind := typ.Kind()
+	switch {
+	//check Ptr first and add optional byte output if ts is nilok,
+	//then get serializer for typ.Elem() which is not a ptr
+	case kind == reflect.Ptr:
+		return serializePtr, nil
+	case kind != reflect.Ptr && reflect.PtrTo(typ).Implements(serializableInterface):
+		return serializeSerializableInterface, nil
+	case typ.AssignableTo(bigInt):
+		return serializeBigIntNoPtr, nil
+	case isUint(kind):
+		return serializeUint, nil
+	case kind == reflect.Bool:
+		return serializeBool, nil
+	case kind == reflect.String:
+		return serializeString, nil
+	case kind == reflect.Slice && isByte(typ.Elem()):
+		return serializeByteSlice, nil
+	case kind == reflect.Array && isByte(typ.Elem()):
+		return serializeByteArray, nil
+	case kind == reflect.Slice || kind == reflect.Array:
+		return serializeList, nil
+	case kind == reflect.Struct:
+		return serializeStruct, nil
+	default:
+		return nil, fmt.Errorf("type %v is not serializable", typ)
+	}
+}
+
+func serializeSerializableInterface(val reflect.Value, w *[]byte, tags Tags) error {
+	if !val.CanAddr() {
+		return fmt.Errorf("ser: unaddressable value of type %v, Serialize is pointer method", val.Type())
+	}
+
+	return val.Addr().Interface().(Serializable).Serialize(w)
+}
+
+func prefillByteArray(size int, barray []byte) ([]byte, error) {
+	len := len(barray)
+	if len > size {
+		return nil, errors.New("barray len is larger then expected size")
+	}
+	if len == size {
+		return barray, nil
+	}
+
+	bytes := make([]byte, size, size)
+	var startIndex = size - len
+	copy(bytes[startIndex:], barray)
+	return bytes, nil
+}
+
+func serializeFixSizeBigUint(val *big.Int, size int, w *[]byte) error {
+	if val == nil {
+		bytes := make([]byte, size, size)
+		*w = append(*w, bytes...)
+		return nil
+	}
+	bytes, err := prefillByteArray(size, val.Bytes())
+	if err == nil {
+		*w = append(*w, bytes...)
+	}
+
+	return err
+}
+
+func serializeBigIntNoPtr(val reflect.Value, w *[]byte, ts Tags) error {
+	i := val.Interface().(big.Int)
+	return serializeBigInt(&i, w)
+}
+
+func serializeBigInt(i *big.Int, w *[]byte) error {
+	var bytes []byte
+	if cmp := i.Cmp(big.NewInt(0)); cmp == -1 {
+		return fmt.Errorf("ser: cannot serialize negative *big.Int")
+	} else if cmp > 0 {
+		bytes = i.Bytes()
+	}
+
+	*w = append(*w, uint8(len(bytes)))
+	*w = append(*w, bytes...)
+	return nil
+}
+
+func serializeBool(val reflect.Value, w *[]byte, ts Tags) error {
+	if val.Bool() {
+		*w = append(*w, 0x01)
+	} else {
+		*w = append(*w, 0x00)
+	}
+
+	return nil
+}
+
+func serializeByteArray(val reflect.Value, w *[]byte, ts Tags) error {
+	if !val.CanAddr() {
+		// Slice requires the value to be addressable.
+		// Make it addressable by copying.
+		copy := reflect.New(val.Type()).Elem()
+		copy.Set(val)
+		val = copy
+	}
+
+	size := val.Len()
+	slice := val.Slice(0, size).Bytes()
+
+	*w = append(*w, slice...)
+	return nil
+}
+
+func writeListLen(w *[]byte, len int, byteSizeOfSliceLen int) error {
+	sizeBytes := make([]byte, byteSizeOfSliceLen)
+	for i := byteSizeOfSliceLen - 1; i >= 0 && len != 0; i-- {
+		sizeBytes[i] = byte(len)
+		len = len >> 8
+	}
+	if len > 0 {
+		return errors.New("barray len is larger then expected size")
+	}
+
+	*w = append(*w, sizeBytes...)
+	return nil
+}
+
+// serializePrependedSizeBytes
+func serializeByteSlice(val reflect.Value, w *[]byte, ts Tags) error {
+	err := writeListLen(w, val.Len(), ts.ByteSizeOfSliceLen)
+	if err != nil {
+		return err
+	}
+
+	bytes := val.Bytes()
+	*w = append(*w, bytes...)
+	return nil
+}
+
+// PrependedSizeListSerializer
+func serializeList(val reflect.Value, w *[]byte, ts Tags) error {
+	typeinfo, err := cachedTypeInfo(val.Type().Elem())
+	if err != nil {
+		return err
+	}
+
+	if val.Kind() == reflect.Slice {
+		err = writeListLen(w, val.Len(), ts.ByteSizeOfSliceLen)
+		if err != nil {
+			return err
+		}
+	}
+
+	vlen := val.Len()
+	for i := 0; i < vlen; i++ {
+		if err := typeinfo.serializer(val.Index(i), w, Tags{ByteSizeOfSliceLen: 1}); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func serializeStruct(val reflect.Value, w *[]byte, ts Tags) error {
+	fields, err := structFields(val.Type())
+	if err != nil {
+		return err
+	}
+
+	for _, f := range fields {
+		if err := f.info.serializer(val.Field(f.index), w, f.tags); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func SerializeStructWithout(val reflect.Value, w *[]byte, excludeList map[string]bool) error {
+	fields, err := structFields(val.Type())
+	if err != nil {
+		return err
+	}
+
+	for _, f := range fields {
+		if excludeList != nil {
+			if _, ok := excludeList[f.name]; ok {
+				continue
+			}
+		}
+
+		if err := f.info.serializer(val.Field(f.index), w, f.tags); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func serializeString(val reflect.Value, w *[]byte, ts Tags) error {
+	s := val.String()
+
+	sizeBytes := make([]byte, 4, 4)
+	binary.BigEndian.PutUint32(sizeBytes, uint32(val.Len()))
+
+	*w = append(*w, sizeBytes...)
+	*w = append(*w, s...)
+	return nil
+}
+
+func serializePtr(val reflect.Value, w *[]byte, ts Tags) error {
+	typ := val.Type()
+	typeinfo, err := cachedTypeInfo(typ.Elem())
+	if err != nil {
+		return err
+	}
+	switch {
+	case val.IsNil() && ts.NilOK:
+		*w = append(*w, 0)
+		return nil
+	case val.IsNil() && typ.Implements(serializableInterface):
+		zero := reflect.New(typ.Elem())
+		return typeinfo.serializer(zero.Elem(), w, ts)
+	case val.IsNil():
+		zero := reflect.Zero(typ.Elem())
+		return typeinfo.serializer(zero, w, ts)
+	default:
+		if ts.NilOK {
+			*w = append(*w, 1)
+		}
+		return typeinfo.serializer(val.Elem(), w, ts)
+	}
+}
+
+func serializeUint(val reflect.Value, w *[]byte, ts Tags) error {
+	kind := val.Type().Kind()
+	value := val.Uint()
+	switch kind {
+	case reflect.Uint8:
+		*w = append(*w, byte(value))
+		return nil
+	case reflect.Uint16:
+		*w = append(*w, byte(value>>8), byte(value))
+		break
+	case reflect.Uint32:
+		*w = append(*w, byte(value>>24), byte(value>>16), byte(value>>8), byte(value))
+		return nil
+	case reflect.Uint64:
+		*w = append(*w, byte(value>>56), byte(value>>48), byte(value>>40), byte(value>>32),
+			byte(value>>24), byte(value>>16), byte(value>>8), byte(value))
+		return nil
+	case reflect.Uint:
+		//As Uint would be 32/64 bit, so
+		var bi big.Int
+		return serializeBigInt(bi.SetUint64(val.Uint()), w)
+	default:
+		return fmt.Errorf("ser: invalid Uint type: %s", val.Type().Name())
+	}
+	return nil
+}

--- a/qkc/serialize/serializer_test.go
+++ b/qkc/serialize/serializer_test.go
@@ -1,0 +1,210 @@
+// Ported verbatim from github.com/QuarkChain/goquarkchain/serialize (byte-compatible).
+
+package serialize
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"math/big"
+	"testing"
+)
+
+type serializableStruct struct {
+	val uint64
+	err error
+}
+
+func (e *serializableStruct) Serialize(w *[]byte) error {
+	if e.err != nil {
+		return e.err
+	} else {
+		*w = append(*w, new(big.Int).SetUint64(e.val).Bytes()...)
+	}
+	return nil
+}
+
+func (e *serializableStruct) Deserialize(bb *ByteBuffer) error {
+	if e == nil {
+
+	} else if bb.Remaining() == 4 {
+		e = nil
+	} else {
+		e.val = 1
+	}
+
+	return nil
+}
+
+type structForTest struct {
+	From         *[]byte
+	To           *[]byte `json:"to"                 ser:"nil"`
+	IgnoredField int     `json:"ignore"             ser:"-"`
+	privateField int     //private field will be Ignored
+}
+
+func newStructForTest(from, to *[]byte) structForTest {
+	s := structForTest{from, to, 0, 0}
+	return s
+}
+
+type testDataForSerialize struct {
+	val           interface{}
+	output, error string
+}
+
+func newUint128(val uint64) *Uint128 {
+	ui := new(Uint128)
+	ui.Value = new(big.Int).SetUint64(val)
+	return ui
+}
+
+func newUint256(val uint64) *Uint256 {
+	ui := new(Uint256)
+	ui.Value = new(big.Int).SetUint64(val)
+	return ui
+}
+
+type LargeBytes struct {
+	Value []byte `bytesizeofslicelen:"4"`
+}
+
+var serdata = []testDataForSerialize{
+	// booleans
+	{val: true, output: "01"},
+	{val: false, output: "00"},
+
+	// integers
+	{val: uint8(0), output: "00"},
+	{val: uint8(128), output: "80"},
+	{val: uint16(0), output: "0000"},
+	{val: uint16(128), output: "0080"},
+	{val: uint32(0), output: "00000000"},
+	{val: uint32(128), output: "00000080"},
+	{val: uint32(1024), output: "00000400"},
+	{val: uint32(0xFFFFFFFF), output: "FFFFFFFF"},
+	{val: uint64(0), output: "0000000000000000"},
+	{val: uint64(128), output: "0000000000000080"},
+	{val: uint64(0xFFFFFFFF), output: "00000000FFFFFFFF"},
+	{val: uint64(0xFFFFFFFFFFFFFFFF), output: "FFFFFFFFFFFFFFFF"},
+	{val: uint(0), output: "00"},
+	{val: uint(128), output: "0180"},
+	{val: uint(1024), output: "020400"},
+	{val: uint(0xFFFFFFFF), output: "04FFFFFFFF"},
+
+	{val: newUint128(0), output: "00000000000000000000000000000000"},
+	{val: newUint128(128), output: "00000000000000000000000000000080"},
+	{val: newUint128(0xFFFFFFFFFFFFFFFF), output: "0000000000000000FFFFFFFFFFFFFFFF"},
+	{val: newUint256(0), output: "0000000000000000000000000000000000000000000000000000000000000000"},
+	{val: newUint256(128), output: "0000000000000000000000000000000000000000000000000000000000000080"},
+	{val: newUint256(0xFFFFFFFFFFFFFFFF), output: "000000000000000000000000000000000000000000000000FFFFFFFFFFFFFFFF"},
+
+	// big integers (should match uint for small values)
+	{val: big.NewInt(0), output: "00"},
+	{val: big.NewInt(1), output: "0101"},
+	{val: big.NewInt(128), output: "0180"},
+	{val: big.NewInt(256), output: "020100"},
+	{val: big.NewInt(1024), output: "020400"},
+	{val: big.NewInt(0xFFFFFF), output: "03FFFFFF"},
+	{val: big.NewInt(0xFFFFFFFFFFFFFF), output: "07FFFFFFFFFFFFFF"},
+	{
+		val:    big.NewInt(0).SetBytes(unhex("102030405060708090A0B0C0D0E0F2")),
+		output: "0F102030405060708090A0B0C0D0E0F2",
+	},
+	{
+		val:    big.NewInt(0).SetBytes(unhex("0100020003000400050006000700080009000A000B000C000D000E01")),
+		output: "1C0100020003000400050006000700080009000A000B000C000D000E01",
+	},
+
+	// non-pointer big.Int
+	{val: *big.NewInt(0), output: "00"},
+	{val: *big.NewInt(0xFFFFFF), output: "03FFFFFF"},
+
+	// negative ints are not supported
+	{val: big.NewInt(-1), error: "ser: cannot serialize negative *big.Int"},
+
+	// byte slices, strings
+	{val: []byte{}, output: "00"},
+	{val: []byte{0x7E}, output: "017E"},
+	{val: []byte{0x80}, output: "0180"},
+	{val: []byte{1, 2, 3}, output: "03010203"},
+
+	{val: &LargeBytes{}, output: "00000000"},
+	{val: &LargeBytes{[]byte{0x7E}}, output: "000000017E"},
+	{val: &LargeBytes{[]byte{0x80}}, output: "0000000180"},
+	{val: &LargeBytes{[]byte{1, 2, 3}}, output: "00000003010203"},
+
+	{val: "", output: "00000000"},
+	{val: "\x7E", output: "000000017E"},
+	{val: "\x80", output: "0000000180"},
+	{val: "dog", output: "00000003646F67"},
+
+	// slices
+	{val: []uint8{}, output: "00"},
+	{val: []uint8{1, 2, 3}, output: "03010203"},
+	{val: []uint32{}, output: "00"},
+	{val: []uint32{1, 2, 3}, output: "03000000010000000200000003"},
+
+	//Array
+	{val: [3]uint8{1, 2, 3}, output: "010203"},
+	{val: [3]uint32{1, 2, 3}, output: "000000010000000200000003"},
+
+	// structs
+	{val: newStructForTest(&[]byte{1, 2, 3}, nil), output: "0301020300"},
+	{val: newStructForTest(&[]byte{1, 2, 3}, &[]byte{4, 5, 6}), output: "030102030103040506"},
+	{val: newStructForTest(nil, &[]byte{4, 5, 6}), output: "000103040506"},
+
+	// nil
+	// as nilOk default value is false, serialize will use default
+	// value to serialize instead of nil
+	{val: (*uint)(nil), output: "00"},
+	{val: (*string)(nil), output: "00000000"},
+	{val: (*[]byte)(nil), output: "00"},
+	{val: (*[10]byte)(nil), output: "00000000000000000000"},
+	{val: (*big.Int)(nil), output: "00"},
+	{val: (*[]string)(nil), output: "00"},
+	{val: (*[10]string)(nil), output: "00000000000000000000000000000000000000000000000000000000000000000000000000000000"},
+	{val: (*[]struct{ uint })(nil), output: "00"},
+
+	// interfaces
+	// Serializer
+	{val: (*serializableStruct)(nil), output: ""},
+	{val: &serializableStruct{val: 0xFFFF}, output: "FFFF"},
+	{val: &serializableStruct{1, errors.New("test error")}, error: "test error"},
+
+	// int is not support
+	{val: int(0), error: "type int is not serializable"},
+	{val: (*interface{})(nil), error: "type interface {} is not serializable"},
+}
+
+func runEncTests(t *testing.T, f func(val interface{}) ([]byte, error)) {
+	for i, test := range serdata {
+		output, err := f(test.val)
+		if err != nil && test.error == "" {
+			t.Errorf("test %d: unexpected error: %v\nvalue %#v\ntype %T",
+				i, err, test.val, test.val)
+			continue
+		}
+		if test.error != "" && fmt.Sprint(err) != test.error {
+			t.Errorf("test %d: error mismatch\ngot   %v\nwant  %v\nvalue %#v\ntype  %T",
+				i, err, test.error, test.val, test.val)
+			continue
+		}
+		if err == nil && !bytes.Equal(output, unhex(test.output)) {
+			t.Errorf("test %d: output mismatch:\ngot   %X\nwant  %s\nvalue %#v\ntype  %T",
+				i, output, test.output, test.val, test.val)
+		}
+	}
+}
+
+func TestSerialize(t *testing.T) {
+	runEncTests(t, func(val interface{}) ([]byte, error) {
+		b := make([]byte, 0, 1)
+		err := Serialize(&b, val)
+		return b, err
+	})
+}
+
+func TestSerializeToBytes(t *testing.T) {
+	runEncTests(t, SerializeToBytes)
+}

--- a/qkc/serialize/typecache.go
+++ b/qkc/serialize/typecache.go
@@ -1,0 +1,140 @@
+// Ported verbatim from github.com/QuarkChain/goquarkchain/serialize (byte-compatible).
+// Modified from go-ethereum under GNU Lesser General Public License
+
+package serialize
+
+import (
+	"fmt"
+	"reflect"
+	"strconv"
+	"strings"
+	"sync"
+)
+
+var (
+	typeCacheMutex   sync.RWMutex
+	typeCache        = make(map[reflect.Type]*typeinfo)
+	fieldsCacheMutex sync.RWMutex
+	fieldsCache      = make(map[reflect.Type][]field)
+)
+
+type typeinfo struct {
+	serializer
+	deserializer
+}
+
+// represents struct Tags
+type Tags struct {
+	// ser:"nil" controls whether empty input results in a nil pointer.
+	NilOK bool
+	// ser:"-" ignores fields.
+	Ignored bool
+	// bytesizeofslicelen: number
+	ByteSizeOfSliceLen int
+}
+
+type deserializer func(*ByteBuffer, reflect.Value, Tags) error
+
+type serializer func(reflect.Value, *[]byte, Tags) error
+
+func cachedTypeInfo(typ reflect.Type) (*typeinfo, error) {
+	typeCacheMutex.RLock()
+	info := typeCache[typ]
+	typeCacheMutex.RUnlock()
+	if info != nil {
+		return info, nil
+	}
+
+	typeCacheMutex.Lock()
+	defer typeCacheMutex.Unlock()
+
+	info, err := genTypeInfo(typ)
+	if err != nil {
+		return nil, err
+	}
+
+	typeCache[typ] = info
+	return typeCache[typ], err
+}
+
+type field struct {
+	index int
+	info  *typeinfo
+	tags  Tags
+	name  string
+}
+
+func structFields(typ reflect.Type) (fields []field, err error) {
+	fieldsCacheMutex.RLock()
+	flds := fieldsCache[typ]
+	fieldsCacheMutex.RUnlock()
+	if flds != nil {
+		return flds, nil
+	}
+	for i := 0; i < typ.NumField(); i++ {
+		if f := typ.Field(i); f.PkgPath == "" { // exported
+			tags, err := parseStructTag(typ, i)
+			if err != nil {
+				return nil, err
+			}
+			if tags.Ignored {
+				continue
+			}
+			info, err := cachedTypeInfo(f.Type)
+			if err != nil {
+				return nil, err
+			}
+			fields = append(fields, field{i, info, tags, f.Name})
+		}
+	}
+	fieldsCacheMutex.Lock()
+	defer fieldsCacheMutex.Unlock()
+	fieldsCache[typ] = fields
+
+	return fields, nil
+}
+
+func parseStructTag(typ reflect.Type, fi int) (Tags, error) {
+	f := typ.Field(fi)
+	var ts Tags
+	ts.ByteSizeOfSliceLen = 1
+	for _, t := range strings.Split(f.Tag.Get("ser"), ",") {
+		switch t = strings.TrimSpace(t); t {
+		case "":
+		case "-":
+			ts.Ignored = true
+		case "nil": // nil equal to optional in PyQuackChain
+			ts.NilOK = true
+		default:
+			return ts, fmt.Errorf("ser: unknown struct tag %q on %v.%s", t, typ, f.Name)
+		}
+	}
+	// bytesizeofslicelen use to specify the number of bytes used to save a slice len
+	// only slice is useful
+	if f.Type.Kind() == reflect.Slice {
+		for _, t := range strings.Split(f.Tag.Get("bytesizeofslicelen"), ",") {
+			t = strings.TrimSpace(t)
+			if t != "" {
+				num, err := strconv.Atoi(t)
+				if err != nil {
+					return ts, err
+				}
+
+				ts.ByteSizeOfSliceLen = num
+			}
+		}
+	}
+
+	return ts, nil
+}
+
+func genTypeInfo(typ reflect.Type) (info *typeinfo, err error) {
+	info = new(typeinfo)
+	if info.serializer, err = makeSerializer(typ); err != nil {
+		return nil, err
+	}
+	if info.deserializer, err = makeDeserializer(typ); err != nil {
+		return nil, err
+	}
+	return info, nil
+}

--- a/qkc/serialize/utils.go
+++ b/qkc/serialize/utils.go
@@ -1,0 +1,58 @@
+// Ported verbatim from github.com/QuarkChain/goquarkchain/serialize (byte-compatible).
+
+package serialize
+
+import (
+	"math/big"
+	"reflect"
+)
+
+var (
+	serializableInterface = reflect.TypeOf(new(Serializable)).Elem()
+	bigInt                = reflect.TypeOf(big.Int{})
+	typUint128            = reflect.TypeOf(Uint128{})
+	typUint256            = reflect.TypeOf(Uint256{})
+	big0                  = big.NewInt(0)
+)
+
+type BigUint struct {
+	Value *big.Int
+}
+
+type Uint128 BigUint
+type Uint256 BigUint
+
+func (ui *Uint128) Serialize(w *[]byte) error {
+	return serializeFixSizeBigUint(ui.Value, 16, w)
+}
+
+func (ui *Uint128) Deserialize(bb *ByteBuffer) error {
+	if ui.Value == nil {
+		ui.Value = new(big.Int)
+	}
+	return deserializeFixSizeBigUint(bb, ui.Value, 16)
+}
+
+func (ui *Uint256) Serialize(w *[]byte) error {
+	return serializeFixSizeBigUint(ui.Value, 32, w)
+}
+
+func (ui *Uint256) Deserialize(bb *ByteBuffer) error {
+	if ui.Value == nil {
+		ui.Value = new(big.Int)
+	}
+	return deserializeFixSizeBigUint(bb, ui.Value, 32)
+}
+
+type Serializable interface {
+	Serialize(w *[]byte) error
+	Deserialize(bb *ByteBuffer) error
+}
+
+func isUint(k reflect.Kind) bool {
+	return k >= reflect.Uint && k <= reflect.Uintptr
+}
+
+func isByte(typ reflect.Type) bool {
+	return typ.Kind() == reflect.Uint8 && !typ.Implements(serializableInterface)
+}


### PR DESCRIPTION
  **Stacked PR 1/8.** Base: `goshard/base`. Bottom of the QuarkChain slavechain
  port stack. Chain: serialize → base → types → rawdb → consensus → core → miner → cmd.
  Review this layer only; merge bottom-up.

  ## Summary
  Verbatim port of `github.com/QuarkChain/goquarkchain/serialize` — QuarkChain's
  reflection-based binary codec, used **instead of RLP** for all slavechain
  headers, blocks and storage records (header hash is `keccak256(serialize(header))`).
  Pure stdlib, zero adaptations.

  ## Tests
  The original golden byte-vector tests (`serializer_test.go`, `deserializer_test.go`):
  every supported type encodes/decodes to the exact expected bytes.