### PR TITLE
accounts/scwallet: use 4-byte public key fingerprint in URLs

### DIFF
--- a/accounts/scwallet/wallet.go
+++ b/accounts/scwallet/wallet.go
@@ -357,7 +357,7 @@ func (w *Wallet) Open(passphrase string) error {
 		// If a previous pairing exists, only ever try to use that
 		if pairing := w.Hub.pairing(w); pairing != nil {
 			if err := w.session.authenticate(*pairing); err != nil {
-				return fmt.Errorf("failed to authenticate card %x: %s", w.PublicKey[:4], err)
+				return fmt.Errorf("failed to authenticate card %x: %s", w.PublicKey[1:5], err)
 			}
 			// Pairing still ok, fall through to PIN checks
 		} else {
@@ -601,7 +601,7 @@ func (w *Wallet) makeAccount(address common.Address, path accounts.DerivationPat
 		Address: address,
 		URL: accounts.URL{
 			Scheme: w.Hub.scheme,
-			Path:   fmt.Sprintf("%x/%s", w.PublicKey[1:3], path.String()),
+			Path:   fmt.Sprintf("%x/%s", w.PublicKey[1:5], path.String()),
 		},
 	}
 }
@@ -794,7 +794,7 @@ func (w *Wallet) findAccountPath(account accounts.Account) (accounts.DerivationP
 		return nil, fmt.Errorf("invalid URL format: %s", account.URL)
 	}
 
-	if url != fmt.Sprintf("%x", w.PublicKey[1:3]) {
+	if url != fmt.Sprintf("%x", w.PublicKey[1:5]) {
 		return nil, fmt.Errorf("URL %s is not for this wallet", account.URL)
 	}
 


### PR DESCRIPTION
## Summary
- `URL()` already identifies a card with `PublicKey[1:5]`, but account paths and lookup still used `PublicKey[1:3]`.
- Align `makeAccount`, `findAccountPath`, and the authenticate error with the same 4-byte fingerprint so wallet URLs stay consistent.

## Test plan
- [ ] `go test ./accounts/scwallet/...`
- [ ] Open a paired scwallet and confirm account URLs use an 8-hex-char card id
- [ ] Lookup an account via `findAccountPath` using the new URL form