### PR TITLE
core/rawdb: prevent truncateHead from returning an error for empty tables

### DIFF
--- a/core/rawdb/freezer_table.go
+++ b/core/rawdb/freezer_table.go
@@ -620,6 +620,7 @@ func (t *freezerTable) truncateHead(items uint64) error {
 			// at the head, so we have to align the table down to the new head.
 			return t.resetTo(items)
 		}
+		return errors.New("truncation below tail")
 	}
 
 	// We need to truncate, save the old size for metrics tracking

--- a/core/rawdb/freezer_table.go
+++ b/core/rawdb/freezer_table.go
@@ -611,9 +611,17 @@ func (t *freezerTable) truncateHead(items uint64) error {
 	if existing <= items {
 		return nil
 	}
-	if items < t.itemHidden.Load() {
-		return errors.New("truncation below tail")
+
+	hidden := t.itemHidden.Load()
+
+	if items < hidden {
+		if existing == hidden {
+			// Empty table means that it is newly added. Its tail would be
+			// at the head, so we have to align the table down to the new head.
+			return t.resetTo(items)
+		}
 	}
+
 	// We need to truncate, save the old size for metrics tracking
 	oldSize, err := t.sizeNolock()
 	if err != nil {


### PR DESCRIPTION
This PR is related to the recent bug reported in #35210.

While trying to reproduce the error, I found that when the head state is missing (e.g. unclean shutdown), we attempt to truncate the head to the most recent block with state across all chain freezer tables.

However, for newly added tables such as the bal table, both the head and tail are initialized to the minimum head of the existing chain freezer tables. As a result, the `truncateHead` fails with the “truncate below tail” error.

This PR fixes the issue by resetting newly added empty tables with `items` as the tail when `truncateHead(items)` is called on them. Below is the log I got.

```
INFO [06-28|19:57:29.465] Loaded most recent local block           number=25,418,388 hash=172433..57ecdb age=18s
INFO [06-28|19:57:29.465] Loaded most recent local finalized block number=25,418,308 hash=3d8de6..8c8c18 age=16m18s
INFO [06-28|19:57:29.465] Loaded last snap-sync pivot marker       number=25,408,034
WARN [06-28|19:57:29.465] Head state missing, repairing            number=25,418,388 hash=172433..57ecdb
INFO [06-28|19:57:29.472] Rewound to block with state              number=25,418,197 hash=deb55a..6ae244
WARN [06-28|19:57:29.494] Truncating freezer table                 database=/data/geth/chaindata/ancient/chain table=receipts items=25,418,309 limit=25,418,198
CRIT [06-28|19:57:29.506] Failed to truncate head block            err="truncation below tail"
```
It seems that `NewFreezer` succeeded, but because the head state was missing, we tried to rewind the chain via `setHeadBeyondRoot` -> `hc.SetHead` -> `TruncateHead`, and that failed.

When I tried to restart Geth after this, it produced the logs below (fails inside of the `NewFreezer`), because the database was already corrupted. This is almost the same as the one we got reported
```
Chain metadata
  databaseVersion: 9 (0x9)
  headBlockHash: 0xdeb55a6ffcb0fea6c3e116565c55a9616e097a29aa0be849867c9519946ae244
  headFastBlockHash: 0x172433f2e16c3ece63f218bf4d3f3d2039372ba789a690ba9287a90d2157ecdb
  headHeaderHash: 0xdeb55a6ffcb0fea6c3e116565c55a9616e097a29aa0be849867c9519946ae244
  lastPivotNumber: 25408034 (0x183b222)
  len(snapshotSyncStatus): 286 bytes
  snapshotDisabled: false
  snapshotJournal: 0 bytes
  snapshotRecoveryNumber: <nil>
  snapshotRoot: 0xae36e07f42cf9d3c043d55da94d60320ed275f1e9d612f4361f9c1f578ae6698
  txIndexTail: 23068389 (0x15ffee5)
  SkeletonSyncStatus: {"Subchains":[{"Head":25418381,"Tail":25418198,"Next":"0xdeb55a6ffcb0fea6c3e116565c55a9616e097a29aa0be849867c9519946ae244"}],"Finalized":25418308}
  filterMapsRange: {Version:2 HeadIndexed:false HeadDelimiter:0 BlocksFirst:23048525 BlocksAfterLast:25418372 MapsFirst:296960 MapsAfterLast:404767 TailPartialEpoch:0}


Fatal: Failed to register the Ethereum service: truncation below tail
Fatal: Failed to register the Ethereum service: truncation below tail
```
