### PR TITLE
p2p/discover: always increment TALKREQ drop counter on timeout

### DIFF
--- a/p2p/discover/v5_talk.go
+++ b/p2p/discover/v5_talk.go
@@ -102,10 +102,10 @@ func (t *talkSystem) handleRequest(id enode.ID, addr netip.AddrPort, req *v5wire
 		}()
 	case <-timeout.C:
 		// Couldn't get it in time, drop the request.
+		t.dropCount++
 		if time.Since(t.lastLog) > 5*time.Second {
 			log.Warn("Dropping TALKREQ due to overload", "ndrop", t.dropCount)
 			t.lastLog = time.Now()
-			t.dropCount++
 		}
 	case <-t.transport.closeCtx.Done():
 		// Transport closed, drop the request.


### PR DESCRIPTION
## Summary
- Increment `dropCount` on every TALKREQ dropped due to overload timeout
- Previously the counter was only updated when the throttled warning log was emitted

## Test plan
- [x] `gofmt` on modified files
- [ ] `go run ./build/ci.go test -short` (p2p/discover)