### PR TITLE
eth/fetcher: count unique hashes in blob queueing metric

### DIFF
--- a/eth/fetcher/blob_fetcher.go
+++ b/eth/fetcher/blob_fetcher.go
@@ -666,13 +666,7 @@ func (f *BlobFetcher) loop() {
 		blobFetcherWaitingPeers.Update(int64(len(f.waitslots)))
 		blobFetcherWaitingHashes.Update(int64(len(f.waitlist)))
 		blobFetcherQueueingPeers.Update(int64(len(f.announces) - len(f.requests)))
-		queued := make(map[common.Hash]struct{})
-		for _, anns := range f.announces {
-			for hash := range anns {
-				queued[hash] = struct{}{}
-			}
-		}
-		blobFetcherQueueingHashes.Update(int64(len(queued)))
+		blobFetcherQueueingHashes.Update(int64(len(f.full) + len(f.partial) - len(f.fetches) - len(f.waitlist)))
 		blobFetcherFetchingPeers.Update(int64(len(f.requests)))
 		blobFetcherFetchingHashes.Update(int64(len(f.fetches)))
 

--- a/eth/fetcher/blob_fetcher.go
+++ b/eth/fetcher/blob_fetcher.go
@@ -666,7 +666,13 @@ func (f *BlobFetcher) loop() {
 		blobFetcherWaitingPeers.Update(int64(len(f.waitslots)))
 		blobFetcherWaitingHashes.Update(int64(len(f.waitlist)))
 		blobFetcherQueueingPeers.Update(int64(len(f.announces) - len(f.requests)))
-		blobFetcherQueueingHashes.Update(int64(len(f.announces)))
+		queued := make(map[common.Hash]struct{})
+		for _, anns := range f.announces {
+			for hash := range anns {
+				queued[hash] = struct{}{}
+			}
+		}
+		blobFetcherQueueingHashes.Update(int64(len(queued)))
 		blobFetcherFetchingPeers.Update(int64(len(f.requests)))
 		blobFetcherFetchingHashes.Update(int64(len(f.fetches)))
 


### PR DESCRIPTION
blobFetcherQueueingHashes used len(announces), which is the number of peers with pending announces, not the number of queued hashes. Count unique hashes across peers instead.