### PR TITLE
cmd/geth: fix db dump-trie max=0 limit

### DIFF
--- a/cmd/geth/dbcmd.go
+++ b/cmd/geth/dbcmd.go
@@ -716,7 +716,7 @@ func dbDumpTrie(ctx *cli.Context) error {
 	var count int64
 	it := trie.NewIterator(trieIt)
 	for it.Next() {
-		if max > 0 && count == max {
+		if max >= 0 && count == max {
 			fmt.Printf("Exiting after %d values\n", count)
 			break
 		}


### PR DESCRIPTION
## Summary
- Fix `db dump-trie` to honor a max count of 0
- The previous `max > 0` check skipped the limit when max was explicitly set to 0

## Test plan
- [x] `gofmt` on modified files
- [ ] `go run ./build/ci.go test -short` (cmd/geth)