### PR TITLE
internal/ethapi: make difficulty override a no-op post-merge in eth_simulateV1

### DIFF
--- a/internal/ethapi/api_test.go
+++ b/internal/ethapi/api_test.go
@@ -2745,11 +2745,6 @@ func TestSimulateV1WithdrawalsByFork(t *testing.T) {
 	})
 }
 
-// TestSimulateV1DifficultyOverridePostMerge checks that a difficulty block
-// override is a no-op for post-merge blocks. Applying it would set a non-zero
-// difficulty on the simulated header, which fails IsPoSHeader and routes block
-// assembly through the legacy (PoW) engine even though the block carries
-// post-merge fields, leading to a panic.
 func TestSimulateV1DifficultyOverridePostMerge(t *testing.T) {
 	t.Parallel()
 

--- a/internal/ethapi/api_test.go
+++ b/internal/ethapi/api_test.go
@@ -2745,6 +2745,52 @@ func TestSimulateV1WithdrawalsByFork(t *testing.T) {
 	})
 }
 
+// TestSimulateV1DifficultyOverridePostMerge checks that a difficulty block
+// override is a no-op for post-merge blocks. Applying it would set a non-zero
+// difficulty on the simulated header, which fails IsPoSHeader and routes block
+// assembly through the legacy (PoW) engine even though the block carries
+// post-merge fields, leading to a panic.
+func TestSimulateV1DifficultyOverridePostMerge(t *testing.T) {
+	t.Parallel()
+
+	gspec := &core.Genesis{Config: params.MergedTestChainConfig, Alloc: types.GenesisAlloc{}}
+	backend := newTestBackend(t, 1, gspec, beacon.New(ethash.NewFaker()), func(i int, b *core.BlockGen) { b.SetPoS() })
+
+	ctx := context.Background()
+	stateDB, baseHeader, err := backend.StateAndHeaderByNumberOrHash(ctx, rpc.BlockNumberOrHashWithNumber(rpc.LatestBlockNumber))
+	if err != nil {
+		t.Fatalf("failed to get state and header: %v", err)
+	}
+	sim := &simulator{
+		b:           backend,
+		state:       stateDB,
+		base:        baseHeader,
+		chainConfig: backend.ChainConfig(),
+		budget:      newGasBudget(0),
+	}
+
+	diff := (*hexutil.Big)(big.NewInt(0xCAFE0000))
+	results, err := sim.execute(ctx, []simBlock{{
+		BlockOverrides: &override.BlockOverrides{Difficulty: diff},
+	}})
+	if err != nil {
+		t.Fatalf("simulation execution failed: %v", err)
+	}
+	require.Len(t, results, 1)
+
+	enc, err := json.Marshal(results[0])
+	if err != nil {
+		t.Fatalf("failed to marshal result: %v", err)
+	}
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(enc, &raw); err != nil {
+		t.Fatalf("failed to unmarshal result: %v", err)
+	}
+	if got := string(raw["difficulty"]); got != `"0x0"` {
+		t.Fatalf("difficulty override was not a no-op post-merge: got %s, want \"0x0\"\n%s", got, enc)
+	}
+}
+
 func TestSignTransaction(t *testing.T) {
 	t.Parallel()
 	// Initialize test accounts

--- a/internal/ethapi/simulate.go
+++ b/internal/ethapi/simulate.go
@@ -578,10 +578,6 @@ func (sim *simulator) makeHeaders(blocks []simBlock) ([]*types.Header, error) {
 			ParentBeaconRoot: parentBeaconRoot,
 		})
 		// A difficulty override is documented as a no-op for post-merge blocks.
-		// MakeHeader applies it unconditionally though, so re-zero it here: a
-		// non-zero difficulty makes the simulated header fail IsPoSHeader, which
-		// routes block assembly through the legacy (PoW) engine even though the
-		// block carries post-merge fields, leading to a panic.
 		if isPostMerge {
 			header.Difficulty = big.NewInt(0)
 		}

--- a/internal/ethapi/simulate.go
+++ b/internal/ethapi/simulate.go
@@ -562,8 +562,9 @@ func (sim *simulator) makeHeaders(blocks []simBlock) ([]*types.Header, error) {
 		}
 		// Set difficulty to zero if the given block is post-merge. Without this, all post-merge hardforks would remain inactive.
 		// For example, calling eth_simulateV1(..., blockParameter: 0x0) on hoodi network will cause all blocks to have a difficulty of 1 and be treated as pre-merge.
+		isPostMerge := sim.chainConfig.IsPostMerge(number.Uint64(), timestamp)
 		difficulty := header.Difficulty
-		if sim.chainConfig.IsPostMerge(number.Uint64(), timestamp) {
+		if isPostMerge {
 			difficulty = big.NewInt(0)
 		}
 		header = overrides.MakeHeader(&types.Header{
@@ -576,6 +577,14 @@ func (sim *simulator) makeHeaders(blocks []simBlock) ([]*types.Header, error) {
 			WithdrawalsHash:  withdrawalsHash,
 			ParentBeaconRoot: parentBeaconRoot,
 		})
+		// A difficulty override is documented as a no-op for post-merge blocks.
+		// MakeHeader applies it unconditionally though, so re-zero it here: a
+		// non-zero difficulty makes the simulated header fail IsPoSHeader, which
+		// routes block assembly through the legacy (PoW) engine even though the
+		// block carries post-merge fields, leading to a panic.
+		if isPostMerge {
+			header.Difficulty = big.NewInt(0)
+		}
 		res[bi] = header
 	}
 	return res, nil


### PR DESCRIPTION
### Rationale

`eth_simulateV1` panics for any call that overrides block `difficulty` on a post-merge chain. The RPC returns:

```
{"jsonrpc":"2.0","id":1,"error":{"code":-32603,"message":"method handler crashed"}}
```

Minimal reproduction against any post-merge Geth node (no state overrides or calls required):

```bash
curl -s -X POST -H 'Content-Type: application/json' --data \
'{"jsonrpc":"2.0","id":1,"method":"eth_simulateV1","params":[{"blockStateCalls":[{"blockOverrides":{"difficulty":"0x1"}}]},"latest"]}' \
https://ethereum-rpc.publicnode.com
```

`difficulty: 0x0` works, any non-zero value crashes, and `prevRandao` is unrelated (overriding it alongside difficulty still crashes). `eth_call` with the same override is unaffected.

### Root cause

`override.BlockOverrides.Difficulty` is documented as *"No-op if we're simulating post-merge calls"*, but `makeHeaders` only zeroes the difficulty **before** `overrides.MakeHeader`, which then re-applies the override unconditionally:

```go
difficulty := header.Difficulty
if sim.chainConfig.IsPostMerge(number.Uint64(), timestamp) {
    difficulty = big.NewInt(0)
}
header = overrides.MakeHeader(&types.Header{ ... Difficulty: difficulty ... }) // override re-applied here
```

The resulting non-zero difficulty makes the simulated header fail `beacon.IsPoSHeader` (which is `difficulty.Cmp(beaconDifficulty) == 0`), so block assembly (`Finalize` / `AssembleBlock`) is routed through the legacy PoW engine even though the block carries post-merge fields (withdrawals, blob gas, beacon root, …). On a live post-merge chain this panics. `eth_call` is immune because it never assembles a block.

### Fix

Re-zero the difficulty **after** `MakeHeader` for post-merge blocks, honouring the documented no-op and keeping the header on the PoS assembly path (identical to the already-working `difficulty: 0x0` case).

### Test

Adds `TestSimulateV1DifficultyOverridePostMerge`, which simulates a post-merge block with a difficulty override and asserts the result reports `difficulty: 0x0`. It fails without the fix (`0xcafe0000`) and passes with it.