### PR TITLE
eth/protocols/snap: set abort when storage range hits limit hash

### DIFF
--- a/eth/protocols/snap/handlers.go
+++ b/eth/protocols/snap/handlers.go
@@ -242,6 +242,7 @@ func ServiceGetStorageRangesQuery(chain *core.BlockChain, req *GetStorageRangesP
 			})
 			// If we've exceeded the request threshold, abort
 			if bytes.Compare(hash[:], limit[:]) >= 0 {
+				abort = true
 				break
 			}
 		}


### PR DESCRIPTION
## Summary

- Set `abort = true` when the storage iterator reaches the requested limit hash in `ServiceGetStorageRangesQuery`.
- Ensures endpoint Merkle proofs are included for capped storage range replies.

## Test plan

- [x] `go test -short ./eth/protocols/snap/`