### PR TITLE
core/txpool/blobpool: fall back on cache version mismatch

### DIFF
--- a/core/txpool/blobpool/cache.go
+++ b/core/txpool/blobpool/cache.go
@@ -201,9 +201,7 @@ func (c *Cache) GetBlobs(ctx context.Context, vhashes []common.Hash, version byt
 		cached := c.entries[vhash]
 		if cached == nil || cached.version != version {
 			cacheMiss += n
-			if cached == nil {
-				misses = append(misses, vhash)
-			}
+			misses = append(misses, vhash)
 			continue
 		}
 		cacheHits += n

--- a/core/txpool/blobpool/cache_test.go
+++ b/core/txpool/blobpool/cache_test.go
@@ -280,6 +280,29 @@ func TestCacheGetBlobs(t *testing.T) {
 	tc.expectEntries(t, tc.vhashes[1]...)
 }
 
+func TestCacheGetBlobsFallsBackOnVersionMismatch(t *testing.T) {
+	tc := newTestCache(t, []txSpec{
+		{blobs: 1, tip: 100},
+	})
+	vhash := tc.vhashes[0][0]
+	tc.expectEntries(t, vhash)
+
+	tc.mu.Lock()
+	tc.entries[vhash].version = types.BlobSidecarVersion0
+	tc.mu.Unlock()
+
+	blobs, _, proofs, err := tc.GetBlobs(context.Background(), []common.Hash{vhash}, types.BlobSidecarVersion1)
+	if err != nil {
+		t.Fatalf("GetBlobs: %v", err)
+	}
+	if blobs[0] == nil {
+		t.Fatal("blob missing in GetBlobs response")
+	}
+	if len(proofs[0]) == 0 {
+		t.Fatal("proofs missing in GetBlobs response")
+	}
+}
+
 // TestCacheTopKRefresh verifies that when a more profitable tx appears in the
 // pool, the next topK tick replaces the cached entry with the better one.
 func TestCacheTopKRefresh(t *testing.T) {


### PR DESCRIPTION
## What

This makes `Cache.GetBlobs` fall back to the underlying blob pool when a cached blob exists but its proof version does not match the requested version.

## Why

The previous code counted a cached version mismatch as a cache miss, but only added the blob hash to the fallback list when the cache entry was nil. This could leave the response empty without consulting the blob pool, even though the request was handled as a miss.

## Validation

- `go test ./core/txpool/blobpool -run TestCacheGetBlobsFallsBackOnVersionMismatch -count=1`
