### PR TITLE
metrics: clone gauge info maps on update and snapshot

### DIFF
--- a/metrics/gauge_info.go
+++ b/metrics/gauge_info.go
@@ -2,6 +2,7 @@ package metrics
 
 import (
 	"encoding/json"
+	"maps"
 	"sync"
 )
 
@@ -53,12 +54,12 @@ type GaugeInfo struct {
 
 // Snapshot returns a read-only copy of the gauge.
 func (g *GaugeInfo) Snapshot() GaugeInfoSnapshot {
-	return GaugeInfoSnapshot(g.value)
+	return GaugeInfoSnapshot(maps.Clone(g.value))
 }
 
 // Update updates the gauge's value.
 func (g *GaugeInfo) Update(v GaugeInfoValue) {
 	g.mutex.Lock()
 	defer g.mutex.Unlock()
-	g.value = v
+	g.value = maps.Clone(v)
 }


### PR DESCRIPTION
Copy the map on Update and Snapshot so callers cannot mutate the gauge's internal state through a shared reference.