### PR TITLE
console: print helpful error when attach stdin is not a terminal

### DIFF
--- a/cmd/geth/consolecmd.go
+++ b/cmd/geth/consolecmd.go
@@ -18,11 +18,13 @@ package main
 
 import (
 	"fmt"
+	"os"
 	"slices"
 	"strings"
 
 	"github.com/ethereum/go-ethereum/cmd/utils"
 	"github.com/ethereum/go-ethereum/console"
+	"github.com/mattn/go-isatty"
 	"github.com/urfave/cli/v2"
 )
 
@@ -141,9 +143,28 @@ func remoteConsole(ctx *cli.Context) error {
 	}
 
 	// Otherwise print the welcome screen and enter interactive mode
+	if err := requireInteractiveTTY(); err != nil {
+		return err
+	}
 	console.Welcome()
 	console.Interactive()
 	return nil
+}
+
+// requireInteractiveTTY ensures stdin is a terminal or an open pipe when starting
+// an interactive attach session. Piped stdin is allowed for scripting and tests;
+// closed or non-interactive sources such as /dev/null are rejected early.
+func requireInteractiveTTY() error {
+	if isatty.IsTerminal(os.Stdin.Fd()) || isatty.IsCygwinTerminal(os.Stdin.Fd()) {
+		return nil
+	}
+	fi, err := os.Stdin.Stat()
+	if err == nil && fi.Mode()&os.ModeNamedPipe != 0 {
+		return nil
+	}
+	return fmt.Errorf(`Cannot start interactive console: input closed or not a terminal.
+Hint: use 'geth attach --exec "eth.blockNumber" <endpoint>' for non-interactive use,
+or run attach inside a TTY (e.g. screen -dmS name bash -lc 'geth attach ...').`)
 }
 
 // ephemeralConsole starts a new geth node, attaches an ephemeral JavaScript

--- a/cmd/geth/consolecmd_test.go
+++ b/cmd/geth/consolecmd_test.go
@@ -119,7 +119,8 @@ func TestAttachWelcome(t *testing.T) {
 }
 
 func testAttachWelcome(t *testing.T, geth *testgeth, endpoint, apis string) {
-	// Attach to a running geth node and terminate immediately
+	// Attach to a running geth node with stdin closed, as happens when
+	// launched without a TTY (e.g. via GNU screen -X screen).
 	attach := runGeth(t, "attach", endpoint)
 	defer attach.ExpectExit()
 	attach.CloseStdin()
@@ -136,7 +137,7 @@ func testAttachWelcome(t *testing.T, geth *testgeth, endpoint, apis string) {
 	attach.SetTemplateFunc("datadir", func() string { return geth.Datadir })
 	attach.SetTemplateFunc("apis", func() string { return apis })
 
-	// Verify the actual welcome message to the required template
+	// Verify the welcome message and non-TTY hint are printed.
 	attach.Expect(`
 Welcome to the Geth JavaScript console!
 
@@ -146,9 +147,11 @@ at block: 0 ({{niltime}}){{if ipc}}
  modules: {{apis}}
 
 To exit, press ctrl-d or type exit
-> {{.InputLine "exit" }}
+> 
+Cannot start interactive console: input closed or not a terminal.
+Hint: use 'geth attach --exec "eth.blockNumber" <endpoint>' for non-interactive use,
+or run attach inside a TTY (e.g. screen -dmS name bash -lc 'geth attach ...').
 `)
-	attach.ExpectExit()
 }
 
 // trulyRandInt generates a crypto random integer used by the console tests to

--- a/console/console.go
+++ b/console/console.go
@@ -429,6 +429,11 @@ func (c *Console) Interactive() {
 				prompt, indents, input = c.prompt, 0, ""
 				continue
 			}
+			if errors.Is(err, io.EOF) {
+				fmt.Fprintln(c.printer, "Cannot start interactive console: input closed or not a terminal.")
+				fmt.Fprintln(c.printer, "Hint: use 'geth attach --exec \"eth.blockNumber\" <endpoint>' for non-interactive use,")
+				fmt.Fprintln(c.printer, "or run attach inside a TTY (e.g. screen -dmS name bash -lc 'geth attach ...').")
+			}
 			return
 
 		case line := <-inputLine:

--- a/console/console_test.go
+++ b/console/console_test.go
@@ -20,6 +20,7 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"strings"
 	"testing"
@@ -72,6 +73,17 @@ func (p *hookedPrompter) AppendHistory(command string)                    {}
 func (p *hookedPrompter) ClearHistory()                                   {}
 func (p *hookedPrompter) SetWordCompleter(completer prompt.WordCompleter) {}
 
+// eofPrompter simulates a closed or non-terminal stdin by returning io.EOF.
+type eofPrompter struct{}
+
+func (eofPrompter) PromptInput(string) (string, error)              { return "", io.EOF }
+func (eofPrompter) PromptPassword(string) (string, error)           { return "", io.EOF }
+func (eofPrompter) PromptConfirm(string) (bool, error)              { return false, io.EOF }
+func (eofPrompter) SetHistory([]string)                             {}
+func (eofPrompter) AppendHistory(string)                            {}
+func (eofPrompter) ClearHistory()                                   {}
+func (eofPrompter) SetWordCompleter(completer prompt.WordCompleter) {}
+
 // tester is a console test environment for the console tests to operate on.
 type tester struct {
 	workspace string
@@ -85,6 +97,10 @@ type tester struct {
 // newTester creates a test environment based on which the console can operate.
 // Please ensure you call Close() on the returned tester to avoid leaks.
 func newTester(t *testing.T, confOverride func(*ethconfig.Config)) *tester {
+	return newTesterWithPrompter(t, &hookedPrompter{scheduler: make(chan string)}, confOverride)
+}
+
+func newTesterWithPrompter(t *testing.T, prompter prompt.UserPrompter, confOverride func(*ethconfig.Config)) *tester {
 	// Create a temporary storage for the node keys and initialize it
 	workspace := t.TempDir()
 
@@ -115,7 +131,6 @@ func newTester(t *testing.T, confOverride func(*ethconfig.Config)) *tester {
 		client.Close()
 	})
 
-	prompter := &hookedPrompter{scheduler: make(chan string)}
 	printer := new(bytes.Buffer)
 
 	console, err := New(Config{
@@ -130,12 +145,16 @@ func newTester(t *testing.T, confOverride func(*ethconfig.Config)) *tester {
 		t.Fatalf("failed to create JavaScript console: %v", err)
 	}
 	// Create the final tester and return
+	var input *hookedPrompter
+	if hp, ok := prompter.(*hookedPrompter); ok {
+		input = hp
+	}
 	return &tester{
 		workspace: workspace,
 		stack:     stack,
 		ethereum:  ethBackend,
 		console:   console,
-		input:     prompter,
+		input:     input,
 		output:    printer,
 	}
 }
@@ -185,6 +204,19 @@ func TestEvaluate(t *testing.T) {
 	tester.console.Evaluate("2 + 2")
 	if output := tester.output.String(); !strings.Contains(output, "4") {
 		t.Fatalf("statement evaluation failed: have %s, want %s", output, "4")
+	}
+}
+
+// Tests that Interactive exits with a helpful message when stdin is closed.
+func TestInteractiveEOF(t *testing.T) {
+	tester := newTesterWithPrompter(t, eofPrompter{}, nil)
+	defer tester.Close(t)
+
+	tester.console.Interactive()
+
+	output := tester.output.String()
+	if want := "not a terminal"; !strings.Contains(output, want) {
+		t.Fatalf("console output missing EOF hint: have\n%s\nwant substring %s", output, want)
 	}
 }
 


### PR DESCRIPTION
## Summary
- Reproduces #32387: `geth attach` exits immediately after welcome when stdin is not a TTY (e.g. `screen -X screen`, `</dev/null`)
- Adds early stdin check for `geth attach` (allows pipes for scripting/tests)
- Prints a helpful message in `Interactive()` when liner returns EOF instead of exiting silently
- Updates integration tests

## Test plan
- [x] `go test ./console/... -count=1`
- [x] `go test ./cmd/geth/... -run Console -count=1`
- [x] Manual: `geth attach http://127.0.0.1:8545 </dev/null` → error with hint
- [x] Manual: `geth attach http://127.0.0.1:8545` in normal terminal → works
- [x] Manual: `geth attach --exec 'eth.blockNumber' <endpoint>` → works

Fixes #32387