### PR TITLE
internal/ethapi: return InvalidParams for malformed sendRawTransaction RLP

### DIFF
--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -1735,7 +1735,7 @@ func (api *TransactionAPI) currentBlobSidecarVersion() byte {
 func (api *TransactionAPI) SendRawTransaction(ctx context.Context, input hexutil.Bytes) (common.Hash, error) {
 	tx := new(types.Transaction)
 	if err := tx.UnmarshalBinary(input); err != nil {
-		return common.Hash{}, err
+		return common.Hash{}, &invalidParamsError{message: err.Error()}
 	}
 
 	// Convert legacy blob transaction proofs.
@@ -1758,7 +1758,7 @@ func (api *TransactionAPI) SendRawTransaction(ctx context.Context, input hexutil
 func (api *TransactionAPI) SendRawTransactionSync(ctx context.Context, input hexutil.Bytes, timeoutMs *uint64) (map[string]interface{}, error) {
 	tx := new(types.Transaction)
 	if err := tx.UnmarshalBinary(input); err != nil {
-		return nil, err
+		return nil, &invalidParamsError{message: err.Error()}
 	}
 
 	// Convert legacy blob transaction proofs.

--- a/internal/ethapi/api_test.go
+++ b/internal/ethapi/api_test.go
@@ -4175,52 +4175,6 @@ func TestSendRawTransactionSync_Timeout(t *testing.T) {
 	}
 }
 
-func TestSendRawTransaction_InvalidParams_OnMalformedRLP(t *testing.T) {
-	t.Parallel()
-	genesis := &core.Genesis{
-		Config: params.TestChainConfig,
-		Alloc:  types.GenesisAlloc{},
-	}
-	b := newTestBackend(t, 0, genesis, ethash.NewFaker(), nil)
-	api := NewTransactionAPI(b, new(AddrLocker))
-
-	cases := []struct {
-		name string
-		raw  string
-	}{
-		{"empty-list", "0xc0"},
-		{"truncated-short-list", "0xd4"},
-		{"unknown-tx-type", "0x09c0"},
-		{"eip4844-truncated-list", "0x03c0"},
-		{"eip7702-truncated-list", "0x04c0"},
-	}
-
-	for _, tc := range cases {
-		t.Run(tc.name+"/SendRawTransaction", func(t *testing.T) {
-			_, err := api.SendRawTransaction(context.Background(), hexutil.MustDecode(tc.raw))
-			assertInvalidParams(t, err)
-		})
-		t.Run(tc.name+"/SendRawTransactionSync", func(t *testing.T) {
-			_, err := api.SendRawTransactionSync(context.Background(), hexutil.MustDecode(tc.raw), nil)
-			assertInvalidParams(t, err)
-		})
-	}
-}
-
-func assertInvalidParams(t *testing.T, err error) {
-	t.Helper()
-	if err == nil {
-		t.Fatal("expected error, got nil")
-	}
-	var ec interface{ ErrorCode() int }
-	if !errors.As(err, &ec) {
-		t.Fatalf("expected error implementing ErrorCode(), got %T: %v", err, err)
-	}
-	if got, want := ec.ErrorCode(), -32602; got != want {
-		t.Fatalf("expected ErrorCode=%d (InvalidParams), got %d (%v)", want, got, err)
-	}
-}
-
 func TestGetStorageValues(t *testing.T) {
 	t.Parallel()
 

--- a/internal/ethapi/api_test.go
+++ b/internal/ethapi/api_test.go
@@ -4175,6 +4175,55 @@ func TestSendRawTransactionSync_Timeout(t *testing.T) {
 	}
 }
 
+// TestSendRawTransaction_InvalidParams_OnMalformedRLP verifies that malformed-RLP
+// inputs are reported with JSON-RPC error code -32602 (InvalidParams), not the
+// default -32000. Aligns with JSON-RPC 2.0 spec and the Reth/Besu implementations.
+func TestSendRawTransaction_InvalidParams_OnMalformedRLP(t *testing.T) {
+	t.Parallel()
+	genesis := &core.Genesis{
+		Config: params.TestChainConfig,
+		Alloc:  types.GenesisAlloc{},
+	}
+	b := newTestBackend(t, 0, genesis, ethash.NewFaker(), nil)
+	api := NewTransactionAPI(b, new(AddrLocker))
+
+	cases := []struct {
+		name string
+		raw  string
+	}{
+		{"empty-list", "0xc0"},
+		{"truncated-short-list", "0xd4"},
+		{"unknown-tx-type", "0x09c0"},
+		{"eip4844-truncated-list", "0x03c0"},
+		{"eip7702-truncated-list", "0x04c0"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name+"/SendRawTransaction", func(t *testing.T) {
+			_, err := api.SendRawTransaction(context.Background(), hexutil.MustDecode(tc.raw))
+			assertInvalidParams(t, err)
+		})
+		t.Run(tc.name+"/SendRawTransactionSync", func(t *testing.T) {
+			_, err := api.SendRawTransactionSync(context.Background(), hexutil.MustDecode(tc.raw), nil)
+			assertInvalidParams(t, err)
+		})
+	}
+}
+
+func assertInvalidParams(t *testing.T, err error) {
+	t.Helper()
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	var ec interface{ ErrorCode() int }
+	if !errors.As(err, &ec) {
+		t.Fatalf("expected error implementing ErrorCode(), got %T: %v", err, err)
+	}
+	if got, want := ec.ErrorCode(), -32602; got != want {
+		t.Fatalf("expected ErrorCode=%d (InvalidParams), got %d (%v)", want, got, err)
+	}
+}
+
 func TestGetStorageValues(t *testing.T) {
 	t.Parallel()
 

--- a/internal/ethapi/api_test.go
+++ b/internal/ethapi/api_test.go
@@ -4175,9 +4175,6 @@ func TestSendRawTransactionSync_Timeout(t *testing.T) {
 	}
 }
 
-// TestSendRawTransaction_InvalidParams_OnMalformedRLP verifies that malformed-RLP
-// inputs are reported with JSON-RPC error code -32602 (InvalidParams), not the
-// default -32000. Aligns with JSON-RPC 2.0 spec and the Reth/Besu implementations.
 func TestSendRawTransaction_InvalidParams_OnMalformedRLP(t *testing.T) {
 	t.Parallel()
 	genesis := &core.Genesis{


### PR DESCRIPTION
## Summary

`SendRawTransaction` and `SendRawTransactionSync` return the bare `UnmarshalBinary` error. Since RLP/decode errors don't implement `rpc.Error.ErrorCode()`, the dispatcher falls back to `errcodeDefault = -32000`. Per [JSON-RPC 2.0](https://www.jsonrpc.org/specification#error_object), malformed params should be `-32602`.

This wires the existing `invalidParamsError` wrapper (`internal/ethapi/errors.go`) into both decode paths. Decoder messages pass through unchanged — only the wire code changes.

## Changes

```diff
 // internal/ethapi/api.go — SendRawTransaction
     if err := tx.UnmarshalBinary(input); err != nil {
-        return common.Hash{}, err
+        return common.Hash{}, &invalidParamsError{message: err.Error()}
     }
 // SendRawTransactionSync — same one-line change
```

## Why -32602

The `-32000` today is a fallback accident, not a deliberate choice. This matches where the spec is heading: [execution-apis#817](https://github.com/ethereum/execution-apis/issues/817) (fjl: input-validation conditions on submit methods are just "invalid parameters") and [#818](https://github.com/ethereum/execution-apis/pull/818) (drops the `-32000 "Invalid input"` group from `eth_sendRawTransaction`). Reth and Besu already return `-32602` for RLP-decode failures; geth and Erigon default to `-32000`.

## Test plan

Added `TestSendRawTransaction_InvalidParams_OnMalformedRLP` (`internal/ethapi/api_test.go`): 5 decode-failure shapes (`0xc0`, `0xd4`, `0x09c0`, `0x03c0`, `0x04c0`) × both methods, asserting `ErrorCode() == -32602` via `errors.As`. All 10 subtests pass.

## Out of scope

- Decoder message wording — unchanged.
- Non-decode paths (`SubmitTransaction`, blob conversion): node-state/operational, not param validation — `-32000` stays.
- Engine API: `UnmarshalBinary` from user-facing JSON-RPC only exists in these two functions.

## Related

- Erigon companion: [erigontech/erigon#21701](https://github.com/erigontech/erigon/pull/21701)
- Nethermind: [NethermindEth/nethermind#11921](https://github.com/NethermindEth/nethermind/issues/11921)
- Spec: [execution-apis#817](https://github.com/ethereum/execution-apis/issues/817), [#818](https://github.com/ethereum/execution-apis/pull/818)