### PR TITLE
eth/gasestimator: treat floor data gas errors as insufficient gas

### DIFF
--- a/eth/gasestimator/gasestimator.go
+++ b/eth/gasestimator/gasestimator.go
@@ -219,6 +219,9 @@ func execute(ctx context.Context, call *core.Message, opts *Options, gasLimit ui
 		if errors.Is(err, core.ErrGasLimitTooHigh) {
 			return true, nil, nil // Special case, lower gas limit
 		}
+		if errors.Is(err, vm.ErrFloorDataGas) {
+			return true, nil, nil // Special case, raise gas limit
+		}
 		return true, nil, err // Bail out
 	}
 	return result.Failed(), result, nil


### PR DESCRIPTION
ErrFloorDataGas means the gas limit is below the EIP-7623 floor cost. Treat it like a gas-related failure so estimation raises the limit instead of aborting.