### PR TITLE
accounts/keystore: revoke unlocks when deleting accounts

### DIFF
--- a/accounts/keystore/keystore.go
+++ b/accounts/keystore/keystore.go
@@ -71,6 +71,7 @@ type KeyStore struct {
 	updating    bool                    // Whether the event notification loop is running
 
 	mu       sync.RWMutex
+	unlockMu sync.Mutex // Serializes unlocks with account deletion
 	importMu sync.Mutex // Import Mutex locks the import to prevent two insertions from racing
 }
 
@@ -232,6 +233,8 @@ func (ks *KeyStore) Accounts() []accounts.Account {
 // Delete deletes the key matched by account if the passphrase is correct.
 // If the account contains no filename, the address must match a unique key.
 func (ks *KeyStore) Delete(a accounts.Account, passphrase string) error {
+	ks.unlockMu.Lock()
+
 	// Decrypting the key isn't really necessary, but we do
 	// it anyway to check the password and zero out the key
 	// immediately afterwards.
@@ -240,6 +243,7 @@ func (ks *KeyStore) Delete(a accounts.Account, passphrase string) error {
 		zeroKey(key.PrivateKey)
 	}
 	if err != nil {
+		ks.unlockMu.Unlock()
 		return err
 	}
 	// The order is crucial here. The key is dropped from the
@@ -248,6 +252,20 @@ func (ks *KeyStore) Delete(a accounts.Account, passphrase string) error {
 	err = os.Remove(a.URL.Path)
 	if err == nil {
 		ks.cache.delete(a)
+
+		// Revoke any in-memory unlock for the deleted account.
+		ks.mu.Lock()
+		if unlocked, ok := ks.unlocked[a.Address]; ok {
+			if unlocked.abort != nil {
+				close(unlocked.abort)
+			}
+			zeroKey(unlocked.PrivateKey)
+			delete(ks.unlocked, a.Address)
+		}
+		ks.mu.Unlock()
+	}
+	ks.unlockMu.Unlock()
+	if err == nil {
 		ks.refreshWallets()
 	}
 	return err
@@ -332,6 +350,9 @@ func (ks *KeyStore) Lock(addr common.Address) error {
 // shortens the active unlock timeout. If the address was previously unlocked
 // indefinitely the timeout is not altered.
 func (ks *KeyStore) TimedUnlock(a accounts.Account, passphrase string, timeout time.Duration) error {
+	ks.unlockMu.Lock()
+	defer ks.unlockMu.Unlock()
+
 	a, key, err := ks.getDecryptedKey(a, passphrase)
 	if err != nil {
 		return err

--- a/accounts/keystore/keystore_test.go
+++ b/accounts/keystore/keystore_test.go
@@ -87,6 +87,29 @@ func TestSign(t *testing.T) {
 	}
 }
 
+func TestDeleteRevokesUnlock(t *testing.T) {
+	t.Parallel()
+	_, ks := tmpKeyStore(t)
+
+	account, err := ks.NewAccount("password")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := ks.Unlock(account, "password"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := ks.SignHash(account, testSigData); err != nil {
+		t.Fatalf("signing before deletion failed: %v", err)
+	}
+
+	if err := ks.Delete(account, "password"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := ks.SignHash(account, testSigData); err != ErrLocked {
+		t.Fatalf("signing after deletion returned %v, want ErrLocked", err)
+	}
+}
+
 func TestSignWithPassphrase(t *testing.T) {
 	t.Parallel()
 	_, ks := tmpKeyStore(t)


### PR DESCRIPTION
## Summary

Deleting a keystore account removed its encrypted key file and cache entry, but left any decrypted key in `KeyStore.unlocked`. The deleted account could therefore continue signing until the process
terminated or the unlock expired.

This change:

- Revokes the in-memory unlock after successful key-file deletion.
- Zeroes the decrypted private key.
- Closes timed-unlock cancellation channels.
- Serializes account deletion with `TimedUnlock` to prevent stale unlocks from being reinserted.
- Refreshes wallet state after releasing the unlock mutex.
- Adds a regression test confirming signing returns `ErrLocked` after deletion.

## Testing

```text
go test ./accounts/keystore -run '^TestDeleteRevokesUnlock$' -count=1
 ```