### PR TITLE
core/state: prevent build goroutine leak when SizeTracker is stopped

### DIFF
--- a/core/state/state_sizer.go
+++ b/core/state/state_sizer.go
@@ -538,7 +538,12 @@ func (t *SizeTracker) build(root common.Hash, blockNumber uint64, done chan buil
 
 	// Wait for all goroutines to complete
 	if err := group.Wait(); err != nil {
-		done <- buildResult{err: err}
+		select {
+		case done <- buildResult{err: err}:
+		case <-t.abort:
+			// The tracker was closed and the receiver in init has
+			// already exited, the result is no longer consumed.
+		}
 	} else {
 		stat := SizeStats{
 			StateRoot:            root,
@@ -554,11 +559,16 @@ func (t *SizeTracker) build(root common.Hash, blockNumber uint64, done chan buil
 			ContractCodes:        codes,
 			ContractCodeBytes:    codeBytes,
 		}
-		done <- buildResult{
+		select {
+		case done <- buildResult{
 			root:        root,
 			blockNumber: blockNumber,
 			stat:        stat,
 			elapsed:     time.Since(start),
+		}:
+		case <-t.abort:
+			// The tracker was closed and the receiver in init has
+			// already exited, the result is no longer consumed.
 		}
 	}
 }


### PR DESCRIPTION
## Problem

`SizeTracker.build` delivers its result on an unbuffered channel created in `init`:

https://github.com/ethereum/go-ethereum/blob/e5c5e189777ec9e4788e4e91b0b19f8cbdb8bdd2/core/state/state_sizer.go#L435-L436

`build` sends on this channel unconditionally when it finishes. However, if the tracker is stopped while the initial measurement is still running, `init` returns through the abort arm of its select loop without ever receiving, and the `build` goroutine blocks forever on the send — regardless of whether the measurement failed (workers observing the closed abort channel) or completed successfully.

The window is easy to hit in practice: the initial measurement iterates the entire persistent state, so shutting the node down while it is in flight leaks the goroutine. `Stop()` itself does not hang (it waits on `t.aborted`, not on `build`), so the leak is silent.

## Fix

Make both send sites in `build` select on `t.abort`, so the goroutine always terminates once the tracker is closed. This stays correct regardless of how the `done` channel is constructed.

## Testing

Added `TestSizeTrackerStopDuringBuild`, which runs `build` with a closed abort channel and an unconsumed result channel. Without the fix it fails (goroutine blocked on the send until the 10s timeout); with the fix it passes. The existing `TestSizeTracker` still passes.