### PR TITLE
eth/protocols/eth: track announced tx hashes only after send, again

### DIFF
--- a/eth/protocols/eth/peer.go
+++ b/eth/protocols/eth/peer.go
@@ -192,12 +192,18 @@ func (p *Peer) AsyncSendTransactions(hashes []common.Hash) {
 // directly as the queueing (memory) and transmission (bandwidth) costs should
 // not be managed directly.
 func (p *Peer) sendPooledTransactionHashes(hashes []common.Hash, types []byte, sizes []uint32, cells types.CustodyBitmap) error {
+	var err error
+	if p.version >= ETH72 {
+		err = p2p.Send(p.rw, NewPooledTransactionHashesMsg, NewPooledTransactionHashesPacket72{Types: types, Sizes: sizes, Hashes: hashes, Mask: cells})
+	} else {
+		err = p2p.Send(p.rw, NewPooledTransactionHashesMsg, NewPooledTransactionHashesPacket71{Types: types, Sizes: sizes, Hashes: hashes})
+	}
+	if err != nil {
+		return err
+	}
 	// Mark all the transactions as known, but ensure we don't overflow our limits
 	p.knownTxs.Add(hashes...)
-	if p.version >= ETH72 {
-		return p2p.Send(p.rw, NewPooledTransactionHashesMsg, NewPooledTransactionHashesPacket72{Types: types, Sizes: sizes, Hashes: hashes, Mask: cells})
-	}
-	return p2p.Send(p.rw, NewPooledTransactionHashesMsg, NewPooledTransactionHashesPacket71{Types: types, Sizes: sizes, Hashes: hashes})
+	return nil
 }
 
 // AsyncSendPooledTransactionHashes queues a list of transactions hashes to eventually

--- a/eth/protocols/eth/peer_test.go
+++ b/eth/protocols/eth/peer_test.go
@@ -24,6 +24,7 @@ import (
 	"testing"
 
 	"github.com/ethereum/go-ethereum/common"
+	types2 "github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/p2p"
 	"github.com/ethereum/go-ethereum/p2p/enode"
 )
@@ -86,5 +87,63 @@ func TestPeerSet(t *testing.T) {
 	s.Add(vals...)
 	if s.Cardinality() < size {
 		t.Fatalf("bad size")
+	}
+}
+
+// TestSendPooledTransactionHashes verifies that announced transaction hashes
+// are only tracked as known by the peer if the announcement was successfully
+// sent. Marking them known upfront would suppress re-announcement of hashes
+// the peer never received.
+func TestSendPooledTransactionHashes(t *testing.T) {
+	var (
+		id     enode.ID
+		hashes = []common.Hash{{0x1}, {0x2}}
+		types  = []byte{0x2, 0x2}
+		sizes  = []uint32{100, 100}
+	)
+	rand.Read(id[:])
+
+	// Announces to all supported protocol versions must mark the hashes as
+	// known only after a successful send.
+	for _, version := range []uint{ETH71, ETH72} {
+		app, net := p2p.MsgPipe()
+		peer := NewPeer(version, p2p.NewPeer(id, "test", nil), net, nil, nil, nil)
+
+		// Drain the remote side so the send can go through
+		go func() {
+			for {
+				msg, err := app.ReadMsg()
+				if err != nil {
+					return
+				}
+				msg.Discard()
+			}
+		}()
+		defer peer.Close()
+		if err := peer.sendPooledTransactionHashes(hashes, types, sizes, types2.CustodyBitmap{}); err != nil {
+			t.Fatalf("version %d: failed to send hashes: %v", version, err)
+		}
+		for _, hash := range hashes {
+			if !peer.KnownTransaction(hash) {
+				t.Fatalf("version %d: hash %v not marked known after successful send", version, hash)
+			}
+		}
+		app.Close()
+		net.Close()
+
+		// A failed send must not mark the hashes as known
+		app, net = p2p.MsgPipe()
+		peer = NewPeer(version, p2p.NewPeer(id, "test", nil), net, nil, nil, nil)
+		defer peer.Close()
+		app.Close()
+		if err := peer.sendPooledTransactionHashes(hashes, types, sizes, types2.CustodyBitmap{}); err == nil {
+			t.Fatalf("version %d: expected send to fail on closed pipe", version)
+		}
+		for _, hash := range hashes {
+			if peer.KnownTransaction(hash) {
+				t.Fatalf("version %d: hash %v marked known after failed send", version, hash)
+			}
+		}
+		net.Close()
 	}
 }

--- a/eth/protocols/eth/peer_test.go
+++ b/eth/protocols/eth/peer_test.go
@@ -24,7 +24,6 @@ import (
 	"testing"
 
 	"github.com/ethereum/go-ethereum/common"
-	types2 "github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/p2p"
 	"github.com/ethereum/go-ethereum/p2p/enode"
 )
@@ -87,63 +86,5 @@ func TestPeerSet(t *testing.T) {
 	s.Add(vals...)
 	if s.Cardinality() < size {
 		t.Fatalf("bad size")
-	}
-}
-
-// TestSendPooledTransactionHashes verifies that announced transaction hashes
-// are only tracked as known by the peer if the announcement was successfully
-// sent. Marking them known upfront would suppress re-announcement of hashes
-// the peer never received.
-func TestSendPooledTransactionHashes(t *testing.T) {
-	var (
-		id     enode.ID
-		hashes = []common.Hash{{0x1}, {0x2}}
-		types  = []byte{0x2, 0x2}
-		sizes  = []uint32{100, 100}
-	)
-	rand.Read(id[:])
-
-	// Announces to all supported protocol versions must mark the hashes as
-	// known only after a successful send.
-	for _, version := range []uint{ETH71, ETH72} {
-		app, net := p2p.MsgPipe()
-		peer := NewPeer(version, p2p.NewPeer(id, "test", nil), net, nil, nil, nil)
-
-		// Drain the remote side so the send can go through
-		go func() {
-			for {
-				msg, err := app.ReadMsg()
-				if err != nil {
-					return
-				}
-				msg.Discard()
-			}
-		}()
-		defer peer.Close()
-		if err := peer.sendPooledTransactionHashes(hashes, types, sizes, types2.CustodyBitmap{}); err != nil {
-			t.Fatalf("version %d: failed to send hashes: %v", version, err)
-		}
-		for _, hash := range hashes {
-			if !peer.KnownTransaction(hash) {
-				t.Fatalf("version %d: hash %v not marked known after successful send", version, hash)
-			}
-		}
-		app.Close()
-		net.Close()
-
-		// A failed send must not mark the hashes as known
-		app, net = p2p.MsgPipe()
-		peer = NewPeer(version, p2p.NewPeer(id, "test", nil), net, nil, nil, nil)
-		defer peer.Close()
-		app.Close()
-		if err := peer.sendPooledTransactionHashes(hashes, types, sizes, types2.CustodyBitmap{}); err == nil {
-			t.Fatalf("version %d: expected send to fail on closed pipe", version)
-		}
-		for _, hash := range hashes {
-			if peer.KnownTransaction(hash) {
-				t.Fatalf("version %d: hash %v marked known after failed send", version, hash)
-			}
-		}
-		net.Close()
 	}
 }


### PR DESCRIPTION
## Description

Commit 1f87331fb moved the known-transaction marking in `sendPooledTransactionHashes` to after a successful send, so hashes are not marked known to the peer if the announcement fails to go out.

The sparse blobpool change (d91b71fb3) reintroduced the original track-before-send ordering when adding the eth/72 packet variant, causing failed announcements to suppress future re-announcements of the same hashes to that peer.

This restores the send-first ordering for both eth/71 and eth/72 packet versions, and adds a regression test covering success and failure paths on both protocol versions.

## Checklist

- [x] Restored mark-known-after-send for ETH71 and ETH72
- [x] Added `TestSendPooledTransactionHashes` covering success and closed-pipe failure