### PR TITLE
trie/bintrie: fix panic in code chunk key computation for chunknr=0

### DIFF
--- a/trie/bintrie/key_encoding.go
+++ b/trie/bintrie/key_encoding.go
@@ -105,7 +105,8 @@ func GetBinaryTreeKeyStorageSlot(address common.Address, slotnum []byte) []byte 
 }
 
 func GetBinaryTreeKeyCodeChunk(address common.Address, chunknr *uint256.Int) []byte {
-	chunkOffset := new(uint256.Int).Add(codeOffset, chunknr).Bytes()
+	chunkOffsetBytes32 := new(uint256.Int).Add(codeOffset, chunknr).Bytes32()
+	chunkOffset := chunkOffsetBytes32[:]
 	return GetBinaryTreeKey(address, chunkOffset)
 }
 

--- a/trie/bintrie/key_encoding_test.go
+++ b/trie/bintrie/key_encoding_test.go
@@ -1,0 +1,34 @@
+// Copyright 2025 go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+
+package bintrie
+
+import (
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/holiman/uint256"
+)
+
+// TestGetBinaryTreeKeyCodeChunkZero is a regression test: chunknr=0 encodes
+// codeOffset (128) to a single byte, which caused getBinaryTreeKey to panic on
+// offset[:31] before the offset was zero-padded to 32 bytes.
+func TestGetBinaryTreeKeyCodeChunkZero(t *testing.T) {
+	key := GetBinaryTreeKeyCodeChunk(common.Address{}, uint256.NewInt(0))
+	if len(key) != 32 {
+		t.Fatalf("expected 32-byte key, got %d", len(key))
+	}
+}


### PR DESCRIPTION
## Summary

- Fix a panic in `GetBinaryTreeKeyCodeChunk` when `chunknr` is zero: `codeOffset + chunknr` encodes to a single byte, and `getBinaryTreeKey` sliced `offset[:31]` on the short buffer.
- Zero-pad the code chunk offset to 32 bytes via `Bytes32()` before hashing, consistent with other key encoding paths.
- Add a regression test for `chunknr=0`.

## Test plan

- [x] `go test -run TestGetBinaryTreeKeyCodeChunkZero -v ./trie/bintrie/`