### PR TITLE
log: clone terminal handler attrs

### DIFF
--- a/log/handler.go
+++ b/log/handler.go
@@ -7,6 +7,7 @@ import (
 	"log/slog"
 	"math/big"
 	"reflect"
+	"slices"
 	"sync"
 	"time"
 
@@ -95,7 +96,7 @@ func (h *TerminalHandler) WithAttrs(attrs []slog.Attr) slog.Handler {
 		wr:           h.wr,
 		lvl:          h.lvl,
 		useColor:     h.useColor,
-		attrs:        append(h.attrs, attrs...),
+		attrs:        append(slices.Clone(h.attrs), attrs...),
 		fieldPadding: make(map[string]int),
 	}
 }


### PR DESCRIPTION
Clone the existing terminal handler attrs before appending new attrs. This avoids a potential attr memory overwrite when append reuses the backing array shared with the parent handler.