### PR TITLE
core: fix remaining spec issues

### DIFF
--- a/core/state_transition.go
+++ b/core/state_transition.go
@@ -242,12 +242,10 @@ func FloorDataGas(rules params.Rules, from common.Address, to *common.Address, v
 		tokenCost = params.TxCostFloorPerToken
 	}
 
-	// The floor is anchored to the transaction base cost. Under EIP-2780 that
-	// base is the per-resource decomposition (the same one used by the intrinsic
-	// gas), so the floor never undercuts the transaction's own base.
+	// The floor is anchored to the transaction base cost.
 	floorBase := params.TxGas
 	if rules.IsAmsterdam {
-		floorBase = intrinsicBaseGasEIP2780(from, to, value)
+		floorBase = params.TxBaseCost2780
 	}
 	// Check for overflow
 	if (math.MaxUint64-floorBase)/tokenCost < tokens {
@@ -755,6 +753,10 @@ func (st *stateTransition) execute() (*ExecutionResult, error) {
 		// performing the resolution and warming.
 		if addr, ok := types.ParseDelegation(st.state.GetCode(*msg.To)); ok {
 			st.state.AddAddressToAccessList(addr)
+			// Record in BAL
+			if rules.IsAmsterdam {
+				st.state.GetCode(addr)
+			}
 		}
 		// EIP-2780: charge the transaction's top-level recipient costs. If the
 		// budget cannot cover the charge, the top frame halts out of gas.

--- a/params/protocol_params.go
+++ b/params/protocol_params.go
@@ -101,13 +101,7 @@ const (
 	TxAccessListStorageKeyGas uint64 = 1900  // Per storage key specified in EIP 2930 access list
 	TxAuthTupleGas            uint64 = 12500 // Per auth tuple code specified in EIP-7702
 
-	// RegularPerAuthBaseCost is defined in EIP-8037 as the sum of:
-	//
-	// - Calldata cost: 1,616 (101 bytes × 16)
-	// - Recovering authority address (ecRecover)
-	// - Reading nonce and code of authority (cold access)
-	// - Storing values in already warm account: 2 x WARM_ACCESS
-	RegularPerAuthBaseCost uint64 = 7500
+	RegularPerAuthBaseCost uint64 = 7816 // As defined by EIP-8037 and EIP-8038
 
 	// EIP-2780: resource-based intrinsic transaction gas.
 	TxBaseCost2780        uint64 = 12000


### PR DESCRIPTION
This PR fixes three remaining differences between master and glamsterdam-devnet-6:
- RegularCost for Auths has been increased, since 8037 increases the WARM_ACCESS cost
- Floor is anchored to the transaction base cost, not the intrinsic cost
- Auth destinations need to be recorded in the BAL before the call is executed