### PR TITLE
internal/ethapi: cap default tx sync timeout at RPC max

### DIFF
--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -1790,6 +1790,9 @@ func (api *TransactionAPI) SendRawTransactionSync(ctx context.Context, input hex
 		defaultTimeout = api.b.RPCTxSyncDefaultTimeout()
 		timeout        = defaultTimeout
 	)
+	if timeout > maxTimeout {
+		timeout = maxTimeout
+	}
 	if timeoutMs != nil && *timeoutMs > 0 {
 		req := time.Duration(*timeoutMs) * time.Millisecond
 		if req > maxTimeout {


### PR DESCRIPTION
SendRawTransactionSync capped an explicitly requested timeout but not the configured default. Clamp defaultTimeout to the max so a misconfigured default cannot wait longer than RPCTxSyncMaxTimeout.