### PR TITLE
accounts/usbwallet: fix De Morgan error dropping stale wallets on refresh

### DIFF
--- a/accounts/usbwallet/hub.go
+++ b/accounts/usbwallet/hub.go
@@ -220,7 +220,7 @@ func (hub *Hub) refreshWallets() {
 		for len(hub.wallets) > 0 {
 			// Abort if we're past the current device and found an operational one
 			_, failure := hub.wallets[0].Status()
-			if hub.wallets[0].URL().Cmp(url) >= 0 || failure == nil {
+			if hub.wallets[0].URL().Cmp(url) >= 0 && failure == nil {
 				break
 			}
 			// Drop the stale and failed devices


### PR DESCRIPTION


The inner loop in refreshWallets drops cached wallets that sort before the next enumerated device or that have failed. When this drop-while logic was refactored into an early break, the condition was negated but the boolean operator was left as ||, so the negation is incomplete.

The drop condition is:

    (URL.Cmp(url) < 0) || (failure != nil)

so the break (abort dropping) condition must be its De Morgan negation:

    (URL.Cmp(url) >= 0) && (failure == nil)

With ||, the loop breaks as soon as the front wallet is operational, even when it sorts before the current device. The stale wallet is not dropped in place, and neither the "wrap new wallet" nor the "keep matching wallet" branch matches, so the still-present device is silently skipped for that refresh cycle (no WalletArrived) and is only re-added on a later refresh.

Switch the operator to && so the break condition correctly mirrors the intended drop semantics.