### PR TITLE
eth: report export finalization errors

### DIFF
--- a/eth/api_admin.go
+++ b/eth/api_admin.go
@@ -43,6 +43,12 @@ func NewAdminAPI(eth *Ethereum) *AdminAPI {
 // ExportChain exports the current blockchain into a local file,
 // or a range of blocks if first and last are non-nil.
 func (api *AdminAPI) ExportChain(file string, first *uint64, last *uint64) (bool, error) {
+	return api.exportChain(file, first, last, func(writer io.Writer) io.WriteCloser {
+		return gzip.NewWriter(writer)
+	})
+}
+
+func (api *AdminAPI) exportChain(file string, first *uint64, last *uint64, newGzipWriter func(io.Writer) io.WriteCloser) (success bool, resultErr error) {
 	if first == nil && last != nil {
 		return false, errors.New("last cannot be specified without first")
 	}
@@ -60,12 +66,23 @@ func (api *AdminAPI) ExportChain(file string, first *uint64, last *uint64) (bool
 	if err != nil {
 		return false, err
 	}
-	defer out.Close()
+	defer func() {
+		if err := out.Close(); err != nil && resultErr == nil {
+			success = false
+			resultErr = fmt.Errorf("failed to close export file: %w", err)
+		}
+	}()
 
 	var writer io.Writer = out
 	if strings.HasSuffix(file, ".gz") {
-		writer = gzip.NewWriter(writer)
-		defer writer.(*gzip.Writer).Close()
+		gzipWriter := newGzipWriter(writer)
+		writer = gzipWriter
+		defer func() {
+			if err := gzipWriter.Close(); err != nil && resultErr == nil {
+				success = false
+				resultErr = fmt.Errorf("failed to finalize gzip stream: %w", err)
+			}
+		}()
 	}
 
 	// Export the blockchain

--- a/eth/api_admin_test.go
+++ b/eth/api_admin_test.go
@@ -1,0 +1,63 @@
+// Copyright 2026 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+
+package eth
+
+import (
+	"compress/gzip"
+	"errors"
+	"io"
+	"math/big"
+	"path/filepath"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/core"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/params"
+)
+
+var errGzipClose = errors.New("gzip close failure")
+
+type closeErrorWriter struct {
+	io.Writer
+}
+
+func (closeErrorWriter) Close() error {
+	return errGzipClose
+}
+
+func TestAdminExportChainGzipCloseError(t *testing.T) {
+	genesis := &core.Genesis{
+		Config: params.TestChainConfig,
+		Alloc: types.GenesisAlloc{
+			{1}: {Balance: big.NewInt(params.Ether)},
+		},
+	}
+	chain := newTestBlockChain(t, 1, genesis, nil)
+	defer chain.Stop()
+
+	api := NewAdminAPI(&Ethereum{blockchain: chain})
+	path := filepath.Join(t.TempDir(), "chain.gz")
+	success, err := api.exportChain(path, nil, nil, func(dst io.Writer) io.WriteCloser {
+		return closeErrorWriter{Writer: gzip.NewWriter(dst)}
+	})
+	if success {
+		t.Fatal("export succeeded despite gzip close failure")
+	}
+	if !errors.Is(err, errGzipClose) {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}


### PR DESCRIPTION
Fixes #35480.

## What changed

- propagate failures while finalizing a gzip chain export
- propagate failures while closing the underlying export file
- add deterministic fault-injection coverage for the late gzip-close path

This keeps `admin_exportChain` from returning `true` for an incomplete archive.

## Testing

- `go test ./eth`
