### PR TITLE
triedb/pathdb: validate restart count and key offsets in trienode decoder

### DIFF
--- a/triedb/pathdb/history_trienode.go
+++ b/triedb/pathdb/history_trienode.go
@@ -397,19 +397,24 @@ func decodeRestartTrailer(keySection []byte) ([]uint32, []uint32, int, error) {
 	}
 	nRestarts := binary.BigEndian.Uint32(keySection[len(keySection)-4:])
 
-	// Decode the trailer
+	// Decode the trailer. The multiplication is performed in 64-bit to prevent
+	// the result from wrapping around for large restart counts.
+	if uint64(len(keySection)) < uint64(nRestarts)*8+4 {
+		return nil, nil, 0, fmt.Errorf("key section too short, restarts: %d, size: %d", nRestarts, len(keySection))
+	}
 	var (
 		keyOffsets = make([]uint32, 0, int(nRestarts))
 		valOffsets = make([]uint32, 0, int(nRestarts))
+		keyLimit   = len(keySection) - 4 - int(nRestarts)*8 // End of key data
 	)
-	if len(keySection) < int(8*nRestarts)+4 {
-		return nil, nil, 0, fmt.Errorf("key section too short, restarts: %d, size: %d", nRestarts, len(keySection))
-	}
 	for i := range int(nRestarts) {
 		o := len(keySection) - 4 - (int(nRestarts)-i)*8
 		keyOffset := binary.BigEndian.Uint32(keySection[o : o+4])
 		if i != 0 && keyOffset <= keyOffsets[i-1] {
 			return nil, nil, 0, fmt.Errorf("key offset is out of order, prev: %v, cur: %v", keyOffsets[i-1], keyOffset)
+		}
+		if int(keyOffset) > keyLimit {
+			return nil, nil, 0, fmt.Errorf("key offset is out of range, offset: %d, limit: %d", keyOffset, keyLimit)
 		}
 		keyOffsets = append(keyOffsets, keyOffset)
 
@@ -421,7 +426,6 @@ func decodeRestartTrailer(keySection []byte) ([]uint32, []uint32, int, error) {
 		}
 		valOffsets = append(valOffsets, valOffset)
 	}
-	keyLimit := len(keySection) - 4 - int(nRestarts)*8 // End of key data
 	return keyOffsets, valOffsets, keyLimit, nil
 }
 

--- a/triedb/pathdb/history_trienode_test.go
+++ b/triedb/pathdb/history_trienode_test.go
@@ -656,6 +656,26 @@ func TestDecodeSingleCorruptedData(t *testing.T) {
 	if err == nil {
 		t.Fatal("Expected error for invalid restart count")
 	}
+
+	// Test with a restart count large enough to overflow the trailer size
+	// computation (8*nRestarts wraps around for nRestarts >= 1<<29).
+	corrupted = make([]byte, len(keySection))
+	copy(corrupted, keySection)
+	binary.BigEndian.PutUint32(corrupted[len(corrupted)-4:], 1<<29)
+	err = decodeSingle(corrupted, nil)
+	if err == nil {
+		t.Fatal("Expected error for overflowing restart count")
+	}
+
+	// Test with a key offset pointing beyond the end of the key data
+	corrupted = make([]byte, 12)
+	binary.BigEndian.PutUint32(corrupted[0:4], 0xffffffff) // key offset
+	binary.BigEndian.PutUint32(corrupted[4:8], 0)          // value offset
+	binary.BigEndian.PutUint32(corrupted[8:12], 1)         // restart count
+	err = decodeSingle(corrupted, nil)
+	if err == nil {
+		t.Fatal("Expected error for out-of-range key offset")
+	}
 }
 
 // Helper function to test encode/decode cycle


### PR DESCRIPTION
`decodeRestartTrailer` validates most of what it reads out of the key section — section length, offset ordering, varint sanity — but two trailer-derived values reach a slice expression unchecked, and both panic instead of returning an error.

### Restart count overflows the size guard

```go
nRestarts := binary.BigEndian.Uint32(keySection[len(keySection)-4:])
...
if len(keySection) < int(8*nRestarts)+4 {
```

`nRestarts` is a `uint32` and `8` is an untyped constant, so `8*nRestarts` is evaluated in 32-bit and wraps: at `nRestarts = 1<<29` it becomes `0`, and the guard degrades to `len(keySection) < 4`, which the check above it has already excluded. The loop then computes `o := len(keySection) - 4 - (int(nRestarts)-i)*8` — that conversion happens before the multiply, so it does not wrap on 64-bit — and indexes with a large negative value:

```
panic: runtime error: slice bounds out of range [:-4294967292]
	triedb/pathdb/history_trienode.go:410
```

The neighbouring expressions at what were lines 409 and 424 both convert before multiplying; line 405 was the only one that did not.

### Key offsets are never bounded by the key limit

The decoded key offsets are checked for strict ordering, but never against the end of the key data, and `decodeSingle` slices with them directly:

```go
keyData = keySection[keyOffsets[i]:keyLimit]
```

A key offset past `keyLimit` gives `lo > hi`:

```
panic: runtime error: slice bounds out of range [4294967295:0]
	triedb/pathdb/history_trienode.go:500
```

`searchSingle` indexes `sr.keyData[keyOffsets[i]:]` with the same values.

### Changes

- Compute the trailer size check in 64-bit so it cannot wrap.
- Bound each key offset by the key limit while decoding the trailer, alongside the existing ordering check.
- Move the `keyOffsets`/`valOffsets` preallocation below the size check, so an unvalidated count no longer drives the allocation.

Net effect is that both inputs produce a descriptive error rather than a panic.

### Testing

Both cases were added to the existing `TestDecodeSingleCorruptedData`, which already has an "invalid restart count" case — it just uses `10000`, which is below the wrap threshold, so the overflow was never exercised. Both new cases panic on master and pass with this change. Full `triedb/pathdb` suite is green.

### Scope

The key section is read back from the node's own freezer via `ReadTrienodeHistoryKeySection`, so this is reachable through on-disk corruption rather than anything a peer supplies — the same reachability as the 32-bit overflow fixed in #33098 for this decoder. No behaviour change for well-formed data.
