### PR TITLE
core: enable EIP-2935 parent block hash processing for Amsterdam

### DIFF
--- a/core/state_processor.go
+++ b/core/state_processor.go
@@ -169,7 +169,7 @@ func PreExecution(ctx context.Context, beaconRoot *common.Hash, parent common.Ha
 		ProcessBeaconBlockRoot(*beaconRoot, evm, blockAccessList)
 	}
 	// EIP-2935
-	if config.IsPrague(number, time) || config.IsUBT(number, time) {
+	if config.IsPrague(number, time) || config.IsAmsterdam(number, time) || config.IsUBT(number, time) {
 		ProcessParentBlockHash(parent, evm, blockAccessList)
 	}
 	return blockAccessList


### PR DESCRIPTION
## Summary

- Add `config.IsAmsterdam(number, time)` check in `PreExecution` so `ProcessParentBlockHash` is called on Amsterdam-enabled networks.
- Previously only Prague and UBT were checked, leaving Amsterdam networks without EIP-2935 processing.

## Test plan

- [x] `go test -short ./core/`