### PR TITLE
cmd/geth: release iterator in checkStateContent

### DIFF
--- a/cmd/geth/dbcmd.go
+++ b/cmd/geth/dbcmd.go
@@ -409,6 +409,7 @@ func checkStateContent(ctx *cli.Context) error {
 		startTime = time.Now()
 		lastLog   = time.Now()
 	)
+	defer it.Release()
 	for it.Next() {
 		count++
 		k := it.Key()


### PR DESCRIPTION
## Summary

`geth db check-state-content` opens a database iterator in `checkStateContent` but never calls `Release()` after use.

Per the `ethdb.Iterator` contract, an iterator must be released after use (including on error paths). This is the same cleanup pattern as recent fixes such as #35250 and #35222.

Practical impact is limited: this is a short-lived CLI command that already defers `db.Close()`, so this is mainly resource hygiene and API consistency rather than a user-visible correctness bug. `defer it.Release()` ensures the underlying cursor/snapshot is closed as soon as the function returns.

## Test plan

- [x] `go build ./cmd/geth/`