### PR TITLE
core/vm/runtime: cap regular gas budget at MaxTxGas for Amsterdam

### DIFF
--- a/core/vm/runtime/runtime.go
+++ b/core/vm/runtime/runtime.go
@@ -143,12 +143,16 @@ func Execute(code, input []byte, cfg *Config) ([]byte, *state.StateDB, error) {
 	cfg.State.CreateAccount(address)
 	// set the receiver's (the executing contract) code for execution.
 	cfg.State.SetCode(address, code, tracing.CodeChangeUnspecified)
+	limit := cfg.GasLimit
+	if rules.IsAmsterdam {
+		limit = min(cfg.GasLimit, params.MaxTxGas)
+	}
 	// Call the code with the given configuration.
 	ret, result, err := vmenv.Call(
 		cfg.Origin,
 		common.BytesToAddress([]byte("contract")),
 		input,
-		vm.NewGasBudget(cfg.GasLimit, 0),
+		vm.NewGasBudget(limit, cfg.GasLimit-limit),
 		uint256.MustFromBig(cfg.Value),
 	)
 	if cfg.EVMConfig.Tracer != nil && cfg.EVMConfig.Tracer.OnTxEnd != nil {
@@ -178,11 +182,15 @@ func Create(input []byte, cfg *Config) ([]byte, common.Address, uint64, error) {
 	// - prepare accessList(post-berlin)
 	// - reset transient storage(eip 1153)
 	cfg.State.Prepare(rules, cfg.Origin, cfg.Coinbase, nil, vm.ActivePrecompiles(rules), nil)
+	limit := cfg.GasLimit
+	if rules.IsAmsterdam {
+		limit = min(cfg.GasLimit, params.MaxTxGas)
+	}
 	// Call the code with the given configuration.
 	code, address, result, _, err := vmenv.Create(
 		cfg.Origin,
 		input,
-		vm.NewGasBudget(cfg.GasLimit, 0),
+		vm.NewGasBudget(limit, cfg.GasLimit-limit),
 		uint256.MustFromBig(cfg.Value),
 	)
 	if cfg.EVMConfig.Tracer != nil && cfg.EVMConfig.Tracer.OnTxEnd != nil {
@@ -212,12 +220,16 @@ func Call(address common.Address, input []byte, cfg *Config) ([]byte, uint64, er
 	// - reset transient storage(eip 1153)
 	statedb.Prepare(rules, cfg.Origin, cfg.Coinbase, &address, vm.ActivePrecompiles(rules), nil)
 
+	limit := cfg.GasLimit
+	if rules.IsAmsterdam {
+		limit = min(cfg.GasLimit, params.MaxTxGas)
+	}
 	// Call the code with the given configuration.
 	ret, result, err := vmenv.Call(
 		cfg.Origin,
 		address,
 		input,
-		vm.NewGasBudget(cfg.GasLimit, 0),
+		vm.NewGasBudget(limit, cfg.GasLimit-limit),
 		uint256.MustFromBig(cfg.Value),
 	)
 	if cfg.EVMConfig.Tracer != nil && cfg.EVMConfig.Tracer.OnTxEnd != nil {


### PR DESCRIPTION
## Summary

- Cap the regular gas budget to `MaxTxGas` in `runtime.Execute` when Amsterdam rules are active.
- Charge the remainder as inflation gas via `NewGasBudget(limit, cfg.GasLimit-limit)`.

## Test plan

- [x] `go test -short ./core/vm/runtime/`