### PR TITLE
miner: don't seal block if a db error occurred

### DIFF
--- a/miner/worker.go
+++ b/miner/worker.go
@@ -235,9 +235,7 @@ func (miner *Miner) generateWork(ctx context.Context, genParam *generateParams, 
 	// weird flush or a trie node missing, we need to bail out and not create a block.
 	if dbErr := work.state.Error(); dbErr != nil {
 		return &newPayloadResult{err: fmt.Errorf("%w: %v", errStateReadFailure, dbErr)}
-
 	}
-
 	return &newPayloadResult{
 		block:    block,
 		fees:     totalFees(block, work.receipts),

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -45,6 +45,7 @@ var (
 	errBlockInterruptedByNewHead  = errors.New("new head arrived while building block")
 	errBlockInterruptedByRecommit = errors.New("recommit interrupt while building block")
 	errBlockInterruptedByTimeout  = errors.New("timeout while building block")
+	errStateReadFailure           = errors.New("state read failed while building block")
 )
 
 // maxBlobsPerBlock returns the maximum number of blobs per block.
@@ -229,6 +230,13 @@ func (miner *Miner) generateWork(ctx context.Context, genParam *generateParams, 
 	_, _, assembleSpanEnd := telemetry.StartSpan(ctx, "miner.AssembleBlock")
 	block := core.AssembleBlock(miner.chain, work.header, work.state, &body, work.receipts, work.bal)
 	assembleSpanEnd(nil)
+
+	// Check for db errors. If anything happened during the mining or IntermediateRoot, such as a
+	// weird flush or a trie node missing, we need to bail out and not create a block.
+	if dbErr := work.state.Error(); dbErr != nil {
+		return &newPayloadResult{err: fmt.Errorf("%w: %v", errStateReadFailure, dbErr)}
+
+	}
 
 	return &newPayloadResult{
 		block:    block,


### PR DESCRIPTION
A corrupted node should not create a bad block, but rather error out