### PR TITLE
core/txpool/blobpool, eth/fetcher: wake fetcher for completed blobs

### DIFF
--- a/core/txpool/blobpool/buffer.go
+++ b/core/txpool/blobpool/buffer.go
@@ -72,6 +72,8 @@ type BlobBuffer struct {
 	completed      []*BlobTxForPool
 	completedCount atomic.Int32
 	cb             BlobBufferFunctions
+
+	completedSignal chan struct{}
 }
 
 type BlobBufferFunctions struct {
@@ -85,7 +87,14 @@ func NewBlobBuffer(cb BlobBufferFunctions) *BlobBuffer {
 		txs:   make(map[common.Hash]*txEntry),
 		cells: make(map[common.Hash]*cellEntry),
 		cb:    cb,
+
+		completedSignal: make(chan struct{}, 1),
 	}
+}
+
+// Completed returns a channel which is signaled when entries are ready to flush.
+func (b *BlobBuffer) Completed() <-chan struct{} {
+	return b.completedSignal
 }
 
 // Flush adds all completed entries to the pool and returns the hashes
@@ -196,6 +205,10 @@ func (b *BlobBuffer) storeCompleted(hash common.Hash, tx *types.Transaction, cel
 
 	b.completed = append(b.completed, pooledTx)
 	b.completedCount.Add(1)
+	select {
+	case b.completedSignal <- struct{}{}:
+	default:
+	}
 	delete(b.cells, hash)
 	delete(b.txs, hash)
 }

--- a/eth/fetcher/tx_fetcher.go
+++ b/eth/fetcher/tx_fetcher.go
@@ -191,6 +191,7 @@ type TxFetcher struct {
 
 	buffer *blobpool.BlobBuffer
 
+	idle     chan struct{}    // Notification channel before the fetcher waits (tests only)
 	step     chan struct{}    // Notification channel when the fetcher loop iterates
 	clock    mclock.Clock     // Monotonic clock or simulated clock for tests
 	realTime func() time.Time // Real system time or simulated time for tests
@@ -518,8 +519,15 @@ func (f *TxFetcher) loop() {
 			underpricedMeter: txReplyUnderpricedMeter,
 			otherRejectMeter: txReplyOtherRejectMeter,
 		})
+		if f.idle != nil {
+			f.idle <- struct{}{}
+		}
 
 		select {
+		case <-f.buffer.Completed():
+			// A blob transaction was completed by the independent blob fetcher.
+			// Flush it at the top of the next loop iteration.
+
 		case ann := <-f.notify:
 			// Drop part of the new announcements if there are too many accumulated.
 			// Note, we could but do not filter already known transactions here as

--- a/eth/fetcher/tx_fetcher_test.go
+++ b/eth/fetcher/tx_fetcher_test.go
@@ -1790,6 +1790,71 @@ func makeInvalidBlobTx() *types.Transaction {
 	return types.MustSignNewTx(key, types.LatestSigner(params.MainnetChainConfig), blobtx)
 }
 
+func TestTransactionFetcherWakesForCompletedBlob(t *testing.T) {
+	key, _ := crypto.GenerateKey()
+	blob := &kzg4844.Blob{byte(0xa)}
+	commitment, _ := kzg4844.BlobToCommitment(blob)
+	blobHash := kzg4844.CalcBlobHashV1(sha256.New(), &commitment)
+	cellProofs, _ := kzg4844.ComputeCellProofs(blob)
+
+	blobtx := &types.BlobTx{
+		ChainID:    uint256.MustFromBig(params.MainnetChainConfig.ChainID),
+		GasTipCap:  uint256.NewInt(100),
+		GasFeeCap:  uint256.NewInt(200),
+		Gas:        21000,
+		BlobFeeCap: uint256.NewInt(200),
+		BlobHashes: []common.Hash{blobHash},
+		Value:      uint256.NewInt(100),
+		Sidecar:    types.NewBlobTxSidecar(types.BlobSidecarVersion1, nil, []kzg4844.Commitment{commitment}, cellProofs),
+	}
+	tx := types.MustSignNewTx(key, types.LatestSigner(params.MainnetChainConfig), blobtx)
+
+	added := make(chan common.Hash, 1)
+	buffer := blobpool.NewBlobBuffer(blobpool.BlobBufferFunctions{
+		ValidateTx: func(*types.Transaction) error { return nil },
+		AddToPool: func(ptx *blobpool.BlobTxForPool) error {
+			added <- ptx.Tx.Hash()
+			return nil
+		},
+		DropPeer: func(string) {},
+	})
+	fetcher := NewTxFetcher(
+		nil,
+		func(common.Hash, byte) error { return nil },
+		func(txs []*types.Transaction) []error { return make([]error, len(txs)) },
+		func(string, []common.Hash) error { return nil },
+		func(string) {},
+		nil,
+		buffer,
+	)
+	fetcher.idle = make(chan struct{}, 1)
+	fetcher.Start()
+	defer fetcher.Stop()
+
+	// Wait until the fetcher has completed its initial empty flush and entered
+	// the select loop before completing the buffer from the blob fetcher path.
+	<-fetcher.idle
+	if err := buffer.AddTx([]*types.Transaction{tx}, "tx-peer")[0]; err != nil {
+		t.Fatal(err)
+	}
+	cells, err := kzg4844.ComputeCells([]kzg4844.Blob{*blob})
+	if err != nil {
+		t.Fatal(err)
+	}
+	buffer.AddCells(tx.Hash(), map[string]*blobpool.PeerDelivery{
+		"cell-peer": {Cells: cells, Indices: types.CustodyBitmapAll.Indices()},
+	}, types.CustodyBitmapAll)
+
+	select {
+	case hash := <-added:
+		if hash != tx.Hash() {
+			t.Fatalf("unexpected transaction added: got %s, want %s", hash, tx.Hash())
+		}
+	case <-time.After(time.Second):
+		t.Fatal("completed blob transaction was not flushed")
+	}
+}
+
 // This test ensures that the peer will be disconnected for protocol violation
 // and all its internal traces should be removed properly.
 func TestTransactionProtocolViolation(t *testing.T) {


### PR DESCRIPTION
## What

Wake `TxFetcher` when the shared `BlobBuffer` finishes assembling a blob transaction, so completed entries are flushed into the pool promptly.

## Why

Blob cell assembly runs on the independent blob fetcher path. `TxFetcher` previously only called `Flush()` at the top of its event loop when woken by its own events (announce / timeout / head / drop / quit). On a quiet network, a fully assembled blob tx could sit in `completed` for an arbitrarily long time.

## How

- Add a buffered `completedSignal` on `BlobBuffer`, fired from `storeCompleted`
- Expose it via `Completed()`
- Select on that channel in `TxFetcher.loop` so the next iteration flushes immediately
- Add a regression test that completes the buffer while the fetcher is idle

## Validation

```
go test ./eth/fetcher/ -run TestTransactionFetcherWakesForCompletedBlob -count=1
go test ./core/txpool/blobpool/ -run 'TestAdd|TestMultiPeer|TestBadCell|TestSort' -count=1
```