### PR TITLE
internal/flags: fix BigFlag value reset in Apply

### DIFF
--- a/internal/flags/flags.go
+++ b/internal/flags/flags.go
@@ -171,7 +171,9 @@ func (f *BigFlag) Apply(set *flag.FlagSet) error {
 		}
 	}
 	eachName(f, func(name string) {
-		f.Value = new(big.Int)
+		if f.Value == nil {
+			f.Value = new(big.Int)
+		}
 		set.Var((*bigValue)(f.Value), name, f.Usage)
 	})
 	return nil

--- a/internal/flags/flags_test.go
+++ b/internal/flags/flags_test.go
@@ -17,9 +17,46 @@
 package flags
 
 import (
+	"flag"
+	"math/big"
 	"runtime"
 	"testing"
 )
+
+func TestBigFlagApplyPreservesDefaultValue(t *testing.T) {
+	defaultVal := big.NewInt(12345)
+	f := &BigFlag{
+		Name:  "test-big",
+		Value: defaultVal,
+	}
+	set := flag.NewFlagSet("test", flag.ContinueOnError)
+	if err := f.Apply(set); err != nil {
+		t.Fatalf("Apply failed: %v", err)
+	}
+	if f.Value.Cmp(defaultVal) != 0 {
+		t.Fatalf("Value after Apply = %s, want %s", f.Value, defaultVal)
+	}
+}
+
+func TestBigFlagApplyPreservesEnvValue(t *testing.T) {
+	t.Setenv("TEST_BIG_FLAG", "999")
+	f := &BigFlag{
+		Name:    "test-big",
+		Value:   big.NewInt(1),
+		EnvVars: []string{"TEST_BIG_FLAG"},
+	}
+	set := flag.NewFlagSet("test", flag.ContinueOnError)
+	if err := f.Apply(set); err != nil {
+		t.Fatalf("Apply failed: %v", err)
+	}
+	want := big.NewInt(999)
+	if f.Value.Cmp(want) != 0 {
+		t.Fatalf("Value after Apply = %s, want %s", f.Value, want)
+	}
+	if !f.HasBeenSet {
+		t.Fatal("HasBeenSet should be true when env var is set")
+	}
+}
 
 func TestPathExpansion(t *testing.T) {
 	home := HomeDir()


### PR DESCRIPTION
## Summary
- Stop unconditionally resetting `BigFlag.Value` to a new zero `big.Int` in `Apply`
- Only allocate when `Value` is nil, preserving defaults and environment overrides
- Add tests covering default and env-backed values after `Apply`

## Test plan
- [x] `gofmt` / `goimports` on modified files
- [x] `go test ./internal/flags/ -run TestBigFlagApply -count=1`