### PR TITLE
eth/downloader: fix flaky sync tests

### DIFF
--- a/eth/downloader/downloader_test.go
+++ b/eth/downloader/downloader_test.go
@@ -456,8 +456,8 @@ func testCanonSync(t *testing.T, protocol uint, mode SyncMode, snapV2 bool) {
 	select {
 	case <-success:
 		assertOwnChain(t, tester, len(chain.blocks))
-	case <-time.NewTimer(time.Second * 3).C:
-		t.Fatalf("Failed to sync chain in three seconds")
+	case <-time.NewTimer(time.Second * 30).C:
+		t.Fatalf("Failed to sync chain in time")
 	}
 }
 
@@ -605,8 +605,8 @@ func testEmptyShortCircuit(t *testing.T, protocol uint, mode SyncMode) {
 			HighestBlock: uint64(len(chain.blocks) - 1),
 			CurrentBlock: uint64(len(chain.blocks) - 1),
 		})
-	case <-time.NewTimer(time.Second * 3).C:
-		t.Fatalf("Failed to sync chain in three seconds")
+	case <-time.NewTimer(time.Second * 30).C:
+		t.Fatalf("Failed to sync chain in time")
 	}
 	assertOwnChain(t, tester, len(chain.blocks))
 
@@ -679,8 +679,8 @@ func testBeaconSync(t *testing.T, protocol uint, mode SyncMode) {
 				if bs := int(tester.chain.CurrentBlock().Number.Uint64()) + 1; bs != len(chain.blocks) {
 					t.Fatalf("synchronised blocks mismatch: have %v, want %v", bs, len(chain.blocks))
 				}
-			case <-time.NewTimer(time.Second * 3).C:
-				t.Fatalf("Failed to sync chain in three seconds")
+			case <-time.NewTimer(time.Second * 30).C:
+				t.Fatalf("Failed to sync chain in time")
 			}
 		})
 	}
@@ -790,8 +790,8 @@ func testSyncProgress(t *testing.T, protocol uint, mode SyncMode) {
 			CurrentBlock: uint64(len(chain.blocks)/2 - 1),
 			HighestBlock: uint64(len(chain.blocks)/2 - 1),
 		})
-	case <-time.NewTimer(time.Second * 3).C:
-		t.Fatalf("Failed to sync chain in three seconds")
+	case <-time.NewTimer(time.Second * 30).C:
+		t.Fatalf("Failed to sync chain in time")
 	}
 
 	// Synchronise all the blocks and check continuation progress
@@ -809,8 +809,8 @@ func testSyncProgress(t *testing.T, protocol uint, mode SyncMode) {
 			CurrentBlock:  uint64(len(chain.blocks) - 1),
 			HighestBlock:  uint64(len(chain.blocks) - 1),
 		})
-	case <-time.NewTimer(time.Second * 3).C:
-		t.Fatalf("Failed to sync chain in three seconds")
+	case <-time.NewTimer(time.Second * 30).C:
+		t.Fatalf("Failed to sync chain in time")
 	}
 }
 

--- a/eth/downloader/skeleton_test.go
+++ b/eth/downloader/skeleton_test.go
@@ -922,7 +922,14 @@ func TestSkeletonSyncRetrievals(t *testing.T) {
 			endpeers = append(tt.peers, tt.newPeer)
 		}
 		if tt.newHead != nil {
-			skeleton.Sync(tt.newHead, nil, true)
+			// The head announcement is rejected if it arrives while the previous
+			// sync cycle is still tearing down (head events are dropped on the
+			// floor during teardown, see #27397). Retry until the syncer accepts
+			// the new head, otherwise the update is lost and the end state below
+			// is never reached.
+			for skeleton.Sync(tt.newHead, nil, true) != nil {
+				time.Sleep(10 * time.Millisecond)
+			}
 		}
 
 		// Wait a bit (bleah) for the second sync loop to go to idle. This might


### PR DESCRIPTION
Caught these while stress-running the tree's tests under `-race` overnight; neither was on the flaky tracker:

```
--- FAIL: TestSkeletonSyncRetrievals (9.91s)
    skeleton_test.go:938: test 9, end: subchain 0 head mismatch: have 1024, want 1026
--- FAIL: TestEmptyShortCircuitFull (3.03s)
    downloader_test.go:609: Failed to sync chain in three seconds
```

Fixes #35379

`TestSkeletonSyncRetrievals` looked like a timeout problem at first, but it is not. Case 9 announces a second head (1026) right after the initial cycle links up, and ignores the `Sync` return value. Head events that arrive while the previous sync cycle is still tearing down are rejected (dropped on the floor since #27397), so with unlucky timing the announcement is consumed by the teardown drain and silently lost, and the persisted progress stays at 1024 forever. I first raised the 2s poll budget to 10s to test the slow-convergence theory: still failed, 1 in 30, same signature, so the budget was never the problem. #29852 closed this exact window for the `newPeer` cases by reordering the peer registration; case 9 (`newHead`, no `newPeer`) stayed exposed. The fix retries the announcement until the syncer accepts it, and leaves the original wait budgets alone.

`TestEmptyShortCircuitFull` is a plain headroom problem: it syncs the full 1224-block test chain against a one-shot 3s failsafe, and under `-race` with `-cpu=1` the test alone takes 1.55-1.79s on an idle machine, so background load eats the rest. The same failsafe guards four sibling tests in the file, so all five timers go from 3s to 30s. The `select`s still return the moment the sync notification arrives, so the happy path is unchanged and a genuine hang still fails, just later.

Verified locally: before the fix `TestSkeletonSyncRetrievals` failed 2/20 executions with `go test -race -count=10 -cpu=1,2`; with the fix, 70 consecutive executions across `-count=40 -cpu=1` and `-count=15 -cpu=1,2` pass on the unchanged 2s budgets, plus a full `go test -race ./eth/downloader/` run.
