### PR TITLE
p2p: skip netrestrict check for nodes without resolved IP

### DIFF
--- a/p2p/dial.go
+++ b/p2p/dial.go
@@ -428,7 +428,7 @@ func (d *dialScheduler) checkDial(n *enode.Node) error {
 	if _, ok := d.pendingInbound[n.ID()]; ok {
 		return errPendingInbound
 	}
-	if d.netRestrict != nil && !d.netRestrict.ContainsAddr(n.IPAddr()) {
+	if d.netRestrict != nil && n.IPAddr().IsValid() && !d.netRestrict.ContainsAddr(n.IPAddr()) {
 		return errNetRestrict
 	}
 	if d.history.contains(string(n.ID().Bytes())) {


### PR DESCRIPTION
## Summary

- Skip the netrestrict check in `checkDial` when a node has no valid IP yet.
- Hostname-only static nodes are resolved later in `dialTask`; applying netrestrict before resolution incorrectly rejected them.

## Test plan

- [x] `go test -short ./p2p/ -run TestDialSchedNetRestrict`