### PR TITLE
accounts/keystore: fix negative timezone sign in toISO8601

### DIFF
--- a/accounts/keystore/key.go
+++ b/accounts/keystore/key.go
@@ -230,7 +230,7 @@ func toISO8601(t time.Time) string {
 	if name == "UTC" {
 		tz = "Z"
 	} else {
-		tz = fmt.Sprintf("%03d00", offset/3600)
+		tz = fmt.Sprintf("%+03d00", offset/3600)
 	}
 	return fmt.Sprintf("%04d-%02d-%02dT%02d-%02d-%02d.%09d%s",
 		t.Year(), t.Month(), t.Day(), t.Hour(), t.Minute(), t.Second(), t.Nanosecond(), tz)


### PR DESCRIPTION
## Summary
- Use `%+03d00` instead of `%03d00` when formatting timezone offsets in `toISO8601`
- Ensures west-of-UTC offsets include the minus sign in keystore timestamps

## Test plan
- [x] `gofmt` on modified files
- [ ] `go run ./build/ci.go test -short` (accounts/keystore)