### PR TITLE
cmd/geth: release storage iterator in snapshot dump

### DIFF
--- a/cmd/geth/snapshot.go
+++ b/cmd/geth/snapshot.go
@@ -922,6 +922,7 @@ func dumpState(ctx *cli.Context) error {
 			for stIt.Next() {
 				da.Storage[stIt.Hash()] = common.Bytes2Hex(stIt.Slot())
 			}
+			stIt.Release()
 		}
 		enc.Encode(da)
 		accounts++


### PR DESCRIPTION
## Summary

- Release the storage iterator after iterating slots in `geth snapshot dump`, matching the existing account iterator cleanup.

## Test plan

- [x] `go build ./cmd/geth/...`
- [ ] Manual: run `geth snapshot dump` on a node with storage data and verify output is unchanged