### PR TITLE
metrics: fix inclusive boundary in runtime histogram percentile

### DIFF
--- a/metrics/runtimehistogram.go
+++ b/metrics/runtimehistogram.go
@@ -224,7 +224,7 @@ func (h *runtimeHistogramSnapshot) computePercentiles(thresh []float64) {
 	for i, count := range h.internal.Counts {
 		totalCount += float64(count)
 
-		for len(thresh) > 0 && thresh[0] < totalCount {
+		for len(thresh) > 0 && thresh[0] <= totalCount {
 			thresh[0] = h.internal.Buckets[i]
 			thresh = thresh[1:]
 		}


### PR DESCRIPTION
When a percentile threshold equals the cumulative count at a bucket boundary, assign that bucket instead of skipping to the next one.