### PR TITLE
all: change reflect.Ptr to reflect.Pointer

### DIFF
--- a/accounts/abi/argument.go
+++ b/accounts/abi/argument.go
@@ -112,7 +112,7 @@ func (arguments Arguments) UnpackIntoMap(v map[string]any, data []byte) error {
 // Copy performs the operation go format -> provided struct.
 func (arguments Arguments) Copy(v any, values []any) error {
 	// make sure the passed value is arguments pointer
-	if reflect.Ptr != reflect.ValueOf(v).Kind() {
+	if reflect.Pointer != reflect.ValueOf(v).Kind() {
 		return fmt.Errorf("abi: Unpack(non-pointer %T)", v)
 	}
 	if len(values) == 0 {

--- a/accounts/abi/pack.go
+++ b/accounts/abi/pack.go
@@ -39,7 +39,7 @@ func packElement(t Type, reflectValue reflect.Value) ([]byte, error) {
 	switch t.T {
 	case UintTy:
 		// make sure to not pack a negative value into a uint type.
-		if reflectValue.Kind() == reflect.Ptr {
+		if reflectValue.Kind() == reflect.Pointer {
 			val := new(big.Int).Set(reflectValue.Interface().(*big.Int))
 			if val.Sign() == -1 {
 				return nil, errInvalidSign
@@ -86,7 +86,7 @@ func packNum(value reflect.Value) []byte {
 		return math.U256Bytes(new(big.Int).SetUint64(value.Uint()))
 	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
 		return math.U256Bytes(big.NewInt(value.Int()))
-	case reflect.Ptr:
+	case reflect.Pointer:
 		return math.U256Bytes(new(big.Int).Set(value.Interface().(*big.Int)))
 	default:
 		panic("abi: fatal error")

--- a/accounts/abi/reflect.go
+++ b/accounts/abi/reflect.go
@@ -53,7 +53,7 @@ func ConvertType(in interface{}, proto interface{}) interface{} {
 // indirect recursively dereferences the value until it either gets the value
 // or finds a big.Int
 func indirect(v reflect.Value) reflect.Value {
-	if v.Kind() == reflect.Ptr && v.Elem().Type() != reflect.TypeFor[big.Int]() {
+	if v.Kind() == reflect.Pointer && v.Elem().Type() != reflect.TypeFor[big.Int]() {
 		return indirect(v.Elem())
 	}
 	return v
@@ -102,9 +102,9 @@ func mustArrayToByteSlice(value reflect.Value) reflect.Value {
 func set(dst, src reflect.Value) error {
 	dstType, srcType := dst.Type(), src.Type()
 	switch {
-	case dstType.Kind() == reflect.Interface && dst.Elem().IsValid() && (dst.Elem().Type().Kind() == reflect.Ptr || dst.Elem().CanSet()):
+	case dstType.Kind() == reflect.Interface && dst.Elem().IsValid() && (dst.Elem().Type().Kind() == reflect.Pointer || dst.Elem().CanSet()):
 		return set(dst.Elem(), src)
-	case dstType.Kind() == reflect.Ptr && dstType.Elem() != reflect.TypeFor[big.Int]():
+	case dstType.Kind() == reflect.Pointer && dstType.Elem() != reflect.TypeFor[big.Int]():
 		return set(dst.Elem(), src)
 	case srcType.AssignableTo(dstType) && dst.CanSet():
 		dst.Set(src)
@@ -138,7 +138,7 @@ func setSlice(dst, src reflect.Value) error {
 }
 
 func setArray(dst, src reflect.Value) error {
-	if src.Kind() == reflect.Ptr {
+	if src.Kind() == reflect.Pointer {
 		return set(dst, indirect(src))
 	}
 	array := reflect.New(dst.Type()).Elem()

--- a/log/format.go
+++ b/log/format.go
@@ -123,7 +123,7 @@ func FormatSlogValue(v slog.Value, tmp []byte) (result []byte) {
 	var value any
 	defer func() {
 		if err := recover(); err != nil {
-			if v := reflect.ValueOf(value); v.Kind() == reflect.Ptr && v.IsNil() {
+			if v := reflect.ValueOf(value); v.Kind() == reflect.Pointer && v.IsNil() {
 				result = []byte("<nil>")
 			} else {
 				panic(err)

--- a/rlp/decode.go
+++ b/rlp/decode.go
@@ -166,7 +166,7 @@ func makeDecoder(typ reflect.Type, tags rlpstruct.Tags) (dec decoder, err error)
 		return decodeU256, nil
 	case typ == u256Int:
 		return decodeU256NoPtr, nil
-	case kind == reflect.Ptr:
+	case kind == reflect.Pointer:
 		return makePtrDecoder(typ, tags)
 	case reflect.PointerTo(typ).Implements(decoderInterface):
 		return decodeDecoder, nil
@@ -936,7 +936,7 @@ func (s *Stream) Decode(val interface{}) error {
 	}
 	rval := reflect.ValueOf(val)
 	rtyp := rval.Type()
-	if rtyp.Kind() != reflect.Ptr {
+	if rtyp.Kind() != reflect.Pointer {
 		return errNoPointer
 	}
 	if rval.IsNil() {

--- a/rlp/encode.go
+++ b/rlp/encode.go
@@ -173,7 +173,7 @@ func makeWriter(typ reflect.Type, ts rlpstruct.Tags) (writer, error) {
 		return writeU256IntPtr, nil
 	case typ == u256Int:
 		return writeU256IntNoPtr, nil
-	case kind == reflect.Ptr:
+	case kind == reflect.Pointer:
 		return makePtrWriter(typ, ts)
 	case reflect.PointerTo(typ).Implements(encoderInterface):
 		return makeEncoderWriter(typ), nil

--- a/rlp/internal/rlpstruct/rlpstruct.go
+++ b/rlp/internal/rlpstruct/rlpstruct.go
@@ -156,7 +156,7 @@ func parseTag(field Field, lastPublic int) (Tags, error) {
 			ts.Ignored = true
 		case "nil", "nilString", "nilList":
 			ts.NilOK = true
-			if field.Type.Kind != reflect.Ptr {
+			if field.Type.Kind != reflect.Pointer {
 				return ts, TagError{Field: name, Tag: t, Err: "field is not a pointer"}
 			}
 			switch t {

--- a/rlp/rlpgen/types.go
+++ b/rlp/rlpgen/types.go
@@ -47,7 +47,7 @@ func typeReflectKind(typ types.Type) reflect.Kind {
 	case *types.Map:
 		return reflect.Map
 	case *types.Pointer:
-		return reflect.Ptr
+		return reflect.Pointer
 	case *types.Signature:
 		return reflect.Func
 	case *types.Slice:

--- a/rlp/typecache.go
+++ b/rlp/typecache.go
@@ -203,7 +203,7 @@ func rtypeToStructType(typ reflect.Type, rec map[reflect.Type]*rlpstruct.Type) *
 		IsDecoder: typ.Implements(decoderInterface),
 	}
 	rec[typ] = t
-	if k == reflect.Array || k == reflect.Slice || k == reflect.Ptr {
+	if k == reflect.Array || k == reflect.Slice || k == reflect.Pointer {
 		t.Elem = rtypeToStructType(typ.Elem(), rec)
 	}
 	return t

--- a/rpc/client.go
+++ b/rpc/client.go
@@ -335,7 +335,7 @@ func (c *Client) Call(result interface{}, method string, args ...interface{}) er
 // The result must be a pointer so that package json can unmarshal into it. You
 // can also pass nil, in which case the result is ignored.
 func (c *Client) CallContext(ctx context.Context, result interface{}, method string, args ...interface{}) error {
-	if result != nil && reflect.TypeOf(result).Kind() != reflect.Ptr {
+	if result != nil && reflect.TypeOf(result).Kind() != reflect.Pointer {
 		return fmt.Errorf("call result parameter must be pointer or nil interface: %v", result)
 	}
 	msg, err := c.newMessage(method, args...)

--- a/rpc/json.go
+++ b/rpc/json.go
@@ -407,7 +407,7 @@ func parsePositionalArguments(rawArgs json.RawMessage, types []reflect.Type) ([]
 	}
 	// Set any missing args to nil.
 	for i := len(args); i < len(types); i++ {
-		if types[i].Kind() != reflect.Ptr {
+		if types[i].Kind() != reflect.Pointer {
 			return nil, fmt.Errorf("missing value for required argument %d", i)
 		}
 		args = append(args, reflect.Zero(types[i]))
@@ -425,7 +425,7 @@ func parseArgumentArray(dec *json.Decoder, types []reflect.Type) ([]reflect.Valu
 		if err := dec.Decode(argval.Interface()); err != nil {
 			return args, fmt.Errorf("invalid argument %d: %v", i, err)
 		}
-		if argval.IsNil() && types[i].Kind() != reflect.Ptr {
+		if argval.IsNil() && types[i].Kind() != reflect.Pointer {
 			return args, fmt.Errorf("missing value for required argument %d", i)
 		}
 		args = append(args, argval.Elem())

--- a/rpc/service.go
+++ b/rpc/service.go
@@ -225,7 +225,7 @@ func isErrorType(t reflect.Type) bool {
 
 // Is t Subscription or *Subscription?
 func isSubscriptionType(t reflect.Type) bool {
-	for t.Kind() == reflect.Ptr {
+	for t.Kind() == reflect.Pointer {
 		t = t.Elem()
 	}
 	return t == subscriptionType


### PR DESCRIPTION
Since go 1.18 reflect has `reflect.Pointer` which replaces `reflect.Ptr`.
Newer versions of `govet` will alert. 
See also: https://pkg.go.dev/reflect#pkg-constants