### PR TITLE
accounts/external, signer: preserve authorization list for set-code transactions

### DIFF
--- a/accounts/external/backend.go
+++ b/accounts/external/backend.go
@@ -245,6 +245,9 @@ func (api *ExternalSigner) SignTx(account accounts.Account, tx *types.Transactio
 		args.Commitments = sidecar.Commitments
 		args.Proofs = sidecar.Proofs
 	}
+	if tx.Type() == types.SetCodeTxType {
+		args.AuthorizationList = tx.SetCodeAuthorizations()
+	}
 
 	var res signTransactionResult
 	if err := api.client.Call(&res, "account_signTransaction", args); err != nil {

--- a/signer/core/apitypes/types.go
+++ b/signer/core/apitypes/types.go
@@ -103,6 +103,9 @@ type SendTxArgs struct {
 	AccessList *types.AccessList `json:"accessList,omitempty"`
 	ChainID    *hexutil.Big      `json:"chainId,omitempty"`
 
+	// For SetCodeTxType
+	AuthorizationList []types.SetCodeAuthorization `json:"authorizationList,omitempty"`
+
 	// For BlobTxType
 	BlobFeeCap *hexutil.Big  `json:"maxFeePerBlobGas,omitempty"`
 	BlobHashes []common.Hash `json:"blobVersionedHashes,omitempty"`
@@ -146,6 +149,26 @@ func (args *SendTxArgs) ToTransaction() (*types.Transaction, error) {
 	}
 	var data types.TxData
 	switch {
+	case args.AuthorizationList != nil:
+		al := types.AccessList{}
+		if args.AccessList != nil {
+			al = *args.AccessList
+		}
+		if to == nil {
+			return nil, errors.New("transaction recipient must be set for set-code transactions")
+		}
+		data = &types.SetCodeTx{
+			To:         *to,
+			ChainID:    uint256.MustFromBig((*big.Int)(args.ChainID)),
+			Nonce:      uint64(args.Nonce),
+			Gas:        uint64(args.Gas),
+			GasFeeCap:  uint256.MustFromBig((*big.Int)(args.MaxFeePerGas)),
+			GasTipCap:  uint256.MustFromBig((*big.Int)(args.MaxPriorityFeePerGas)),
+			Value:      uint256.MustFromBig((*big.Int)(&args.Value)),
+			Data:       args.data(),
+			AccessList: al,
+			AuthList:   args.AuthorizationList,
+		}
 	case args.BlobHashes != nil:
 		al := types.AccessList{}
 		if args.AccessList != nil {

--- a/signer/core/apitypes/types_test.go
+++ b/signer/core/apitypes/types_test.go
@@ -99,6 +99,52 @@ func TestTxArgs(t *testing.T) {
 	}
 }
 
+// TestSetCodeTxArgs checks that a set-code (EIP-7702) transaction survives the
+// round-trip through SendTxArgs. It carries an authorization list and sets
+// maxFeePerGas, so without a dedicated branch ToTransaction would infer a plain
+// dynamic-fee transaction and silently drop the authorizations.
+func TestSetCodeTxArgs(t *testing.T) {
+	data := []byte(`{"from":"0x1b442286e32ddcaa6e2570ce9ed85f4b4fc87425","to":"0x1b442286e32ddcaa6e2570ce9ed85f4b4fc87425","chainId":"0x7","gas":"0x5208","maxFeePerGas":"0x6fc23ac00","maxPriorityFeePerGas":"0x3b9aca00","nonce":"0x0","input":"0x","value":"0x0","authorizationList":[{"chainId":"0x7","address":"0x1b442286e32ddcaa6e2570ce9ed85f4b4fc87425","nonce":"0x1","yParity":"0x0","r":"0x1","s":"0x1"}]}`)
+	var txArgs SendTxArgs
+	if err := json.Unmarshal(data, &txArgs); err != nil {
+		t.Fatal(err)
+	}
+	tx, err := txArgs.ToTransaction()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if have := tx.Type(); have != types.SetCodeTxType {
+		t.Fatalf("have type %d, want %d", have, types.SetCodeTxType)
+	}
+	auths := tx.SetCodeAuthorizations()
+	if len(auths) != 1 {
+		t.Fatalf("have %d authorizations, want 1", len(auths))
+	}
+	if want := common.HexToAddress("0x1b442286e32ddcaa6e2570ce9ed85f4b4fc87425"); auths[0].Address != want {
+		t.Errorf("authorization address: have %x, want %x", auths[0].Address, want)
+	}
+	if auths[0].Nonce != 1 {
+		t.Errorf("authorization nonce: have %d, want 1", auths[0].Nonce)
+	}
+	// The args must also re-marshal so the authorization list crosses the clef
+	// boundary intact: a missing or dropped field would change the tx hash.
+	blob, err := json.Marshal(txArgs)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var txArgs2 SendTxArgs
+	if err := json.Unmarshal(blob, &txArgs2); err != nil {
+		t.Fatal(err)
+	}
+	tx2, err := txArgs2.ToTransaction()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if have, want := tx2.Hash(), tx.Hash(); have != want {
+		t.Errorf("round-trip changed tx: have %v, want %v", have, want)
+	}
+}
+
 func TestBlobTxs(t *testing.T) {
 	blob := kzg4844.Blob{0x1}
 	commitment, err := kzg4844.BlobToCommitment(&blob)


### PR DESCRIPTION
Closes #35092.

When a set-code transaction (EIP-7702, type `0x04`) is signed through the external signer path (Clef), its authorization list is silently dropped and the transaction is reconstructed as the wrong type.

Two gaps:

1. `ExternalSigner.SignTx` folds `SetCodeTxType` into the same case as dynamic-fee and blob txs, so only the fee fields and access list are copied into `SendTxArgs`; `tx.SetCodeAuthorizations()` is never read.
2. `apitypes.SendTxArgs` has no field for the authorization list, and `ToTransaction` has no `SetCodeTx` branch. Since the switch tests `MaxFeePerGas != nil` before the legacy fallback, a set-code tx (which has `MaxFeePerGas` set) is rebuilt as a plain `DynamicFeeTx`, changing the type and losing the authorizations.

Fix:

- Add `AuthorizationList` to `SendTxArgs`.
- Populate it in `SignTx` for set-code txs, alongside the existing access-list and blob field copies.
- Add a `SetCodeTx` branch to `ToTransaction`, ordered before the `MaxFeePerGas` case, mirroring the existing `ethapi.TransactionArgs` conversion.

Added `TestSetCodeTxArgs` covering the JSON round-trip: a set-code tx now comes back as `SetCodeTxType` with its authorization list intact, and re-marshaling preserves the tx hash.