### PR TITLE
miner, core: reuse the chain's jumpdest cache when building payloads

### DIFF
--- a/core/blockchain_reader.go
+++ b/core/blockchain_reader.go
@@ -524,6 +524,12 @@ func (bc *BlockChain) CodeDB() *state.CodeDB {
 	return bc.codedb
 }
 
+// JumpDestCache retrieves the shared JUMPDEST analysis cache, so callers such
+// as the miner can reuse bitmaps already computed during block import.
+func (bc *BlockChain) JumpDestCache() vm.JumpDestCache {
+	return bc.jumpDestCache
+}
+
 // HeaderChain returns the underlying header chain.
 func (bc *BlockChain) HeaderChain() *HeaderChain {
 	return bc.hc

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -345,6 +345,8 @@ func (miner *Miner) makeEnv(parent *types.Header, header *types.Header, coinbase
 		}
 	}
 	state.StartPrefetcher("miner", bundle)
+	evm := vm.NewEVM(core.NewEVMBlockContext(header, miner.chain, &coinbase), state, miner.chainConfig, vm.Config{})
+	evm.SetJumpDestCache(miner.chain.JumpDestCache())
 
 	// Note the passed coinbase may be different with header.Coinbase.
 	return &environment{
@@ -356,7 +358,7 @@ func (miner *Miner) makeEnv(parent *types.Header, header *types.Header, coinbase
 		header:   header,
 		bal:      bal.NewConstructionBlockAccessList(),
 		witness:  state.Witness(),
-		evm:      vm.NewEVM(core.NewEVMBlockContext(header, miner.chain, &coinbase), state, miner.chainConfig, vm.Config{}),
+		evm:      evm,
 	}, nil
 }
 


### PR DESCRIPTION
Follow-up to #34850. The miner's payload EVM previously used a private per-EVM JUMPDEST map, so every ~2s payload rebuild re-analyzed the code bitmap of every contract the block touches.