### PR TITLE
miner: skip oversized tx instead of aborting block fill

### DIFF
--- a/miner/worker.go
+++ b/miner/worker.go
@@ -427,6 +427,8 @@ func (miner *Miner) commitTransactions(ctx context.Context, env *environment, pl
 	defer spanEnd(nil)
 
 	isCancun := miner.chainConfig.IsCancun(env.header.Number, env.header.Time)
+	var fixSizeRetry = 0
+	const fixSizeRetryLimit = 10
 	for {
 		// Check interruption signal and abort building if it's fired.
 		if interrupt != nil {
@@ -497,9 +499,17 @@ func (miner *Miner) commitTransactions(ctx context.Context, env *environment, pl
 		}
 
 		// if inclusion of the transaction would put the block size over the
-		// maximum we allow, don't add any more txs to the payload.
+		// maximum we allow, skip this sender and try the next sender's
+		// transactions, consistent with the gas and blob space checks above.
 		if !env.txFitsSize(tx) {
-			break
+			log.Trace("Not enough block space left for transaction", "hash", ltx.Hash, "size", tx.Size())
+			txs.Pop()
+			fixSizeRetry++
+			if fixSizeRetry <= fixSizeRetryLimit {
+				continue
+			} else {
+				break
+			}
 		}
 		// Error may be ignored here. The error has already been checked
 		// during transaction acceptance in the transaction pool.


### PR DESCRIPTION
When filling a block, the transaction loop checks three resource limits before committing a candidate: remaining gas, remaining blob space, and remaining block size. The gas and blob checks call txs.Pop() and continue, which drops only the current sender's transactions from the price-sorted heap and moves on to the next best sender.

The block-size check instead did a plain break, aborting the entire selection loop the moment the highest-priced candidate did not fit. That discarded every remaining transaction from all other senders, even though many smaller ones could still fit under params.MaxBlockSize. A single large-calldata, top-priced transaction near the size limit would therefore under-fill the block and leave includable fees on the table.

Make the size check consistent with the gas and blob checks: Pop the offending sender and continue to the next one.