### PR TITLE
triedb/pathdb: log the expected version in obsolete-index cleanup

### DIFF
--- a/triedb/pathdb/history_indexer.go
+++ b/triedb/pathdb/history_indexer.go
@@ -766,7 +766,7 @@ func checkVersion(disk ethdb.KeyValueStore, typ historyType) {
 	if err == nil {
 		version = fmt.Sprintf("%d", m.Version)
 	}
-	log.Info("Cleaned up obsolete history index", "type", typ, "version", version, "want", version)
+	log.Info("Cleaned up obsolete history index", "type", typ, "version", version, "want", fmt.Sprintf("%d", ver))
 }
 
 // newHistoryIndexer constructs the history indexer and launches the background


### PR DESCRIPTION
In `repairHistoryIndex`, the cleanup log line passes the same variable to both the `version` and `want` fields:

```go
version := "unknown"
if err == nil {
    version = fmt.Sprintf("%d", m.Version)
}
log.Info("Cleaned up obsolete history index", "type", typ, "version", version, "want", version)
```

`version` is the version that was *found* in the metadata (or "unknown"). The `want` field is meant to show the version that was *expected* — which is `ver` (`stateHistoryIndexVersion` / `trienodeHistoryIndexVersion`, the value just checked against on line 750). As written, `want` just repeats the found version, so the log can never tell you what version the index was rebuilt to match.

This logs `ver` under `want` so the line reads found-vs-expected as intended. Log-only change, no behavior change.

`go build ./triedb/...` and `go vet ./triedb/pathdb/` pass.