### PR TITLE
core/types: reduce allocs in CreateBloom

### DIFF
--- a/core/types/bloom9.go
+++ b/core/types/bloom9.go
@@ -110,9 +110,9 @@ func CreateBloom(receipt *Receipt) Bloom {
 		buf [6]byte
 	)
 	for _, log := range receipt.Logs {
-		bin.AddWithBuffer(log.Address.Bytes(), &buf)
-		for _, b := range log.Topics {
-			bin.AddWithBuffer(b[:], &buf)
+		bin.AddWithBuffer(log.Address[:], &buf)
+		for k := range log.Topics {
+			bin.AddWithBuffer(log.Topics[k][:], &buf)
 		}
 	}
 	return bin


### PR DESCRIPTION
## Summary
- Use `log.Address[:]` instead of `log.Address.Bytes()` to avoid slice escaping to the heap
- Index `log.Topics` directly instead of ranging over copies of `common.Hash`

## Benchmark code

```go
package types

import (
	"testing"

	"github.com/ethereum/go-ethereum/common"
)

func makeReceiptsWithTopics(n int) Receipts {
	receipts := make(Receipts, n)
	for i := range receipts {
		receipts[i] = &Receipt{
			Logs: []*Log{
				{
					Address: common.BytesToAddress([]byte{byte(i), 0x11}),
					Topics: []common.Hash{
						common.HexToHash("0x1111111111111111111111111111111111111111111111111111111111111111"),
						common.HexToHash("0x2222222222222222222222222222222222222222222222222222222222222222"),
						common.HexToHash("0x3333333333333333333333333333333333333333333333333333333333333333"),
					},
				},
				{
					Address: common.BytesToAddress([]byte{byte(i), 0x22}),
					Topics: []common.Hash{
						common.HexToHash("0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"),
						common.HexToHash("0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"),
					},
				},
			},
		}
	}
	return receipts
}

func benchmarkCreateBloomReceipts(b *testing.B, receipts Receipts) {
	b.Helper()
	b.ReportAllocs()
	b.ResetTimer()
	for i := 0; i < b.N; i++ {
		for _, receipt := range receipts {
			_ = CreateBloom(receipt)
		}
	}
}

func BenchmarkCreateBloomWithTopicsSmall(b *testing.B) {
	benchmarkCreateBloomReceipts(b, makeReceiptsWithTopics(2))
}

func BenchmarkCreateBloomWithTopicsLarge(b *testing.B) {
	benchmarkCreateBloomReceipts(b, makeReceiptsWithTopics(200))
}
```

Also measured with the existing `BenchmarkCreateBloom` sub-benchmarks in `bloom9_test.go`.

## Benchmark results

Apple M4, `go test -benchmem -count=10`, compared with `benchstat`.

### Without topics (`BenchmarkCreateBloom`)

| Benchmark | CPU | Memory | allocs/op |
|---|---|---|---|
| small-createbloom (2 receipts) | 1.042 µs → 1.005 µs (−3.6%) | 112 B → 16 B (−86%) | 6 → 2 (−67%) |
| large-createbloom (200 receipts) | 103.6 µs → 99.9 µs (−3.5%) | 11.0 KiB → 1.6 KiB (−86%) | 600 → 200 (−67%) |

### With topics (`BenchmarkCreateBloomWithTopics`)

| Benchmark | CPU | Memory | allocs/op |
|---|---|---|---|
| WithTopicsSmall (2 receipts) | 3.51 µs → 3.37 µs (−4.0%) | 432 B → 16 B (−96%) | 16 → 2 (−87.5%) |
| WithTopicsLarge (200 receipts) | 351.1 µs → 337.7 µs (−3.8%) | 42.2 KiB → 1.6 KiB (−96%) | 1600 → 200 (−87.5%) |

## Test plan
- [x] `gofmt` on modified files
- [x] `go test ./core/types/ -run TestBloom -count=1`
- [ ] `go run ./build/ci.go test -short` (core/types)