### PR TITLE
miner: use EIP-2780 base cost as packing gas floor after Amsterdam

### DIFF
--- a/miner/worker.go
+++ b/miner/worker.go
@@ -452,8 +452,12 @@ func (miner *Miner) commitTransactions(ctx context.Context, env *environment, pl
 			}
 		}
 		// If we don't have enough gas for any further transactions then we're done.
-		if env.gasPool.Gas() < params.TxGas {
-			log.Trace("Not enough gas for further transactions", "have", env.gasPool, "want", params.TxGas)
+		minTxGas := params.TxGas
+		if miner.chainConfig.IsAmsterdam(env.header.Number, env.header.Time) {
+			minTxGas = params.TxBaseCost2780
+		}
+		if env.gasPool.Gas() < minTxGas {
+			log.Trace("Not enough gas for further transactions", "have", env.gasPool, "want", minTxGas)
 			break
 		}
 		// If we don't have enough blob space for any further blob transactions,

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -444,6 +444,7 @@ func (miner *Miner) commitTransactions(ctx context.Context, env *environment, pl
 	defer spanEnd(nil)
 
 	isCancun := miner.chainConfig.IsCancun(env.header.Number, env.header.Time)
+	isAmsterdam := miner.chainConfig.IsAmsterdam(env.header.Number, env.header.Time)
 	for {
 		// Check interruption signal and abort building if it's fired.
 		if interrupt != nil {
@@ -452,7 +453,7 @@ func (miner *Miner) commitTransactions(ctx context.Context, env *environment, pl
 			}
 		}
 		// If we don't have enough gas for any further transactions then we're done.
-		if env.gasPool.Gas() < params.TxGas {
+		if !isAmsterdam && env.gasPool.Gas() < params.TxGas {
 			log.Trace("Not enough gas for further transactions", "have", env.gasPool, "want", params.TxGas)
 			break
 		}
@@ -487,7 +488,13 @@ func (miner *Miner) commitTransactions(ctx context.Context, env *environment, pl
 			break
 		}
 		// If we don't have enough space for the next transaction, skip the account.
-		if env.gasPool.Gas() < ltx.Gas {
+		if isAmsterdam {
+			if err := env.gasPool.CheckGasAmsterdam(min(ltx.Gas, params.MaxTxGas), ltx.Gas); err != nil {
+				log.Trace("Not enough gas left for transaction", "hash", ltx.Hash, "left", env.gasPool.Gas(), "needed", ltx.Gas)
+				txs.Pop()
+				continue
+			}
+		} else if env.gasPool.Gas() < ltx.Gas {
 			log.Trace("Not enough gas left for transaction", "hash", ltx.Hash, "left", env.gasPool.Gas(), "needed", ltx.Gas)
 			txs.Pop()
 			continue


### PR DESCRIPTION
## Summary
- After Amsterdam (EIP-2780), the intrinsic gas floor drops from `TxGas` (21000) to `TxBaseCost2780` (12000).
- Update the block packing early-exit so packing can continue when remaining gas is below 21000 but still above the Amsterdam floor.

## Test plan
- [ ] `go test ./miner/...`
- [ ] Confirm pre-Amsterdam packing still stops below 21000 gas
- [ ] Confirm post-Amsterdam packing continues down to 12000 gas remaining