### PR TITLE
p2p/nat: return exactly n random STUN servers on every call

### DIFF
--- a/p2p/nat/stun.go
+++ b/p2p/nat/stun.go
@@ -91,15 +91,9 @@ func (s *stun) ExternalIP() (net.IP, error) {
 
 func (s *stun) randomServers(n int) []string {
 	n = min(n, len(s.serverList))
-	m := make(map[int]struct{}, n)
 	list := make([]string, 0, n)
-	for i := 0; i < len(s.serverList)*2 && len(list) < n; i++ {
-		index := rand.Intn(len(s.serverList))
-		if _, alreadyHit := m[index]; alreadyHit {
-			continue
-		}
+	for _, index := range rand.Perm(len(s.serverList))[:n] {
 		list = append(list, s.serverList[index])
-		m[index] = struct{}{}
 	}
 	return list
 }


### PR DESCRIPTION
randomServers drew indices with rand.Intn into a dedup map, bounded by len(serverList)*2 iterations. When n approaches the number of configured servers, repeated random collisions can exhaust the iteration budget before n unique servers are collected, so the function sometimes returns fewer servers than requested even though enough exist.

For example, with 2 configured servers and requestLimit==3 (capped to 2), the four allowed draws can collide and yield only a single server. If that server is down, ExternalIP fails without ever trying the other.

Replace the sampling loop with rand.Perm, which produces a uniform permutation of all indices in one pass. Slicing the first n entries always yields exactly min(n, len(serverList)) distinct servers, with no probabilistic shortfall.