### PR TITLE
eth: don't read a blob pool that is still initialising

### DIFF
--- a/core/txpool/blobpool/blobpool.go
+++ b/core/txpool/blobpool/blobpool.go
@@ -1294,13 +1294,16 @@ func (p *BlobPool) vhashesByTx() map[common.Hash][]common.Hash {
 // getByVhash reads and decodes the blob transaction which has the given
 // versioned hash. Returns nil if unavailable.
 func (p *BlobPool) getByVhash(vhash common.Hash) *BlobTxForPool {
+	// Init populates the lookup before assigning the store, so a lookup hit
+	// does not imply a usable store.
 	p.lock.RLock()
+	store := p.store
 	txID, exists := p.lookup.storeidOfBlob(vhash)
 	p.lock.RUnlock()
-	if !exists {
+	if !exists || store == nil {
 		return nil
 	}
-	data, err := p.store.Get(txID)
+	data, err := store.Get(txID)
 	if err != nil {
 		log.Error("Tracked blob transaction missing from store", "id", txID, "err", err)
 		return nil

--- a/core/txpool/blobpool/blobpool.go
+++ b/core/txpool/blobpool/blobpool.go
@@ -1294,16 +1294,13 @@ func (p *BlobPool) vhashesByTx() map[common.Hash][]common.Hash {
 // getByVhash reads and decodes the blob transaction which has the given
 // versioned hash. Returns nil if unavailable.
 func (p *BlobPool) getByVhash(vhash common.Hash) *BlobTxForPool {
-	// Init populates the lookup before assigning the store, so a lookup hit
-	// does not imply a usable store.
 	p.lock.RLock()
-	store := p.store
 	txID, exists := p.lookup.storeidOfBlob(vhash)
 	p.lock.RUnlock()
-	if !exists || store == nil {
+	if !exists {
 		return nil
 	}
-	data, err := store.Get(txID)
+	data, err := p.store.Get(txID)
 	if err != nil {
 		log.Error("Tracked blob transaction missing from store", "id", txID, "err", err)
 		return nil

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -330,12 +330,14 @@ func New(stack *node.Node, config *ethconfig.Config) (*Ethereum, error) {
 		config.BlobPool.Datadir = stack.ResolvePath(config.BlobPool.Datadir)
 	}
 	eth.blobTxPool = blobpool.New(config.BlobPool, eth.blockchain, legacyPool.HasPendingAuth)
-	eth.blobCache = blobpool.NewCache(eth.blobTxPool)
 
 	eth.txPool, err = txpool.New(config.TxPool.PriceLimit, eth.blockchain, []txpool.SubPool{legacyPool, eth.blobTxPool})
 	if err != nil {
 		return nil, err
 	}
+	// Only after txpool.New has run the pool's Init: the cache reads the pool's
+	// lookup and store, which Init builds without holding the pool lock.
+	eth.blobCache = blobpool.NewCache(eth.blobTxPool)
 
 	if !config.TxPool.NoLocals {
 		rejournal := config.TxPool.Rejournal


### PR DESCRIPTION
Note: found and written by LLM.

`BlobPool.Init` builds the lookup, index and store without holding `p.lock`, and `eth/backend.go` publishes the pool to `blobpool.NewCache` before `txpool.New` runs Init. Cache.update spawns a goroutine calling `getByVhash`, so it can read the pool mid-construction:

```
    panic: runtime error: invalid memory address or nil pointer dereference
    [signal SIGSEGV: segmentation violation code=0x1 addr=0x28]
    blobpool.(*BlobPool).getByVhash(...)  blobpool.go:1303
    blobpool.(*Cache).update.func1()      cache.go:429
```

`Init` fills the lookup inside `billy.Open`, whose index callback runs `parseTransaction` -> `trackTransaction`, and assigns `p.store` only once `billy.Open` returns. For that window a lookup hit names a transaction whose store does not exist yet, and `p.store.Get` dereferences nil.

Build the cache after `txpool.New` so no reader exists while `Init` runs -- `getByVhash` has exactly one caller -- and have `getByVhash` read the store under the same lock as the lookup, returning nil when it is not set.

A benchmark harness that restarts the client once per test hit this on 1-4% of starts; a node that starts once rarely will.

Note this does not make Init itself safe: it still writes the lookup maps unlocked, which races with any reader that takes only `p.lock.RLock`. Closing that needs the lock held across `Init`, and `SetGasTip`, `convertLegacyTxs` and `convertLegacyLimbo` all take `p.lock` themselves, so each would need splitting into a wrapper and an unlocked body.

Reproduction commit here: https://github.com/jochem-brouwer/go-ethereum/commit/67f76da3ec388979e9d79807fa026f1c2e2162c4

The benchmark machine we are using has blobs in its database. The benchmark machine fails random tests because it hits this nil dereference.

