### PR TITLE
eth/catalyst: allow Bogota fork in GetPayloadV5

### DIFF
--- a/eth/catalyst/api.go
+++ b/eth/catalyst/api.go
@@ -498,6 +498,7 @@ func (api *ConsensusAPI) GetPayloadV5(payloadID engine.PayloadID) (*engine.Execu
 			forks.BPO3,
 			forks.BPO4,
 			forks.BPO5,
+			forks.Bogota,
 		})
 }
 


### PR DESCRIPTION
GetPayloadV5 already accepts Osaka and BPO forks. Include Bogota so payloads built under that schedule can be retrieved through the same endpoint.