### PR TITLE
eth/fetcher: clear partial map when dropping last waitlist peer

### DIFF
--- a/eth/fetcher/blob_fetcher.go
+++ b/eth/fetcher/blob_fetcher.go
@@ -615,6 +615,7 @@ func (f *BlobFetcher) loop() {
 					if len(f.waitlist[hash]) == 0 {
 						delete(f.waitlist, hash)
 						delete(f.waittime, hash)
+						delete(f.partial, hash)
 					}
 				}
 				delete(f.waitslots, drop.peer)


### PR DESCRIPTION
When a peer drop removes the last waiter for a hash, waitlist and waittime were cleaned up but partial could retain a stale entry. Delete it too so the hash is fully forgotten.