### PR TITLE
core: remove logs for burn accounts

### DIFF
--- a/core/state/statedb.go
+++ b/core/state/statedb.go
@@ -769,39 +769,6 @@ type removedAccountWithBalance struct {
 	balance *uint256.Int
 }
 
-// LogsForBurnAccounts returns the eth burn logs for accounts scheduled for
-// removal which still have positive balance. The purpose of this function is
-// to handle a corner case of EIP-7708 where a self-destructed account might
-// still receive funds between sending/burning its previous balance and actual
-// removal. In this case the burning of these remaining balances still need to
-// be logged.
-// Specification EIP-7708: https://eips.ethereum.org/EIPS/eip-7708
-//
-// This function should only be invoked at the transaction boundary, specifically
-// before the Finalise.
-func (s *StateDB) LogsForBurnAccounts() []*types.Log {
-	var list []removedAccountWithBalance
-	for addr := range s.journal.mutations {
-		if obj, exist := s.stateObjects[addr]; exist && obj.selfDestructed && !obj.Balance().IsZero() {
-			list = append(list, removedAccountWithBalance{
-				address: obj.address,
-				balance: obj.Balance(),
-			})
-		}
-	}
-	if list == nil {
-		return nil
-	}
-	sort.Slice(list, func(i, j int) bool {
-		return list[i].address.Cmp(list[j].address) < 0
-	})
-	logs := make([]*types.Log, len(list))
-	for i, acct := range list {
-		logs[i] = types.EthBurnLog(acct.address, acct.balance)
-	}
-	return logs
-}
-
 // Finalise finalises the state by removing the destructed objects and clears
 // the journal as well as the refunds. Finalise, however, will not push any updates
 // into the tries just yet. Only IntermediateRoot or Commit will do that.

--- a/core/state/statedb_hooked.go
+++ b/core/state/statedb_hooked.go
@@ -230,10 +230,6 @@ func (s *hookedStateDB) AddLog(log *types.Log) {
 	}
 }
 
-func (s *hookedStateDB) LogsForBurnAccounts() []*types.Log {
-	return s.inner.LogsForBurnAccounts()
-}
-
 func (s *hookedStateDB) Finalise(deleteEmptyObjects bool) *bal.ConstructionBlockAccessList {
 	if s.hooks.OnBalanceChange == nil && s.hooks.OnNonceChangeV2 == nil && s.hooks.OnNonceChange == nil && s.hooks.OnCodeChangeV2 == nil && s.hooks.OnCodeChange == nil {
 		// Short circuit if no relevant hooks are set.

--- a/core/state_transition.go
+++ b/core/state_transition.go
@@ -740,12 +740,6 @@ func (st *stateTransition) execute() (*ExecutionResult, error) {
 		}
 	}
 
-	// EIP-7708: Emit the ETH-burn logs
-	if rules.IsAmsterdam {
-		for _, log := range st.evm.StateDB.LogsForBurnAccounts() {
-			st.evm.StateDB.AddLog(log)
-		}
-	}
 	return &ExecutionResult{
 		UsedGas:    gasUsed,
 		MaxUsedGas: peakUsed,

--- a/core/vm/instructions.go
+++ b/core/vm/instructions.go
@@ -938,12 +938,9 @@ func opSelfdestruct6780(pc *uint64, evm *EVM, scope *ScopeContext) ([]byte, erro
 		evm.StateDB.SubBalance(this, balance, tracing.BalanceDecreaseSelfdestruct)
 		evm.StateDB.AddBalance(beneficiary, balance, tracing.BalanceIncreaseSelfdestruct)
 	}
-	if evm.chainRules.IsAmsterdam && !balance.IsZero() {
-		if this != beneficiary {
-			evm.StateDB.AddLog(types.EthTransferLog(this, beneficiary, balance))
-		} else if newContract {
-			evm.StateDB.AddLog(types.EthBurnLog(this, balance))
-		}
+	// EIP-7708: emit a transfer log when value moves to a distinct beneficiary.
+	if evm.chainRules.IsAmsterdam && !balance.IsZero() && this != beneficiary {
+		evm.StateDB.AddLog(types.EthTransferLog(this, beneficiary, balance))
 	}
 
 	if tracer := evm.Config.Tracer; tracer != nil {

--- a/core/vm/interface.go
+++ b/core/vm/interface.go
@@ -90,7 +90,6 @@ type StateDB interface {
 	Snapshot() int
 
 	AddLog(*types.Log)
-	LogsForBurnAccounts() []*types.Log
 	AddPreimage(common.Hash, []byte)
 
 	Witness() *stateless.Witness


### PR DESCRIPTION
New spec doesn't emit logs for burned accounts anymore