### PR TITLE
eth/protocols/eth: discard message before size check

### DIFF
--- a/eth/protocols/eth/handler.go
+++ b/eth/protocols/eth/handler.go
@@ -224,10 +224,10 @@ func handleMessage(backend Backend, peer *Peer) error {
 	if err != nil {
 		return err
 	}
+	defer msg.Discard()
 	if msg.Size > maxMessageSize {
 		return fmt.Errorf("%w: %v > %v", errMsgTooLarge, msg.Size, maxMessageSize)
 	}
-	defer msg.Discard()
 
 	var handlers map[uint64]msgHandler
 	switch peer.version {

--- a/eth/protocols/snap/handler.go
+++ b/eth/protocols/snap/handler.go
@@ -160,10 +160,10 @@ func HandleMessage(backend Backend, peer *Peer) error {
 	if err != nil {
 		return err
 	}
+	defer msg.Discard()
 	if msg.Size > maxMessageSize {
 		return fmt.Errorf("%w: %v > %v", errMsgTooLarge, msg.Size, maxMessageSize)
 	}
-	defer msg.Discard()
 
 	var handlers map[uint64]msgHandler
 	switch peer.version {


### PR DESCRIPTION
## Summary

- Move `msg.Discard` defer ahead of the max message size check in `handleMessage`.
- Ensures oversized messages are released when the handler returns early.

## Test plan

- [x] `go test -short ./eth/protocols/eth/`