### PR TITLE
cmd/evm: set Random from genesis mixhash in runCmd

### DIFF
--- a/cmd/evm/runner.go
+++ b/cmd/evm/runner.go
@@ -280,6 +280,7 @@ func runCmd(ctx *cli.Context) error {
 		GasPrice:    flags.GlobalBig(ctx, PriceFlag.Name),
 		Value:       flags.GlobalBig(ctx, ValueFlag.Name),
 		Difficulty:  genesisConfig.Difficulty,
+		Random:      &genesisConfig.Mixhash,
 		Time:        genesisConfig.Timestamp,
 		Coinbase:    genesisConfig.Coinbase,
 		BlockNumber: new(big.Int).SetUint64(genesisConfig.Number),


### PR DESCRIPTION
Populate BlockContext.Random with the genesis Mixhash so PREVRANDAO and post-merge opcodes see a consistent randomness value during evm run.