### PR TITLE
common: clear unused prefix bytes in Hash and Address SetBytes

### DIFF
--- a/common/types.go
+++ b/common/types.go
@@ -158,7 +158,9 @@ func (h *Hash) SetBytes(b []byte) {
 		b = b[len(b)-HashLength:]
 	}
 
-	copy(h[HashLength-len(b):], b)
+	offset := HashLength - len(b)
+	copy(h[offset:], b)
+	clear(h[:offset])
 }
 
 // Generate implements testing/quick.Generator.
@@ -329,7 +331,9 @@ func (a *Address) SetBytes(b []byte) {
 	if len(b) > len(a) {
 		b = b[len(b)-AddressLength:]
 	}
-	copy(a[AddressLength-len(b):], b)
+	offset := AddressLength - len(b)
+	copy(a[offset:], b)
+	clear(a[:offset])
 }
 
 // MarshalText returns the hex representation of a.


### PR DESCRIPTION
## Summary
- `Hash.SetBytes` and `Address.SetBytes` previously only copied the input into the trailing bytes, leaving any existing prefix unchanged when the input was shorter than the fixed length.
- Clear the unused leading bytes after the copy so repeated `SetBytes` calls with shorter inputs do not retain stale data.

## Test plan
- [ ] `go test ./common/...`
- [ ] Cover `SetBytes` with a short input on a non-zero `Hash`/`Address` and confirm the prefix is zeroed