### PR TITLE
core/vm/runtime: propagate SlotNum to EVM block context

### DIFF
--- a/core/vm/runtime/env.go
+++ b/core/vm/runtime/env.go
@@ -41,6 +41,7 @@ func NewEnv(cfg *Config) *vm.EVM {
 		BaseFee:          cfg.BaseFee,
 		BlobBaseFee:      cfg.BlobBaseFee,
 		Random:           cfg.Random,
+		SlotNum:          cfg.SlotNum,
 		CostPerStateByte: params.CostPerStateByte,
 	}
 

--- a/core/vm/runtime/runtime.go
+++ b/core/vm/runtime/runtime.go
@@ -49,6 +49,7 @@ type Config struct {
 	BlobHashes  []common.Hash
 	BlobFeeCap  *big.Int
 	Random      *common.Hash
+	SlotNum     uint64
 
 	State     *state.StateDB
 	GetHashFn func(n uint64) common.Hash


### PR DESCRIPTION
## Summary

- Add `SlotNum` to `runtime.Config` and pass it through in `NewEnv`.
- Ensures the SLOTNUM opcode returns the expected value when executing via the runtime package.

## Test plan

- [x] `go test -short ./core/vm/runtime/`