### PR TITLE
cmd/geth: truncate BAL freezer when pruning history

### DIFF
--- a/cmd/geth/chaincmd.go
+++ b/cmd/geth/chaincmd.go
@@ -782,6 +782,9 @@ func pruneHistory(ctx *cli.Context) error {
 	if _, err := chaindb.TruncateTail(rawdb.ChainFreezerBlockDataGroup, targetBlock); err != nil {
 		return fmt.Errorf("failed to truncate ancient data: %v", err)
 	}
+	if _, err := chaindb.TruncateTail(rawdb.ChainFreezerBALTable, targetBlock); err != nil {
+		return fmt.Errorf("failed to truncate ancient BAL data: %v", err)
+	}
 	log.Info("History pruning completed", "tail", targetBlock, "elapsed", common.PrettyDuration(time.Since(start)))
 
 	// TODO(s1na): what if there is a crash between the two prune operations?


### PR DESCRIPTION
## Summary

- Truncate `ChainFreezerBALTable` in `pruneHistory` after truncating block data.
- Keeps ancient block access list data consistent with the pruned history tail.

## Test plan

- [x] `go build ./cmd/geth/`