### PR TITLE
cmd/devp2p: handle password prompt error in loadSigningKey

### DIFF
--- a/cmd/devp2p/dnscmd.go
+++ b/cmd/devp2p/dnscmd.go
@@ -257,7 +257,10 @@ func loadSigningKey(keyfile string) *ecdsa.PrivateKey {
 	if err != nil {
 		exit(fmt.Errorf("failed to read the keyfile at '%s': %v", keyfile, err))
 	}
-	password, _ := prompt.Stdin.PromptPassword("Please enter the password for '" + keyfile + "': ")
+	password, err := prompt.Stdin.PromptPassword("Please enter the password for '" + keyfile + "': ")
+	if err != nil {
+		exit(fmt.Errorf("error reading password: %v", err))
+	}
 	key, err := keystore.DecryptKey(keyjson, password)
 	if err != nil {
 		exit(fmt.Errorf("error decrypting key: %v", err))


### PR DESCRIPTION
## Summary

- Check the error returned by `PromptPassword` in `loadSigningKey`.
- Exit early instead of continuing with an empty password when the prompt fails.

## Test plan

- [x] `go build ./cmd/devp2p/`