### PR TITLE
core/rawdb: fix freezer metadata log field ordering

### DIFF
--- a/core/rawdb/freezer_meta.go
+++ b/core/rawdb/freezer_meta.go
@@ -112,7 +112,7 @@ func decodeV2(file *os.File) *freezerTableMeta {
 		return nil
 	}
 	if o.Offset > math.MaxInt64 {
-		log.Error("Invalid flushOffset %d in freezer metadata", o.Offset, "file", file.Name())
+		log.Error("Invalid flushOffset %d in freezer metadata", "offset", o.Offset, "file", file.Name())
 		return nil
 	}
 	return &freezerTableMeta{


### PR DESCRIPTION
## Summary
- Fix structured log field ordering in `decodeV2` when reporting an invalid flush offset
- The offset value was passed without a key label, breaking the log output

## Test plan
- [x] `gofmt` on modified files
- [ ] `go run ./build/ci.go test -short` (core/rawdb)