### PR TITLE
core/state: fix account prefetching for absent accounts and add test for witness inclusion

### DIFF
--- a/core/state/statedb.go
+++ b/core/state/statedb.go
@@ -614,15 +614,16 @@ func (s *StateDB) getStateObject(addr common.Address) *stateObject {
 	}
 	s.AccountReads += time.Since(start)
 
-	// Short circuit if the account is not found
-	if acct == nil {
-		return nil
-	}
-	// Schedule the resolved account for prefetching if it's enabled.
+	// Schedule the account path for prefetching if it's enabled. Even if the
+	// account is absent, the trie path proves its non-existence for witnesses.
 	if s.prefetcher != nil {
 		if err = s.prefetcher.prefetch(common.Hash{}, s.originalRoot, common.Address{}, []common.Address{addr}, nil, true); err != nil {
 			log.Error("Failed to prefetch account", "addr", addr, "err", err)
 		}
+	}
+	// Short circuit if the account is not found
+	if acct == nil {
+		return nil
 	}
 	// Insert into the live set
 	obj := newObject(s, addr, acct)

--- a/core/state/statedb_test.go
+++ b/core/state/statedb_test.go
@@ -33,6 +33,7 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/rawdb"
 	"github.com/ethereum/go-ethereum/core/state/snapshot"
+	"github.com/ethereum/go-ethereum/core/stateless"
 	"github.com/ethereum/go-ethereum/core/tracing"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/crypto"
@@ -995,6 +996,45 @@ func TestDeleteCreateRevert(t *testing.T) {
 
 	if state.getStateObject(addr) != nil {
 		t.Fatalf("self-destructed contract came alive")
+	}
+}
+
+func TestWitnessIncludesAbsentAccountReads(t *testing.T) {
+	db := NewDatabaseForTesting()
+	state, _ := New(types.EmptyRootHash, db)
+	for i := byte(0); i < 3; i++ {
+		addr := common.Address{i + 1}
+		state.SetBalance(addr, uint256.NewInt(uint64(i+1)), tracing.BalanceChangeUnspecified)
+	}
+	root, err := state.Commit(0, false, false)
+	if err != nil {
+		t.Fatalf("failed to commit initial state: %v", err)
+	}
+	state, err = New(root, db)
+	if err != nil {
+		t.Fatalf("failed to reopen state: %v", err)
+	}
+
+	witness := &stateless.Witness{
+		Codes: make(map[string]struct{}),
+		State: make(map[string]struct{}),
+	}
+	state.StartPrefetcher("test", witness)
+	missing := common.HexToAddress("0x017655eac00c837122cabbbc0dd604a196906648")
+	if balance := state.GetBalance(missing); balance.Sign() != 0 {
+		t.Fatalf("unexpected balance for absent account: %v", balance)
+	}
+	if err := state.Error(); err != nil {
+		t.Fatalf("unexpected state error after read: %v", err)
+	}
+	if got := state.IntermediateRoot(false); got != root {
+		t.Fatalf("unexpected root after read-only access: have %x want %x", got, root)
+	}
+	if err := state.Error(); err != nil {
+		t.Fatalf("unexpected state error after root calculation: %v", err)
+	}
+	if len(witness.State) == 0 {
+		t.Fatal("missing witness nodes for absent account read")
 	}
 }
 


### PR DESCRIPTION
## Summary

- Include absent account reads in StateDB account prefetching.
- Add regression coverage that execution witnesses include proof nodes for missing account reads.

## Why this is required

Execution witnesses must include the trie path for every account read, including reads of accounts that do not exist. Previously, `getStateObject` returned immediately when `reader.Account(addr)` was nil, so the prefetcher was never scheduled for absent accounts.

That meant witness generation could omit the nodes required to prove account non-existence. This change schedules account prefetching before the absent-account return, allowing witnesses to include the required proof path without changing read-only state behavior or the resulting state root.

## Context

I started using Geth as a `t8n` substitute for EEST benchmark filling on the `projects/zkevm-releases` branch. Using EEST Python directly is too slow for this workflow, for the same reason we cannot practically fill the general EEST benchmarks with EEST itself (non zkevm related).

In an initial run, I used Geth to fill benchmark fixtures and compared them against @omerfirmak's guest program. The guest program reported disagreements while consuming the generated execution witnesses. After investigating the mismatch, I found that absent account reads were not being included in the witness proof data. This change [fixes those disagreements](https://discord.com/channels/595666850260713488/1517623278397685940/1518876762426052660).

The issue is not an execution-result mismatch: Geth still computes the correct state transition. The missing piece is witness completeness. Reads of absent accounts also require trie proof nodes, because the witness must prove non-existence.

This change only adds required proof data to the execution witness. It should be compatible with existing consumers because it makes the witness more complete without changing execution semantics.