### PR TITLE
eth/catalyst: make `headBlock` reorging to `finalized` possible

### DIFF
--- a/eth/catalyst/api.go
+++ b/eth/catalyst/api.go
@@ -333,7 +333,7 @@ func (api *ConsensusAPI) forkchoiceUpdated(ctx context.Context, update engine.Fo
 		// generating the payload. It's a special corner case that a few slots are
 		// missing and we are requested to generate the payload in slot.
 	} else {
-		if finalized := api.eth.BlockChain().CurrentFinalBlock(); finalized != nil && block.NumberU64() <= finalized.Number.Uint64() {
+		if finalized := api.eth.BlockChain().CurrentFinalBlock(); finalized != nil && block.NumberU64() < finalized.Number.Uint64() {
 			log.Info("Skipping beacon update to finalized ancestor", "number", block.NumberU64(), "hash", update.HeadBlockHash)
 			return valid(nil), nil
 		}


### PR DESCRIPTION
(text below written by LLM and edited)

I ran into these reorg problems with Geth on our latest benchmarks for jochemnet. This is new as a few months ago this was not a problem, but it seems that Geth has become more "strict".

----

[execution-apis#786](https://github.com/ethereum/execution-apis/pull/786) narrowed the no-reorg optimisation specifically so that ELs would honour reorgs down to finality, and [go-ethereum#34767](https://github.com/ethereum/go-ethereum/pull/34767) — "allow reorging the head block to a parent" — implements it. If finality is the floor of that range, the finalized block itself seems like it should be the last reachable point rather than the first unreachable one: it is the block every competing branch is built on, so being asked to put the head there is an ordinary request. With `<=`, it is the one block a forkchoice update can never reach.

The skip is also indistinguishable from success. Point 2 mandates `{status: VALID, latestValidHash: <requested head>, payloadId: null}`, exactly what an applied update returns, so a caller cannot tell whether the head moved. We had an anchor forkchoice report `VALID` across three separate runs while the head never moved, which is what made it expensive to find.

It also has a concrete effect, because this return sits in front of `SetCanonical` ([`core/blockchain.go:2812`](https://github.com/ethereum/go-ethereum/blob/master/core/blockchain.go#L2812)), which calls `recoverAncestors` to re-execute and rebuild a state the node no longer holds. The other entry point declines by design — `newPayload` checks `HasBlockAndState` and answers `ACCEPTED`, correct per `engine_newPayloadV1` points 5-6 for a non-canonical payload. So once the head drifts past PathDB's `maxDiffLayers = 128` window, the finalized block becomes the one block geth will neither retain state for nor rebuild, even though re-execution would recover it.

The wording may support this, though we would not lean on it: point 2 covers a head that references a *"`VALID` **ancestor of** the latest known finalized block"*, and a block is not its own ancestor, which would leave `head == finalized` to point 7's **MUST** update. But the spec never defines "ancestor", and reading it as "at or below" is just as natural — so the question is really what was intended, and the text could say so either way.

If the answer is that it should be reachable, `<=` → `<` is sufficient: blocks strictly below finalized are still refused, `-38006` depth limiting is untouched, and the full `eth/catalyst` suite passes. A 69-line test reproduces it with no state pruning — finalize block 5 with the head at 10, forkchoice back to block 5, and the head stays at 10 while the call reports `VALID`. Real-world impact is limited, since a live node's head stays within ~2 epochs of finality; this surfaced in a benchmark harness that replays every test from a fixed anchor block and moves the head 258 blocks past it.
