### PR TITLE
core/rawdb: decode v6 tx lookup without big.Int

### DIFF
--- a/core/rawdb/accessors_indexes.go
+++ b/core/rawdb/accessors_indexes.go
@@ -36,7 +36,10 @@ import (
 func DecodeTxLookupEntry(data []byte, db ethdb.Reader) *uint64 {
 	// Database v6 tx lookup just stores the block number
 	if len(data) < common.HashLength {
-		number := new(big.Int).SetBytes(data).Uint64()
+		var number uint64
+		for _, b := range data {
+			number = number<<8 | uint64(b)
+		}
 		return &number
 	}
 	// Database v4-v5 tx lookup format just stores the hash


### PR DESCRIPTION
## Summary
- Decode database v6 tx lookup entries (raw block number bytes) with a simple big-endian loop
- Avoid `big.Int` allocation on the hot path in `DecodeTxLookupEntry`

## Benchmark code

```go
package rawdb

import (
	"math/big"
	"testing"
)

func encodeV6TxLookupNumber(number uint64) []byte {
	return new(big.Int).SetUint64(number).Bytes()
}

func benchmarkDecodeTxLookupEntryV6(b *testing.B, data []byte) {
	b.Helper()
	b.ReportAllocs()
	b.ResetTimer()
	for i := 0; i < b.N; i++ {
		if got := DecodeTxLookupEntry(data, nil); got == nil {
			b.Fatal("expected block number")
		}
	}
}

func BenchmarkDecodeTxLookupEntryV6_1Byte(b *testing.B) {
	benchmarkDecodeTxLookupEntryV6(b, encodeV6TxLookupNumber(1))
}

func BenchmarkDecodeTxLookupEntryV6_3Byte(b *testing.B) {
	benchmarkDecodeTxLookupEntryV6(b, encodeV6TxLookupNumber(18_000_000))
}

func BenchmarkDecodeTxLookupEntryV6_8Byte(b *testing.B) {
	benchmarkDecodeTxLookupEntryV6(b, encodeV6TxLookupNumber(^uint64(0)))
}
```

## Benchmark results

Apple M4, `go test -run='^$' -bench=BenchmarkDecodeTxLookupEntryV6 -benchmem -count=10`, compared with `benchstat`.

| Benchmark | CPU (before → after) | B/op | allocs/op |
|---|---|---|---|
| V6 1 byte | 12.99 ns → 6.47 ns (−50.2%) | 16 → 8 (−50%) | 2 → 1 (−50%) |
| V6 3 byte | 14.03 ns → 7.36 ns (−47.6%) | 16 → 8 (−50%) | 2 → 1 (−50%) |
| V6 8 byte | 13.08 ns → 8.91 ns (−31.8%) | 16 → 8 (−50%) | 2 → 1 (−50%) |
| **geomean** | 13.36 ns → 7.51 ns (−43.7%) | 16 → 8 (−50%) | 2 → 1 (−50%) |

## Test plan
- [x] `gofmt` on modified files
- [ ] `go run ./build/ci.go test -short` (core/rawdb)