### PR TITLE
common/mclock: rename symbol to remove conflicts with other languages

### DIFF
--- a/common/mclock/simclock.go
+++ b/common/mclock/simclock.go
@@ -43,7 +43,7 @@ type simTimer struct {
 	at    AbsTime
 	index int // position in s.scheduled
 	s     *Simulated
-	do    func()
+	run   func()
 	ch    <-chan AbsTime
 }
 
@@ -62,7 +62,7 @@ func (s *Simulated) Run(d time.Duration) {
 	var do []func()
 	for len(s.scheduled) > 0 && s.scheduled[0].at <= end {
 		ev := heap.Pop(&s.scheduled).(*simTimer)
-		do = append(do, ev.do)
+		do = append(do, ev.run)
 	}
 	s.now = end
 	s.mu.Unlock()
@@ -135,7 +135,7 @@ func (s *Simulated) schedule(d time.Duration, fn func()) *simTimer {
 	s.init()
 
 	at := s.now.Add(d)
-	ev := &simTimer{do: fn, at: at, s: s}
+	ev := &simTimer{run: fn, at: at, s: s}
 	heap.Push(&s.scheduled, ev)
 	s.cond.Broadcast()
 	return ev


### PR DESCRIPTION
Calling a function `do` is fine in go, but when interacting with other languages, namely C, this clashes with a known keyword, which some compilers don't like.

Starting my cuiweixie arc.