### PR TITLE
trie/bintrie: preserve low balance bytes

### DIFF
--- a/trie/bintrie/trie.go
+++ b/trie/bintrie/trie.go
@@ -259,7 +259,7 @@ func (t *BinaryTrie) UpdateAccount(addr common.Address, acc *types.StateAccount,
 	// TODO: reduce the size of the allocation in devmode, then panic instead
 	// of truncating.
 	if len(balanceBytes) > 16 {
-		balanceBytes = balanceBytes[16:]
+		balanceBytes = balanceBytes[len(balanceBytes)-16:]
 	}
 	copy(basicData[HashSize-len(balanceBytes):], balanceBytes[:])
 	values[BasicDataLeafKey] = basicData[:]

--- a/trie/bintrie/trie_test.go
+++ b/trie/bintrie/trie_test.go
@@ -271,6 +271,28 @@ func makeAccount(nonce uint64, balance uint64, codeHash common.Hash) *types.Stat
 	}
 }
 
+func TestUpdateAccountTruncatesBalanceToLow128Bits(t *testing.T) {
+	tr := newEmptyTestTrie(t)
+	addr := common.HexToAddress("0x1234567890abcdef1234567890abcdef12345678")
+	balanceBytes := common.Hex2Bytes("0102030405060708090a0b0c0d0e0f1011")
+	account := &types.StateAccount{
+		Balance:  new(uint256.Int).SetBytes(balanceBytes),
+		CodeHash: types.EmptyCodeHash[:],
+	}
+
+	if err := tr.UpdateAccount(addr, account, 0); err != nil {
+		t.Fatalf("UpdateAccount: %v", err)
+	}
+	got, err := tr.GetAccount(addr)
+	if err != nil {
+		t.Fatalf("GetAccount: %v", err)
+	}
+	want := new(uint256.Int).SetBytes(balanceBytes[1:])
+	if got.Balance.Cmp(want) != 0 {
+		t.Fatalf("Balance: got %s, want %s", got.Balance, want)
+	}
+}
+
 // TestDeleteAccountRoundTrip verifies the basic delete path: create an
 // account, read it back, delete it, confirm subsequent reads return nil.
 // Regression test for the no-op DeleteAccount bug where the deletion was


### PR DESCRIPTION
## Summary

- Preserve the least-significant 16 bytes when truncating oversized BinaryTrie account balances.
- Add a regression test for a 17-byte balance.

## Why

EIP-7864 stores balances as 16-byte big-endian values. The previous slice used `balanceBytes[16:]`, which kept only `len(balanceBytes)-16` bytes for 17–31 byte inputs and silently encoded the wrong balance. The existing temporary truncation behavior is retained for dev-mode allocations until oversized balances can be rejected.

## Tests

- `go test ./trie/bintrie`