### PR TITLE
cmd/utils: return ErrImportInterrupted sentinel from batch-import interrupt

### DIFF
--- a/cmd/utils/cmd.go
+++ b/cmd/utils/cmd.go
@@ -221,7 +221,7 @@ func ImportChain(chain *core.BlockChain, fn string) error {
 		}
 		// Import the batch.
 		if checkInterrupt() {
-			return errors.New("interrupted")
+			return ErrImportInterrupted
 		}
 		missing := missingBlocks(chain, blocks[:i])
 		if len(missing) == 0 {


### PR DESCRIPTION


ImportChain has two interrupt checkpoints. The one before loading a batch correctly returns the exported ErrImportInterrupted sentinel, but the one before inserting a batch returned a freshly constructed errors.New("interrupted") instead.

The caller in cmd/geth/chaincmd.go detects interruption with `err == utils.ErrImportInterrupted` to stop processing the remaining files in a multi-file import. A fresh error value never compares equal to the sentinel, so an interrupt caught at this checkpoint was treated as an ordinary per-file failure and the loop kept importing subsequent files.

Return the ErrImportInterrupted sentinel here too so both checkpoints are recognized by the caller.