### PR TITLE
beacon/engine: attach block access list in ExecutableDataToBlockNoHash

### DIFF
--- a/beacon/engine/types.go
+++ b/beacon/engine/types.go
@@ -347,7 +347,11 @@ func ExecutableDataToBlockNoHash(data ExecutableData, versionedHashes []common.H
 		SlotNumber:          data.SlotNumber,
 		BlockAccessListHash: blockAccessListHash,
 	}
-	return types.NewBlockWithHeader(header).WithBody(types.Body{Transactions: txs, Uncles: nil, Withdrawals: data.Withdrawals}), nil
+	block := types.NewBlockWithHeader(header).WithBody(types.Body{Transactions: txs, Uncles: nil, Withdrawals: data.Withdrawals})
+	if data.BlockAccessList != nil {
+		block = block.WithAccessListUnsafe(data.BlockAccessList)
+	}
+	return block, nil
 }
 
 // BlockToExecutableData constructs the ExecutableData structure by filling the


### PR DESCRIPTION
## Summary

- Preserve `BlockAccessList` when rebuilding a block from `ExecutableData` in `ExecutableDataToBlockNoHash`.
- Ensures the reconstructed block matches the engine input when a block access list is present.

## Test plan

- [x] `go test -short ./beacon/engine/`