### PR TITLE
core: wire precompile cache into parallel block execution

### DIFF
--- a/core/state_processor.go
+++ b/core/state_processor.go
@@ -66,7 +66,7 @@ func (p *StateProcessor) chainConfig() *params.ChainConfig {
 // transactions failed to execute due to insufficient gas it will return an error.
 func (p *StateProcessor) Process(ctx context.Context, block *types.Block, statedb *state.StateDB, jumpDestCache vm.JumpDestCache, precompileCache *vm.PrecompileCache, cfg vm.Config, execIndex *atomic.Int64) (*ProcessResult, error) {
 	if supportsParallelExecution(block, p.chainConfig(), statedb.Witness() != nil, cfg.Tracer != nil, cfg.DisableParallelExecution) {
-		return p.processParallel(ctx, block, statedb, jumpDestCache, cfg)
+		return p.processParallel(ctx, block, statedb, jumpDestCache, precompileCache, cfg)
 	}
 	var (
 		config      = p.chainConfig()

--- a/core/state_processor_parallel.go
+++ b/core/state_processor_parallel.go
@@ -83,7 +83,7 @@ type txExecResult struct {
 
 // processParallel executes the block's transactions concurrently using the
 // block-level access list.
-func (p *StateProcessor) processParallel(ctx context.Context, block *types.Block, statedb *state.StateDB, jumpDestCache vm.JumpDestCache, cfg vm.Config) (*ProcessResult, error) {
+func (p *StateProcessor) processParallel(ctx context.Context, block *types.Block, statedb *state.StateDB, jumpDestCache vm.JumpDestCache, precompileCache *vm.PrecompileCache, cfg vm.Config) (*ProcessResult, error) {
 	var (
 		config = p.chainConfig()
 		header = block.Header()
@@ -154,6 +154,9 @@ func (p *StateProcessor) processParallel(ctx context.Context, block *types.Block
 	preEVM := vm.NewEVM(context, preState, config, cfg)
 	if jumpDestCache != nil {
 		preEVM.SetJumpDestCache(jumpDestCache)
+	}
+	if precompileCache != nil {
+		preEVM.SetPrecompileCache(precompileCache)
 	}
 	blockAccessList.Merge(PreExecution(ctx, block.BeaconRoot(), parent, config, preEVM, header.Number, header.Time))
 	preEVM.Release()


### PR DESCRIPTION
Pass the precompile cache through to processParallel and attach it to the pre-execution EVM so parallel processing can reuse cached results.