### PR TITLE
crypto/kzg4844: add BlobsFromDataCells for zero-KZG blob reconstruction

### DIFF
--- a/crypto/kzg4844/kzg4844.go
+++ b/crypto/kzg4844/kzg4844.go
@@ -270,7 +270,7 @@ func RecoverBlobs(cells []Cell, cellIndices []uint64) ([]Blob, error) {
 	return gokzgRecoverBlobs(cells, cellIndices)
 }
 
-// BlobsFromDataCells reconstructs blobs from their data cells without performing
+// blobsFromDataCells reconstructs blobs from their data cells without performing
 // any KZG reconstruction. The data cells of a blob (cell indices 0..DataPerBlob-1)
 // are, by definition, its contents, so when all of them are present the blob is
 // simply their concatenation.
@@ -291,7 +291,7 @@ func RecoverBlobs(cells []Cell, cellIndices []uint64) ([]Blob, error) {
 // input this silently yields a malformed blob.
 //
 // For the layout of cells and cellIndices, see RecoverBlobs.
-func BlobsFromDataCells(cells []Cell, cellIndices []uint64) ([]Blob, bool) {
+func blobsFromDataCells(cells []Cell, cellIndices []uint64) ([]Blob, bool) {
 	if validateCellIndices(cells, cellIndices) != nil {
 		return nil, false
 	}
@@ -330,19 +330,19 @@ func BlobsFromDataCells(cells []Cell, cellIndices []uint64) ([]Blob, bool) {
 // RecoverBlobsUnchecked is RecoverBlobs for callers that have already
 // established the cells' authenticity (e.g. verified via VerifyCells at ingest).
 // When the data cells are all present it returns their concatenation directly
-// (via BlobsFromDataCells), skipping the KZG erasure decode; otherwise it falls
+// (via blobsFromDataCells), skipping the KZG erasure decode; otherwise it falls
 // back to full recovery. The result is byte-identical to RecoverBlobs either way.
 //
 // Prerequisite: "unchecked" refers to the cell contents -- neither this nor
 // RecoverBlobs verifies cell proofs or the commitment. The paths differ only in
 // field-element canonicalness: the erasure-decode fallback rejects non-canonical
 // encodings while deserializing, whereas the fast path (a raw concatenation, see
-// BlobsFromDataCells) does not. Since callers cannot choose which path runs, the
+// blobsFromDataCells) does not. Since callers cannot choose which path runs, the
 // weaker contract governs: pass only cells whose authenticity is already assured.
 //
 // For the layout of cells and cellIndices, see RecoverBlobs.
 func RecoverBlobsUnchecked(cells []Cell, cellIndices []uint64) ([]Blob, error) {
-	if blobs, ok := BlobsFromDataCells(cells, cellIndices); ok {
+	if blobs, ok := blobsFromDataCells(cells, cellIndices); ok {
 		return blobs, nil
 	}
 	return RecoverBlobs(cells, cellIndices)

--- a/crypto/kzg4844/kzg4844.go
+++ b/crypto/kzg4844/kzg4844.go
@@ -270,35 +270,20 @@ func RecoverBlobs(cells []Cell, cellIndices []uint64) ([]Blob, error) {
 	return gokzgRecoverBlobs(cells, cellIndices)
 }
 
-// blobsFromDataCells reconstructs blobs from their data cells without performing
-// any KZG reconstruction. The data cells of a blob (cell indices 0..DataPerBlob-1)
-// are, by definition, its contents, so when all of them are present the blob is
-// simply their concatenation.
-//
-// It returns ok=false when the data cells are not all present, or the inputs are
-// otherwise unsuitable (including non-canonical cell indices), in which case the
-// caller should fall back to RecoverBlobs. The inputs accepted here are a strict
-// subset of those accepted by RecoverBlobs, so a successful result always equals
-// what RecoverBlobs would return. Because it only copies bytes, it is independent
-// of the selected KZG backend.
-//
-// Prerequisite: this checks nothing about the cell contents. Being a raw byte
-// concatenation, it does not even reject non-canonical field-element encodings --
-// the one check RecoverBlobs performs, as a side effect of deserialization. Note
-// that neither this nor RecoverBlobs verifies cell proofs or the commitment, so
-// establishing authenticity is the caller's responsibility in both cases: callers
-// MUST pass cells already verified (e.g. via VerifyCells at ingest); on unverified
-// input this silently yields a malformed blob.
+// blobsFromDataCells reconstructs blobs by concatenating their data cells (cell
+// indices 0..DataPerBlob-1, by definition the blob contents), with no KZG
+// involvement and no validation of the cell contents whatsoever (see
+// RecoverBlobsUnchecked for the contract). It accepts a strict subset of the
+// inputs RecoverBlobs accepts and returns identical bytes; on ok=false the
+// caller should fall back to RecoverBlobs.
 //
 // For the layout of cells and cellIndices, see RecoverBlobs.
 func blobsFromDataCells(cells []Cell, cellIndices []uint64) ([]Blob, bool) {
 	if validateCellIndices(cells, cellIndices) != nil {
 		return nil, false
 	}
-	// The fast path applies only when the leading cells are exactly the data
-	// cells in canonical order, i.e. cellIndices[i] == i for i < DataPerBlob.
-	// RecoverBlobs requires ascending indices, so this keeps the accepted inputs
-	// a strict subset of what RecoverBlobs accepts (and thus byte-identical).
+	// The head must be exactly the data cells in canonical order:
+	// cellIndices[i] == i for i < DataPerBlob.
 	if len(cellIndices) < DataPerBlob {
 		return nil, false
 	}
@@ -307,10 +292,8 @@ func blobsFromDataCells(cells []Cell, cellIndices []uint64) ([]Blob, bool) {
 			return nil, false
 		}
 	}
-	// The extension tail is ignored by the concatenation, but it must still be
-	// checked: the slow paths delegate index validation to the KZG library,
-	// which the fast path never reaches. Declining malformed tails here keeps
-	// the accepted inputs a strict subset of what RecoverBlobs accepts.
+	// The tail is ignored by the concatenation but must still be well-formed:
+	// the KZG library that would reject it is never reached on this path.
 	for i := DataPerBlob; i < len(cellIndices); i++ {
 		if cellIndices[i] <= cellIndices[i-1] || cellIndices[i] >= CellsPerBlob {
 			return nil, false
@@ -328,17 +311,14 @@ func blobsFromDataCells(cells []Cell, cellIndices []uint64) ([]Blob, bool) {
 }
 
 // RecoverBlobsUnchecked is RecoverBlobs for callers that have already
-// established the cells' authenticity (e.g. verified via VerifyCells at ingest).
-// When the data cells are all present it returns their concatenation directly
-// (via blobsFromDataCells), skipping the KZG erasure decode; otherwise it falls
-// back to full recovery. The result is byte-identical to RecoverBlobs either way.
+// established the cells' authenticity (e.g. via VerifyCells at ingest): when the
+// data cells are all present, the blobs are returned as their concatenation,
+// skipping the KZG erasure decode. The result is byte-identical to RecoverBlobs.
 //
-// Prerequisite: "unchecked" refers to the cell contents -- neither this nor
-// RecoverBlobs verifies cell proofs or the commitment. The paths differ only in
-// field-element canonicalness: the erasure-decode fallback rejects non-canonical
-// encodings while deserializing, whereas the fast path (a raw concatenation, see
-// blobsFromDataCells) does not. Since callers cannot choose which path runs, the
-// weaker contract governs: pass only cells whose authenticity is already assured.
+// "Unchecked" refers to the cell contents: the concatenation validates nothing,
+// not even field-element canonicalness -- the one check RecoverBlobs performs
+// (neither verifies cell proofs or the commitment). Pass only cells whose
+// authenticity is already assured.
 //
 // For the layout of cells and cellIndices, see RecoverBlobs.
 func RecoverBlobsUnchecked(cells []Cell, cellIndices []uint64) ([]Blob, error) {

--- a/crypto/kzg4844/kzg4844.go
+++ b/crypto/kzg4844/kzg4844.go
@@ -282,11 +282,13 @@ func RecoverBlobs(cells []Cell, cellIndices []uint64) ([]Blob, error) {
 // what RecoverBlobs would return. Because it only copies bytes, it is independent
 // of the selected KZG backend.
 //
-// Prerequisite: this performs NO validation of cell contents. Unlike RecoverBlobs
-// (whose deserialization rejects non-canonical field elements), it is a raw byte
-// concatenation and checks neither field-element canonicalness, nor cell proofs,
-// nor the commitment. Callers MUST pass cells already validated (e.g. verified via
-// VerifyCells at ingest); on unvalidated input it silently yields a malformed blob.
+// Prerequisite: this checks nothing about the cell contents. Being a raw byte
+// concatenation, it does not even reject non-canonical field-element encodings --
+// the one check RecoverBlobs performs, as a side effect of deserialization. Note
+// that neither this nor RecoverBlobs verifies cell proofs or the commitment, so
+// establishing authenticity is the caller's responsibility in both cases: callers
+// MUST pass cells already verified (e.g. via VerifyCells at ingest); on unverified
+// input this silently yields a malformed blob.
 //
 // For the layout of cells and cellIndices, see RecoverBlobs.
 func BlobsFromDataCells(cells []Cell, cellIndices []uint64) ([]Blob, bool) {
@@ -314,6 +316,27 @@ func BlobsFromDataCells(cells []Cell, cellIndices []uint64) ([]Blob, bool) {
 		}
 	}
 	return blobs, true
+}
+
+// RecoverBlobsUnchecked is RecoverBlobs for callers that have already
+// established the cells' authenticity (e.g. verified via VerifyCells at ingest).
+// When the data cells are all present it returns their concatenation directly
+// (via BlobsFromDataCells), skipping the KZG erasure decode; otherwise it falls
+// back to full recovery. The result is byte-identical to RecoverBlobs either way.
+//
+// Prerequisite: "unchecked" refers to the cell contents -- neither this nor
+// RecoverBlobs verifies cell proofs or the commitment. The paths differ only in
+// field-element canonicalness: the erasure-decode fallback rejects non-canonical
+// encodings while deserializing, whereas the fast path (a raw concatenation, see
+// BlobsFromDataCells) does not. Since callers cannot choose which path runs, the
+// weaker contract governs: pass only cells whose authenticity is already assured.
+//
+// For the layout of cells and cellIndices, see RecoverBlobs.
+func RecoverBlobsUnchecked(cells []Cell, cellIndices []uint64) ([]Blob, error) {
+	if blobs, ok := BlobsFromDataCells(cells, cellIndices); ok {
+		return blobs, nil
+	}
+	return RecoverBlobs(cells, cellIndices)
 }
 
 func validateCellIndices(cells []Cell, cellIndices []uint64) error {

--- a/crypto/kzg4844/kzg4844.go
+++ b/crypto/kzg4844/kzg4844.go
@@ -303,11 +303,9 @@ func BlobsFromDataCells(cells []Cell, cellIndices []uint64) ([]Blob, bool) {
 	blobCount := len(cells) / len(cellIndices)
 	blobs := make([]Blob, blobCount)
 	for b := range blobCount {
-		offset := b * len(cellIndices)
-		blob := &blobs[b]
-		for i := range DataPerBlob {
-			cell := &cells[offset+i]
-			copy(blob[i*len(cell):], cell[:])
+		data := cells[b*len(cellIndices):][:DataPerBlob]
+		for i := range data {
+			copy(blobs[b][i*len(data[i]):], data[i][:])
 		}
 	}
 	return blobs, true

--- a/crypto/kzg4844/kzg4844.go
+++ b/crypto/kzg4844/kzg4844.go
@@ -59,6 +59,11 @@ func (c *Cell) MarshalText() ([]byte, error) {
 // Blob represents a 4844 data blob.
 type Blob [131072]byte
 
+// A blob is exactly its DataPerBlob data cells, concatenated; the remaining
+// cells (indices DataPerBlob..CellsPerBlob-1) carry redundancy only. Code
+// reassembling blobs from cells relies on this, so assert it at compile time.
+var _ [len(Blob{})]byte = [DataPerBlob * len(Cell{})]byte{}
+
 // UnmarshalJSON parses a blob in hex syntax.
 func (b *Blob) UnmarshalJSON(input []byte) error {
 	return hexutil.UnmarshalFixedJSON(blobT, input, b[:])

--- a/crypto/kzg4844/kzg4844.go
+++ b/crypto/kzg4844/kzg4844.go
@@ -307,6 +307,15 @@ func BlobsFromDataCells(cells []Cell, cellIndices []uint64) ([]Blob, bool) {
 			return nil, false
 		}
 	}
+	// The extension tail is ignored by the concatenation, but it must still be
+	// checked: the slow paths delegate index validation to the KZG library,
+	// which the fast path never reaches. Declining malformed tails here keeps
+	// the accepted inputs a strict subset of what RecoverBlobs accepts.
+	for i := DataPerBlob; i < len(cellIndices); i++ {
+		if cellIndices[i] <= cellIndices[i-1] || cellIndices[i] >= CellsPerBlob {
+			return nil, false
+		}
+	}
 	blobCount := len(cells) / len(cellIndices)
 	blobs := make([]Blob, blobCount)
 	for b := range blobCount {

--- a/crypto/kzg4844/kzg4844.go
+++ b/crypto/kzg4844/kzg4844.go
@@ -265,6 +265,54 @@ func RecoverBlobs(cells []Cell, cellIndices []uint64) ([]Blob, error) {
 	return gokzgRecoverBlobs(cells, cellIndices)
 }
 
+// BlobsFromDataCells reconstructs blobs from their data cells without performing
+// any KZG reconstruction. The data cells of a blob (cell indices 0..DataPerBlob-1)
+// are, by definition, its contents, so when all of them are present the blob is
+// simply their concatenation.
+//
+// It returns ok=false when the data cells are not all present, or the inputs are
+// otherwise unsuitable (including non-canonical cell indices), in which case the
+// caller should fall back to RecoverBlobs. The inputs accepted here are a strict
+// subset of those accepted by RecoverBlobs, so a successful result always equals
+// what RecoverBlobs would return. Because it only copies bytes, it is independent
+// of the selected KZG backend.
+//
+// Prerequisite: this performs NO validation of cell contents. Unlike RecoverBlobs
+// (whose deserialization rejects non-canonical field elements), it is a raw byte
+// concatenation and checks neither field-element canonicalness, nor cell proofs,
+// nor the commitment. Callers MUST pass cells already validated (e.g. verified via
+// VerifyCells at ingest); on unvalidated input it silently yields a malformed blob.
+//
+// For the layout of cells and cellIndices, see RecoverBlobs.
+func BlobsFromDataCells(cells []Cell, cellIndices []uint64) ([]Blob, bool) {
+	if validateCellIndices(cells, cellIndices) != nil {
+		return nil, false
+	}
+	// The fast path applies only when the leading cells are exactly the data
+	// cells in canonical order, i.e. cellIndices[i] == i for i < DataPerBlob.
+	// RecoverBlobs requires ascending indices, so this keeps the accepted inputs
+	// a strict subset of what RecoverBlobs accepts (and thus byte-identical).
+	if len(cellIndices) < DataPerBlob {
+		return nil, false
+	}
+	for i := range DataPerBlob {
+		if cellIndices[i] != uint64(i) {
+			return nil, false
+		}
+	}
+	blobCount := len(cells) / len(cellIndices)
+	blobs := make([]Blob, blobCount)
+	for b := range blobCount {
+		offset := b * len(cellIndices)
+		blob := &blobs[b]
+		for i := range DataPerBlob {
+			cell := &cells[offset+i]
+			copy(blob[i*len(cell):], cell[:])
+		}
+	}
+	return blobs, true
+}
+
 func validateCellIndices(cells []Cell, cellIndices []uint64) error {
 	switch {
 	case len(cellIndices) == 0:

--- a/crypto/kzg4844/kzg4844_test.go
+++ b/crypto/kzg4844/kzg4844_test.go
@@ -519,6 +519,50 @@ func testBlobsFromDataCells(t *testing.T, ckzg bool) {
 	if _, ok := BlobsFromDataCells(collect(short), short); ok {
 		t.Fatalf("insufficient: fast path succeeded, expected decline")
 	}
+
+	// Malformed extension tails: the leading data cells are canonical, but the
+	// tail is not something RecoverBlobs would accept (the concatenation never
+	// reads it, and the KZG library that would reject it is never reached on
+	// the fast path). Each must be declined rather than accepted.
+	duplicate := append(slices.Clone(dataIndices), DataPerBlob-1) // 63 repeated
+	if _, ok := BlobsFromDataCells(collect(duplicate), duplicate); ok {
+		t.Fatalf("duplicate-tail: fast path succeeded, expected decline")
+	}
+	if _, err := RecoverBlobs(collect(duplicate), duplicate); err == nil {
+		t.Fatalf("duplicate-tail: RecoverBlobs succeeded, expected error")
+	}
+	unorderedTail := append(slices.Clone(dataIndices), 65, 64)
+	if _, ok := BlobsFromDataCells(collect(unorderedTail), unorderedTail); ok {
+		t.Fatalf("unordered-tail: fast path succeeded, expected decline")
+	}
+	outOfRange := append(slices.Clone(dataIndices), CellsPerBlob)
+	cellsOOR := append(slices.Clone(collect(dataIndices)[:DataPerBlob]), Cell{}) // one blob
+	if _, ok := BlobsFromDataCells(cellsOOR, outOfRange); ok {
+		t.Fatalf("out-of-range-tail: fast path succeeded, expected decline")
+	}
+
+	// Single blob: the slicing math must hold for blobCount == 1 too.
+	d1 := newBlobs(t, 1)
+	single, ok := BlobsFromDataCells(d1.cells[:DataPerBlob], dataIndices)
+	if !ok {
+		t.Fatalf("single-blob: fast path declined, expected success")
+	}
+	if single[0] != d1.blobs[0] {
+		t.Fatalf("single-blob: reconstructed blob does not match original")
+	}
+
+	// Randomized well-formed tails: the data cells plus a random sorted subset
+	// of the extension indices must be accepted and agree with RecoverBlobs.
+	for iter := range 10 {
+		rng := mrand.New(mrand.NewSource(int64(iter)))
+		perm := rng.Perm(CellsPerBlob - DataPerBlob)
+		tail := make([]uint64, rng.Intn(CellsPerBlob-DataPerBlob+1))
+		for i := range tail {
+			tail[i] = uint64(DataPerBlob + perm[i])
+		}
+		slices.Sort(tail)
+		assertRecovers("random-tail", append(slices.Clone(dataIndices), tail...))
+	}
 }
 
 func TestCKZGRecoverBlobsUnchecked(t *testing.T)  { testRecoverBlobsUnchecked(t, true) }

--- a/crypto/kzg4844/kzg4844_test.go
+++ b/crypto/kzg4844/kzg4844_test.go
@@ -434,3 +434,89 @@ func testRecoverBlobWithInsufficientCells(t *testing.T, ckzg bool) {
 		t.Fatalf("expected error with only %d cells, got none", len(indices))
 	}
 }
+
+func TestCKZGBlobsFromDataCells(t *testing.T)  { testBlobsFromDataCells(t, true) }
+func TestGoKZGBlobsFromDataCells(t *testing.T) { testBlobsFromDataCells(t, false) }
+
+// testBlobsFromDataCells checks that the KZG-free fast path reconstructs the
+// original blobs whenever the data cells are present, agrees byte-for-byte with
+// RecoverBlobs, and declines (ok=false) when a data cell is missing.
+func testBlobsFromDataCells(t *testing.T, ckzg bool) {
+	defer switchBackend(t, ckzg)()
+
+	const blobCount = 3
+	d := newBlobs(t, blobCount)
+
+	// collect gathers the cells for the given per-blob indices across all blobs.
+	collect := func(indices []uint64) []Cell {
+		var cells []Cell
+		for bi := range blobCount {
+			for _, idx := range indices {
+				cells = append(cells, d.cells[bi*CellsPerBlob+int(idx)])
+			}
+		}
+		return cells
+	}
+	// assertRecovers checks the fast path succeeds and matches both the original
+	// blobs and RecoverBlobs.
+	assertRecovers := func(name string, indices []uint64) {
+		t.Helper()
+		cells := collect(indices)
+		fast, ok := BlobsFromDataCells(cells, indices)
+		if !ok {
+			t.Fatalf("%s: fast path declined, expected success", name)
+		}
+		slow, err := RecoverBlobs(cells, indices)
+		if err != nil {
+			t.Fatalf("%s: RecoverBlobs failed: %v", name, err)
+		}
+		for i := range d.blobs {
+			if fast[i] != d.blobs[i] {
+				t.Fatalf("%s: fast blob %d does not match original", name, i)
+			}
+			if fast[i] != slow[i] {
+				t.Fatalf("%s: fast blob %d does not match RecoverBlobs", name, i)
+			}
+		}
+	}
+
+	// Exactly the data cells, in canonical order.
+	dataIndices := make([]uint64, DataPerBlob)
+	for i := range dataIndices {
+		dataIndices[i] = uint64(i)
+	}
+	assertRecovers("data-only", dataIndices)
+
+	// Full custody: all cells present, data cells plus extension cells.
+	allIndices := make([]uint64, CellsPerBlob)
+	for i := range allIndices {
+		allIndices[i] = uint64(i)
+	}
+	assertRecovers("full-custody", allIndices)
+
+	// Data cells present but not in canonical order: RecoverBlobs rejects
+	// non-ascending indices, so the fast path must decline too rather than
+	// accept an input the slow path would error on.
+	unordered := slices.Clone(dataIndices)
+	unordered[0], unordered[1] = unordered[1], unordered[0]
+	if _, ok := BlobsFromDataCells(collect(unordered), unordered); ok {
+		t.Fatalf("unordered-data: fast path succeeded, expected decline")
+	}
+
+	// A data cell missing (index 63 replaced by an extension cell): the fast
+	// path must decline, while RecoverBlobs can still reconstruct.
+	missing := slices.Clone(dataIndices)
+	missing[DataPerBlob-1] = DataPerBlob // drop data cell 63, add extension cell 64
+	if _, ok := BlobsFromDataCells(collect(missing), missing); ok {
+		t.Fatalf("missing-data: fast path succeeded, expected decline")
+	}
+	if _, err := RecoverBlobs(collect(missing), missing); err != nil {
+		t.Fatalf("missing-data: RecoverBlobs failed: %v", err)
+	}
+
+	// Too few cells for recovery at all: fast path declines.
+	short := dataIndices[:DataPerBlob-1]
+	if _, ok := BlobsFromDataCells(collect(short), short); ok {
+		t.Fatalf("insufficient: fast path succeeded, expected decline")
+	}
+}

--- a/crypto/kzg4844/kzg4844_test.go
+++ b/crypto/kzg4844/kzg4844_test.go
@@ -494,9 +494,8 @@ func testBlobsFromDataCells(t *testing.T, ckzg bool) {
 	}
 	assertRecovers("full-custody", allIndices)
 
-	// Data cells present but not in canonical order: RecoverBlobs rejects
-	// non-ascending indices, so the fast path must decline too rather than
-	// accept an input the slow path would error on.
+	// Data cells present but out of order: must decline, as RecoverBlobs
+	// rejects non-ascending indices.
 	unordered := slices.Clone(dataIndices)
 	unordered[0], unordered[1] = unordered[1], unordered[0]
 	if _, ok := blobsFromDataCells(collect(unordered), unordered); ok {
@@ -520,10 +519,8 @@ func testBlobsFromDataCells(t *testing.T, ckzg bool) {
 		t.Fatalf("insufficient: fast path succeeded, expected decline")
 	}
 
-	// Malformed extension tails: the leading data cells are canonical, but the
-	// tail is not something RecoverBlobs would accept (the concatenation never
-	// reads it, and the KZG library that would reject it is never reached on
-	// the fast path). Each must be declined rather than accepted.
+	// Malformed extension tails: inputs RecoverBlobs would reject, which the
+	// fast path must decline rather than accept.
 	duplicate := append(slices.Clone(dataIndices), DataPerBlob-1) // 63 repeated
 	if _, ok := blobsFromDataCells(collect(duplicate), duplicate); ok {
 		t.Fatalf("duplicate-tail: fast path succeeded, expected decline")
@@ -612,9 +609,8 @@ func testRecoverBlobsUnchecked(t *testing.T, ckzg bool) {
 	}
 	assertRecovers("data-only (fast path)", dataIndices)
 
-	// Fallback: a non-data subset that blobsFromDataCells declines (data cell 0
-	// dropped, extension cell 64 added), so recovery must route through the KZG
-	// erasure decode -- and still reconstruct the originals.
+	// Fallback: a non-data subset (data cell 0 swapped for extension cell 64)
+	// must route through the KZG erasure decode and still reconstruct.
 	sparse := slices.Clone(dataIndices)
 	sparse[0] = DataPerBlob // drop data cell 0, add extension cell 64
 	slices.Sort(sparse)

--- a/crypto/kzg4844/kzg4844_test.go
+++ b/crypto/kzg4844/kzg4844_test.go
@@ -520,3 +520,68 @@ func testBlobsFromDataCells(t *testing.T, ckzg bool) {
 		t.Fatalf("insufficient: fast path succeeded, expected decline")
 	}
 }
+
+func TestCKZGRecoverBlobsUnchecked(t *testing.T)  { testRecoverBlobsUnchecked(t, true) }
+func TestGoKZGRecoverBlobsUnchecked(t *testing.T) { testRecoverBlobsUnchecked(t, false) }
+
+// testRecoverBlobsUnchecked checks that the unchecked recovery takes the
+// KZG-free fast path when the data cells are present and falls back to full
+// erasure recovery otherwise, matching the original blobs in both cases.
+func testRecoverBlobsUnchecked(t *testing.T, ckzg bool) {
+	defer switchBackend(t, ckzg)()
+
+	const blobCount = 3
+	d := newBlobs(t, blobCount)
+
+	// collect gathers the cells for the given per-blob indices across all blobs.
+	collect := func(indices []uint64) []Cell {
+		var cells []Cell
+		for bi := range blobCount {
+			for _, idx := range indices {
+				cells = append(cells, d.cells[bi*CellsPerBlob+int(idx)])
+			}
+		}
+		return cells
+	}
+	// assertRecovers checks recovery succeeds, verifies against the cell proofs,
+	// and matches the original blobs.
+	assertRecovers := func(name string, indices []uint64) {
+		t.Helper()
+		blobs, err := RecoverBlobsUnchecked(collect(indices), indices)
+		if err != nil {
+			t.Fatalf("%s: recovery failed: %v", name, err)
+		}
+		if err := VerifyCellProofs(blobs, d.commitments, d.proofs); err != nil {
+			t.Fatalf("%s: recovered blobs failed verification: %v", name, err)
+		}
+		for i := range d.blobs {
+			if blobs[i] != d.blobs[i] {
+				t.Fatalf("%s: recovered blob %d does not match original", name, i)
+			}
+		}
+	}
+
+	// Fast path: exactly the data cells, in canonical order.
+	dataIndices := make([]uint64, DataPerBlob)
+	for i := range dataIndices {
+		dataIndices[i] = uint64(i)
+	}
+	assertRecovers("data-only (fast path)", dataIndices)
+
+	// Fallback: a non-data subset that BlobsFromDataCells declines (data cell 0
+	// dropped, extension cell 64 added), so recovery must route through the KZG
+	// erasure decode -- and still reconstruct the originals.
+	sparse := slices.Clone(dataIndices)
+	sparse[0] = DataPerBlob // drop data cell 0, add extension cell 64
+	slices.Sort(sparse)
+	if _, ok := BlobsFromDataCells(collect(sparse), sparse); ok {
+		t.Fatalf("test setup: expected fast path to decline for the sparse subset")
+	}
+	assertRecovers("sparse (fallback)", sparse)
+
+	// Insufficient cells: recovery must error, like RecoverBlobs.
+	short := dataIndices[:DataPerBlob-1]
+	if _, err := RecoverBlobsUnchecked(collect(short), short); err == nil {
+		t.Fatalf("insufficient: expected error, got none")
+	}
+}

--- a/crypto/kzg4844/kzg4844_test.go
+++ b/crypto/kzg4844/kzg4844_test.go
@@ -462,7 +462,7 @@ func testBlobsFromDataCells(t *testing.T, ckzg bool) {
 	assertRecovers := func(name string, indices []uint64) {
 		t.Helper()
 		cells := collect(indices)
-		fast, ok := BlobsFromDataCells(cells, indices)
+		fast, ok := blobsFromDataCells(cells, indices)
 		if !ok {
 			t.Fatalf("%s: fast path declined, expected success", name)
 		}
@@ -499,7 +499,7 @@ func testBlobsFromDataCells(t *testing.T, ckzg bool) {
 	// accept an input the slow path would error on.
 	unordered := slices.Clone(dataIndices)
 	unordered[0], unordered[1] = unordered[1], unordered[0]
-	if _, ok := BlobsFromDataCells(collect(unordered), unordered); ok {
+	if _, ok := blobsFromDataCells(collect(unordered), unordered); ok {
 		t.Fatalf("unordered-data: fast path succeeded, expected decline")
 	}
 
@@ -507,7 +507,7 @@ func testBlobsFromDataCells(t *testing.T, ckzg bool) {
 	// path must decline, while RecoverBlobs can still reconstruct.
 	missing := slices.Clone(dataIndices)
 	missing[DataPerBlob-1] = DataPerBlob // drop data cell 63, add extension cell 64
-	if _, ok := BlobsFromDataCells(collect(missing), missing); ok {
+	if _, ok := blobsFromDataCells(collect(missing), missing); ok {
 		t.Fatalf("missing-data: fast path succeeded, expected decline")
 	}
 	if _, err := RecoverBlobs(collect(missing), missing); err != nil {
@@ -516,7 +516,7 @@ func testBlobsFromDataCells(t *testing.T, ckzg bool) {
 
 	// Too few cells for recovery at all: fast path declines.
 	short := dataIndices[:DataPerBlob-1]
-	if _, ok := BlobsFromDataCells(collect(short), short); ok {
+	if _, ok := blobsFromDataCells(collect(short), short); ok {
 		t.Fatalf("insufficient: fast path succeeded, expected decline")
 	}
 
@@ -525,25 +525,25 @@ func testBlobsFromDataCells(t *testing.T, ckzg bool) {
 	// reads it, and the KZG library that would reject it is never reached on
 	// the fast path). Each must be declined rather than accepted.
 	duplicate := append(slices.Clone(dataIndices), DataPerBlob-1) // 63 repeated
-	if _, ok := BlobsFromDataCells(collect(duplicate), duplicate); ok {
+	if _, ok := blobsFromDataCells(collect(duplicate), duplicate); ok {
 		t.Fatalf("duplicate-tail: fast path succeeded, expected decline")
 	}
 	if _, err := RecoverBlobs(collect(duplicate), duplicate); err == nil {
 		t.Fatalf("duplicate-tail: RecoverBlobs succeeded, expected error")
 	}
 	unorderedTail := append(slices.Clone(dataIndices), 65, 64)
-	if _, ok := BlobsFromDataCells(collect(unorderedTail), unorderedTail); ok {
+	if _, ok := blobsFromDataCells(collect(unorderedTail), unorderedTail); ok {
 		t.Fatalf("unordered-tail: fast path succeeded, expected decline")
 	}
 	outOfRange := append(slices.Clone(dataIndices), CellsPerBlob)
 	cellsOOR := append(slices.Clone(collect(dataIndices)[:DataPerBlob]), Cell{}) // one blob
-	if _, ok := BlobsFromDataCells(cellsOOR, outOfRange); ok {
+	if _, ok := blobsFromDataCells(cellsOOR, outOfRange); ok {
 		t.Fatalf("out-of-range-tail: fast path succeeded, expected decline")
 	}
 
 	// Single blob: the slicing math must hold for blobCount == 1 too.
 	d1 := newBlobs(t, 1)
-	single, ok := BlobsFromDataCells(d1.cells[:DataPerBlob], dataIndices)
+	single, ok := blobsFromDataCells(d1.cells[:DataPerBlob], dataIndices)
 	if !ok {
 		t.Fatalf("single-blob: fast path declined, expected success")
 	}
@@ -612,13 +612,13 @@ func testRecoverBlobsUnchecked(t *testing.T, ckzg bool) {
 	}
 	assertRecovers("data-only (fast path)", dataIndices)
 
-	// Fallback: a non-data subset that BlobsFromDataCells declines (data cell 0
+	// Fallback: a non-data subset that blobsFromDataCells declines (data cell 0
 	// dropped, extension cell 64 added), so recovery must route through the KZG
 	// erasure decode -- and still reconstruct the originals.
 	sparse := slices.Clone(dataIndices)
 	sparse[0] = DataPerBlob // drop data cell 0, add extension cell 64
 	slices.Sort(sparse)
-	if _, ok := BlobsFromDataCells(collect(sparse), sparse); ok {
+	if _, ok := blobsFromDataCells(collect(sparse), sparse); ok {
 		t.Fatalf("test setup: expected fast path to decline for the sparse subset")
 	}
 	assertRecovers("sparse (fallback)", sparse)

--- a/crypto/kzg4844/kzg4844_test.go
+++ b/crypto/kzg4844/kzg4844_test.go
@@ -550,7 +550,7 @@ func testBlobsFromDataCells(t *testing.T, ckzg bool) {
 
 	// Randomized well-formed tails: the data cells plus a random sorted subset
 	// of the extension indices must be accepted and agree with RecoverBlobs.
-	for iter := range 10 {
+	for iter := range 5 {
 		rng := mrand.New(mrand.NewSource(int64(iter)))
 		perm := rng.Perm(CellsPerBlob - DataPerBlob)
 		tail := make([]uint64, rng.Intn(CellsPerBlob-DataPerBlob+1))


### PR DESCRIPTION
When the full data domain (cell indices 0..DataPerBlob-1) is present, a blob is the concatenation of its data cells, so it can be reconstructed without any KZG work. Add BlobsFromDataCells, which returns the blobs by concatenation when the data cells are present in canonical order and declines otherwise (so callers fall back to RecoverBlobs). Its accepted inputs are a strict subset of those accepted by RecoverBlobs, so a successful result is byte-identical; being pure byte copying it is independent of the selected KZG backend.

Shared primitive: used both to skip KZG recovery when serving blobs and by the cell-recovery path (RecoverCells).