### PR TITLE
eth, eth/peerstats: split peer quality aggregation out of txtracker

### DIFF
--- a/eth/backend.go
+++ b/eth/backend.go
@@ -479,7 +479,7 @@ func (s *Ethereum) Start() error {
 	s.handler.Start(s.p2pServer.MaxPeers)
 
 	// Start the connection manager with inclusion-based peer protection.
-	s.dropper.Start(s.p2pServer, func() bool { return !s.Synced() }, s.handler.txTracker.GetAllPeerStats)
+	s.dropper.Start(s.p2pServer, func() bool { return !s.Synced() }, s.handler.peerStats.GetAllPeerStats)
 
 	// Subscribe to chain events for the filterMaps head updater.
 	s.fmHeadSub = s.blockchain.SubscribeChainEvent(s.fmHeadEventCh)

--- a/eth/dropper.go
+++ b/eth/dropper.go
@@ -25,7 +25,7 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/mclock"
-	"github.com/ethereum/go-ethereum/eth/txtracker"
+	"github.com/ethereum/go-ethereum/eth/peerstats"
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/metrics"
 	"github.com/ethereum/go-ethereum/p2p"
@@ -42,9 +42,9 @@ const (
 	// dropping when no more peers can be added. Larger numbers result in more
 	// aggressive drop behavior.
 	peerDropThreshold = 0
-	// Fraction of inbound/dialed peers to protect based on inclusion stats.
-	// The top inclusionProtectionFrac of each category (by score) are
-	// shielded from random dropping. 0.1 = top 10%.
+	// Fraction of inbound/dialed peers to protect per inclusion-based
+	// scoring category. The top inclusionProtectionFrac of each category
+	// (by score) are shielded from random dropping. 0.1 = top 10%.
 	inclusionProtectionFrac = 0.1
 )
 
@@ -55,25 +55,25 @@ var (
 	droppedOutbound = metrics.NewRegisteredMeter("eth/dropper/outbound", nil)
 	// dropSkipped counts times a drop was attempted but no peer was dropped,
 	// for any reason (pool has headroom, all candidates trusted/static/young,
-	// or protected by inclusion stats).
+	// or protected by peer quality stats).
 	dropSkipped = metrics.NewRegisteredMeter("eth/dropper/skipped", nil)
 )
 
-// Callback type to get per-peer inclusion statistics.
-type getPeerStatsFunc func() map[string]txtracker.PeerStats
+// Callback type to get per-peer quality statistics (inclusion and latency).
+type getPeerStatsFunc func() map[string]peerstats.PeerStats
 
 // protectionCategory defines a peer scoring function and the fraction of peers
 // to protect per inbound/dialed category. Multiple categories are unioned.
 type protectionCategory struct {
-	score func(txtracker.PeerStats) float64
+	score func(peerstats.PeerStats) float64
 	frac  float64 // fraction of max peers to protect (0.0–1.0)
 }
 
 // protectionCategories is the list of protection criteria. Each category
 // independently selects its top-N peers per pool; the union is protected.
 var protectionCategories = []protectionCategory{
-	{func(s txtracker.PeerStats) float64 { return s.RecentFinalized }, inclusionProtectionFrac}, // Recent finalized
-	{func(s txtracker.PeerStats) float64 { return s.RecentIncluded }, inclusionProtectionFrac},  // Recent included
+	{func(s peerstats.PeerStats) float64 { return s.RecentFinalized }, inclusionProtectionFrac}, // Recent finalized
+	{func(s peerstats.PeerStats) float64 { return s.RecentIncluded }, inclusionProtectionFrac},  // Recent included
 }
 
 // dropper monitors the state of the peer pool and introduces churn by
@@ -88,10 +88,10 @@ var protectionCategories = []protectionCategory{
 //   - Trusted and static peers are never dropped.
 //   - Recently connected peers are also protected from dropping to give them time
 //     to prove their value before being at risk of disconnection.
-//   - Some peers are protected from dropping based on their contribution
-//     to the tx pool. Each pool (inbound/dialed) independently selects its
-//     top fraction of peers by a per-peer EMA score — a slow EMA of
-//     finalized inclusions (~1-day half-life, rewards sustained long-term
+//   - Some peers are protected from dropping based on their usefulness as
+//     tx-pool sources. Each pool (inbound/dialed) independently selects its
+//     top fraction of peers per scoring category — a slow EMA of finalized
+//     inclusions (~1-day half-life, rewards sustained long-term
 //     contribution) and a fast EMA of recent block inclusions (rewards
 //     current activity). The union of all protected sets is shielded from
 //     random dropping, and the drop target is chosen randomly from the
@@ -101,7 +101,7 @@ type dropper struct {
 	maxInboundPeers int // maximum number of inbound peers
 	peersFunc       getPeersFunc
 	syncingFunc     getSyncingFunc
-	peerStatsFunc   getPeerStatsFunc // optional: inclusion stats for protection
+	peerStatsFunc   getPeerStatsFunc // optional: peer quality stats for protection
 
 	// peerDropTimer introduces churn if we are close to limit capacity.
 	// We handle Dialed and Inbound connections separately
@@ -197,7 +197,7 @@ func (cm *dropper) dropRandomPeer() bool {
 }
 
 // protectedPeers computes the set of peers that should not be dropped based
-// on inclusion stats. Each protection category independently selects its
+// on peer quality stats. Each protection category independently selects its
 // top-N peers per inbound/dialed pool; the union is returned.
 func (cm *dropper) protectedPeers(peers []*p2p.Peer) map[*p2p.Peer]bool {
 	if cm.peerStatsFunc == nil {
@@ -228,7 +228,7 @@ func (cm *dropper) protectedPeers(peers []*p2p.Peer) map[*p2p.Peer]bool {
 // Factored from protectedPeers so tests can exercise the per-pool
 // selection logic without needing to construct direction-flagged
 // *p2p.Peer instances (which require unexported p2p types).
-func protectedPeersByPool(inbound, dialed []*p2p.Peer, stats map[string]txtracker.PeerStats) map[*p2p.Peer]bool {
+func protectedPeersByPool(inbound, dialed []*p2p.Peer, stats map[string]peerstats.PeerStats) map[*p2p.Peer]bool {
 	result := make(map[*p2p.Peer]bool)
 	// protectPool selects the top-frac peers from pool by score and adds them to result.
 	protectPool := func(pool []*p2p.Peer, cat protectionCategory) {

--- a/eth/dropper_test.go
+++ b/eth/dropper_test.go
@@ -20,23 +20,30 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/ethereum/go-ethereum/eth/txtracker"
+	"github.com/ethereum/go-ethereum/eth/peerstats"
 	"github.com/ethereum/go-ethereum/p2p"
 	"github.com/ethereum/go-ethereum/p2p/enode"
 )
 
 func makePeers(n int) []*p2p.Peer {
+	return makePeersOffset(n, 0)
+}
+
+// makePeersOffset is like makePeers but shifts the node-ID byte and name index
+// by offset, so a second pool of peers in the same test gets distinct IDs that
+// don't collide with a makePeers(0-based) set.
+func makePeersOffset(n, offset int) []*p2p.Peer {
 	peers := make([]*p2p.Peer, n)
 	for i := range peers {
-		id := enode.ID{byte(i)}
-		peers[i] = p2p.NewPeer(id, fmt.Sprintf("peer%d", i), nil)
+		id := enode.ID{byte(offset + i)}
+		peers[i] = p2p.NewPeer(id, fmt.Sprintf("peer%d", offset+i), nil)
 	}
 	return peers
 }
 
 func TestProtectedPeersNoStats(t *testing.T) {
 	cm := &dropper{maxDialPeers: 20, maxInboundPeers: 30}
-	cm.peerStatsFunc = func() map[string]txtracker.PeerStats { return nil }
+	cm.peerStatsFunc = func() map[string]peerstats.PeerStats { return nil }
 
 	peers := makePeers(10)
 	protected := cm.protectedPeers(peers)
@@ -47,8 +54,8 @@ func TestProtectedPeersNoStats(t *testing.T) {
 
 func TestProtectedPeersEmptyStats(t *testing.T) {
 	cm := &dropper{maxDialPeers: 20, maxInboundPeers: 30}
-	cm.peerStatsFunc = func() map[string]txtracker.PeerStats {
-		return map[string]txtracker.PeerStats{}
+	cm.peerStatsFunc = func() map[string]peerstats.PeerStats {
+		return map[string]peerstats.PeerStats{}
 	}
 
 	peers := makePeers(10)
@@ -63,11 +70,11 @@ func TestProtectedPeersTopPeer(t *testing.T) {
 	cm := &dropper{maxDialPeers: 20, maxInboundPeers: 30}
 
 	peers := makePeers(20)
-	stats := make(map[string]txtracker.PeerStats)
-	stats[peers[0].ID().String()] = txtracker.PeerStats{RecentFinalized: 100}
-	stats[peers[1].ID().String()] = txtracker.PeerStats{RecentIncluded: 5.0}
+	stats := make(map[string]peerstats.PeerStats)
+	stats[peers[0].ID().String()] = peerstats.PeerStats{RecentFinalized: 100}
+	stats[peers[1].ID().String()] = peerstats.PeerStats{RecentIncluded: 5.0}
 
-	cm.peerStatsFunc = func() map[string]txtracker.PeerStats { return stats }
+	cm.peerStatsFunc = func() map[string]peerstats.PeerStats { return stats }
 
 	protected := cm.protectedPeers(peers)
 	if len(protected) != 2 {
@@ -85,11 +92,11 @@ func TestProtectedPeersZeroScore(t *testing.T) {
 	cm := &dropper{maxDialPeers: 20, maxInboundPeers: 30}
 
 	peers := makePeers(10)
-	stats := make(map[string]txtracker.PeerStats)
+	stats := make(map[string]peerstats.PeerStats)
 	for _, p := range peers {
-		stats[p.ID().String()] = txtracker.PeerStats{}
+		stats[p.ID().String()] = peerstats.PeerStats{}
 	}
-	cm.peerStatsFunc = func() map[string]txtracker.PeerStats { return stats }
+	cm.peerStatsFunc = func() map[string]peerstats.PeerStats { return stats }
 
 	protected := cm.protectedPeers(peers)
 	if len(protected) != 0 {
@@ -102,10 +109,10 @@ func TestProtectedPeersOverlap(t *testing.T) {
 	cm := &dropper{maxDialPeers: 20, maxInboundPeers: 30}
 
 	peers := makePeers(20)
-	stats := make(map[string]txtracker.PeerStats)
-	stats[peers[0].ID().String()] = txtracker.PeerStats{RecentFinalized: 100, RecentIncluded: 5.0}
+	stats := make(map[string]peerstats.PeerStats)
+	stats[peers[0].ID().String()] = peerstats.PeerStats{RecentFinalized: 100, RecentIncluded: 5.0}
 
-	cm.peerStatsFunc = func() map[string]txtracker.PeerStats { return stats }
+	cm.peerStatsFunc = func() map[string]peerstats.PeerStats { return stats }
 
 	protected := cm.protectedPeers(peers)
 	if len(protected) != 1 {
@@ -131,19 +138,15 @@ func TestProtectedPeersNilFunc(t *testing.T) {
 // for the RecentFinalized category since we don't set RecentIncluded.
 func TestProtectedByPoolPerPoolTopN(t *testing.T) {
 	inbound := makePeers(10)
-	dialed := makePeers(10)
-	// Distinguish dialed peer IDs from inbound so stats maps don't collide.
-	for i := range dialed {
-		id := enode.ID{byte(100 + i)}
-		dialed[i] = p2p.NewPeer(id, fmt.Sprintf("dialed%d", i), nil)
-	}
+	// Offset dialed peer IDs from inbound so stats maps don't collide.
+	dialed := makePeersOffset(10, 100)
 	// Strictly increasing scores: highest wins in each pool.
-	stats := make(map[string]txtracker.PeerStats)
+	stats := make(map[string]peerstats.PeerStats)
 	for i, p := range inbound {
-		stats[p.ID().String()] = txtracker.PeerStats{RecentFinalized: float64(1 + i)}
+		stats[p.ID().String()] = peerstats.PeerStats{RecentFinalized: float64(1 + i)}
 	}
 	for i, p := range dialed {
-		stats[p.ID().String()] = txtracker.PeerStats{RecentFinalized: float64(1 + i)}
+		stats[p.ID().String()] = peerstats.PeerStats{RecentFinalized: float64(1 + i)}
 	}
 
 	protected := protectedPeersByPool(inbound, dialed, stats)
@@ -173,10 +176,10 @@ func TestProtectedByPoolCrossCategoryOverlap(t *testing.T) {
 	//   RecentFinalized winners: P2 (tie-broken-ok), P0
 	//   RecentIncluded winners: P2, P1
 	// Union: {P0, P1, P2}.
-	stats := make(map[string]txtracker.PeerStats)
-	stats[dialed[0].ID().String()] = txtracker.PeerStats{RecentFinalized: 100, RecentIncluded: 0}
-	stats[dialed[1].ID().String()] = txtracker.PeerStats{RecentFinalized: 0, RecentIncluded: 5.0}
-	stats[dialed[2].ID().String()] = txtracker.PeerStats{RecentFinalized: 200, RecentIncluded: 10.0}
+	stats := make(map[string]peerstats.PeerStats)
+	stats[dialed[0].ID().String()] = peerstats.PeerStats{RecentFinalized: 100, RecentIncluded: 0}
+	stats[dialed[1].ID().String()] = peerstats.PeerStats{RecentFinalized: 0, RecentIncluded: 5.0}
+	stats[dialed[2].ID().String()] = peerstats.PeerStats{RecentFinalized: 200, RecentIncluded: 10.0}
 
 	protected := protectedPeersByPool(nil, dialed, stats)
 
@@ -198,18 +201,14 @@ func TestProtectedByPoolPerPoolIndependence(t *testing.T) {
 	// 20 inbound, 20 dialed — frac=0.1 → 2 protected per pool per category.
 	// Global top-4 of RecentFinalized would be inbound[16..19] — zero dialed.
 	inbound := makePeers(20)
-	dialed := make([]*p2p.Peer, 20)
-	for i := range dialed {
-		id := enode.ID{byte(100 + i)}
-		dialed[i] = p2p.NewPeer(id, fmt.Sprintf("dialed%d", i), nil)
-	}
-	stats := make(map[string]txtracker.PeerStats)
+	dialed := makePeersOffset(20, 100)
+	stats := make(map[string]peerstats.PeerStats)
 	// Every inbound peer outscores every dialed peer.
 	for i, p := range inbound {
-		stats[p.ID().String()] = txtracker.PeerStats{RecentFinalized: float64(1000 + i)}
+		stats[p.ID().String()] = peerstats.PeerStats{RecentFinalized: float64(1000 + i)}
 	}
 	for i, p := range dialed {
-		stats[p.ID().String()] = txtracker.PeerStats{RecentFinalized: float64(1 + i)}
+		stats[p.ID().String()] = peerstats.PeerStats{RecentFinalized: float64(1 + i)}
 	}
 
 	protected := protectedPeersByPool(inbound, dialed, stats)

--- a/eth/handler.go
+++ b/eth/handler.go
@@ -328,6 +328,7 @@ func (h *handler) runEthPeer(peer *eth.Peer, handler eth.Handler) error {
 		peer.Log().Error("Ethereum peer registration failed", "err", err)
 		return err
 	}
+	h.peerStats.NotifyPeerConnect(peer.ID())
 	defer h.unregisterPeer(peer.ID())
 
 	p := h.peers.peer(peer.ID())

--- a/eth/handler.go
+++ b/eth/handler.go
@@ -38,6 +38,7 @@ import (
 	"github.com/ethereum/go-ethereum/eth/downloader"
 	"github.com/ethereum/go-ethereum/eth/ethconfig"
 	"github.com/ethereum/go-ethereum/eth/fetcher"
+	"github.com/ethereum/go-ethereum/eth/peerstats"
 	"github.com/ethereum/go-ethereum/eth/protocols/eth"
 	"github.com/ethereum/go-ethereum/eth/protocols/snap"
 	"github.com/ethereum/go-ethereum/eth/txtracker"
@@ -142,6 +143,7 @@ type handler struct {
 	txFetcher      *fetcher.TxFetcher
 	blobFetcher    *fetcher.BlobFetcher
 	txTracker      *txtracker.Tracker
+	peerStats      *peerstats.Stats
 	peers          *peerSet
 	txBroadcastKey [16]byte
 
@@ -211,6 +213,7 @@ func newHandler(config *handlerConfig) (*handler, error) {
 		return nil
 	}
 	h.txTracker = txtracker.New()
+	h.peerStats = peerstats.New()
 	h.txFetcher = fetcher.NewTxFetcher(h.chain, validateMeta, addTxs, fetchTx, h.removePeer, h.txTracker.NotifyAccepted, blobBuffer)
 
 	// Construct the blob fetcher for cell-based blob data availability
@@ -456,7 +459,7 @@ func (h *handler) unregisterPeer(id string) {
 	h.downloader.UnregisterPeer(id)
 	h.txFetcher.Drop(id)
 	h.blobFetcher.Drop(id)
-	h.txTracker.NotifyPeerDrop(id)
+	h.peerStats.NotifyPeerDrop(id)
 
 	if err := h.peers.unregisterPeer(id); err != nil {
 		logger.Error("Ethereum peer removal failed", "err", err)
@@ -481,8 +484,10 @@ func (h *handler) Start(maxPeers int) {
 	h.txFetcher.Start()
 	h.blobFetcher.Start()
 
-	// Start the transaction tracker (records tx deliveries, credits peer inclusions).
-	h.txTracker.Start(h.chain)
+	// Start the transaction tracker; it emits per-block inclusion and
+	// finalization signals to peerStats, which the dropper queries for
+	// protection decisions.
+	h.txTracker.Start(h.chain, h.peerStats)
 
 	// start peer handler tracker
 	h.wg.Add(1)

--- a/eth/peerstats/peerstats.go
+++ b/eth/peerstats/peerstats.go
@@ -1,0 +1,124 @@
+// Copyright 2026 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+
+// Package peerstats maintains per-peer quality metrics used by the peer
+// dropper to protect high-value peers from random disconnection.
+//
+// The package is a passive accumulator: it exposes entry points for its
+// signal producers (txtracker for inclusion/finalization, the handler for
+// peer-drop cleanup) and a read-only snapshot for its consumer (the
+// dropper). It has no goroutine of its own — all mutation is serialized
+// by a single mutex.
+//
+// Signal sources:
+//   - NotifyBlock(inclusions, finalized) — per-block deltas from txtracker
+//     (computed under txtracker's own lock, then passed in after release)
+//   - NotifyPeerDrop(peer) — disconnect cleanup, from the handler
+package peerstats
+
+import (
+	"sync"
+)
+
+const (
+	// EMA smoothing factor for per-block inclusion rate.
+	emaAlpha = 0.05
+	// EMA smoothing factor for per-block finalization rate. Very slow on
+	// purpose: finalization is permanent, and the score should reflect
+	// sustained contribution over long windows, not recent bursts.
+	// Half-life ≈ 6930 chain heads (~23 hours on 12s blocks).
+	finalizedEMAAlpha = 0.0001
+)
+
+// PeerStats is the exported per-peer snapshot returned by GetAllPeerStats.
+// It carries exactly the fields the dropper scores on.
+type PeerStats struct {
+	RecentFinalized float64 // EMA of per-block finalization credits (slow)
+	RecentIncluded  float64 // EMA of per-block inclusions (fast)
+}
+
+// peerStats is the internal mutable state per peer.
+type peerStats struct {
+	recentFinalized float64
+	recentIncluded  float64
+}
+
+// Stats is the per-peer quality aggregator.
+type Stats struct {
+	mu    sync.Mutex
+	peers map[string]*peerStats
+}
+
+// New creates an empty Stats.
+func New() *Stats {
+	return &Stats{peers: make(map[string]*peerStats)}
+}
+
+// NotifyBlock ingests a per-block update. `inclusions` is the count of the
+// head block's transactions attributed to each peer, `finalized` the
+// per-peer credits accumulated since the last call.
+//
+// A peer with a positive inclusion delta gets a stats entry on first
+// sight — this is the path by which peerstats learns about a peer.
+// Finalization credits for unknown peers are ignored: they may have been
+// removed by NotifyPeerDrop and must not be resurrected from historical
+// data. Tracked peers absent from a delta map decay with a zero sample.
+//
+// NotifyBlock must NOT be called while the caller holds any other lock that
+// could be acquired by peerstats callers in reverse order. Current callers
+// (txtracker.handleChainHead) release their lock before invoking NotifyBlock.
+func (s *Stats) NotifyBlock(inclusions, finalized map[string]int) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	// Ensure a stats entry exists for any peer that just had an inclusion.
+	for peer, count := range inclusions {
+		if count > 0 && s.peers[peer] == nil {
+			s.peers[peer] = &peerStats{}
+		}
+	}
+	// Update inclusion and finalization EMAs for every tracked peer. A
+	// peer not present in the respective delta map gets a 0 contribution
+	// — pure decay.
+	for peer, ps := range s.peers {
+		ps.recentIncluded = (1-emaAlpha)*ps.recentIncluded + emaAlpha*float64(inclusions[peer])
+		ps.recentFinalized = (1-finalizedEMAAlpha)*ps.recentFinalized + finalizedEMAAlpha*float64(finalized[peer])
+	}
+}
+
+// NotifyPeerDrop removes a disconnected peer's stats to prevent unbounded
+// growth. Safe to call from any goroutine.
+func (s *Stats) NotifyPeerDrop(peer string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	delete(s.peers, peer)
+}
+
+// GetAllPeerStats returns a snapshot of per-peer stats. Called by the
+// dropper every few minutes; allocation cost is negligible at that rate.
+func (s *Stats) GetAllPeerStats() map[string]PeerStats {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	result := make(map[string]PeerStats, len(s.peers))
+	for id, ps := range s.peers {
+		result[id] = PeerStats{
+			RecentFinalized: ps.recentFinalized,
+			RecentIncluded:  ps.recentIncluded,
+		}
+	}
+	return result
+}

--- a/eth/peerstats/peerstats.go
+++ b/eth/peerstats/peerstats.go
@@ -19,14 +19,21 @@
 //
 // The package is a passive accumulator: it exposes entry points for its
 // signal producers (txtracker for inclusion/finalization, the handler for
-// peer-drop cleanup) and a read-only snapshot for its consumer (the
+// peer lifecycle) and a read-only snapshot for its consumer (the
 // dropper). It has no goroutine of its own — all mutation is serialized
 // by a single mutex.
 //
+// Peer lifecycle is explicit: an entry exists only between NotifyPeerConnect
+// and NotifyPeerDrop. Every other signal updates an existing entry and is
+// ignored for unknown peers, so a signal that races in after a disconnect (or
+// that names a peer which delivered txs before disconnecting) cannot create or
+// resurrect an entry. This bounds the map to currently-connected peers with no
+// separate sweep.
+//
 // Signal sources:
+//   - NotifyPeerConnect(peer) / NotifyPeerDrop(peer) — lifecycle, from the handler
 //   - NotifyBlock(inclusions, finalized) — per-block deltas from txtracker
 //     (computed under txtracker's own lock, then passed in after release)
-//   - NotifyPeerDrop(peer) — disconnect cleanup, from the handler
 package peerstats
 
 import (
@@ -67,15 +74,24 @@ func New() *Stats {
 	return &Stats{peers: make(map[string]*peerStats)}
 }
 
-// NotifyBlock ingests a per-block update. `inclusions` is the count of the
-// head block's transactions attributed to each peer, `finalized` the
-// per-peer credits accumulated since the last call.
-//
-// A peer with a positive inclusion delta gets a stats entry on first
-// sight — this is the path by which peerstats learns about a peer.
-// Finalization credits for unknown peers are ignored: they may have been
-// removed by NotifyPeerDrop and must not be resurrected from historical
-// data. Tracked peers absent from a delta map decay with a zero sample.
+// NotifyPeerConnect registers a peer so its subsequent signals are tracked.
+// It is the only path that creates an entry; every other signal updates an
+// existing one. Idempotent — re-registering a tracked peer keeps its stats.
+func (s *Stats) NotifyPeerConnect(peer string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.peers[peer] == nil {
+		s.peers[peer] = &peerStats{}
+	}
+}
+
+// NotifyBlock ingests a per-block update. `inclusions` is the count of the head
+// block's transactions attributed to each peer, `finalized` the per-peer
+// credits accumulated since the last call. Both only ever update entries for
+// currently-registered (connected) peers; a delta naming an unknown peer is
+// ignored, so a tx delivered before a peer disconnected cannot resurrect its
+// entry once dropped. Registered peers absent from a delta map decay with a
+// zero sample.
 //
 // NotifyBlock must NOT be called while the caller holds any other lock that
 // could be acquired by peerstats callers in reverse order. Current callers
@@ -84,23 +100,19 @@ func (s *Stats) NotifyBlock(inclusions, finalized map[string]int) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	// Ensure a stats entry exists for any peer that just had an inclusion.
-	for peer, count := range inclusions {
-		if count > 0 && s.peers[peer] == nil {
-			s.peers[peer] = &peerStats{}
-		}
-	}
-	// Update inclusion and finalization EMAs for every tracked peer. A
+	// Update inclusion and finalization EMAs for every registered peer. A
 	// peer not present in the respective delta map gets a 0 contribution
-	// — pure decay.
+	// — pure decay. Deltas for unregistered peers are ignored entirely.
 	for peer, ps := range s.peers {
 		ps.recentIncluded = (1-emaAlpha)*ps.recentIncluded + emaAlpha*float64(inclusions[peer])
 		ps.recentFinalized = (1-finalizedEMAAlpha)*ps.recentFinalized + finalizedEMAAlpha*float64(finalized[peer])
 	}
 }
 
-// NotifyPeerDrop removes a disconnected peer's stats to prevent unbounded
-// growth. Safe to call from any goroutine.
+// NotifyPeerDrop removes a peer's stats on disconnect. Since every other
+// signal only updates existing entries, a stray signal racing in after this
+// deletion is ignored rather than recreating an orphan, so the map stays
+// bounded to currently-connected peers with no separate sweep.
 func (s *Stats) NotifyPeerDrop(peer string) {
 	s.mu.Lock()
 	defer s.mu.Unlock()

--- a/eth/peerstats/peerstats_test.go
+++ b/eth/peerstats/peerstats_test.go
@@ -20,98 +20,145 @@ import (
 	"testing"
 )
 
-// TestNotifyBlockCreatesEntryOnInclusion verifies that a positive
-// inclusion delta creates the peer's entry — the path by which
-// peerstats learns about a peer — and feeds its inclusion EMA.
-func TestNotifyBlockCreatesEntryOnInclusion(t *testing.T) {
+// newStats returns a Stats with the given peer ids pre-registered, matching
+// the production lifecycle where a peer is registered on connect before any
+// of its signals arrive.
+func newStats(ids ...string) *Stats {
 	s := New()
-	s.NotifyBlock(map[string]int{"peerA": 2}, nil)
-
-	ps, ok := s.GetAllPeerStats()["peerA"]
-	if !ok {
-		t.Fatal("inclusion delta should create the peer entry")
+	for _, id := range ids {
+		s.NotifyPeerConnect(id)
 	}
-	if ps.RecentIncluded == 0 {
-		t.Error("RecentIncluded should be non-zero after an inclusion")
+	return s
+}
+
+// TestNotifyPeerConnectCreatesEntry verifies registration creates a zeroed
+// entry and is idempotent (re-registering keeps accumulated stats).
+func TestNotifyPeerConnectCreatesEntry(t *testing.T) {
+	s := New()
+	s.NotifyPeerConnect("peerA")
+	if _, ok := s.GetAllPeerStats()["peerA"]; !ok {
+		t.Fatal("expected peerA entry after connect")
+	}
+	// Accumulate some state, then re-connect: stats must be preserved.
+	s.NotifyBlock(map[string]int{"peerA": 3}, nil)
+	before := s.GetAllPeerStats()["peerA"].RecentIncluded
+	s.NotifyPeerConnect("peerA")
+	if got := s.GetAllPeerStats()["peerA"].RecentIncluded; got != before {
+		t.Fatalf("re-connect wiped stats: got RecentIncluded %f, want %f", got, before)
 	}
 }
 
-// TestNotifyBlockInclusionEMAUpdate verifies the EMA formula for a
-// single step from a zeroed entry.
-func TestNotifyBlockInclusionEMAUpdate(t *testing.T) {
-	s := New()
-	s.NotifyBlock(map[string]int{"peerA": 10}, nil)
+// TestNotifyBlockUpdatesRegisteredPeer verifies that inclusions update the
+// EMA of a registered peer.
+func TestNotifyBlockUpdatesRegisteredPeer(t *testing.T) {
+	s := newStats("peerA")
+	s.NotifyBlock(map[string]int{"peerA": 3}, nil)
 
-	got := s.GetAllPeerStats()["peerA"].RecentIncluded
-	want := emaAlpha * 10.0
-	if diff := got - want; diff < -1e-9 || diff > 1e-9 {
-		t.Fatalf("RecentIncluded after one block: got %f, want %f", got, want)
+	ps := s.GetAllPeerStats()["peerA"]
+	// EMA after first block: (1-0.05)*0 + 0.05*3 = 0.15
+	if ps.RecentIncluded <= 0 {
+		t.Fatalf("expected RecentIncluded > 0 after inclusion, got %f", ps.RecentIncluded)
 	}
 }
 
-// TestNotifyBlockDecaysKnownPeers verifies that a block without a
-// tracked peer's inclusions decays its EMA (zero contribution).
+// TestNotifyBlockIgnoresUnregisteredPeer verifies that inclusions (and
+// finalization credits) for a peer with no entry never create one — a tx
+// delivered by a peer that has since disconnected cannot resurrect its stats.
+func TestNotifyBlockIgnoresUnregisteredPeer(t *testing.T) {
+	s := New()
+	s.NotifyBlock(map[string]int{"ghost": 3}, map[string]int{"ghost": 5})
+	if n := len(s.GetAllPeerStats()); n != 0 {
+		t.Fatalf("signals for unregistered peer must not create entries, got %d", n)
+	}
+}
+
+// TestNotifyBlockDecaysKnownPeers verifies that registered peers get their
+// RecentIncluded EMA decayed when they have no inclusions in a block.
 func TestNotifyBlockDecaysKnownPeers(t *testing.T) {
-	s := New()
-	s.NotifyBlock(map[string]int{"peerA": 10}, nil)
-	first := s.GetAllPeerStats()["peerA"].RecentIncluded
+	s := newStats("peerA")
+	s.NotifyBlock(map[string]int{"peerA": 3}, nil)
+	initial := s.GetAllPeerStats()["peerA"].RecentIncluded
 
+	// Empty block — peerA should decay.
 	s.NotifyBlock(nil, nil)
-	second := s.GetAllPeerStats()["peerA"].RecentIncluded
-	if second >= first {
-		t.Fatalf("RecentIncluded should decay on an empty block: %f >= %f", second, first)
+	after := s.GetAllPeerStats()["peerA"].RecentIncluded
+
+	if after >= initial {
+		t.Fatalf("expected decay, got %f >= %f", after, initial)
 	}
 }
 
-// TestNotifyBlockFinalizationCredits verifies finalization deltas feed
-// the slow EMA of a tracked peer.
-func TestNotifyBlockFinalizationCredits(t *testing.T) {
-	s := New()
-	s.NotifyBlock(map[string]int{"peerA": 1}, nil) // create via inclusion
-	s.NotifyBlock(nil, map[string]int{"peerA": 5})
-
-	if got := s.GetAllPeerStats()["peerA"].RecentFinalized; got == 0 {
-		t.Fatal("RecentFinalized should be non-zero after finalization credits")
-	}
-}
-
-// TestNotifyBlockDecaysFinalized verifies the finalization EMA decays
-// monotonically across credit-free blocks.
-func TestNotifyBlockDecaysFinalized(t *testing.T) {
-	s := New()
-	s.NotifyBlock(map[string]int{"peerA": 1}, map[string]int{"peerA": 5})
-	prev := s.GetAllPeerStats()["peerA"].RecentFinalized
-	if prev == 0 {
-		t.Fatal("seeding RecentFinalized failed")
-	}
-	for i := 0; i < 50; i++ {
-		s.NotifyBlock(nil, nil)
-		cur := s.GetAllPeerStats()["peerA"].RecentFinalized
-		if cur >= prev {
-			t.Fatalf("RecentFinalized should decay monotonically: block %d: %f >= %f", i, cur, prev)
-		}
-		prev = cur
-	}
-}
-
-// TestNotifyBlockDropThenFinalizeNoResurrect verifies that finalization
-// credit arriving after NotifyPeerDrop does not resurrect the entry —
-// historical data must not repopulate the map.
+// TestNotifyBlockDropThenFinalizeNoResurrect verifies the full drop→finalize
+// sequence: a dropped peer doesn't come back via finalization credits.
 func TestNotifyBlockDropThenFinalizeNoResurrect(t *testing.T) {
-	s := New()
+	s := newStats("peerA")
 	s.NotifyBlock(map[string]int{"peerA": 1}, nil)
 	s.NotifyPeerDrop("peerA")
+	s.NotifyBlock(nil, map[string]int{"peerA": 10})
+
+	if stats := s.GetAllPeerStats(); len(stats) != 0 {
+		t.Fatalf("dropped peer must not be resurrected, got %d peers", len(stats))
+	}
+}
+
+// TestNotifyBlockFinalizationCredits an existing peer.
+func TestNotifyBlockFinalizationCredits(t *testing.T) {
+	s := newStats("peerA")
+	s.NotifyBlock(map[string]int{"peerA": 1}, nil)
 	s.NotifyBlock(nil, map[string]int{"peerA": 3})
 
-	if _, ok := s.GetAllPeerStats()["peerA"]; ok {
-		t.Fatal("finalization credit must not resurrect a dropped peer")
+	// RecentFinalized is a slow EMA, not a cumulative count: assert it
+	// moved in the positive direction, not the exact value.
+	if got := s.GetAllPeerStats()["peerA"].RecentFinalized; got <= 0 {
+		t.Fatalf("expected RecentFinalized>0 after credits, got %f", got)
+	}
+}
+
+// TestNotifyBlockDecaysFinalized verifies that the finalization EMA decays
+// for a peer that earned credits in the past but has no new finalization
+// activity. The decay is slow (α=0.0001), so assert monotonic decrease,
+// not convergence to zero.
+func TestNotifyBlockDecaysFinalized(t *testing.T) {
+	s := newStats("peerA")
+	s.NotifyBlock(nil, map[string]int{"peerA": 5})
+	peak := s.GetAllPeerStats()["peerA"].RecentFinalized
+	if peak <= 0 {
+		t.Fatalf("expected RecentFinalized>0 after credits, got %f", peak)
+	}
+
+	// Credit-free blocks — the EMA must decay monotonically.
+	for i := 0; i < 50; i++ {
+		s.NotifyBlock(nil, nil)
+	}
+	after := s.GetAllPeerStats()["peerA"].RecentFinalized
+	if after >= peak {
+		t.Fatalf("expected RecentFinalized to decay, got %f >= peak %f", after, peak)
+	}
+}
+
+// TestNotifyBlockInclusionEMAUpdate verifies the EMA formula (1-α)·old + α·count.
+func TestNotifyBlockInclusionEMAUpdate(t *testing.T) {
+	s := newStats("peerA")
+	// Three inclusions: EMA = 0.05 * 3 = 0.15
+	s.NotifyBlock(map[string]int{"peerA": 3}, nil)
+	got := s.GetAllPeerStats()["peerA"].RecentIncluded
+	want := 0.15
+	if diff := got - want; diff < -1e-9 || diff > 1e-9 {
+		t.Fatalf("EMA after one sample: got %f, want %f", got, want)
+	}
+	// Next block with 10 inclusions: EMA = 0.95*0.15 + 0.05*10 = 0.6425
+	s.NotifyBlock(map[string]int{"peerA": 10}, nil)
+	got = s.GetAllPeerStats()["peerA"].RecentIncluded
+	want = 0.6425
+	if diff := got - want; diff < -1e-9 || diff > 1e-9 {
+		t.Fatalf("EMA after two samples: got %f, want %f", got, want)
 	}
 }
 
 // TestNotifyPeerDropClearsStats verifies disconnect cleanup removes the
 // peer's entry.
 func TestNotifyPeerDropClearsStats(t *testing.T) {
-	s := New()
+	s := newStats("peerA")
 	s.NotifyBlock(map[string]int{"peerA": 1}, nil)
 	s.NotifyPeerDrop("peerA")
 

--- a/eth/peerstats/peerstats_test.go
+++ b/eth/peerstats/peerstats_test.go
@@ -1,0 +1,121 @@
+// Copyright 2026 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+
+package peerstats
+
+import (
+	"testing"
+)
+
+// TestNotifyBlockCreatesEntryOnInclusion verifies that a positive
+// inclusion delta creates the peer's entry — the path by which
+// peerstats learns about a peer — and feeds its inclusion EMA.
+func TestNotifyBlockCreatesEntryOnInclusion(t *testing.T) {
+	s := New()
+	s.NotifyBlock(map[string]int{"peerA": 2}, nil)
+
+	ps, ok := s.GetAllPeerStats()["peerA"]
+	if !ok {
+		t.Fatal("inclusion delta should create the peer entry")
+	}
+	if ps.RecentIncluded == 0 {
+		t.Error("RecentIncluded should be non-zero after an inclusion")
+	}
+}
+
+// TestNotifyBlockInclusionEMAUpdate verifies the EMA formula for a
+// single step from a zeroed entry.
+func TestNotifyBlockInclusionEMAUpdate(t *testing.T) {
+	s := New()
+	s.NotifyBlock(map[string]int{"peerA": 10}, nil)
+
+	got := s.GetAllPeerStats()["peerA"].RecentIncluded
+	want := emaAlpha * 10.0
+	if diff := got - want; diff < -1e-9 || diff > 1e-9 {
+		t.Fatalf("RecentIncluded after one block: got %f, want %f", got, want)
+	}
+}
+
+// TestNotifyBlockDecaysKnownPeers verifies that a block without a
+// tracked peer's inclusions decays its EMA (zero contribution).
+func TestNotifyBlockDecaysKnownPeers(t *testing.T) {
+	s := New()
+	s.NotifyBlock(map[string]int{"peerA": 10}, nil)
+	first := s.GetAllPeerStats()["peerA"].RecentIncluded
+
+	s.NotifyBlock(nil, nil)
+	second := s.GetAllPeerStats()["peerA"].RecentIncluded
+	if second >= first {
+		t.Fatalf("RecentIncluded should decay on an empty block: %f >= %f", second, first)
+	}
+}
+
+// TestNotifyBlockFinalizationCredits verifies finalization deltas feed
+// the slow EMA of a tracked peer.
+func TestNotifyBlockFinalizationCredits(t *testing.T) {
+	s := New()
+	s.NotifyBlock(map[string]int{"peerA": 1}, nil) // create via inclusion
+	s.NotifyBlock(nil, map[string]int{"peerA": 5})
+
+	if got := s.GetAllPeerStats()["peerA"].RecentFinalized; got == 0 {
+		t.Fatal("RecentFinalized should be non-zero after finalization credits")
+	}
+}
+
+// TestNotifyBlockDecaysFinalized verifies the finalization EMA decays
+// monotonically across credit-free blocks.
+func TestNotifyBlockDecaysFinalized(t *testing.T) {
+	s := New()
+	s.NotifyBlock(map[string]int{"peerA": 1}, map[string]int{"peerA": 5})
+	prev := s.GetAllPeerStats()["peerA"].RecentFinalized
+	if prev == 0 {
+		t.Fatal("seeding RecentFinalized failed")
+	}
+	for i := 0; i < 50; i++ {
+		s.NotifyBlock(nil, nil)
+		cur := s.GetAllPeerStats()["peerA"].RecentFinalized
+		if cur >= prev {
+			t.Fatalf("RecentFinalized should decay monotonically: block %d: %f >= %f", i, cur, prev)
+		}
+		prev = cur
+	}
+}
+
+// TestNotifyBlockDropThenFinalizeNoResurrect verifies that finalization
+// credit arriving after NotifyPeerDrop does not resurrect the entry —
+// historical data must not repopulate the map.
+func TestNotifyBlockDropThenFinalizeNoResurrect(t *testing.T) {
+	s := New()
+	s.NotifyBlock(map[string]int{"peerA": 1}, nil)
+	s.NotifyPeerDrop("peerA")
+	s.NotifyBlock(nil, map[string]int{"peerA": 3})
+
+	if _, ok := s.GetAllPeerStats()["peerA"]; ok {
+		t.Fatal("finalization credit must not resurrect a dropped peer")
+	}
+}
+
+// TestNotifyPeerDropClearsStats verifies disconnect cleanup removes the
+// peer's entry.
+func TestNotifyPeerDropClearsStats(t *testing.T) {
+	s := New()
+	s.NotifyBlock(map[string]int{"peerA": 1}, nil)
+	s.NotifyPeerDrop("peerA")
+
+	if _, ok := s.GetAllPeerStats()["peerA"]; ok {
+		t.Fatal("NotifyPeerDrop should remove the entry")
+	}
+}

--- a/eth/txtracker/tracker.go
+++ b/eth/txtracker/tracker.go
@@ -14,16 +14,14 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
 
-// Package txtracker provides minimal per-peer transaction inclusion tracking.
+// Package txtracker maps accepted transactions to their delivering peer
+// and observes chain-head and finalization events to emit per-block
+// per-peer signals to a StatsConsumer (typically eth/peerstats).
 //
-// It records which peer delivered each accepted transaction (via NotifyAccepted)
-// and monitors the chain for inclusion and finalization events. When a
-// delivered transaction is finalized on chain, the delivering peer is
-// credited. A per-block exponential moving average (EMA) of inclusions
-// tracks recent peer productivity.
-//
-// The primary consumer is the peer dropper (eth/dropper.go), which uses
-// these stats to protect high-value peers from random disconnection.
+// The tracker owns the tx-hash → deliverer mapping with FIFO eviction,
+// a chain-head subscription goroutine, and the computation of per-block
+// inclusion counts and finalization credits. It does NOT maintain
+// per-peer aggregates — that is peerstats' job.
 package txtracker
 
 import (
@@ -41,20 +39,7 @@ import (
 const (
 	// Maximum number of tx→deliverer mappings to retain.
 	maxTracked = 262144
-	// EMA smoothing factor for per-block inclusion rate.
-	emaAlpha = 0.05
-	// EMA smoothing factor for per-block finalization rate. Very slow on
-	// purpose: finalization is permanent, and the score should reflect
-	// sustained contribution over long windows, not recent bursts.
-	// Half-life ≈ 6930 chain heads (~23 hours on 12s blocks).
-	finalizedEMAAlpha = 0.0001
 )
-
-// PeerStats holds the per-peer inclusion data.
-type PeerStats struct {
-	RecentFinalized float64 // EMA of per-block finalization credits (slow)
-	RecentIncluded  float64 // EMA of per-block inclusions (fast)
-}
 
 // Chain is the blockchain interface needed by the tracker.
 type Chain interface {
@@ -64,9 +49,18 @@ type Chain interface {
 	CurrentFinalBlock() *types.Header
 }
 
-type peerStats struct {
-	recentFinalized float64
-	recentIncluded  float64
+// StatsConsumer receives per-block signals about peer inclusion and
+// finalization. The tracker invokes NotifyBlock exactly once per handled chain
+// head, AFTER releasing its own lock, with:
+//
+//   - inclusions: per-peer count of transactions in the head block
+//   - finalized:  per-peer count of transactions in blocks that became
+//     finalized since the previous call (possibly zero-range)
+//
+// Either map may be empty but the map itself is never nil when called.
+// NotifyBlock must not call back into the tracker.
+type StatsConsumer interface {
+	NotifyBlock(inclusions, finalized map[string]int)
 }
 
 // TxInfo records the per-transaction state the tracker maintains.
@@ -87,14 +81,14 @@ type TxInfo struct {
 	BlockHash common.Hash
 }
 
-// Tracker records which peer delivered each transaction and credits peers
-// when their transactions appear on chain.
+// Tracker records which peer delivered each transaction and emits
+// per-block inclusion and finalization signals to a StatsConsumer.
 type Tracker struct {
-	mu    sync.Mutex
-	txs   lru.BasicLRU[common.Hash, *TxInfo] // tx hash -> tx info with lru eviction
-	peers map[string]*peerStats
+	mu  sync.Mutex
+	txs lru.BasicLRU[common.Hash, *TxInfo] // tx hash -> tx info with lru eviction
 
 	chain        Chain
+	consumer     StatsConsumer
 	lastFinalNum uint64 // last finalized block number processed
 	headCh       chan core.ChainHeadEvent
 	sub          event.Subscription
@@ -109,17 +103,19 @@ type Tracker struct {
 // New creates a new tracker.
 func New() *Tracker {
 	return &Tracker{
-		txs:   lru.NewBasicLRU[common.Hash, *TxInfo](maxTracked),
-		peers: make(map[string]*peerStats),
-		quit:  make(chan struct{}),
-		step:  make(chan struct{}, 1),
-		now:   func() uint64 { return uint64(time.Now().Unix()) },
+		txs:  lru.NewBasicLRU[common.Hash, *TxInfo](maxTracked),
+		quit: make(chan struct{}),
+		step: make(chan struct{}, 1),
+		now:  func() uint64 { return uint64(time.Now().Unix()) },
 	}
 }
 
-// Start begins listening for chain head events.
-func (t *Tracker) Start(chain Chain) {
+// Start begins listening for chain head events. `consumer` receives
+// per-block signals; if nil, signals are computed but discarded
+// (useful in tests that exercise only the tx-lifecycle surface).
+func (t *Tracker) Start(chain Chain, consumer StatsConsumer) {
 	t.chain = chain
+	t.consumer = consumer
 	// Seed lastFinalNum so checkFinalization doesn't backfill from genesis.
 	if fh := chain.CurrentFinalBlock(); fh != nil {
 		t.lastFinalNum = fh.Number.Uint64()
@@ -128,14 +124,6 @@ func (t *Tracker) Start(chain Chain) {
 	t.sub = chain.SubscribeChainHeadEvent(t.headCh)
 	t.wg.Add(1)
 	go t.loop()
-}
-
-// NotifyPeerDrop removes a disconnected peer's stats to prevent unbounded
-// growth. Safe to call from any goroutine.
-func (t *Tracker) NotifyPeerDrop(peer string) {
-	t.mu.Lock()
-	defer t.mu.Unlock()
-	delete(t.peers, peer)
 }
 
 // Stop shuts down the tracker.
@@ -164,26 +152,6 @@ func (t *Tracker) NotifyAccepted(peer string, hashes []common.Hash) {
 		}
 		t.txs.Add(hash, &TxInfo{Deliverer: peer, AddedAt: addedAt})
 	}
-	// Ensure the delivering peer has a stats entry.
-	if len(hashes) > 0 && t.peers[peer] == nil {
-		t.peers[peer] = &peerStats{}
-	}
-}
-
-// GetAllPeerStats returns a snapshot of per-peer inclusion statistics.
-// Safe to call from any goroutine.
-func (t *Tracker) GetAllPeerStats() map[string]PeerStats {
-	t.mu.Lock()
-	defer t.mu.Unlock()
-
-	result := make(map[string]PeerStats, len(t.peers))
-	for id, ps := range t.peers {
-		result[id] = PeerStats{
-			RecentFinalized: ps.recentFinalized,
-			RecentIncluded:  ps.recentIncluded,
-		}
-	}
-	return result
 }
 
 func (t *Tracker) loop() {
@@ -205,6 +173,10 @@ func (t *Tracker) loop() {
 	}
 }
 
+// handleChainHead computes per-peer deltas for the new head block and any
+// newly-finalized blocks, then hands them to the StatsConsumer AFTER
+// releasing t.mu. The lock-release-before-consumer pattern avoids any
+// cross-package lock ordering.
 func (t *Tracker) handleChainHead(ev core.ChainHeadEvent) {
 	// Fetch the head block by hash (not just number) to avoid using a
 	// reorged block if the tracker goroutine lags behind the chain.
@@ -213,39 +185,35 @@ func (t *Tracker) handleChainHead(ev core.ChainHeadEvent) {
 		return
 	}
 	t.mu.Lock()
-	defer t.mu.Unlock()
 
-	// Count per-peer inclusions in this block for the inclusion EMA, and
-	// record (BlockNum, BlockHash) on first inclusion so the iterate-t.txs
-	// finalization scan can find the entry later without re-reading the
-	// block. Skip txs whose delivery arrived at or after this block's slot
-	// — those are likely post-slot re-broadcasts of an already-mined tx,
-	// not genuine relay work.
+	// Count per-peer inclusions in this block, and record (BlockNum,
+	// BlockHash) on first inclusion so the iterate-t.txs finalization
+	// scan can find the entry later without re-reading the block. Skip
+	// txs whose delivery arrived at or after this block's slot — those
+	// are likely post-slot re-broadcasts of an already-mined tx, not
+	// genuine relay work.
 	blockTime := block.Time()
 	blockNum := block.Number().Uint64()
 	blockHash := block.Hash()
-	blockIncl := make(map[string]int)
+	inclusions := make(map[string]int)
 	for _, tx := range block.Transactions() {
 		ti, ok := t.txs.Peek(tx.Hash())
 		if !ok || ti.AddedAt >= blockTime {
 			continue
 		}
-		blockIncl[ti.Deliverer]++
+		inclusions[ti.Deliverer]++
 		if ti.BlockNum == 0 {
 			ti.BlockNum = blockNum
 			ti.BlockHash = blockHash
 		}
 	}
 	// Accumulate per-peer finalization credits over the newly-finalized
-	// range (possibly zero blocks). Only counts peers still tracked.
-	blockFinal := t.collectFinalizationCredits()
+	// range (possibly zero blocks).
+	finalized := t.collectFinalizationCredits()
+	t.mu.Unlock()
 
-	// Update both EMAs for all tracked peers (decays inactive ones).
-	// Don't create entries for unknown peers — they may have been
-	// removed by NotifyPeerDrop and should not be resurrected.
-	for peer, ps := range t.peers {
-		ps.recentIncluded = (1-emaAlpha)*ps.recentIncluded + emaAlpha*float64(blockIncl[peer])
-		ps.recentFinalized = (1-finalizedEMAAlpha)*ps.recentFinalized + finalizedEMAAlpha*float64(blockFinal[peer])
+	if t.consumer != nil {
+		t.consumer.NotifyBlock(inclusions, finalized)
 	}
 }
 

--- a/eth/txtracker/tracker_test.go
+++ b/eth/txtracker/tracker_test.go
@@ -17,6 +17,7 @@
 package txtracker
 
 import (
+	"maps"
 	"math/big"
 	"sync"
 	"testing"
@@ -95,7 +96,6 @@ func (c *mockChain) addBlockAtHeight(num, salt uint64, txs []*types.Transaction,
 func (c *mockChain) addBlockAtHeightWithTime(num, salt uint64, txs []*types.Transaction, canonical bool, blockTime uint64) *types.Block {
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	// Mix salt into Extra so siblings at the same height get distinct hashes.
 	header := &types.Header{
 		Number: new(big.Int).SetUint64(num),
 		Extra:  big.NewInt(int64(salt)).Bytes(),
@@ -147,6 +147,35 @@ func makeTx(nonce uint64) *types.Transaction {
 	return types.NewTx(&types.LegacyTx{Nonce: nonce, GasPrice: big.NewInt(1), Gas: 21000})
 }
 
+// mockConsumer captures NotifyBlock invocations so tests can assert on the
+// signals the tracker emits.
+type mockConsumer struct {
+	mu      sync.Mutex
+	signals []signal
+}
+
+type signal struct {
+	inclusions, finalized map[string]int
+}
+
+func (c *mockConsumer) NotifyBlock(inclusions, finalized map[string]int) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	// Clone so tests inspecting older signals aren't tripped up by later
+	// iterations mutating the same map (they don't today, but this keeps
+	// the assertion model simple).
+	c.signals = append(c.signals, signal{maps.Clone(inclusions), maps.Clone(finalized)})
+}
+
+func (c *mockConsumer) last() signal {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if len(c.signals) == 0 {
+		return signal{}
+	}
+	return c.signals[len(c.signals)-1]
+}
+
 // waitStep blocks until the tracker has processed one event.
 func waitStep(t *testing.T, tr *Tracker) {
 	t.Helper()
@@ -157,232 +186,187 @@ func waitStep(t *testing.T, tr *Tracker) {
 	}
 }
 
-func TestNotifyReceived(t *testing.T) {
+// TestNotifyAcceptedRecordsMapping verifies the tx-lifecycle surface:
+// NotifyAccepted records tx→peer mappings in insertion order, with
+// first-deliverer-wins semantics on duplicates.
+func TestNotifyAcceptedRecordsMapping(t *testing.T) {
 	tr := New()
-	chain := newMockChain()
-	tr.Start(chain)
-	defer tr.Stop()
 
 	txs := []*types.Transaction{makeTx(1), makeTx(2), makeTx(3)}
 	hashes := hashTxs(txs)
 	tr.NotifyAccepted("peerA", hashes)
 
-	// Public surface: peer entry was created with zero stats before any
-	// chain events. Map lookups would return a zero value for a missing
-	// key, so assert presence explicitly.
-	stats := tr.GetAllPeerStats()
-	if len(stats) != 1 {
-		t.Fatalf("expected 1 peer entry, got %d", len(stats))
-	}
-	ps, ok := stats["peerA"]
-	if !ok {
-		t.Fatal("expected peerA entry, not found")
-	}
-	if ps.RecentFinalized != 0 || ps.RecentIncluded != 0 {
-		t.Fatalf("expected zero stats before chain events, got %+v", ps)
-	}
-
-	// Internal state: all tx→deliverer mappings recorded.
 	tr.mu.Lock()
 	defer tr.mu.Unlock()
 	if tr.txs.Len() != 3 {
 		t.Fatalf("expected 3 tracked txs, got %d", tr.txs.Len())
 	}
+	// Keys() walks the internal list from the least-recently-added end,
+	// which for the tracker's add-once/Peek-only usage is insertion order.
+	for i, h := range tr.txs.Keys() {
+		if hashes[i] != h {
+			t.Fatalf("insertion order mismatch at %d", i)
+		}
+	}
 	for i, h := range hashes {
-		got, ok := tr.txs.Peek(h)
+		ti, ok := tr.txs.Peek(h)
 		if !ok {
 			t.Fatalf("tx %d: not tracked", i)
 		}
-		if got.Deliverer != "peerA" {
-			t.Fatalf("tx %d: expected deliverer=peerA, got %q", i, got.Deliverer)
+		if ti.Deliverer != "peerA" {
+			t.Fatalf("tx %d: expected deliverer=peerA, got %q", i, ti.Deliverer)
 		}
 	}
 }
 
-func TestInclusionEMA(t *testing.T) {
+// TestNotifyAcceptedFirstDelivererWins verifies duplicate accepts
+// preserve the original deliverer.
+func TestNotifyAcceptedFirstDelivererWins(t *testing.T) {
 	tr := New()
-	chain := newMockChain()
-	tr.Start(chain)
-	defer tr.Stop()
-
 	tx := makeTx(1)
 	tr.NotifyAccepted("peerA", []common.Hash{tx.Hash()})
+	tr.NotifyAccepted("peerB", []common.Hash{tx.Hash()})
 
-	// Block 1 includes peerA's tx.
-	chain.addBlock(1, []*types.Transaction{tx})
-	chain.sendHead(1)
-	waitStep(t, tr)
-
-	stats := tr.GetAllPeerStats()
-	if stats["peerA"].RecentIncluded <= 0 {
-		t.Fatalf("expected RecentIncluded > 0 after inclusion, got %f", stats["peerA"].RecentIncluded)
+	tr.mu.Lock()
+	defer tr.mu.Unlock()
+	ti, ok := tr.txs.Peek(tx.Hash())
+	if !ok {
+		t.Fatal("tx not tracked")
 	}
-	ema1 := stats["peerA"].RecentIncluded
-
-	// Block 2 has no txs from peerA — EMA should decay.
-	chain.addBlock(2, nil)
-	chain.sendHead(2)
-	waitStep(t, tr)
-
-	stats = tr.GetAllPeerStats()
-	if stats["peerA"].RecentIncluded >= ema1 {
-		t.Fatalf("expected EMA to decay, got %f >= %f", stats["peerA"].RecentIncluded, ema1)
+	if ti.Deliverer != "peerA" {
+		t.Fatalf("expected first deliverer peerA to win, got %q", ti.Deliverer)
+	}
+	if tr.txs.Len() != 1 {
+		t.Fatalf("expected single tracked tx, got %d", tr.txs.Len())
 	}
 }
 
-func TestFinalization(t *testing.T) {
+// TestHandleChainHeadEmitsInclusions verifies the tracker emits a
+// correct per-peer inclusion map to its consumer when a head block
+// contains tracked transactions.
+func TestHandleChainHeadEmitsInclusions(t *testing.T) {
 	tr := New()
 	chain := newMockChain()
-	tr.Start(chain)
+	consumer := &mockConsumer{}
+	tr.Start(chain, consumer)
 	defer tr.Stop()
 
-	tx := makeTx(1)
-	tr.NotifyAccepted("peerA", []common.Hash{tx.Hash()})
-
-	// Include in block 1.
-	chain.addBlock(1, []*types.Transaction{tx})
-	chain.sendHead(1)
-	waitStep(t, tr)
-
-	// Not finalized yet.
-	stats := tr.GetAllPeerStats()
-	if stats["peerA"].RecentFinalized != 0 {
-		t.Fatalf("expected RecentFinalized=0 before finalization, got %f", stats["peerA"].RecentFinalized)
-	}
-
-	// Finalize block 1, then send head 2 to trigger the finalization EMA update.
-	chain.setFinalBlock(1)
-	chain.addBlock(2, nil)
-	chain.sendHead(2)
-	waitStep(t, tr)
-
-	stats = tr.GetAllPeerStats()
-	if stats["peerA"].RecentFinalized <= 0 {
-		t.Fatalf("expected RecentFinalized>0 after finalization, got %f", stats["peerA"].RecentFinalized)
-	}
-}
-
-func TestMultiplePeers(t *testing.T) {
-	tr := New()
-	chain := newMockChain()
-	tr.Start(chain)
-	defer tr.Stop()
-
-	tx1 := makeTx(1)
-	tx2 := makeTx(2)
+	tx1, tx2 := makeTx(1), makeTx(2)
 	tr.NotifyAccepted("peerA", []common.Hash{tx1.Hash()})
 	tr.NotifyAccepted("peerB", []common.Hash{tx2.Hash()})
 
-	// Both included in block 1.
 	chain.addBlock(1, []*types.Transaction{tx1, tx2})
 	chain.sendHead(1)
 	waitStep(t, tr)
 
-	// Finalize.
+	sig := consumer.last()
+	if sig.inclusions["peerA"] != 1 {
+		t.Errorf("peerA inclusions: got %d, want 1", sig.inclusions["peerA"])
+	}
+	if sig.inclusions["peerB"] != 1 {
+		t.Errorf("peerB inclusions: got %d, want 1", sig.inclusions["peerB"])
+	}
+	if len(sig.finalized) != 0 {
+		t.Errorf("expected empty finalized map, got %v", sig.finalized)
+	}
+}
+
+// TestHandleChainHeadEmptyBlock verifies an empty head block emits an
+// empty inclusion map (so peerstats can decay all known peers).
+func TestHandleChainHeadEmptyBlock(t *testing.T) {
+	tr := New()
+	chain := newMockChain()
+	consumer := &mockConsumer{}
+	tr.Start(chain, consumer)
+	defer tr.Stop()
+
+	chain.addBlock(1, nil)
+	chain.sendHead(1)
+	waitStep(t, tr)
+
+	sig := consumer.last()
+	if len(sig.inclusions) != 0 {
+		t.Errorf("expected empty inclusions, got %v", sig.inclusions)
+	}
+}
+
+// TestHandleChainHeadEmitsFinalization verifies that when finalization
+// advances, the consumer receives per-peer finalization credits
+// accumulated over the newly-finalized range.
+func TestHandleChainHeadEmitsFinalization(t *testing.T) {
+	tr := New()
+	chain := newMockChain()
+	consumer := &mockConsumer{}
+	tr.Start(chain, consumer)
+	defer tr.Stop()
+
+	tx := makeTx(1)
+	tr.NotifyAccepted("peerA", []common.Hash{tx.Hash()})
+
+	// Include in block 1, not yet finalized.
+	chain.addBlock(1, []*types.Transaction{tx})
+	chain.sendHead(1)
+	waitStep(t, tr)
+
+	if credits := consumer.last().finalized["peerA"]; credits != 0 {
+		t.Fatalf("expected no finalization credits before finalization, got %d", credits)
+	}
+
+	// Finalize block 1; next head triggers the finalization scan.
 	chain.setFinalBlock(1)
 	chain.addBlock(2, nil)
 	chain.sendHead(2)
 	waitStep(t, tr)
 
-	stats := tr.GetAllPeerStats()
-	if stats["peerA"].RecentFinalized <= 0 {
-		t.Fatalf("peerA: expected RecentFinalized>0, got %f", stats["peerA"].RecentFinalized)
-	}
-	if stats["peerB"].RecentFinalized <= 0 {
-		t.Fatalf("peerB: expected RecentFinalized>0, got %f", stats["peerB"].RecentFinalized)
+	if credits := consumer.last().finalized["peerA"]; credits != 1 {
+		t.Fatalf("expected 1 finalization credit, got %d", credits)
 	}
 }
 
-func TestFirstDelivererWins(t *testing.T) {
+// TestFinalizationSkipsOrphanedInclusion verifies the finalization scan
+// re-checks the recorded inclusion block hash against the canonical chain:
+// a tx whose recorded inclusion block was reorged out must not yield a
+// finalization credit.
+func TestFinalizationSkipsOrphanedInclusion(t *testing.T) {
 	tr := New()
 	chain := newMockChain()
-	tr.Start(chain)
+	consumer := &mockConsumer{}
+	tr.Start(chain, consumer)
 	defer tr.Stop()
 
 	tx := makeTx(1)
 	tr.NotifyAccepted("peerA", []common.Hash{tx.Hash()})
-	tr.NotifyAccepted("peerB", []common.Hash{tx.Hash()}) // duplicate, should be ignored
 
-	chain.addBlock(1, []*types.Transaction{tx})
-	chain.sendHead(1)
+	// The tx is first seen in block A at height 1 (canonical at the time),
+	// recording (BlockNum=1, BlockHash=A).
+	blockA := chain.addBlockAtHeight(1, 1, []*types.Transaction{tx}, true)
+	chain.sendHeadBlock(blockA)
 	waitStep(t, tr)
 
+	// Reorg: sibling B (without the tx) becomes canonical at height 1.
+	chain.addBlockAtHeight(1, 2, nil, true)
+
+	// Finalize height 1; next head triggers the finalization scan. The
+	// recorded hash A no longer matches canonical-at-1 (now B), so no
+	// credit may be emitted.
 	chain.setFinalBlock(1)
 	chain.addBlock(2, nil)
 	chain.sendHead(2)
 	waitStep(t, tr)
 
-	stats := tr.GetAllPeerStats()
-	if stats["peerA"].RecentFinalized <= 0 {
-		t.Fatalf("peerA should be credited, got RecentFinalized=%f", stats["peerA"].RecentFinalized)
-	}
-	if stats["peerB"].RecentFinalized != 0 {
-		t.Fatalf("peerB should NOT be credited, got RecentFinalized=%f", stats["peerB"].RecentFinalized)
+	if credits := consumer.last().finalized["peerA"]; credits != 0 {
+		t.Fatalf("expected no credit for orphaned inclusion, got %d", credits)
 	}
 }
 
-func TestNoFinalizationCredit(t *testing.T) {
-	tr := New()
-	chain := newMockChain()
-	tr.Start(chain)
-	defer tr.Stop()
-
-	tx := makeTx(1)
-	tr.NotifyAccepted("peerA", []common.Hash{tx.Hash()})
-
-	// Include but don't finalize.
-	chain.addBlock(1, []*types.Transaction{tx})
-	chain.sendHead(1)
-	waitStep(t, tr)
-
-	// Send more heads without finalization.
-	chain.addBlock(2, nil)
-	chain.sendHead(2)
-	waitStep(t, tr)
-
-	stats := tr.GetAllPeerStats()
-	if stats["peerA"].RecentFinalized != 0 {
-		t.Fatalf("expected RecentFinalized=0 without finalization, got %f", stats["peerA"].RecentFinalized)
-	}
-}
-
-func TestEMADecay(t *testing.T) {
-	tr := New()
-	chain := newMockChain()
-	tr.Start(chain)
-	defer tr.Stop()
-
-	tx := makeTx(1)
-	tr.NotifyAccepted("peerA", []common.Hash{tx.Hash()})
-
-	// Include in block 1.
-	chain.addBlock(1, []*types.Transaction{tx})
-	chain.sendHead(1)
-	waitStep(t, tr)
-
-	// Send 30 empty blocks — EMA should decay close to zero.
-	for i := uint64(2); i <= 31; i++ {
-		chain.addBlock(i, nil)
-		chain.sendHead(i)
-		waitStep(t, tr)
-	}
-
-	stats := tr.GetAllPeerStats()
-	if stats["peerA"].RecentIncluded > 0.02 {
-		t.Fatalf("expected RecentIncluded near zero after 30 empty blocks, got %f", stats["peerA"].RecentIncluded)
-	}
-}
-
-// TestReorgSafety verifies that handleChainHead resolves the head block by
-// HASH (not just by number), so a head event announcing a sibling block at
-// the same height does not credit transactions from the canonical block.
-//
-// Regression check: handleChainHead uses GetBlock(hash, number) so a head
-// event announcing sibling B fetches B, not the canonical block A.
+// TestReorgSafety verifies the tracker resolves the head block by HASH
+// so a head event pointing at a sibling block does not emit inclusions
+// from the canonical block at the same height.
 func TestReorgSafety(t *testing.T) {
 	tr := New()
 	chain := newMockChain()
-	tr.Start(chain)
+	consumer := &mockConsumer{}
+	tr.Start(chain, consumer)
 	defer tr.Stop()
 
 	tx := makeTx(1)
@@ -395,77 +379,33 @@ func TestReorgSafety(t *testing.T) {
 		t.Fatal("sibling blocks ended up with the same hash")
 	}
 
-	// Head announces sibling B. A hash-aware tracker fetches B, sees no
-	// peerA txs, and leaves the EMA at zero. A number-only tracker would
-	// instead fetch A and credit peerA.
+	// Head announces sibling B — emit must contain no peerA inclusions.
 	chain.sendHeadBlock(blockB)
 	waitStep(t, tr)
-
-	if got := tr.GetAllPeerStats()["peerA"].RecentIncluded; got != 0 {
-		t.Fatalf("expected RecentIncluded=0 after sibling-B head event, got %f (tracker followed the wrong block)", got)
+	if incl := consumer.last().inclusions["peerA"]; incl != 0 {
+		t.Fatalf("sibling-B head should emit 0 peerA inclusions, got %d", incl)
 	}
 
-	// Now announce canonical A; peerA should be credited.
+	// Head announces canonical A — emit must contain 1 peerA inclusion.
 	chain.sendHeadBlock(blockA)
 	waitStep(t, tr)
-
-	if got := tr.GetAllPeerStats()["peerA"].RecentIncluded; got <= 0 {
-		t.Fatalf("expected RecentIncluded>0 after canonical-A head event, got %f", got)
-	}
-}
-
-// TestRecentFinalizedDecays verifies that the finalization EMA decays
-// for a peer that earned credits in the past but has no new
-// finalization activity. The decay is slow (α=0.0001), so we
-// just assert monotonic decrease, not convergence to zero.
-func TestRecentFinalizedDecays(t *testing.T) {
-	tr := New()
-	chain := newMockChain()
-	tr.Start(chain)
-	defer tr.Stop()
-
-	tx := makeTx(1)
-	tr.NotifyAccepted("peerA", []common.Hash{tx.Hash()})
-
-	// Include and finalize in block 1.
-	chain.addBlock(1, []*types.Transaction{tx})
-	chain.sendHead(1)
-	waitStep(t, tr)
-	chain.setFinalBlock(1)
-	chain.addBlock(2, nil)
-	chain.sendHead(2)
-	waitStep(t, tr)
-
-	peak := tr.GetAllPeerStats()["peerA"].RecentFinalized
-	if peak <= 0 {
-		t.Fatalf("expected RecentFinalized>0 after finalization, got %f", peak)
-	}
-
-	// Send many empty heads — peer contributes zero each block,
-	// EMA should decay monotonically.
-	for i := uint64(3); i <= 50; i++ {
-		chain.addBlock(i, nil)
-		chain.sendHead(i)
-		waitStep(t, tr)
-	}
-
-	after := tr.GetAllPeerStats()["peerA"].RecentFinalized
-	if after >= peak {
-		t.Fatalf("expected RecentFinalized to decay, got %f >= peak %f", after, peak)
+	if incl := consumer.last().inclusions["peerA"]; incl != 1 {
+		t.Fatalf("canonical-A head should emit 1 peerA inclusion, got %d", incl)
 	}
 }
 
 // TestPreSlotGate verifies that a tx delivered at or after the slot of its
-// inclusion block earns no credit. This blocks the simple
-// post-block-propagation re-broadcast attribution attack: a peer that
+// inclusion block is not reported in the inclusion signal. This blocks the
+// simple post-block-propagation re-broadcast attribution attack: a peer that
 // learns a tx from the just-mined block and re-broadcasts it to our pool
 // should not gain credit when that block is processed. The finalization
-// path applies the same gate (ti.AddedAt >= blockTime) and is exercised
-// by the existing TestFinalization with the new clock semantics.
+// path applies the same gate (ti.AddedAt >= blockTime) because entries
+// skipped here never record a BlockNum/BlockHash.
 func TestPreSlotGate(t *testing.T) {
 	tr := New()
 	chain := newMockChain()
-	tr.Start(chain)
+	consumer := &mockConsumer{}
+	tr.Start(chain, consumer)
 	defer tr.Stop()
 
 	// Pin the tracker's clock so NotifyAccepted records a known addedAt.
@@ -482,9 +422,8 @@ func TestPreSlotGate(t *testing.T) {
 	chain.sendHead(1)
 	waitStep(t, tr)
 
-	preEMA := tr.GetAllPeerStats()["peerA"].RecentIncluded
-	if preEMA <= 0 {
-		t.Fatalf("expected RecentIncluded>0 after pre-slot delivery, got %f", preEMA)
+	if incl := consumer.last().inclusions["peerA"]; incl != 1 {
+		t.Fatalf("expected 1 inclusion for pre-slot delivery, got %d", incl)
 	}
 
 	// Block 2: slot strictly BEFORE delivery — post-slot, must NOT credit.
@@ -492,10 +431,20 @@ func TestPreSlotGate(t *testing.T) {
 	chain.sendHead(2)
 	waitStep(t, tr)
 
-	// With the gate, only EMA decay occurs (no contribution this block).
-	// Without the gate, RecentIncluded would have ticked up again.
-	after := tr.GetAllPeerStats()["peerA"].RecentIncluded
-	if after >= preEMA {
-		t.Fatalf("expected EMA to decay (no credit for post-slot tx), got %f >= preEMA %f", after, preEMA)
+	if incl := consumer.last().inclusions["peerA"]; incl != 0 {
+		t.Fatalf("expected 0 inclusions for post-slot delivery, got %d", incl)
 	}
+}
+
+// TestHandleChainHeadNilConsumer verifies the tracker tolerates a nil
+// consumer (useful for tests that only exercise tx-lifecycle behavior).
+func TestHandleChainHeadNilConsumer(t *testing.T) {
+	tr := New()
+	chain := newMockChain()
+	tr.Start(chain, nil)
+	defer tr.Stop()
+
+	chain.addBlock(1, nil)
+	chain.sendHead(1)
+	waitStep(t, tr) // should not panic
 }


### PR DESCRIPTION
This splits the per-peer quality statistics that #34702 embedded in eth/txtracker into a dedicated eth/peerstats package, as groundwork for adding further protection signals (request latency in #34771 will be rebased on top of this). 

@healthykim I've split this out of #34771 to simplify review.