### PR TITLE
cmd/geth: propagate import error when --nocompaction is set

### DIFF
--- a/cmd/geth/chaincmd.go
+++ b/cmd/geth/chaincmd.go
@@ -420,7 +420,7 @@ func importChain(ctx *cli.Context) error {
 	fmt.Printf("GC pause:      %v\n\n", time.Duration(mem.PauseTotalNs))
 
 	if ctx.Bool(utils.NoCompactionFlag.Name) {
-		return nil
+		return importErr
 	}
 
 	// Compact the entire database to more accurately measure disk io and print the stats


### PR DESCRIPTION
importChain records the first import failure in importErr, logs it, and returns it at the end of the function so that "geth import" exits with a non-zero status on failure. However, the --nocompaction early return returned nil instead of importErr, so an import that failed while that flag was set was reported as success (exit code 0).

This silently masked import failures from any script or CI step that relies on the exit code. Return importErr from the early-return path as well, matching the normal (compacting) path.