### PR TITLE
core/rawdb: reject Reset on read-only memory freezer

### DIFF
--- a/core/rawdb/freezer_memory.go
+++ b/core/rawdb/freezer_memory.go
@@ -447,6 +447,10 @@ func (f *MemoryFreezer) Reset() error {
 	f.lock.Lock()
 	defer f.lock.Unlock()
 
+	if f.readonly {
+		return errReadOnly
+	}
+
 	tables := make(map[string]*memoryTable)
 	tails := make(map[string]uint64)
 	for name, table := range f.tables {


### PR DESCRIPTION
Return errReadOnly from MemoryFreezer.Reset when the freezer is opened in read-only mode, matching other mutating methods.