### PR TITLE
params: enable amsterdam fork in dev and test chain configs

### DIFF
--- a/params/config.go
+++ b/params/config.go
@@ -228,6 +228,7 @@ var (
 		TerminalTotalDifficulty: big.NewInt(0),
 		PragueTime:              newUint64(0),
 		OsakaTime:               newUint64(0),
+		AmsterdamTime:           newUint64(0),
 		BlobScheduleConfig: &BlobScheduleConfig{
 			Cancun: DefaultCancunBlobConfig,
 			Prague: DefaultPragueBlobConfig,
@@ -318,6 +319,7 @@ var (
 		CancunTime:              newUint64(0),
 		PragueTime:              newUint64(0),
 		OsakaTime:               newUint64(0),
+		AmsterdamTime:           newUint64(0),
 		UBTTime:                 nil,
 		TerminalTotalDifficulty: big.NewInt(0),
 		Ethash:                  new(EthashConfig),


### PR DESCRIPTION
## Summary
- Enable `AmsterdamTime` at genesis in `AllDevChainProtocolChanges` and `MergedTestChainConfig`
- Ensures dev and merged test chains activate all accepted protocol changes including EIP-8037

## Test plan
- [x] `gofmt` on modified files
- [ ] `go run ./build/ci.go test -short` (params)