### PR TITLE
core: honor ExecuteConfig.EnableTracer for the EVM-level tracing hooks

### DIFF
--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -2128,20 +2128,11 @@ type ExecuteConfig struct {
 	EnableWitnessStats bool
 }
 
-// vmConfig returns the EVM configuration to execute a block with, honouring the
+// overrideTracerActivation returns the EVM configuration to execute a block with, honoring the
 // caller's tracing intent.
-//
-// The tracer held in bc.cfg.VmConfig is the node-wide live tracer: a single
-// stateful instance shared by the whole node, whose hooks are documented as
-// being invoked serially from the chain-insertion goroutine. Callers that
-// execute blocks outside that goroutine (RPC handlers such as
-// debug_executionWitness) must not fire it: interleaving two hook streams
-// corrupts the tracer's internal state, and any state journal wrapped around it
-// (see tracing.WrapWithJournal), and reports blocks that were never imported.
-// Such callers leave EnableTracer false, which detaches the tracer here.
-func (bc *BlockChain) vmConfig(config ExecuteConfig) vm.Config {
+func (bc *BlockChain) overrideTracerActivation(tracerOn bool) vm.Config {
 	vmConfig := bc.cfg.VmConfig
-	if !config.EnableTracer {
+	if !tracerOn {
 		vmConfig.Tracer = nil
 	}
 	return vmConfig
@@ -2221,7 +2212,7 @@ func (bc *BlockChain) setupExecutionState(parentRoot common.Hash, block *types.B
 		go func(start time.Time) {
 			// Speculative prefetching is never traced, regardless of the caller's
 			// intent: its execution is discarded and runs on its own goroutine.
-			vmCfg := bc.vmConfig(ExecuteConfig{EnableTracer: false})
+			vmCfg := bc.overrideTracerActivation(false)
 			bc.prefetcher.Prefetch(block, throwaway, bc.jumpDestCache, bc.precompileCache.PrefetchView(), vmCfg, interrupt, execIndex)
 
 			blockPrefetchExecuteTimer.Update(time.Since(start))
@@ -2292,7 +2283,7 @@ func (bc *BlockChain) ProcessBlock(ctx context.Context, parentRoot common.Hash, 
 	// bc.cfg.VmConfig is a stateful, node-wide singleton whose hooks are only
 	// safe to drive from the chain-insertion goroutine, so it is attached only
 	// when the caller opts in via EnableTracer.
-	vmConfig := bc.vmConfig(config)
+	vmConfig := bc.overrideTracerActivation(config.EnableTracer)
 
 	// Instrument the blockchain tracing
 	if config.EnableTracer {

--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -2128,6 +2128,25 @@ type ExecuteConfig struct {
 	EnableWitnessStats bool
 }
 
+// vmConfig returns the EVM configuration to execute a block with, honouring the
+// caller's tracing intent.
+//
+// The tracer held in bc.cfg.VmConfig is the node-wide live tracer: a single
+// stateful instance shared by the whole node, whose hooks are documented as
+// being invoked serially from the chain-insertion goroutine. Callers that
+// execute blocks outside that goroutine (RPC handlers such as
+// debug_executionWitness) must not fire it: interleaving two hook streams
+// corrupts the tracer's internal state, and any state journal wrapped around it
+// (see tracing.WrapWithJournal), and reports blocks that were never imported.
+// Such callers leave EnableTracer false, which detaches the tracer here.
+func (bc *BlockChain) vmConfig(config ExecuteConfig) vm.Config {
+	vmConfig := bc.cfg.VmConfig
+	if !config.EnableTracer {
+		vmConfig.Tracer = nil
+	}
+	return vmConfig
+}
+
 // useBALExecution reports whether the block will be executed through the
 // BAL-driven parallel processor.
 func (bc *BlockChain) useBALExecution(block *types.Block, wantWitness bool) bool {
@@ -2200,9 +2219,9 @@ func (bc *BlockChain) setupExecutionState(parentRoot common.Hash, block *types.B
 			return nil, nil, err
 		}
 		go func(start time.Time) {
-			// Disable tracing for prefetcher executions.
-			vmCfg := bc.cfg.VmConfig
-			vmCfg.Tracer = nil
+			// Speculative prefetching is never traced, regardless of the caller's
+			// intent: its execution is discarded and runs on its own goroutine.
+			vmCfg := bc.vmConfig(ExecuteConfig{EnableTracer: false})
 			bc.prefetcher.Prefetch(block, throwaway, bc.jumpDestCache, bc.precompileCache.PrefetchView(), vmCfg, interrupt, execIndex)
 
 			blockPrefetchExecuteTimer.Update(time.Since(start))
@@ -2269,6 +2288,12 @@ func (bc *BlockChain) ProcessBlock(ctx context.Context, parentRoot common.Hash, 
 		defer statedb.StopPrefetcher()
 	}
 
+	// Resolve the EVM config for this execution. The live tracer stored in
+	// bc.cfg.VmConfig is a stateful, node-wide singleton whose hooks are only
+	// safe to drive from the chain-insertion goroutine, so it is attached only
+	// when the caller opts in via EnableTracer.
+	vmConfig := bc.vmConfig(config)
+
 	// Instrument the blockchain tracing
 	if config.EnableTracer {
 		if bc.logger != nil && bc.logger.OnBlockStart != nil {
@@ -2288,7 +2313,7 @@ func (bc *BlockChain) ProcessBlock(ctx context.Context, parentRoot common.Hash, 
 	// Process block using the parent state as reference point
 	pstart := time.Now()
 	pctx, _, spanEnd := telemetry.StartSpan(ctx, "bc.processor.Process")
-	res, err := bc.processor.Process(pctx, block, statedb, bc.jumpDestCache, bc.precompileCache, bc.cfg.VmConfig, &execIndex)
+	res, err := bc.processor.Process(pctx, block, statedb, bc.jumpDestCache, bc.precompileCache, vmConfig, &execIndex)
 	spanEnd(&err)
 	if err != nil {
 		bc.reportBadBlock(block, res, err)
@@ -2323,7 +2348,7 @@ func (bc *BlockChain) ProcessBlock(ctx context.Context, parentRoot common.Hash, 
 		task := types.NewBlockWithHeader(context).WithBody(*block.Body())
 
 		// Run the stateless self-cross-validation
-		crossStateRoot, crossReceiptRoot, err := ExecuteStateless(ctx, bc.chainConfig, bc.cfg.VmConfig, task, witness)
+		crossStateRoot, crossReceiptRoot, err := ExecuteStateless(ctx, bc.chainConfig, vmConfig, task, witness)
 		if err != nil {
 			return nil, fmt.Errorf("stateless self-validation failed: %v", err)
 		}

--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -2210,8 +2210,7 @@ func (bc *BlockChain) setupExecutionState(parentRoot common.Hash, block *types.B
 			return nil, nil, err
 		}
 		go func(start time.Time) {
-			// Speculative prefetching is never traced, regardless of the caller's
-			// intent: its execution is discarded and runs on its own goroutine.
+			// Disable tracing for prefetcher executions.
 			vmCfg := bc.overrideTracerActivation(false)
 			bc.prefetcher.Prefetch(block, throwaway, bc.jumpDestCache, bc.precompileCache.PrefetchView(), vmCfg, interrupt, execIndex)
 

--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -2140,8 +2140,8 @@ func (bc *BlockChain) overrideTracerActivation(tracerOn bool) vm.Config {
 
 // useBALExecution reports whether the block will be executed through the
 // BAL-driven parallel processor.
-func (bc *BlockChain) useBALExecution(block *types.Block, wantWitness bool) bool {
-	return supportsParallelExecution(block, bc.chainConfig, wantWitness, bc.cfg.VmConfig.Tracer != nil, bc.cfg.VmConfig.DisableParallelExecution)
+func (bc *BlockChain) useBALExecution(block *types.Block, vmConfig vm.Config, wantWitness bool) bool {
+	return supportsParallelExecution(block, bc.chainConfig, wantWitness, vmConfig.Tracer != nil, vmConfig.DisableParallelExecution)
 }
 
 // setupExecutionState builds the state instance that block execution reads from
@@ -2156,7 +2156,7 @@ func (bc *BlockChain) useBALExecution(block *types.Block, wantWitness bool) bool
 //     speculative whole-block prefetcher share one cached reader.
 //
 //   - No prefetching: a plain reader, with a no-op cleanup.
-func (bc *BlockChain) setupExecutionState(parentRoot common.Hash, block *types.Block, config ExecuteConfig, interrupt *atomic.Bool, execIndex *atomic.Int64) (*state.StateDB, func(*blockProcessingResult), error) {
+func (bc *BlockChain) setupExecutionState(parentRoot common.Hash, block *types.Block, vmConfig vm.Config, config ExecuteConfig, interrupt *atomic.Bool, execIndex *atomic.Int64) (*state.StateDB, func(*blockProcessingResult), error) {
 	noop := func(*blockProcessingResult) {}
 
 	var sdb state.Database
@@ -2174,7 +2174,7 @@ func (bc *BlockChain) setupExecutionState(parentRoot common.Hash, block *types.B
 	wantWitness := config.StatelessSelfValidation || config.MakeWitness
 
 	switch warmer, ok := sdb.(prewarmReader); {
-	case bc.useBALExecution(block, wantWitness):
+	case bc.useBALExecution(block, vmConfig, wantWitness):
 		base, err := sdb.Reader(parentRoot)
 		if err != nil {
 			return nil, nil, err
@@ -2211,7 +2211,8 @@ func (bc *BlockChain) setupExecutionState(parentRoot common.Hash, block *types.B
 		}
 		go func(start time.Time) {
 			// Disable tracing for prefetcher executions.
-			vmCfg := bc.overrideTracerActivation(false)
+			vmCfg := vmConfig
+			vmCfg.Tracer = nil
 			bc.prefetcher.Prefetch(block, throwaway, bc.jumpDestCache, bc.precompileCache.PrefetchView(), vmCfg, interrupt, execIndex)
 
 			blockPrefetchExecuteTimer.Update(time.Since(start))
@@ -2248,9 +2249,18 @@ func (bc *BlockChain) ProcessBlock(ctx context.Context, parentRoot common.Hash, 
 	defer interrupt.Store(true) // terminate the prefetch at the end
 	execIndex.Store(-1)         // no transaction executed yet
 
+	// Resolve the EVM config for this execution before any component consults
+	// it. The live tracer stored in bc.cfg.VmConfig is a stateful, node-wide
+	// singleton whose hooks are only safe to drive from the chain-insertion
+	// goroutine, so it is attached only when the caller opts in via
+	// EnableTracer. Both the reader topology (setupExecutionState) and the
+	// execution strategy (StateProcessor.Process) key off this resolved
+	// config, keeping the BAL-parallel/sequential decision consistent.
+	vmConfig := bc.overrideTracerActivation(config.EnableTracer)
+
 	// Set up the state reader feeding execution, along with a cleanup to run once
 	// processing is complete (stop the prefetcher, upload reader statistics).
-	statedb, cleanup, err := bc.setupExecutionState(parentRoot, block, config, &interrupt, &execIndex)
+	statedb, cleanup, err := bc.setupExecutionState(parentRoot, block, vmConfig, config, &interrupt, &execIndex)
 	if err != nil {
 		return nil, err
 	}
@@ -2277,12 +2287,6 @@ func (bc *BlockChain) ProcessBlock(ctx context.Context, parentRoot common.Hash, 
 		statedb.StartPrefetcher("chain", witness)
 		defer statedb.StopPrefetcher()
 	}
-
-	// Resolve the EVM config for this execution. The live tracer stored in
-	// bc.cfg.VmConfig is a stateful, node-wide singleton whose hooks are only
-	// safe to drive from the chain-insertion goroutine, so it is attached only
-	// when the caller opts in via EnableTracer.
-	vmConfig := bc.overrideTracerActivation(config.EnableTracer)
 
 	// Instrument the blockchain tracing
 	if config.EnableTracer {

--- a/core/blockchain_livetracer_test.go
+++ b/core/blockchain_livetracer_test.go
@@ -122,7 +122,7 @@ func tracedChain(t *testing.T, config *params.ChainConfig) (*BlockChain, *types.
 			Config:  config,
 			BaseFee: big.NewInt(params.InitialBaseFee),
 			Alloc: types.GenesisAlloc{
-				addr: {Balance: funds},
+				addr:                             {Balance: funds},
 				params.BeaconRootsAddress:        {Nonce: 1, Code: params.BeaconRootsCode, Balance: common.Big0},
 				params.HistoryStorageAddress:     {Nonce: 1, Code: params.HistoryStorageCode, Balance: common.Big0},
 				params.WithdrawalQueueAddress:    {Nonce: 1, Code: params.WithdrawalQueueCode, Balance: common.Big0},

--- a/core/blockchain_livetracer_test.go
+++ b/core/blockchain_livetracer_test.go
@@ -1,0 +1,200 @@
+// Copyright 2025 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+
+package core
+
+import (
+	"context"
+	"math/big"
+	"sync"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/consensus/beacon"
+	"github.com/ethereum/go-ethereum/consensus/ethash"
+	"github.com/ethereum/go-ethereum/core/rawdb"
+	"github.com/ethereum/go-ethereum/core/tracing"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/core/vm"
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/ethereum/go-ethereum/params"
+)
+
+// hookRecorder counts every live-tracer hook invocation, keyed by hook name.
+type hookRecorder struct {
+	mu     sync.Mutex
+	counts map[string]int
+}
+
+func (r *hookRecorder) mark(name string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.counts == nil {
+		r.counts = make(map[string]int)
+	}
+	r.counts[name]++
+}
+
+func (r *hookRecorder) total() int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	var n int
+	for _, c := range r.counts {
+		n += c
+	}
+	return n
+}
+
+func (r *hookRecorder) fired() map[string]int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	out := make(map[string]int, len(r.counts))
+	for k, v := range r.counts {
+		out[k] = v
+	}
+	return out
+}
+
+// hooks builds a live tracer covering the hooks a plain value-transfer block
+// exercises, both at block scope and inside the EVM.
+func (r *hookRecorder) hooks() *tracing.Hooks {
+	return &tracing.Hooks{
+		OnBlockStart: func(tracing.BlockEvent) { r.mark("OnBlockStart") },
+		OnBlockEnd:   func(error) { r.mark("OnBlockEnd") },
+		OnTxStart: func(*tracing.VMContext, *types.Transaction, common.Address) {
+			r.mark("OnTxStart")
+		},
+		OnTxEnd: func(*types.Receipt, error) { r.mark("OnTxEnd") },
+		OnEnter: func(int, byte, common.Address, common.Address, []byte, uint64, *big.Int) {
+			r.mark("OnEnter")
+		},
+		OnExit: func(int, []byte, uint64, error, bool) { r.mark("OnExit") },
+		OnOpcode: func(uint64, byte, uint64, uint64, tracing.OpContext, []byte, int, error) {
+			r.mark("OnOpcode")
+		},
+		OnBalanceChange: func(common.Address, *big.Int, *big.Int, tracing.BalanceChangeReason) {
+			r.mark("OnBalanceChange")
+		},
+		OnStorageChange: func(common.Address, common.Hash, common.Hash, common.Hash) {
+			r.mark("OnStorageChange")
+		},
+		OnLog: func(*types.Log) { r.mark("OnLog") },
+	}
+}
+
+// TestProcessBlockTracerOptIn asserts that ExecuteConfig.EnableTracer is the
+// single switch governing the node-wide live tracer, at every layer.
+//
+// The tracer held in BlockChainConfig.VmConfig is a stateful singleton shared by
+// the whole node, and its hooks are only safe to drive from the chain-insertion
+// goroutine. Callers that execute blocks elsewhere — debug_executionWitness runs
+// ProcessBlock straight off an RPC goroutine — leave EnableTracer false and must
+// see no hook of any kind fire. Gating only the OnBlockStart/OnBlockEnd envelope
+// is not enough: the tx-level hooks reach the same singleton through the
+// vm.Config handed to the processor, and firing them without an enclosing block
+// is worse than not gating at all.
+func TestProcessBlockTracerOptIn(t *testing.T) {
+	var (
+		engine = beacon.New(ethash.NewFaker())
+		key, _ = crypto.HexToECDSA("b71c71a67e1177ad4e901695e1b4b9ee17ae16c6668d313eac2f96dbcda3f291")
+		addr   = crypto.PubkeyToAddress(key.PublicKey)
+		to     = common.HexToAddress("0x00000000000000000000000000000000deadbeef")
+		funds  = new(big.Int).Mul(big.NewInt(1000), big.NewInt(params.Ether))
+		config = *params.AllEthashProtocolChanges
+		gspec  = &Genesis{
+			Config:  &config,
+			BaseFee: big.NewInt(params.InitialBaseFee),
+			Alloc:   types.GenesisAlloc{addr: {Balance: funds}},
+		}
+	)
+	gspec.Config.TerminalTotalDifficulty = common.Big0
+	gspec.Config.ShanghaiTime = u64(0)
+	signer := types.LatestSigner(gspec.Config)
+
+	// A single block carrying one value transfer, so that both the block-scope
+	// and the tx-scope hooks have something to report.
+	_, blocks, _ := GenerateChainWithGenesis(gspec, engine, 1, func(i int, b *BlockGen) {
+		tx, err := types.SignNewTx(key, signer, &types.DynamicFeeTx{
+			ChainID:   gspec.Config.ChainID,
+			Nonce:     0,
+			To:        &to,
+			Gas:       100000,
+			GasFeeCap: big.NewInt(params.InitialBaseFee * 2),
+			GasTipCap: big.NewInt(1),
+			Value:     big.NewInt(1000),
+		})
+		if err != nil {
+			t.Fatalf("failed to sign tx: %v", err)
+		}
+		b.AddTx(tx)
+	})
+	if got := len(blocks[0].Transactions()); got != 1 {
+		t.Fatalf("test block carries %d transactions, want 1", got)
+	}
+
+	// newChain returns a chain whose node-wide vm.Config carries the live tracer,
+	// as `geth --vmtrace` configures it.
+	newChain := func(t *testing.T) (*BlockChain, *hookRecorder) {
+		t.Helper()
+		recorder := new(hookRecorder)
+		options := DefaultConfig().WithStateScheme(rawdb.HashScheme)
+		options.VmConfig = vm.Config{Tracer: recorder.hooks()}
+
+		chain, err := NewBlockChain(rawdb.NewMemoryDatabase(), gspec, engine, options)
+		if err != nil {
+			t.Fatalf("failed to create chain: %v", err)
+		}
+		t.Cleanup(chain.Stop)
+		recorder.counts = nil // discard OnBlockchainInit/OnGenesisBlock
+		return chain, recorder
+	}
+
+	parentRoot := gspec.ToBlock().Root()
+
+	t.Run("opted out", func(t *testing.T) {
+		// The exact config debug_executionWitness uses.
+		chain, recorder := newChain(t)
+		_, err := chain.ProcessBlock(context.Background(), parentRoot, blocks[0], ExecuteConfig{
+			WriteState:   false,
+			EnableTracer: false,
+			MakeWitness:  true,
+		})
+		if err != nil {
+			t.Fatalf("failed to process block: %v", err)
+		}
+		if n := recorder.total(); n != 0 {
+			t.Errorf("live tracer fired %d hook(s) with EnableTracer=false: %v", n, recorder.fired())
+		}
+	})
+
+	t.Run("opted in", func(t *testing.T) {
+		// Canonical import: the tracer must still see the whole block.
+		chain, recorder := newChain(t)
+		_, err := chain.ProcessBlock(context.Background(), parentRoot, blocks[0], ExecuteConfig{
+			WriteState:   true,
+			WriteHead:    true,
+			EnableTracer: true,
+		})
+		if err != nil {
+			t.Fatalf("failed to process block: %v", err)
+		}
+		for _, hook := range []string{"OnBlockStart", "OnBlockEnd", "OnTxStart", "OnTxEnd", "OnEnter", "OnExit", "OnBalanceChange"} {
+			if recorder.fired()[hook] == 0 {
+				t.Errorf("%s did not fire with EnableTracer=true; fired: %v", hook, recorder.fired())
+			}
+		}
+	})
+}

--- a/core/blockchain_livetracer_test.go
+++ b/core/blockchain_livetracer_test.go
@@ -48,6 +48,14 @@ func (r *hookRecorder) mark(name string) {
 	r.counts[name]++
 }
 
+// reset drops every recorded hook, so that a subsequent census only reflects
+// the invocations made after this point.
+func (r *hookRecorder) reset() {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.counts = nil
+}
+
 func (r *hookRecorder) total() int {
 	r.mu.Lock()
 	defer r.mu.Unlock()
@@ -95,40 +103,30 @@ func (r *hookRecorder) hooks() *tracing.Hooks {
 	}
 }
 
-// TestProcessBlockTracerOptIn asserts that ExecuteConfig.EnableTracer is the
-// single switch governing the node-wide live tracer, at every layer.
-//
-// The tracer held in BlockChainConfig.VmConfig is a stateful singleton shared by
-// the whole node, and its hooks are only safe to drive from the chain-insertion
-// goroutine. Callers that execute blocks elsewhere — debug_executionWitness runs
-// ProcessBlock straight off an RPC goroutine — leave EnableTracer false and must
-// see no hook of any kind fire. Gating only the OnBlockStart/OnBlockEnd envelope
-// is not enough: the tx-level hooks reach the same singleton through the
-// vm.Config handed to the processor, and firing them without an enclosing block
-// is worse than not gating at all.
-func TestProcessBlockTracerOptIn(t *testing.T) {
+// tracedChain builds a chain whose node-wide vm.Config carries a hook-counting
+// live tracer, as `geth --vmtrace` configures it, together with a single block
+// carrying one value transfer, so that both the block-scope and the tx-scope
+// hooks have something to report. The returned recorder starts empty; the
+// hooks fired while the genesis is committed are discarded.
+func tracedChain(t *testing.T, config *params.ChainConfig) (*BlockChain, *types.Block, common.Hash, *hookRecorder) {
+	t.Helper()
+
 	var (
 		engine = beacon.New(ethash.NewFaker())
 		key, _ = crypto.HexToECDSA("b71c71a67e1177ad4e901695e1b4b9ee17ae16c6668d313eac2f96dbcda3f291")
 		addr   = crypto.PubkeyToAddress(key.PublicKey)
 		to     = common.HexToAddress("0x00000000000000000000000000000000deadbeef")
 		funds  = new(big.Int).Mul(big.NewInt(1000), big.NewInt(params.Ether))
-		config = *params.AllEthashProtocolChanges
+		signer = types.LatestSigner(config)
 		gspec  = &Genesis{
-			Config:  &config,
+			Config:  config,
 			BaseFee: big.NewInt(params.InitialBaseFee),
 			Alloc:   types.GenesisAlloc{addr: {Balance: funds}},
 		}
 	)
-	gspec.Config.TerminalTotalDifficulty = common.Big0
-	gspec.Config.ShanghaiTime = u64(0)
-	signer := types.LatestSigner(gspec.Config)
-
-	// A single block carrying one value transfer, so that both the block-scope
-	// and the tx-scope hooks have something to report.
 	_, blocks, _ := GenerateChainWithGenesis(gspec, engine, 1, func(i int, b *BlockGen) {
 		tx, err := types.SignNewTx(key, signer, &types.DynamicFeeTx{
-			ChainID:   gspec.Config.ChainID,
+			ChainID:   config.ChainID,
 			Nonce:     0,
 			To:        &to,
 			Gas:       100000,
@@ -144,30 +142,37 @@ func TestProcessBlockTracerOptIn(t *testing.T) {
 	if got := len(blocks[0].Transactions()); got != 1 {
 		t.Fatalf("test block carries %d transactions, want 1", got)
 	}
+	recorder := new(hookRecorder)
+	options := DefaultConfig().WithStateScheme(rawdb.HashScheme)
+	options.VmConfig = vm.Config{Tracer: recorder.hooks()}
 
-	// newChain returns a chain whose node-wide vm.Config carries the live tracer,
-	// as `geth --vmtrace` configures it.
-	newChain := func(t *testing.T) (*BlockChain, *hookRecorder) {
-		t.Helper()
-		recorder := new(hookRecorder)
-		options := DefaultConfig().WithStateScheme(rawdb.HashScheme)
-		options.VmConfig = vm.Config{Tracer: recorder.hooks()}
-
-		chain, err := NewBlockChain(rawdb.NewMemoryDatabase(), gspec, engine, options)
-		if err != nil {
-			t.Fatalf("failed to create chain: %v", err)
-		}
-		t.Cleanup(chain.Stop)
-		recorder.counts = nil // discard OnBlockchainInit/OnGenesisBlock
-		return chain, recorder
+	chain, err := NewBlockChain(rawdb.NewMemoryDatabase(), gspec, engine, options)
+	if err != nil {
+		t.Fatalf("failed to create chain: %v", err)
 	}
+	t.Cleanup(chain.Stop)
+	recorder.reset() // discard OnBlockchainInit/OnGenesisBlock
 
-	parentRoot := gspec.ToBlock().Root()
+	return chain, blocks[0], gspec.ToBlock().Root(), recorder
+}
+
+// TestProcessBlockTracerOptIn asserts that ExecuteConfig.EnableTracer gates every
+// tracing hook that block execution reaches through vm.Config: the
+// OnBlockStart/OnBlockEnd envelope, the transaction and EVM frame hooks, and the
+// state hooks carried by the hooked StateDB.
+func TestProcessBlockTracerOptIn(t *testing.T) {
+	// mergedConfig is the pre-Amsterdam chain the sequential processor runs.
+	mergedConfig := func() *params.ChainConfig {
+		config := *params.AllEthashProtocolChanges
+		config.TerminalTotalDifficulty = common.Big0
+		config.ShanghaiTime = u64(0)
+		return &config
+	}
 
 	t.Run("opted out", func(t *testing.T) {
 		// The exact config debug_executionWitness uses.
-		chain, recorder := newChain(t)
-		_, err := chain.ProcessBlock(context.Background(), parentRoot, blocks[0], ExecuteConfig{
+		chain, block, parentRoot, recorder := tracedChain(t, mergedConfig())
+		_, err := chain.ProcessBlock(context.Background(), parentRoot, block, ExecuteConfig{
 			WriteState:   false,
 			EnableTracer: false,
 			MakeWitness:  true,
@@ -180,10 +185,36 @@ func TestProcessBlockTracerOptIn(t *testing.T) {
 		}
 	})
 
+	t.Run("opted out without witness", func(t *testing.T) {
+		// The opted-out combination debug_executionWitness does not reach: no
+		// witness requested, on an Amsterdam block carrying a block access list.
+		// Detaching the tracer makes the execution eligible for the BAL-driven
+		// parallel processor, which wires no tracing hooks at all, so the gate
+		// must hold on that path too.
+		config := *params.MergedTestChainConfig
+		config.AmsterdamTime = u64(0)
+
+		chain, block, parentRoot, recorder := tracedChain(t, &config)
+		if block.AccessList() == nil {
+			t.Fatal("test block carries no access list, parallel execution unreachable")
+		}
+		_, err := chain.ProcessBlock(context.Background(), parentRoot, block, ExecuteConfig{
+			WriteState:   false,
+			EnableTracer: false,
+			MakeWitness:  false,
+		})
+		if err != nil {
+			t.Fatalf("failed to process block: %v", err)
+		}
+		if n := recorder.total(); n != 0 {
+			t.Errorf("live tracer fired %d hook(s) with EnableTracer=false: %v", n, recorder.fired())
+		}
+	})
+
 	t.Run("opted in", func(t *testing.T) {
 		// Canonical import: the tracer must still see the whole block.
-		chain, recorder := newChain(t)
-		_, err := chain.ProcessBlock(context.Background(), parentRoot, blocks[0], ExecuteConfig{
+		chain, block, parentRoot, recorder := tracedChain(t, mergedConfig())
+		_, err := chain.ProcessBlock(context.Background(), parentRoot, block, ExecuteConfig{
 			WriteState:   true,
 			WriteHead:    true,
 			EnableTracer: true,

--- a/core/blockchain_livetracer_test.go
+++ b/core/blockchain_livetracer_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 The go-ethereum Authors
+// Copyright 2026 The go-ethereum Authors
 // This file is part of the go-ethereum library.
 //
 // The go-ethereum library is free software: you can redistribute it and/or modify

--- a/core/blockchain_livetracer_test.go
+++ b/core/blockchain_livetracer_test.go
@@ -121,7 +121,15 @@ func tracedChain(t *testing.T, config *params.ChainConfig) (*BlockChain, *types.
 		gspec  = &Genesis{
 			Config:  config,
 			BaseFee: big.NewInt(params.InitialBaseFee),
-			Alloc:   types.GenesisAlloc{addr: {Balance: funds}},
+			Alloc: types.GenesisAlloc{
+				addr: {Balance: funds},
+				params.BeaconRootsAddress:        {Nonce: 1, Code: params.BeaconRootsCode, Balance: common.Big0},
+				params.HistoryStorageAddress:     {Nonce: 1, Code: params.HistoryStorageCode, Balance: common.Big0},
+				params.WithdrawalQueueAddress:    {Nonce: 1, Code: params.WithdrawalQueueCode, Balance: common.Big0},
+				params.ConsolidationQueueAddress: {Nonce: 1, Code: params.ConsolidationQueueCode, Balance: common.Big0},
+				params.BuilderDepositAddress:     {Nonce: 1, Code: params.BuilderDepositCode, Balance: common.Big0},
+				params.BuilderExitAddress:        {Nonce: 1, Code: params.BuilderExitCode, Balance: common.Big0},
+			},
 		}
 	)
 	_, blocks, _ := GenerateChainWithGenesis(gspec, engine, 1, func(i int, b *BlockGen) {


### PR DESCRIPTION
`ExecuteConfig.EnableTracer` gates only the `OnBlockStart`/`OnBlockEnd` envelope. `ProcessBlock` passes `bc.cfg.VmConfig` — tracer included — to `bc.processor.Process` and to `ExecuteStateless`, so the node-wide live tracer still receives the transaction-level hooks when a caller opts out.

`debug_executionWitness` is the caller that opts out (`eth/api_debug.go`, `EnableTracer: false`), and it runs `ProcessBlock` directly on an RPC goroutine. On a node started with `--vmtrace`, a single call therefore replays a whole block into the live tracer concurrently with chain insertion.

### Evidence

Processing a one-transaction block with `EnableTracer: false` on master:

```
live tracer fired 9 hook(s) with EnableTracer=false:
  map[OnTxStart:1 OnEnter:1 OnExit:1 OnTxEnd:1 OnBalanceChange:5]
```

`OnBlockStart`/`OnBlockEnd` correctly stay silent, which makes the current state worse rather than better: the live tracer is a stateful singleton whose hooks are documented as being invoked serially during import, and here it observes transactions with no enclosing block. Interleaving two hook streams also corrupts a journal wrapped around the tracer via `tracing.WrapWithJournal`, whose revision stack underflows in `popRevision`.

### Change

Resolve the `vm.Config` for an execution from `ExecuteConfig` in one place (`bc.vmConfig`) and use it at both remaining call sites, so `EnableTracer` is the single switch governing the tracer at every layer. The speculative prefetcher, which hand-rolled the same `Tracer = nil`, now goes through the same helper.

`useBALExecution` deliberately keeps keying off the node-wide `bc.cfg.VmConfig.Tracer`, so no path flips between sequential and BAL-parallel execution. It is moot for `debug_executionWitness` anyway, where `supportsParallelExecution` already returns false because a witness is wanted.

### Tests

`TestProcessBlockTracerOptIn` installs a hook-counting live tracer as the chain's `VmConfig.Tracer` and asserts that the `debug_executionWitness` config fires zero hooks, while the import config still fires the full set. It fails on master with the census above.

`go test ./core/ ./core/state/ ./eth/tracers/...` passes; `gofmt` and `go vet` are clean.