### PR TITLE
internal/ethapi: skip transfer capture for callcode in log tracer

### DIFF
--- a/internal/ethapi/logtracer.go
+++ b/internal/ethapi/logtracer.go
@@ -80,7 +80,7 @@ func (t *tracer) Hooks() *tracing.Hooks {
 
 func (t *tracer) onEnter(depth int, typ byte, from common.Address, to common.Address, input []byte, gas uint64, value *big.Int) {
 	t.logs = append(t.logs, make([]*types.Log, 0))
-	if vm.OpCode(typ) != vm.DELEGATECALL && value != nil && value.Cmp(common.Big0) > 0 {
+	if vm.OpCode(typ) != vm.DELEGATECALL && vm.OpCode(typ) != vm.CALLCODE && value != nil && value.Cmp(common.Big0) > 0 {
 		t.captureTransfer(from, to, value)
 	}
 }


### PR DESCRIPTION
## Summary
- Exclude `CALLCODE` from transfer capture in the log tracer, alongside `DELEGATECALL`
- `CALLCODE` executes in the caller's context and does not transfer value to the callee

## Test plan
- [x] `gofmt` on modified files
- [ ] `go run ./build/ci.go test -short` (internal/ethapi)