### PR TITLE
triedb/pathdb: shrink slice capacity when popping history index entries

### DIFF
--- a/triedb/pathdb/history_index_block.go
+++ b/triedb/pathdb/history_index_block.go
@@ -446,7 +446,7 @@ func (b *blockWriter) pop(id uint64) error {
 		return fmt.Errorf("pop element is not found, last: %d, this: %d", b.desc.max, id)
 	}
 	b.desc.max = prev
-	b.data = b.data[:pos]
+	b.data = b.data[:pos:pos]
 	b.desc.entries -= 1
 	return b.rebuildBitmap()
 }


### PR DESCRIPTION
Reslice with an explicit capacity when removing the last element so unused capacity is not retained after pop.