### PR TITLE
core/types/bal: enhance the bal validation

### DIFF
--- a/core/types/bal/bal_encoding.go
+++ b/core/types/bal/bal_encoding.go
@@ -80,7 +80,7 @@ func (e *BlockAccessList) DecodeRLP(s *rlp.Stream) error {
 // according to the spec or any code changes are contained which exceed protocol
 // max code size.
 func (e *BlockAccessList) Validate(blockGasLimit uint64, blockTxCount int) error {
-	if !slices.IsSortedFunc(*e, func(a, b AccountAccess) int {
+	if !isStrictlySortedFunc(*e, func(a, b AccountAccess) int {
 		return bytes.Compare(a.Address[:], b.Address[:])
 	}) {
 		return errors.New("block access list accounts not in lexicographic order")


### PR DESCRIPTION
EIP-7928 requires that each address appears exactly once in the block access list. 

In the `BlockAccessList.Validate`, the strict `isStrictlySortedFunc` is required to detect the duplicated accounts.