### PR TITLE
accounts/abi/abigen: validate bytecode before code generation

### DIFF
--- a/accounts/abi/abigen/bind.go
+++ b/accounts/abi/abigen/bind.go
@@ -231,10 +231,14 @@ func Bind(types []string, abis []string, bytecodes []string, fsigs []map[string]
 			receive = &tmplMethod{Original: evmABI.Receive}
 		}
 
+		bytecode, err := normalizeBytecode(bytecodes[i])
+		if err != nil {
+			return "", fmt.Errorf("invalid bytecode for %q: %w", types[i], err)
+		}
 		contracts[types[i]] = &tmplContract{
 			Type:        abi.ToCamelCase(types[i]),
 			InputABI:    strings.ReplaceAll(strippedABI, "\"", "\\\""),
-			InputBin:    strings.TrimPrefix(strings.TrimSpace(bytecodes[i]), "0x"),
+			InputBin:    bytecode,
 			Constructor: evmABI.Constructor,
 			Calls:       calls,
 			Transacts:   transacts,

--- a/accounts/abi/abigen/bindv2.go
+++ b/accounts/abi/abigen/bindv2.go
@@ -332,7 +332,11 @@ func BindV2(types []string, abis []string, bytecodes []string, pkg string, libs 
 		if err != nil {
 			return "", err
 		}
-		b.contracts[types[i]] = newTmplContractV2(types[i], abis[i], bytecodes[i], evmABI.Constructor, cb)
+		bytecode, err := normalizeBytecode(bytecodes[i])
+		if err != nil {
+			return "", fmt.Errorf("invalid bytecode for %q: %w", types[i], err)
+		}
+		b.contracts[types[i]] = newTmplContractV2(types[i], abis[i], bytecode, evmABI.Constructor, cb)
 	}
 
 	invertedLibs := make(map[string]string)

--- a/accounts/abi/abigen/bytecode.go
+++ b/accounts/abi/abigen/bytecode.go
@@ -1,0 +1,55 @@
+// Copyright 2026 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+
+package abigen
+
+import (
+	"fmt"
+	"strings"
+)
+
+// normalizeBytecode strips the optional 0x prefix and validates deployment
+// bytecode before it is interpolated into generated Go source. Besides hex
+// digits, Solidity library placeholders of the form __$<hex>$__ are allowed.
+func normalizeBytecode(bytecode string) (string, error) {
+	bytecode = strings.TrimPrefix(strings.TrimSpace(bytecode), "0x")
+	for pos := 0; pos < len(bytecode); {
+		if isHexByte(bytecode[pos]) {
+			pos++
+			continue
+		}
+		if strings.HasPrefix(bytecode[pos:], "__$") {
+			rest := bytecode[pos+3:]
+			end := strings.Index(rest, "$__")
+			if end <= 0 {
+				return "", fmt.Errorf("malformed library placeholder at offset %d", pos)
+			}
+			for i := 0; i < end; i++ {
+				if !isHexByte(rest[i]) {
+					return "", fmt.Errorf("malformed library placeholder at offset %d", pos)
+				}
+			}
+			pos += 3 + end + 3
+			continue
+		}
+		return "", fmt.Errorf("invalid character at offset %d", pos)
+	}
+	return bytecode, nil
+}
+
+func isHexByte(c byte) bool {
+	return c >= '0' && c <= '9' || c >= 'a' && c <= 'f' || c >= 'A' && c <= 'F'
+}

--- a/accounts/abi/abigen/bytecode_test.go
+++ b/accounts/abi/abigen/bytecode_test.go
@@ -1,0 +1,66 @@
+// Copyright 2026 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+
+package abigen
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestNormalizeBytecode(t *testing.T) {
+	placeholder := "__$0123456789abcdef0123456789abcdef01$__"
+	tests := []struct {
+		name  string
+		input string
+		want  string
+		ok    bool
+	}{
+		{"empty", "", "", true},
+		{"hex", "0x6000aBcD", "6000aBcD", true},
+		{"outer whitespace", "  0x6000\n", "6000", true},
+		{"library placeholder", "60" + placeholder + "00", "60" + placeholder + "00", true},
+		{"quote", "6000\"", "", false},
+		{"embedded whitespace", "60 00", "", false},
+		{"malformed placeholder", "60__$xyz$__00", "", false},
+		{"unterminated placeholder", "60__$abcd", "", false},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got, err := normalizeBytecode(test.input)
+			if test.ok {
+				if err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+				if got != test.want {
+					t.Fatalf("got %q, want %q", got, test.want)
+				}
+			} else if err == nil {
+				t.Fatalf("expected invalid bytecode to be rejected, got %q", got)
+			}
+		})
+	}
+}
+
+func TestBindRejectsInvalidBytecode(t *testing.T) {
+	bad := "6000\";\nvar injected = true\nvar _ = \""
+	if _, err := Bind([]string{"Test"}, []string{"[]"}, []string{bad}, nil, "test", nil, nil); err == nil || !strings.Contains(err.Error(), "invalid bytecode") {
+		t.Fatalf("Bind accepted invalid bytecode, err %v", err)
+	}
+	if _, err := BindV2([]string{"Test"}, []string{"[]"}, []string{bad}, "test", nil, nil); err == nil || !strings.Contains(err.Error(), "invalid bytecode") {
+		t.Fatalf("BindV2 accepted invalid bytecode, err %v", err)
+	}
+}


### PR DESCRIPTION
Reject invalid deployment bytecode before it reaches the Go source templates.

The validation accepts hexadecimal bytecode and Solidity library placeholders, while rejecting other characters that could escape the generated string literal. Both the legacy and v2 binding generators use the same normalization path.

Regression tests cover valid hex, library placeholders, malformed input, and rejection in both `Bind` and `BindV2`.

Validation: `go test ./accounts/abi/abigen` passed in the fork workflow.

Fixes #35431