### PR TITLE
triedb/pathdb: fix obsolete history index log version

### DIFF
--- a/triedb/pathdb/history_indexer.go
+++ b/triedb/pathdb/history_indexer.go
@@ -766,7 +766,7 @@ func checkVersion(disk ethdb.KeyValueStore, typ historyType) {
 	if err == nil {
 		version = fmt.Sprintf("%d", m.Version)
 	}
-	log.Info("Cleaned up obsolete history index", "type", typ, "version", version, "want", version)
+	log.Info("Cleaned up obsolete history index", "type", typ, "version", version, "want", ver)
 }
 
 // newHistoryIndexer constructs the history indexer and launches the background


### PR DESCRIPTION
Log the expected history index version in the obsolete index cleanup message. The diagnostic previously reused the detected on-disk version for both the current and wanted values, hiding which version triggered the cleanup.