### PR TITLE
rpc: add --rpc.http-body-limit flag for HTTP request body size

### DIFF
--- a/cmd/geth/main.go
+++ b/cmd/geth/main.go
@@ -176,6 +176,7 @@ var (
 		utils.AllowUnprotectedTxs,
 		utils.BatchRequestLimit,
 		utils.BatchResponseMaxSize,
+		utils.HTTPBodyLimitFlag,
 		utils.RPCTxSyncDefaultTimeoutFlag,
 		utils.RPCTxSyncMaxTimeoutFlag,
 		utils.RPCGlobalRangeLimitFlag,

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -856,6 +856,12 @@ var (
 		Value:    node.DefaultConfig.BatchResponseMaxSize,
 		Category: flags.APICategory,
 	}
+	HTTPBodyLimitFlag = &cli.IntFlag{
+		Name:     "rpc.http-body-limit",
+		Usage:    "Maximum size (in megabytes) of an HTTP request body",
+		Value:    node.DefaultConfig.HTTPBodyLimit / (1024 * 1024),
+		Category: flags.APICategory,
+	}
 
 	// Network Settings
 	MaxPeersFlag = &cli.IntFlag{
@@ -1355,6 +1361,10 @@ func setHTTP(ctx *cli.Context, cfg *node.Config) {
 
 	if ctx.IsSet(BatchResponseMaxSize.Name) {
 		cfg.BatchResponseMaxSize = ctx.Int(BatchResponseMaxSize.Name)
+	}
+
+	if ctx.IsSet(HTTPBodyLimitFlag.Name) {
+		cfg.HTTPBodyLimit = ctx.Int(HTTPBodyLimitFlag.Name) * 1024 * 1024
 	}
 }
 

--- a/node/config.go
+++ b/node/config.go
@@ -198,6 +198,9 @@ type Config struct {
 	// BatchResponseMaxSize is the maximum number of bytes returned from a batched rpc call.
 	BatchResponseMaxSize int `toml:",omitempty"`
 
+	// HTTPBodyLimit is the maximum size (in bytes) of an HTTP request body.
+	HTTPBodyLimit int `toml:",omitempty"`
+
 	// JWTSecret is the path to the hex-encoded jwt secret.
 	JWTSecret string `toml:",omitempty"`
 

--- a/node/defaults.go
+++ b/node/defaults.go
@@ -67,6 +67,7 @@ var DefaultConfig = Config{
 	WSModules:            []string{"net", "web3"},
 	BatchRequestLimit:    1000,
 	BatchResponseMaxSize: 25 * 1000 * 1000,
+	HTTPBodyLimit:        5 * 1024 * 1024,
 	GraphQLVirtualHosts:  []string{"localhost"},
 	P2P: p2p.Config{
 		ListenAddr:  ":30303",

--- a/node/node.go
+++ b/node/node.go
@@ -392,6 +392,7 @@ func (n *Node) startRPC() error {
 	rpcConfig := rpcEndpointConfig{
 		batchItemLimit:         n.config.BatchRequestLimit,
 		batchResponseSizeLimit: n.config.BatchResponseMaxSize,
+		httpBodyLimit:          n.config.HTTPBodyLimit,
 	}
 
 	initHttp := func(server *httpServer, port int) error {


### PR DESCRIPTION
The HTTP JSON-RPC server caps request bodies at a hardcoded 5 MB (`defaultBodyLimit`), with no way to raise it. EEST bloatnet depth benchmarks post worst-case batch requests larger than that during fill-stateful, which the server rejects with `413 Request Entity Too Large`.

This adds `node.Config.HTTPBodyLimit` (default 5 MB), wired through to the HTTP/WS server config, and exposes it via `--rpc.http-body-limit` (value in **megabytes**, default 5). Default behaviour is unchanged.
