### PR TITLE
core/vm: charge consumed gas in opPush1EIP4762 for consistency

### DIFF
--- a/core/vm/eips.go
+++ b/core/vm/eips.go
@@ -403,7 +403,7 @@ func opPush1EIP4762(pc *uint64, evm *EVM, scope *ScopeContext) ([]byte, error) {
 			// advanced past this boundary.
 			contractAddr := scope.Contract.Address()
 			consumed, wanted := evm.AccessEvents.CodeChunksRangeGas(contractAddr, *pc+1, uint64(1), uint64(len(scope.Contract.Code)), false, scope.Contract.Gas.RegularGas)
-			scope.Contract.UseGas(GasCosts{RegularGas: wanted}, evm.Config.Tracer, tracing.GasChangeUnspecified)
+			scope.Contract.UseGas(GasCosts{RegularGas: consumed}, evm.Config.Tracer, tracing.GasChangeUnspecified)
 			if consumed < wanted {
 				return nil, ErrOutOfGas
 			}


### PR DESCRIPTION
opPush1EIP4762 charged the full `wanted` gas returned by CodeChunksRangeGas, while its two sibling functions (opExtCodeCopyEIP4762 and makePushEIP4762) charge `consumed`, the amount actually affordable. Unify it to `consumed`.

This is a consistency cleanup, not a consensus change:

  - The two values only differ when consumed < wanted, which happens only on the OOG path. There, consumed equals the full remaining budget and wanted exceeds it, so GasBudget.Charge(wanted) fails its `budget < cost` guard and deducts nothing (no underflow is possible). Charging consumed instead deducts exactly the remaining budget, leaving zero.

  - Either way the opcode then returns ErrOutOfGas, after which the call frame exhausts all remaining gas (gas.Exhaust), so the gas returned to the caller is zero regardless. No state or consensus difference.

The only observable effect is on tracing: charging consumed emits the correct partial GasChange event for the witness gas actually accounted, where charging wanted silently emitted none because Charge failed.