### PR TITLE
eth/protocols/snap: skip accounts only read by the BAL

### DIFF
--- a/eth/protocols/snap/bal_apply.go
+++ b/eth/protocols/snap/bal_apply.go
@@ -124,6 +124,20 @@ func (s *syncerV2) applyAccessList(b *bal.BlockAccessList, batch ethdb.Batch) er
 		if !s.isFetched(accountHash) {
 			continue
 		}
+		// Skip the account update if the block didn't change the account
+		// metadata (balance, nonce, code), mirroring the read-only skip in
+		// the canonical access list application (see applyBlockAccessList
+		// in core/state). Access lists also enumerate addresses that were
+		// only read and accounts with pure storage changes (e.g. system
+		// contracts), so rewriting the unchanged entry every block is
+		// wasted work. Worse, an account that is empty by the EIP-161
+		// definition yet still present in the state would be misclassified
+		// below as drained by the block and deleted. No such account can
+		// exist on mainnet (see EIP-7523), but the flat state must not
+		// invent deletions the access list doesn't express.
+		if len(access.BalanceChanges) == 0 && len(access.NonceChanges) == 0 && len(access.CodeChanges) == 0 {
+			continue
+		}
 		// Read the existing account from flat state (may not exist yet)
 		var (
 			account types.StateAccount

--- a/eth/protocols/snap/bal_apply_test.go
+++ b/eth/protocols/snap/bal_apply_test.go
@@ -586,3 +586,55 @@ func TestAccessListApplicationDestroyExisting(t *testing.T) {
 			account.Balance, account.Nonce, account.CodeHash)
 	}
 }
+
+// TestAccessListApplicationAccountRead verifies that an account which the block
+// only accessed, without changing its balance, nonce or code, is left alone in
+// the flat state. Notably an account that is empty by the EIP-161 definition,
+// yet still part of the state through its storage, must not be mistaken for
+// one the block has drained and be deleted.
+func TestAccessListApplicationAccountRead(t *testing.T) {
+	t.Parallel()
+	db := rawdb.NewMemoryDatabase()
+	syncer := newSyncerV2(db, rawdb.HashScheme)
+	addr := common.HexToAddress("0x06")
+	accountHash := crypto.Keccak256Hash(addr[:])
+
+	// Zero nonce, zero balance and no code, only kept alive by its storage.
+	original := types.StateAccount{
+		Nonce:    0,
+		Balance:  uint256.NewInt(0),
+		Root:     common.HexToHash("0xbeef"),
+		CodeHash: types.EmptyCodeHash[:],
+	}
+	rawdb.WriteAccountSnapshot(db, accountHash, types.SlimAccountRLP(original))
+
+	// The block reads the account and one of its slots, changing neither.
+	cb := bal.NewConstructionBlockAccessList()
+	cb.AccountRead(addr)
+	cb.StorageRead(addr, common.HexToHash("0xaa"))
+	b := buildTestBAL(t, cb)
+
+	// The application must not produce any database write at all.
+	batch := db.NewBatch()
+	if err := syncer.applyAccessList(b, batch); err != nil {
+		t.Fatalf("applyAccessList failed: %v", err)
+	}
+	if batch.ValueSize() != 0 {
+		t.Errorf("read-only access produced database writes: %d bytes", batch.ValueSize())
+	}
+	if err := batch.Write(); err != nil {
+		t.Fatalf("failed to commit BAL batch: %v", err)
+	}
+	data := rawdb.ReadAccountSnapshot(db, accountHash)
+	if len(data) == 0 {
+		t.Fatal("account read by the block was deleted from flat state")
+	}
+	if !bytes.Equal(data, types.SlimAccountRLP(original)) {
+		account, err := types.FullAccount(data)
+		if err != nil {
+			t.Fatalf("failed to decode account: %v", err)
+		}
+		t.Errorf("account read by the block was modified: balance=%v, nonce=%d, codeHash=%x, root=%v",
+			account.Balance, account.Nonce, account.CodeHash, account.Root)
+	}
+}


### PR DESCRIPTION
Skip the account update for access list entries with no balance, nonce or code change, as applyBlockAccessList in core/state already does: it avoids rewriting the unchanged entry every block and stops an account that is empty per EIP-161 but still part of the state from being misread as drained and deleted.