### PR TITLE
cmd/devp2p: fix test error message formats

### DIFF
--- a/cmd/devp2p/internal/ethtest/suite.go
+++ b/cmd/devp2p/internal/ethtest/suite.go
@@ -413,7 +413,7 @@ func (s *Suite) TestGetBlockBodies(t *utesting.T) {
 		t.Fatalf("error reading block bodies msg: %v", err)
 	}
 	if got, want := resp.RequestId, req.RequestId; got != want {
-		t.Fatalf("unexpected request id in respond", got, want)
+		t.Fatalf("unexpected request id in response: got %d, want %d", got, want)
 	}
 	if resp.List.Len() != len(req.GetBlockBodiesRequest) {
 		t.Fatalf("wrong bodies in response: expected %d bodies, got %d", len(req.GetBlockBodiesRequest), resp.List.Len())

--- a/cmd/devp2p/internal/ethtest/suite.go
+++ b/cmd/devp2p/internal/ethtest/suite.go
@@ -457,7 +457,7 @@ func (s *Suite) TestGetReceipts(t *utesting.T) {
 			t.Fatalf("error reading block receipts msg: %v", err)
 		}
 		if got, want := resp.RequestId, req.RequestId; got != want {
-			t.Fatalf("unexpected request id in respond", got, want)
+			t.Fatalf("unexpected request id in response: got %d, want %d", got, want)
 		}
 		if resp.List.Len() != len(req.GetReceiptsRequest) {
 			t.Fatalf("wrong receipts in response: expected %d receipts, got %d", len(req.GetReceiptsRequest), resp.List.Len())
@@ -478,7 +478,7 @@ func (s *Suite) TestGetReceipts(t *utesting.T) {
 			t.Fatalf("error reading block receipts msg: %v", err)
 		}
 		if got, want := resp.RequestId, req.RequestId; got != want {
-			t.Fatalf("unexpected request id in respond", got, want)
+			t.Fatalf("unexpected request id in response: got %d, want %d", got, want)
 		}
 		if resp.List.Len() != len(req.GetReceiptsRequest) {
 			t.Fatalf("wrong receipts in response: expected %d receipts, got %d", len(req.GetReceiptsRequest), resp.List.Len())

--- a/cmd/devp2p/internal/v5test/discv5tests.go
+++ b/cmd/devp2p/internal/v5test/discv5tests.go
@@ -186,7 +186,7 @@ func (s *Suite) TestHandshakeResend(t *utesting.T) {
 			t.Fatalf("wrong nonce %x in WHOAREYOU (want %x)", resp.Nonce[:], challenge1.Nonce[:])
 		}
 		if !bytes.Equal(resp.ChallengeData, challenge1.ChallengeData) {
-			t.Fatalf("wrong ChallengeData in resent WHOAREYOU (want %x)", resp.ChallengeData, challenge1.ChallengeData)
+			t.Fatalf("wrong ChallengeData in resent WHOAREYOU: got %x, want %x", resp.ChallengeData, challenge1.ChallengeData)
 		}
 		resp.Node = conn.remote
 	default:


### PR DESCRIPTION
Include the actual and expected request IDs in the GetBlockBodies response failure message. This also fixes the typo in the diagnostic so mismatched responses report a useful error.