### PR TITLE
core: genesis slot number parsing

### DIFF
--- a/core/gen_genesis.go
+++ b/core/gen_genesis.go
@@ -34,7 +34,7 @@ func (g Genesis) MarshalJSON() ([]byte, error) {
 		BaseFee       *math.HexOrDecimal256                      `json:"baseFeePerGas"`
 		ExcessBlobGas *math.HexOrDecimal64                       `json:"excessBlobGas"`
 		BlobGasUsed   *math.HexOrDecimal64                       `json:"blobGasUsed"`
-		SlotNumber    *uint64                                    `json:"slotNumber"`
+		SlotNumber    *math.HexOrDecimal64                       `json:"slotNumber"`
 	}
 	var enc Genesis
 	enc.Config = g.Config
@@ -57,7 +57,7 @@ func (g Genesis) MarshalJSON() ([]byte, error) {
 	enc.BaseFee = (*math.HexOrDecimal256)(g.BaseFee)
 	enc.ExcessBlobGas = (*math.HexOrDecimal64)(g.ExcessBlobGas)
 	enc.BlobGasUsed = (*math.HexOrDecimal64)(g.BlobGasUsed)
-	enc.SlotNumber = g.SlotNumber
+	enc.SlotNumber = (*math.HexOrDecimal64)(g.SlotNumber)
 	return json.Marshal(&enc)
 }
 
@@ -79,7 +79,7 @@ func (g *Genesis) UnmarshalJSON(input []byte) error {
 		BaseFee       *math.HexOrDecimal256                      `json:"baseFeePerGas"`
 		ExcessBlobGas *math.HexOrDecimal64                       `json:"excessBlobGas"`
 		BlobGasUsed   *math.HexOrDecimal64                       `json:"blobGasUsed"`
-		SlotNumber    *uint64                                    `json:"slotNumber"`
+		SlotNumber    *math.HexOrDecimal64                       `json:"slotNumber"`
 	}
 	var dec Genesis
 	if err := json.Unmarshal(input, &dec); err != nil {
@@ -137,7 +137,7 @@ func (g *Genesis) UnmarshalJSON(input []byte) error {
 		g.BlobGasUsed = (*uint64)(dec.BlobGasUsed)
 	}
 	if dec.SlotNumber != nil {
-		g.SlotNumber = dec.SlotNumber
+		g.SlotNumber = (*uint64)(dec.SlotNumber)
 	}
 	return nil
 }

--- a/core/genesis.go
+++ b/core/genesis.go
@@ -263,6 +263,7 @@ type genesisSpecMarshaling struct {
 	BaseFee       *math.HexOrDecimal256
 	ExcessBlobGas *math.HexOrDecimal64
 	BlobGasUsed   *math.HexOrDecimal64
+	SlotNumber    *math.HexOrDecimal64
 }
 
 // GenesisMismatchError is raised when trying to overwrite an existing


### PR DESCRIPTION
Small fix to the parsing of the `slotNumber` in the genesis file. Found during hive testing.