### PR TITLE
accounts/abi: set stringKind for contract-typed arguments

### DIFF
--- a/accounts/abi/type.go
+++ b/accounts/abi/type.go
@@ -222,6 +222,7 @@ func NewType(t string, internalType string, components []ArgumentMarshaling) (ty
 		if strings.HasPrefix(internalType, "contract ") {
 			typ.Size = 20
 			typ.T = AddressTy
+			typ.stringKind = "address"
 		} else {
 			return Type{}, fmt.Errorf("unsupported arg type: %s", t)
 		}


### PR DESCRIPTION
## Summary

- Set `stringKind` to `"address"` when mapping `contract` internal types to `AddressTy`.
- Ensures `Type.String()` returns the correct ABI signature for contract-typed arguments.

## Test plan

- [x] `go test -short ./accounts/abi/`