### PR TITLE
node: handle JWT secret read errors

### DIFF
--- a/node/node.go
+++ b/node/node.go
@@ -342,10 +342,14 @@ func ObtainJWTSecret(fileName string) ([]byte, error) {
 		}
 		log.Error("Invalid JWT secret", "path", fileName, "length", len(jwtSecret))
 		return nil, errors.New("invalid JWT secret")
+	} else if !errors.Is(err, os.ErrNotExist) {
+		return nil, fmt.Errorf("failed to read JWT secret file %q: %w", fileName, err)
 	}
 	// Need to generate one
 	jwtSecret := make([]byte, 32)
-	crand.Read(jwtSecret)
+	if _, err := crand.Read(jwtSecret); err != nil {
+		return nil, fmt.Errorf("failed to generate JWT secret: %w", err)
+	}
 	// if we're in --dev mode, don't bother saving, just show it
 	if fileName == "" {
 		log.Info("Generated ephemeral JWT secret", "secret", hexutil.Encode(jwtSecret))

--- a/node/node_test.go
+++ b/node/node_test.go
@@ -22,11 +22,14 @@ import (
 	"io"
 	"net"
 	"net/http"
+	"os"
+	"path/filepath"
 	"reflect"
 	"slices"
 	"strings"
 	"testing"
 
+	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/ethdb"
 	"github.com/ethereum/go-ethereum/p2p"
@@ -103,6 +106,59 @@ func TestNodeUsedDataDir(t *testing.T) {
 	_, err = New(&Config{DataDir: dir})
 	if err != ErrDatadirUsed {
 		t.Fatalf("duplicate datadir failure mismatch: have %v, want %v", err, ErrDatadirUsed)
+	}
+}
+
+func TestObtainJWTSecretGeneratesMissingFile(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "jwtsecret")
+
+	secret, err := ObtainJWTSecret(path)
+	if err != nil {
+		t.Fatalf("failed to generate JWT secret: %v", err)
+	}
+	if len(secret) != 32 {
+		t.Fatalf("JWT secret length mismatch: have %d, want 32", len(secret))
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("failed to read generated JWT secret file: %v", err)
+	}
+	if have, want := string(data), hexutil.Encode(secret); have != want {
+		t.Fatalf("JWT secret file mismatch: have %q, want %q", have, want)
+	}
+	loaded, err := ObtainJWTSecret(path)
+	if err != nil {
+		t.Fatalf("failed to load generated JWT secret: %v", err)
+	}
+	if !slices.Equal(loaded, secret) {
+		t.Fatalf("loaded JWT secret mismatch: have %x, want %x", loaded, secret)
+	}
+}
+
+func TestObtainJWTSecretFailsOnReadError(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "jwtsecret")
+	original := []byte("0x" + strings.Repeat("11", 32))
+	if err := os.WriteFile(path, original, 0200); err != nil {
+		t.Fatalf("failed to write JWT secret: %v", err)
+	}
+	t.Cleanup(func() {
+		os.Chmod(path, 0600)
+	})
+	if _, err := os.ReadFile(path); err == nil {
+		t.Skip("test requires unreadable files")
+	}
+	if _, err := ObtainJWTSecret(path); err == nil {
+		t.Fatal("generated JWT secret after read failure")
+	}
+	if err := os.Chmod(path, 0600); err != nil {
+		t.Fatalf("failed to restore JWT secret permissions: %v", err)
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("failed to read JWT secret file: %v", err)
+	}
+	if string(data) != string(original) {
+		t.Fatalf("JWT secret was overwritten: have %q, want %q", data, original)
 	}
 }
 


### PR DESCRIPTION
This makes `ObtainJWTSecret` generate a new JWT secret only when the configured file is missing. Other read failures now return an error instead of falling through to generation, which avoids replacing auth material when the existing file cannot be read.

The generated-file path is otherwise unchanged, apart from checking the return value from `crypto/rand.Read`.

Tests cover missing file generation and preserving an existing secret on read error.

Checks:
- `go test ./node -run 'TestObtainJWTSecret'`
- `go test ./node`
- `go test ./cmd/blsync`
- `go test ./cmd/geth -run '^$'`