### PR TITLE
internal/flags: allow wrapping at exact line width

### DIFF
--- a/internal/flags/helpers.go
+++ b/internal/flags/helpers.go
@@ -192,7 +192,7 @@ func wordWrap(s string, width int) string {
 			word = s[:sp]
 		}
 		wlen := len(word)
-		over := lineLength+wlen >= width
+		over := lineLength+wlen > width
 		if over {
 			output.WriteByte('\n')
 			lineLength = 0


### PR DESCRIPTION
Use a strict greater-than check so a word that fills the remaining line width is kept on the current line instead of wrapping early.