### PR TITLE
params: return AmsterdamTime from ChainConfig.Timestamp

### DIFF
--- a/params/config.go
+++ b/params/config.go
@@ -1231,6 +1231,8 @@ func (c *ChainConfig) Timestamp(fork forks.Fork) *uint64 {
 		return c.CancunTime
 	case fork == forks.Shanghai:
 		return c.ShanghaiTime
+	case fork == forks.Amsterdam:
+		return c.AmsterdamTime
 	default:
 		return nil
 	}


### PR DESCRIPTION
## Summary

- Add the missing `forks.Amsterdam` case to `ChainConfig.Timestamp`.
- Callers can now look up the Amsterdam fork activation time.

## Test plan

- [x] `go test -short ./params/`