### PR TITLE
eth/catalyst, eth/ethconfig, cmd: make engine API max reorg depth configurable

### DIFF
--- a/cmd/geth/main.go
+++ b/cmd/geth/main.go
@@ -174,6 +174,7 @@ var (
 		utils.RPCGlobalEVMTimeoutFlag,
 		utils.RPCGlobalTxFeeCapFlag,
 		utils.RPCGlobalLogQueryLimit,
+		utils.EngineMaxReorgDepthFlag,
 		utils.AllowUnprotectedTxs,
 		utils.BatchRequestLimit,
 		utils.BatchResponseMaxSize,

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -679,6 +679,12 @@ var (
 		Value:    ethconfig.Defaults.RangeLimit,
 		Category: flags.APICategory,
 	}
+	EngineMaxReorgDepthFlag = &cli.Uint64Flag{
+		Name:     "engine.maxreorgdepth",
+		Usage:    "Maximum depth the chain head can be rewound to a canonical ancestor via engine forkchoiceUpdated (0 = no limit)",
+		Value:    ethconfig.Defaults.EngineMaxReorgDepth,
+		Category: flags.APICategory,
+	}
 	// Authenticated RPC HTTP settings
 	AuthListenFlag = &cli.StringFlag{
 		Name:     "authrpc.addr",
@@ -1914,6 +1920,14 @@ func SetEthConfig(ctx *cli.Context, stack *node.Node, cfg *ethconfig.Config) {
 	}
 	if ctx.IsSet(RPCGlobalTxFeeCapFlag.Name) {
 		cfg.RPCTxFeeCap = ctx.Float64(RPCGlobalTxFeeCapFlag.Name)
+	}
+	if ctx.IsSet(EngineMaxReorgDepthFlag.Name) {
+		cfg.EngineMaxReorgDepth = ctx.Uint64(EngineMaxReorgDepthFlag.Name)
+		if cfg.EngineMaxReorgDepth != 0 {
+			log.Info("Set engine API maximum reorg depth", "depth", cfg.EngineMaxReorgDepth)
+		} else {
+			log.Info("Engine API reorg depth limit disabled")
+		}
 	}
 	if ctx.Bool(NoDiscoverFlag.Name) {
 		cfg.EthDiscoveryURLs, cfg.SnapDiscoveryURLs = []string{}, []string{}

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -1923,11 +1923,11 @@ func SetEthConfig(ctx *cli.Context, stack *node.Node, cfg *ethconfig.Config) {
 	}
 	if ctx.IsSet(EngineMaxReorgDepthFlag.Name) {
 		cfg.EngineMaxReorgDepth = ctx.Uint64(EngineMaxReorgDepthFlag.Name)
-		if cfg.EngineMaxReorgDepth != 0 {
-			log.Info("Set engine API maximum reorg depth", "depth", cfg.EngineMaxReorgDepth)
-		} else {
-			log.Info("Engine API reorg depth limit disabled")
-		}
+	}
+	if cfg.EngineMaxReorgDepth != 0 {
+		log.Info("Engine API maximum reorg depth", "depth", cfg.EngineMaxReorgDepth)
+	} else {
+		log.Info("Engine API reorg depth limit disabled")
 	}
 	if ctx.Bool(NoDiscoverFlag.Name) {
 		cfg.EthDiscoveryURLs, cfg.SnapDiscoveryURLs = []string{}, []string{}

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -449,6 +449,7 @@ func (s *Ethereum) Downloader() *downloader.Downloader { return s.handler.downlo
 func (s *Ethereum) Synced() bool                       { return s.handler.synced.Load() }
 func (s *Ethereum) SetSynced()                         { s.handler.enableSyncedFeatures() }
 func (s *Ethereum) ArchiveMode() bool                  { return s.config.NoPruning }
+func (s *Ethereum) EngineMaxReorgDepth() uint64        { return s.config.EngineMaxReorgDepth }
 
 // Protocols returns all the currently configured
 // network protocols to start.

--- a/eth/catalyst/api.go
+++ b/eth/catalyst/api.go
@@ -82,13 +82,14 @@ const (
 	// beaconUpdateWarnFrequency is the frequency at which to warn the user that
 	// the beacon client is offline.
 	beaconUpdateWarnFrequency = 5 * time.Minute
-
-	// maxReorgDepth is the maximum reorg depth accepted via forkchoiceUpdated.
-	maxReorgDepth = 32
 )
 
 type ConsensusAPI struct {
 	eth *eth.Ethereum
+
+	// maxReorgDepth is the maximum reorg depth accepted via forkchoiceUpdated
+	// (0 = no limit). Configured via ethconfig.Config.EngineMaxReorgDepth.
+	maxReorgDepth uint64
 
 	remoteBlocks *headerQueue  // Cache of remote payloads received
 	localBlocks  *payloadQueue // Cache of local payloads generated
@@ -145,6 +146,7 @@ func newConsensusAPIWithoutHeartbeat(eth *eth.Ethereum) *ConsensusAPI {
 	}
 	api := &ConsensusAPI{
 		eth:               eth,
+		maxReorgDepth:     eth.EngineMaxReorgDepth(),
 		remoteBlocks:      newHeaderQueue(),
 		localBlocks:       newPayloadQueue(),
 		invalidBlocksHits: make(map[common.Hash]int),
@@ -330,9 +332,9 @@ func (api *ConsensusAPI) forkchoiceUpdated(ctx context.Context, update engine.Fo
 			return valid(nil), nil
 		}
 		depth := api.eth.BlockChain().CurrentBlock().Number.Uint64() - block.NumberU64()
-		if depth >= maxReorgDepth {
+		if api.maxReorgDepth > 0 && depth >= api.maxReorgDepth {
 			log.Warn("Refusing too deep reorg", "depth", depth, "head", update.HeadBlockHash)
-			return engine.STATUS_INVALID, engine.TooDeepReorg.With(fmt.Errorf("reorg depth %d exceeds limit %d", depth, maxReorgDepth))
+			return engine.STATUS_INVALID, engine.TooDeepReorg.With(fmt.Errorf("reorg depth %d exceeds limit %d", depth, api.maxReorgDepth))
 		}
 		if !api.eth.Synced() {
 			log.Info("Ignoring beacon update to old head while syncing", "number", block.NumberU64(), "hash", update.HeadBlockHash)

--- a/eth/catalyst/api_test.go
+++ b/eth/catalyst/api_test.go
@@ -426,8 +426,9 @@ func TestEth2DeepReorg(t *testing.T) {
 	*/
 }
 
-// startEthService creates a full node instance for testing.
-func startEthService(t testing.TB, genesis *core.Genesis, blocks []*types.Block) (*node.Node, *eth.Ethereum) {
+// startEthService creates a full node instance for testing. The default test
+// configuration can be adjusted through optional modifier functions.
+func startEthService(t testing.TB, genesis *core.Genesis, blocks []*types.Block, mods ...func(*ethconfig.Config)) (*node.Node, *eth.Ethereum) {
 	t.Helper()
 
 	n, err := node.New(&node.Config{
@@ -448,6 +449,9 @@ func startEthService(t testing.TB, genesis *core.Genesis, blocks []*types.Block)
 		TrieCleanCache: 256,
 		Miner:          miner.DefaultConfig,
 	}
+	for _, mod := range mods {
+		mod(ethcfg)
+	}
 	ethservice, err := eth.New(n, ethcfg)
 	if err != nil {
 		t.Fatal("can't create eth service:", err)
@@ -465,6 +469,54 @@ func startEthService(t testing.TB, genesis *core.Genesis, blocks []*types.Block)
 
 	ethservice.SetSynced()
 	return n, ethservice
+}
+
+// TestForkchoiceUpdatedReorgDepthLimit tests that forkchoiceUpdated refuses to
+// rewind the chain head to a canonical ancestor deeper than the configured
+// EngineMaxReorgDepth, and that the limit can be lifted via the configuration.
+func TestForkchoiceUpdatedReorgDepthLimit(t *testing.T) {
+	genesis, blocks := generateMergeChain(10, true)
+
+	t.Run("limited", func(t *testing.T) {
+		n, ethservice := startEthService(t, genesis, blocks, func(cfg *ethconfig.Config) {
+			cfg.EngineMaxReorgDepth = 5
+		})
+		defer n.Close()
+
+		api := newConsensusAPIWithoutHeartbeat(ethservice)
+
+		// Rewinding the head a few blocks within the limit is accepted.
+		shallow := engine.ForkchoiceStateV1{HeadBlockHash: blocks[6].Hash()}
+		if _, err := api.ForkchoiceUpdatedV1(context.Background(), shallow, nil); err != nil {
+			t.Fatalf("rewind within reorg depth limit failed: %v", err)
+		}
+		if head := ethservice.BlockChain().CurrentBlock().Number.Uint64(); head != blocks[6].NumberU64() {
+			t.Fatalf("chain head not rewound: have %d, want %d", head, blocks[6].NumberU64())
+		}
+		// Rewinding beyond the limit is refused.
+		deep := engine.ForkchoiceStateV1{HeadBlockHash: genesis.ToBlock().Hash()}
+		_, err := api.ForkchoiceUpdatedV1(context.Background(), deep, nil)
+		var apiErr *engine.EngineAPIError
+		if !errors.As(err, &apiErr) || apiErr.ErrorCode() != engine.TooDeepReorg.ErrorCode() {
+			t.Fatalf("rewind beyond reorg depth limit: have error %v, want %v", err, engine.TooDeepReorg)
+		}
+	})
+	t.Run("unlimited", func(t *testing.T) {
+		n, ethservice := startEthService(t, genesis, blocks, func(cfg *ethconfig.Config) {
+			cfg.EngineMaxReorgDepth = 0 // no limit
+		})
+		defer n.Close()
+
+		api := newConsensusAPIWithoutHeartbeat(ethservice)
+
+		update := engine.ForkchoiceStateV1{HeadBlockHash: genesis.ToBlock().Hash()}
+		if _, err := api.ForkchoiceUpdatedV1(context.Background(), update, nil); err != nil {
+			t.Fatalf("rewind with disabled reorg depth limit failed: %v", err)
+		}
+		if head := ethservice.BlockChain().CurrentBlock().Number.Uint64(); head != 0 {
+			t.Fatalf("chain head not rewound to genesis: have %d, want 0", head)
+		}
+	})
 }
 
 func TestFullAPI(t *testing.T) {

--- a/eth/ethconfig/config.go
+++ b/eth/ethconfig/config.go
@@ -207,7 +207,7 @@ type Config struct {
 	// EngineMaxReorgDepth is the maximum depth the chain head can be rewound
 	// to an already-canonical ancestor by engine API forkchoiceUpdated calls
 	// (0 = no limit).
-	EngineMaxReorgDepth uint64
+	EngineMaxReorgDepth uint64 `toml:",omitempty"`
 
 	// OverrideOsaka (TODO: remove after the fork)
 	OverrideOsaka *uint64 `toml:",omitempty"`

--- a/eth/ethconfig/config.go
+++ b/eth/ethconfig/config.go
@@ -75,6 +75,7 @@ var Defaults = Config{
 	RPCEVMTimeout:           5 * time.Second,
 	GPO:                     FullNodeGPO,
 	RPCTxFeeCap:             1, // 1 ether
+	EngineMaxReorgDepth:     32,
 	TxSyncDefaultTimeout:    20 * time.Second,
 	TxSyncMaxTimeout:        1 * time.Minute,
 	SlowBlockThreshold:      -1, // Disabled by default; set via --debug.logslowblock flag
@@ -202,6 +203,11 @@ type Config struct {
 	// RPCTxFeeCap is the global transaction fee (price * gas limit) cap for
 	// send-transaction variants. The unit is ether.
 	RPCTxFeeCap float64
+
+	// EngineMaxReorgDepth is the maximum depth the chain head can be rewound
+	// to an already-canonical ancestor by engine API forkchoiceUpdated calls
+	// (0 = no limit).
+	EngineMaxReorgDepth uint64
 
 	// OverrideOsaka (TODO: remove after the fork)
 	OverrideOsaka *uint64 `toml:",omitempty"`

--- a/eth/ethconfig/gen_config.go
+++ b/eth/ethconfig/gen_config.go
@@ -63,6 +63,7 @@ func (c Config) MarshalTOML() (interface{}, error) {
 		RPCGasCap               uint64
 		RPCEVMTimeout           time.Duration
 		RPCTxFeeCap             float64
+		EngineMaxReorgDepth     uint64
 		OverrideOsaka           *uint64       `toml:",omitempty"`
 		OverrideAmsterdam       *uint64       `toml:",omitempty"`
 		OverrideBPO1            *uint64       `toml:",omitempty"`
@@ -119,6 +120,7 @@ func (c Config) MarshalTOML() (interface{}, error) {
 	enc.RPCGasCap = c.RPCGasCap
 	enc.RPCEVMTimeout = c.RPCEVMTimeout
 	enc.RPCTxFeeCap = c.RPCTxFeeCap
+	enc.EngineMaxReorgDepth = c.EngineMaxReorgDepth
 	enc.OverrideOsaka = c.OverrideOsaka
 	enc.OverrideAmsterdam = c.OverrideAmsterdam
 	enc.OverrideBPO1 = c.OverrideBPO1
@@ -179,6 +181,7 @@ func (c *Config) UnmarshalTOML(unmarshal func(interface{}) error) error {
 		RPCGasCap               *uint64
 		RPCEVMTimeout           *time.Duration
 		RPCTxFeeCap             *float64
+		EngineMaxReorgDepth     *uint64
 		OverrideOsaka           *uint64        `toml:",omitempty"`
 		OverrideAmsterdam       *uint64        `toml:",omitempty"`
 		OverrideBPO1            *uint64        `toml:",omitempty"`
@@ -329,6 +332,9 @@ func (c *Config) UnmarshalTOML(unmarshal func(interface{}) error) error {
 	}
 	if dec.RPCTxFeeCap != nil {
 		c.RPCTxFeeCap = *dec.RPCTxFeeCap
+	}
+	if dec.EngineMaxReorgDepth != nil {
+		c.EngineMaxReorgDepth = *dec.EngineMaxReorgDepth
 	}
 	if dec.OverrideOsaka != nil {
 		c.OverrideOsaka = dec.OverrideOsaka

--- a/eth/ethconfig/gen_config.go
+++ b/eth/ethconfig/gen_config.go
@@ -63,7 +63,7 @@ func (c Config) MarshalTOML() (interface{}, error) {
 		RPCGasCap               uint64
 		RPCEVMTimeout           time.Duration
 		RPCTxFeeCap             float64
-		EngineMaxReorgDepth     uint64
+		EngineMaxReorgDepth     uint64        `toml:",omitempty"`
 		OverrideOsaka           *uint64       `toml:",omitempty"`
 		OverrideAmsterdam       *uint64       `toml:",omitempty"`
 		OverrideBPO1            *uint64       `toml:",omitempty"`
@@ -181,7 +181,7 @@ func (c *Config) UnmarshalTOML(unmarshal func(interface{}) error) error {
 		RPCGasCap               *uint64
 		RPCEVMTimeout           *time.Duration
 		RPCTxFeeCap             *float64
-		EngineMaxReorgDepth     *uint64
+		EngineMaxReorgDepth     *uint64        `toml:",omitempty"`
 		OverrideOsaka           *uint64        `toml:",omitempty"`
 		OverrideAmsterdam       *uint64        `toml:",omitempty"`
 		OverrideBPO1            *uint64        `toml:",omitempty"`


### PR DESCRIPTION
## TLDR

The `enginex` simulator runs multiple tests against a single client instance, for each test, the simulator FCUs to genesis and then after each payload in the test: This triggers reorgs larger than currently supported by geth. More details in the [enginex docs](https://github.com/danceratopz/execution-specs/blob/a5da2157f765ef3b64f556f40438a1dbe01ec72d/docs/running_tests/running.md#enginex). The simulator's FCU behavior was designed to be consistent with the original `engine` simulator; an alternative would be to change the simulator to only verify payloads without FCU, but I think it's cleaner as it is currently (per docs above).

Feel free to close this PR/re-implement as you see fit; whatever's easiest. Thanks!

## Motivation

#34767 (implementing execution-apis#786) introduced a hardcoded cap of 32 on the depth of chain rewinds accepted via `engine_forkchoiceUpdated` when the target block is an already-canonical ancestor. This breaks systematic testing with EEST's `consume enginex` simulator (via hive):

- enginex reuses one client across many tests within a pre-allocation group, and each test starts by sending a forkchoiceUpdated with `head = genesis` to reset the shared client.
- That reset is a canonical-ancestor rewind whose depth equals the chain height left by the previous test. As soon as one test's chain reaches height >= 32, the reset is refused with `-38006 Too deep reorg` (e.g. `reorg depth 37 exceeds limit 32`).
- Because the refused rewind leaves the head in place, every subsequent test on that client fails identically — a single deep test permanently poisons the shared client.

Erigon has the same cap but reads it from the `MAX_REORG_DEPTH` environment variable, which is how hive already works around it for enginex runs (ethereum/hive#1568, raising it to 512). Geth currently offers no knob.

## Changes

- New flag `--engine.maxreorgdepth` (default: 32, `0` = no limit), wired through `ethconfig.Config.EngineMaxReorgDepth` following the `--rpc.gascap` pattern. Since all geth flags are auto-exposed as environment variables, it can also be set via `GETH_ENGINE_MAXREORGDEPTH`; older geth versions ignore unknown `GETH_*` variables with a warning, so test runners can set it unconditionally.
- `catalyst.ConsensusAPI` reads the limit from the config at construction instead of the package-level constant. A limit of 0 disables the check, matching the `--rpc.gascap` "0 disables" convention (and pre-#34767 behavior). Default CLI behavior is unchanged (32).
- Added `TestForkchoiceUpdatedReorgDepthLimit` covering refusal beyond the configured limit, acceptance within it, and unlimited rewind-to-genesis with the check disabled. `startEthService` gained optional config-modifier arguments; existing callers are untouched.

## Notes

- `core/blockchain.go`'s reorg path still logs `Impossible reorg, please file an issue` (error level) for canonical rewinds deeper than its hardcoded 32 heuristic, even when the operator has raised the engine API limit; the rewind itself proceeds correctly. Left as-is to keep this change small — happy to plumb the configured limit into `BlockChainConfig` in this PR or a follow-up if preferred.
- Hive-side companion (required for enginex runs to benefit): ethereum/hive#1572 sets `GETH_ENGINE_MAXREORGDEPTH=512` in `clients/go-ethereum/geth.sh` when the simulator requests deep reorgs, mirroring the erigon fix in ethereum/hive#1568.

## Verification

Verified against EEST's `consume enginex` in hive `--dev` mode, using the minimal failing pair: a 37-block test followed by any test on the same shared client (the second test's reset-to-genesis forkchoiceUpdated is a depth-37 canonical rewind).

Setup, in a hive checkout: rsync this branch to `clients/go-ethereum/go-ethereum-local/` (exclude `.git`), add `export GETH_ENGINE_MAXREORGDEPTH=512` to `clients/go-ethereum/geth.sh` (this is what ethereum/hive#1572 does, gated on the simulator opting in — that PR is required for enginex runs to pick this fix up), and create `geth-local.yaml`:

```yaml
- client: go-ethereum
  nametag: maxreorg-local
  dockerfile: local
  build_args:
    local_path: go-ethereum-local
```

Fastest: run hive in `--dev` mode and drive it with consume from an execution-specs (EEST) checkout, filling the two fixtures locally instead of downloading the release:

```bash
./hive --dev --client go-ethereum --client-file geth-local.yaml \
  --docker.output --dev.addr 127.0.0.1:3011
```

```bash
uv run fill --generate-all-formats -m blockchain_test_engine_x --output=fixtures/ --clean \
  --regex='.*fork_Osaka-blockchain_test_engine_x-test_program_program_(BALANCE|CALLER)-debug.*' \
  tests/frontier/scenarios/ -v

export HIVE_SIMULATOR=http://127.0.0.1:3011
uv run consume enginex --input=fixtures/ -v
```

Alternatively, run the two tests with a single standalone hive command (the first run builds the simulator image, which downloads the `tests@v20.0.0` fixture release):

```bash
./hive --sim ethereum/eels/consume-enginex \
  --sim.buildarg fixtures=tests@v20.0.0 \
  --client go-ethereum --client-file geth-local.yaml \
  --sim.limit '.*fork_Osaka-blockchain_test_engine_x-test_program_program_(BALANCE|CALLER)-debug.*' \
  --docker.output
```

Results (identical in both modes):

- Control (this branch, `GETH_ENGINE_MAXREORGDEPTH` unset, default 32 — identical to current master): `BALANCE` passes leaving the head at block 37, `CALLER` fails its initial forkchoice update with `-38006 Too deep reorg: reorg depth 37 exceeds limit 32`.
- With `GETH_ENGINE_MAXREORGDEPTH=512`: client logs `Set engine API maximum reorg depth depth=512`; both tests pass.
