### PR TITLE
core/txpool/locals: nil journal writer before checking close error

### DIFF
--- a/core/txpool/locals/journal.go
+++ b/core/txpool/locals/journal.go
@@ -119,10 +119,11 @@ func (journal *journal) load(add func([]*types.Transaction) []error) error {
 
 func (journal *journal) setupWriter() error {
 	if journal.writer != nil {
-		if err := journal.writer.Close(); err != nil {
+		err := journal.writer.Close()
+		journal.writer = nil
+		if err != nil {
 			return err
 		}
-		journal.writer = nil
 	}
 
 	// Re-open the journal file for appending

--- a/core/txpool/locals/journal.go
+++ b/core/txpool/locals/journal.go
@@ -152,10 +152,11 @@ func (journal *journal) insert(tx *types.Transaction) error {
 func (journal *journal) rotate(all map[common.Address]types.Transactions) error {
 	// Close the current journal (if any is open)
 	if journal.writer != nil {
-		if err := journal.writer.Close(); err != nil {
+		err := journal.writer.Close()
+		journal.writer = nil
+		if err != nil {
 			return err
 		}
-		journal.writer = nil
 	}
 	// Generate a new journal with the contents of the current pool
 	replacement, err := os.OpenFile(journal.path+".new", os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0644)


### PR DESCRIPTION
## Summary

- Clear `journal.writer` immediately after `Close()` in `rotate`, before checking the error.
- Prevents leaving a stale file handle that could be reused if close fails.

## Test plan

- [x] `go test -short ./core/txpool/locals/`