### PR TITLE
eth/protocols/snap: parallelize the state response processing

### DIFF
--- a/eth/protocols/snap/metrics.go
+++ b/eth/protocols/snap/metrics.go
@@ -58,10 +58,6 @@ var (
 	// to retrieved concurrently.
 	largeStorageGauge = metrics.NewRegisteredGauge("eth/protocols/snap/sync/storage/large", nil)
 
-	// skipStorageHealingGauge is the metric to track how many storages are retrieved
-	// in multiple requests but healing is not necessary.
-	skipStorageHealingGauge = metrics.NewRegisteredGauge("eth/protocols/snap/sync/storage/noheal", nil)
-
 	// largeStorageDiscardGauge is the metric to track how many chunked storages are
 	// discarded during the snap sync.
 	largeStorageDiscardGauge = metrics.NewRegisteredGauge("eth/protocols/snap/sync/storage/chunk/discard", nil)

--- a/eth/protocols/snap/sync.go
+++ b/eth/protocols/snap/sync.go
@@ -466,12 +466,15 @@ type syncer struct {
 	bytecodeReqs map[uint64]*bytecodeRequest // Bytecode requests currently running
 	storageReqs  map[uint64]*storageRequest  // Storage requests currently running
 
-	accountSynced  uint64             // Number of accounts downloaded
-	accountBytes   common.StorageSize // Number of account trie bytes persisted to disk
-	bytecodeSynced uint64             // Number of bytecodes downloaded
-	bytecodeBytes  common.StorageSize // Number of bytecode bytes downloaded
-	storageSynced  uint64             // Number of storage slots downloaded
-	storageBytes   common.StorageSize // Number of storage trie bytes persisted to disk
+	accountSynced  uint64       // Number of accounts downloaded
+	accountBytes   atomic.Int64 // Number of account trie bytes persisted to disk, updated by the workers
+	bytecodeSynced uint64       // Number of bytecodes downloaded
+	bytecodeBytes  atomic.Int64 // Number of bytecode bytes downloaded, updated by the workers
+	storageSynced  uint64       // Number of storage slots downloaded
+	storageBytes   atomic.Int64 // Number of storage trie bytes persisted to disk, updated by the workers
+
+	syncExec       *syncRunner  // Executor running persistence and trie generation off the runloop
+	skippableHeals atomic.Int64 // Number of storages healed even though they were retrieved in full
 
 	extProgress *syncProgress // progress that can be exposed to external caller.
 
@@ -515,7 +518,7 @@ type syncer struct {
 // newSyncer creates the snap/1 state syncer. It is unexported; callers outside
 // the package obtain a Syncer through NewV1Syncer.
 func newSyncer(db ethdb.KeyValueStore, scheme string) *syncer {
-	return &syncer{
+	s := &syncer{
 		db:     db,
 		scheme: scheme,
 
@@ -543,6 +546,8 @@ func newSyncer(db ethdb.KeyValueStore, scheme string) *syncer {
 
 		extProgress: new(syncProgress),
 	}
+	s.syncExec = newSyncRunner(s)
+	return s
 }
 
 // Register injects a new data source into the syncer's peerset.
@@ -688,7 +693,7 @@ func (s *syncer) Sync(root common.Hash, cancel chan struct{}) error {
 		schedStart := time.Now()
 		s.cleanStorageTasks()
 		s.cleanAccountTasks()
-		if len(s.tasks) == 0 && s.healer.scheduler.Pending() == 0 {
+		if len(s.tasks) == 0 && s.healer.scheduler.Pending() == 0 && !s.syncExec.pending() {
 			// State healing phase completed, record the elapsed time in metrics.
 			// Note: healing may be rerun in subsequent cycles to fill gaps between
 			// pivot states (e.g., if chain sync takes longer).
@@ -704,7 +709,7 @@ func (s *syncer) Sync(root common.Hash, cancel chan struct{}) error {
 		s.assignBytecodeTasks(bytecodeResps, bytecodeReqFails, cancel)
 		s.assignStorageTasks(storageResps, storageReqFails, cancel)
 
-		if len(s.tasks) == 0 {
+		if len(s.tasks) == 0 && !s.syncExec.pending() {
 			// State sync phase completed, record the elapsed time in metrics.
 			// Note: the initial state sync runs only once, regardless of whether
 			// a new cycle is started later. Any state differences in subsequent
@@ -724,11 +729,11 @@ func (s *syncer) Sync(root common.Hash, cancel chan struct{}) error {
 		s.lock.Lock()
 		s.extProgress = &syncProgress{
 			AccountSynced:      s.accountSynced,
-			AccountBytes:       s.accountBytes,
+			AccountBytes:       common.StorageSize(s.accountBytes.Load()),
 			BytecodeSynced:     s.bytecodeSynced,
-			BytecodeBytes:      s.bytecodeBytes,
+			BytecodeBytes:      common.StorageSize(s.bytecodeBytes.Load()),
 			StorageSynced:      s.storageSynced,
-			StorageBytes:       s.storageBytes,
+			StorageBytes:       common.StorageSize(s.storageBytes.Load()),
 			TrienodeHealSynced: s.trienodeHealSynced,
 			TrienodeHealBytes:  s.trienodeHealBytes,
 			BytecodeHealSynced: s.bytecodeHealSynced,
@@ -814,7 +819,7 @@ func (s *syncer) loadSyncStatus() {
 				task.genBatch = ethdb.HookedBatch{
 					Batch: s.db.NewBatch(),
 					OnPut: func(key []byte, value []byte) {
-						s.accountBytes += common.StorageSize(len(key) + len(value))
+						s.accountBytes.Add(int64(len(key) + len(value)))
 					},
 				}
 				if s.scheme == rawdb.HashScheme {
@@ -829,7 +834,7 @@ func (s *syncer) loadSyncStatus() {
 						subtask.genBatch = ethdb.HookedBatch{
 							Batch: s.db.NewBatch(),
 							OnPut: func(key []byte, value []byte) {
-								s.storageBytes += common.StorageSize(len(key) + len(value))
+								s.storageBytes.Add(int64(len(key) + len(value)))
 							},
 						}
 						if s.scheme == rawdb.HashScheme {
@@ -847,11 +852,11 @@ func (s *syncer) loadSyncStatus() {
 			s.snapped = len(s.tasks) == 0
 
 			s.accountSynced = progress.AccountSynced
-			s.accountBytes = progress.AccountBytes
+			s.accountBytes.Store(int64(progress.AccountBytes))
 			s.bytecodeSynced = progress.BytecodeSynced
-			s.bytecodeBytes = progress.BytecodeBytes
+			s.bytecodeBytes.Store(int64(progress.BytecodeBytes))
 			s.storageSynced = progress.StorageSynced
-			s.storageBytes = progress.StorageBytes
+			s.storageBytes.Store(int64(progress.StorageBytes))
 
 			s.trienodeHealSynced = progress.TrienodeHealSynced
 			s.trienodeHealBytes = progress.TrienodeHealBytes
@@ -864,9 +869,10 @@ func (s *syncer) loadSyncStatus() {
 	// Start a fresh sync by chunking up the account range and scheduling
 	// them for retrieval.
 	s.tasks = nil
-	s.accountSynced, s.accountBytes = 0, 0
-	s.bytecodeSynced, s.bytecodeBytes = 0, 0
-	s.storageSynced, s.storageBytes = 0, 0
+	s.accountSynced, s.bytecodeSynced, s.storageSynced = 0, 0, 0
+	s.accountBytes.Store(0)
+	s.bytecodeBytes.Store(0)
+	s.storageBytes.Store(0)
 	s.trienodeHealSynced, s.trienodeHealBytes = 0, 0
 	s.bytecodeHealSynced, s.bytecodeHealBytes = 0, 0
 
@@ -886,7 +892,7 @@ func (s *syncer) loadSyncStatus() {
 		batch := ethdb.HookedBatch{
 			Batch: s.db.NewBatch(),
 			OnPut: func(key []byte, value []byte) {
-				s.accountBytes += common.StorageSize(len(key) + len(value))
+				s.accountBytes.Add(int64(len(key) + len(value)))
 			},
 		}
 		var tr genTrie
@@ -911,6 +917,9 @@ func (s *syncer) loadSyncStatus() {
 
 // saveSyncStatus marshals the remaining sync tasks into leveldb.
 func (s *syncer) saveSyncStatus() {
+	// Wait out all the in-flight jobs
+	s.syncExec.barrier()
+
 	// Serialize any partial progress to disk before spinning down
 	for _, task := range s.tasks {
 		// Claim the right boundary as incomplete before flushing the
@@ -943,11 +952,11 @@ func (s *syncer) saveSyncStatus() {
 	progress := &syncProgress{
 		Tasks:              s.tasks,
 		AccountSynced:      s.accountSynced,
-		AccountBytes:       s.accountBytes,
+		AccountBytes:       common.StorageSize(s.accountBytes.Load()),
 		BytecodeSynced:     s.bytecodeSynced,
-		BytecodeBytes:      s.bytecodeBytes,
+		BytecodeBytes:      common.StorageSize(s.bytecodeBytes.Load()),
 		StorageSynced:      s.storageSynced,
-		StorageBytes:       s.storageBytes,
+		StorageBytes:       common.StorageSize(s.storageBytes.Load()),
 		TrienodeHealSynced: s.trienodeHealSynced,
 		TrienodeHealBytes:  s.trienodeHealBytes,
 		BytecodeHealSynced: s.bytecodeHealSynced,
@@ -2048,11 +2057,12 @@ func (s *syncer) processAccountResponse(res *accountResponse) {
 // processBytecodeResponse integrates an already validated bytecode response
 // into the account tasks.
 func (s *syncer) processBytecodeResponse(res *bytecodeResponse) {
+	procStart := time.Now()
+
 	var (
-		start = time.Now()
-		tally = s.profile.commitTally
-		batch = s.db.NewBatch()
-		codes uint64
+		codes  uint64
+		hashes []common.Hash
+		blobs  [][]byte
 	)
 	for i, hash := range res.hashes {
 		code := res.codes[i]
@@ -2069,20 +2079,22 @@ func (s *syncer) processBytecodeResponse(res *bytecodeResponse) {
 				res.task.pend--
 			}
 		}
-		// Push the bytecode into a database batch
+		// Collect the bytecode for asynchronous persistence
 		codes++
-		rawdb.WriteCode(batch, hash, code)
+		hashes = append(hashes, hash)
+		blobs = append(blobs, code)
 	}
-	bytes := common.StorageSize(batch.ValueSize())
-	commitStart := time.Now()
-	if err := batch.Write(); err != nil {
-		log.Crit("Failed to persist bytecodes", "err", err)
-	}
-	s.observeCommit(profBytecode, commitStart)
 	s.bytecodeSynced += codes
-	s.bytecodeBytes += bytes
-	log.Debug("Persisted set of bytecodes", "count", codes, "bytes", bytes)
-	s.profile.process[profBytecode].observe(time.Since(start) - (s.profile.commitTally - tally))
+
+	// Bytecodes are content addressed with no ordering constraints, hand the
+	// writes over to the workers keyed by the job itself (fully parallel).
+	if len(hashes) > 0 {
+		job := &bytecodeJob{hashes: hashes, codes: blobs}
+		s.syncExec.submit(profBytecode, job, func() { s.executeBytecodeJob(job) })
+	}
+	log.Debug("Queued set of bytecodes", "count", codes)
+
+	s.profile.process[profBytecode].observe(time.Since(procStart))
 
 	// If this delivery completed the last pending task, forward the account task
 	// to the next chunk
@@ -2097,26 +2109,18 @@ func (s *syncer) processBytecodeResponse(res *bytecodeResponse) {
 // processStorageResponse integrates an already validated storage response
 // into the account tasks.
 func (s *syncer) processStorageResponse(res *storageResponse) {
-	var (
-		start = time.Now()
-		tally = s.profile.commitTally
-	)
+	procStart := time.Now()
+
 	// Switch the subtask from pending to idle
 	if res.subTask != nil {
 		res.subTask.req = nil
 	}
-	batch := ethdb.HookedBatch{
-		Batch: s.db.NewBatch(),
-		OnPut: func(key []byte, value []byte) {
-			s.storageBytes += common.StorageSize(len(key) + len(value))
-		},
-	}
 	var (
-		slots           int
-		oldStorageBytes = s.storageBytes
+		slots    int
+		smallJob *storageJob
+		subJob   *storageJob
 	)
-	// Iterate over all the accounts and reconstruct their storage tries from the
-	// delivered slots
+	// Iterate over all the accounts and route their storage slots
 	for i, account := range res.accounts {
 		// If the account was not delivered, reschedule it
 		if i >= len(res.hashes) {
@@ -2124,11 +2128,13 @@ func (s *syncer) processStorageResponse(res *storageResponse) {
 			continue
 		}
 		// State was delivered, if complete mark as not needed any more, otherwise
-		// mark the account as needing healing
-		for j, hash := range res.mainTask.res.hashes {
-			if account != hash {
-				continue
-			}
+		// mark the account as needing healing. The response hashes are sorted,
+		// locate the account by binary search: with batched small-contract
+		// responses a linear scan is quadratic and dominates the loop.
+		j := sort.Search(len(res.mainTask.res.hashes), func(k int) bool {
+			return bytes.Compare(res.mainTask.res.hashes[k][:], account[:]) >= 0
+		})
+		if j < len(res.mainTask.res.hashes) && res.mainTask.res.hashes[j] == account {
 			acc := res.mainTask.res.accounts[j]
 
 			// If the packet contains multiple contract storage slots, all
@@ -2183,7 +2189,7 @@ func (s *syncer) processStorageResponse(res *storageResponse) {
 					batch := ethdb.HookedBatch{
 						Batch: s.db.NewBatch(),
 						OnPut: func(key []byte, value []byte) {
-							s.storageBytes += common.StorageSize(len(key) + len(value))
+							s.storageBytes.Add(int64(len(key) + len(value)))
 						},
 					}
 					var tr genTrie
@@ -2205,7 +2211,7 @@ func (s *syncer) processStorageResponse(res *storageResponse) {
 						batch := ethdb.HookedBatch{
 							Batch: s.db.NewBatch(),
 							OnPut: func(key []byte, value []byte) {
-								s.storageBytes += common.StorageSize(len(key) + len(value))
+								s.storageBytes.Add(int64(len(key) + len(value)))
 							},
 						}
 						var tr genTrie
@@ -2259,80 +2265,47 @@ func (s *syncer) processStorageResponse(res *storageResponse) {
 				}
 			}
 		}
-		// Iterate over all the complete contracts, reconstruct the trie nodes and
-		// push them to disk. If the contract is chunked, the trie nodes will be
-		// reconstructed later.
 		slots += len(res.hashes[i])
 
-		if i < len(res.hashes)-1 || res.subTask == nil {
-			// no need to make local reassignment of account: this closure does not outlive the loop
-			var tr genTrie
-			if s.scheme == rawdb.HashScheme {
-				tr = newHashTrie(batch)
+		// Package the account's flat writes and trie generation into jobs.
+		// One-shot small contracts are coalesced into a single job sharing
+		// one batch (they are independent, and per-account batches would
+		// fragment the writes); the chunked-contract feed goes into its own
+		// job, keyed so that feeds of the same subtask execute in order.
+		if i == len(res.hashes)-1 && res.subTask != nil {
+			subJob = &storageJob{
+				subTask:    res.subTask,
+				subAccount: account,
+				subHashes:  res.hashes[i],
+				subSlots:   res.slots[i],
+				finish:     res.subTask.done,
+				mainTask:   res.mainTask,
 			}
-			if s.scheme == rawdb.PathScheme {
-				// Keep the left boundary as it's complete
-				tr = newPathTrie(account, false, s.db, batch)
+		} else {
+			if smallJob == nil {
+				smallJob = &storageJob{mainTask: res.mainTask}
 			}
-			for j := 0; j < len(res.hashes[i]); j++ {
-				tr.update(res.hashes[i][j][:], res.slots[i][j])
-			}
-			tr.commit(true)
-		}
-		// Persist the received storage segments. These flat state maybe
-		// outdated during the sync, but it can be fixed later during the
-		// snapshot generation.
-		for j := 0; j < len(res.hashes[i]); j++ {
-			rawdb.WriteStorageSnapshot(batch, account, res.hashes[i][j], res.slots[i][j])
-
-			// If we're storing large contracts, generate the trie nodes
-			// on the fly to not trash the gluing points
-			if i == len(res.hashes)-1 && res.subTask != nil {
-				res.subTask.genTrie.update(res.hashes[i][j][:], res.slots[i][j])
-			}
+			smallJob.accounts = append(smallJob.accounts, account)
+			smallJob.hashes = append(smallJob.hashes, res.hashes[i])
+			smallJob.slots = append(smallJob.slots, res.slots[i])
 		}
 	}
-	// Large contracts could have generated new trie nodes, flush them to disk
-	if res.subTask != nil {
-		if res.subTask.done {
-			root := res.subTask.genTrie.commit(res.subTask.Last == common.MaxHash)
-			commitStart := time.Now()
-			if err := res.subTask.genBatch.Write(); err != nil {
-				log.Error("Failed to persist stack slots", "err", err)
-			}
-			s.observeCommit(profStorage, commitStart)
-			res.subTask.genBatch.Reset()
-
-			// If the chunk's root is an overflown but full delivery,
-			// clear the heal request.
-			accountHash := res.accounts[len(res.accounts)-1]
-			if root == res.subTask.root && rawdb.HasTrieNode(s.db, accountHash, nil, root, s.scheme) {
-				for i, account := range res.mainTask.res.hashes {
-					if account == accountHash {
-						res.mainTask.needHeal[i] = false
-						skipStorageHealingGauge.Inc(1)
-					}
-				}
-			}
-		} else if res.subTask.genBatch.ValueSize() > batchSizeThreshold {
-			res.subTask.genTrie.commit(false)
-			commitStart := time.Now()
-			if err := res.subTask.genBatch.Write(); err != nil {
-				log.Error("Failed to persist stack slots", "err", err)
-			}
-			s.observeCommit(profStorage, commitStart)
-			res.subTask.genBatch.Reset()
-		}
+	// Hand the execution over to the workers and update the stats. The
+	// coalesced small-contract job is independent of everything, keyed by
+	// itself; subtask feeds serialize on their subtask.
+	if smallJob != nil {
+		job := smallJob
+		s.syncExec.submit(profStorage, job, func() { s.executeStorageJob(job) })
 	}
-	// Flush anything written just now and update the stats
-	commitStart := time.Now()
-	if err := batch.Write(); err != nil {
-		log.Crit("Failed to persist storage slots", "err", err)
+	if subJob != nil {
+		job := subJob
+		s.syncExec.submit(profStorage, job.subTask, func() { s.executeStorageJob(job) })
 	}
-	s.observeCommit(profStorage, commitStart)
 	s.storageSynced += uint64(slots)
-	log.Debug("Persisted set of storage slots", "accounts", len(res.hashes), "slots", slots, "bytes", s.storageBytes-oldStorageBytes)
-	s.profile.process[profStorage].observe(time.Since(start) - (s.profile.commitTally - tally))
+
+	log.Debug("Queued set of storage slots", "accounts", len(res.hashes), "slots", slots)
+
+	s.profile.process[profStorage].observe(time.Since(procStart))
 
 	// If this delivery completed the last pending task, forward the account task
 	// to the next chunk
@@ -2477,59 +2450,21 @@ func (s *syncer) forwardAccountTask(task *accountTask) {
 	}
 	task.res = nil
 
-	start, tally := time.Now(), s.profile.commitTally
+	fwStart := time.Now()
 	defer func() {
-		s.profile.process[profAccount].observe(time.Since(start) - (s.profile.commitTally - tally))
+		s.profile.process[profAccount].observe(time.Since(fwStart))
 	}()
-	// Persist the received account segments. These flat state maybe
-	// outdated during the sync, but it can be fixed later during the
-	// snapshot generation.
-	oldAccountBytes := s.accountBytes
 
-	batch := ethdb.HookedBatch{
-		Batch: s.db.NewBatch(),
-		OnPut: func(key []byte, value []byte) {
-			s.accountBytes += common.StorageSize(len(key) + len(value))
-		},
-	}
-	for i, hash := range res.hashes {
+	// Determine the consecutive prefix of complete accounts and push the
+	// chunk marker forward over them.
+	last := len(res.hashes)
+	for i := range res.hashes {
 		if task.needCode[i] || task.needState[i] {
+			last = i
 			break
 		}
-		slim := types.SlimAccountRLP(*res.accounts[i])
-		rawdb.WriteAccountSnapshot(batch, hash, slim)
-
-		if !task.needHeal[i] {
-			// If the storage task is complete, drop it into the stack trie
-			// to generate account trie nodes for it
-			full, err := types.FullAccountRLP(slim) // TODO(karalabe): Slim parsing can be omitted
-			if err != nil {
-				panic(err) // Really shouldn't ever happen
-			}
-			task.genTrie.update(hash[:], full)
-		} else {
-			// If the storage task is incomplete, explicitly delete the corresponding
-			// account item from the account trie to ensure that all nodes along the
-			// path to the incomplete storage trie are cleaned up.
-			if err := task.genTrie.delete(hash[:]); err != nil {
-				panic(err) // Really shouldn't ever happen
-			}
-		}
 	}
-	// Flush anything written just now and update the stats
-	commitStart := time.Now()
-	if err := batch.Write(); err != nil {
-		log.Crit("Failed to persist accounts", "err", err)
-	}
-	s.observeCommit(profAccount, commitStart)
-	s.accountSynced += uint64(len(res.accounts))
-
-	// Task filling persisted, push it the chunk marker forward to the first
-	// account still missing data.
-	for i, hash := range res.hashes {
-		if task.needCode[i] || task.needState[i] {
-			return
-		}
+	for _, hash := range res.hashes[:last] {
 		task.Next = incHash(hash)
 
 		// Remove the completion flag once the account range is pushed
@@ -2537,34 +2472,28 @@ func (s *syncer) forwardAccountTask(task *accountTask) {
 		// cycle.
 		delete(task.stateCompleted, hash)
 	}
-	// All accounts marked as complete, track if the entire task is done
-	task.done = !res.cont
+	if last == len(res.hashes) {
+		// All accounts marked as complete, track if the entire task is done
+		task.done = !res.cont
 
-	// Error out if there is any leftover completion flag.
-	if task.done && len(task.stateCompleted) != 0 {
-		panic(fmt.Errorf("storage completion flags should be emptied, %d left", len(task.stateCompleted)))
-	}
-	// Stack trie could have generated trie nodes, push them to disk (we need to
-	// flush after finalizing task.done. It's fine even if we crash and lose this
-	// write as it will only cause more data to be downloaded during heal.
-	if task.done {
-		task.genTrie.commit(task.Last == common.MaxHash)
-		gbStart := time.Now()
-		if err := task.genBatch.Write(); err != nil {
-			log.Error("Failed to persist stack account", "err", err)
+		// Error out if there is any leftover completion flag.
+		if task.done && len(task.stateCompleted) != 0 {
+			panic(fmt.Errorf("storage completion flags should be emptied, %d left", len(task.stateCompleted)))
 		}
-		s.observeCommit(profAccount, gbStart)
-		task.genBatch.Reset()
-	} else if task.genBatch.ValueSize() > batchSizeThreshold {
-		task.genTrie.commit(false)
-		gbStart := time.Now()
-		if err := task.genBatch.Write(); err != nil {
-			log.Error("Failed to persist stack account", "err", err)
-		}
-		s.observeCommit(profAccount, gbStart)
-		task.genBatch.Reset()
 	}
-	log.Debug("Persisted range of accounts", "accounts", len(res.accounts), "bytes", s.accountBytes-oldAccountBytes)
+	s.accountSynced += uint64(len(res.accounts))
+
+	if last == 0 && !task.done {
+		return // nothing to persist
+	}
+	job := &accountJob{
+		task:     task,
+		hashes:   res.hashes[:last],
+		accounts: res.accounts[:last],
+		needHeal: task.needHeal[:last],
+		finish:   task.done,
+	}
+	s.syncExec.submit(profAccount, task, func() { s.executeAccountJob(job) })
 }
 
 // OnAccounts is a callback method to invoke when a range of accounts are
@@ -3184,7 +3113,7 @@ func (s *syncer) reportSyncProgress(force bool) {
 		return
 	}
 	// Don't report anything until we have a meaningful progress
-	synced := s.accountBytes + s.bytecodeBytes + s.storageBytes
+	synced := common.StorageSize(s.accountBytes.Load() + s.bytecodeBytes.Load() + s.storageBytes.Load())
 	if synced == 0 {
 		return
 	}
@@ -3215,9 +3144,9 @@ func (s *syncer) reportSyncProgress(force bool) {
 	// Create a mega progress report
 	var (
 		progress = fmt.Sprintf("%.2f%%", float64(synced)*100/estBytes)
-		accounts = fmt.Sprintf("%v@%v", log.FormatLogfmtUint64(s.accountSynced), s.accountBytes.TerminalString())
-		storage  = fmt.Sprintf("%v@%v", log.FormatLogfmtUint64(s.storageSynced), s.storageBytes.TerminalString())
-		bytecode = fmt.Sprintf("%v@%v", log.FormatLogfmtUint64(s.bytecodeSynced), s.bytecodeBytes.TerminalString())
+		accounts = fmt.Sprintf("%v@%v", log.FormatLogfmtUint64(s.accountSynced), common.StorageSize(s.accountBytes.Load()).TerminalString())
+		storage  = fmt.Sprintf("%v@%v", log.FormatLogfmtUint64(s.storageSynced), common.StorageSize(s.storageBytes.Load()).TerminalString())
+		bytecode = fmt.Sprintf("%v@%v", log.FormatLogfmtUint64(s.bytecodeSynced), common.StorageSize(s.bytecodeBytes.Load()).TerminalString())
 	)
 	log.Info("Syncing: state download in progress", "synced", progress, "state", synced,
 		"accounts", accounts, "slots", storage, "codes", bytecode, "eta", common.PrettyDuration(estTime-elapsed))

--- a/eth/protocols/snap/sync.go
+++ b/eth/protocols/snap/sync.go
@@ -502,10 +502,11 @@ type syncer struct {
 	storageHealed      uint64             // Number of storage slots downloaded during the healing stage
 	storageHealedBytes common.StorageSize // Number of raw storage bytes persisted to disk during the healing stage
 
-	startTime     time.Time // Time instance when snapshot sync started
-	healStartTime time.Time // Time instance when the state healing started
-	syncTimeOnce  sync.Once // Ensure that the state sync time is uploaded only once
-	logTime       time.Time // Time instance when status was last reported
+	startTime     time.Time   // Time instance when snapshot sync started
+	healStartTime time.Time   // Time instance when the state healing started
+	syncTimeOnce  sync.Once   // Ensure that the state sync time is uploaded only once
+	logTime       time.Time   // Time instance when status was last reported
+	profile       syncProfile // Wall-clock statistics of the runloop and the peer handovers
 
 	pend sync.WaitGroup // Tracks network request goroutines for graceful shutdown
 	lock sync.RWMutex   // Protects fields that can change outside of sync (peers, reqs, root)
@@ -684,6 +685,7 @@ func (s *syncer) Sync(root common.Hash, cancel chan struct{}) error {
 	)
 	for {
 		// Remove all completed tasks and terminate sync if everything's done
+		schedStart := time.Now()
 		s.cleanStorageTasks()
 		s.cleanAccountTasks()
 		if len(s.tasks) == 0 && s.healer.scheduler.Pending() == 0 {
@@ -710,6 +712,7 @@ func (s *syncer) Sync(root common.Hash, cancel chan struct{}) error {
 			s.syncTimeOnce.Do(func() {
 				stateSyncTimeGauge.Update(int64(time.Since(s.startTime)))
 				log.Info("State sync phase is completed", "elapsed", common.PrettyDuration(time.Since(s.startTime)))
+				s.reportProfile()
 			})
 			if s.healStartTime.IsZero() {
 				s.healStartTime = time.Now()
@@ -732,37 +735,53 @@ func (s *syncer) Sync(root common.Hash, cancel chan struct{}) error {
 			BytecodeHealBytes:  s.bytecodeHealBytes,
 		}
 		s.lock.Unlock()
+		s.profile.schedule.observe(time.Since(schedStart))
+
 		// Wait for something to happen
+		idleStart := time.Now()
 		select {
 		case <-s.update:
 			// Something happened (new peer, delivery, timeout), recheck tasks
+			s.profile.idle.observe(time.Since(idleStart))
 		case <-peerJoin:
 			// A new peer joined, try to schedule it new tasks
+			s.profile.idle.observe(time.Since(idleStart))
 		case id := <-peerDrop:
+			s.profile.idle.observe(time.Since(idleStart))
 			s.revertRequests(id)
 		case <-cancel:
 			return ErrCancelled
 
 		case req := <-accountReqFails:
+			s.profile.idle.observe(time.Since(idleStart))
 			s.revertAccountRequest(req)
 		case req := <-bytecodeReqFails:
+			s.profile.idle.observe(time.Since(idleStart))
 			s.revertBytecodeRequest(req)
 		case req := <-storageReqFails:
+			s.profile.idle.observe(time.Since(idleStart))
 			s.revertStorageRequest(req)
 		case req := <-trienodeHealReqFails:
+			s.profile.idle.observe(time.Since(idleStart))
 			s.revertTrienodeHealRequest(req)
 		case req := <-bytecodeHealReqFails:
+			s.profile.idle.observe(time.Since(idleStart))
 			s.revertBytecodeHealRequest(req)
 
 		case res := <-accountResps:
+			s.profile.idle.observe(time.Since(idleStart))
 			s.processAccountResponse(res)
 		case res := <-bytecodeResps:
+			s.profile.idle.observe(time.Since(idleStart))
 			s.processBytecodeResponse(res)
 		case res := <-storageResps:
+			s.profile.idle.observe(time.Since(idleStart))
 			s.processStorageResponse(res)
 		case res := <-trienodeHealResps:
+			s.profile.idle.observe(time.Since(idleStart))
 			s.processTrienodeHealResponse(res)
 		case res := <-bytecodeHealResps:
+			s.profile.idle.observe(time.Since(idleStart))
 			s.processBytecodeHealResponse(res)
 		}
 		// Report stats if something meaningful happened
@@ -1903,6 +1922,8 @@ func (s *syncer) revertBytecodeHealRequest(req *bytecodeHealRequest) {
 // processAccountResponse integrates an already validated account range response
 // into the account tasks.
 func (s *syncer) processAccountResponse(res *accountResponse) {
+	start := time.Now()
+
 	// Switch the task from pending to filling
 	res.task.req = nil
 	res.task.res = res
@@ -2012,6 +2033,8 @@ func (s *syncer) processAccountResponse(res *accountResponse) {
 			}
 		}
 	}
+	s.profile.process[profAccount].observe(time.Since(start))
+
 	// If the account range contained no contracts, or all have been fully filled
 	// beforehand, short circuit storage filling and forward to the next task
 	if res.task.pend == 0 {
@@ -2025,9 +2048,12 @@ func (s *syncer) processAccountResponse(res *accountResponse) {
 // processBytecodeResponse integrates an already validated bytecode response
 // into the account tasks.
 func (s *syncer) processBytecodeResponse(res *bytecodeResponse) {
-	batch := s.db.NewBatch()
-
-	var codes uint64
+	var (
+		start = time.Now()
+		tally = s.profile.commitTally
+		batch = s.db.NewBatch()
+		codes uint64
+	)
 	for i, hash := range res.hashes {
 		code := res.codes[i]
 
@@ -2048,13 +2074,15 @@ func (s *syncer) processBytecodeResponse(res *bytecodeResponse) {
 		rawdb.WriteCode(batch, hash, code)
 	}
 	bytes := common.StorageSize(batch.ValueSize())
+	commitStart := time.Now()
 	if err := batch.Write(); err != nil {
 		log.Crit("Failed to persist bytecodes", "err", err)
 	}
+	s.observeCommit(profBytecode, commitStart)
 	s.bytecodeSynced += codes
 	s.bytecodeBytes += bytes
-
 	log.Debug("Persisted set of bytecodes", "count", codes, "bytes", bytes)
+	s.profile.process[profBytecode].observe(time.Since(start) - (s.profile.commitTally - tally))
 
 	// If this delivery completed the last pending task, forward the account task
 	// to the next chunk
@@ -2069,6 +2097,10 @@ func (s *syncer) processBytecodeResponse(res *bytecodeResponse) {
 // processStorageResponse integrates an already validated storage response
 // into the account tasks.
 func (s *syncer) processStorageResponse(res *storageResponse) {
+	var (
+		start = time.Now()
+		tally = s.profile.commitTally
+	)
 	// Switch the subtask from pending to idle
 	if res.subTask != nil {
 		res.subTask.req = nil
@@ -2264,9 +2296,11 @@ func (s *syncer) processStorageResponse(res *storageResponse) {
 	if res.subTask != nil {
 		if res.subTask.done {
 			root := res.subTask.genTrie.commit(res.subTask.Last == common.MaxHash)
+			commitStart := time.Now()
 			if err := res.subTask.genBatch.Write(); err != nil {
 				log.Error("Failed to persist stack slots", "err", err)
 			}
+			s.observeCommit(profStorage, commitStart)
 			res.subTask.genBatch.Reset()
 
 			// If the chunk's root is an overflown but full delivery,
@@ -2282,19 +2316,23 @@ func (s *syncer) processStorageResponse(res *storageResponse) {
 			}
 		} else if res.subTask.genBatch.ValueSize() > batchSizeThreshold {
 			res.subTask.genTrie.commit(false)
+			commitStart := time.Now()
 			if err := res.subTask.genBatch.Write(); err != nil {
 				log.Error("Failed to persist stack slots", "err", err)
 			}
+			s.observeCommit(profStorage, commitStart)
 			res.subTask.genBatch.Reset()
 		}
 	}
 	// Flush anything written just now and update the stats
+	commitStart := time.Now()
 	if err := batch.Write(); err != nil {
 		log.Crit("Failed to persist storage slots", "err", err)
 	}
+	s.observeCommit(profStorage, commitStart)
 	s.storageSynced += uint64(slots)
-
 	log.Debug("Persisted set of storage slots", "accounts", len(res.hashes), "slots", slots, "bytes", s.storageBytes-oldStorageBytes)
+	s.profile.process[profStorage].observe(time.Since(start) - (s.profile.commitTally - tally))
 
 	// If this delivery completed the last pending task, forward the account task
 	// to the next chunk
@@ -2439,6 +2477,10 @@ func (s *syncer) forwardAccountTask(task *accountTask) {
 	}
 	task.res = nil
 
+	start, tally := time.Now(), s.profile.commitTally
+	defer func() {
+		s.profile.process[profAccount].observe(time.Since(start) - (s.profile.commitTally - tally))
+	}()
 	// Persist the received account segments. These flat state maybe
 	// outdated during the sync, but it can be fixed later during the
 	// snapshot generation.
@@ -2475,9 +2517,11 @@ func (s *syncer) forwardAccountTask(task *accountTask) {
 		}
 	}
 	// Flush anything written just now and update the stats
+	commitStart := time.Now()
 	if err := batch.Write(); err != nil {
 		log.Crit("Failed to persist accounts", "err", err)
 	}
+	s.observeCommit(profAccount, commitStart)
 	s.accountSynced += uint64(len(res.accounts))
 
 	// Task filling persisted, push it the chunk marker forward to the first
@@ -2505,15 +2549,19 @@ func (s *syncer) forwardAccountTask(task *accountTask) {
 	// write as it will only cause more data to be downloaded during heal.
 	if task.done {
 		task.genTrie.commit(task.Last == common.MaxHash)
+		gbStart := time.Now()
 		if err := task.genBatch.Write(); err != nil {
 			log.Error("Failed to persist stack account", "err", err)
 		}
+		s.observeCommit(profAccount, gbStart)
 		task.genBatch.Reset()
 	} else if task.genBatch.ValueSize() > batchSizeThreshold {
 		task.genTrie.commit(false)
+		gbStart := time.Now()
 		if err := task.genBatch.Write(); err != nil {
 			log.Error("Failed to persist stack account", "err", err)
 		}
+		s.observeCommit(profAccount, gbStart)
 		task.genBatch.Reset()
 	}
 	log.Debug("Persisted range of accounts", "accounts", len(res.accounts), "bytes", s.accountBytes-oldAccountBytes)
@@ -2611,11 +2659,13 @@ func (s *syncer) OnAccounts(peer SyncPeer, id uint64, hashes []common.Hash, acco
 		accounts: accs,
 		cont:     cont,
 	}
+	deliverStart := time.Now()
 	select {
 	case req.deliver <- response:
 	case <-req.cancel:
 	case <-req.stale:
 	}
+	s.profile.deliver[profAccount].observe(time.Since(deliverStart))
 	return nil
 }
 
@@ -2722,11 +2772,13 @@ func (s *syncer) onByteCodes(peer SyncPeer, id uint64, bytecodes [][]byte) error
 		hashes: req.hashes,
 		codes:  codes,
 	}
+	deliverStart := time.Now()
 	select {
 	case req.deliver <- response:
 	case <-req.cancel:
 	case <-req.stale:
 	}
+	s.profile.deliver[profBytecode].observe(time.Since(deliverStart))
 	return nil
 }
 
@@ -2871,11 +2923,13 @@ func (s *syncer) OnStorage(peer SyncPeer, id uint64, hashes [][]common.Hash, slo
 		slots:    slots,
 		cont:     cont,
 	}
+	deliverStart := time.Now()
 	select {
 	case req.deliver <- response:
 	case <-req.cancel:
 	case <-req.stale:
 	}
+	s.profile.deliver[profStorage].observe(time.Since(deliverStart))
 	return nil
 }
 

--- a/eth/protocols/snap/sync.go
+++ b/eth/protocols/snap/sync.go
@@ -473,7 +473,7 @@ type syncer struct {
 	storageSynced  uint64       // Number of storage slots downloaded
 	storageBytes   atomic.Int64 // Number of storage trie bytes persisted to disk, updated by the workers
 
-	syncExec       *syncRunner  // Executor running persistence and trie generation off the runloop
+	syncRunner     *syncRunner  // Executor running persistence and trie generation off the runloop
 	skippableHeals atomic.Int64 // Number of storages healed even though they were retrieved in full
 
 	extProgress *syncProgress // progress that can be exposed to external caller.
@@ -546,7 +546,7 @@ func newSyncer(db ethdb.KeyValueStore, scheme string) *syncer {
 
 		extProgress: new(syncProgress),
 	}
-	s.syncExec = newSyncRunner(s)
+	s.syncRunner = newSyncRunner(s)
 	return s
 }
 
@@ -693,7 +693,7 @@ func (s *syncer) Sync(root common.Hash, cancel chan struct{}) error {
 		schedStart := time.Now()
 		s.cleanStorageTasks()
 		s.cleanAccountTasks()
-		if len(s.tasks) == 0 && s.healer.scheduler.Pending() == 0 && !s.syncExec.pending() {
+		if len(s.tasks) == 0 && s.healer.scheduler.Pending() == 0 && !s.syncRunner.pending() {
 			// State healing phase completed, record the elapsed time in metrics.
 			// Note: healing may be rerun in subsequent cycles to fill gaps between
 			// pivot states (e.g., if chain sync takes longer).
@@ -709,7 +709,7 @@ func (s *syncer) Sync(root common.Hash, cancel chan struct{}) error {
 		s.assignBytecodeTasks(bytecodeResps, bytecodeReqFails, cancel)
 		s.assignStorageTasks(storageResps, storageReqFails, cancel)
 
-		if len(s.tasks) == 0 && !s.syncExec.pending() {
+		if len(s.tasks) == 0 && !s.syncRunner.pending() {
 			// State sync phase completed, record the elapsed time in metrics.
 			// Note: the initial state sync runs only once, regardless of whether
 			// a new cycle is started later. Any state differences in subsequent
@@ -918,7 +918,7 @@ func (s *syncer) loadSyncStatus() {
 // saveSyncStatus marshals the remaining sync tasks into leveldb.
 func (s *syncer) saveSyncStatus() {
 	// Wait out all the in-flight jobs
-	s.syncExec.barrier()
+	s.syncRunner.barrier()
 
 	// Serialize any partial progress to disk before spinning down
 	for _, task := range s.tasks {
@@ -2090,7 +2090,7 @@ func (s *syncer) processBytecodeResponse(res *bytecodeResponse) {
 	// writes over to the workers keyed by the job itself (fully parallel).
 	if len(hashes) > 0 {
 		job := &bytecodeJob{hashes: hashes, codes: blobs}
-		s.syncExec.submit(profBytecode, job, func() { s.executeBytecodeJob(job) })
+		s.syncRunner.submit(profBytecode, job, func() { s.executeBytecodeJob(job) })
 	}
 	log.Debug("Queued set of bytecodes", "count", codes)
 
@@ -2279,11 +2279,10 @@ func (s *syncer) processStorageResponse(res *storageResponse) {
 				subHashes:  res.hashes[i],
 				subSlots:   res.slots[i],
 				finish:     res.subTask.done,
-				mainTask:   res.mainTask,
 			}
 		} else {
 			if smallJob == nil {
-				smallJob = &storageJob{mainTask: res.mainTask}
+				smallJob = new(storageJob)
 			}
 			smallJob.accounts = append(smallJob.accounts, account)
 			smallJob.hashes = append(smallJob.hashes, res.hashes[i])
@@ -2295,11 +2294,11 @@ func (s *syncer) processStorageResponse(res *storageResponse) {
 	// itself; subtask feeds serialize on their subtask.
 	if smallJob != nil {
 		job := smallJob
-		s.syncExec.submit(profStorage, job, func() { s.executeStorageJob(job) })
+		s.syncRunner.submit(profStorage, job, func() { s.executeStorageJob(job) })
 	}
 	if subJob != nil {
 		job := subJob
-		s.syncExec.submit(profStorage, job.subTask, func() { s.executeStorageJob(job) })
+		s.syncRunner.submit(profStorage, job.subTask, func() { s.executeStorageJob(job) })
 	}
 	s.storageSynced += uint64(slots)
 
@@ -2493,7 +2492,7 @@ func (s *syncer) forwardAccountTask(task *accountTask) {
 		needHeal: task.needHeal[:last],
 		finish:   task.done,
 	}
-	s.syncExec.submit(profAccount, task, func() { s.executeAccountJob(job) })
+	s.syncRunner.submit(profAccount, task, func() { s.executeAccountJob(job) })
 }
 
 // OnAccounts is a callback method to invoke when a range of accounts are

--- a/eth/protocols/snap/sync.go
+++ b/eth/protocols/snap/sync.go
@@ -917,7 +917,11 @@ func (s *syncer) loadSyncStatus() {
 
 // saveSyncStatus marshals the remaining sync tasks into leveldb.
 func (s *syncer) saveSyncStatus() {
-	// Wait out all the in-flight jobs
+	// Wait out all the in-flight jobs: the in-memory task cursors run ahead
+	// of the database, so the journal must not be persisted until every job
+	// it accounts for has flushed its data. On this side of the barrier the
+	// journal can only ever trail the disk, which a resume repairs by
+	// re-downloading the overlap.
 	s.syncRunner.barrier()
 
 	// Serialize any partial progress to disk before spinning down
@@ -2455,7 +2459,10 @@ func (s *syncer) forwardAccountTask(task *accountTask) {
 	}()
 
 	// Determine the consecutive prefix of complete accounts and push the
-	// chunk marker forward over them.
+	// chunk marker forward over them. Note the cursor advances before the
+	// data is persisted by the packaged job below: the in-memory progress
+	// runs ahead of the database, which is safe as the journal is only
+	// saved behind a runner barrier.
 	last := len(res.hashes)
 	for i := range res.hashes {
 		if task.needCode[i] || task.needState[i] {

--- a/eth/protocols/snap/sync_profile.go
+++ b/eth/protocols/snap/sync_profile.go
@@ -1,0 +1,99 @@
+// Copyright 2026 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+
+package snap
+
+import (
+	"fmt"
+	"sync/atomic"
+	"time"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/log"
+)
+
+// Profile buckets, one per response type.
+const (
+	profAccount = iota
+	profBytecode
+	profStorage
+	profKinds
+)
+
+var profKindNames = [profKinds]string{
+	"account",
+	"bytecode",
+	"storage",
+}
+
+// profStat aggregates wall-clock samples of one instrumentation point.
+type profStat struct {
+	count atomic.Int64
+	sum   atomic.Int64 // nanoseconds
+	max   atomic.Int64 // nanoseconds
+}
+
+func (p *profStat) observe(d time.Duration) {
+	p.count.Add(1)
+	p.sum.Add(int64(d))
+
+	// Best effort
+	if old := p.max.Load(); int64(d) > old {
+		p.max.CompareAndSwap(old, int64(d))
+	}
+}
+
+// String renders the aggregate as count/total/mean/max.
+func (p *profStat) String() string {
+	cnt, sum, max := p.count.Load(), p.sum.Load(), p.max.Load()
+	if cnt == 0 {
+		return "-"
+	}
+	return fmt.Sprintf("n=%d total=%v avg=%v max=%v", cnt, common.PrettyDuration(sum), common.PrettyDuration(sum/cnt), common.PrettyDuration(max))
+}
+
+// syncProfile aggregates wall-clock statistics about each operation in
+// the snap sync, quantifying how much the loop's serialization costs
+// overall sync throughput.
+type syncProfile struct {
+	idle     profStat // runloop blocked in select, waiting for events
+	schedule profStat // runloop top-of-loop cleanup/assignment work
+
+	deliver [profKinds]profStat // peer threads blocked handing a verified response to the runloop
+	process [profKinds]profStat // runloop handling one response
+	commit  [profKinds]profStat // batch writes within the response handlers
+
+	// commitTally accumulates the batch-write time of the current runloop
+	// operation, letting the enclosing process observation net the commits
+	// out.
+	commitTally time.Duration
+}
+
+// observeCommit records one batch write, tallying it up so the enclosing
+// process/forward observation can net it out.
+func (s *syncer) observeCommit(kind int, start time.Time) {
+	elapsed := time.Since(start)
+	s.profile.commit[kind].observe(elapsed)
+	s.profile.commitTally += elapsed
+}
+
+// reportProfile dumps the accumulated statistics.
+func (s *syncer) reportProfile() {
+	log.Info("State sync profile", "idle", s.profile.idle.String(), "schedule", s.profile.schedule.String())
+	for i, name := range profKindNames {
+		log.Info("State sync profile: "+name, "wait", s.profile.deliver[i].String(), "process", s.profile.process[i].String(), "commit", s.profile.commit[i].String())
+	}
+}

--- a/eth/protocols/snap/sync_profile.go
+++ b/eth/protocols/snap/sync_profile.go
@@ -72,28 +72,25 @@ type syncProfile struct {
 	idle     profStat // runloop blocked in select, waiting for events
 	schedule profStat // runloop top-of-loop cleanup/assignment work
 
-	deliver [profKinds]profStat // peer threads blocked handing a verified response to the runloop
-	process [profKinds]profStat // runloop handling one response
-	commit  [profKinds]profStat // batch writes within the response handlers
-
-	// commitTally accumulates the batch-write time of the current runloop
-	// operation, letting the enclosing process observation net the commits
-	// out.
-	commitTally time.Duration
+	deliver    [profKinds]profStat // peer threads blocked handing a verified response to the runloop
+	process    [profKinds]profStat // runloop bookkeeping of one response, persistence excluded
+	submitWait [profKinds]profStat // runloop blocked acquiring an in-flight slot on job submission
+	exec       [profKinds]profStat // job execution on the worker pool, net of commits
+	commit     [profKinds]profStat // batch writes within the job execution on the worker threads
 }
 
-// observeCommit records one batch write, tallying it up so the enclosing
-// process/forward observation can net it out.
-func (s *syncer) observeCommit(kind int, start time.Time) {
+// observeCommit records one batch write, returning its duration so that the
+// enclosing job execution can net it out of its own timing.
+func (s *syncer) observeCommit(kind int, start time.Time) time.Duration {
 	elapsed := time.Since(start)
 	s.profile.commit[kind].observe(elapsed)
-	s.profile.commitTally += elapsed
+	return elapsed
 }
 
 // reportProfile dumps the accumulated statistics.
 func (s *syncer) reportProfile() {
-	log.Info("State sync profile", "idle", s.profile.idle.String(), "schedule", s.profile.schedule.String())
+	log.Info("State sync profile", "idle", s.profile.idle.String(), "schedule", s.profile.schedule.String(), "skippableheals", s.skippableHeals.Load())
 	for i, name := range profKindNames {
-		log.Info("State sync profile: "+name, "wait", s.profile.deliver[i].String(), "process", s.profile.process[i].String(), "commit", s.profile.commit[i].String())
+		log.Info("State sync profile: "+name, "deliverwait", s.profile.deliver[i].String(), "process", s.profile.process[i].String(), "submitwait", s.profile.submitWait[i].String(), "exec", s.profile.exec[i].String(), "commit", s.profile.commit[i].String())
 	}
 }

--- a/eth/protocols/snap/sync_runner.go
+++ b/eth/protocols/snap/sync_runner.go
@@ -28,7 +28,7 @@ import (
 	"github.com/ethereum/go-ethereum/log"
 )
 
-// syncTaskThreshold bounds the jobs buffered in the sync executor. Submissions
+// syncTaskThreshold bounds the jobs buffered in the sync runner. Submissions
 // block once the bound is hit, pushing the backpressure onto the runloop and
 // further onto the peers.
 const syncTaskThreshold = 512
@@ -50,12 +50,10 @@ type storageJob struct {
 	subAccount common.Hash
 	subHashes  []common.Hash
 	subSlots   [][]byte
-	finish     bool         // subtask completed by this feed
-	mainTask   *accountTask // origin account task
+	finish     bool // subtask completed by this feed
 }
 
-// syncRunner runs sync jobs (storage deliveries and account deliveries) on a
-// bounded worker pool.
+// syncRunner runs sync jobs on a bounded worker pool.
 type syncRunner struct {
 	s      *syncer
 	lock   sync.Mutex
@@ -112,14 +110,17 @@ func (e *syncRunner) drain(key any) {
 		if empty {
 			delete(e.queues, key)
 		}
+		idle := len(e.queues) == 0
 		e.lock.Unlock()
 
 		<-e.tasks
 
-		// Ping the runloop on every completed job
-		select {
-		case e.s.update <- struct{}{}:
-		default:
+		// Wake the runloop when the runner drains fully
+		if idle {
+			select {
+			case e.s.update <- struct{}{}:
+			default:
+			}
 		}
 		if empty {
 			return

--- a/eth/protocols/snap/sync_runner.go
+++ b/eth/protocols/snap/sync_runner.go
@@ -1,0 +1,317 @@
+// Copyright 2026 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+
+package snap
+
+import (
+	"runtime"
+	"sync"
+	"time"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/rawdb"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/ethdb"
+	"github.com/ethereum/go-ethereum/log"
+)
+
+// syncTaskThreshold bounds the jobs buffered in the sync executor. Submissions
+// block once the bound is hit, pushing the backpressure onto the runloop and
+// further onto the peers.
+const syncTaskThreshold = 512
+
+// storageJob is the execution part of the storage delivery: the flat-state
+// writes, the trie generation and the batch flushes.
+//
+// A response's one-shot small contracts are coalesced into one job sharing
+// a single batch; the chunked-contract feed (at most one per response) rides
+// in its own job so that feeds of the same subtask serialize.
+type storageJob struct {
+	// One-shot small contracts, complete tries built in one pass
+	accounts []common.Hash
+	hashes   [][]common.Hash
+	slots    [][][]byte
+
+	// Chunked contract
+	subTask    *storageTask
+	subAccount common.Hash
+	subHashes  []common.Hash
+	subSlots   [][]byte
+	finish     bool         // subtask completed by this feed
+	mainTask   *accountTask // origin account task
+}
+
+// syncRunner runs sync jobs (storage deliveries and account deliveries) on a
+// bounded worker pool.
+type syncRunner struct {
+	s      *syncer
+	lock   sync.Mutex
+	queues map[any][]func()
+	wg     sync.WaitGroup
+	tokens chan struct{}
+	tasks  chan struct{}
+}
+
+func newSyncRunner(s *syncer) *syncRunner {
+	return &syncRunner{
+		s:      s,
+		queues: make(map[any][]func()),
+		tokens: make(chan struct{}, runtime.GOMAXPROCS(0)),
+		tasks:  make(chan struct{}, syncTaskThreshold),
+	}
+}
+
+// submit queues a job for execution, blocking when too many are in flight.
+// Jobs sharing a key execute in submission order.
+func (e *syncRunner) submit(kind int, key any, run func()) {
+	waitStart := time.Now()
+	e.tasks <- struct{}{}
+	e.s.profile.submitWait[kind].observe(time.Since(waitStart))
+
+	e.lock.Lock()
+	e.queues[key] = append(e.queues[key], run)
+	if len(e.queues[key]) > 1 {
+		e.lock.Unlock() // drainer already active on this key
+		return
+	}
+	e.lock.Unlock()
+
+	e.wg.Add(1)
+	go e.drain(key)
+}
+
+// drain runs the queued jobs of one key in order, exiting when none remain.
+func (e *syncRunner) drain(key any) {
+	defer e.wg.Done()
+
+	for {
+		e.lock.Lock()
+		run := e.queues[key][0]
+		e.lock.Unlock()
+
+		e.tokens <- struct{}{}
+		run()
+		<-e.tokens
+
+		e.lock.Lock()
+		e.queues[key] = e.queues[key][1:]
+		empty := len(e.queues[key]) == 0
+		if empty {
+			delete(e.queues, key)
+		}
+		e.lock.Unlock()
+
+		<-e.tasks
+
+		// Ping the runloop on every completed job
+		select {
+		case e.s.update <- struct{}{}:
+		default:
+		}
+		if empty {
+			return
+		}
+	}
+}
+
+// pending reports whether any jobs are queued or executing.
+func (e *syncRunner) pending() bool {
+	e.lock.Lock()
+	defer e.lock.Unlock()
+
+	return len(e.queues) > 0
+}
+
+// barrier blocks until every submitted job has fully executed.
+func (e *syncRunner) barrier() {
+	e.wg.Wait()
+}
+
+// executeStorageJob runs one storage job on a worker thread.
+func (s *syncer) executeStorageJob(job *storageJob) {
+	var (
+		start   = time.Now()
+		commits time.Duration
+	)
+	batch := ethdb.HookedBatch{
+		Batch: s.db.NewBatch(),
+		OnPut: func(key []byte, value []byte) {
+			s.storageBytes.Add(int64(len(key) + len(value)))
+		},
+	}
+	// One-shot small contracts: reconstruct the complete storage tries and
+	// persist the received storage segments. The flat state maybe outdated
+	// during the sync, but it can be fixed later during the snapshot
+	// generation.
+	for k, account := range job.accounts {
+		var tr genTrie
+		if s.scheme == rawdb.HashScheme {
+			tr = newHashTrie(batch)
+		}
+		if s.scheme == rawdb.PathScheme {
+			// Keep the left boundary as it's complete
+			tr = newPathTrie(account, false, s.db, batch)
+		}
+		for j := 0; j < len(job.hashes[k]); j++ {
+			tr.update(job.hashes[k][j][:], job.slots[k][j])
+		}
+		tr.commit(true)
+
+		for j := 0; j < len(job.hashes[k]); j++ {
+			rawdb.WriteStorageSnapshot(batch, account, job.hashes[k][j], job.slots[k][j])
+		}
+	}
+	// Chunked contract: persist the slots and generate the trie nodes on
+	// the fly to not trash the gluing points
+	if job.subTask != nil {
+		for j := 0; j < len(job.subHashes); j++ {
+			rawdb.WriteStorageSnapshot(batch, job.subAccount, job.subHashes[j], job.subSlots[j])
+			job.subTask.genTrie.update(job.subHashes[j][:], job.subSlots[j])
+		}
+	}
+	// Large contracts could have generated new trie nodes, flush them to disk
+	if job.subTask != nil {
+		if job.finish {
+			root := job.subTask.genTrie.commit(job.subTask.Last == common.MaxHash)
+			gbStart := time.Now()
+			if err := job.subTask.genBatch.Write(); err != nil {
+				log.Error("Failed to persist stack slots", "err", err)
+			}
+			commits += s.observeCommit(profStorage, gbStart)
+			job.subTask.genBatch.Reset()
+
+			// The chunk came out complete in full: the account used to have
+			// its healing mark cleared here, but with asynchronous execution
+			// the verdict would race the task forwarding, so the storage is
+			// healed regardless. Count the missed skips to quantify the cost.
+			if root == job.subTask.root && rawdb.HasTrieNode(s.db, job.subAccount, nil, root, s.scheme) {
+				s.skippableHeals.Add(1)
+			}
+		} else if job.subTask.genBatch.ValueSize() > batchSizeThreshold {
+			job.subTask.genTrie.commit(false)
+			gbStart := time.Now()
+			if err := job.subTask.genBatch.Write(); err != nil {
+				log.Error("Failed to persist stack slots", "err", err)
+			}
+			commits += s.observeCommit(profStorage, gbStart)
+			job.subTask.genBatch.Reset()
+		}
+	}
+	// Flush the flat state writes
+	commitStart := time.Now()
+	if err := batch.Write(); err != nil {
+		log.Crit("Failed to persist storage slots", "err", err)
+	}
+	commits += s.observeCommit(profStorage, commitStart)
+	s.profile.exec[profStorage].observe(time.Since(start) - commits)
+}
+
+// accountJob is the execution part of an account-task forward: the flat
+// account writes and the account-trie generation.
+type accountJob struct {
+	task     *accountTask
+	hashes   []common.Hash
+	accounts []*types.StateAccount
+	needHeal []bool
+	finish   bool // task fully done by this forward: commit the trie boundary
+}
+
+// executeAccountJob runs one account-forward job on a worker thread.
+func (s *syncer) executeAccountJob(job *accountJob) {
+	var (
+		start   = time.Now()
+		commits time.Duration
+	)
+	batch := ethdb.HookedBatch{
+		Batch: s.db.NewBatch(),
+		OnPut: func(key []byte, value []byte) {
+			s.accountBytes.Add(int64(len(key) + len(value)))
+		},
+	}
+	for i, hash := range job.hashes {
+		slim := types.SlimAccountRLP(*job.accounts[i])
+		rawdb.WriteAccountSnapshot(batch, hash, slim)
+
+		if !job.needHeal[i] {
+			// If the storage task is complete, drop it into the stack trie
+			// to generate account trie nodes for it
+			full, err := types.FullAccountRLP(slim) // TODO(karalabe): Slim parsing can be omitted
+			if err != nil {
+				panic(err) // Really shouldn't ever happen
+			}
+			job.task.genTrie.update(hash[:], full)
+		} else {
+			// If the storage task is incomplete, explicitly delete the corresponding
+			// account item from the account trie to ensure that all nodes along the
+			// path to the incomplete storage trie are cleaned up.
+			if err := job.task.genTrie.delete(hash[:]); err != nil {
+				panic(err) // Really shouldn't ever happen
+			}
+		}
+	}
+	// Flush anything written just now
+	commitStart := time.Now()
+	if err := batch.Write(); err != nil {
+		log.Crit("Failed to persist accounts", "err", err)
+	}
+	commits += s.observeCommit(profAccount, commitStart)
+
+	// Stack trie could have generated trie nodes, push them to disk. It's fine
+	// even if we crash and lose this write as it will only cause more data to
+	// be downloaded during heal.
+	if job.finish {
+		job.task.genTrie.commit(job.task.Last == common.MaxHash)
+		gbStart := time.Now()
+		if err := job.task.genBatch.Write(); err != nil {
+			log.Error("Failed to persist stack account", "err", err)
+		}
+		commits += s.observeCommit(profAccount, gbStart)
+		job.task.genBatch.Reset()
+	} else if job.task.genBatch.ValueSize() > batchSizeThreshold {
+		job.task.genTrie.commit(false)
+		gbStart := time.Now()
+		if err := job.task.genBatch.Write(); err != nil {
+			log.Error("Failed to persist stack account", "err", err)
+		}
+		commits += s.observeCommit(profAccount, gbStart)
+		job.task.genBatch.Reset()
+	}
+	s.profile.exec[profAccount].observe(time.Since(start) - commits)
+}
+
+// bytecodeJob is the execution part of a bytecode delivery: the code writes
+// are content addressed and carry no ordering constraints.
+type bytecodeJob struct {
+	hashes []common.Hash
+	codes  [][]byte
+}
+
+// executeBytecodeJob runs one bytecode-persistence job on a worker thread.
+func (s *syncer) executeBytecodeJob(job *bytecodeJob) {
+	start := time.Now()
+	batch := s.db.NewBatch()
+	for i, hash := range job.hashes {
+		rawdb.WriteCode(batch, hash, job.codes[i])
+	}
+	s.bytecodeBytes.Add(int64(batch.ValueSize()))
+
+	commitStart := time.Now()
+	if err := batch.Write(); err != nil {
+		log.Crit("Failed to persist bytecodes", "err", err)
+	}
+	commits := s.observeCommit(profBytecode, commitStart)
+	s.profile.exec[profBytecode].observe(time.Since(start) - commits)
+}

--- a/eth/protocols/snap/sync_test.go
+++ b/eth/protocols/snap/sync_test.go
@@ -131,6 +131,7 @@ type testPeer struct {
 	test          *testing.T
 	remote        *syncer
 	logger        log.Logger
+	trieLock      sync.Mutex
 	accountTrie   *trie.Trie
 	accountValues []*kv
 	storageTries  map[common.Hash]*trie.Trie
@@ -217,6 +218,9 @@ func (t *testPeer) RequestByteCodes(id uint64, hashes []common.Hash, bytes int) 
 
 // defaultTrieRequestHandler is a well-behaving handler for trie healing requests
 func defaultTrieRequestHandler(t *testPeer, requestId uint64, root common.Hash, paths []TrieNodePathSet, cap int) error {
+	t.trieLock.Lock()
+	defer t.trieLock.Unlock()
+
 	// Pass the response
 	var nodes [][]byte
 	for _, pathset := range paths {
@@ -256,6 +260,9 @@ func defaultAccountRequestHandler(t *testPeer, id uint64, root common.Hash, orig
 }
 
 func createAccountRequestResponse(t *testPeer, root common.Hash, origin common.Hash, limit common.Hash, cap int) (keys []common.Hash, vals [][]byte, proofs [][]byte) {
+	t.trieLock.Lock()
+	defer t.trieLock.Unlock()
+
 	var size int
 	if limit == (common.Hash{}) {
 		limit = common.MaxHash
@@ -313,6 +320,9 @@ func defaultCodeRequestHandler(t *testPeer, id uint64, hashes []common.Hash, max
 }
 
 func createStorageRequestResponse(t *testPeer, root common.Hash, accounts []common.Hash, origin, limit []byte, max int) (hashes [][]common.Hash, slots [][][]byte, proofs [][]byte) {
+	t.trieLock.Lock()
+	defer t.trieLock.Unlock()
+
 	var size int
 	for _, account := range accounts {
 		// The first account might start from a different origin and end sooner
@@ -379,6 +389,9 @@ func createStorageRequestResponse(t *testPeer, root common.Hash, accounts []comm
 // createStorageRequestResponseAlwaysProve tests a cornercase, where the peer always
 // supplies the proof for the last account, even if it is 'complete'.
 func createStorageRequestResponseAlwaysProve(t *testPeer, root common.Hash, accounts []common.Hash, bOrigin, bLimit []byte, max int) (hashes [][]common.Hash, slots [][][]byte, proofs [][]byte) {
+	t.trieLock.Lock()
+	defer t.trieLock.Unlock()
+
 	var size int
 	max = max * 3 / 4
 


### PR DESCRIPTION
 This PR moves the state response persistence and trie generation from the single-threaded loop to background, maximizing concurrency for a shorter sync time.

One behavioral change: previously, if a storage retrieval was flagged as chunked but the peer delivered all remaining slots within a single range, the healing of that account was skipped. In this PR this behavior would race the account task forwarding, so such accounts are now healed regardless. This ends up with ~9k additionally healed accounts, still a small portion.