### PR TITLE
accounts/external: forward blob fee cap to external signer

### DIFF
--- a/accounts/external/backend.go
+++ b/accounts/external/backend.go
@@ -237,6 +237,7 @@ func (api *ExternalSigner) SignTx(account accounts.Account, tx *types.Transactio
 	}
 	if tx.Type() == types.BlobTxType {
 		args.BlobHashes = tx.BlobHashes()
+		args.BlobFeeCap = (*hexutil.Big)(tx.BlobGasFeeCap())
 		sidecar := tx.BlobTxSidecar()
 		if sidecar == nil {
 			return nil, errors.New("blobs must be present for signing")


### PR DESCRIPTION
SignTx populated BlobHashes and the sidecar fields (Blobs/Commitments/ Proofs) for a blob transaction but never set args.BlobFeeCap. As a result the external (clef) signer received maxFeePerBlobGas:null and signed a transaction inconsistent with the one passed in, silently dropping the blob fee cap.

Set args.BlobFeeCap from tx.BlobGasFeeCap() so the signing request faithfully reflects the input transaction. This mirrors the existing handling of the other blob-tx fields.