### PR TITLE
cmd/utils: keep metrics tag values containing '='

### DIFF
--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -2268,7 +2268,7 @@ func SplitTagsFlag(tagsFlag string) map[string]string {
 
 	for _, t := range tags {
 		if t != "" {
-			kv := strings.Split(t, "=")
+			kv := strings.SplitN(t, "=", 2)
 
 			if len(kv) == 2 {
 				tagsMap[kv[0]] = kv[1]

--- a/cmd/utils/flags_test.go
+++ b/cmd/utils/flags_test.go
@@ -52,7 +52,9 @@ func Test_SplitTagsFlag(t *testing.T) {
 		{
 			"garbage",
 			"smth=smthelse=123",
-			map[string]string{},
+			map[string]string{
+				"smth": "smthelse=123",
+			},
 		},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
SplitTagsFlag split each "k=v" tag on every "=" with strings.Split, producing more than two parts whenever the value itself contained an "=" (e.g. build=release=2026). Such a tag failed the len(kv) == 2 check and was silently dropped.

Use strings.SplitN(t, "=", 2) so the split happens only on the first "=", keeping the remainder as the value. A tag list like 'host=node1,build=release=2026' now retains the build tag.