### PR TITLE
metrics: return error for unsupported metric type in Register

### DIFF
--- a/metrics/registry.go
+++ b/metrics/registry.go
@@ -112,7 +112,10 @@ func (r *StandardRegistry) Register(name string, i interface{}) error {
 		return fmt.Errorf("%w: %v", ErrDuplicateMetric, name)
 	}
 
-	_, loaded, _ := r.loadOrRegister(name, i)
+	_, loaded, supported := r.loadOrRegister(name, i)
+	if !supported {
+		return fmt.Errorf("unsupported metric type: %T", i)
+	}
 	if loaded {
 		return fmt.Errorf("%w: %v", ErrDuplicateMetric, name)
 	}


### PR DESCRIPTION
## Summary
- Return an error from `StandardRegistry.Register` when the metric type is not supported
- Previously unsupported types were silently ignored via the discarded `supported` return value

## Test plan
- [x] `gofmt` on modified files
- [ ] `go run ./build/ci.go test -short` (metrics)