### PR TITLE
src: paginate release listings

### DIFF
--- a/src/pages/downloads.tsx
+++ b/src/pages/downloads.tsx
@@ -68,42 +68,40 @@ export const getStaticProps: GetStaticProps = async () => {
   // 1) fetch XML data
   try {
     const [
-      ALL_LINUX_RELEASES_XML_DATA,
-      ALL_LINUX_ARM64_RELEASES_XML_DATA,
-      ALL_LINUX_ALL_TOOLS_RELEASES_XML_DATA,
-      ALL_WINDOWS_RELEASES_XML_DATA,
-      ALL_WINDOWS_ALL_TOOLS_RELEASES_XML_DATA,
-      ALL_ANDROID_RELEASES_XML_DATA,
-      ALL_IOS_RELEASES_XML_DATA
+      ALL_LINUX_RELEASES_XML_PAGES,
+      ALL_LINUX_ARM64_RELEASES_XML_PAGES,
+      ALL_LINUX_ALL_TOOLS_RELEASES_XML_PAGES,
+      ALL_WINDOWS_RELEASES_XML_PAGES,
+      ALL_WINDOWS_ALL_TOOLS_RELEASES_XML_PAGES,
+      ALL_ANDROID_RELEASES_XML_PAGES,
+      ALL_IOS_RELEASES_XML_PAGES
     ] = await fetchXMLData();
 
     // 2) XML data parsing
     const parser = new XMLParser();
+    const parseBlobs = (pages: string[]) =>
+      pages.flatMap(page => {
+        const blobs = parser.parse(page).EnumerationResults.Blobs?.Blob;
+        if (!blobs) return [];
+        return Array.isArray(blobs) ? blobs : [blobs];
+      });
 
     // linux
-    const linuxJson = parser.parse(ALL_LINUX_RELEASES_XML_DATA);
-    const ALL_LINUX_BLOBS_JSON_DATA = linuxJson.EnumerationResults.Blobs.Blob;
-
-    const linuxArm64Json = parser.parse(ALL_LINUX_ARM64_RELEASES_XML_DATA);
-    const ALL_LINUX_ARM64_BLOBS_JSON_DATA = linuxArm64Json.EnumerationResults.Blobs.Blob;
-
-    const linuxAllToolsJson = parser.parse(ALL_LINUX_ALL_TOOLS_RELEASES_XML_DATA);
-    const ALL_LINUX_ALL_TOOLS_BLOBS_JSON_DATA = linuxAllToolsJson.EnumerationResults.Blobs.Blob;
+    const ALL_LINUX_BLOBS_JSON_DATA = parseBlobs(ALL_LINUX_RELEASES_XML_PAGES);
+    const ALL_LINUX_ARM64_BLOBS_JSON_DATA = parseBlobs(ALL_LINUX_ARM64_RELEASES_XML_PAGES);
+    const ALL_LINUX_ALL_TOOLS_BLOBS_JSON_DATA = parseBlobs(ALL_LINUX_ALL_TOOLS_RELEASES_XML_PAGES);
 
     // windows
-    const windowsJson = parser.parse(ALL_WINDOWS_RELEASES_XML_DATA);
-    const ALL_WINDOWS_BLOBS_JSON_DATA = windowsJson.EnumerationResults.Blobs.Blob;
-
-    const windowsAllToolsJson = parser.parse(ALL_WINDOWS_ALL_TOOLS_RELEASES_XML_DATA);
-    const ALL_WINDOWS_ALL_TOOLS_BLOBS_JSON_DATA = windowsAllToolsJson.EnumerationResults.Blobs.Blob;
+    const ALL_WINDOWS_BLOBS_JSON_DATA = parseBlobs(ALL_WINDOWS_RELEASES_XML_PAGES);
+    const ALL_WINDOWS_ALL_TOOLS_BLOBS_JSON_DATA = parseBlobs(
+      ALL_WINDOWS_ALL_TOOLS_RELEASES_XML_PAGES
+    );
 
     // android
-    const androidJson = parser.parse(ALL_ANDROID_RELEASES_XML_DATA);
-    const ALL_ANDROID_BLOBS_JSON_DATA = androidJson.EnumerationResults.Blobs.Blob;
+    const ALL_ANDROID_BLOBS_JSON_DATA = parseBlobs(ALL_ANDROID_RELEASES_XML_PAGES);
 
     // iOS
-    const iOSJson = parser.parse(ALL_IOS_RELEASES_XML_DATA);
-    const ALL_IOS_BLOBS_JSON_DATA = iOSJson.EnumerationResults.Blobs.Blob;
+    const ALL_IOS_BLOBS_JSON_DATA = parseBlobs(ALL_IOS_RELEASES_XML_PAGES);
 
     // 3) get blobs
     // linux

--- a/src/utils/fetchXMLData.ts
+++ b/src/utils/fetchXMLData.ts
@@ -1,3 +1,5 @@
+import { XMLParser } from 'fast-xml-parser';
+
 import {
   ALL_ANDROID_GETH_RELEASES_URL,
   ALL_IOS_GETH_RELEASES_URL,
@@ -7,6 +9,29 @@ import {
   ALL_WINDOWS_ALLTOOLS_GETH_RELEASES_URL,
   ALL_WINDOWS_GETH_RELEASES_URL
 } from '../constants';
+
+const fetchXMLPages = async (url: string): Promise<string[]> => {
+  const parser = new XMLParser();
+  const pages: string[] = [];
+  let marker = '';
+
+  do {
+    const pageURL = new URL(url);
+    if (marker) pageURL.searchParams.set('marker', marker);
+
+    const response = await fetch(pageURL);
+    if (!response.ok) {
+      throw new Error(`Failed to fetch releases from ${pageURL}: ${response.status}`);
+    }
+    const xml = await response.text();
+    const nextMarker = parser.parse(xml)?.EnumerationResults?.NextMarker;
+
+    pages.push(xml);
+    marker = typeof nextMarker === 'string' ? nextMarker : '';
+  } while (marker);
+
+  return pages;
+};
 
 export const fetchXMLData = () => {
   const urls = [
@@ -19,5 +44,5 @@ export const fetchXMLData = () => {
     ALL_IOS_GETH_RELEASES_URL
   ];
 
-  return Promise.all(urls.map(url => fetch(url).then(response => response.text())));
+  return Promise.all(urls.map(fetchXMLPages));
 };


### PR DESCRIPTION
Azure limits blob listing responses to 5,000 entries. The Windows v1.17.1 archive is on the second page, so it never reaches the downloads page.

Follow `NextMarker` until each listing is exhausted and combine the returned blobs before mapping releases. This also restores entries truncated from the broader Linux listings. Since the page serializes every release, the generated page data grows from about 5.3 MiB to 10.8 MiB.

Tested with:
- `npm run lint`
- `./node_modules/.bin/tsc --noEmit`
- `./node_modules/.bin/prettier src/pages/downloads.tsx src/utils/fetchXMLData.ts --check --config .prettierrc`
- `GITHUB_TOKEN_READ_ONLY=<token> ./node_modules/.bin/next build`

Netlify runs fork previews without sensitive environment variables. I reproduced its existing GitHub-backed prerender failure locally without `GITHUB_TOKEN_READ_ONLY`; the same production build passes with the token set.

The generated downloads data contains `geth-windows-amd64-1.17.1-16783c16.zip`.

Fixes #34113
