### PR TITLE
cmd/devp2p/internal/v5test: fix challenge data mismatch error

### DIFF
--- a/cmd/devp2p/internal/v5test/discv5tests.go
+++ b/cmd/devp2p/internal/v5test/discv5tests.go
@@ -186,7 +186,7 @@ func (s *Suite) TestHandshakeResend(t *utesting.T) {
 			t.Fatalf("wrong nonce %x in WHOAREYOU (want %x)", resp.Nonce[:], challenge1.Nonce[:])
 		}
 		if !bytes.Equal(resp.ChallengeData, challenge1.ChallengeData) {
-			t.Fatalf("wrong ChallengeData in resent WHOAREYOU (want %x)", resp.ChallengeData, challenge1.ChallengeData)
+			t.Fatalf("wrong ChallengeData in resent WHOAREYOU: got %x, want %x", resp.ChallengeData, challenge1.ChallengeData)
 		}
 		resp.Node = conn.remote
 	default:


### PR DESCRIPTION
Label the actual and expected challenge data values in the WHOAREYOU resend test failure. This makes the diagnostic clear when the resent ChallengeData does not match the original challenge.