### PR TITLE
cmd: add gogc flag

### DIFF
--- a/cmd/geth/main.go
+++ b/cmd/geth/main.go
@@ -103,6 +103,7 @@ var (
 		utils.CacheLogSizeFlag,
 		utils.FDLimitFlag,
 		utils.MemoryLimitFlag,
+		utils.GOGCFlag,
 		utils.CryptoKZGFlag,
 		utils.ListenPortFlag,
 		utils.DiscoveryPortFlag,

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -568,8 +568,8 @@ var (
 	}
 	GOGCFlag = &cli.IntFlag{
 		Name:     "gogc",
-		Usage:    "Go garbage collection target percentage (default = 100, negative disables)",
-		Value:    100,
+		Usage:    "Go garbage collection target percentage (default = 50, negative disables)",
+		Value:    50,
 		Category: flags.PerfCategory,
 	}
 	CryptoKZGFlag = &cli.StringFlag{

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -566,6 +566,12 @@ var (
 		Usage:    "Soft memory limit for the Go runtime in megabytes (default = no limit)",
 		Category: flags.PerfCategory,
 	}
+	GOGCFlag = &cli.IntFlag{
+		Name:     "gogc",
+		Usage:    "Go garbage collection target percentage (default = 100, negative disables)",
+		Value:    100,
+		Category: flags.PerfCategory,
+	}
 	CryptoKZGFlag = &cli.StringFlag{
 		Name:     "crypto.kzg",
 		Usage:    "KZG library implementation to use; gokzg (recommended) or ckzg",
@@ -1778,10 +1784,19 @@ func SetEthConfig(ctx *cli.Context, stack *node.Node, cfg *ethconfig.Config) {
 		}
 	}
 
-	godebug.SetGCPercent(100)
+	// Setting go runtime settings
+	if ctx.IsSet(GOGCFlag.Name) {
+		gcPercent := ctx.Int(GOGCFlag.Name)
+		log.Info("Sanitizing Go's GC trigger", "percent", gcPercent)
+		godebug.SetGCPercent(gcPercent)
+	}
 	if ctx.IsSet(MemoryLimitFlag.Name) {
 		memLimit := int64(ctx.Int(MemoryLimitFlag.Name)) * 1024 * 1024
-		log.Debug("Setting Go memory limit", "MB", memLimit/1024/1024)
+		if memLimit > int64(total) {
+			log.Info("Sanitizing memory limit", "provided(MB)", memLimit/1024/1024, "updated(MB)", total/1024/1024)
+			memLimit = int64(total)
+		}
+		log.Info("Setting Go memory limit", "MB", memLimit/1024/1024)
 		godebug.SetMemoryLimit(memLimit)
 	}
 

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -1785,19 +1785,24 @@ func SetEthConfig(ctx *cli.Context, stack *node.Node, cfg *ethconfig.Config) {
 	}
 
 	// Setting go runtime settings
+	gcPercent := ctx.Int(GOGCFlag.Name)
 	if ctx.IsSet(GOGCFlag.Name) {
-		gcPercent := ctx.Int(GOGCFlag.Name)
 		log.Info("Sanitizing Go's GC trigger", "percent", gcPercent)
-		godebug.SetGCPercent(gcPercent)
 	}
+	godebug.SetGCPercent(gcPercent)
+
 	if ctx.IsSet(MemoryLimitFlag.Name) {
 		memLimit := int64(ctx.Int(MemoryLimitFlag.Name)) * 1024 * 1024
 		if memLimit > int64(total) {
 			log.Info("Sanitizing memory limit", "provided(MB)", memLimit/1024/1024, "updated(MB)", total/1024/1024)
 			memLimit = int64(total)
 		}
-		log.Info("Setting Go memory limit", "MB", memLimit/1024/1024)
-		godebug.SetMemoryLimit(memLimit)
+		if memLimit < 0 {
+			log.Warn("Ignoring negative Go memory limit")
+		} else {
+			log.Info("Setting Go memory limit", "MB", memLimit/1024/1024)
+			godebug.SetMemoryLimit(memLimit)
+		}
 	}
 
 	if ctx.IsSet(SyncTargetFlag.Name) {


### PR DESCRIPTION
This PR adds the CLI flag gogc for twisting the garbage collection target.

The default value is chosen as the 50, balancing the performance gain and potential memory peak.