### PR TITLE
eth/protocols/eth: trim knownCache after adding hashes

### DIFF
--- a/eth/protocols/eth/peer.go
+++ b/eth/protocols/eth/peer.go
@@ -688,11 +688,11 @@ func newKnownCache(max int) *knownCache {
 
 // Add adds a list of elements to the set.
 func (k *knownCache) Add(hashes ...common.Hash) {
-	for k.hashes.Cardinality() > max(0, k.max-len(hashes)) {
-		k.hashes.Pop()
-	}
 	for _, hash := range hashes {
 		k.hashes.Add(hash)
+	}
+	for k.hashes.Cardinality() > k.max {
+		k.hashes.Pop()
 	}
 }
 


### PR DESCRIPTION
Pre-evicting based on len(hashes) could drop more entries than needed when some hashes were already present. Add first, then Pop until the cache is within max.