### PR TITLE
core/rawdb: fix swapped want/have args in TestFreezerCloseSync

### DIFF
--- a/core/rawdb/freezer_test.go
+++ b/core/rawdb/freezer_test.go
@@ -516,7 +516,7 @@ func TestFreezerCloseSync(t *testing.T) {
 	if err := f.SyncAncient(); err == nil {
 		t.Fatalf("want error, have nil")
 	} else if have, want := err.Error(), "[closed closed]"; have != want {
-		t.Fatalf("want %v, have %v", have, want)
+		t.Fatalf("want %v, have %v", want, have)
 	}
 }
 


### PR DESCRIPTION
The failure message in `TestFreezerCloseSync` reads `"want %v, have %v"` but
the arguments were passed as `(have, want)`, so a test failure would print
the actual and expected values in the wrong positions.

```go
// Before
t.Fatalf("want %v, have %v", have, want)

// After
t.Fatalf("want %v, have %v", want, have)
```

Similar to #35134 and #35136.