### PR TITLE
core/txpool/txorder: skip redundant GasTipCap set with base fee

### DIFF
--- a/core/txpool/txorder/ordering.go
+++ b/core/txpool/txorder/ordering.go
@@ -37,7 +37,7 @@ type txWithMinerFee struct {
 // miner gasTipCap if a base fee is provided.
 // Returns error in case of a negative effective miner gasTipCap.
 func newTxWithMinerFee(tx *txpool.LazyTransaction, from common.Address, baseFee *uint256.Int) (*txWithMinerFee, error) {
-	tip := new(uint256.Int).Set(tx.GasTipCap)
+	tip := new(uint256.Int)
 	if baseFee != nil {
 		if tx.GasFeeCap.Cmp(baseFee) < 0 {
 			return nil, types.ErrGasFeeCapTooLow
@@ -46,6 +46,8 @@ func newTxWithMinerFee(tx *txpool.LazyTransaction, from common.Address, baseFee 
 		if tip.Gt(tx.GasTipCap) {
 			tip = tx.GasTipCap
 		}
+	} else {
+		tip.Set(tx.GasTipCap)
 	}
 	return &txWithMinerFee{
 		tx:   tx,


### PR DESCRIPTION
## Summary
- Defer `GasTipCap` copying in `newTxWithMinerFee` until the legacy (`baseFee == nil`) path
- Avoid a redundant `Set` on EIP-1559 transactions where the tip is immediately recomputed from `GasFeeCap - baseFee`

## Benchmark code

```go
package txorder

import (
	"crypto/ecdsa"
	"math/big"
	"testing"
	"time"

	"github.com/ethereum/go-ethereum/common"
	"github.com/ethereum/go-ethereum/core/txpool"
	"github.com/ethereum/go-ethereum/core/types"
	"github.com/ethereum/go-ethereum/crypto"
	"github.com/holiman/uint256"
)

func makeLazyLegacyTx(key *ecdsa.PrivateKey, nonce uint64, gasPrice int64) *txpool.LazyTransaction {
	signer := types.LatestSignerForChainID(common.Big1)
	tx, _ := types.SignTx(types.NewTx(&types.LegacyTx{
		Nonce:    nonce,
		To:       &common.Address{},
		Value:    big.NewInt(100),
		Gas:      100,
		GasPrice: big.NewInt(gasPrice),
	}), signer, key)
	return &txpool.LazyTransaction{
		Hash:      tx.Hash(),
		Tx:        tx,
		Time:      time.Now(),
		GasFeeCap: uint256.MustFromBig(tx.GasFeeCap()),
		GasTipCap: uint256.MustFromBig(tx.GasTipCap()),
		Gas:       tx.Gas(),
	}
}

func makeLazy1559Tx(key *ecdsa.PrivateKey, nonce uint64, gasFeeCap, gasTipCap int64) *txpool.LazyTransaction {
	signer := types.LatestSignerForChainID(common.Big1)
	tx, _ := types.SignTx(types.NewTx(&types.DynamicFeeTx{
		ChainID:   common.Big1,
		Nonce:     nonce,
		To:        &common.Address{},
		Value:     big.NewInt(100),
		Gas:       100,
		GasFeeCap: big.NewInt(gasFeeCap),
		GasTipCap: big.NewInt(gasTipCap),
	}), signer, key)
	return &txpool.LazyTransaction{
		Hash:      tx.Hash(),
		Tx:        tx,
		Time:      time.Now(),
		GasFeeCap: uint256.MustFromBig(tx.GasFeeCap()),
		GasTipCap: uint256.MustFromBig(tx.GasTipCap()),
		Gas:       tx.Gas(),
	}
}

func makeLazyTxGroups(accounts, txsPerAccount int, legacy bool) (map[common.Address][]*txpool.LazyTransaction, common.Address) {
	groups := make(map[common.Address][]*txpool.LazyTransaction, accounts)
	var first common.Address
	for i := 0; i < accounts; i++ {
		key, _ := crypto.GenerateKey()
		addr := crypto.PubkeyToAddress(key.PublicKey)
		if i == 0 {
			first = addr
		}
		for j := 0; j < txsPerAccount; j++ {
			if legacy {
				groups[addr] = append(groups[addr], makeLazyLegacyTx(key, uint64(j), int64(j+10)))
			} else {
				groups[addr] = append(groups[addr], makeLazy1559Tx(key, uint64(j), int64(j+50), int64(j+5)))
			}
		}
	}
	return groups, first
}

func BenchmarkNewTxWithMinerFeeLegacy(b *testing.B) {
	key, _ := crypto.GenerateKey()
	addr := crypto.PubkeyToAddress(key.PublicKey)
	tx := makeLazyLegacyTx(key, 0, 100)
	b.ReportAllocs()
	b.ResetTimer()
	for i := 0; i < b.N; i++ {
		if _, err := newTxWithMinerFee(tx, addr, nil); err != nil {
			b.Fatal(err)
		}
	}
}

func BenchmarkNewTxWithMinerFee1559(b *testing.B) {
	key, _ := crypto.GenerateKey()
	addr := crypto.PubkeyToAddress(key.PublicKey)
	tx := makeLazy1559Tx(key, 0, 100, 10)
	baseFee := uint256.NewInt(5)
	b.ReportAllocs()
	b.ResetTimer()
	for i := 0; i < b.N; i++ {
		if _, err := newTxWithMinerFee(tx, addr, baseFee); err != nil {
			b.Fatal(err)
		}
	}
}

func BenchmarkNewTransactionsByPriceAndNonceLegacy(b *testing.B) {
	signer := types.LatestSignerForChainID(common.Big1)
	groups, _ := makeLazyTxGroups(100, 10, true)
	b.ReportAllocs()
	b.ResetTimer()
	for i := 0; i < b.N; i++ {
		txs := make(map[common.Address][]*txpool.LazyTransaction, len(groups))
		for addr, list := range groups {
			cpy := make([]*txpool.LazyTransaction, len(list))
			copy(cpy, list)
			txs[addr] = cpy
		}
		_ = NewTransactionsByPriceAndNonce(signer, txs, nil)
	}
}

func BenchmarkNewTransactionsByPriceAndNonce1559(b *testing.B) {
	signer := types.LatestSignerForChainID(common.Big1)
	groups, _ := makeLazyTxGroups(100, 10, false)
	baseFee := big.NewInt(5)
	b.ReportAllocs()
	b.ResetTimer()
	for i := 0; i < b.N; i++ {
		txs := make(map[common.Address][]*txpool.LazyTransaction, len(groups))
		for addr, list := range groups {
			cpy := make([]*txpool.LazyTransaction, len(list))
			copy(cpy, list)
			txs[addr] = cpy
		}
		_ = NewTransactionsByPriceAndNonce(signer, txs, baseFee)
	}
}
```

## Benchmark results

Apple M4, `go test -benchmem -count=10`, compared with `benchstat`.

### `newTxWithMinerFee`

| Benchmark | CPU | Memory | allocs/op |
|---|---|---|---|
| Legacy (`baseFee == nil`) | 23.66 ns → 23.09 ns (−2.4%) | 80 B | 2 → 2 |
| 1559 (`baseFee != nil`) | 34.14 ns → 33.95 ns (~ no change) | 112 B | 3 → 3 |

### `NewTransactionsByPriceAndNonce` (100 accounts × 10 txs)

| Benchmark | CPU | Memory | allocs/op |
|---|---|---|---|
| Legacy | 10.46 µs → 10.35 µs (−1.0%) | 23.05 KiB | 307 → 307 |
| 1559 | 11.84 µs → 11.90 µs (~ no change) | 26.20 KiB | 408 → 408 |

No change in heap allocations; the win is skipping redundant `GasTipCap` copying on the EIP-1559 path.

## Test plan
- [x] `gofmt` on modified files
- [x] `go test ./core/txpool/txorder/ -count=1`
- [ ] `go run ./build/ci.go test -short` (core/txpool/txorder)