### PR TITLE
cmd/geth: release account iterator in listEIP7610EligibleAccounts

### DIFF
--- a/cmd/geth/snapshot.go
+++ b/cmd/geth/snapshot.go
@@ -1054,6 +1054,7 @@ func listEIP7610EligibleAccounts(ctx *cli.Context) error {
 		log.Error("Failed to get account iterator", "err", err)
 		return err
 	}
+	defer iter.Release()
 	var (
 		start    = time.Now()
 		accounts []common.Address


### PR DESCRIPTION
listEIP7610EligibleAccounts opens an account iterator and never releases it.