### PR TITLE
cmd/geth: fix logging line count error

### DIFF
--- a/cmd/geth/logging_test.go
+++ b/cmd/geth/logging_test.go
@@ -96,7 +96,7 @@ func testConsoleLogging(t *testing.T, format string, tStart, tEnd int) {
 		}
 	}
 	if len(haveLines) != len(wantLines) {
-		t.Errorf("format %v, want %d lines, have %d", format, len(haveLines), len(wantLines))
+		t.Errorf("format %v, want %d lines, have %d", format, len(wantLines), len(haveLines))
 	}
 }
 


### PR DESCRIPTION
Report the expected and actual console log line counts in the correct order. The test already compares the lengths correctly, but the failure message printed have before want.