### PR TITLE
internal/ethapi: reject gasPrice with blob hashes

### DIFF
--- a/internal/ethapi/transaction_args.go
+++ b/internal/ethapi/transaction_args.go
@@ -201,6 +201,9 @@ func (args *TransactionArgs) setFeeDefaults(ctx context.Context, b Backend, head
 	if args.GasPrice != nil && args.AuthorizationList != nil {
 		return errors.New("both gasPrice and authorizationList specified")
 	}
+	if args.GasPrice != nil && args.BlobHashes != nil {
+		return errors.New("both gasPrice and blobVersionedHashes specified")
+	}
 	// If the tx has completely specified a fee mechanism, no default is needed.
 	// This allows users who are not yet synced past London to get defaults for
 	// other tx values. See https://github.com/ethereum/go-ethereum/pull/23274

--- a/internal/ethapi/transaction_args_test.go
+++ b/internal/ethapi/transaction_args_test.go
@@ -225,6 +225,13 @@ func TestSetFeeDefaults(t *testing.T) {
 			errors.New("both gasPrice and (maxFeePerGas or maxPriorityFeePerGas) specified"),
 		},
 		{
+			"set gas price and blob hashes",
+			"cancun",
+			&TransactionArgs{GasPrice: fortytwo, BlobHashes: []common.Hash{{0x01}}},
+			nil,
+			errors.New("both gasPrice and blobVersionedHashes specified"),
+		},
+		{
 			"fill maxFeePerBlobGas",
 			"cancun",
 			&TransactionArgs{BlobHashes: []common.Hash{}},


### PR DESCRIPTION
Reject gasPrice together with blobVersionedHashes