### PR TITLE
triedb/pathdb: prealloc node map in nodeSet.write

### DIFF
--- a/triedb/pathdb/nodes.go
+++ b/triedb/pathdb/nodes.go
@@ -279,7 +279,7 @@ func (s *nodeSet) decode(r *rlp.Stream) error {
 
 // write flushes nodes into the provided database batch as a whole.
 func (s *nodeSet) write(batch ethdb.Batch, clean *fastcache.Cache) int {
-	nodes := make(map[common.Hash]map[string]*trienode.Node)
+	nodes := make(map[common.Hash]map[string]*trienode.Node, len(s.storageNodes)+1)
 	if len(s.accountNodes) > 0 {
 		nodes[common.Hash{}] = s.accountNodes
 	}


### PR DESCRIPTION
## Summary
- Preallocate the outer `nodes` map in `nodeSet.write` with capacity `len(s.storageNodes)+1` to avoid repeated map growth

## Test plan
- [x] `gofmt` / `goimports` on modified files
- [ ] `go run ./build/ci.go test -short` (triedb/pathdb)