### PR TITLE
cmd/devp2p/internal/ethtest: add eth/71 (EIP-8159) tests

### DIFF
--- a/cmd/devp2p/internal/ethtest/accesslists.go
+++ b/cmd/devp2p/internal/ethtest/accesslists.go
@@ -1,0 +1,116 @@
+// Copyright 2026 The go-ethereum Authors
+// This file is part of go-ethereum.
+//
+// go-ethereum is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// go-ethereum is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with go-ethereum. If not, see <http://www.gnu.org/licenses/>.
+
+package ethtest
+
+import (
+	"bytes"
+	"fmt"
+
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/core/types/bal"
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/ethereum/go-ethereum/internal/utesting"
+	"github.com/ethereum/go-ethereum/rlp"
+)
+
+// validateAccessListsResponse validates a BlockAccessLists response shared by
+// the snap/2 (EIP-8189) and eth/71 (EIP-8159) test suites. Both protocols use
+// the same positional response list where the RLP empty string (0x80) marks an
+// unavailable BAL.
+func (s *Suite) validateAccessListsResponse(t *utesting.T, tc *accessListsTest, reqID, resID uint64, accessLists rlp.RawList[rlp.RawValue]) error {
+	if resID != reqID {
+		return fmt.Errorf("request id mismatch: got %d, want %d", resID, reqID)
+	}
+
+	// Check list length bounds.
+	got := accessLists.Len()
+	if got < tc.minEntries || got > tc.maxEntries {
+		return fmt.Errorf("response has %d entries, want between %d and %d", got, tc.minEntries, tc.maxEntries)
+	}
+
+	// Build a map of request-index -> block so we can verify BAL hashes.
+	blocks := make(map[int]*types.Block)
+	for i, h := range tc.hashes {
+		for _, b := range s.chain.blocks {
+			if b.Hash() == h {
+				blocks[i] = b
+				break
+			}
+		}
+	}
+
+	// Iterate the response, validating each entry positionally.
+	var (
+		idx int
+		it  = accessLists.ContentIterator()
+	)
+	for it.Next() {
+		raw := it.Value()
+		block := blocks[idx]
+
+		// Empty entry: per spec, indicates BAL is unavailable for that block.
+		if bytes.Equal(raw, rlp.EmptyString) {
+			if block != nil && block.Header().BlockAccessListHash != nil {
+				// Not a failure — the server is allowed to legitimately not
+				// have the BAL. But we log it so the test output is diagnosable.
+				t.Logf("    entry %d: server returned empty for known post-Amsterdam block %x", idx, tc.hashes[idx])
+			}
+			idx++
+			continue
+		}
+
+		// Non-empty entry. A BAL is only legitimate for a block we know
+		// locally whose header commits to one; for any other hash the only
+		// valid response is the RLP empty string, so receiving data here
+		// means the server fabricated it.
+		if block == nil {
+			return fmt.Errorf("entry %d: server returned BAL data for unknown hash %x", idx, tc.hashes[idx])
+		}
+		if block.Header().BlockAccessListHash == nil {
+			return fmt.Errorf("entry %d: server returned BAL data for a block with no expected BAL (hash %x)", idx, tc.hashes[idx])
+		}
+
+		// Per EIP-8189: compute keccak256(rlp.encode(bal)) against the raw
+		// bytes actually received on the wire, and compare to the header
+		// commitment. Hashing raw bytes (rather than re-encoding after a
+		// decode round-trip) catches peers that send non-canonical BAL
+		// encodings.
+		have := crypto.Keccak256Hash(raw)
+		want := *block.Header().BlockAccessListHash
+		if have != want {
+			return fmt.Errorf("entry %d: BAL hash mismatch: have %x, want %x", idx, have, want)
+		}
+
+		// Decode and validate the BAL's internal structure: ordering of
+		// accounts/slots/changes, code-size limits, and per-entry access-index
+		// bounds, against the known block.
+		var accessList bal.BlockAccessList
+		if err := rlp.DecodeBytes(raw, &accessList); err != nil {
+			return fmt.Errorf("entry %d: invalid BAL RLP: %v", idx, err)
+		}
+		if err := accessList.Validate(block.GasLimit(), len(block.Transactions())); err != nil {
+			return fmt.Errorf("entry %d: BAL failed validation: %v", idx, err)
+		}
+		idx++
+	}
+
+	// Sanity: iterator consumed exactly the reported number of entries.
+	if idx != got {
+		return fmt.Errorf("iterator visited %d entries, expected %d", idx, got)
+	}
+	return nil
+}

--- a/cmd/devp2p/internal/ethtest/conn.go
+++ b/cmd/devp2p/internal/ethtest/conn.go
@@ -97,6 +97,19 @@ func (s *Suite) dialSnap2() (*Conn, error) {
 	return conn, nil
 }
 
+// dialEth71 creates a connection advertising eth/71 as the only eth capability.
+// This is used by the eth/71 (EIP-8159) test suite to force the peer to
+// negotiate eth/71 rather than falling back to an earlier eth version.
+func (s *Suite) dialEth71() (*Conn, error) {
+	conn, err := s.dial()
+	if err != nil {
+		return nil, fmt.Errorf("dial failed: %v", err)
+	}
+	conn.caps = []p2p.Cap{{Name: "eth", Version: eth.ETH71}}
+	conn.ourHighestProtoVersion = eth.ETH71
+	return conn, nil
+}
+
 // Conn represents an individual connection with a peer
 type Conn struct {
 	*rlpx.Conn

--- a/cmd/devp2p/internal/ethtest/eth71.go
+++ b/cmd/devp2p/internal/ethtest/eth71.go
@@ -1,0 +1,171 @@
+// Copyright 2026 The go-ethereum Authors
+// This file is part of go-ethereum.
+//
+// go-ethereum is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// go-ethereum is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with go-ethereum. If not, see <http://www.gnu.org/licenses/>.
+
+package ethtest
+
+import (
+	"fmt"
+	"math/rand"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/eth/protocols/eth"
+	"github.com/ethereum/go-ethereum/internal/utesting"
+)
+
+// Eth/71 (EIP-8159) adds BAL exchange to the eth protocol:
+// GetBlockAccessLists (0x12) / BlockAccessLists (0x13).
+//
+// The tests in this file focus on the wire behavior introduced in eth/71.
+// Tests for messages unchanged from earlier eth versions are covered by the
+// main eth suite.
+
+// TestEth71GetBlockAccessLists exercises GetBlockAccessLists requests defined
+// in EIP-8159. Per the spec:
+//
+//   - BlockAccessLists entries correspond to request hashes in order.
+//   - Unavailable BALs are returned as the RLP empty string (0x80) at the
+//     matching position.
+//   - The server may return fewer entries than requested when applying
+//     response-size or implementation-defined limits, truncating from the tail.
+//   - When a BAL is returned, its keccak256(rlp.encode(bal)) MUST match the
+//     block-access-list-hash field of the corresponding block header.
+func (s *Suite) TestEth71GetBlockAccessLists(t *utesting.T) {
+	var (
+		head     = s.chain.Head()
+		headHash = head.Hash()
+		preHash  = s.chain.blocks[s.chain.Len()-2].Hash()
+		unknown  = common.HexToHash("0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef")
+	)
+
+	// Collect a window of recent canonical block hashes. Limit to at most 16
+	// entries to keep the request small and well under any reasonable limit.
+	var recent []common.Hash
+	start := s.chain.Len() - 16
+	if start < 1 {
+		start = 1
+	}
+	for i := start; i < s.chain.Len(); i++ {
+		recent = append(recent, s.chain.blocks[i].Hash())
+	}
+
+	tests := []accessListsTest{
+		{
+			desc: `An empty request. The server must respond with an empty list and must
+not disconnect.`,
+			hashes:     nil,
+			minEntries: 0,
+			maxEntries: 0,
+		},
+		{
+			desc: `A request for a single random/unknown block hash. Per the spec the
+server must respond and include an RLP empty string (0x80) at that position.`,
+			hashes:     []common.Hash{unknown},
+			minEntries: 1,
+			maxEntries: 1,
+		},
+		{
+			desc: `A request for multiple random/unknown block hashes. The server must
+preserve request order and return an RLP empty string for each position.`,
+			hashes: []common.Hash{
+				unknown,
+				common.HexToHash("0x0000000000000000000000000000000000000000000000000000000000000001"),
+				common.HexToHash("0x0000000000000000000000000000000000000000000000000000000000000002"),
+			},
+			minEntries: 3,
+			maxEntries: 3,
+		},
+		{
+			desc: `A request for the chain head. The server must respond. If the node is
+post-Amsterdam and has the BAL for this block, the returned BAL must hash to
+the block-access-list-hash in the header. Otherwise an empty entry is valid.`,
+			hashes:     []common.Hash{headHash},
+			minEntries: 1,
+			maxEntries: 1,
+		},
+		{
+			desc: `A request for the chain head and its parent. The server must return
+exactly two entries, in request order.`,
+			hashes:     []common.Hash{headHash, preHash},
+			minEntries: 2,
+			maxEntries: 2,
+		},
+		{
+			desc: `A mixed request with known and unknown hashes. The server must
+return entries in request order, with the RLP empty string at positions
+corresponding to unknown hashes.`,
+			hashes: []common.Hash{headHash, unknown, preHash, unknown},
+			// We expect exactly 4 entries because the mixed response is small and
+			// well under the recommended 2 MiB soft limit.
+			minEntries: 4,
+			maxEntries: 4,
+		},
+		{
+			desc: `A request spanning the most recent canonical window. Implementations
+may return empty entries for unavailable BALs or truncate from the tail, but
+the entries that are returned must preserve request order.`,
+			hashes:     recent,
+			minEntries: 0,
+			maxEntries: len(recent),
+		},
+		{
+			desc: `A request containing the same hash repeated. The server must treat
+each position independently and preserve request order.`,
+			hashes:     []common.Hash{headHash, headHash, headHash},
+			minEntries: 3,
+			maxEntries: 3,
+		},
+	}
+
+	for i, tc := range tests {
+		if i > 0 {
+			t.Log("\n")
+		}
+		t.Logf("-- Test %d", i)
+		t.Log(tc.desc)
+		t.Log("  request:")
+		t.Logf("      hashes: %d", len(tc.hashes))
+		if err := s.eth71GetBlockAccessLists(t, &tc); err != nil {
+			t.Errorf("test %d failed: %v", i, err)
+		}
+	}
+}
+
+// eth71GetBlockAccessLists sends a GetBlockAccessLists request over eth/71 and
+// validates the response against EIP-8159, using the response validation
+// shared with the snap/2 suite.
+func (s *Suite) eth71GetBlockAccessLists(t *utesting.T, tc *accessListsTest) error {
+	conn, err := s.dialEth71()
+	if err != nil {
+		return fmt.Errorf("dial failed: %v", err)
+	}
+	defer conn.Close()
+	if err = conn.peer(s.chain, nil); err != nil {
+		return fmt.Errorf("peering failed: %v", err)
+	}
+
+	req := &eth.GetBlockAccessListsPacket{
+		RequestId:                  uint64(rand.Int63()),
+		GetBlockAccessListsRequest: tc.hashes,
+	}
+	if err := conn.Write(ethProto, eth.GetBlockAccessListsMsg, req); err != nil {
+		return fmt.Errorf("access list request failed: %v", err)
+	}
+	var res eth.BlockAccessListPacket
+	if err := conn.ReadMsg(ethProto, eth.BlockAccessListsMsg, &res); err != nil {
+		return fmt.Errorf("access list response failed: %v", err)
+	}
+	return s.validateAccessListsResponse(t, tc, req.RequestId, res.RequestId, res.List)
+}

--- a/cmd/devp2p/internal/ethtest/snap2.go
+++ b/cmd/devp2p/internal/ethtest/snap2.go
@@ -17,14 +17,10 @@
 package ethtest
 
 import (
-	"bytes"
 	"fmt"
 	"math/rand"
 
 	"github.com/ethereum/go-ethereum/common"
-	"github.com/ethereum/go-ethereum/core/types"
-	"github.com/ethereum/go-ethereum/core/types/bal"
-	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/eth/protocols/snap"
 	"github.com/ethereum/go-ethereum/internal/utesting"
 	"github.com/ethereum/go-ethereum/rlp"
@@ -291,85 +287,5 @@ func (s *Suite) snapGetAccessLists(t *utesting.T, tc *accessListsTest) error {
 	if !ok {
 		return fmt.Errorf("unexpected response type: %T", msg)
 	}
-	if res.ID != req.ID {
-		return fmt.Errorf("request id mismatch: got %d, want %d", res.ID, req.ID)
-	}
-
-	// Check list length bounds.
-	got := res.AccessLists.Len()
-	if got < tc.minEntries || got > tc.maxEntries {
-		return fmt.Errorf("response has %d entries, want between %d and %d", got, tc.minEntries, tc.maxEntries)
-	}
-
-	// Build a map of request-index -> block so we can verify BAL hashes.
-	blocks := make(map[int]*types.Block)
-	for i, h := range tc.hashes {
-		for _, b := range s.chain.blocks {
-			if b.Hash() == h {
-				blocks[i] = b
-				break
-			}
-		}
-	}
-
-	// Iterate the response, validating each entry positionally.
-	var (
-		idx int
-		it  = res.AccessLists.ContentIterator()
-	)
-	for it.Next() {
-		raw := it.Value()
-		block := blocks[idx]
-
-		// Empty entry: per spec, indicates BAL is unavailable for that block.
-		if bytes.Equal(raw, rlp.EmptyString) {
-			if block != nil && block.Header().BlockAccessListHash != nil {
-				// Not a failure — the server is allowed to legitimately not
-				// have the BAL. But we log it so the test output is diagnosable.
-				t.Logf("    entry %d: server returned empty for known post-Amsterdam block %x", idx, tc.hashes[idx])
-			}
-			idx++
-			continue
-		}
-
-		// Non-empty entry. A BAL is only legitimate for a block we know
-		// locally whose header commits to one; for any other hash the only
-		// valid response is the RLP empty string, so receiving data here
-		// means the server fabricated it.
-		if block == nil {
-			return fmt.Errorf("entry %d: server returned BAL data for unknown hash %x", idx, tc.hashes[idx])
-		}
-		if block.Header().BlockAccessListHash == nil {
-			return fmt.Errorf("entry %d: server returned BAL data for a block with no expected BAL (hash %x)", idx, tc.hashes[idx])
-		}
-
-		// Per EIP-8189: compute keccak256(rlp.encode(bal)) against the raw
-		// bytes actually received on the wire, and compare to the header
-		// commitment. Hashing raw bytes (rather than re-encoding after a
-		// decode round-trip) catches peers that send non-canonical BAL
-		// encodings.
-		have := crypto.Keccak256Hash(raw)
-		want := *block.Header().BlockAccessListHash
-		if have != want {
-			return fmt.Errorf("entry %d: BAL hash mismatch: have %x, want %x", idx, have, want)
-		}
-
-		// Decode and validate the BAL's internal structure: ordering of
-		// accounts/slots/changes, code-size limits, and per-entry access-index
-		// bounds, against the known block.
-		var accessList bal.BlockAccessList
-		if err := rlp.DecodeBytes(raw, &accessList); err != nil {
-			return fmt.Errorf("entry %d: invalid BAL RLP: %v", idx, err)
-		}
-		if err := accessList.Validate(block.GasLimit(), len(block.Transactions())); err != nil {
-			return fmt.Errorf("entry %d: BAL failed validation: %v", idx, err)
-		}
-		idx++
-	}
-
-	// Sanity: iterator consumed exactly the reported number of entries.
-	if idx != got {
-		return fmt.Errorf("iterator visited %d entries, expected %d", idx, got)
-	}
-	return nil
+	return s.validateAccessListsResponse(t, tc, req.ID, res.ID, res.AccessLists)
 }

--- a/cmd/devp2p/internal/ethtest/suite.go
+++ b/cmd/devp2p/internal/ethtest/suite.go
@@ -81,6 +81,8 @@ func (s *Suite) EthTests() []utesting.Test {
 		{Name: "SimultaneousRequests", Fn: s.TestSimultaneousRequests},
 		{Name: "SameRequestID", Fn: s.TestSameRequestID},
 		{Name: "ZeroRequestID", Fn: s.TestZeroRequestID},
+		// get block access lists (eth/71)
+		{Name: "GetBlockAccessLists", Fn: s.TestEth71GetBlockAccessLists},
 		// get history
 		{Name: "GetBlockBodies", Fn: s.TestGetBlockBodies},
 		{Name: "GetReceipts", Fn: s.TestGetReceipts},


### PR DESCRIPTION
Adds eth/71 wire conformance tests analogous to [this PR](https://github.com/jrhea/go-ethereum/pull/4).

Tested through hive via `hive --sim devp2p --sim.limit eth/TestEth71GetBlockAccessLists` against Besu (couple of months ago, opening PR only now because back then eth/71 was not yet on master).

Response validation is reused between snap/2 and eth/71.