### PR TITLE
rpc, p2p/discover/v5wire: fix data race, KDF error handling, and DoS in ServeListener

### DIFF
--- a/p2p/discover/v5wire/crypto.go
+++ b/p2p/discover/v5wire/crypto.go
@@ -127,8 +127,12 @@ func deriveKeys(hash hashFn, priv *ecdsa.PrivateKey, pub *ecdsa.PublicKey, n1, n
 	}
 	kdf := hkdf.New(hash, eph, challenge, info)
 	sec := session{writeKey: make([]byte, aesKeySize), readKey: make([]byte, aesKeySize)}
-	kdf.Read(sec.writeKey)
-	kdf.Read(sec.readKey)
+	if _, err := kdf.Read(sec.writeKey); err != nil {
+		return nil
+	}
+	if _, err := kdf.Read(sec.readKey); err != nil {
+		return nil
+	}
 	clear(eph)
 	return &sec
 }

--- a/rpc/handler.go
+++ b/rpc/handler.go
@@ -357,6 +357,10 @@ func (h *handler) handleNonBatchCall(cp *callProc, msg *jsonrpcMessage) {
 			writeSpanEnd(&err)
 		})
 	}
+	// Ensure we synchronize with the timer goroutine before reading responseError
+	// in the deferred serverSpanEnd. This prevents a data race when the timer
+	// fires and writes responseError while the main goroutine is about to return.
+	responded.Do(func() {})
 
 	// Enable notification sending of subscriptions, since the response with
 	// subscription ID has now been sent.

--- a/rpc/ipc.go
+++ b/rpc/ipc.go
@@ -26,6 +26,10 @@ import (
 
 // ServeListener accepts connections on l, serving JSON-RPC on them.
 func (s *Server) ServeListener(l net.Listener) error {
+	var sem chan struct{}
+	if s.maxConns > 0 {
+		sem = make(chan struct{}, s.maxConns)
+	}
 	for {
 		conn, err := l.Accept()
 		if netutil.IsTemporaryError(err) {
@@ -34,8 +38,22 @@ func (s *Server) ServeListener(l net.Listener) error {
 		} else if err != nil {
 			return err
 		}
+		if sem != nil {
+			select {
+			case sem <- struct{}{}:
+			default:
+				log.Warn("RPC connection limit reached, rejecting", "conn", conn.RemoteAddr())
+				conn.Close()
+				continue
+			}
+		}
 		log.Trace("Accepted RPC connection", "conn", conn.RemoteAddr())
-		go s.ServeCodec(NewCodec(conn), 0)
+		go func() {
+			s.ServeCodec(NewCodec(conn), 0)
+			if sem != nil {
+				<-sem
+			}
+		}()
 	}
 }
 

--- a/rpc/server.go
+++ b/rpc/server.go
@@ -56,6 +56,7 @@ type Server struct {
 	batchResponseLimit int
 	httpBodyLimit      int
 	wsReadLimit        int64
+	maxConns           int
 	tracerProvider     trace.TracerProvider
 }
 
@@ -99,6 +100,14 @@ func (s *Server) SetHTTPBodyLimit(limit int) {
 // This method should be called before processing any requests via Websocket server.
 func (s *Server) SetWebsocketReadLimit(limit int64) {
 	s.wsReadLimit = limit
+}
+
+// SetMaxConns sets the maximum number of concurrent connections allowed by
+// ServeListener. A value of 0 means no limit.
+//
+// This method should be called before ServeListener.
+func (s *Server) SetMaxConns(maxConns int) {
+	s.maxConns = maxConns
 }
 
 // RegisterName creates a service for the given receiver type under the given name. When no


### PR DESCRIPTION
## Summary

This PR addresses three security issues in go-ethereum:

### 1. Data race on \esponseError\ in \pc/handler.go\

In \handleNonBatchCall\, the timeout timer goroutine writes \esponseError\ via \esponded.Do\, while the deferred \serverSpanEnd\ reads it. When \handleCallMsg\ returns nil (e.g. for notifications), the main goroutine never calls \esponded.Do\, so there is no happens-before guarantee between the timer's write and the deferred read.

**Fix:** Added \esponded.Do(func(){})\ to ensure the main goroutine synchronizes with any in-progress timer write before \serverSpanEnd\ reads \esponseError\.

### 2. Unchecked KDF read errors in \p2p/discover/v5wire/crypto.go\

\deriveKeys\ calls \kdf.Read()\ for both \writeKey\ and \eadKey\ without checking the returned error. If the KDF produces insufficient data, session keys would be partially zeroed, catastrophically weakening encryption.

**Fix:** Check the error from both \kdf.Read()\ calls and return \
il\ on failure, consistent with the existing \eph == nil\ check.

### 3. DoS via unlimited connections in \pc/ipc.go\

\ServeListener\ accepts an unlimited number of connections. An attacker can open thousands of connections to exhaust file descriptors and memory.

**Fix:**
- Added \maxConns\ field to \Server\ struct
- Added \SetMaxConns(int)\ method (0 = no limit, backward compatible)
- \ServeListener\ uses a buffered channel semaphore to enforce the limit
- Connections beyond the limit are rejected with a warning log