### PR TITLE
eth: release state on error in stateAtTransaction

### DIFF
--- a/eth/state_accessor.go
+++ b/eth/state_accessor.go
@@ -267,11 +267,13 @@ func (eth *Ethereum) stateAtTransaction(ctx context.Context, block *types.Block,
 		// Not yet the searched for transaction, execute on top of the current state
 		statedb.SetTxContext(tx.Hash(), idx, uint32(idx+1))
 		if _, err := core.ApplyMessage(evm, msg, nil); err != nil {
+			release()
 			return nil, vm.BlockContext{}, nil, nil, fmt.Errorf("transaction %#x failed: %v", tx.Hash(), err)
 		}
 		// Ensure any modifications are committed to the state
 		// Only delete empty objects if EIP158/161 (a.k.a Spurious Dragon) is in effect
 		statedb.Finalise(evm.ChainConfig().IsEIP158(block.Number()))
 	}
+	release()
 	return nil, vm.BlockContext{}, nil, nil, fmt.Errorf("transaction index %d out of range for block %#x", txIndex, block.Hash())
 }


### PR DESCRIPTION
## Summary

- Call the state release function on `ApplyMessage` failure in `stateAtTransaction`.
- Also release state when the requested transaction index is out of range.
- Avoids leaking state snapshots on error paths.

## Test plan

- [x] `go test -short ./eth/`