### PR TITLE
core: cleanup txlookup entries on chain rewind

### DIFF
--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -1094,7 +1094,13 @@ func (bc *BlockChain) setHeadBeyondRoot(head uint64, time uint64, root common.Ha
 			rawdb.DeleteBody(db, hash, num)
 			rawdb.DeleteReceipts(db, hash, num)
 		}
-		// Todo(rjl493456442) txlookup, log index, etc
+		// Remove the transaction lookup entries. These are always stored
+		// in the key-value store, even for ancient blocks.
+		if body := rawdb.ReadBody(bc.db, hash, num); body != nil {
+			for _, tx := range body.Transactions {
+				rawdb.DeleteTxLookupEntry(db, tx.Hash())
+			}
+		}
 	}
 	// If SetHead was only called as a chain reparation method, try to skip
 	// touching the header chain altogether, unless the freezer is broken


### PR DESCRIPTION
When the chain is rewound via `debug.setHead` or similar, block bodies and receipts are deleted but the transaction lookup entries (tx hash → block number mapping) are left behind, causing data inconsistency.

This PR adds cleanup of txlookup entries in the `delFn` callback during chain rewind. The body is read for each deleted block and the corresponding txlookup entries are removed. This applies to both ancient and non-ancient blocks since txlookup entries are always stored in the key-value store.

Fixes #33744

```go
if body := rawdb.ReadBody(bc.db, hash, num); body != nil {
    for _, tx := range body.Transactions {
        rawdb.DeleteTxLookupEntry(db, tx.Hash())
    }
}
```