### PR TITLE
core/txpool/blobpool: fall back to pool for cell-less cache entries

### DIFF
--- a/core/txpool/blobpool/cache.go
+++ b/core/txpool/blobpool/cache.go
@@ -265,7 +265,7 @@ func (c *Cache) GetCells(vhashes []common.Hash, mask types.CustodyBitmap) ([][]*
 	c.mu.Lock()
 	for vhash, idxs := range indices {
 		cached, ok := c.entries[vhash]
-		if !ok {
+		if !ok || cached.cell == nil {
 			misses = append(misses, vhash)
 			continue
 		}

--- a/core/txpool/blobpool/cache_test.go
+++ b/core/txpool/blobpool/cache_test.go
@@ -283,6 +283,43 @@ func TestCacheGetBlobs(t *testing.T) {
 	tc.expectEntries(t, tc.vhashes[1]...)
 }
 
+// TestCacheGetCellsBlobModeFallback checks that GetCells falls back to the
+// blobpool when the cached entry was created in blob mode and holds no cells.
+// Such entries exist whenever the CL has not (yet) advertised getBlobsV4
+// support; without the fallback they would shadow the pool and produce
+// all-null responses for blobs that are fully available on disk.
+func TestCacheGetCellsBlobModeFallback(t *testing.T) {
+	tc := newTestCache(t, []txSpec{{blobs: 1, tip: 100}})
+	tc.expectEntries(t, tc.vhashes[0]...)
+
+	// The initial topK update ran in blob mode, so the cached entry must
+	// hold a recovered blob but no cells.
+	tc.mu.Lock()
+	entry := tc.entries[tc.vhashes[0][0]]
+	tc.mu.Unlock()
+	if entry == nil {
+		t.Fatal("expected the initial topK update to cache the blob")
+	}
+	if entry.blob == nil || entry.cell != nil {
+		t.Fatalf("expected a blob-mode cache entry, have blob=%v cells=%v", entry.blob != nil, entry.cell != nil)
+	}
+	cells, proofs, err := tc.GetCells(tc.vhashes[0], types.CustodyBitmapAll)
+	if err != nil {
+		t.Fatalf("GetCells: %v", err)
+	}
+	for i := range cells {
+		var missing int
+		for j := range cells[i] {
+			if cells[i][j] == nil || proofs[i][j] == nil {
+				missing++
+			}
+		}
+		if missing > 0 {
+			t.Errorf("blob %d: %d of %d requested cells missing in GetCells response", i, missing, len(cells[i]))
+		}
+	}
+}
+
 // TestCacheTopKRefresh verifies that when a more profitable tx appears in the
 // pool, the next topK tick replaces the cached entry with the better one.
 func TestCacheTopKRefresh(t *testing.T) {


### PR DESCRIPTION
Entries created by `loadBlobs` while the cache is in blob mode leave `cell` nil and `custody` zeroed, but `Cache.GetCells` only checks for entry existence — so such an entry never reaches the blobpool fallback and returns all-null cells for a transaction the pool holds in full.

`GetBlobsV4` then treats the non-nil (but all-null) cell slice as a complete hit, so the CL receives a `BlobCellsAndProofsV1` full of nulls while the request is counted towards the getBlobs hit metrics.

Blob mode is the default until `engine_exchangeCapabilities` advertises `engine_getBlobsV4`. (Separately: `ExchangeCapabilities` also passes `false` to `SetCellMode`, despite the comment calling the toggle one-directional, which widens the window.)

`GetBlobs` directly above already guards the symmetric case with `cached.blob == nil`.

The added regression test fails on master with `blob 0: 128 of 128 requested cells missing in GetCells response`.
