### PR TITLE
ethdb/memorydb: avoid corrupting prefix slice in NewIterator

### DIFF
--- a/ethdb/memorydb/memorydb.go
+++ b/ethdb/memorydb/memorydb.go
@@ -169,7 +169,7 @@ func (db *Database) NewIterator(prefix []byte, start []byte) ethdb.Iterator {
 
 	var (
 		pr     = string(prefix)
-		st     = string(append(prefix, start...))
+		st     = string(prefix) + string(start)
 		keys   = make([]string, 0, len(db.db))
 		values = make([][]byte, 0, len(db.db))
 	)


### PR DESCRIPTION
## Summary

- Build the iterator start key with string concatenation instead of `append(prefix, start...)`.
- Prevents mutating the caller's `prefix` slice when it has spare capacity.

## Test plan

- [x] `go test -short ./ethdb/memorydb/`