### PR TITLE
core, eth/catalyst, beacon/engine: fix pre-fork field and BAL validation for devnet-8

### DIFF
--- a/beacon/engine/types.go
+++ b/beacon/engine/types.go
@@ -328,9 +328,10 @@ func ExecutableDataToBlockNoHash(data ExecutableData, versionedHashes []common.H
 	// even for empty blocks with no state transitions.
 	//
 	// If Amsterdam is not enabled yet, blockAccessListHash is expected
-	// to be nil.
+	// to be nil. An empty blockAccessList carries no access list: leave
+	// the hash unset so the block hash check catches the mismatch.
 	var blockAccessListHash *common.Hash
-	if data.BlockAccessList != nil {
+	if len(data.BlockAccessList) > 0 {
 		hash := crypto.Keccak256Hash(data.BlockAccessList)
 		blockAccessListHash = &hash
 	}
@@ -359,7 +360,7 @@ func ExecutableDataToBlockNoHash(data ExecutableData, versionedHashes []common.H
 		BlockAccessListHash: blockAccessListHash,
 	}
 	body := types.Body{Transactions: txs, Uncles: nil, Withdrawals: data.Withdrawals}
-	if data.BlockAccessList != nil {
+	if len(data.BlockAccessList) > 0 {
 		var accessList bal.BlockAccessList
 		if err := rlp.DecodeBytes(data.BlockAccessList, &accessList); err != nil {
 			return nil, fmt.Errorf("failed to decode BAL: %w", err)

--- a/cmd/geth/dbcmd.go
+++ b/cmd/geth/dbcmd.go
@@ -217,7 +217,7 @@ WARNING: This is a low-level operation which may cause database corruption!`,
 		ArgsUsage: "<file>",
 		Flags:     slices.Concat(utils.NetworkFlags, utils.DatabaseFlags),
 		Description: `The import-badblocks command loads bad blocks into the database's bad-block
-store so they can be inspected offline with debug.traceBadBlock / debug.getBadBlocks.`,
+store so they can be inspected locally.`,
 	}
 	dbExportCmd = &cli.Command{
 		Action:      exportChaindata,

--- a/cmd/geth/dbcmd.go
+++ b/cmd/geth/dbcmd.go
@@ -18,6 +18,7 @@ package main
 
 import (
 	"bytes"
+	"encoding/json"
 	"fmt"
 	"math"
 	"os"
@@ -104,6 +105,7 @@ Remove blockchain and state databases`,
 			dbCheckStateContentCmd,
 			dbInspectHistoryCmd,
 			dbPebbleUpgradeCmd,
+			dbImportBadBlocksCmd,
 		},
 	}
 	dbInspectCmd = &cli.Command{
@@ -207,6 +209,15 @@ WARNING: This is a low-level operation which may cause database corruption!`,
 		ArgsUsage:   "<dumpfile> <start (optional)",
 		Flags:       slices.Concat(utils.NetworkFlags, utils.DatabaseFlags),
 		Description: "The import command imports the specific chain data from an RLP encoded stream.",
+	}
+	dbImportBadBlocksCmd = &cli.Command{
+		Action:    importBadBlocks,
+		Name:      "import-badblocks",
+		Usage:     "Imports bad blocks into the local bad-block store from a file",
+		ArgsUsage: "<file>",
+		Flags:     slices.Concat(utils.NetworkFlags, utils.DatabaseFlags),
+		Description: `The import-badblocks command loads bad blocks into the database's bad-block
+store so they can be inspected offline with debug.traceBadBlock / debug.getBadBlocks.`,
 	}
 	dbExportCmd = &cli.Command{
 		Action:      exportChaindata,
@@ -868,6 +879,69 @@ var chainExporters = map[string]func(db ethdb.Database) utils.ChainDataIterator{
 		iter := db.NewIterator(rawdb.CodePrefix, nil)
 		return &codeIterator{iter: iter}
 	},
+}
+
+// badBlockEntry mirrors a single entry of the debug_getBadBlocks RPC output.
+// Only the fields needed for import are decoded.
+type badBlockEntry struct {
+	Hash common.Hash `json:"hash"`
+	RLP  string      `json:"rlp"`
+}
+
+// importBadBlocks loads bad blocks from a file into the local bad-block store so
+// they can later be inspected with debug.traceBadBlock / debug.getBadBlocks.
+func importBadBlocks(ctx *cli.Context) error {
+	if ctx.NArg() != 1 {
+		return fmt.Errorf("required arguments: %v", ctx.Command.ArgsUsage)
+	}
+	stack, _ := makeConfigNode(ctx)
+	defer stack.Close()
+
+	db := utils.MakeChainDatabase(ctx, stack, false)
+	defer db.Close()
+
+	path := ctx.Args().Get(0)
+	blob, err := os.ReadFile(path)
+	if err != nil {
+		return fmt.Errorf("failed to read %q: %v", path, err)
+	}
+	var envelope struct {
+		Result []badBlockEntry `json:"result"`
+	}
+	if err := json.Unmarshal(blob, &envelope); err != nil || envelope.Result == nil {
+		if err2 := json.Unmarshal(blob, &envelope.Result); err2 != nil {
+			return fmt.Errorf("failed to parse %q as bad-block json: %v", path, err2)
+		}
+	}
+	if len(envelope.Result) == 0 {
+		return fmt.Errorf("no bad blocks found in %q", path)
+	}
+
+	var imported int
+	for i, entry := range envelope.Result {
+		if entry.RLP == "" {
+			log.Warn("Skipping bad block without rlp", "index", i, "hash", entry.Hash)
+			continue
+		}
+		raw, err := hexutil.Decode(entry.RLP)
+		if err != nil {
+			log.Warn("Skipping bad block with invalid rlp", "index", i, "hash", entry.Hash, "err", err)
+			continue
+		}
+		var block types.Block
+		if err := rlp.DecodeBytes(raw, &block); err != nil {
+			log.Warn("Skipping bad block that failed to decode", "index", i, "hash", entry.Hash, "err", err)
+			continue
+		}
+		if entry.Hash != (common.Hash{}) && block.Hash() != entry.Hash {
+			log.Warn("Bad block hash mismatch, importing decoded block anyway", "index", i, "want", entry.Hash, "have", block.Hash())
+		}
+		rawdb.WriteBadBlock(db, &block)
+		imported++
+		log.Info("Imported bad block", "number", block.NumberU64(), "hash", block.Hash())
+	}
+	log.Info("Imported bad blocks", "file", path, "count", imported, "note", "the bad-block store only retains the highest-numbered blocks (badBlockToKeep)")
+	return nil
 }
 
 func exportChaindata(ctx *cli.Context) error {

--- a/core/block_validator.go
+++ b/core/block_validator.go
@@ -150,6 +150,26 @@ func (v *BlockValidator) ValidateState(block *types.Block, statedb *state.StateD
 		return errors.New("nil ProcessResult value")
 	}
 	header := block.Header()
+	// Verify the block-level access list once Amsterdam is enabled. This runs
+	// before the gas and receipt checks: a mismatching access list perturbs
+	// execution itself (transaction reads are served from it), so downstream
+	// divergences should be reported as an access list failure.
+	if !stateless && v.config.IsAmsterdam(block.Number(), block.Time()) {
+		if res.Bal == nil {
+			return errors.New("block access list is not available in amsterdam")
+		}
+		if block.Header().BlockAccessListHash == nil {
+			return errors.New("block access list hash not set in header")
+		}
+		enc := res.Bal.ToEncodingObj()
+		local, remote := enc.Hash(), *block.Header().BlockAccessListHash
+		if local != remote {
+			return fmt.Errorf("access list hash mismatch, local: %x, remote: %x", local, remote)
+		}
+		if err := enc.Validate(block.GasLimit(), len(block.Transactions())); err != nil {
+			return fmt.Errorf("invalid block access list: %v", err)
+		}
+	}
 	if block.GasUsed() != res.GasUsed {
 		return fmt.Errorf("invalid gas used (remote: %d local: %d)", block.GasUsed(), res.GasUsed)
 	}
@@ -181,23 +201,6 @@ func (v *BlockValidator) ValidateState(block *types.Block, statedb *state.StateD
 		}
 	} else if res.Requests != nil {
 		return errors.New("block has requests before prague fork")
-	}
-	// Verify Block-level accessList once Amsterdam is enabled
-	if v.config.IsAmsterdam(block.Number(), block.Time()) {
-		if res.Bal == nil {
-			return errors.New("block access list is not available in amsterdam")
-		}
-		if block.Header().BlockAccessListHash == nil {
-			return errors.New("block access list hash not set in header")
-		}
-		enc := res.Bal.ToEncodingObj()
-		local, remote := enc.Hash(), *block.Header().BlockAccessListHash
-		if local != remote {
-			return fmt.Errorf("access list hash mismatch, local: %x, remote: %x", local, remote)
-		}
-		if err := enc.Validate(block.GasLimit(), len(block.Transactions())); err != nil {
-			return fmt.Errorf("invalid block access list: %v", err)
-		}
 	}
 	// Validate the state root against the received state root and throw
 	// an error if they don't match.

--- a/core/rawdb/accessors_chain.go
+++ b/core/rawdb/accessors_chain.go
@@ -839,6 +839,12 @@ const badBlockToKeep = 10
 type badBlock struct {
 	Header *types.Header
 	Body   *types.Body
+
+	// AccessList is the EIP-7928 block-level access list attached to the block
+	// (when present). It is stored so that bad blocks can later be inspected
+	// with details. Optional for backwards compatibility with previously stored
+	// bad blocks.
+	AccessList *bal.BlockAccessList `rlp:"optional"`
 }
 
 // ReadBadBlock retrieves the bad block with the corresponding block hash.
@@ -856,6 +862,9 @@ func ReadBadBlock(db ethdb.Reader, hash common.Hash) *types.Block {
 			block := types.NewBlockWithHeader(bad.Header)
 			if bad.Body != nil {
 				block = block.WithBody(*bad.Body)
+			}
+			if bad.AccessList != nil {
+				block = block.WithAccessListUnsafe(bad.AccessList)
 			}
 			return block
 		}
@@ -879,6 +888,9 @@ func ReadAllBadBlocks(db ethdb.Reader) []*types.Block {
 		block := types.NewBlockWithHeader(bad.Header)
 		if bad.Body != nil {
 			block = block.WithBody(*bad.Body)
+		}
+		if bad.AccessList != nil {
+			block = block.WithAccessListUnsafe(bad.AccessList)
 		}
 		blocks = append(blocks, block)
 	}
@@ -905,8 +917,9 @@ func WriteBadBlock(db ethdb.KeyValueStore, block *types.Block) {
 		}
 	}
 	badBlocks = append(badBlocks, &badBlock{
-		Header: block.Header(),
-		Body:   block.Body(),
+		Header:     block.Header(),
+		Body:       block.Body(),
+		AccessList: block.AccessList(),
 	})
 	slices.SortFunc(badBlocks, func(a, b *badBlock) int {
 		// Note: sorting in descending number order.

--- a/core/rawdb/accessors_chain.go
+++ b/core/rawdb/accessors_chain.go
@@ -834,21 +834,60 @@ func DeleteBlockWithoutNumber(db ethdb.KeyValueWriter, hash common.Hash, number 
 	DeleteAccessList(db, hash, number)
 }
 
-const badBlockToKeep = 10
+const badBlockToKeep = 30
 
 type badBlock struct {
 	Header *types.Header
 	Body   *types.Body
 
-	// AccessList is the EIP-7928 block-level access list attached to the block
-	// (when present). It is stored so that bad blocks can later be inspected
-	// with details. Optional for backwards compatibility with previously stored
-	// bad blocks.
+	// The fields below are optional and trailing, so that legacy records and bad
+	// blocks reported by other clients, which carry none of them still decode
+	// cleanly. They are populated for blocks that were built locally but then
+	// failed to re-import (a build-vs-import inconsistency), to aid debugging.
+
+	// AccessList is the EIP-7928 block-level access list attached to the block.
 	AccessList *bal.BlockAccessList `rlp:"optional"`
+
+	// Receipts are the receipts produced during local block building.
+	Receipts []*types.ReceiptForStorage `rlp:"optional"`
+
+	// Reason is the error that made the block fail to re-import.
+	Reason string `rlp:"optional"`
+
+	// Reverted holds the transactions that were executed during local block
+	// building but then reverted (excluded from the block), with the block-access
+	// index each was assigned. They allow the build process to be fully replayed.
+	Reverted []*RevertedTx `rlp:"optional"`
 }
 
-// ReadBadBlock retrieves the bad block with the corresponding block hash.
-func ReadBadBlock(db ethdb.Reader, hash common.Hash) *types.Block {
+// RevertedTx records a transaction that was executed during local block building
+// but then reverted (and excluded from the block), along with the block-access
+// index it was assigned when tried. Persisting these lets the block-building
+// process including transactions that never made it into the block be replayed
+// faithfully.
+type RevertedTx struct {
+	Index uint32
+	Tx    *types.Transaction
+}
+
+// toBlock reconstructs the stored block, re-attaching the access list if present.
+func (b *badBlock) toBlock() *types.Block {
+	block := types.NewBlockWithHeader(b.Header)
+	if b.Body != nil {
+		block = block.WithBody(*b.Body)
+	}
+	// A nil AccessList that had to be encoded (because later optional fields are
+	// present) decodes back as a non-nil empty slice; only re-attach a genuinely
+	// non-empty access list so such records don't gain a spurious empty one.
+	if b.AccessList != nil && len(*b.AccessList) > 0 {
+		block = block.WithAccessListUnsafe(b.AccessList)
+	}
+	return block
+}
+
+// readBadBlocks decodes the stored list of bad blocks, returning nil if the list
+// is absent or cannot be decoded.
+func readBadBlocks(db ethdb.Reader) []*badBlock {
 	blob, err := db.Get(badBlockKey)
 	if err != nil {
 		return nil
@@ -857,16 +896,14 @@ func ReadBadBlock(db ethdb.Reader, hash common.Hash) *types.Block {
 	if err := rlp.DecodeBytes(blob, &badBlocks); err != nil {
 		return nil
 	}
-	for _, bad := range badBlocks {
+	return badBlocks
+}
+
+// ReadBadBlock retrieves the bad block with the corresponding block hash.
+func ReadBadBlock(db ethdb.Reader, hash common.Hash) *types.Block {
+	for _, bad := range readBadBlocks(db) {
 		if bad.Header.Hash() == hash {
-			block := types.NewBlockWithHeader(bad.Header)
-			if bad.Body != nil {
-				block = block.WithBody(*bad.Body)
-			}
-			if bad.AccessList != nil {
-				block = block.WithAccessListUnsafe(bad.AccessList)
-			}
-			return block
+			return bad.toBlock()
 		}
 	}
 	return nil
@@ -875,31 +912,57 @@ func ReadBadBlock(db ethdb.Reader, hash common.Hash) *types.Block {
 // ReadAllBadBlocks retrieves all the bad blocks in the database.
 // All returned blocks are sorted in reverse order by number.
 func ReadAllBadBlocks(db ethdb.Reader) []*types.Block {
-	blob, err := db.Get(badBlockKey)
-	if err != nil {
-		return nil
-	}
-	var badBlocks []*badBlock
-	if err := rlp.DecodeBytes(blob, &badBlocks); err != nil {
-		return nil
-	}
 	var blocks []*types.Block
-	for _, bad := range badBlocks {
-		block := types.NewBlockWithHeader(bad.Header)
-		if bad.Body != nil {
-			block = block.WithBody(*bad.Body)
-		}
-		if bad.AccessList != nil {
-			block = block.WithAccessListUnsafe(bad.AccessList)
-		}
-		blocks = append(blocks, block)
+	for _, bad := range readBadBlocks(db) {
+		blocks = append(blocks, bad.toBlock())
 	}
 	return blocks
+}
+
+// BadBlockDetails carries a bad block together with any locally-built receipts,
+// access list and failure reason recorded alongside it (populated only for
+// build-vs-import mismatches; empty for legacy or other-client bad blocks).
+type BadBlockDetails struct {
+	Block    *types.Block   // block as stored (carries the access list if present)
+	Receipts types.Receipts // receipts from local block building, nil if not recorded
+	Reason   string         // reason the block failed to re-import, empty if not recorded
+	Reverted []*RevertedTx  // txs tried-and-reverted during local build, nil if not recorded
+}
+
+// ReadBadBlockWithDetails retrieves a bad block along with the extra debugging
+// information recorded for build-vs-import mismatches. Returns nil if not found.
+func ReadBadBlockWithDetails(db ethdb.Reader, hash common.Hash) *BadBlockDetails {
+	for _, bad := range readBadBlocks(db) {
+		if bad.Header.Hash() == hash {
+			var receipts types.Receipts
+			if len(bad.Receipts) > 0 {
+				receipts = make(types.Receipts, len(bad.Receipts))
+				for i, r := range bad.Receipts {
+					receipts[i] = (*types.Receipt)(r)
+				}
+			}
+			return &BadBlockDetails{
+				Block:    bad.toBlock(),
+				Receipts: receipts,
+				Reason:   bad.Reason,
+				Reverted: bad.Reverted,
+			}
+		}
+	}
+	return nil
 }
 
 // WriteBadBlock serializes the bad block into the database. If the cumulated
 // bad blocks exceeds the limitation, the oldest will be dropped.
 func WriteBadBlock(db ethdb.KeyValueStore, block *types.Block) {
+	WriteBadBlockWithDetails(db, block, nil, nil, "")
+}
+
+// WriteBadBlockWithDetails serializes a bad block into the database together with
+// the receipts, tried-and-reverted transactions and failure reason from local
+// block building. Any of receipts/reverted/reason may be empty for ordinary bad
+// blocks.
+func WriteBadBlockWithDetails(db ethdb.KeyValueStore, block *types.Block, receipts types.Receipts, reverted []*RevertedTx, reason string) {
 	blob, err := db.Get(badBlockKey)
 	if err != nil {
 		log.Warn("Failed to load old bad blocks", "error", err)
@@ -916,10 +979,20 @@ func WriteBadBlock(db ethdb.KeyValueStore, block *types.Block) {
 			return
 		}
 	}
+	var storageReceipts []*types.ReceiptForStorage
+	if len(receipts) > 0 {
+		storageReceipts = make([]*types.ReceiptForStorage, len(receipts))
+		for i, r := range receipts {
+			storageReceipts[i] = (*types.ReceiptForStorage)(r)
+		}
+	}
 	badBlocks = append(badBlocks, &badBlock{
 		Header:     block.Header(),
 		Body:       block.Body(),
 		AccessList: block.AccessList(),
+		Receipts:   storageReceipts,
+		Reason:     reason,
+		Reverted:   reverted,
 	})
 	slices.SortFunc(badBlocks, func(a, b *badBlock) int {
 		// Note: sorting in descending number order.

--- a/core/rawdb/accessors_chain_test.go
+++ b/core/rawdb/accessors_chain_test.go
@@ -185,6 +185,113 @@ func TestPartialBlockStorage(t *testing.T) {
 }
 
 // Tests block storage and retrieval operations.
+func TestBadBlockDetailsAndCompat(t *testing.T) {
+	mkHeader := func(n int64, extra string) *types.Header {
+		return &types.Header{
+			Number:      big.NewInt(n),
+			Extra:       []byte(extra),
+			UncleHash:   types.EmptyUncleHash,
+			TxHash:      types.EmptyTxsHash,
+			ReceiptHash: types.EmptyReceiptsHash,
+		}
+	}
+	receipts := types.Receipts{
+		{Status: types.ReceiptStatusSuccessful, CumulativeGasUsed: 21000, Logs: []*types.Log{}},
+		{Status: types.ReceiptStatusFailed, CumulativeGasUsed: 42000, Logs: []*types.Log{}},
+	}
+
+	// 1. Legacy compatibility: a record written in the old two-field format
+	// (Header, Body only), as produced by older geth or other clients, must
+	// still decode with empty details.
+	t.Run("legacy", func(t *testing.T) {
+		db := NewMemoryDatabase()
+		type legacyBadBlockV1 struct {
+			Header *types.Header
+			Body   *types.Body
+		}
+		h := mkHeader(1, "legacy")
+		blk := types.NewBlockWithHeader(h)
+		blob, err := rlp.EncodeToBytes([]*legacyBadBlockV1{{Header: h, Body: blk.Body()}})
+		if err != nil {
+			t.Fatalf("encode legacy: %v", err)
+		}
+		if err := db.Put(badBlockKey, blob); err != nil {
+			t.Fatalf("put legacy: %v", err)
+		}
+		if got := ReadAllBadBlocks(db); len(got) != 1 || got[0].Hash() != blk.Hash() {
+			t.Fatalf("legacy bad block not decoded: %v", got)
+		}
+		if d := ReadBadBlockWithDetails(db, blk.Hash()); d == nil {
+			t.Fatal("legacy details not found")
+		} else if len(d.Receipts) != 0 || d.Reason != "" {
+			t.Fatalf("legacy should have empty details, got receipts=%d reason=%q", len(d.Receipts), d.Reason)
+		}
+	})
+
+	// 2. A locally-built mismatch block with receipts, reason and access list
+	// round-trips, and the legacy ReadBadBlock still works on it.
+	t.Run("with-details", func(t *testing.T) {
+		db := NewMemoryDatabase()
+		al := bal.NewConstructionBlockAccessList()
+		al.BalanceChange(1, common.Address{0xaa}, uint256.NewInt(100))
+		block := types.NewBlockWithHeader(mkHeader(2, "mismatch")).WithAccessList(al.ToEncodingObj())
+		reverted := []*RevertedTx{
+			{Index: 3, Tx: types.NewTx(&types.LegacyTx{Nonce: 7, Gas: 21000, GasPrice: big.NewInt(1)})},
+			{Index: 5, Tx: types.NewTx(&types.LegacyTx{Nonce: 8, Gas: 21000, GasPrice: big.NewInt(1)})},
+		}
+
+		WriteBadBlockWithDetails(db, block, receipts, reverted, "access list hash mismatch")
+
+		d := ReadBadBlockWithDetails(db, block.Hash())
+		if d == nil {
+			t.Fatal("details not found")
+		}
+		if d.Reason != "access list hash mismatch" {
+			t.Fatalf("reason mismatch: %q", d.Reason)
+		}
+		if len(d.Receipts) != 2 || d.Receipts[0].CumulativeGasUsed != 21000 || d.Receipts[1].CumulativeGasUsed != 42000 {
+			t.Fatalf("receipts round-trip failed: %+v", d.Receipts)
+		}
+		if d.Block.AccessList() == nil {
+			t.Fatal("access list lost")
+		}
+		if len(d.Reverted) != 2 || d.Reverted[0].Index != 3 || d.Reverted[1].Index != 5 ||
+			d.Reverted[0].Tx.Hash() != reverted[0].Tx.Hash() || d.Reverted[1].Tx.Hash() != reverted[1].Tx.Hash() {
+			t.Fatalf("reverted txs round-trip failed: %+v", d.Reverted)
+		}
+		if b := ReadBadBlock(db, block.Hash()); b == nil || b.Hash() != block.Hash() {
+			t.Fatal("ReadBadBlock failed for detailed record")
+		}
+	})
+
+	// 3. Details present but no access list (nil middle optional field) must
+	// still round-trip.
+	t.Run("details-no-accesslist", func(t *testing.T) {
+		db := NewMemoryDatabase()
+		plain := types.NewBlockWithHeader(mkHeader(3, "no-al"))
+		if plain.AccessList() != nil {
+			t.Fatal("expected nil access list")
+		}
+		reverted := []*RevertedTx{{Index: 1, Tx: types.NewTx(&types.LegacyTx{Nonce: 1, Gas: 21000, GasPrice: big.NewInt(1)})}}
+
+		// AccessList is nil while Receipts/Reason/Reverted are present: the nil
+		// access list is a non-trailing empty optional. The trailing fields must
+		// still round-trip, and the reconstructed block must not gain a spurious
+		// (empty) access list.
+		WriteBadBlockWithDetails(db, plain, receipts, reverted, "invalid gas used")
+		d := ReadBadBlockWithDetails(db, plain.Hash())
+		if d == nil || d.Reason != "invalid gas used" || len(d.Receipts) != 2 {
+			t.Fatalf("no-access-list round-trip failed: %+v", d)
+		}
+		if len(d.Reverted) != 1 || d.Reverted[0].Index != 1 {
+			t.Fatalf("reverted round-trip failed with nil access list: %+v", d.Reverted)
+		}
+		if d.Block.AccessList() != nil {
+			t.Fatal("reconstructed block gained a spurious access list")
+		}
+	})
+}
+
 func TestBadBlockStorage(t *testing.T) {
 	db := NewMemoryDatabase()
 

--- a/core/state_processor.go
+++ b/core/state_processor.go
@@ -398,6 +398,9 @@ func ProcessBuilderExitQueue(requests *[][]byte, rules params.Rules, evm *vm.EVM
 }
 
 func processRequestsSystemCall(requests *[][]byte, rules params.Rules, evm *vm.EVM, requestType byte, addr common.Address, blockAccessIndex uint32, blockAccessList *bal.ConstructionBlockAccessList) error {
+	if evm.StateDB.GetCodeSize(addr) == 0 {
+		return fmt.Errorf("empty system contract: no code at %v", addr)
+	}
 	if tracer := evm.Config.Tracer; tracer != nil {
 		onSystemCallStart(tracer, evm.GetVMContext())
 		if tracer.OnSystemCallEnd != nil {

--- a/eth/api_debug_replay.go
+++ b/eth/api_debug_replay.go
@@ -1,0 +1,215 @@
+// Copyright 2024 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+
+package eth
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core"
+	"github.com/ethereum/go-ethereum/core/rawdb"
+	"github.com/ethereum/go-ethereum/core/state"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/core/types/bal"
+	"github.com/ethereum/go-ethereum/core/vm"
+)
+
+// ReplayBadBlock re-executes a stored bad block using all the information
+// captured for build-vs-import mismatches, and returns the build side and the
+// import side of the execution side by side for diffing.
+//
+// Block building and block import execute the block's included transactions
+// identically; the only thing that distinguishes the build from a plain import
+// is the transactions that were tried-and-reverted during building. So both
+// sides are produced by the same serial execution here, and differ only in
+// whether those reverted transactions are injected: the "build" side injects
+// them, the "import" side does not.
+func (api *DebugAPI) ReplayBadBlock(ctx context.Context, hash common.Hash) (map[string]interface{}, error) {
+	details := rawdb.ReadBadBlockWithDetails(api.eth.chainDb, hash)
+	if details == nil {
+		return nil, fmt.Errorf("bad block %#x not found", hash)
+	}
+	block := details.Block
+
+	parent := api.eth.blockchain.GetBlock(block.ParentHash(), block.NumberU64()-1)
+	if parent == nil {
+		return nil, fmt.Errorf("parent block %#x not found", block.ParentHash())
+	}
+	statedb, release, err := api.eth.stateAtBlock(ctx, parent, nil, false, false)
+	if err != nil {
+		return nil, fmt.Errorf("parent state unavailable: %w", err)
+	}
+	defer release()
+
+	importState := statedb.Copy() // snapshot before the build replay mutates it
+
+	// Build side: same serial execution, with the reverted transactions injected.
+	buildBAL, buildReceipts, buildGas, buildRoot, err := api.replayBuild(ctx, block, statedb, details.Reverted)
+	if err != nil {
+		return nil, fmt.Errorf("build replay: %w", err)
+	}
+	// Import side: identical execution without the reverted transactions.
+	importBAL, importReceipts, importGas, importRoot, err := api.replayBuild(ctx, block, importState, nil)
+	if err != nil {
+		return nil, fmt.Errorf("import replay: %w", err)
+	}
+	buildHash, importHash := buildBAL.Hash(), importBAL.Hash()
+
+	out := map[string]interface{}{
+		"reason":        details.Reason,
+		"revertedCount": len(details.Reverted),
+		"reverted":      details.Reverted,
+
+		// Gas accounting.
+		"headerGasUsed": block.GasUsed(),
+		"buildGasUsed":  buildGas,
+		"importGasUsed": importGas,
+
+		// Block-level access list.
+		"headerBALHash": block.Header().BlockAccessListHash,
+		"buildBALHash":  buildHash,
+		"importBALHash": importHash,
+		"buildBAL":      buildBAL,
+		"importBAL":     importBAL,
+
+		// State root.
+		"headerStateRoot": block.Root(),
+		"buildStateRoot":  buildRoot,
+		"importStateRoot": importRoot,
+
+		// Receipts: the ones recorded at build time, plus both replays.
+		"storedBuildReceipts": details.Receipts,
+		"buildReceipts":       buildReceipts,
+		"importReceipts":      importReceipts,
+	}
+	return out, nil
+}
+
+// replayBuild re-executes a block's construction against the provided state.
+//
+// Passing reverted == nil yields a plain import; passing the block's recorded
+// reverted transactions yields the build side.
+func (api *DebugAPI) replayBuild(ctx context.Context, block *types.Block, statedb *state.StateDB, reverted []*rawdb.RevertedTx) (*bal.BlockAccessList, types.Receipts, uint64, common.Hash, error) {
+	bc := api.eth.blockchain
+	config := bc.Config()
+
+	parent := bc.GetHeader(block.ParentHash(), block.NumberU64()-1)
+	if parent == nil {
+		return nil, nil, 0, common.Hash{}, fmt.Errorf("parent header %#x not found", block.ParentHash())
+	}
+	// Reconstruct the sealing header, resetting the fields accumulated during
+	// execution so the replay starts from the same point as building/import.
+	header := types.CopyHeader(block.Header())
+	header.GasUsed = 0
+	if header.BlobGasUsed != nil {
+		header.BlobGasUsed = new(uint64)
+	}
+	header.RequestsHash = nil
+	header.BlockAccessListHash = nil
+
+	coinbase := block.Coinbase()
+	evm := vm.NewEVM(core.NewEVMBlockContext(header, bc, &coinbase), statedb, config, vm.Config{})
+	defer evm.Release()
+
+	var (
+		signer    = types.MakeSigner(config, header.Number, header.Time)
+		gp        = core.NewGasPool(header.GasLimit)
+		blockAL   = bal.NewConstructionBlockAccessList()
+		blockHash = block.Hash()
+		committed = block.Transactions()
+		receipts  types.Receipts
+		tcount    = 0
+	)
+	// Pre-execution system calls.
+	blockAL.Merge(core.PreExecution(ctx, header.ParentBeaconRoot, parent, config, evm, header.Number, header.Time))
+
+	// Group the reverted transactions by build slot (index-1). Reverted txs at
+	// slot k were tried when tcount==k, before committing the k-th block tx;
+	// those sharing an index keep their recorded order.
+	revBySlot := make(map[int][]*types.Transaction)
+	for _, r := range reverted {
+		if r.Index == 0 {
+			continue
+		}
+		revBySlot[int(r.Index)-1] = append(revBySlot[int(r.Index)-1], r.Tx)
+	}
+
+	// applyReverted executes a tx that was reverted during building — so its reads
+	// reach the access list exactly as they did then — and rolls it back. It is
+	// never merged into the block-level access list.
+	applyReverted := func(rtx *types.Transaction) {
+		msg, err := core.TransactionToMessage(rtx, signer, header.BaseFee)
+		if err != nil {
+			return
+		}
+		statedb.SetTxContext(rtx.Hash(), tcount, uint32(tcount+1))
+		snap, gpSnap := statedb.Snapshot(), gp.Snapshot()
+		core.ApplyTransactionWithEVM(msg, gp, statedb, header.Number, blockHash, header.Time, rtx, evm)
+		statedb.RevertToSnapshot(snap)
+		gp.Set(gpSnap)
+	}
+
+	for k := 0; k <= len(committed); k++ {
+		for _, rtx := range revBySlot[k] {
+			applyReverted(rtx)
+		}
+		if k == len(committed) {
+			break
+		}
+		tx := committed[k]
+		msg, err := core.TransactionToMessage(tx, signer, header.BaseFee)
+		if err != nil {
+			return nil, nil, 0, common.Hash{}, fmt.Errorf("could not convert tx %d [%v]: %w", k, tx.Hash().Hex(), err)
+		}
+		statedb.SetTxContext(tx.Hash(), tcount, uint32(tcount+1))
+		receipt, txBal, err := core.ApplyTransactionWithEVM(msg, gp, statedb, header.Number, blockHash, header.Time, tx, evm)
+		if err != nil {
+			return nil, nil, 0, common.Hash{}, fmt.Errorf("could not apply committed tx %d [%v]: %w", k, tx.Hash().Hex(), err)
+		}
+		receipts = append(receipts, receipt)
+		if tx.Type() == types.BlobTxType && header.BlobGasUsed != nil {
+			*header.BlobGasUsed += receipt.BlobGasUsed
+		}
+		tcount++
+		blockAL.Merge(txBal)
+	}
+
+	// Post-execution system calls and finalize.
+	var allLogs []*types.Log
+	for _, r := range receipts {
+		allLogs = append(allLogs, r.Logs...)
+	}
+	_, postBal, err := core.PostExecution(ctx, config, header.Number, header.Time, allLogs, evm, uint32(tcount+1))
+	if err != nil {
+		return nil, nil, 0, common.Hash{}, err
+	}
+	blockAL.Merge(postBal)
+	body := types.Body{
+		Transactions: committed,
+		Withdrawals:  block.Withdrawals(),
+	}
+	bc.Engine().Finalize(bc, header, statedb, &body, uint32(tcount+1), blockAL)
+
+	// Compute the post-transition state root. Besides giving a value to compare
+	// against the header's Root (catching invalid-merkle-root style mismatches),
+	// this runs a final Finalise that folds post-finalize state changes (e.g.
+	// withdrawals) into the access list, exactly as AssembleBlock does.
+	root := statedb.IntermediateRoot(config.IsEIP158(header.Number))
+
+	return blockAL.ToEncodingObj(), receipts, gp.Used(), root, nil
+}

--- a/eth/catalyst/api.go
+++ b/eth/catalyst/api.go
@@ -845,6 +845,10 @@ func (api *ConsensusAPI) NewPayloadV4(ctx context.Context, params engine.Executa
 		return invalidStatus, paramsErr("nil beaconRoot post-cancun")
 	case executionRequests == nil:
 		return invalidStatus, paramsErr("nil executionRequests post-prague")
+	case params.SlotNumber != nil:
+		return invalidStatus, paramsErr("non-nil slotNumber pre-amsterdam")
+	case len(params.BlockAccessList) > 0:
+		return invalidStatus, paramsErr("non-nil blockAccessList pre-amsterdam")
 	case !api.checkFork(params.Timestamp, forks.Prague, forks.Osaka, forks.BPO1, forks.BPO2, forks.BPO3, forks.BPO4, forks.BPO5):
 		return invalidStatus, unsupportedForkErr("newPayloadV4 must only be called for prague/osaka payloads")
 	}

--- a/eth/catalyst/api.go
+++ b/eth/catalyst/api.go
@@ -999,9 +999,9 @@ func (api *ConsensusAPI) newPayload(ctx context.Context, params engine.Executabl
 
 		// If this block was also built locally, its local build succeeded while
 		// re-import now fails.
-		localBlock, localReceipts, revertedTxs, revertedIdx := api.localBlocks.getByBlockHash(block.Hash())
+		localBlock, localReceipts, revertedTxs, revertedIdx := api.localBlocks.getByStateRoot(block.Root())
 		if localBlock != nil {
-			log.Warn("NewPayload: locally-built block failed to import", "number", localBlock.NumberU64(), "hash", localBlock.Hash())
+			log.Warn("NewPayload: locally-built block failed to import", "number", localBlock.NumberU64(), "hash", localBlock.Hash(), "root", localBlock.Root())
 
 			reverted := make([]*rawdb.RevertedTx, len(revertedTxs))
 			for i, tx := range revertedTxs {

--- a/eth/catalyst/api.go
+++ b/eth/catalyst/api.go
@@ -997,6 +997,18 @@ func (api *ConsensusAPI) newPayload(ctx context.Context, params engine.Executabl
 	if err != nil {
 		log.Warn("NewPayload: inserting block failed", "error", err)
 
+		// If this block was also built locally, its local build succeeded while
+		// re-import now fails.
+		localBlock, localReceipts, revertedTxs, revertedIdx := api.localBlocks.getByBlockHash(block.Hash())
+		if localBlock != nil {
+			log.Warn("NewPayload: locally-built block failed to import", "number", localBlock.NumberU64(), "hash", localBlock.Hash())
+
+			reverted := make([]*rawdb.RevertedTx, len(revertedTxs))
+			for i, tx := range revertedTxs {
+				reverted[i] = &rawdb.RevertedTx{Index: revertedIdx[i], Tx: tx}
+			}
+			rawdb.WriteBadBlockWithDetails(api.eth.ChainDb(), localBlock, localReceipts, reverted, err.Error())
+		}
 		api.invalidLock.Lock()
 		api.invalidBlocksHits[block.Hash()] = 1
 		api.invalidTipsets[block.Hash()] = block.Header()

--- a/eth/catalyst/queue.go
+++ b/eth/catalyst/queue.go
@@ -91,6 +91,26 @@ func (q *payloadQueue) get(id engine.PayloadID, full bool) *engine.ExecutionPayl
 	return nil
 }
 
+// getByBlockHash returns the tracked local payload whose full block has the
+// given hash, along with that block, its build-time receipts, and the
+// transactions tried-and-reverted during building (with their block-access
+// indices).
+func (q *payloadQueue) getByBlockHash(hash common.Hash) (*types.Block, []*types.Receipt, []*types.Transaction, []uint32) {
+	q.lock.RLock()
+	defer q.lock.RUnlock()
+
+	for _, item := range q.payloads {
+		if item == nil {
+			return nil, nil, nil, nil // no more items
+		}
+		block, receipts, revertedTxs, revertedIdx := item.payload.FullBlockAndReceipts()
+		if block != nil && block.Hash() == hash {
+			return block, receipts, revertedTxs, revertedIdx
+		}
+	}
+	return nil, nil, nil, nil
+}
+
 // has checks if a particular payload is already tracked.
 func (q *payloadQueue) has(id engine.PayloadID) bool {
 	q.lock.RLock()

--- a/eth/catalyst/queue.go
+++ b/eth/catalyst/queue.go
@@ -91,11 +91,11 @@ func (q *payloadQueue) get(id engine.PayloadID, full bool) *engine.ExecutionPayl
 	return nil
 }
 
-// getByBlockHash returns the tracked local payload whose full block has the
-// given hash, along with that block, its build-time receipts, and the
+// getByStateRoot returns the tracked local payload whose full block has the
+// given state root, along with that block, its build-time receipts, and the
 // transactions tried-and-reverted during building (with their block-access
 // indices).
-func (q *payloadQueue) getByBlockHash(hash common.Hash) (*types.Block, []*types.Receipt, []*types.Transaction, []uint32) {
+func (q *payloadQueue) getByStateRoot(root common.Hash) (*types.Block, []*types.Receipt, []*types.Transaction, []uint32) {
 	q.lock.RLock()
 	defer q.lock.RUnlock()
 
@@ -104,7 +104,7 @@ func (q *payloadQueue) getByBlockHash(hash common.Hash) (*types.Block, []*types.
 			return nil, nil, nil, nil // no more items
 		}
 		block, receipts, revertedTxs, revertedIdx := item.payload.FullBlockAndReceipts()
-		if block != nil && block.Hash() == hash {
+		if block != nil && block.Root() == root {
 			return block, receipts, revertedTxs, revertedIdx
 		}
 	}

--- a/miner/payload_building.go
+++ b/miner/payload_building.go
@@ -80,11 +80,16 @@ func (args *BuildPayloadArgs) Id() engine.PayloadID {
 // the revenue. Therefore, the empty-block here is always available and full-block
 // will be set/updated afterwards.
 type Payload struct {
-	id            engine.PayloadID
-	empty         *types.Block
-	emptyWitness  *stateless.Witness
-	full          *types.Block
-	fullWitness   *stateless.Witness
+	id           engine.PayloadID
+	empty        *types.Block
+	emptyWitness *stateless.Witness
+
+	full            *types.Block
+	fullReceipts    []*types.Receipt
+	fullRevertedTxs []*types.Transaction
+	fullRevertedIdx []uint32
+	fullWitness     *stateless.Witness
+
 	sidecars      []*types.BlobTxSidecar
 	emptyRequests [][]byte
 	requests      [][]byte
@@ -124,6 +129,9 @@ func (payload *Payload) update(r *newPayloadResult, elapsed time.Duration) (resu
 	// fee(apart from the mev revenue) is the only indicator for comparison.
 	if payload.full == nil || r.fees.Cmp(payload.fullFees) > 0 {
 		payload.full = r.block
+		payload.fullReceipts = r.receipts
+		payload.fullRevertedTxs = r.revertedTxs
+		payload.fullRevertedIdx = r.revertedIdx
 		payload.fullFees = r.fees
 		payload.sidecars = r.sidecars
 		payload.requests = r.requests
@@ -145,6 +153,16 @@ func (payload *Payload) update(r *newPayloadResult, elapsed time.Duration) (resu
 	}
 	payload.cond.Broadcast() // fire signal for notifying full block
 	return
+}
+
+// FullBlockAndReceipts returns the latest built full block together with the
+// receipts produced during its construction and the transactions that were
+// tried-and-reverted during building.
+func (payload *Payload) FullBlockAndReceipts() (*types.Block, []*types.Receipt, []*types.Transaction, []uint32) {
+	payload.lock.Lock()
+	defer payload.lock.Unlock()
+
+	return payload.full, payload.fullReceipts, payload.fullRevertedTxs, payload.fullRevertedIdx
 }
 
 // Resolve returns the latest built payload and also terminates the background

--- a/miner/payload_building.go
+++ b/miner/payload_building.go
@@ -137,8 +137,11 @@ func (payload *Payload) update(r *newPayloadResult, elapsed time.Duration) (resu
 		payload.requests = r.requests
 		payload.fullWitness = r.witness
 
-		feesInEther := new(big.Float).Quo(new(big.Float).SetInt(r.fees), big.NewFloat(params.Ether))
-		log.Info("Updated payload",
+		var (
+			attrs       []any
+			feesInEther = new(big.Float).Quo(new(big.Float).SetInt(r.fees), big.NewFloat(params.Ether))
+		)
+		attrs = append(attrs,
 			"id", payload.id,
 			"number", r.block.NumberU64(),
 			"hash", r.block.Hash(),
@@ -149,6 +152,10 @@ func (payload *Payload) update(r *newPayloadResult, elapsed time.Duration) (resu
 			"root", r.block.Root(),
 			"elapsed", common.PrettyDuration(elapsed),
 		)
+		if r.block.BlockAccessListHash() != nil {
+			attrs = append(attrs, "balhash", r.block.BlockAccessListHash().Hex())
+		}
+		log.Info("Updated payload", attrs...)
 		result = true
 	}
 	payload.cond.Broadcast() // fire signal for notifying full block

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -76,6 +76,13 @@ type environment struct {
 	blobs    int
 	bal      *bal.ConstructionBlockAccessList
 
+	// revertedTxs / revertedIdx record transactions that were executed during
+	// block building but then reverted (excluded from the block), together with
+	// the block-access index each was tried at (tcount+1). They let the build
+	// process be replayed faithfully for debugging.
+	revertedTxs []*types.Transaction
+	revertedIdx []uint32
+
 	witness *stateless.Witness
 }
 
@@ -114,6 +121,11 @@ type newPayloadResult struct {
 	receipts []*types.Receipt       // Receipts collected during construction
 	requests [][]byte               // Consensus layer requests collected during block construction
 	witness  *stateless.Witness     // Witness is an optional stateless proof
+
+	// revertedTxs / revertedIdx record the transactions tried-and-reverted during
+	// construction and the block-access index each was assigned.
+	revertedTxs []*types.Transaction
+	revertedIdx []uint32
 }
 
 // generateParams wraps various settings for generating sealing task.
@@ -237,13 +249,15 @@ func (miner *Miner) generateWork(ctx context.Context, genParam *generateParams, 
 		return &newPayloadResult{err: fmt.Errorf("%w: %v", errStateReadFailure, dbErr)}
 	}
 	return &newPayloadResult{
-		block:    block,
-		fees:     totalFees(block, work.receipts),
-		sidecars: work.sidecars,
-		stateDB:  work.state,
-		receipts: work.receipts,
-		requests: requests,
-		witness:  work.witness,
+		block:       block,
+		fees:        totalFees(block, work.receipts),
+		sidecars:    work.sidecars,
+		stateDB:     work.state,
+		receipts:    work.receipts,
+		requests:    requests,
+		witness:     work.witness,
+		revertedTxs: work.revertedTxs,
+		revertedIdx: work.revertedIdx,
 	}
 }
 
@@ -433,6 +447,9 @@ func (miner *Miner) applyTransaction(env *environment, tx *types.Transaction) (*
 	if err != nil {
 		env.state.RevertToSnapshot(snap)
 		env.gasPool.Set(gp)
+
+		env.revertedTxs = append(env.revertedTxs, tx.WithoutBlobTxSidecar())
+		env.revertedIdx = append(env.revertedIdx, uint32(env.tcount+1))
 		return nil, nil, err
 	}
 	env.header.GasUsed = env.gasPool.Used()


### PR DESCRIPTION
d98ade3: reject `slotNumber`/`blockAccessList` in pre-Amsterdam payloads with `-32602`, and treat empty `blockAccessList` bytes as absent so the block hash check runs instead of a BAL decode error.

1a76e89: invalidate blocks whose request system calls target a codeless contract instead of silently succeeding.

6d24c8d: validate the block access list before gas used, since parallel execution reads from the declared BAL and a corrupted one diverges gas first.
