### PR TITLE
rpc: canonicalize header keys in WithHeaders

### DIFF
--- a/rpc/client_opt.go
+++ b/rpc/client_opt.go
@@ -92,7 +92,7 @@ func WithHeaders(headers http.Header) ClientOption {
 	return optionFunc(func(cfg *clientConfig) {
 		cfg.initHeaders()
 		for k, vs := range headers {
-			cfg.httpHeaders[k] = vs
+			cfg.httpHeaders[http.CanonicalHeaderKey(k)] = vs
 		}
 	})
 }


### PR DESCRIPTION
## Summary

- Canonicalize HTTP header keys in `WithHeaders` using `http.CanonicalHeaderKey`.
- Aligns with `WithHeader` and avoids duplicate headers when keys differ only by casing.

## Test plan

- [x] `go test -short ./rpc/`