### PR TITLE
internal/ethapi: return invalid params for undecodable raw transactions

### DIFF
--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -1738,7 +1738,7 @@ func (api *TransactionAPI) currentBlobSidecarVersion() byte {
 func (api *TransactionAPI) SendRawTransaction(ctx context.Context, input hexutil.Bytes) (common.Hash, error) {
 	tx := new(types.Transaction)
 	if err := tx.UnmarshalBinary(input); err != nil {
-		return common.Hash{}, err
+		return common.Hash{}, &invalidParamsError{message: err.Error()}
 	}
 
 	// Convert legacy blob transaction proofs.
@@ -1761,7 +1761,7 @@ func (api *TransactionAPI) SendRawTransaction(ctx context.Context, input hexutil
 func (api *TransactionAPI) SendRawTransactionSync(ctx context.Context, input hexutil.Bytes, timeoutMs *uint64) (map[string]interface{}, error) {
 	tx := new(types.Transaction)
 	if err := tx.UnmarshalBinary(input); err != nil {
-		return nil, err
+		return nil, &invalidParamsError{message: err.Error()}
 	}
 
 	// Convert legacy blob transaction proofs.

--- a/internal/ethapi/api_test.go
+++ b/internal/ethapi/api_test.go
@@ -4132,6 +4132,32 @@ func TestSendRawTransactionSync_Success(t *testing.T) {
 	}
 }
 
+func TestSendRawTransaction_InvalidInputReturnsInvalidParams(t *testing.T) {
+	t.Parallel()
+	genesis := &core.Genesis{
+		Config: params.TestChainConfig,
+		Alloc:  types.GenesisAlloc{},
+	}
+	b := newTestBackend(t, 0, genesis, ethash.NewFaker(), nil)
+	api := NewTransactionAPI(b, new(AddrLocker))
+
+	// Inputs that fail to decode into a transaction are invalid parameters and
+	// must surface as -32602, not the generic -32000.
+	for _, input := range []hexutil.Bytes{{}, {0x02}} {
+		_, err := api.SendRawTransaction(context.Background(), input)
+		if err == nil {
+			t.Fatalf("input %#x: expected error, got nil", []byte(input))
+		}
+		var de interface{ ErrorCode() int }
+		if !errors.As(err, &de) {
+			t.Fatalf("input %#x: expected coded error, got %T %v", []byte(input), err, err)
+		}
+		if de.ErrorCode() != errCodeInvalidParams {
+			t.Fatalf("input %#x: expected code %d, got %d", []byte(input), errCodeInvalidParams, de.ErrorCode())
+		}
+	}
+}
+
 func TestSendRawTransactionSync_Timeout(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
### Rationale

`eth_sendRawTransaction` (and `eth_sendRawTransactionSync`) return the `tx.UnmarshalBinary(input)` decode error as a plain `error`:

```go
tx := new(types.Transaction)
if err := tx.UnmarshalBinary(input); err != nil {
    return common.Hash{}, err   // plain error -> surfaces as -32000
}
```

An input that fails to decode into a transaction (empty, truncated, `"typed transaction too short"`, unknown type, …) is an **invalid parameter**, so per EIP-1474 it should surface as **`-32602`** (invalid params), not the generic `-32000`. This also matches how the rest of this package already reports parameter-decode failures (`decodeStorageKey`, `"empty request"`), which return `invalidParamsError`.

### Change

Wrap the decode error in `invalidParamsError` in both `SendRawTransaction` and `SendRawTransactionSync`:

```go
if err := tx.UnmarshalBinary(input); err != nil {
    return common.Hash{}, &invalidParamsError{message: err.Error()}
}
```

The underlying message is preserved (`err.Error()`), so no diagnostic detail is lost — only the code changes to `-32602`. The blob-sidecar-conversion error path is unchanged.

### Tests

Added `TestSendRawTransaction_InvalidInputReturnsInvalidParams` asserting that undecodable inputs (empty, and a lone type byte `0x02`) return a coded error with `ErrorCode() == -32602`. `go test ./internal/ethapi/` passes; `go build ./...` clean.