### PR TITLE
rpc: reject block parameter with neither number nor hash

### DIFF
--- a/rpc/types.go
+++ b/rpc/types.go
@@ -158,6 +158,9 @@ func (bnh *BlockNumberOrHash) UnmarshalJSON(data []byte) error {
 		if e.BlockNumber != nil && e.BlockHash != nil {
 			return errors.New("cannot specify both BlockHash and BlockNumber, choose one or the other")
 		}
+		if e.BlockNumber == nil && e.BlockHash == nil {
+			return errors.New("must specify either BlockHash or BlockNumber")
+		}
 		bnh.BlockNumber = e.BlockNumber
 		bnh.BlockHash = e.BlockHash
 		bnh.RequireCanonical = e.RequireCanonical

--- a/rpc/types_test.go
+++ b/rpc/types_test.go
@@ -109,6 +109,8 @@ func TestBlockNumberOrHash_UnmarshalJSON(t *testing.T) {
 		27: {`{"blockNumber":"safe"}`, false, BlockNumberOrHashWithNumber(SafeBlockNumber)},
 		28: {`{"blockNumber":"finalized"}`, false, BlockNumberOrHashWithNumber(FinalizedBlockNumber)},
 		29: {`{"blockNumber":"0x1", "blockHash":"0x0000000000000000000000000000000000000000000000000000000000000000"}`, true, BlockNumberOrHash{}},
+		30: {`{}`, true, BlockNumberOrHash{}},
+		31: {`{"requireCanonical":true}`, true, BlockNumberOrHash{}},
 	}
 
 	for i, test := range tests {


### PR DESCRIPTION
### Rationale

An EIP-1898 block-parameter object that specifies **neither** `blockNumber` **nor** `blockHash` (e.g. `{}`) is invalid. Today `BlockNumberOrHash.UnmarshalJSON` accepts it (both fields `nil`, no error), and it is only rejected later in the backend:

```go
// eth/api_backend.go
return nil, nil, errors.New("invalid arguments; neither block nor hash specified")
```

Because that is a plain `error`, it surfaces to the client as a generic `-32000`. Per EIP-1474, an invalid parameter should be `-32602` (invalid params).

### Change

Reject the empty object during unmarshalling, mirroring the existing sibling check for specifying *both*:

```go
if e.BlockNumber != nil && e.BlockHash != nil {
    return errors.New("cannot specify both BlockHash and BlockNumber, choose one or the other")
}
if e.BlockNumber == nil && e.BlockHash == nil {
    return errors.New("neither BlockNumber nor BlockHash specified")
}
```

Since the RPC handler wraps `parsePositionalArguments` failures in `invalidParamsError`, the client now receives a correct `-32602` for `{}` (and for objects carrying only `requireCanonical`). This also handles every `BlockNumberOrHash` method consistently, at the source, instead of relying on per-backend downstream checks.

### Tests

Added cases to `TestBlockNumberOrHash_UnmarshalJSON` for `{}` and `{"requireCanonical":true}` (both must fail). `go test ./rpc/` passes (96 tests); `internal/ethapi` and `eth` build cleanly.