### PR TITLE
core/rawdb: don't drop bad block execution detail on duplicated write

### DIFF
--- a/core/rawdb/accessors_chain.go
+++ b/core/rawdb/accessors_chain.go
@@ -991,24 +991,35 @@ func WriteBadBlockWithDetails(db ethdb.KeyValueStore, block *types.Block, detail
 			badBlocks = nil
 		}
 	}
+	var known bool
 	for _, b := range badBlocks {
 		if b.Header.Number.Uint64() == block.NumberU64() && b.Header.Hash() == block.Hash() {
-			log.Info("Skip duplicated bad block", "number", block.NumberU64(), "hash", block.Hash())
-			return
+			// The import path records the bad block before the details of the
+			// local build become available, so a rewrite carrying a detail
+			// attaches it to the existing entry rather than being dropped.
+			if detail == nil {
+				log.Info("Skip duplicated bad block", "number", block.NumberU64(), "hash", block.Hash())
+				return
+			}
+			b.Detail = detail
+			known = true
+			break
 		}
 	}
-	// A block's access list is not part of its RLP encoding, so the
-	// detail is the only place it survives.
-	if detail == nil && block.AccessList() != nil {
-		detail = &ExecutionDetail{
-			AccessList: block.AccessList(),
+	if !known {
+		// A block's access list is not part of its RLP encoding, so the
+		// detail is the only place it survives.
+		if detail == nil && block.AccessList() != nil {
+			detail = &ExecutionDetail{
+				AccessList: block.AccessList(),
+			}
 		}
+		badBlocks = append(badBlocks, &badBlock{
+			Header: block.Header(),
+			Body:   block.Body(),
+			Detail: detail,
+		})
 	}
-	badBlocks = append(badBlocks, &badBlock{
-		Header: block.Header(),
-		Body:   block.Body(),
-		Detail: detail,
-	})
 	slices.SortFunc(badBlocks, func(a, b *badBlock) int {
 		// Note: sorting in descending number order.
 		return -a.Header.Number.Cmp(b.Header.Number)

--- a/core/rawdb/accessors_chain_test.go
+++ b/core/rawdb/accessors_chain_test.go
@@ -246,6 +246,40 @@ func TestBadBlockStorage(t *testing.T) {
 	}
 }
 
+// Tests that rewriting an already-stored bad block with an execution detail
+// attaches the detail to the existing entry. This is the order the engine API
+// produces: the import path records the plain bad block first, the newPayload
+// error handler then rewrites it with the details of the local build.
+func TestBadBlockDetailUpgrade(t *testing.T) {
+	db := NewMemoryDatabase()
+
+	block := types.NewBlockWithHeader(&types.Header{
+		Number:      big.NewInt(1),
+		Extra:       []byte("bad block"),
+		UncleHash:   types.EmptyUncleHash,
+		TxHash:      types.EmptyTxsHash,
+		ReceiptHash: types.EmptyReceiptsHash,
+	})
+	WriteBadBlock(db, block)
+	WriteBadBlockWithDetails(db, block, &ExecutionDetail{Reason: "invalid merkle root"})
+
+	entry := ReadBadBlockWithDetails(db, block.Hash())
+	if entry == nil {
+		t.Fatalf("Stored bad block not found")
+	}
+	if entry.Reason != "invalid merkle root" {
+		t.Fatalf("Detail dropped on duplicated write: reason %q", entry.Reason)
+	}
+	// A later plain rewrite of the same block must not clobber the detail.
+	WriteBadBlock(db, block)
+	if entry := ReadBadBlockWithDetails(db, block.Hash()); entry.Reason != "invalid merkle root" {
+		t.Fatalf("Detail clobbered by plain rewrite: reason %q", entry.Reason)
+	}
+	if blocks := ReadAllBadBlocks(db); len(blocks) != 1 {
+		t.Fatalf("Duplicated bad block stored: %d entries", len(blocks))
+	}
+}
+
 // Tests that canonical numbers can be mapped to hashes and retrieved.
 func TestCanonicalMappingStorage(t *testing.T) {
 	db := NewMemoryDatabase()


### PR DESCRIPTION
When a locally-built block fails to re-import, reportBadBlock records the plain bad block first, so the engine API's follow-up write carrying the build details (receipts, failure reason, reverted txs) hits the duplicate check and is dropped — leaving debug_replayBadBlock with an empty build-vs-import diff in its primary scenario; attach the detail to the existing entry instead.