### PR TITLE
cmd/devp2p: use isSubdomain for Cloudflare DNS record filtering

### DIFF
--- a/cmd/devp2p/dns_cloudflare.go
+++ b/cmd/devp2p/dns_cloudflare.go
@@ -121,7 +121,7 @@ func (c *cloudflareClient) uploadRecords(name string, records map[string]string)
 	}
 	existing := make(map[string]cloudflare.DNSRecord)
 	for _, entry := range entries {
-		if !strings.HasSuffix(entry.Name, name) {
+		if !isSubdomain(entry.Name, name) {
 			continue
 		}
 		existing[strings.ToLower(entry.Name)] = entry


### PR DESCRIPTION
## Summary

- Replace `strings.HasSuffix` with `isSubdomain` when matching existing Cloudflare TXT records.
- Avoids false positives on zone names that share a suffix.

## Test plan

- [ ] `go test -short ./cmd/devp2p/`