### PR TITLE
ethapi: make net_listening reflect the actual P2P listener state

### DIFF
--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -2166,7 +2166,7 @@ func NewNetAPI(net *p2p.Server, networkVersion uint64) *NetAPI {
 
 // Listening returns an indication if the node is listening for network connections.
 func (api *NetAPI) Listening() bool {
-	return true // always listening
+	return api.net != nil && api.net.ListenAddr != ""
 }
 
 // PeerCount returns the number of connected peers

--- a/internal/ethapi/net_api_test.go
+++ b/internal/ethapi/net_api_test.go
@@ -1,0 +1,47 @@
+// Copyright 2026 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+
+package ethapi
+
+import (
+	"testing"
+
+	"github.com/ethereum/go-ethereum/p2p"
+)
+
+func TestNetAPIListening(t *testing.T) {
+	tests := []struct {
+		name string
+		net  *p2p.Server
+		want bool
+	}{
+		// A node with no P2P TCP listener (e.g. a --dev node) must report
+		// that it is not listening for network connections.
+		{"no p2p listener", &p2p.Server{}, false},
+		// Without a P2P server there is no listener to report.
+		{"no p2p server", nil, false},
+		// A node with an enabled P2P listener keeps reporting true.
+		{"p2p listener enabled", &p2p.Server{Config: p2p.Config{ListenAddr: ":30303"}}, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			api := NewNetAPI(tt.net, 1)
+			if got := api.Listening(); got != tt.want {
+				t.Errorf("Listening() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Fixes #35482.

`NetAPI.Listening()` returned the literal `true` for every node state, so a node with the P2P TCP listener disabled (e.g. `geth --dev`, which clears `p2p.Config.ListenAddr`) still reported `net_listening` as `true` while `admin_nodeInfo` showed an empty `listenAddr` and listener port `0`.

This PR derives the result from the P2P server's actual listening state instead of a constant: `Listening()` now returns `api.net != nil && api.net.ListenAddr != ""`. `p2p.Server.start` only binds the TCP listener when `ListenAddr` is set, and `setupListening` then updates it to the bound address, so:

- a node with an enabled listener keeps reporting `true` (no behavior change for the default configuration), and
- a node with no listener (dev mode, `--port 0` alone does not disable it, only an empty `ListenAddr` does) now reports `false`.

A node started with `--maxpeers 0` (non-dev) still binds the TCP listener, so `net_listening` remains `true` there, matching the endpoint's "actively listening for network connections" definition. Only the reported broken state (no listener at all) changes.

Added `TestNetAPIListening` covering the disabled-listener, missing-server, and enabled-listener cases.

Verified locally:
- `go test ./internal/ethapi/ -run TestNetAPIListening -count=1` passes.
- `go test ./internal/ethapi/... -count=1` passes (no regressions).