### PR TITLE
p2p/enode: close sources added after FairMix shutdown

### DIFF
--- a/p2p/enode/iter.go
+++ b/p2p/enode/iter.go
@@ -356,6 +356,7 @@ func (m *FairMix) AddSource(it Iterator) {
 	defer m.mu.Unlock()
 
 	if m.closed == nil {
+		it.Close()
 		return
 	}
 	m.wg.Add(1)


### PR DESCRIPTION
`FairMix.AddSource` takes ownership of the supplied iterator, but if the mixer has already been closed it currently returns without closing that iterator. Close the rejected source in this shutdown path so callers racing with `Close` do not leak iterator resources.
