### PR TITLE
eth/protocols: fix Cells/GetCells RLP encoding

### DIFF
--- a/eth/protocols/eth/handlers.go
+++ b/eth/protocols/eth/handlers.go
@@ -694,7 +694,7 @@ func handleGetCells(backend Backend, msg Decoder, peer *Peer) error {
 	if err := msg.Decode(&query); err != nil {
 		return err
 	}
-	hashes, cells, custody := answerGetCells(backend, query.GetCellsRequest)
+	hashes, cells, custody := answerGetCells(backend, GetCellsRequest{Hashes: query.Hashes, Mask: query.Mask})
 	return peer.ReplyCells(query.RequestId, hashes, cells, custody)
 }
 
@@ -754,12 +754,16 @@ func handleCells(backend Backend, msg Decoder, peer *Peer) error {
 	tresp := tracker.Response{
 		ID:      cellsResponse.RequestId,
 		MsgCode: CellsMsg,
-		Size:    cellsResponse.CellsResponse.Cells.Len(),
+		Size:    cellsResponse.Cells.Len(),
 	}
 	if err := peer.tracker.Fulfil(tresp); err != nil {
 		return fmt.Errorf("Cells: %w", err)
 	}
-	return backend.Handle(peer, &cellsResponse.CellsResponse)
+	return backend.Handle(peer, &CellsResponse{
+		Hashes: cellsResponse.Hashes,
+		Cells:  cellsResponse.Cells,
+		Mask:   cellsResponse.Mask,
+	})
 }
 
 // handleGetBlockAccessLists serves a GetBlockAccessLists request.

--- a/eth/protocols/eth/peer.go
+++ b/eth/protocols/eth/peer.go
@@ -267,11 +267,9 @@ func (p *Peer) ReplyCells(id uint64, hashes []common.Hash, cells [][]kzg4844.Cel
 	}
 	return p2p.Send(p.rw, CellsMsg, &CellsPacket{
 		RequestId: id,
-		CellsResponse: CellsResponse{
-			Hashes: hashes,
-			Cells:  rawCells,
-			Mask:   mask,
-		},
+		Hashes:    hashes,
+		Cells:     rawCells,
+		Mask:      mask,
 	})
 }
 
@@ -291,10 +289,8 @@ func (p *Peer) RequestPayload(hashes []common.Hash, cell types.CustodyBitmap) er
 	}
 	return p2p.Send(p.rw, GetCellsMsg, &GetCellsRequestPacket{
 		RequestId: id,
-		GetCellsRequest: GetCellsRequest{
-			Hashes: hashes,
-			Mask:   cell,
-		},
+		Hashes:    hashes,
+		Mask:      cell,
 	})
 }
 

--- a/eth/protocols/eth/protocol.go
+++ b/eth/protocols/eth/protocol.go
@@ -314,7 +314,8 @@ type GetCellsRequest struct {
 // GetCellsRequestPacket represents a cell request with request ID wrapping.
 type GetCellsRequestPacket struct {
 	RequestId uint64
-	GetCellsRequest
+	Hashes    []common.Hash
+	Mask      types.CustodyBitmap
 }
 
 // CellsResponse represents a response containing cells for blob transactions.
@@ -327,7 +328,9 @@ type CellsResponse struct {
 // CellsPacket represents a cells response with request ID wrapping.
 type CellsPacket struct {
 	RequestId uint64
-	CellsResponse
+	Hashes    []common.Hash
+	Cells     rlp.RawList[rlp.RawList[kzg4844.Cell]]
+	Mask      types.CustodyBitmap
 }
 
 type GetBlockAccessListsRequest []common.Hash


### PR DESCRIPTION
This PR aligns the `Cells` and `GetCells` message implementations with the
spec: https://github.com/ethereum/devp2p/blob/master/caps/eth.md#getcells-0x14

Previously, `GetCellsPacket` and `CellsPacket` embedded `GetCellsRequest` and
`CellsResponse`. This caused them to be encoded as nested lists, which does not 
match the wire format defined by the spec. This PR inlines their fields to flatten 
the RLP layout of `Cells` and `GetCells`.