### PR TITLE
cmd/geth: return error when traverse-rawstate root is missing

### DIFF
--- a/cmd/geth/snapshot.go
+++ b/cmd/geth/snapshot.go
@@ -796,8 +796,8 @@ func traverseRawState(ctx *cli.Context) error {
 	}
 	reader, err := triedb.NodeReader(root)
 	if err != nil {
-		log.Error("State is non-existent", "root", root)
-		return nil
+		log.Error("State is non-existent", "root", root, "err", err)
+		return err
 	}
 	for accIter.Next(true) {
 		nodes += 1


### PR DESCRIPTION
traverseRawState logged "State is non-existent" but returned nil when triedb.NodeReader(root) failed, so the command exited 0 as if traversal had succeeded. An operator verifying state with `geth snapshot traverse-rawstate <root>` against a root that is absent from the database would get a false success.

Return the error (and include it in the log) so the command fails loudly on a missing state root, matching the behavior of the neighboring trie/iterator open paths.