### PR TITLE
core/txpool/blobpool: lock lookup when logging corrupt tx blobs

### DIFF
--- a/core/txpool/blobpool/blobpool.go
+++ b/core/txpool/blobpool/blobpool.go
@@ -1740,7 +1740,9 @@ func (p *BlobPool) Get(hash common.Hash) *types.Transaction {
 	}
 	var ptx BlobTxForPool
 	if err := rlp.DecodeBytes(data, &ptx); err != nil {
+		p.lock.RLock()
 		id, _ := p.lookup.storeidOfTx(hash)
+		p.lock.RUnlock()
 		log.Error("Blobs corrupted for traced transaction", "hash", hash, "id", id, "err", err)
 		return nil
 	}


### PR DESCRIPTION
## Description
In `Get`, hold the pool read lock around `storeidOfTx` on the RLP decode error path so the lookup is not accessed without synchronization when logging corrupted blob data.

## Test plan
- [ ] `go test ./core/txpool/blobpool/ -count=1`