### PR TITLE
signer/fourbyte: fix swapped Want/Have values in stuffed-data error

### DIFF
--- a/signer/fourbyte/abi.go
+++ b/signer/fourbyte/abi.go
@@ -128,9 +128,9 @@ func parseCallData(calldata []byte, unescapedAbidata string) (*decodedCallData, 
 		return nil, err
 	}
 	if !bytes.Equal(encoded, argdata) {
-		was := common.Bytes2Hex(encoded)
-		exp := common.Bytes2Hex(argdata)
-		return nil, fmt.Errorf("WARNING: Supplied data is stuffed with extra data. \nWant %s\nHave %s\nfor method %v", exp, was, method.Sig)
+		have := common.Bytes2Hex(argdata)
+		want := common.Bytes2Hex(encoded)
+		return nil, fmt.Errorf("WARNING: Supplied data is stuffed with extra data. \nWant %s\nHave %s\nfor method %v", want, have, method.Sig)
 	}
 	return &decoded, nil
 }


### PR DESCRIPTION
While reading through the fourbyte call-data decoder I noticed the "stuffed with extra data" verification error prints its two hex values the wrong way round.

After decoding the arguments, `parseCallData` re-encodes them and compares against the supplied bytes; a mismatch means the input carried extra trailing data. The error labels were inverted though: the supplied `argdata` was printed under "Want" and the canonical re-encoding under "Have", so the message told the user the stuffed input was what was wanted.

```
-		was := common.Bytes2Hex(encoded)
-		exp := common.Bytes2Hex(argdata)
-		return nil, fmt.Errorf("... \nWant %s\nHave %s\n...", exp, was, method.Sig)
+		have := common.Bytes2Hex(argdata)
+		want := common.Bytes2Hex(encoded)
+		return nil, fmt.Errorf("... \nWant %s\nHave %s\n...", want, have, method.Sig)
```

Now "Want" shows the expected canonical encoding and "Have" shows the data as supplied. Locals renamed to match the labels.

`go test ./signer/fourbyte/` passes.