### PR TITLE
ethclient: include data in call arguments

### DIFF
--- a/ethclient/ethclient.go
+++ b/ethclient/ethclient.go
@@ -786,7 +786,9 @@ func toCallArg(msg ethereum.CallMsg) interface{} {
 		"to":   msg.To,
 	}
 	if len(msg.Data) > 0 {
-		arg["input"] = hexutil.Bytes(msg.Data)
+		input := hexutil.Bytes(msg.Data)
+		arg["input"] = input
+		arg["data"] = input
 	}
 	if msg.Value != nil {
 		arg["value"] = (*hexutil.Big)(msg.Value)

--- a/ethclient/gethclient/gethclient.go
+++ b/ethclient/gethclient/gethclient.go
@@ -370,7 +370,9 @@ func toCallArg(msg ethereum.CallMsg) interface{} {
 		"to":   msg.To,
 	}
 	if len(msg.Data) > 0 {
-		arg["input"] = hexutil.Bytes(msg.Data)
+		input := hexutil.Bytes(msg.Data)
+		arg["input"] = input
+		arg["data"] = input
 	}
 	if msg.Value != nil {
 		arg["value"] = (*hexutil.Big)(msg.Value)

--- a/ethclient/gethclient/gethclient_test.go
+++ b/ethclient/gethclient/gethclient_test.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/consensus/ethash"
 	"github.com/ethereum/go-ethereum/core"
 	"github.com/ethereum/go-ethereum/core/types"
@@ -271,6 +272,21 @@ func testAccessList(t *testing.T, client *rpc.Client) {
 		haveList, _ := json.MarshalIndent(al, "", "  ")
 		if have, want := string(haveList), tc.wantAL; have != want {
 			t.Fatalf("test %d: access list wrong, have:\n%v\nwant:\n%v", i, have, want)
+		}
+	}
+}
+
+func TestToCallArgIncludesDataAndInput(t *testing.T) {
+	input := common.FromHex("0x01020304")
+	arg := toCallArg(ethereum.CallMsg{Data: input}).(map[string]interface{})
+
+	for _, key := range []string{"input", "data"} {
+		have, ok := arg[key].(hexutil.Bytes)
+		if !ok {
+			t.Fatalf("missing call arg %q", key)
+		}
+		if !bytes.Equal(have, input) {
+			t.Fatalf("call arg %q = %x, want %x", key, have, input)
 		}
 	}
 }

--- a/ethclient/types_test.go
+++ b/ethclient/types_test.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/hexutil"
 )
 
 func TestToFilterArg(t *testing.T) {
@@ -177,5 +178,20 @@ func TestToFilterArg(t *testing.T) {
 				t.Fatalf("expected filter arg %v but got %v", testCase.output, output)
 			}
 		})
+	}
+}
+
+func TestToCallArgIncludesDataAndInput(t *testing.T) {
+	input := common.FromHex("0x01020304")
+	arg := toCallArg(ethereum.CallMsg{Data: input}).(map[string]interface{})
+
+	for _, key := range []string{"input", "data"} {
+		have, ok := arg[key].(hexutil.Bytes)
+		if !ok {
+			t.Fatalf("missing call arg %q", key)
+		}
+		if !reflect.DeepEqual(have, hexutil.Bytes(input)) {
+			t.Fatalf("call arg %q = %x, want %x", key, have, input)
+		}
 	}
 }


### PR DESCRIPTION
## Summary

- include both `input` and `data` when encoding `ethereum.CallMsg` call arguments with calldata
- keep `ethclient` and `ethclient/gethclient` call argument encoding consistent
- add regression tests for both helpers

## Root cause

`toCallArg` only emitted the newer `input` field for calldata. Some RPC endpoints still only accept the legacy `data` field for `eth_call`, which can result in empty call results and downstream ABI unpacking errors. Geth already accepts both fields when they match, so sending both preserves compatibility without changing the preferred input semantics.

Fixes #29642

## Testing

- `go test ./ethclient ./ethclient/gethclient`
