### PR TITLE
core, params: rename RegularPerAuthBaseCost to ExecutionPerAuthBaseCost

### DIFF
--- a/core/eip2780_test.go
+++ b/core/eip2780_test.go
@@ -95,7 +95,7 @@ func TestEIP2780Intrinsic(t *testing.T) {
 			// Each authorization adds the state-independent per-auth base
 			// (cold authority access included).
 			want: params.TxBaseCost2780 + params.ColdAccountAccessAmsterdam +
-				params.TxValueCost2780 + 3*params.RegularPerAuthBaseCost,
+				params.TxValueCost2780 + 3*params.ExecutionPerAuthBaseCost,
 		},
 	}
 	for _, tc := range cases {
@@ -404,7 +404,7 @@ func TestEIP2780RecipientOOG(t *testing.T) {
 	auth, authority := signAuth(t, authKeyA, delegate8037, 0)
 	recipient := common.HexToAddress("0xbeef000000000000000000000000000000000004")
 	intrinsic := params.TxBaseCost2780 + params.ColdAccountAccessAmsterdam +
-		params.TxValueCost2780 + params.RegularPerAuthBaseCost
+		params.TxValueCost2780 + params.ExecutionPerAuthBaseCost
 	// The reservoir case needs a near-cap intrinsic cost. This leaves just
 	// enough total budget for the authorization but not for the recipient leaf.
 	const (
@@ -667,7 +667,7 @@ func TestEIP2780InstallDispatch(t *testing.T) {
 	const (
 		base     = params.TxBaseCost2780
 		cold     = params.ColdAccountAccessAmsterdam
-		perAuth  = params.RegularPerAuthBaseCost
+		perAuth  = params.ExecutionPerAuthBaseCost
 		valueCst = params.TxValueCost2780
 	)
 	auth, authority := signAuth(t, authKeyA, delegate8037, 0)
@@ -977,7 +977,7 @@ func TestEIP2780AuthorityAccountWrite(t *testing.T) {
 		base     = params.TxBaseCost2780
 		cold     = params.ColdAccountAccessAmsterdam
 		aw       = params.AccountWriteAmsterdam
-		perAuth  = params.RegularPerAuthBaseCost
+		perAuth  = params.ExecutionPerAuthBaseCost
 		valueCst = params.TxValueCost2780
 	)
 	existingEOA := common.HexToAddress("0xe0a0000000000000000000000000000000000002")
@@ -1115,7 +1115,7 @@ func TestEIP2780DelegationTargetPrewarmed(t *testing.T) {
 		cold    = params.ColdAccountAccessAmsterdam
 		warm    = params.WarmAccountAccessAmsterdam
 		aw      = params.AccountWriteAmsterdam
-		perAuth = params.RegularPerAuthBaseCost
+		perAuth = params.ExecutionPerAuthBaseCost
 	)
 	delegatedAcct := common.HexToAddress("0xde1e000000000000000000000000000000000002")
 

--- a/core/eip8037_test.go
+++ b/core/eip8037_test.go
@@ -809,9 +809,9 @@ func TestAuthIntrinsicBaseOnly(t *testing.T) {
 		t.Fatal(err)
 	}
 	// The recipient touch and the per-authorization authority access (priced
-	// into RegularPerAuthBaseCost) are both charged at the cold rate
+	// into ExecutionPerAuthBaseCost) are both charged at the cold rate
 	// unconditionally at the intrinsic phase (EIP-2780).
-	want := params.TxBaseCost2780 + params.ColdAccountAccessAmsterdam + params.RegularPerAuthBaseCost
+	want := params.TxBaseCost2780 + params.ColdAccountAccessAmsterdam + params.ExecutionPerAuthBaseCost
 	if cost != want {
 		t.Fatalf("intrinsic gas = %d, want %d", cost, want)
 	}

--- a/core/state_transition.go
+++ b/core/state_transition.go
@@ -84,7 +84,7 @@ func IntrinsicGas(data []byte, accessList types.AccessList, authList []types.Set
 	// Add gas for authorizations
 	if authList != nil {
 		if rules.IsAmsterdam {
-			gas += uint64(len(authList)) * params.RegularPerAuthBaseCost
+			gas += uint64(len(authList)) * params.ExecutionPerAuthBaseCost
 		} else {
 			gas += uint64(len(authList)) * params.CallNewAccountGas
 		}

--- a/core/state_transition_test.go
+++ b/core/state_transition_test.go
@@ -307,14 +307,14 @@ func TestIntrinsicGas(t *testing.T) {
 			isEIP2028:   true,
 			isAmsterdam: true,
 			// EIP-2780: the recipient touch and the per-authorization authority
-			// access (priced into RegularPerAuthBaseCost) are both charged at the
+			// access (priced into ExecutionPerAuthBaseCost) are both charged at the
 			// cold rate unconditionally at the intrinsic phase; the account leaf
 			// and indicator bytes are charged at runtime.
 			want: params.TxBaseCost2780 + params.ColdAccountAccessAmsterdam +
 				100*params.TxDataNonZeroGasEIP2028 +
 				1*params.TxAccessListAddressGasAmsterdam + 1*params.TxAccessListStorageKeyGasAmsterdam +
 				1*amsterdamAddressCost + 1*amsterdamStorageKeyCost +
-				1*params.RegularPerAuthBaseCost,
+				1*params.ExecutionPerAuthBaseCost,
 		},
 		{
 			name:        "amsterdam/value-transfer-call",

--- a/params/protocol_params.go
+++ b/params/protocol_params.go
@@ -97,14 +97,14 @@ const (
 	TxAccessListStorageKeyGas uint64 = 1900  // Per storage key specified in EIP 2930 access list
 	TxAuthTupleGas            uint64 = 12500 // Per auth tuple code specified in EIP-7702
 
-	// RegularPerAuthBaseCost is the state-independent per-authorization floor,
+	// ExecutionPerAuthBaseCost is the state-independent per-authorization floor,
 	// defined in EIP-8037 as the sum of:
 	//
 	// - Calldata cost for the authorization tuple
 	// - ECDSA recovery of the authority address
 	// - Cold authority access (COLD_ACCOUNT_ACCESS)
 	// - Warm writes to the authority account
-	RegularPerAuthBaseCost uint64 = 7816
+	ExecutionPerAuthBaseCost uint64 = 7816
 
 	// EIP-2780: resource-based intrinsic transaction gas.
 	TxBaseCost2780  uint64 = 12000


### PR DESCRIPTION
Completes the regular → execution gas rename from #35457. The constant now
matches the EIP-8037 spec name `EXECUTION_PER_AUTH_BASE_COST`.

Pure mechanical rename, no value change.