### PR TITLE
eth: prealloc seen map in handleTransactions

### DIFF
--- a/eth/handler_eth.go
+++ b/eth/handler_eth.go
@@ -89,7 +89,7 @@ func (h *ethHandler) Handle(peer *eth.Peer, packet eth.Packet) error {
 // handleTransactions marks all given transactions as known to the peer
 // and performs basic validations.
 func handleTransactions(peer *eth.Peer, list []*types.Transaction, directBroadcast bool) error {
-	seen := make(map[common.Hash]struct{})
+	seen := make(map[common.Hash]struct{}, len(list))
 	for _, tx := range list {
 		if tx.Type() == types.BlobTxType {
 			if directBroadcast {


### PR DESCRIPTION
## Summary
- Preallocate the transaction deduplication map in `handleTransactions` with capacity `len(list)`

## Test plan
- [x] `gofmt` on modified files
- [ ] `go run ./build/ci.go test -short` (eth)