### PR TITLE
core/txpool/blobpool: skip cells-first counter on completed txs

### DIFF
--- a/core/txpool/blobpool/buffer.go
+++ b/core/txpool/blobpool/buffer.go
@@ -163,6 +163,7 @@ func (b *BlobBuffer) AddCells(hash common.Hash, deliveries map[string]*PeerDeliv
 	}
 	if txe, ok := b.txs[hash]; ok {
 		b.storeCompleted(hash, txe.tx, b.cells[hash])
+		return
 	}
 	blobBufferCellsFirstCounter.Inc(1)
 }


### PR DESCRIPTION
AddCells incremented blobBufferCellsFirstCounter even when the tx was already buffered and storeCompleted ran. Return after that path so the counter only tracks first cell arrivals without a matching tx.