### PR TITLE
node: strip bearer prefix case-insensitively

### DIFF
--- a/node/jwt_handler.go
+++ b/node/jwt_handler.go
@@ -47,8 +47,10 @@ func (handler *jwtHandler) ServeHTTP(out http.ResponseWriter, r *http.Request) {
 		strToken string
 		claims   jwt.RegisteredClaims
 	)
+	// RFC 7235: authentication schemes are case-insensitive. Match with EqualFold
+	// and slice off the scheme prefix (do not use TrimPrefix, which is case-sensitive).
 	if auth := r.Header.Get("Authorization"); len(auth) >= 7 && strings.EqualFold(auth[:7], "bearer ") {
-		strToken = strings.TrimPrefix(auth, "Bearer ")
+		strToken = auth[7:]
 	}
 	if len(strToken) == 0 {
 		http.Error(out, "missing token", http.StatusUnauthorized)

--- a/node/rpcstack_test.go
+++ b/node/rpcstack_test.go
@@ -371,6 +371,16 @@ func TestJWT(t *testing.T) {
 				"bar": "baz",
 			}))
 		},
+		// RFC 7235: authentication scheme is case-insensitive.
+		func() string {
+			return fmt.Sprintf("bearer %v", issueToken(secret, nil, testClaim{"iat": time.Now().Unix()}))
+		},
+		func() string {
+			return fmt.Sprintf("BEARER %v", issueToken(secret, nil, testClaim{"iat": time.Now().Unix()}))
+		},
+		func() string {
+			return fmt.Sprintf("bEaReR %v", issueToken(secret, nil, testClaim{"iat": time.Now().Unix()}))
+		},
 	}
 	for i, tokenFn := range expOk {
 		token := tokenFn()
@@ -420,9 +430,6 @@ func TestJWT(t *testing.T) {
 		},
 		func() string {
 			return fmt.Sprintf("Bearer  %v", issueToken(secret, nil, testClaim{"iat": time.Now().Unix()}))
-		},
-		func() string {
-			return fmt.Sprintf("bearer %v", issueToken(secret, nil, testClaim{"iat": time.Now().Unix()}))
 		},
 		func() string {
 			return fmt.Sprintf("Bearer: %v", issueToken(secret, nil, testClaim{"iat": time.Now().Unix()}))


### PR DESCRIPTION
## Summary

#35022 intended to match the HTTP Authorization scheme case-insensitively (RFC 7235), but still used case-sensitive `strings.TrimPrefix(auth, "Bearer ")` after the `EqualFold` check. Headers like `bearer …` / `BEARER …` therefore never had the scheme stripped and JWT parsing always failed.

This change slices off the first 7 bytes after a successful case-insensitive match, and updates `TestJWT` to accept alternate casings of the scheme.

## Test plan

- [x] `go test ./node/ -run TestJWT`