### PR TITLE
accounts/abi/abigen: add GetABI() method to abigen v2 generated bindings

### DIFF
--- a/accounts/abi/abigen/source2.go.tpl
+++ b/accounts/abi/abigen/source2.go.tpl
@@ -59,6 +59,11 @@ var (
 		abi abi.ABI
 	}
 
+	// GetABI returns the ABI associated with this contract binding.
+	func (c *{{.Type}}) GetABI() abi.ABI {
+		return c.abi
+	}
+
 	// New{{.Type}} creates a new instance of {{.Type}}.
 	func New{{.Type}}() *{{.Type}} {
 		parsed, err := {{.Type}}MetaData.ParseABI()

--- a/accounts/abi/abigen/testdata/v2/callbackparam.go.txt
+++ b/accounts/abi/abigen/testdata/v2/callbackparam.go.txt
@@ -36,6 +36,11 @@ type CallbackParam struct {
 	abi abi.ABI
 }
 
+// GetABI returns the ABI associated with this contract binding.
+func (c *CallbackParam) GetABI() abi.ABI {
+	return c.abi
+}
+
 // NewCallbackParam creates a new instance of CallbackParam.
 func NewCallbackParam() *CallbackParam {
 	parsed, err := CallbackParamMetaData.ParseABI()

--- a/accounts/abi/abigen/testdata/v2/crowdsale.go.txt
+++ b/accounts/abi/abigen/testdata/v2/crowdsale.go.txt
@@ -36,6 +36,11 @@ type Crowdsale struct {
 	abi abi.ABI
 }
 
+// GetABI returns the ABI associated with this contract binding.
+func (c *Crowdsale) GetABI() abi.ABI {
+	return c.abi
+}
+
 // NewCrowdsale creates a new instance of Crowdsale.
 func NewCrowdsale() *Crowdsale {
 	parsed, err := CrowdsaleMetaData.ParseABI()

--- a/accounts/abi/abigen/testdata/v2/dao.go.txt
+++ b/accounts/abi/abigen/testdata/v2/dao.go.txt
@@ -36,6 +36,11 @@ type DAO struct {
 	abi abi.ABI
 }
 
+// GetABI returns the ABI associated with this contract binding.
+func (c *DAO) GetABI() abi.ABI {
+	return c.abi
+}
+
 // NewDAO creates a new instance of DAO.
 func NewDAO() *DAO {
 	parsed, err := DAOMetaData.ParseABI()

--- a/accounts/abi/abigen/testdata/v2/deeplynestedarray.go.txt
+++ b/accounts/abi/abigen/testdata/v2/deeplynestedarray.go.txt
@@ -36,6 +36,11 @@ type DeeplyNestedArray struct {
 	abi abi.ABI
 }
 
+// GetABI returns the ABI associated with this contract binding.
+func (c *DeeplyNestedArray) GetABI() abi.ABI {
+	return c.abi
+}
+
 // NewDeeplyNestedArray creates a new instance of DeeplyNestedArray.
 func NewDeeplyNestedArray() *DeeplyNestedArray {
 	parsed, err := DeeplyNestedArrayMetaData.ParseABI()

--- a/accounts/abi/abigen/testdata/v2/empty.go.txt
+++ b/accounts/abi/abigen/testdata/v2/empty.go.txt
@@ -36,6 +36,11 @@ type Empty struct {
 	abi abi.ABI
 }
 
+// GetABI returns the ABI associated with this contract binding.
+func (c *Empty) GetABI() abi.ABI {
+	return c.abi
+}
+
 // NewEmpty creates a new instance of Empty.
 func NewEmpty() *Empty {
 	parsed, err := EmptyMetaData.ParseABI()

--- a/accounts/abi/abigen/testdata/v2/eventchecker.go.txt
+++ b/accounts/abi/abigen/testdata/v2/eventchecker.go.txt
@@ -35,6 +35,11 @@ type EventChecker struct {
 	abi abi.ABI
 }
 
+// GetABI returns the ABI associated with this contract binding.
+func (c *EventChecker) GetABI() abi.ABI {
+	return c.abi
+}
+
 // NewEventChecker creates a new instance of EventChecker.
 func NewEventChecker() *EventChecker {
 	parsed, err := EventCheckerMetaData.ParseABI()

--- a/accounts/abi/abigen/testdata/v2/getter.go.txt
+++ b/accounts/abi/abigen/testdata/v2/getter.go.txt
@@ -36,6 +36,11 @@ type Getter struct {
 	abi abi.ABI
 }
 
+// GetABI returns the ABI associated with this contract binding.
+func (c *Getter) GetABI() abi.ABI {
+	return c.abi
+}
+
 // NewGetter creates a new instance of Getter.
 func NewGetter() *Getter {
 	parsed, err := GetterMetaData.ParseABI()

--- a/accounts/abi/abigen/testdata/v2/identifiercollision.go.txt
+++ b/accounts/abi/abigen/testdata/v2/identifiercollision.go.txt
@@ -36,6 +36,11 @@ type IdentifierCollision struct {
 	abi abi.ABI
 }
 
+// GetABI returns the ABI associated with this contract binding.
+func (c *IdentifierCollision) GetABI() abi.ABI {
+	return c.abi
+}
+
 // NewIdentifierCollision creates a new instance of IdentifierCollision.
 func NewIdentifierCollision() *IdentifierCollision {
 	parsed, err := IdentifierCollisionMetaData.ParseABI()

--- a/accounts/abi/abigen/testdata/v2/inputchecker.go.txt
+++ b/accounts/abi/abigen/testdata/v2/inputchecker.go.txt
@@ -35,6 +35,11 @@ type InputChecker struct {
 	abi abi.ABI
 }
 
+// GetABI returns the ABI associated with this contract binding.
+func (c *InputChecker) GetABI() abi.ABI {
+	return c.abi
+}
+
 // NewInputChecker creates a new instance of InputChecker.
 func NewInputChecker() *InputChecker {
 	parsed, err := InputCheckerMetaData.ParseABI()

--- a/accounts/abi/abigen/testdata/v2/interactor.go.txt
+++ b/accounts/abi/abigen/testdata/v2/interactor.go.txt
@@ -36,6 +36,11 @@ type Interactor struct {
 	abi abi.ABI
 }
 
+// GetABI returns the ABI associated with this contract binding.
+func (c *Interactor) GetABI() abi.ABI {
+	return c.abi
+}
+
 // NewInteractor creates a new instance of Interactor.
 func NewInteractor() *Interactor {
 	parsed, err := InteractorMetaData.ParseABI()

--- a/accounts/abi/abigen/testdata/v2/nameconflict.go.txt
+++ b/accounts/abi/abigen/testdata/v2/nameconflict.go.txt
@@ -42,6 +42,11 @@ type NameConflict struct {
 	abi abi.ABI
 }
 
+// GetABI returns the ABI associated with this contract binding.
+func (c *NameConflict) GetABI() abi.ABI {
+	return c.abi
+}
+
 // NewNameConflict creates a new instance of NameConflict.
 func NewNameConflict() *NameConflict {
 	parsed, err := NameConflictMetaData.ParseABI()

--- a/accounts/abi/abigen/testdata/v2/numericmethodname.go.txt
+++ b/accounts/abi/abigen/testdata/v2/numericmethodname.go.txt
@@ -36,6 +36,11 @@ type NumericMethodName struct {
 	abi abi.ABI
 }
 
+// GetABI returns the ABI associated with this contract binding.
+func (c *NumericMethodName) GetABI() abi.ABI {
+	return c.abi
+}
+
 // NewNumericMethodName creates a new instance of NumericMethodName.
 func NewNumericMethodName() *NumericMethodName {
 	parsed, err := NumericMethodNameMetaData.ParseABI()

--- a/accounts/abi/abigen/testdata/v2/outputchecker.go.txt
+++ b/accounts/abi/abigen/testdata/v2/outputchecker.go.txt
@@ -35,6 +35,11 @@ type OutputChecker struct {
 	abi abi.ABI
 }
 
+// GetABI returns the ABI associated with this contract binding.
+func (c *OutputChecker) GetABI() abi.ABI {
+	return c.abi
+}
+
 // NewOutputChecker creates a new instance of OutputChecker.
 func NewOutputChecker() *OutputChecker {
 	parsed, err := OutputCheckerMetaData.ParseABI()

--- a/accounts/abi/abigen/testdata/v2/overload.go.txt
+++ b/accounts/abi/abigen/testdata/v2/overload.go.txt
@@ -36,6 +36,11 @@ type Overload struct {
 	abi abi.ABI
 }
 
+// GetABI returns the ABI associated with this contract binding.
+func (c *Overload) GetABI() abi.ABI {
+	return c.abi
+}
+
 // NewOverload creates a new instance of Overload.
 func NewOverload() *Overload {
 	parsed, err := OverloadMetaData.ParseABI()

--- a/accounts/abi/abigen/testdata/v2/rangekeyword.go.txt
+++ b/accounts/abi/abigen/testdata/v2/rangekeyword.go.txt
@@ -36,6 +36,11 @@ type RangeKeyword struct {
 	abi abi.ABI
 }
 
+// GetABI returns the ABI associated with this contract binding.
+func (c *RangeKeyword) GetABI() abi.ABI {
+	return c.abi
+}
+
 // NewRangeKeyword creates a new instance of RangeKeyword.
 func NewRangeKeyword() *RangeKeyword {
 	parsed, err := RangeKeywordMetaData.ParseABI()

--- a/accounts/abi/abigen/testdata/v2/slicer.go.txt
+++ b/accounts/abi/abigen/testdata/v2/slicer.go.txt
@@ -36,6 +36,11 @@ type Slicer struct {
 	abi abi.ABI
 }
 
+// GetABI returns the ABI associated with this contract binding.
+func (c *Slicer) GetABI() abi.ABI {
+	return c.abi
+}
+
 // NewSlicer creates a new instance of Slicer.
 func NewSlicer() *Slicer {
 	parsed, err := SlicerMetaData.ParseABI()

--- a/accounts/abi/abigen/testdata/v2/structs.go.txt
+++ b/accounts/abi/abigen/testdata/v2/structs.go.txt
@@ -41,6 +41,11 @@ type Structs struct {
 	abi abi.ABI
 }
 
+// GetABI returns the ABI associated with this contract binding.
+func (c *Structs) GetABI() abi.ABI {
+	return c.abi
+}
+
 // NewStructs creates a new instance of Structs.
 func NewStructs() *Structs {
 	parsed, err := StructsMetaData.ParseABI()

--- a/accounts/abi/abigen/testdata/v2/token.go.txt
+++ b/accounts/abi/abigen/testdata/v2/token.go.txt
@@ -36,6 +36,11 @@ type Token struct {
 	abi abi.ABI
 }
 
+// GetABI returns the ABI associated with this contract binding.
+func (c *Token) GetABI() abi.ABI {
+	return c.abi
+}
+
 // NewToken creates a new instance of Token.
 func NewToken() *Token {
 	parsed, err := TokenMetaData.ParseABI()

--- a/accounts/abi/abigen/testdata/v2/tuple.go.txt
+++ b/accounts/abi/abigen/testdata/v2/tuple.go.txt
@@ -61,6 +61,11 @@ type Tuple struct {
 	abi abi.ABI
 }
 
+// GetABI returns the ABI associated with this contract binding.
+func (c *Tuple) GetABI() abi.ABI {
+	return c.abi
+}
+
 // NewTuple creates a new instance of Tuple.
 func NewTuple() *Tuple {
 	parsed, err := TupleMetaData.ParseABI()

--- a/accounts/abi/abigen/testdata/v2/tupler.go.txt
+++ b/accounts/abi/abigen/testdata/v2/tupler.go.txt
@@ -36,6 +36,11 @@ type Tupler struct {
 	abi abi.ABI
 }
 
+// GetABI returns the ABI associated with this contract binding.
+func (c *Tupler) GetABI() abi.ABI {
+	return c.abi
+}
+
 // NewTupler creates a new instance of Tupler.
 func NewTupler() *Tupler {
 	parsed, err := TuplerMetaData.ParseABI()

--- a/accounts/abi/abigen/testdata/v2/underscorer.go.txt
+++ b/accounts/abi/abigen/testdata/v2/underscorer.go.txt
@@ -36,6 +36,11 @@ type Underscorer struct {
 	abi abi.ABI
 }
 
+// GetABI returns the ABI associated with this contract binding.
+func (c *Underscorer) GetABI() abi.ABI {
+	return c.abi
+}
+
 // NewUnderscorer creates a new instance of Underscorer.
 func NewUnderscorer() *Underscorer {
 	parsed, err := UnderscorerMetaData.ParseABI()

--- a/accounts/abi/bind/v2/internal/contracts/db/bindings.go
+++ b/accounts/abi/bind/v2/internal/contracts/db/bindings.go
@@ -43,6 +43,11 @@ type DB struct {
 	abi abi.ABI
 }
 
+// GetABI returns the ABI associated with this contract binding.
+func (c *DB) GetABI() abi.ABI {
+	return c.abi
+}
+
 // NewDB creates a new instance of DB.
 func NewDB() *DB {
 	parsed, err := DBMetaData.ParseABI()

--- a/accounts/abi/bind/v2/internal/contracts/events/bindings.go
+++ b/accounts/abi/bind/v2/internal/contracts/events/bindings.go
@@ -36,6 +36,11 @@ type C struct {
 	abi abi.ABI
 }
 
+// GetABI returns the ABI associated with this contract binding.
+func (c *C) GetABI() abi.ABI {
+	return c.abi
+}
+
 // NewC creates a new instance of C.
 func NewC() *C {
 	parsed, err := CMetaData.ParseABI()

--- a/accounts/abi/bind/v2/internal/contracts/nested_libraries/bindings.go
+++ b/accounts/abi/bind/v2/internal/contracts/nested_libraries/bindings.go
@@ -40,6 +40,11 @@ type C1 struct {
 	abi abi.ABI
 }
 
+// GetABI returns the ABI associated with this contract binding.
+func (c *C1) GetABI() abi.ABI {
+	return c.abi
+}
+
 // NewC1 creates a new instance of C1.
 func NewC1() *C1 {
 	parsed, err := C1MetaData.ParseABI()
@@ -118,6 +123,11 @@ type C2 struct {
 	abi abi.ABI
 }
 
+// GetABI returns the ABI associated with this contract binding.
+func (c *C2) GetABI() abi.ABI {
+	return c.abi
+}
+
 // NewC2 creates a new instance of C2.
 func NewC2() *C2 {
 	parsed, err := C2MetaData.ParseABI()
@@ -192,6 +202,11 @@ type L1 struct {
 	abi abi.ABI
 }
 
+// GetABI returns the ABI associated with this contract binding.
+func (c *L1) GetABI() abi.ABI {
+	return c.abi
+}
+
 // NewL1 creates a new instance of L1.
 func NewL1() *L1 {
 	parsed, err := L1MetaData.ParseABI()
@@ -255,6 +270,11 @@ var L2MetaData = bind.MetaData{
 // L2 is an auto generated Go binding around an Ethereum contract.
 type L2 struct {
 	abi abi.ABI
+}
+
+// GetABI returns the ABI associated with this contract binding.
+func (c *L2) GetABI() abi.ABI {
+	return c.abi
 }
 
 // NewL2 creates a new instance of L2.
@@ -322,6 +342,11 @@ type L2b struct {
 	abi abi.ABI
 }
 
+// GetABI returns the ABI associated with this contract binding.
+func (c *L2b) GetABI() abi.ABI {
+	return c.abi
+}
+
 // NewL2b creates a new instance of L2b.
 func NewL2b() *L2b {
 	parsed, err := L2bMetaData.ParseABI()
@@ -382,6 +407,11 @@ var L3MetaData = bind.MetaData{
 // L3 is an auto generated Go binding around an Ethereum contract.
 type L3 struct {
 	abi abi.ABI
+}
+
+// GetABI returns the ABI associated with this contract binding.
+func (c *L3) GetABI() abi.ABI {
+	return c.abi
 }
 
 // NewL3 creates a new instance of L3.
@@ -450,6 +480,11 @@ type L4 struct {
 	abi abi.ABI
 }
 
+// GetABI returns the ABI associated with this contract binding.
+func (c *L4) GetABI() abi.ABI {
+	return c.abi
+}
+
 // NewL4 creates a new instance of L4.
 func NewL4() *L4 {
 	parsed, err := L4MetaData.ParseABI()
@@ -513,6 +548,11 @@ var L4bMetaData = bind.MetaData{
 // L4b is an auto generated Go binding around an Ethereum contract.
 type L4b struct {
 	abi abi.ABI
+}
+
+// GetABI returns the ABI associated with this contract binding.
+func (c *L4b) GetABI() abi.ABI {
+	return c.abi
 }
 
 // NewL4b creates a new instance of L4b.

--- a/accounts/abi/bind/v2/internal/contracts/solc_errors/bindings.go
+++ b/accounts/abi/bind/v2/internal/contracts/solc_errors/bindings.go
@@ -36,6 +36,11 @@ type C struct {
 	abi abi.ABI
 }
 
+// GetABI returns the ABI associated with this contract binding.
+func (c *C) GetABI() abi.ABI {
+	return c.abi
+}
+
 // NewC creates a new instance of C.
 func NewC() *C {
 	parsed, err := CMetaData.ParseABI()
@@ -171,6 +176,11 @@ var C2MetaData = bind.MetaData{
 // C2 is an auto generated Go binding around an Ethereum contract.
 type C2 struct {
 	abi abi.ABI
+}
+
+// GetABI returns the ABI associated with this contract binding.
+func (c *C2) GetABI() abi.ABI {
+	return c.abi
 }
 
 // NewC2 creates a new instance of C2.

--- a/accounts/abi/bind/v2/internal/contracts/uint256arrayreturn/bindings.go
+++ b/accounts/abi/bind/v2/internal/contracts/uint256arrayreturn/bindings.go
@@ -36,6 +36,11 @@ type MyContract struct {
 	abi abi.ABI
 }
 
+// GetABI returns the ABI associated with this contract binding.
+func (c *MyContract) GetABI() abi.ABI {
+	return c.abi
+}
+
 // NewMyContract creates a new instance of MyContract.
 func NewMyContract() *MyContract {
 	parsed, err := MyContractMetaData.ParseABI()


### PR DESCRIPTION
## Summary

Adds a `GetABI() abi.ABI` method to the contract struct generated by abigen v2 (`source2.go.tpl`).

Currently the `abi` field on the generated struct is unexported, so callers in other packages can't access it without re-parsing via `ParseABI()`. This makes common patterns like building `ethereum.FilterQuery` topics across multiple contracts awkward:

```go
// Before — have to call ParseABI() manually from each package
storageABI, _ := StorageMetaData.ParseABI()
```

With `GetABI()` the usage becomes:

```go
// After
fq := ethereum.FilterQuery{
    Topics: [][]common.Hash{
        contractA.GetABI().Events[ContractA.ContractAFooEventName].ID,
        contractB.GetABI().Events[ContractB.ContractBBarEventName].ID,
    },
}
```

## Changes

- Added `GetABI() abi.ABI` to `source2.go.tpl`
- Regenerated all 21 golden files under `testdata/v2/` (`WRITE_TEST_FILES=1 go test`)

## Test plan

- [x] `go test ./accounts/abi/abigen/...` — all tests pass

Closes #34705