### PR TITLE
node: enforce single active WebSocket endpoint in admin_startWS

### DIFF
--- a/node/api.go
+++ b/node/api.go
@@ -18,6 +18,7 @@ package node
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 
@@ -276,6 +277,18 @@ func (api *adminAPI) StartWS(host *string, port *int, allowedOrigins *string, ap
 
 	// Enable WebSocket on the server.
 	server := api.node.wsServerForPort(*port, false)
+	// Only one WebSocket endpoint may be active at a time. The duplicate check
+	// in enableWS is local to the selected server, so also reject the call when
+	// the other server already has a WebSocket endpoint enabled.
+	var other *httpServer
+	if server == api.node.http {
+		other = api.node.ws
+	} else {
+		other = api.node.http
+	}
+	if other.wsAllowed() {
+		return false, errors.New("JSON-RPC over WebSocket is already enabled")
+	}
 	if err := server.setListenAddr(*host, *port); err != nil {
 		return false, err
 	}

--- a/node/api_test.go
+++ b/node/api_test.go
@@ -241,6 +241,36 @@ func TestStartRPC(t *testing.T) {
 			wantRPC:       true,
 			wantWS:        true,
 		},
+		{
+			name: "ws single endpoint across servers",
+			cfg:  Config{HTTPHost: "127.0.0.1"},
+			fn: func(t *testing.T, n *Node, api *adminAPI) {
+				// Enable WebSocket on the HTTP server, sharing its port.
+				wsport := n.http.port
+				_, err := api.StartWS(sp("127.0.0.1"), ip(wsport), nil, nil)
+				assert.NoError(t, err)
+
+				// Pick a different port to open a second WebSocket endpoint on.
+				listener, err := net.Listen("tcp", "127.0.0.1:0")
+				if err != nil {
+					t.Fatal("can't listen:", err)
+				}
+				other := listener.Addr().(*net.TCPAddr).Port
+				listener.Close()
+
+				// Only one WebSocket endpoint may be active at a time. Starting
+				// one on a second port must be rejected even though it selects
+				// a different internal server.
+				_, err = api.StartWS(sp("127.0.0.1"), ip(other), nil, nil)
+				if err == nil || !strings.Contains(err.Error(), "JSON-RPC over WebSocket is already enabled") {
+					t.Fatalf("StartWS on second port: want 'already enabled' error, got %v", err)
+				}
+			},
+			wantReachable: true,
+			wantHandlers:  true,
+			wantRPC:       true,
+			wantWS:        true,
+		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
This fixes #35483.

## Problem

The docs guarantee that only one WebSocket endpoint can be active at a time. That guarantee is currently enforced only per internal `httpServer` object. When the existing WebSocket endpoint shares the HTTP server's port, calling `admin_startWS` with a different port selects the separate `n.ws` server. The duplicate check in `enableWS` is local to the selected server, so it does not see the already-active endpoint and both ports remain reachable.

## Fix

Before enabling WebSocket on the server selected by `wsServerForPort`, also check whether the other server already has a WebSocket endpoint enabled via the existing `httpServer.wsAllowed()` accessor, and reject the call with the same "already enabled" error used on the same-server path.

## Test

Adds a `TestStartRPC` case that enables WebSocket on the shared HTTP server port and then asserts that starting a second endpoint on a different port is rejected. The new case fails on the old code (the second `admin_startWS` returns success) and passes with the fix.