### PR TITLE
core, internal/ethapi: validate simulate transaction gas limit

### DIFF
--- a/core/state_transition.go
+++ b/core/state_transition.go
@@ -293,6 +293,11 @@ type Message struct {
 	// - From is not verified to be an EOA
 	// - GasLimit is not checked against the protocol defined tx gaslimit
 	SkipTransactionChecks bool
+
+	// When set together with transaction checks enabled, the sender EOA check is
+	// skipped. This is used by eth_simulateV1 validation mode, which validates
+	// transaction gas limits but permits contract senders.
+	SkipFromEOACheck bool
 }
 
 // TransactionToMessage converts a transaction into a Message.
@@ -563,6 +568,8 @@ func (st *stateTransition) preCheck(rules params.Rules) error {
 		if !rules.IsAmsterdam && rules.IsOsaka && msg.GasLimit > params.MaxTxGas {
 			return fmt.Errorf("%w (cap: %d, tx: %d)", ErrGasLimitTooHigh, params.MaxTxGas, msg.GasLimit)
 		}
+	}
+	if !msg.SkipTransactionChecks && !msg.SkipFromEOACheck {
 		// Make sure the sender is an EOA
 		code := st.state.GetCode(msg.From)
 		_, delegated := types.ParseDelegation(code)

--- a/internal/ethapi/simulate.go
+++ b/internal/ethapi/simulate.go
@@ -345,6 +345,8 @@ func (sim *simulator) processBlock(ctx context.Context, block *simBlock, header,
 		// EoA check is always skipped, even in validation mode.
 		sim.state.SetTxContext(txHash, i, uint32(i+1))
 		msg := call.ToMessage(header.BaseFee, !sim.validate)
+		msg.SkipTransactionChecks = !sim.validate
+		msg.SkipFromEOACheck = true
 		result, err := applyMessageWithEVM(ctx, evm, msg, timeout, gp)
 		if err != nil {
 			txErr := txValidationError(err)

--- a/internal/ethapi/simulate_test.go
+++ b/internal/ethapi/simulate_test.go
@@ -17,13 +17,60 @@
 package ethapi
 
 import (
+	"context"
 	"math/big"
+	"strings"
 	"testing"
 
+	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/ethereum/go-ethereum/consensus/beacon"
+	"github.com/ethereum/go-ethereum/consensus/ethash"
+	"github.com/ethereum/go-ethereum/core"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/internal/ethapi/override"
+	"github.com/ethereum/go-ethereum/params"
+	"github.com/ethereum/go-ethereum/rpc"
 )
+
+type uncappedTestBackend struct{ *testBackend }
+
+func (uncappedTestBackend) RPCGasCap() uint64 { return 0 }
+
+func TestSimulateValidationChecksTransactionGasLimit(t *testing.T) {
+	var (
+		sender    = common.Address{0xaa}
+		recipient = common.Address{0xbb}
+		gas       = hexutil.Uint64(params.MaxTxGas + 1)
+		blockGas  = hexutil.Uint64(params.MaxTxGas + 2)
+		genesis   = &core.Genesis{
+			Config: params.MergedTestChainConfig,
+			Alloc: types.GenesisAlloc{
+				sender: {Balance: big.NewInt(params.Ether)},
+			},
+		}
+	)
+	backend := newTestBackend(t, 0, genesis, beacon.New(ethash.NewFaker()), func(int, *core.BlockGen) {})
+	api := NewBlockChainAPI(uncappedTestBackend{backend})
+	opts := simOpts{
+		Validation: true,
+		BlockStateCalls: []simBlock{{
+			BlockOverrides: &override.BlockOverrides{GasLimit: &blockGas},
+			Calls: []TransactionArgs{{
+				From:                 &sender,
+				To:                   &recipient,
+				Gas:                  &gas,
+				MaxFeePerGas:         newInt(1_000_000_000),
+				MaxPriorityFeePerGas: newInt(1),
+			}},
+		}},
+	}
+	latest := rpc.BlockNumberOrHashWithNumber(rpc.LatestBlockNumber)
+	_, err := api.SimulateV1(context.Background(), opts, &latest)
+	if err == nil || !strings.Contains(err.Error(), core.ErrGasLimitTooHigh.Error()) {
+		t.Fatalf("expected transaction gas limit error, got %v", err)
+	}
+}
 
 func TestSimulateSanitizeBlockOrder(t *testing.T) {
 	type result struct {


### PR DESCRIPTION
Closes #35479.

Root cause: TransactionArgs.ToMessage skips transaction checks for simulated calls, so validation mode also bypasses the EIP-7825 gas cap.

Change: separate the contract-sender exception from transaction checks. Validation mode now enforces the transaction gas cap while still permitting contract senders.

Validation:
- RED: focused test accepted MaxTxGas + 1 before the fix
- go test ./internal/ethapi -count=1
- go run ./build/ci.go test -short
- go run ./build/ci.go test
- go run ./build/ci.go lint
- go run ./build/ci.go check_generate
- go run ./build/ci.go check_baddeps