### PR TITLE
node: pass HTTPBodyLimit when starting HTTP via admin API

### DIFF
--- a/node/api.go
+++ b/node/api.go
@@ -181,6 +181,7 @@ func (api *adminAPI) StartHTTP(host *string, port *int, cors *string, apis *stri
 		rpcEndpointConfig: rpcEndpointConfig{
 			batchItemLimit:         api.node.config.BatchRequestLimit,
 			batchResponseSizeLimit: api.node.config.BatchResponseMaxSize,
+			httpBodyLimit:          api.node.config.HTTPBodyLimit,
 		},
 	}
 	if cors != nil {


### PR DESCRIPTION
admin_startHTTP configured batch limits but omitted HTTPBodyLimit, so dynamically started HTTP servers ignored the configured body size cap. Propagate the node config value like the normal HTTP startup path.