### PR TITLE
core/rawdb: drop stray %d verb from freezer metadata log message

### DIFF
--- a/core/rawdb/freezer_meta.go
+++ b/core/rawdb/freezer_meta.go
@@ -112,7 +112,7 @@ func decodeV2(file *os.File) *freezerTableMeta {
 		return nil
 	}
 	if o.Offset > math.MaxInt64 {
-		log.Error("Invalid flushOffset %d in freezer metadata", "offset", o.Offset, "file", file.Name())
+		log.Error("Invalid flushOffset in freezer metadata", "offset", o.Offset, "file", file.Name())
 		return nil
 	}
 	return &freezerTableMeta{


### PR DESCRIPTION
The error logged when a freezer table metadata carries an out-of-range `flushOffset` includes a `%d` verb in its message:

```go
log.Error("Invalid flushOffset %d in freezer metadata", "offset", o.Offset, "file", file.Name())
```

`log.Error` takes a plain message followed by structured key/value pairs, not a printf format string, so the `%d` is never substituted and is printed verbatim. The offset is already emitted through the `offset` field, making the verb both non-functional and redundant.

Before:

```
ERROR[07-14|11:25:50.003] Invalid flushOffset %d in freezer metadata offset=9,223,372,036,854,775,808 file=table.ranges
```

After:

```
ERROR[07-14|11:26:14.917] Invalid flushOffset in freezer metadata offset=9,223,372,036,854,775,808 file=table.ranges
```

This drops the leftover verb from the message text; the offset value is unchanged and still shown via the `offset` field.