### PR TITLE
core/txpool/blobpool: fix cells-first metric accounting

### DIFF
--- a/core/txpool/blobpool/buffer.go
+++ b/core/txpool/blobpool/buffer.go
@@ -163,8 +163,9 @@ func (b *BlobBuffer) AddCells(hash common.Hash, deliveries map[string]*PeerDeliv
 	}
 	if txe, ok := b.txs[hash]; ok {
 		b.storeCompleted(hash, txe.tx, b.cells[hash])
+	} else {
+		blobBufferCellsFirstCounter.Inc(1)
 	}
-	blobBufferCellsFirstCounter.Inc(1)
 }
 
 // storeCompleted verifies cells per-peer, sorts them, and schedules them for

--- a/core/txpool/blobpool/buffer_test.go
+++ b/core/txpool/blobpool/buffer_test.go
@@ -88,6 +88,8 @@ func TestAddTxThenCells(t *testing.T) {
 	key, _ := crypto.GenerateKey()
 	blobCount := 2
 	buf := newTestBuffer(t)
+	txFirstBefore := blobBufferTxFirstCounter.Snapshot().Count()
+	cellsFirstBefore := blobBufferCellsFirstCounter.Snapshot().Count()
 
 	tx := makeV1Tx(t, 0, blobCount, 0, key)
 	hash := tx.Hash()
@@ -110,12 +112,20 @@ func TestAddTxThenCells(t *testing.T) {
 	if buf.HasTx(hash) || buf.HasCells(hash) {
 		t.Fatal("buffer should be empty after add")
 	}
+	if got := blobBufferTxFirstCounter.Snapshot().Count() - txFirstBefore; got != 1 {
+		t.Fatalf("tx-first counter incremented by %d, want 1", got)
+	}
+	if got := blobBufferCellsFirstCounter.Snapshot().Count() - cellsFirstBefore; got != 0 {
+		t.Fatalf("cells-first counter incremented by %d, want 0", got)
+	}
 }
 
 func TestAddCellsThenTx(t *testing.T) {
 	key, _ := crypto.GenerateKey()
 	blobCount := 2
 	buf := newTestBuffer(t)
+	txFirstBefore := blobBufferTxFirstCounter.Snapshot().Count()
+	cellsFirstBefore := blobBufferCellsFirstCounter.Snapshot().Count()
 
 	tx := makeV1Tx(t, 0, blobCount, 0, key)
 	hash := tx.Hash()
@@ -137,6 +147,12 @@ func TestAddCellsThenTx(t *testing.T) {
 	}
 	if buf.HasTx(hash) || buf.HasCells(hash) {
 		t.Fatal("buffer should be empty after add")
+	}
+	if got := blobBufferTxFirstCounter.Snapshot().Count() - txFirstBefore; got != 0 {
+		t.Fatalf("tx-first counter incremented by %d, want 0", got)
+	}
+	if got := blobBufferCellsFirstCounter.Snapshot().Count() - cellsFirstBefore; got != 1 {
+		t.Fatalf("cells-first counter incremented by %d, want 1", got)
 	}
 }
 


### PR DESCRIPTION
The `blobpool/buffer/cellsfirst` counter is currently incremented for every `AddCells` call, including when the corresponding transaction is already buffered.

This makes the two arrival-order counters overlap. In the transaction-first case:

1. `AddTx` increments `blobpool/buffer/txfirst`.
2. `AddCells` finds the buffered transaction and completes the entry.
3. `AddCells` also increments `blobpool/buffer/cellsfirst`.

As a result, both counters are incremented for the same transaction, even though the cells did not arrive first.

Increment `blobpool/buffer/cellsfirst` only when no matching transaction is buffered, making it symmetric with the existing `txfirst` accounting.

No functional blob-buffer behavior is changed; this only corrects metric accounting.