### PR TITLE
core: delete access list when rewinding block chain

### DIFF
--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -1093,6 +1093,7 @@ func (bc *BlockChain) setHeadBeyondRoot(head uint64, time uint64, root common.Ha
 			// removed by the hc.SetHead function.
 			rawdb.DeleteBody(db, hash, num)
 			rawdb.DeleteReceipts(db, hash, num)
+			rawdb.DeleteAccessList(db, hash, num)
 		}
 		// Todo(rjl493456442) txlookup, log index, etc
 	}

--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -1070,6 +1070,7 @@ func (bc *BlockChain) setHeadBeyondRoot(head uint64, time uint64, root common.Ha
 			// removed by the hc.SetHead function.
 			rawdb.DeleteBody(db, hash, num)
 			rawdb.DeleteReceipts(db, hash, num)
+			rawdb.DeleteAccessList(db, hash, num)
 		}
 		// Todo(rjl493456442) txlookup, log index, etc
 	}


### PR DESCRIPTION
## Summary

- Delete block access lists from the KV store in `setHeadBeyondRoot` during chain rewind.
- Matches existing cleanup of bodies and receipts to avoid stale access list data after a reorg.

## Test plan

- [ ] Manual chain rewind / setHead scenario with access lists enabled