### PR TITLE
accounts/abi/bind: fix typo in comment

### DIFF
--- a/accounts/abi/bind/v2/internal/contracts/db/contract.sol
+++ b/accounts/abi/bind/v2/internal/contracts/db/contract.sol
@@ -25,7 +25,7 @@ contract DB {
         if (v == 0) {
             return _keys.length;
         }
-        // Check if a key is being overriden
+        // Check if a key is being overridden
         if (_store[k] == 0) {
             _keys.push(k);
             _stats.inserts++;


### PR DESCRIPTION
Fixes a spelling mistake (`overriden` → `overridden`) in a comment in the bind v2 test contract. Comment-only — no functional changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)