### PR TITLE
go.mod: bump github.com/gorilla/websocket to v1.5.3

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -34,7 +34,7 @@ require (
 	github.com/golang/snappy v1.0.0
 	github.com/google/gofuzz v1.2.0
 	github.com/google/uuid v1.6.0
-	github.com/gorilla/websocket v1.4.2
+	github.com/gorilla/websocket v1.5.3
 	github.com/graph-gophers/graphql-go v1.3.0
 	github.com/hashicorp/go-bexpr v0.1.10
 	github.com/holiman/billy v0.0.0-20250707135307-f2f9b9aae7db

--- a/go.sum
+++ b/go.sum
@@ -192,8 +192,8 @@ github.com/google/pprof v0.0.0-20230207041349-798e818bf904/go.mod h1:uglQLonpP8q
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/gorilla/mux v1.8.0/go.mod h1:DVbg23sWSpFRCP0SfiEN6jmj59UnW/n46BH5rLB71So=
-github.com/gorilla/websocket v1.4.2 h1:+/TMaTYc4QFitKJxsQ7Yye35DkWvkdLcvGKqM+x0Ufc=
-github.com/gorilla/websocket v1.4.2/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
+github.com/gorilla/websocket v1.5.3 h1:saDtZ6Pbx/0u+bgYQ3q96pZgCzfhKXGPqt7kZ72aNNg=
+github.com/gorilla/websocket v1.5.3/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/grafana/pyroscope-go v1.2.7 h1:VWBBlqxjyR0Cwk2W6UrE8CdcdD80GOFNutj0Kb1T8ac=
 github.com/grafana/pyroscope-go v1.2.7/go.mod h1:o/bpSLiJYYP6HQtvcoVKiE9s5RiNgjYTj1DhiddP2Pc=
 github.com/grafana/pyroscope-go/godeltaprof v0.1.9 h1:c1Us8i6eSmkW+Ez05d3co8kasnuOY813tbMN8i/a3Og=


### PR DESCRIPTION
## Description

`gorilla/websocket` v1.4.2 derives WebSocket frame masking keys from `math/rand`, a non-cryptographic PRNG. RFC 6455 requires clients to mask frames with an unpredictable key, so a predictable key weakens the masking (CWE-338). Upstream moved mask-key generation to `crypto/rand` in the v1.5.x line.

go-ethereum dials WebSocket endpoints as a **client** in:
- `rpc/websocket.go`, `rpc/client_opt.go` (`rpc.DialWebsocket`)
- `ethstats/ethstats.go` (stats reporter)

so the client mask path is reachable.

`v1.5.3` is a drop-in for the APIs go-ethereum uses: the change is a single `go.mod` line with no transitive dependency or `go` directive changes.

### Verified

- `go build ./...` clean; `go vet ./rpc/` clean.
- `go test ./rpc/ -count=1` passes (exercises the WS server and client paths).

Addresses #35164.