### PR TITLE
core/state: batch storage and account trie updates

### DIFF
--- a/core/state/state_object.go
+++ b/core/state/state_object.go
@@ -344,9 +344,14 @@ func (s *stateObject) updateTrie() (Trie, error) {
 	// If the deletion is handled first, then `P` would be left with only one child, thus collapsed
 	// into a shortnode. This requires `B` to be resolved from disk.
 	// Whereas if the created node is handled first, then the collapse is avoided, and `B` is not resolved.
+	// The updates are applied as one batch, which shards them across the storage
+	// trie's root children and applies each group concurrently. Deletions follow
+	// per key, preserving the updates-before-deletions order above.
 	var (
-		deletions []common.Hash
-		used      = make([]common.Hash, 0, len(s.uncommittedStorage))
+		updateKeys [][]byte // slot keys with a new non-zero value
+		updateVals [][]byte // the trimmed values, aligned to updateKeys
+		deletions  []common.Hash
+		used       = make([]common.Hash, 0, len(s.uncommittedStorage))
 	)
 	for key, origin := range s.uncommittedStorage {
 		// Skip noop changes, persist actual changes
@@ -360,16 +365,18 @@ func (s *stateObject) updateTrie() (Trie, error) {
 			continue
 		}
 		if (value != common.Hash{}) {
-			if err := tr.UpdateStorage(s.address, key[:], common.TrimLeftZeroes(value[:])); err != nil {
-				s.db.setError(err)
-				return nil, err
-			}
+			updateKeys = append(updateKeys, key.Bytes())
+			updateVals = append(updateVals, common.TrimLeftZeroes(value[:]))
 			s.db.StorageUpdated.Add(1)
 		} else {
 			deletions = append(deletions, key)
 		}
 		// Cache the items for preloading
 		used = append(used, key) // Copy needed for closure
+	}
+	if err := tr.UpdateStorageBatch(s.address, updateKeys, updateVals); err != nil {
+		s.db.setError(err)
+		return nil, err
 	}
 	for _, key := range deletions {
 		if err := tr.DeleteStorage(s.address, key[:]); err != nil {

--- a/core/state/statedb.go
+++ b/core/state/statedb.go
@@ -571,17 +571,6 @@ func (s *StateDB) GetTransientState(addr common.Address, key common.Hash) common
 // Setting, updating & deleting state object methods.
 //
 
-// updateStateObject writes the given object to the trie.
-func (s *StateDB) updateStateObject(obj *stateObject) {
-	// Encode the account and update the account trie
-	if err := s.trie.UpdateAccount(obj.Address(), &obj.data, len(obj.code)); err != nil {
-		s.setError(fmt.Errorf("updateStateObject (%x) error: %v", obj.Address(), err))
-	}
-	if obj.dirtyCode {
-		s.trie.UpdateContractCode(obj.Address(), common.BytesToHash(obj.CodeHash()), obj.code)
-	}
-}
-
 // deleteStateObject removes the given object from the state trie.
 func (s *StateDB) deleteStateObject(addr common.Address) {
 	if err := s.trie.DeleteAccount(addr); err != nil {
@@ -1074,6 +1063,9 @@ func (s *StateDB) IntermediateRoot(deleteEmptyObjects bool) common.Hash {
 	var (
 		usedAddrs    []common.Address
 		deletedAddrs []common.Address
+		updateAddrs  []common.Address
+		updateAccts  []*types.StateAccount
+		updateCodes  []int
 	)
 	for addr, op := range s.mutations {
 		if op.applied {
@@ -1085,16 +1077,26 @@ func (s *StateDB) IntermediateRoot(deleteEmptyObjects bool) common.Hash {
 			deletedAddrs = append(deletedAddrs, addr)
 		} else {
 			obj := s.stateObjects[addr]
-			s.updateStateObject(obj)
+			updateAddrs = append(updateAddrs, obj.Address())
+			updateAccts = append(updateAccts, &obj.data)
+			updateCodes = append(updateCodes, len(obj.code))
 			s.AccountUpdated += 1
 
 			// Count code writes post-Finalise so reverted CREATEs are excluded.
 			if obj.dirtyCode {
+				s.trie.UpdateContractCode(obj.Address(), common.BytesToHash(obj.CodeHash()), obj.code)
 				s.CodeUpdated += 1
 				s.CodeUpdateBytes += len(obj.code)
 			}
 		}
 		usedAddrs = append(usedAddrs, addr) // Copy needed for closure
+	}
+	// Apply the gathered updates as one batch. UpdateAccountBatch shards them across
+	// the root children and applies each group concurrently.
+	if len(updateAddrs) > 0 {
+		if err := s.trie.UpdateAccountBatch(updateAddrs, updateAccts, updateCodes); err != nil {
+			s.setError(fmt.Errorf("updateStateObjects error: %v", err))
+		}
 	}
 	for _, deletedAddr := range deletedAddrs {
 		s.deleteStateObject(deletedAddr)


### PR DESCRIPTION
Each mutated account's storage trie is updated in its own worker goroutine, but the slots within an account go one at a time. A block that piles thousands of SSTOREs into a single contract (XEN/CoinTool batch minting) serializes that whole trie on one goroutine. This PR utilizes trie.UpdateBatch from PR #32448 which shards a batch by leading nibble and applies the groups to separate root children concurrently. It also batches the account-trie updates in IntermediateRoot via UpdateAccountBatch.