### PR TITLE
eth/filters: fix flaky TestPendingTxFilterDeadlock

### DIFF
--- a/eth/filters/filter_system_test.go
+++ b/eth/filters/filter_system_test.go
@@ -731,6 +731,7 @@ func TestPendingTxFilterDeadlock(t *testing.T) {
 		api          = NewFilterAPI(sys)
 		done         = make(chan struct{})
 	)
+	defer close(done)
 
 	go func() {
 		// Bombard feed with txes until signal was received to stop
@@ -752,6 +753,7 @@ func TestPendingTxFilterDeadlock(t *testing.T) {
 	// timeout either in 100ms or 200ms
 	subs := make([]*Subscription, 20)
 	for i := range subs {
+		created := time.Now()
 		fid := api.NewPendingTransactionFilter(nil)
 		api.filtersMu.Lock()
 		f, ok := api.filters[fid]
@@ -763,6 +765,14 @@ func TestPendingTxFilterDeadlock(t *testing.T) {
 		// Wait for at least one tx to arrive in filter
 		for {
 			hashes, err := api.GetFilterChanges(fid)
+			if errors.Is(err, errFilterNotFound) && time.Since(created) >= timeout {
+				// The filter was not polled for longer than the configured
+				// timeout and has already been uninstalled. This can happen
+				// on a loaded system and is not a deadlock: the uninstall
+				// is verified through sub.Err() below. The time check keeps
+				// this tolerance from masking uninstalls before the deadline.
+				break
+			}
 			if err != nil {
 				t.Fatalf("Filter should exist: %v\n", err)
 			}


### PR DESCRIPTION
`TestPendingTxFilterDeadlock` fails intermittently under the race detector:

```
--- FAIL: TestPendingTxFilterDeadlock (0.86s)
    filter_system_test.go:767: Filter should exist: filter not found
```

## Cause

The test sets a 100ms filter timeout and polls `GetFilterChanges` until each filter has seen a transaction. Every successful poll resets the filter deadline. On a loaded system (race detector, `t.Parallel`, low `GOMAXPROCS`) a single gap longer than 100ms between two polls lets `timeoutLoop` uninstall the filter, so the next poll returns `errFilterNotFound` and the test fails.

This early timeout is not the deadlock the test guards against (#22131). That deadlock froze `filtersMu`, so `GetFilterChanges` would block on the lock instead of returning `errFilterNotFound`.

This is the only test in the package that configures a non-default filter timeout, so no other test is exposed to this race.

## Fix

- Treat `errFilterNotFound` during the setup poll as a benign early timeout. The tolerance only applies once the filter has lived at least the configured timeout, so a regression that uninstalls filters before their deadline still fails the test. The uninstall itself is still verified by the `sub.Err()` wait at the end.
- Close the `done` channel on test exit. The tx-sending goroutine was never stopped and kept spinning for the rest of the test binary, adding load to subsequent tests.

## Verification

Before (M-series Mac):

- `go test -race -count=20 ./eth/filters/`: 3 failures in 20 runs
- `go test -race -count=30 -cpu=1,2 -run 'TestPendingTxFilterDeadlock$' ./eth/filters/`: 9+ failures

After:

- `-count=100` and `-count=100 -cpu=1,2` (300 executions): all pass
- full `go test -race ./eth/filters/`: pass
