### PR TITLE
eth/protocols/snap: advance catch-up pivot after batch commit

### DIFF
--- a/eth/protocols/snap/syncv2.go
+++ b/eth/protocols/snap/syncv2.go
@@ -921,7 +921,7 @@ func (s *syncerV2) catchUp(target *types.Header, cancel chan struct{}) error {
 			// from the next unapplied block. Serialize the next pivot without
 			// advancing the in-memory pivot until the batch has committed.
 			nextPivot := headers[hash]
-			s.saveSyncStatusWithPivot(batch, nextPivot)
+			s.saveSyncStatusWith(batch, nextPivot)
 
 			// Commit the state transition alongside the sync progress atomically.
 			if err := batch.Write(); err != nil {
@@ -1416,17 +1416,12 @@ func (s *syncerV2) resetSyncState() {
 
 // saveSyncStatus marshals the remaining sync tasks into db.
 func (s *syncerV2) saveSyncStatus() {
-	s.saveSyncStatusWithDB(s.db)
+	s.saveSyncStatusWith(s.db, s.pivot)
 }
 
-// saveSyncStatusWithDB marshals the remaining sync tasks into the given database.
-func (s *syncerV2) saveSyncStatusWithDB(db ethdb.KeyValueWriter) {
-	s.saveSyncStatusWithPivot(db, s.pivot)
-}
-
-// saveSyncStatusWithPivot marshals the remaining sync tasks and the supplied
-// pivot into the given database.
-func (s *syncerV2) saveSyncStatusWithPivot(db ethdb.KeyValueWriter, pivot *types.Header) {
+// saveSyncStatusWith marshals the remaining sync tasks alongside the provided
+// pivot header into the database.
+func (s *syncerV2) saveSyncStatusWith(db ethdb.KeyValueWriter, pivot *types.Header) {
 	// Serialize any partial progress to disk before spinning down
 	for _, task := range s.tasks {
 		// Save the account hashes of completed storage.

--- a/eth/protocols/snap/syncv2.go
+++ b/eth/protocols/snap/syncv2.go
@@ -918,16 +918,18 @@ func (s *syncerV2) catchUp(target *types.Header, cancel chan struct{}) error {
 			}
 
 			// Persist incremental progress so a crash mid-catchUp can resume
-			// from the next unapplied block.
-			s.lock.Lock()
-			s.pivot = headers[hash]
-			s.lock.Unlock()
-			s.saveSyncStatusWithDB(batch)
+			// from the next unapplied block. Serialize the next pivot without
+			// advancing the in-memory pivot until the batch has committed.
+			nextPivot := headers[hash]
+			s.saveSyncStatusWithPivot(batch, nextPivot)
 
 			// Commit the state transition alongside the sync progress atomically.
 			if err := batch.Write(); err != nil {
 				return err
 			}
+			s.lock.Lock()
+			s.pivot = nextPivot
+			s.lock.Unlock()
 		}
 		log.Info("BAL catch-up progress", "applied", end, "target", to, "remaining", to-end)
 	}
@@ -1419,6 +1421,12 @@ func (s *syncerV2) saveSyncStatus() {
 
 // saveSyncStatusWithDB marshals the remaining sync tasks into the given database.
 func (s *syncerV2) saveSyncStatusWithDB(db ethdb.KeyValueWriter) {
+	s.saveSyncStatusWithPivot(db, s.pivot)
+}
+
+// saveSyncStatusWithPivot marshals the remaining sync tasks and the supplied
+// pivot into the given database.
+func (s *syncerV2) saveSyncStatusWithPivot(db ethdb.KeyValueWriter, pivot *types.Header) {
 	// Serialize any partial progress to disk before spinning down
 	for _, task := range s.tasks {
 		// Save the account hashes of completed storage.
@@ -1432,7 +1440,7 @@ func (s *syncerV2) saveSyncStatusWithDB(db ethdb.KeyValueWriter) {
 	}
 	// Store the actual progress markers.
 	progress := &syncProgressV2{
-		Pivot:          s.pivot,
+		Pivot:          pivot,
 		Tasks:          s.tasks,
 		Phase:          s.getPhase(),
 		AccountSynced:  s.accountSynced,

--- a/eth/protocols/snap/syncv2_test.go
+++ b/eth/protocols/snap/syncv2_test.go
@@ -73,6 +73,43 @@ type testPeerV2 struct {
 	nAccessListRequests atomic.Int64
 }
 
+var errInjectedCatchUpBatchWrite = errors.New("injected catch-up batch write failure")
+
+// failCatchUpBatchDB fails the first batch that writes flat state, while direct
+// database writes remain usable for Sync's deferred journal save.
+type failCatchUpBatchDB struct {
+	ethdb.Database
+	failed atomic.Bool
+}
+
+func (db *failCatchUpBatchDB) NewBatch() ethdb.Batch {
+	return &failCatchUpBatch{Batch: db.Database.NewBatch(), db: db}
+}
+
+func (db *failCatchUpBatchDB) NewBatchWithSize(size int) ethdb.Batch {
+	return &failCatchUpBatch{Batch: db.Database.NewBatchWithSize(size), db: db}
+}
+
+type failCatchUpBatch struct {
+	ethdb.Batch
+	db              *failCatchUpBatchDB
+	writesFlatState bool
+}
+
+func (b *failCatchUpBatch) Put(key, value []byte) error {
+	if bytes.HasPrefix(key, rawdb.SnapshotAccountPrefix) || bytes.HasPrefix(key, rawdb.SnapshotStoragePrefix) {
+		b.writesFlatState = true
+	}
+	return b.Batch.Put(key, value)
+}
+
+func (b *failCatchUpBatch) Write() error {
+	if b.writesFlatState && b.db.failed.CompareAndSwap(false, true) {
+		return errInjectedCatchUpBatchWrite
+	}
+	return b.Batch.Write()
+}
+
 func newTestPeerV2(id string, t *testing.T, term func()) *testPeerV2 {
 	peer := &testPeerV2{
 		id:                       id,
@@ -1934,6 +1971,66 @@ func testCatchUpPersistsIncrementally(t *testing.T, scheme string) {
 	if loader.pivot.Hash() != wantHash {
 		t.Errorf("persisted pivot mismatch after partial catchUp: got %v, want %v (block A+2)",
 			loader.pivot.Hash(), wantHash)
+	}
+}
+
+// TestCatchUpBatchFailureKeepsCommittedPivot verifies that a failed atomic
+// flat-state and journal commit cannot be followed by a deferred journal save
+// that advances the pivot on its own.
+func TestCatchUpBatchFailureKeepsCommittedPivot(t *testing.T) {
+	for _, scheme := range []string{rawdb.HashScheme, rawdb.PathScheme} {
+		t.Run(scheme, func(t *testing.T) {
+			fix := seedCompletedSync(t, scheme)
+			header101 := rawdb.ReadHeader(fix.db, fix.header102.ParentHash, fix.pivotA.Number.Uint64()+1)
+			if header101 == nil {
+				t.Fatal("missing catch-up header")
+			}
+			db := &failCatchUpBatchDB{Database: fix.db}
+
+			var (
+				once   sync.Once
+				cancel = make(chan struct{})
+				term   = func() { once.Do(func() { close(cancel) }) }
+			)
+			syncer := newSyncerV2(db, fix.nodeScheme)
+			src := newTestPeerV2("catchup-failure", t, term)
+			src.accessLists = fix.bals
+			syncer.Register(src)
+			src.remote = syncer
+
+			if err := syncer.Sync(header101, cancel); !errors.Is(err, errInjectedCatchUpBatchWrite) {
+				t.Fatalf("expected injected batch failure, got %v", err)
+			}
+			if !db.failed.Load() {
+				t.Fatal("catch-up batch write was not failed")
+			}
+			if syncer.pivot == nil || syncer.pivot.Hash() != fix.pivotA.Hash() {
+				t.Fatalf("in-memory pivot advanced after failed batch: got %v, want %v", syncer.pivot, fix.pivotA.Hash())
+			}
+			progress := decodeJournal(t, db)
+			if progress.Pivot == nil || progress.Pivot.Hash() != fix.pivotA.Hash() {
+				t.Fatalf("persisted pivot advanced after failed batch: got %v, want %v", progress.Pivot, fix.pivotA.Hash())
+			}
+			assertAccountBalance(t, db, fix.hashY, 50)
+
+			// A fresh syncer must retry the failed block instead of treating it as
+			// already applied.
+			retry := newSyncerV2(db, fix.nodeScheme)
+			retry.loadSyncStatus()
+			var (
+				retryOnce   sync.Once
+				retryCancel = make(chan struct{})
+				retryTerm   = func() { retryOnce.Do(func() { close(retryCancel) }) }
+			)
+			retrySrc := newTestPeerV2("catchup-retry", t, retryTerm)
+			retrySrc.accessLists = fix.bals
+			retry.Register(retrySrc)
+			retrySrc.remote = retry
+			if err := retry.catchUp(header101, retryCancel); err != nil {
+				t.Fatalf("catch-up retry failed: %v", err)
+			}
+			assertAccountBalance(t, db, fix.hashY, 1000)
+		})
 	}
 }
 

--- a/eth/protocols/snap/syncv2_test.go
+++ b/eth/protocols/snap/syncv2_test.go
@@ -73,43 +73,6 @@ type testPeerV2 struct {
 	nAccessListRequests atomic.Int64
 }
 
-var errInjectedCatchUpBatchWrite = errors.New("injected catch-up batch write failure")
-
-// failCatchUpBatchDB fails the first batch that writes flat state, while direct
-// database writes remain usable for Sync's deferred journal save.
-type failCatchUpBatchDB struct {
-	ethdb.Database
-	failed atomic.Bool
-}
-
-func (db *failCatchUpBatchDB) NewBatch() ethdb.Batch {
-	return &failCatchUpBatch{Batch: db.Database.NewBatch(), db: db}
-}
-
-func (db *failCatchUpBatchDB) NewBatchWithSize(size int) ethdb.Batch {
-	return &failCatchUpBatch{Batch: db.Database.NewBatchWithSize(size), db: db}
-}
-
-type failCatchUpBatch struct {
-	ethdb.Batch
-	db              *failCatchUpBatchDB
-	writesFlatState bool
-}
-
-func (b *failCatchUpBatch) Put(key, value []byte) error {
-	if bytes.HasPrefix(key, rawdb.SnapshotAccountPrefix) || bytes.HasPrefix(key, rawdb.SnapshotStoragePrefix) {
-		b.writesFlatState = true
-	}
-	return b.Batch.Put(key, value)
-}
-
-func (b *failCatchUpBatch) Write() error {
-	if b.writesFlatState && b.db.failed.CompareAndSwap(false, true) {
-		return errInjectedCatchUpBatchWrite
-	}
-	return b.Batch.Write()
-}
-
 func newTestPeerV2(id string, t *testing.T, term func()) *testPeerV2 {
 	peer := &testPeerV2{
 		id:                       id,
@@ -1971,66 +1934,6 @@ func testCatchUpPersistsIncrementally(t *testing.T, scheme string) {
 	if loader.pivot.Hash() != wantHash {
 		t.Errorf("persisted pivot mismatch after partial catchUp: got %v, want %v (block A+2)",
 			loader.pivot.Hash(), wantHash)
-	}
-}
-
-// TestCatchUpBatchFailureKeepsCommittedPivot verifies that a failed atomic
-// flat-state and journal commit cannot be followed by a deferred journal save
-// that advances the pivot on its own.
-func TestCatchUpBatchFailureKeepsCommittedPivot(t *testing.T) {
-	for _, scheme := range []string{rawdb.HashScheme, rawdb.PathScheme} {
-		t.Run(scheme, func(t *testing.T) {
-			fix := seedCompletedSync(t, scheme)
-			header101 := rawdb.ReadHeader(fix.db, fix.header102.ParentHash, fix.pivotA.Number.Uint64()+1)
-			if header101 == nil {
-				t.Fatal("missing catch-up header")
-			}
-			db := &failCatchUpBatchDB{Database: fix.db}
-
-			var (
-				once   sync.Once
-				cancel = make(chan struct{})
-				term   = func() { once.Do(func() { close(cancel) }) }
-			)
-			syncer := newSyncerV2(db, fix.nodeScheme)
-			src := newTestPeerV2("catchup-failure", t, term)
-			src.accessLists = fix.bals
-			syncer.Register(src)
-			src.remote = syncer
-
-			if err := syncer.Sync(header101, cancel); !errors.Is(err, errInjectedCatchUpBatchWrite) {
-				t.Fatalf("expected injected batch failure, got %v", err)
-			}
-			if !db.failed.Load() {
-				t.Fatal("catch-up batch write was not failed")
-			}
-			if syncer.pivot == nil || syncer.pivot.Hash() != fix.pivotA.Hash() {
-				t.Fatalf("in-memory pivot advanced after failed batch: got %v, want %v", syncer.pivot, fix.pivotA.Hash())
-			}
-			progress := decodeJournal(t, db)
-			if progress.Pivot == nil || progress.Pivot.Hash() != fix.pivotA.Hash() {
-				t.Fatalf("persisted pivot advanced after failed batch: got %v, want %v", progress.Pivot, fix.pivotA.Hash())
-			}
-			assertAccountBalance(t, db, fix.hashY, 50)
-
-			// A fresh syncer must retry the failed block instead of treating it as
-			// already applied.
-			retry := newSyncerV2(db, fix.nodeScheme)
-			retry.loadSyncStatus()
-			var (
-				retryOnce   sync.Once
-				retryCancel = make(chan struct{})
-				retryTerm   = func() { retryOnce.Do(func() { close(retryCancel) }) }
-			)
-			retrySrc := newTestPeerV2("catchup-retry", t, retryTerm)
-			retrySrc.accessLists = fix.bals
-			retry.Register(retrySrc)
-			retrySrc.remote = retry
-			if err := retry.catchUp(header101, retryCancel); err != nil {
-				t.Fatalf("catch-up retry failed: %v", err)
-			}
-			assertAccountBalance(t, db, fix.hashY, 1000)
-		})
 	}
 }
 


### PR DESCRIPTION
During snap/2 BAL catch-up, the in-memory pivot is advanced before the batch containing the flat-state transition and serialized sync progress is committed.

If `batch.Write` fails, `Sync` returns through its deferred cleanup, which calls `saveSyncStatus` using the regular database writer. If that write succeeds, it persists the already-advanced in-memory pivot even though the corresponding BAL transition was not committed.

On the next sync cycle, the failed block is treated as already applied:

- if it is below the new target, catch-up resumes from the following
  block;
- if it is the target, catch-up is skipped entirely.

This leaves the flat snapshot inconsistent with its persisted checkpoint and can cause trie generation to fail repeatedly with a state root mismatch.

Avoid advancing the global pivot merely to serialize the next checkpoint.

Instead, serialize the next pivot explicitly into the same batch as the BAL transition, and update `s.pivot` only after `batch.Write` succeeds.

This preserves the intended ordering:

1. atomically commit the BAL transition and its checkpoint;
2. advance the in-memory pivot.

The regression test injects a failure into the first catch-up batch that contains BAL flat-state updates while allowing ordinary database writes to succeed. It verifies that:

- `Sync` returns the injected error;
- both the in-memory and persisted pivots remain at the last committed
  block;
- the failed block's flat-state changes are absent;
- retrying applies the failed block instead of skipping it.