### PR TITLE
core/txpool/blobpool, eth: don't start the blob cache before the pool is initialized

### DIFF
--- a/core/txpool/blobpool/blobpool.go
+++ b/core/txpool/blobpool/blobpool.go
@@ -567,6 +567,12 @@ type BlobPool struct {
 	state  *state.StateDB               // Current state at the head of the chain
 	gasTip atomic.Pointer[uint256.Int]  // Currently accepted minimum gas tip
 
+	// initialized is set once Init has completed, signaling that the persistent
+	// store and the in-memory index are ready for the blob cache to read. It is
+	// set only after all of Init's setup (including the store assignment) has
+	// finished, so the cache loop can safely check it without racing on p.store.
+	initialized atomic.Bool
+
 	lookup *lookup                          // Lookup table mapping blobs to txs and txs to billy entries
 	index  map[common.Address][]*blobTxMeta // Blob transactions grouped by accounts, sorted by nonce
 	spent  map[common.Address]*uint256.Int  // Expenditure tracking for individual accounts
@@ -743,6 +749,10 @@ func (p *BlobPool) Init(gasTip uint64, head *types.Header, reserver txpool.Reser
 	if len(convertLimbo) > 0 {
 		p.cQueue.launchConversion(func() { p.convertLegacyLimbo(convertLimbo) })
 	}
+	// The pool is fully set up (head, store, index, limbo, gas tip): signal
+	// readiness so the blob cache can start selecting transactions. The cache
+	// loop may start before this point and must not touch the pool meanwhile.
+	p.initialized.Store(true)
 	return nil
 }
 

--- a/core/txpool/blobpool/cache.go
+++ b/core/txpool/blobpool/cache.go
@@ -524,6 +524,15 @@ func (c *Cache) selectTopTxs() []common.Hash {
 	if head == nil {
 		return nil
 	}
+	// The pool's persistent store is only assigned at the end of Init, whereas
+	// its head and in-memory index are populated earlier in Init. The cache loop
+	// starts immediately on NewCache, so it can run inside this window: selecting
+	// transactions before the store exists makes the update goroutine dereference
+	// the nil store and crash the node. Bail out until the pool is fully
+	// initialized (see #35508).
+	if !p.initialized.Load() {
+		return nil
+	}
 	config := p.chain.Config()
 	baseFee := eip1559.CalcBaseFee(config, head)
 

--- a/core/txpool/blobpool/cache_test.go
+++ b/core/txpool/blobpool/cache_test.go
@@ -328,3 +328,93 @@ func TestCacheTopKRefresh(t *testing.T) {
 	tc.wait(t, topKTimeout)
 	tc.expectEntries(t, better...)
 }
+
+// TestCacheStartupBeforePoolInit checks that the blob cache tolerates being
+// started before BlobPool.Init has completed. The cache loop begins selecting
+// top transactions immediately on NewCache; if it runs in the window inside
+// Init where the pool's head is set but its persistent store is still nil (the
+// store is only assigned at the very end of Init), the update goroutine reads
+// the nil store and panics. Regression test for #35508.
+func TestCacheStartupBeforePoolInit(t *testing.T) {
+	// Set up a pool but deliberately do NOT call Init: the persistent store
+	// stays nil while we still populate the head and the in-memory index, which
+	// is exactly the state the cache loop can observe during the Init window.
+	storage := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(storage, pendingTransactionStore), 0700); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	statedb, _ := state.New(types.EmptyRootHash, state.NewDatabaseForTesting())
+
+	cancunTime := uint64(0)
+	config := &params.ChainConfig{
+		ChainID:     big.NewInt(1),
+		LondonBlock: big.NewInt(0),
+		BerlinBlock: big.NewInt(0),
+		CancunTime:  &cancunTime,
+		OsakaTime:   &cancunTime,
+		BlobScheduleConfig: &params.BlobScheduleConfig{
+			Cancun: &params.BlobConfig{
+				Target:         1,
+				Max:            1,
+				UpdateFraction: params.DefaultCancunBlobConfig.UpdateFraction,
+			},
+		},
+	}
+	chain := &testBlockChain{
+		config:  config,
+		basefee: uint256.NewInt(1),
+		blobfee: uint256.NewInt(1),
+		statedb: statedb,
+	}
+	pool := New(Config{}, chain, nil)
+
+	// Reproduce the mid-Init state observed by the cache loop: the head is set
+	// (as Init does before opening the store) and a transaction has been indexed
+	// from the on-disk scan, but the store itself is still nil.
+	pool.head.Store(chain.CurrentBlock())
+	pool.reserver = newReserver()
+
+	key, _ := crypto.GenerateKey()
+	tx := makeMultiBlobTx(0, 1_000_000, 1_000_000, 1_000_000, 1, 0, key)
+	blob := encodeForPool(tx)
+	if err := pool.parseTransaction(0, uint32(len(blob)), blob); err != nil {
+		t.Fatalf("index tx: %v", err)
+	}
+	// Sanity check the preconditions that make this exercise the bug: a tx is
+	// indexed, so the only missing piece is the store itself (nil until Init
+	// completes).
+	pool.lock.RLock()
+	indexed := len(pool.index)
+	pool.lock.RUnlock()
+	if indexed == 0 {
+		t.Fatalf("test setup: expected a transaction indexed in the uninitialized pool")
+	}
+
+	clock := &mclock.Simulated{}
+	iterCh := make(chan struct{}, 1)
+	c := newCache(pool, clock, func() {
+		select {
+		case iterCh <- struct{}{}:
+		default:
+		}
+	})
+
+	// Wait for the loop's initial topK iteration. On the unpatched code this
+	// iteration selects the indexed transaction and its update goroutine reads
+	// the nil store, crashing the node. On the patched code selectTopTxs bails
+	// out until Init has completed, so the loop updates nothing.
+	select {
+	case <-iterCh:
+	case <-time.After(2 * time.Second):
+		t.Fatal("cache loop did not complete its initial iteration")
+	}
+	// Give any spawned update goroutine a chance to run: on the unpatched code
+	// the nil-store dereference aborts the test here.
+	c.inflight.Wait()
+	c.Stop()
+
+	// The cache must not have selected anything from the uninitialized pool.
+	if want := c.selectTopTxs(); len(want) != 0 {
+		t.Fatalf("cache selected %d txs from a blob pool that was not initialized", len(want))
+	}
+}

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -330,12 +330,16 @@ func New(stack *node.Node, config *ethconfig.Config) (*Ethereum, error) {
 		config.BlobPool.Datadir = stack.ResolvePath(config.BlobPool.Datadir)
 	}
 	eth.blobTxPool = blobpool.New(config.BlobPool, eth.blockchain, legacyPool.HasPendingAuth)
-	eth.blobCache = blobpool.NewCache(eth.blobTxPool)
 
 	eth.txPool, err = txpool.New(config.TxPool.PriceLimit, eth.blockchain, []txpool.SubPool{legacyPool, eth.blobTxPool})
 	if err != nil {
 		return nil, err
 	}
+	// The blob cache must only be started after the blob pool has been
+	// initialized (BlobPool.Init runs inside txpool.New). Starting the cache
+	// earlier lets its loop read the pool's index while the persistent store is
+	// still being assigned, crashing the node with a nil dereference (see #35508).
+	eth.blobCache = blobpool.NewCache(eth.blobTxPool)
 
 	if !config.TxPool.NoLocals {
 		rejournal := config.TxPool.Rejournal


### PR DESCRIPTION
## Problem

`BlobPool.Cache` can panic with a nil pointer dereference on `p.store` due to a race between `NewCache()` starting its background loop and `BlobPool.Init()` assigning `p.store`. On nodes with existing blobpool data on disk the race is highly reproducible (one reporter observed 81 crash-loops before a lucky startup):

```
panic: runtime error: invalid memory address or nil pointer dereference
...
github.com/ethereum/go-ethereum/core/txpool/blobpool.(*BlobPool).getByVhash(...)
        core/txpool/blobpool/blobpool.go:1303
github.com/ethereum/go-ethereum/core/txpool/blobpool.(*Cache).update.func1()
        core/txpool/blobpool/cache.go:429
created by (*Cache).update in goroutine ...
        core/txpool/blobpool/cache.go:415
```

## Root cause

In `eth/backend.go` the blob cache is created before the pool is initialized:

```go
eth.blobTxPool = blobpool.New(...)       // store is nil
eth.blobCache = blobpool.NewCache(...)   // starts the loop goroutine immediately
eth.txPool, err = txpool.New(...)        // calls BlobPool.Init, which assigns p.store
```

`BlobPool.Init` sets `p.head` early (before the on-disk scan). The cache loop's existing `head == nil` guard therefore does not protect the window in which `billy.Open()` populates `p.lookup`/`p.index` while `p.store` is still nil. If `selectTopTxs()` runs inside that window it returns the vhashes of the freshly-indexed transactions, and the update goroutine then calls `getByVhash()` -> `p.store.Get()` on the nil store -> `SIGSEGV`.

## Fix

Two layers, both minimal:

- `eth/backend.go`: create the blob cache only after `txpool.New()` has returned, i.e. after `BlobPool.Init` (which `txpool.New` invokes synchronously for each subpool) has completed. This closes the race window entirely for the node's startup path.
- `core/txpool/blobpool`: the pool tracks an `initialized` flag set at the very end of `Init()` (after the store assignment and all index/limbo setup), and `Cache.selectTopTxs()` returns nothing until that flag is set. This keeps the cache safe even if it is started before the pool is initialized, independent of caller ordering, and is race-free (no reads of the unsynchronized `p.store` field).

## Test

`TestCacheStartupBeforePoolInit` in `core/txpool/blobpool/cache_test.go` starts a cache on a deliberately un-initialized pool that has its head set and one transaction indexed via `parseTransaction` (exactly the state observable inside the `Init()` window). On the unpatched code the loop's initial topK iteration selects that transaction and the update goroutine dereferences the nil store, crashing the test with the reported panic. With the fix `selectTopTxs` bails out until `Init` completes, so the loop selects nothing and the cache stays empty.

Verified: `go test ./core/txpool/blobpool/ -run '^TestCacheStartupBeforePoolInit$' -count=1` passes.

Fixes #35508.