### PR TITLE
internal/ethapi: reject missing "to" for blob/setcode calls in CallDefaults

### DIFF
--- a/internal/ethapi/transaction_args.go
+++ b/internal/ethapi/transaction_args.go
@@ -138,7 +138,7 @@ func (args *TransactionArgs) setDefaults(ctx context.Context, b Backend, config 
 		if len(args.data()) == 0 {
 			return errors.New(`contract creation without any data provided`)
 		}
-		if len(args.AuthorizationList) > 0 {
+		if args.AuthorizationList != nil {
 			return errors.New(`authorizationList provided for contract creation, but "to" field is missing`)
 		}
 	}
@@ -444,6 +444,18 @@ func (args *TransactionArgs) CallDefaults(globalGasCap uint64, baseFee *big.Int,
 	}
 	if args.BlobFeeCap == nil && args.BlobHashes != nil {
 		args.BlobFeeCap = new(hexutil.Big)
+	}
+	// create check: neither blob transactions nor setcode transactions can
+	// be contract creations, reject them here instead of panicking when the
+	// arguments are converted into a transaction (e.g. by eth_simulateV1 or
+	// debug_traceCall). The errors mirror the state transition checks.
+	if args.To == nil {
+		if args.BlobHashes != nil {
+			return core.ErrBlobTxCreate
+		}
+		if args.AuthorizationList != nil {
+			return core.ErrSetCodeTxCreate
+		}
 	}
 
 	return nil

--- a/internal/ethapi/transaction_args_test.go
+++ b/internal/ethapi/transaction_args_test.go
@@ -264,6 +264,63 @@ func TestSetFeeDefaults(t *testing.T) {
 	}
 }
 
+// TestCallDefaultsSetCode checks that CallDefaults rejects argument combinations
+// that cannot be converted into a valid transaction, instead of letting
+// ToTransaction panic on them (e.g. via eth_simulateV1 or debug_traceCall).
+func TestCallDefaultsSetCode(t *testing.T) {
+	t.Parallel()
+
+	var (
+		to       = common.Address{0xaa}
+		authList = []types.SetCodeAuthorization{{Address: common.Address{0xbb}}}
+	)
+	tests := []struct {
+		name    string
+		args    *TransactionArgs
+		wantErr error
+	}{
+		{
+			name:    "authorization list without to",
+			args:    &TransactionArgs{AuthorizationList: authList},
+			wantErr: core.ErrSetCodeTxCreate,
+		},
+		{
+			name:    "empty authorization list without to",
+			args:    &TransactionArgs{AuthorizationList: []types.SetCodeAuthorization{}},
+			wantErr: core.ErrSetCodeTxCreate,
+		},
+		{
+			name:    "blob hashes without to",
+			args:    &TransactionArgs{BlobHashes: []common.Hash{{0x01}}},
+			wantErr: core.ErrBlobTxCreate,
+		},
+		{
+			name: "authorization list with to",
+			args: &TransactionArgs{To: &to, AuthorizationList: authList},
+		},
+		{
+			name: "contract creation",
+			args: &TransactionArgs{Data: &hexutil.Bytes{0x60}},
+		},
+	}
+	for _, test := range tests {
+		err := test.args.CallDefaults(50_000_000, big.NewInt(1), big.NewInt(1))
+		if test.wantErr != nil {
+			if !errors.Is(err, test.wantErr) {
+				t.Fatalf("test %s: expected error %q, got %v", test.name, test.wantErr, err)
+			}
+			continue
+		}
+		if err != nil {
+			t.Fatalf("test %s: unexpected error: %v", test.name, err)
+		}
+		// The conversion to a transaction must not panic on sanitized arguments
+		if tx := test.args.ToTransaction(types.DynamicFeeTxType); tx == nil {
+			t.Fatalf("test %s: failed to convert to transaction", test.name)
+		}
+	}
+}
+
 type backendMock struct {
 	current *types.Header
 	config  *params.ChainConfig


### PR DESCRIPTION
## Summary

- Reject blob and set-code call arguments with a missing `to` field in `CallDefaults` before conversion, returning `core.ErrBlobTxCreate` / `core.ErrSetCodeTxCreate` instead of panicking in `ToTransaction`
- Treat an explicitly empty `authorizationList` the same as a non-empty one in `setDefaults` so the send path cannot panic either
- Add regression coverage for the `eth_simulateV1` / `debug_traceCall` path through `CallDefaults`

## Motivation

`setDefaults` already rejects set-code contract creation for `eth_sendTransaction` and related RPCs. The call/trace/simulate family uses `CallDefaults`, which did not perform that check. When `authorizationList` or `blobVersionedHashes` is present and `to` is nil, `ToTransaction` selects `SetCodeTx` / `BlobTx` and dereferences `args.To`, panicking.

## Test plan

- [x] `go test ./internal/ethapi/ -count=1`
- [x] `go test ./eth/tracers/ -count=1 -short`