### PR TITLE
cmd/devp2p/internal/ethtest: validate received txs, not the sent ones

### DIFF
--- a/cmd/devp2p/internal/ethtest/transaction.go
+++ b/cmd/devp2p/internal/ethtest/transaction.go
@@ -155,7 +155,8 @@ func (s *Suite) sendInvalidTxs(t *utesting.T, txs []*types.Transaction) error {
 
 		switch msg := msg.(type) {
 		case *eth.TransactionsPacket:
-			for _, tx := range txs {
+			received, _ := msg.Items()
+			for _, tx := range received {
 				if _, ok := invalids[tx.Hash()]; ok {
 					return fmt.Errorf("received bad tx: %s", tx.Hash())
 				}

--- a/cmd/devp2p/internal/ethtest/transaction.go
+++ b/cmd/devp2p/internal/ethtest/transaction.go
@@ -155,7 +155,10 @@ func (s *Suite) sendInvalidTxs(t *utesting.T, txs []*types.Transaction) error {
 
 		switch msg := msg.(type) {
 		case *eth.TransactionsPacket:
-			received, _ := msg.Items()
+			received, err := msg.Items()
+			if err != nil {
+				return fmt.Errorf("failed to decode received transactions: %w", err)
+			}
 			for _, tx := range received {
 				if _, ok := invalids[tx.Hash()]; ok {
 					return fmt.Errorf("received bad tx: %s", tx.Hash())


### PR DESCRIPTION
sendInvalidTxs's *eth.TransactionsPacket case iterated `txs` — the locally-sent invalid transactions, every one of which is in `invalids` by construction — instead of the transactions actually carried by the received packet. As a result the loop returned "received bad tx" on the very first TransactionsPacket the peer sent, regardless of its contents, and never inspected what was really propagated.

Iterate msg.Items() (the decoded contents of the received packet) so the "node must not propagate invalid txs" conformance check tests the real condition instead of producing a false negative.