### PR TITLE
core/rawdb: fix freezer close sync error message

### DIFF
--- a/core/rawdb/freezer_test.go
+++ b/core/rawdb/freezer_test.go
@@ -516,7 +516,7 @@ func TestFreezerCloseSync(t *testing.T) {
 	if err := f.SyncAncient(); err == nil {
 		t.Fatalf("want error, have nil")
 	} else if have, want := err.Error(), "[closed closed]"; have != want {
-		t.Fatalf("want %v, have %v", have, want)
+		t.Fatalf("want %v, have %v", want, have)
 	}
 }
 


### PR DESCRIPTION
Print the expected freezer close sync error before the actual value in TestFreezerCloseSync. The assertion already compared have and want correctly, but the failure message reported them in the wrong order.