### PR TITLE
node: hold node lock in StopHTTP

### DIFF
--- a/node/api.go
+++ b/node/api.go
@@ -223,6 +223,8 @@ func (api *adminAPI) StartRPC(host *string, port *int, cors *string, apis *strin
 
 // StopHTTP shuts down the HTTP server.
 func (api *adminAPI) StopHTTP() (bool, error) {
+	api.node.lock.Lock()
+	defer api.node.lock.Unlock()
 	api.node.http.stop()
 	return true, nil
 }


### PR DESCRIPTION
## Summary
- `StartHTTP` already takes `node.lock`, but `StopHTTP` did not.
- Acquire the same lock in `StopHTTP` so concurrent start/stop of the HTTP endpoint cannot race.

## Test plan
- [ ] `go test ./node/...`
- [ ] Call `admin_startHTTP` / `admin_stopHTTP` concurrently and confirm no races under `-race`