### PR TITLE
eth/fetcher: stop availability timer when blob waitlist drains

### DIFF
--- a/eth/fetcher/blob_fetcher.go
+++ b/eth/fetcher/blob_fetcher.go
@@ -287,9 +287,10 @@ func (f *BlobFetcher) loop() {
 			}
 
 			var (
-				idleWait   = len(f.waittime) == 0
-				_, oldPeer = f.announces[ann.origin]
-				nextSeq    = func() uint64 {
+				idleWait     = len(f.waittime) == 0
+				waitPromoted = false // Whether a transaction left the waitlist
+				_, oldPeer   = f.announces[ann.origin]
+				nextSeq      = func() uint64 {
 					seq := f.txSeq
 					f.txSeq++
 					return seq
@@ -378,6 +379,7 @@ func (f *BlobFetcher) loop() {
 							}
 							delete(f.waitlist, hash)
 							delete(f.waittime, hash)
+							waitPromoted = true
 						}
 						continue
 					}
@@ -397,8 +399,12 @@ func (f *BlobFetcher) loop() {
 				}
 			}
 
-			// If a new item was added to the waitlist, schedule its timeout
-			if idleWait && len(f.waittime) > 0 {
+			// Reschedule the availability timer if the waitlist membership
+			// changed in a way that can move its earliest deadline: a new item
+			// added to an idle waitlist, or an item promoted out of it. Items
+			// appended to a non-empty waitlist are always the latest, so they
+			// cannot advance the deadline.
+			if (idleWait && len(f.waittime) > 0) || waitPromoted {
 				f.rescheduleWait(waitTimer, waitTrigger)
 			}
 
@@ -443,10 +449,9 @@ func (f *BlobFetcher) loop() {
 			if len(reschedule) > 0 {
 				f.scheduleFetches(timeoutTimer, timeoutTrigger, reschedule)
 			}
-			// If transactions are still waiting for availability, reschedule the wait timer
-			if len(f.waittime) > 0 {
-				f.rescheduleWait(waitTimer, waitTrigger)
-			}
+			// Reschedule the wait timer for the transactions still waiting
+			// for availability, or disarm it if none are left.
+			f.rescheduleWait(waitTimer, waitTrigger)
 
 		case <-timeoutTrigger:
 			// Clean up any expired retrievals and avoid re-requesting them from the
@@ -619,9 +624,7 @@ func (f *BlobFetcher) loop() {
 					}
 				}
 				delete(f.waitslots, drop.peer)
-				if len(f.waitlist) > 0 {
-					f.rescheduleWait(waitTimer, waitTrigger)
-				}
+				f.rescheduleWait(waitTimer, waitTrigger)
 			}
 			// Clean up general announcement tracking
 			if _, ok := f.announces[drop.peer]; ok {
@@ -678,9 +681,16 @@ func (f *BlobFetcher) loop() {
 	}
 }
 
+// rescheduleWait arms the availability timer for the earliest transaction in
+// the waitlist. If the waitlist is empty, the timer is left disarmed instead
+// of being re-armed on a stale deadline.
 func (f *BlobFetcher) rescheduleWait(timer *mclock.Timer, trigger chan struct{}) {
 	if *timer != nil {
 		(*timer).Stop()
+		*timer = nil
+	}
+	if len(f.waittime) == 0 {
+		return
 	}
 	now := f.clock.Now()
 
@@ -698,7 +708,12 @@ func (f *BlobFetcher) rescheduleWait(timer *mclock.Timer, trigger chan struct{})
 	})
 }
 
-// Exactly same as the one in TxFetcher
+// rescheduleTimeout arms the fetch timeout timer for the earliest request in
+// flight. Like its TxFetcher counterpart, the timer is deliberately kept armed
+// even when no request is in flight: every fire runs scheduleFetches, which is
+// what retries announces that could not be dispatched earlier (e.g. because
+// the peer's cell request tokens were exhausted). Disarming on an idle fetcher
+// would leave such announces stranded until an unrelated event.
 func (f *BlobFetcher) rescheduleTimeout(timer *mclock.Timer, trigger chan struct{}) {
 	if *timer != nil {
 		(*timer).Stop()

--- a/eth/fetcher/blob_fetcher_test.go
+++ b/eth/fetcher/blob_fetcher_test.go
@@ -19,6 +19,7 @@ package fetcher
 import (
 	"slices"
 	"testing"
+	"time"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/mclock"
@@ -505,8 +506,10 @@ func TestBlobFetcherPartialDelivery(t *testing.T) {
 					},
 				},
 			},
-			// Delivery from E -> complete
-			doWait{time: blobFetchTimeout / 2, step: true},
+			// Delivery from E -> complete. No timer is due within this window
+			// (the availability timer was disarmed when the waitlist drained),
+			// so only advance the clock without expecting a loop iteration.
+			doWait{time: blobFetchTimeout / 2, step: false},
 			doBlobEnqueue{
 				peer:    "E",
 				hashes:  []common.Hash{testBlobTxHashes[0]},
@@ -776,6 +779,106 @@ func TestBlobFetcherFetchTimeout(t *testing.T) {
 			isBlobScheduled{announces: nil, fetching: nil},
 			isFetching{hashes: nil},
 		},
+	})
+}
+
+// TestBlobFetcherAvailabilityTimerLifecycle tests that the availability timer
+// tracks the waitlist: it is disarmed when the waitlist drains, whether by
+// promotion to the fetching stage or by dropping the last waiting peer, and
+// re-armed on the next deadline when a transaction is promoted while others
+// keep waiting. A stale timer would fire on deadlines that no longer exist,
+// causing spurious loop iterations.
+func TestBlobFetcherAvailabilityTimerLifecycle(t *testing.T) {
+	newFetcher := func() (*BlobFetcher, *mclock.Simulated, chan struct{}) {
+		clock := new(mclock.Simulated)
+		wait := make(chan struct{})
+		fetcher := NewBlobFetcher(
+			BlobFetcherFunctions{
+				HasPayload: func(common.Hash) bool { return false },
+				AddCells:   func(common.Hash, map[string]*PeerCellDelivery, types.CustodyBitmap) {},
+				FetchPayloads: func(string, []common.Hash, types.CustodyBitmap) error {
+					return nil
+				},
+				DropPeer: func(string) {},
+			},
+			custody,
+			&mockRand{value: 60}, // Force partial requests (60 >= fetchProbability)
+			15,
+		)
+		fetcher.clock = clock
+		fetcher.step = wait
+		fetcher.Start()
+		return fetcher, clock, wait
+	}
+	t.Run("promotion", func(t *testing.T) {
+		fetcher, clock, wait := newFetcher()
+		defer fetcher.Stop()
+
+		// The first full-custody announce puts the transaction on the
+		// waitlist and arms the availability timer.
+		fetcher.Notify("A", []common.Hash{testBlobTxHashes[0]}, fullCustody)
+		<-wait
+		if n := clock.ActiveTimers(); n != 1 {
+			t.Fatalf("waiting transaction: %d active timers, want 1 (availability)", n)
+		}
+		// The second announce reaches the availability threshold and promotes
+		// the transaction to the fetching stage. The availability timer must
+		// be disarmed, leaving only the fetch timeout timer.
+		fetcher.Notify("B", []common.Hash{testBlobTxHashes[0]}, fullCustody)
+		<-wait
+		if n := clock.ActiveTimers(); n != 1 {
+			t.Fatalf("drained waitlist: %d active timers, want 1 (fetch timeout)", n)
+		}
+	})
+	t.Run("drop", func(t *testing.T) {
+		fetcher, clock, wait := newFetcher()
+		defer fetcher.Stop()
+
+		fetcher.Notify("A", []common.Hash{testBlobTxHashes[0]}, fullCustody)
+		<-wait
+		if n := clock.ActiveTimers(); n != 1 {
+			t.Fatalf("waiting transaction: %d active timers, want 1 (availability)", n)
+		}
+		// Dropping the only waiting peer drains the waitlist. The availability
+		// timer must be disarmed with it.
+		fetcher.Drop("A")
+		<-wait
+		if n := clock.ActiveTimers(); n != 0 {
+			t.Fatalf("drained waitlist: %d active timers, want 0", n)
+		}
+	})
+	t.Run("partial promotion", func(t *testing.T) {
+		fetcher, clock, wait := newFetcher()
+		defer fetcher.Stop()
+
+		// Two transactions enter the waitlist one second apart, so the timer
+		// is armed on the first one's deadline.
+		fetcher.Notify("A", []common.Hash{testBlobTxHashes[0]}, fullCustody)
+		<-wait
+		clock.Run(time.Second)
+		fetcher.Notify("A", []common.Hash{testBlobTxHashes[1]}, fullCustody)
+		<-wait
+
+		// Promote the first transaction only. The second one is not due until
+		// a second later, so the timer must be re-armed on its deadline rather
+		// than left on the promoted transaction's.
+		fetcher.Notify("B", []common.Hash{testBlobTxHashes[0]}, fullCustody)
+		<-wait
+		clock.Run(blobAvailabilityTimeout - time.Second + txGatherSlack)
+		select {
+		case <-wait:
+			t.Fatal("loop woke up on the promoted transaction's stale deadline")
+		case <-time.After(100 * time.Millisecond):
+		}
+		// The timer must have been re-armed on the second transaction's
+		// deadline: advancing past it must wake the loop to convert the
+		// timed-out partial fetch to a full one.
+		clock.Run(time.Second)
+		select {
+		case <-wait:
+		case <-time.After(time.Second):
+			t.Fatal("availability timer was not re-armed on the waiting transaction")
+		}
 	})
 }
 


### PR DESCRIPTION
TestBlobFetcherPartialDelivery is flaky on master: 8/500 failures without
-race, one run in three with -race.

Nothing disarms the availability timer when the waitlist drains, either by
promotion to the fetching stage or by dropping the last waiting peer, and
nothing re-arms it when a transaction is promoted while later ones keep
waiting. The stale timer then fires on a deadline that no longer exists: a
no-op wakeup in production, but the extra loop iteration desynchronizes the
step notifier the tests rely on, so the test reads fetcher state while the
loop is still writing it.

rescheduleWait now owns the timer lifecycle and disarms it when the waitlist
is empty, and the notify path reschedules whenever waitlist membership changes
in a way that can move the earliest deadline. The fetch timeout timer is left
alone: its periodic fire doubles as the retry tick that re-runs scheduleFetches
for announces that could not be dispatched earlier, so it is intentionally
always armed and only its comment changed to record that.

TestBlobFetcherAvailabilityTimerLifecycle counts active timers on the simulated
clock and fails on master for all three paths. One doWait in
TestBlobFetcherPartialDelivery relied on the stale timer for a loop iteration
and drops its step expectation.

After: 500/500 without -race, 50/50 with -race, package green under -race
-count=10. TxFetcher arms its wait timer the same way, left untouched to keep
this change contained.
