### PR TITLE
core/types: reject empty authorizationList in SetCodeTx JSON

### DIFF
--- a/core/types/transaction_marshalling.go
+++ b/core/types/transaction_marshalling.go
@@ -474,8 +474,8 @@ func (tx *Transaction) UnmarshalJSON(input []byte) error {
 		if dec.AccessList != nil {
 			itx.AccessList = *dec.AccessList
 		}
-		if dec.AuthorizationList == nil {
-			return errors.New("missing required field 'authorizationList' in transaction")
+		if len(dec.AuthorizationList) == 0 {
+			return errors.New("'authorizationList' must contain at least one authorization")
 		}
 		itx.AuthList = dec.AuthorizationList
 


### PR DESCRIPTION
## Summary

- Check `len(authorizationList)` instead of nil when unmarshaling SetCodeTx JSON.
- Reject empty arrays with a clear error, consistent with `blobVersionedHashes`.

## Test plan

- [x] `go test -short ./core/types/`