### PR TITLE
p2p/enode: close FairMix source iterators when runSource exits

### DIFF
--- a/p2p/enode/iter.go
+++ b/p2p/enode/iter.go
@@ -477,6 +477,7 @@ func (m *FairMix) deleteSource(s *mixSource) {
 func (m *FairMix) runSource(closed chan struct{}, s *mixSource) {
 	defer m.wg.Done()
 	defer close(s.next)
+	defer s.it.Close()
 	for s.it.Next() {
 		item := iteratorItem{s.it.Node(), s.it.NodeSource()}
 		select {


### PR DESCRIPTION
## Summary

- Close each FairMix source iterator when its `runSource` goroutine exits.
- Prevents iterators that finish before `FairMix.Close` from leaking until mixer shutdown.

## Test plan

- [x] `go test -short ./p2p/enode/`