### PR TITLE
eth/protocols/snap: make GetStorageRanges always make progress

### DIFF
--- a/eth/protocols/snap/handlers.go
+++ b/eth/protocols/snap/handlers.go
@@ -189,7 +189,7 @@ func ServiceGetStorageRangesQuery(chain *core.BlockChain, req *GetStorageRangesP
 	for _, account := range req.Accounts {
 		// If we've exceeded the requested data limit, abort without opening
 		// a new storage range (that we'd need to prove due to exceeded size)
-		if size >= req.Bytes {
+		if size > req.Bytes {
 			break
 		}
 		// The first account might start from a different origin and end sooner


### PR DESCRIPTION
The storage-range handler guarded its per-account loop with `size >= req.Bytes`, evaluated at the top of the loop before any data is served. A request with Bytes == 0 therefore breaks immediately and returns zero slots.

The sibling handlers use a strict `>` comparison and so always serve at least one item before aborting: GetAccountRange (handlers.go:100) and GetByteCodes (handlers.go:368) both append an entry first and break only once size strictly exceeds the limit. The snap protocol relies on this "always make progress" property; a handler that can return an empty response for a small/zero-byte request can stall the requesting peer.

Switch the storage guard to `>` so the first account's storage range is always served, matching the account and bytecode handlers.