### PR TITLE
cmd/devp2p: add discovery endpoint tests

### DIFF
--- a/cmd/devp2p/discv5cmd.go
+++ b/cmd/devp2p/discv5cmd.go
@@ -19,11 +19,13 @@ package main
 import (
 	"errors"
 	"fmt"
+	"net/netip"
 	"slices"
 	"time"
 
 	"github.com/ethereum/go-ethereum/cmd/devp2p/internal/v5test"
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/internal/utesting"
 	"github.com/ethereum/go-ethereum/p2p/discover"
 	"github.com/urfave/cli/v2"
 )
@@ -126,14 +128,49 @@ func discv5Crawl(ctx *cli.Context) error {
 
 // discv5Test runs the protocol test suite.
 func discv5Test(ctx *cli.Context) error {
+	expectIP, err := parseExpectedIP(ctx.String(testExpectedIPFlag.Name), false)
+	if err != nil {
+		return err
+	}
+	expectIP6, err := parseExpectedIP(ctx.String(testExpectedIP6Flag.Name), true)
+	if err != nil {
+		return err
+	}
 	suite := &v5test.Suite{
 		Dest:      getNodeArg(ctx),
 		Listen1:   ctx.String(testListen1Flag.Name),
 		Listen2:   ctx.String(testListen2Flag.Name),
-		ExpectIP:  ctx.String(testExpectedIPFlag.Name),
-		ExpectIP6: ctx.String(testExpectedIP6Flag.Name),
+		ExpectIP:  expectIP,
+		ExpectIP6: expectIP6,
 	}
-	return runTests(ctx, suite.AllTests())
+	tests := suite.AllTests()
+	if (expectIP.IsValid() || expectIP6.IsValid()) && ctx.IsSet(testPatternFlag.Name) {
+		matches := utesting.MatchTests(tests, ctx.String(testPatternFlag.Name))
+		if !slices.ContainsFunc(matches, func(test utesting.Test) bool {
+			return test.Name == "FindnodeZeroDistance"
+		}) {
+			return errors.New("--expect-ip and --expect-ip6 require running FindnodeZeroDistance")
+		}
+	}
+	return runTests(ctx, tests)
+}
+
+func parseExpectedIP(raw string, ipv6 bool) (netip.Addr, error) {
+	if raw == "" {
+		return netip.Addr{}, nil
+	}
+	addr, err := netip.ParseAddr(raw)
+	if err != nil {
+		return netip.Addr{}, err
+	}
+	if ipv6 {
+		if !addr.Is6() || addr.Is4In6() {
+			return netip.Addr{}, fmt.Errorf("invalid expected IPv6 address %q", raw)
+		}
+	} else if !addr.Is4() {
+		return netip.Addr{}, fmt.Errorf("invalid expected IPv4 address %q", raw)
+	}
+	return addr, nil
 }
 
 func discv5Listen(ctx *cli.Context) error {

--- a/cmd/devp2p/discv5cmd.go
+++ b/cmd/devp2p/discv5cmd.go
@@ -70,6 +70,8 @@ var (
 			testTAPFlag,
 			testListen1Flag,
 			testListen2Flag,
+			testExpectedIPFlag,
+			testExpectedIP6Flag,
 		},
 	}
 	discv5ListenCommand = &cli.Command{
@@ -125,9 +127,11 @@ func discv5Crawl(ctx *cli.Context) error {
 // discv5Test runs the protocol test suite.
 func discv5Test(ctx *cli.Context) error {
 	suite := &v5test.Suite{
-		Dest:    getNodeArg(ctx),
-		Listen1: ctx.String(testListen1Flag.Name),
-		Listen2: ctx.String(testListen2Flag.Name),
+		Dest:      getNodeArg(ctx),
+		Listen1:   ctx.String(testListen1Flag.Name),
+		Listen2:   ctx.String(testListen2Flag.Name),
+		ExpectIP:  ctx.String(testExpectedIPFlag.Name),
+		ExpectIP6: ctx.String(testExpectedIP6Flag.Name),
 	}
 	return runTests(ctx, suite.AllTests())
 }

--- a/cmd/devp2p/discv5cmd.go
+++ b/cmd/devp2p/discv5cmd.go
@@ -147,9 +147,9 @@ func discv5Test(ctx *cli.Context) error {
 	if (expectIP.IsValid() || expectIP6.IsValid()) && ctx.IsSet(testPatternFlag.Name) {
 		matches := utesting.MatchTests(tests, ctx.String(testPatternFlag.Name))
 		if !slices.ContainsFunc(matches, func(test utesting.Test) bool {
-			return test.Name == "FindnodeZeroDistance"
+			return test.Name == v5test.FindnodeZeroDistanceName
 		}) {
-			return errors.New("--expect-ip and --expect-ip6 require running FindnodeZeroDistance")
+			return fmt.Errorf("--expect-ip and --expect-ip6 require running %s", v5test.FindnodeZeroDistanceName)
 		}
 	}
 	return runTests(ctx, tests)
@@ -169,6 +169,9 @@ func parseExpectedIP(raw string, ipv6 bool) (netip.Addr, error) {
 		}
 	} else if !addr.Is4() {
 		return netip.Addr{}, fmt.Errorf("invalid expected IPv4 address %q", raw)
+	}
+	if addr.Zone() != "" || addr.IsUnspecified() || addr.IsMulticast() {
+		return netip.Addr{}, fmt.Errorf("invalid expected IP address %q", raw)
 	}
 	return addr, nil
 }

--- a/cmd/devp2p/discv5cmd_test.go
+++ b/cmd/devp2p/discv5cmd_test.go
@@ -1,0 +1,49 @@
+// Copyright 2026 The go-ethereum Authors
+// This file is part of go-ethereum.
+//
+// go-ethereum is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// go-ethereum is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with go-ethereum. If not, see <http://www.gnu.org/licenses/>.
+
+package main
+
+import "testing"
+
+func TestParseExpectedIPRejectsUnusableAddresses(t *testing.T) {
+	tests := []struct {
+		name    string
+		raw     string
+		ipv6    bool
+		wantErr bool
+	}{
+		{name: "valid ipv4", raw: "192.0.2.1"},
+		{name: "valid ipv6", raw: "2001:db8::1", ipv6: true},
+		{name: "wrong family", raw: "2001:db8::1", wantErr: true},
+		{name: "v4 mapped ipv6", raw: "::ffff:192.0.2.1", ipv6: true, wantErr: true},
+		{name: "zoned ipv6", raw: "fe80::1%eth0", ipv6: true, wantErr: true},
+		{name: "unspecified ipv4", raw: "0.0.0.0", wantErr: true},
+		{name: "unspecified ipv6", raw: "::", ipv6: true, wantErr: true},
+		{name: "multicast ipv4", raw: "224.0.0.1", wantErr: true},
+		{name: "multicast ipv6", raw: "ff02::1", ipv6: true, wantErr: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := parseExpectedIP(tt.raw, tt.ipv6)
+			if tt.wantErr && err == nil {
+				t.Fatal("expected error")
+			}
+			if !tt.wantErr && err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+		})
+	}
+}

--- a/cmd/devp2p/internal/v4test/discv4tests.go
+++ b/cmd/devp2p/internal/v4test/discv4tests.go
@@ -22,6 +22,7 @@ import (
 	"errors"
 	"fmt"
 	"net"
+	"strings"
 	"time"
 
 	"github.com/ethereum/go-ethereum/crypto"
@@ -397,9 +398,13 @@ func FindnodePastExpiration(t *utesting.T) {
 
 // bond performs the endpoint proof with the remote node.
 func bond(t *utesting.T, te *testenv) {
+	bondWithTCP(t, te, 0)
+}
+
+func bondWithTCP(t *utesting.T, te *testenv, tcpPort uint16) {
 	pingHash := te.send(te.l1, &v4wire.Ping{
 		Version:    4,
-		From:       te.localEndpoint(te.l1),
+		From:       te.localEndpointWithTCP(te.l1, tcpPort),
 		To:         te.remoteEndpoint(),
 		Expiration: futureExpiration(),
 	})
@@ -425,6 +430,126 @@ func bond(t *utesting.T, te *testenv) {
 			gotPong = true
 		}
 	}
+}
+
+// FindnodeDistinctUDPAndTCP checks that a learned peer keeps distinct UDP and TCP ports
+// when returned through NEIGHBORS.
+func FindnodeDistinctUDPAndTCP(t *utesting.T) {
+	seed := newTestEnv(Remote, Listen1, Listen2)
+	defer seed.close()
+	query := newTestEnv(Remote, Listen1, Listen2)
+	defer query.close()
+
+	seedEndpoint := seed.localEndpoint(seed.l1)
+	seedTCP := distinctTCPPort(seedEndpoint.UDP)
+	seedID := v4wire.EncodePubkey(&seed.key.PublicKey)
+	t.Logf("bonding seed peer %x at %v:%d with advertised TCP port %d", seedID[:8], seedEndpoint.IP, seedEndpoint.UDP, seedTCP)
+	bondWithTCP(t, seed, seedTCP)
+
+	t.Log("bonding query peer")
+	bond(t, query)
+
+	deadline := time.Now().Add(60 * time.Second)
+	var last []v4wire.Node
+	var lastMismatch string
+	for time.Now().Before(deadline) {
+		node, found, nodes, err := query.findNeighbor(seedID)
+		if err != nil {
+			t.Fatal("findnode failed:", err)
+		}
+		last = nodes
+		if found {
+			if err := checkNeighborPorts(node, seedEndpoint, seedTCP); err == nil {
+				t.Logf("NEIGHBORS preserved distinct ports for seed %x: udp=%d tcp=%d", node.ID[:8], node.UDP, node.TCP)
+				return
+			} else {
+				lastMismatch = err.Error()
+			}
+		}
+		time.Sleep(500 * time.Millisecond)
+	}
+
+	if lastMismatch != "" {
+		t.Fatalf("seed peer %x was returned by NEIGHBORS with wrong endpoint fields: %s; last response had %d nodes: %s",
+			seedID[:8], lastMismatch, len(last), formatNodes(last))
+	}
+	t.Fatalf("seed peer %x not returned by NEIGHBORS before timeout; last response had %d nodes: %s",
+		seedID[:8], len(last), formatNodes(last))
+}
+
+func (te *testenv) findNeighbor(target v4wire.Pubkey) (v4wire.Node, bool, []v4wire.Node, error) {
+	var findnode v4wire.Findnode
+	findnode.Target = target
+	findnode.Expiration = futureExpiration()
+	te.send(te.l1, &findnode)
+
+	deadline := time.Now().Add(2 * time.Second)
+	var nodes []v4wire.Node
+	for time.Now().Before(deadline) {
+		reply, hash, err := te.read(te.l1)
+		if isTimeout(err) {
+			return v4wire.Node{}, false, nodes, nil
+		}
+		if err != nil {
+			return v4wire.Node{}, false, nodes, err
+		}
+
+		switch msg := reply.(type) {
+		case *v4wire.Ping:
+			te.send(te.l1, &v4wire.Pong{
+				To:         te.remoteEndpoint(),
+				ReplyTok:   hash,
+				Expiration: futureExpiration(),
+			})
+		case *v4wire.Neighbors:
+			nodes = append(nodes, msg.Nodes...)
+			for _, node := range msg.Nodes {
+				if node.ID == target {
+					return node, true, nodes, nil
+				}
+			}
+		}
+	}
+	return v4wire.Node{}, false, nodes, nil
+}
+
+func checkNeighborPorts(node v4wire.Node, wantEndpoint v4wire.Endpoint, wantTCP uint16) error {
+	if !node.IP.Equal(wantEndpoint.IP) {
+		return fmt.Errorf("IP got %v, want %v", node.IP, wantEndpoint.IP)
+	}
+	if node.UDP != wantEndpoint.UDP {
+		return fmt.Errorf("UDP port got %d, want %d", node.UDP, wantEndpoint.UDP)
+	}
+	if node.TCP != wantTCP {
+		return fmt.Errorf("TCP port got %d, want %d", node.TCP, wantTCP)
+	}
+	return nil
+}
+
+func distinctTCPPort(udp uint16) uint16 {
+	if udp > 32768 {
+		return udp - 10000
+	}
+	return udp + 10000
+}
+
+func isTimeout(err error) bool {
+	if err == nil {
+		return false
+	}
+	netErr, ok := err.(net.Error)
+	return ok && netErr.Timeout()
+}
+
+func formatNodes(nodes []v4wire.Node) string {
+	if len(nodes) == 0 {
+		return "[]"
+	}
+	formatted := make([]string, len(nodes))
+	for i, node := range nodes {
+		formatted[i] = fmt.Sprintf("{id=%x ip=%v udp=%d tcp=%d}", node.ID[:8], node.IP, node.UDP, node.TCP)
+	}
+	return "[" + strings.Join(formatted, ", ") + "]"
 }
 
 // FindnodeAmplificationInvalidPongHash attempts to perform a traffic amplification attack against a
@@ -544,6 +669,7 @@ var AllTests = []utesting.Test{
 	{Name: "ENRRequest", Fn: ENRRequest},
 	{Name: "Findnode/WithoutEndpointProof", Fn: FindnodeWithoutEndpointProof},
 	{Name: "Findnode/BasicFindnode", Fn: BasicFindnode},
+	{Name: "Findnode/DistinctUDPAndTCP", Fn: FindnodeDistinctUDPAndTCP},
 	{Name: "Findnode/UnsolicitedNeighbors", Fn: UnsolicitedNeighbors},
 	{Name: "Findnode/PastExpiration", Fn: FindnodePastExpiration},
 	{Name: "Amplification/InvalidPongHash", Fn: FindnodeAmplificationInvalidPongHash},

--- a/cmd/devp2p/internal/v4test/discv4tests.go
+++ b/cmd/devp2p/internal/v4test/discv4tests.go
@@ -439,33 +439,44 @@ func bondWithTCP(t *utesting.T, te *testenv, tcpPort uint16) v4wire.Endpoint {
 // FindnodeDistinctUDPAndTCP checks that a learned peer keeps distinct UDP and TCP ports
 // when returned through NEIGHBORS.
 func FindnodeDistinctUDPAndTCP(t *utesting.T) {
-	te := newTestEnv(Remote, Listen1, Listen2)
-	defer te.close()
+	seed := newTestEnv(Remote, Listen1, Listen2)
+	defer seed.close()
+	query := newTestEnv(Remote, Listen1, Listen2)
+	defer query.close()
 
-	local := te.localEndpoint(te.l1)
+	local := seed.localEndpoint(seed.l1)
 	tcpPort := local.UDP ^ 1
-	id := v4wire.EncodePubkey(&te.key.PublicKey)
+	id := v4wire.EncodePubkey(&seed.key.PublicKey)
 	t.Logf("bonding peer %x at %v:%d with advertised TCP port %d", id[:8], local.IP, local.UDP, tcpPort)
-	observed := bondWithTCP(t, te, tcpPort)
+	observed := bondWithTCP(t, seed, tcpPort)
+	done := make(chan struct{})
+	seedErr := seed.answerPings(done)
+	defer func() {
+		close(done)
+		<-seedErr
+	}()
+	bond(t, query)
 
-	deadline := time.Now().Add(10 * time.Second)
+	deadline := time.Now().Add(30 * time.Second)
 	var last []v4wire.Node
 	var lastMismatch error
 	for time.Now().Before(deadline) {
-		node, found, nodes, err := te.findNeighbor(id)
+		if err := checkSeedResponder(seedErr); err != nil {
+			t.Fatal("seed responder failed:", err)
+		}
+		node, found, nodes, err := query.findNeighbor(id)
 		if err != nil {
 			t.Fatal("findnode failed:", err)
 		}
 		last = nodes
 		if found {
-			if err := checkNeighborPorts(node, observed.UDP, tcpPort); err != nil {
+			if err := checkNeighborEndpoint(node, observed, tcpPort); err != nil {
 				lastMismatch = err
 			} else {
 				t.Logf("NEIGHBORS preserved distinct ports for seed %x: udp=%d tcp=%d", node.ID[:8], node.UDP, node.TCP)
 				return
 			}
 		}
-		time.Sleep(500 * time.Millisecond)
 	}
 
 	if lastMismatch != nil {
@@ -474,6 +485,50 @@ func FindnodeDistinctUDPAndTCP(t *utesting.T) {
 	}
 	t.Fatalf("seed peer %x not returned by NEIGHBORS before timeout; last response had %d nodes: %s",
 		id[:8], len(last), formatNodes(last))
+}
+
+func (te *testenv) answerPings(done <-chan struct{}) <-chan error {
+	errc := make(chan error, 1)
+	go func() {
+		defer close(errc)
+		for {
+			select {
+			case <-done:
+				return
+			default:
+			}
+			req, hash, err := te.read(te.l1)
+			if isTimeout(err) {
+				continue
+			}
+			if err != nil {
+				select {
+				case <-done:
+				case errc <- err:
+				}
+				return
+			}
+			if req.Kind() == v4wire.PingPacket {
+				te.send(te.l1, &v4wire.Pong{
+					To:         te.remoteEndpoint(),
+					ReplyTok:   hash,
+					Expiration: futureExpiration(),
+				})
+			}
+		}
+	}()
+	return errc
+}
+
+func checkSeedResponder(errc <-chan error) error {
+	select {
+	case err, ok := <-errc:
+		if ok {
+			return err
+		}
+	default:
+	}
+	return nil
 }
 
 func (te *testenv) findNeighbor(target v4wire.Pubkey) (v4wire.Node, bool, []v4wire.Node, error) {
@@ -487,7 +542,7 @@ func (te *testenv) findNeighbor(target v4wire.Pubkey) (v4wire.Node, bool, []v4wi
 	for time.Now().Before(deadline) {
 		reply, hash, err := te.read(te.l1)
 		if isTimeout(err) {
-			return v4wire.Node{}, false, nodes, nil
+			continue
 		}
 		if err != nil {
 			return v4wire.Node{}, false, nodes, err
@@ -512,9 +567,12 @@ func (te *testenv) findNeighbor(target v4wire.Pubkey) (v4wire.Node, bool, []v4wi
 	return v4wire.Node{}, false, nodes, nil
 }
 
-func checkNeighborPorts(node v4wire.Node, wantUDP, wantTCP uint16) error {
-	if node.UDP != wantUDP {
-		return fmt.Errorf("UDP port got %d, want %d", node.UDP, wantUDP)
+func checkNeighborEndpoint(node v4wire.Node, want v4wire.Endpoint, wantTCP uint16) error {
+	if !node.IP.Equal(want.IP) {
+		return fmt.Errorf("IP got %v, want %v", node.IP, want.IP)
+	}
+	if node.UDP != want.UDP {
+		return fmt.Errorf("UDP port got %d, want %d", node.UDP, want.UDP)
 	}
 	if node.TCP != wantTCP {
 		return fmt.Errorf("TCP port got %d, want %d", node.TCP, wantTCP)
@@ -523,7 +581,11 @@ func checkNeighborPorts(node v4wire.Node, wantUDP, wantTCP uint16) error {
 }
 
 func isTimeout(err error) bool {
-	return errors.Is(err, os.ErrDeadlineExceeded)
+	if errors.Is(err, os.ErrDeadlineExceeded) {
+		return true
+	}
+	var netErr net.Error
+	return errors.As(err, &netErr) && netErr.Timeout()
 }
 
 func formatNodes(nodes []v4wire.Node) string {

--- a/cmd/devp2p/internal/v4test/discv4tests.go
+++ b/cmd/devp2p/internal/v4test/discv4tests.go
@@ -22,6 +22,7 @@ import (
 	"errors"
 	"fmt"
 	"net"
+	"os"
 	"strings"
 	"time"
 
@@ -401,7 +402,7 @@ func bond(t *utesting.T, te *testenv) {
 	bondWithTCP(t, te, 0)
 }
 
-func bondWithTCP(t *utesting.T, te *testenv, tcpPort uint16) {
+func bondWithTCP(t *utesting.T, te *testenv, tcpPort uint16) v4wire.Endpoint {
 	pingHash := te.send(te.l1, &v4wire.Ping{
 		Version:    4,
 		From:       te.localEndpointWithTCP(te.l1, tcpPort),
@@ -409,6 +410,7 @@ func bondWithTCP(t *utesting.T, te *testenv, tcpPort uint16) {
 		Expiration: futureExpiration(),
 	})
 
+	observed := te.localEndpointWithTCP(te.l1, tcpPort)
 	var gotPing, gotPong bool
 	for !gotPing || !gotPong {
 		req, hash, err := te.read(te.l1)
@@ -427,54 +429,51 @@ func bondWithTCP(t *utesting.T, te *testenv, tcpPort uint16) {
 			if err := te.checkPong(req, pingHash); err != nil {
 				t.Fatal(err)
 			}
+			observed = req.(*v4wire.Pong).To
 			gotPong = true
 		}
 	}
+	return observed
 }
 
 // FindnodeDistinctUDPAndTCP checks that a learned peer keeps distinct UDP and TCP ports
 // when returned through NEIGHBORS.
 func FindnodeDistinctUDPAndTCP(t *utesting.T) {
-	seed := newTestEnv(Remote, Listen1, Listen2)
-	defer seed.close()
-	query := newTestEnv(Remote, Listen1, Listen2)
-	defer query.close()
+	te := newTestEnv(Remote, Listen1, Listen2)
+	defer te.close()
 
-	seedEndpoint := seed.localEndpoint(seed.l1)
-	seedTCP := distinctTCPPort(seedEndpoint.UDP)
-	seedID := v4wire.EncodePubkey(&seed.key.PublicKey)
-	t.Logf("bonding seed peer %x at %v:%d with advertised TCP port %d", seedID[:8], seedEndpoint.IP, seedEndpoint.UDP, seedTCP)
-	bondWithTCP(t, seed, seedTCP)
+	local := te.localEndpoint(te.l1)
+	tcpPort := local.UDP ^ 1
+	id := v4wire.EncodePubkey(&te.key.PublicKey)
+	t.Logf("bonding peer %x at %v:%d with advertised TCP port %d", id[:8], local.IP, local.UDP, tcpPort)
+	observed := bondWithTCP(t, te, tcpPort)
 
-	t.Log("bonding query peer")
-	bond(t, query)
-
-	deadline := time.Now().Add(60 * time.Second)
+	deadline := time.Now().Add(10 * time.Second)
 	var last []v4wire.Node
-	var lastMismatch string
+	var lastMismatch error
 	for time.Now().Before(deadline) {
-		node, found, nodes, err := query.findNeighbor(seedID)
+		node, found, nodes, err := te.findNeighbor(id)
 		if err != nil {
 			t.Fatal("findnode failed:", err)
 		}
 		last = nodes
 		if found {
-			if err := checkNeighborPorts(node, seedEndpoint, seedTCP); err == nil {
+			if err := checkNeighborPorts(node, observed.UDP, tcpPort); err != nil {
+				lastMismatch = err
+			} else {
 				t.Logf("NEIGHBORS preserved distinct ports for seed %x: udp=%d tcp=%d", node.ID[:8], node.UDP, node.TCP)
 				return
-			} else {
-				lastMismatch = err.Error()
 			}
 		}
 		time.Sleep(500 * time.Millisecond)
 	}
 
-	if lastMismatch != "" {
+	if lastMismatch != nil {
 		t.Fatalf("seed peer %x was returned by NEIGHBORS with wrong endpoint fields: %s; last response had %d nodes: %s",
-			seedID[:8], lastMismatch, len(last), formatNodes(last))
+			id[:8], lastMismatch, len(last), formatNodes(last))
 	}
 	t.Fatalf("seed peer %x not returned by NEIGHBORS before timeout; last response had %d nodes: %s",
-		seedID[:8], len(last), formatNodes(last))
+		id[:8], len(last), formatNodes(last))
 }
 
 func (te *testenv) findNeighbor(target v4wire.Pubkey) (v4wire.Node, bool, []v4wire.Node, error) {
@@ -513,12 +512,9 @@ func (te *testenv) findNeighbor(target v4wire.Pubkey) (v4wire.Node, bool, []v4wi
 	return v4wire.Node{}, false, nodes, nil
 }
 
-func checkNeighborPorts(node v4wire.Node, wantEndpoint v4wire.Endpoint, wantTCP uint16) error {
-	if !node.IP.Equal(wantEndpoint.IP) {
-		return fmt.Errorf("IP got %v, want %v", node.IP, wantEndpoint.IP)
-	}
-	if node.UDP != wantEndpoint.UDP {
-		return fmt.Errorf("UDP port got %d, want %d", node.UDP, wantEndpoint.UDP)
+func checkNeighborPorts(node v4wire.Node, wantUDP, wantTCP uint16) error {
+	if node.UDP != wantUDP {
+		return fmt.Errorf("UDP port got %d, want %d", node.UDP, wantUDP)
 	}
 	if node.TCP != wantTCP {
 		return fmt.Errorf("TCP port got %d, want %d", node.TCP, wantTCP)
@@ -526,19 +522,8 @@ func checkNeighborPorts(node v4wire.Node, wantEndpoint v4wire.Endpoint, wantTCP 
 	return nil
 }
 
-func distinctTCPPort(udp uint16) uint16 {
-	if udp > 32768 {
-		return udp - 10000
-	}
-	return udp + 10000
-}
-
 func isTimeout(err error) bool {
-	if err == nil {
-		return false
-	}
-	netErr, ok := err.(net.Error)
-	return ok && netErr.Timeout()
+	return errors.Is(err, os.ErrDeadlineExceeded)
 }
 
 func formatNodes(nodes []v4wire.Node) string {

--- a/cmd/devp2p/internal/v4test/framework.go
+++ b/cmd/devp2p/internal/v4test/framework.go
@@ -103,11 +103,15 @@ func (te *testenv) read(c net.PacketConn) (v4wire.Packet, []byte, error) {
 }
 
 func (te *testenv) localEndpoint(c net.PacketConn) v4wire.Endpoint {
+	return te.localEndpointWithTCP(c, 0)
+}
+
+func (te *testenv) localEndpointWithTCP(c net.PacketConn, tcpPort uint16) v4wire.Endpoint {
 	addr := c.LocalAddr().(*net.UDPAddr)
 	return v4wire.Endpoint{
 		IP:  addr.IP.To4(),
 		UDP: uint16(addr.Port),
-		TCP: 0,
+		TCP: tcpPort,
 	}
 }
 

--- a/cmd/devp2p/internal/v4test/framework.go
+++ b/cmd/devp2p/internal/v4test/framework.go
@@ -37,11 +37,11 @@ type testenv struct {
 }
 
 func newTestEnv(remote string, listen1, listen2 string) *testenv {
-	l1, err := net.ListenPacket("udp", fmt.Sprintf("%v:0", listen1))
+	l1, err := net.ListenPacket("udp", net.JoinHostPort(listen1, "0"))
 	if err != nil {
 		panic(err)
 	}
-	l2, err := net.ListenPacket("udp", fmt.Sprintf("%v:0", listen2))
+	l2, err := net.ListenPacket("udp", net.JoinHostPort(listen2, "0"))
 	if err != nil {
 		panic(err)
 	}

--- a/cmd/devp2p/internal/v5test/discv5tests.go
+++ b/cmd/devp2p/internal/v5test/discv5tests.go
@@ -18,8 +18,10 @@ package v5test
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"net"
+	"net/netip"
 	"slices"
 	"strings"
 	"sync"
@@ -36,8 +38,8 @@ import (
 type Suite struct {
 	Dest             *enode.Node
 	Listen1, Listen2 string // listening addresses
-	ExpectIP         string
-	ExpectIP6        string
+	ExpectIP         netip.Addr
+	ExpectIP6        netip.Addr
 }
 
 func (s *Suite) listen1(log logger) (*conn, net.PacketConn) {
@@ -253,258 +255,166 @@ func (s *Suite) TestFindnodeZeroDistance(t *utesting.T) {
 	if nodes[0].ID() != conn.remote.ID() {
 		t.Errorf("ID of response node is %v, want %v", nodes[0].ID(), conn.remote.ID())
 	}
-	summary, err := validateEndpointPairs(nodes[0].Record())
+	summary, err := checkSelfRecord(nodes[0], s.ExpectIP, s.ExpectIP6)
 	if err != nil {
 		t.Fatal("self record has invalid endpoint entries:", err)
-	}
-	if s.ExpectIP != "" || s.ExpectIP6 != "" {
-		summary, err = requireExpectedEndpointEntries(nodes[0].Record(), s.ExpectIP, s.ExpectIP6)
-		if err != nil {
-			t.Fatal("self record does not include expected endpoint entries:", err)
-		}
 	}
 	t.Logf("self record seq=%d endpoints: %s", nodes[0].Seq(), summary)
 }
 
-func validateEndpointPairs(record *enr.Record) (string, error) {
-	if record.Seq() == 0 {
-		return "", fmt.Errorf("ENR sequence is zero")
-	}
-
-	ip4, hasIP4, err := loadENRIPv4(record)
+func checkSelfRecord(n *enode.Node, wantIP4, wantIP6 netip.Addr) (string, error) {
+	entries, err := loadEndpointEntries(n.Record())
 	if err != nil {
 		return "", err
 	}
-	ip6, hasIP6, err := loadENRIPv6(record)
-	if err != nil {
+	if err := entries.checkDanglingPorts(); err != nil {
 		return "", err
 	}
-	udp, hasUDP, err := loadENRUDP(record)
-	if err != nil {
-		return "", err
-	}
-	udp6, hasUDP6, err := loadENRUDP6(record)
-	if err != nil {
-		return "", err
-	}
-	tcp, hasTCP, err := loadENRTCP(record)
-	if err != nil {
-		return "", err
-	}
-	tcp6, hasTCP6, err := loadENRTCP6(record)
-	if err != nil {
-		return "", err
-	}
-
-	if hasUDP && !hasIP4 && !hasIP6 {
-		return "", fmt.Errorf("udp is present without ip or ip6")
-	}
-	if hasTCP && !hasIP4 && !hasIP6 {
-		return "", fmt.Errorf("tcp is present without ip or ip6")
-	}
-	if hasUDP6 && !hasIP6 {
-		return "", fmt.Errorf("udp6 is present without ip6")
-	}
-	if hasTCP6 && !hasIP6 {
-		return "", fmt.Errorf("tcp6 is present without ip6")
-	}
-	if hasIP4 && !hasUDP {
-		return "", fmt.Errorf("ip is present without udp")
-	}
-	if hasIP6 && !hasUDP6 && !hasUDP {
-		return "", fmt.Errorf("ip6 is present without udp6 or udp fallback")
-	}
-	if !((hasIP4 && hasUDP) || (hasIP6 && (hasUDP6 || hasUDP))) {
-		return "", fmt.Errorf("ENR has no usable discovery endpoint")
-	}
-
-	var endpoints []string
-	if hasIP4 {
-		endpoints = append(endpoints, fmt.Sprintf("ip=%s udp=%d", ip4, udp))
-		if hasTCP {
-			endpoints[len(endpoints)-1] += fmt.Sprintf(" tcp=%d", tcp)
-		}
-	}
-	if hasIP6 {
-		v6UDP := udp
-		if hasUDP6 {
-			v6UDP = udp6
-		}
-		endpoints = append(endpoints, fmt.Sprintf("ip6=%s udp6=%d", ip6, v6UDP))
-		if hasTCP6 {
-			endpoints[len(endpoints)-1] += fmt.Sprintf(" tcp6=%d", tcp6)
-		}
-	}
-	return strings.Join(endpoints, "; "), nil
-}
-
-func requireExpectedEndpointEntries(record *enr.Record, wantIPv4, wantIPv6 string) (string, error) {
-	ip4, hasIP4, err := loadENRIPv4(record)
-	if err != nil {
-		return "", err
-	}
-	ip6, hasIP6, err := loadENRIPv6(record)
-	if err != nil {
-		return "", err
-	}
-	udp, hasUDP, err := loadENRUDP(record)
-	if err != nil {
-		return "", err
-	}
-	udp6, hasUDP6, err := loadENRUDP6(record)
-	if err != nil {
-		return "", err
-	}
-	tcp, hasTCP, err := loadENRTCP(record)
-	if err != nil {
-		return "", err
-	}
-	tcp6, hasTCP6, err := loadENRTCP6(record)
-	if err != nil {
-		return "", err
-	}
-
-	if wantIPv4 != "" {
-		expectedIPv4 := net.ParseIP(wantIPv4).To4()
-		if expectedIPv4 == nil {
-			return "", fmt.Errorf("invalid expected IPv4 address %q", wantIPv4)
-		}
-		if !hasIP4 {
+	if wantIP4.IsValid() {
+		if !entries.hasIP4 {
 			return "", fmt.Errorf("missing ip entry")
 		}
-		if !hasUDP {
+		if entries.udp == 0 {
 			return "", fmt.Errorf("missing udp entry")
 		}
-		if !ip4.Equal(expectedIPv4) {
-			return "", fmt.Errorf("ip entry got %s, want %s", ip4, expectedIPv4)
+		if entries.ip4 != wantIP4 {
+			return "", fmt.Errorf("ip entry got %s, want %s", entries.ip4, wantIP4)
 		}
 	}
-	if wantIPv6 != "" {
-		expectedIPv6 := net.ParseIP(wantIPv6)
-		if expectedIPv6 == nil || expectedIPv6.To4() != nil {
-			return "", fmt.Errorf("invalid expected IPv6 address %q", wantIPv6)
-		}
-		if !hasIP6 {
+	if wantIP6.IsValid() {
+		if !entries.hasIP6 {
 			return "", fmt.Errorf("missing ip6 entry")
 		}
-		if !hasUDP6 && !hasUDP {
+		if entries.ip6 != wantIP6 {
+			return "", fmt.Errorf("ip6 entry got %s, want %s", entries.ip6, wantIP6)
+		}
+		if entries.udp6 == 0 && entries.udp == 0 {
 			return "", fmt.Errorf("missing udp6 entry or udp fallback")
 		}
-		if !ip6.Equal(expectedIPv6) {
-			return "", fmt.Errorf("ip6 entry got %s, want %s", ip6, expectedIPv6)
-		}
 	}
+	if _, ok := n.UDPEndpoint(); !ok && !entries.hasUsableDiscoveryEndpoint() {
+		return "", errors.New("record has no usable UDP endpoint")
+	}
+	return entries.summary(), nil
+}
 
+type endpointEntries struct {
+	ip4, ip6             netip.Addr
+	udp, udp6, tcp, tcp6 uint16
+	hasIP4, hasIP6       bool
+	hasUDP, hasUDP6      bool
+	hasTCP, hasTCP6      bool
+}
+
+func loadEndpointEntries(record *enr.Record) (endpointEntries, error) {
+	var entries endpointEntries
+	var ip4 enr.IPv4Addr
+	var ip6 enr.IPv6Addr
+	var udp enr.UDP
+	var udp6 enr.UDP6
+	var tcp enr.TCP
+	var tcp6 enr.TCP6
+
+	loaders := []struct {
+		entry enr.Entry
+		set   func(bool)
+	}{
+		{&ip4, func(ok bool) {
+			entries.hasIP4 = ok
+			entries.ip4 = netip.Addr(ip4)
+		}},
+		{&ip6, func(ok bool) {
+			entries.hasIP6 = ok
+			entries.ip6 = netip.Addr(ip6)
+		}},
+		{&udp, func(ok bool) {
+			entries.hasUDP = ok
+			entries.udp = uint16(udp)
+		}},
+		{&udp6, func(ok bool) {
+			entries.hasUDP6 = ok
+			entries.udp6 = uint16(udp6)
+		}},
+		{&tcp, func(ok bool) {
+			entries.hasTCP = ok
+			entries.tcp = uint16(tcp)
+		}},
+		{&tcp6, func(ok bool) {
+			entries.hasTCP6 = ok
+			entries.tcp6 = uint16(tcp6)
+		}},
+	}
+	for _, loader := range loaders {
+		ok, err := loadEntry(record, loader.entry)
+		if err != nil {
+			return endpointEntries{}, err
+		}
+		loader.set(ok)
+	}
+	return entries, nil
+}
+
+func loadEntry(record *enr.Record, entry enr.Entry) (bool, error) {
+	if err := record.Load(entry); err != nil {
+		if enr.IsNotFound(err) {
+			return false, nil
+		}
+		return false, fmt.Errorf("invalid %s entry: %w", entry.ENRKey(), err)
+	}
+	return true, nil
+}
+
+func (entries endpointEntries) checkDanglingPorts() error {
+	if entries.hasUDP && !entries.hasIP4 && !entries.hasIP6 {
+		return fmt.Errorf("udp is present without ip or ip6")
+	}
+	if entries.hasTCP && !entries.hasIP4 && !entries.hasIP6 {
+		return fmt.Errorf("tcp is present without ip or ip6")
+	}
+	if entries.hasUDP6 && !entries.hasIP6 {
+		return fmt.Errorf("udp6 is present without ip6")
+	}
+	if entries.hasTCP6 && !entries.hasIP6 {
+		return fmt.Errorf("tcp6 is present without ip6")
+	}
+	return nil
+}
+
+func (entries endpointEntries) hasUsableDiscoveryEndpoint() bool {
+	return entries.hasIP4 && usableIP(entries.ip4) && entries.udp != 0 ||
+		entries.hasIP6 && usableIP(entries.ip6) && (entries.udp6 != 0 || entries.udp != 0)
+}
+
+func usableIP(addr netip.Addr) bool {
+	return addr.IsValid() && !addr.IsUnspecified() && !addr.IsMulticast()
+}
+
+func (entries endpointEntries) summary() string {
 	var endpoints []string
-	if hasIP4 {
-		endpoints = append(endpoints, fmt.Sprintf("ip=%s udp=%d", ip4, udp))
-		if hasTCP {
-			endpoints[len(endpoints)-1] += fmt.Sprintf(" tcp=%d", tcp)
+	if entries.hasIP4 {
+		fields := []string{fmt.Sprintf("ip=%s", entries.ip4)}
+		if entries.hasUDP {
+			fields = append(fields, fmt.Sprintf("udp=%d", entries.udp))
 		}
-	}
-	if hasIP6 {
-		v6UDP := udp
-		if hasUDP6 {
-			v6UDP = udp6
+		if entries.hasTCP {
+			fields = append(fields, fmt.Sprintf("tcp=%d", entries.tcp))
 		}
-		endpoints = append(endpoints, fmt.Sprintf("ip6=%s udp6=%d", ip6, v6UDP))
-		if hasTCP6 {
-			endpoints[len(endpoints)-1] += fmt.Sprintf(" tcp6=%d", tcp6)
+		endpoints = append(endpoints, strings.Join(fields, " "))
+	}
+	if entries.hasIP6 {
+		fields := []string{fmt.Sprintf("ip6=%s", entries.ip6)}
+		switch {
+		case entries.hasUDP6:
+			fields = append(fields, fmt.Sprintf("udp6=%d", entries.udp6))
+		case entries.hasUDP:
+			fields = append(fields, fmt.Sprintf("udp6=%d", entries.udp))
 		}
-	}
-	return strings.Join(endpoints, "; "), nil
-}
-
-func loadENRIPv4(record *enr.Record) (net.IP, bool, error) {
-	var ip enr.IPv4
-	if err := record.Load(&ip); err != nil {
-		if enr.IsNotFound(err) {
-			return nil, false, nil
+		if entries.hasTCP6 {
+			fields = append(fields, fmt.Sprintf("tcp6=%d", entries.tcp6))
 		}
-		return nil, false, fmt.Errorf("invalid ip entry: %w", err)
+		endpoints = append(endpoints, strings.Join(fields, " "))
 	}
-	ip4 := net.IP(ip).To4()
-	if ip4 == nil {
-		return nil, false, fmt.Errorf("ip entry is not IPv4: %v", net.IP(ip))
-	}
-	if ip4.IsUnspecified() || ip4.IsMulticast() {
-		return nil, false, fmt.Errorf("ip entry is not usable: %v", ip4)
-	}
-	return ip4, true, nil
-}
-
-func loadENRIPv6(record *enr.Record) (net.IP, bool, error) {
-	var ip enr.IPv6
-	if err := record.Load(&ip); err != nil {
-		if enr.IsNotFound(err) {
-			return nil, false, nil
-		}
-		return nil, false, fmt.Errorf("invalid ip6 entry: %w", err)
-	}
-	ip6 := net.IP(ip)
-	if ip6.To16() == nil || ip6.To4() != nil {
-		return nil, false, fmt.Errorf("ip6 entry is not native IPv6: %v", ip6)
-	}
-	if ip6.IsUnspecified() || ip6.IsMulticast() {
-		return nil, false, fmt.Errorf("ip6 entry is not usable: %v", ip6)
-	}
-	return ip6, true, nil
-}
-
-func loadENRUDP(record *enr.Record) (uint16, bool, error) {
-	var port enr.UDP
-	if err := record.Load(&port); err != nil {
-		if enr.IsNotFound(err) {
-			return 0, false, nil
-		}
-		return 0, false, fmt.Errorf("invalid udp entry: %w", err)
-	}
-	if port == 0 {
-		return 0, false, fmt.Errorf("udp entry is zero")
-	}
-	return uint16(port), true, nil
-}
-
-func loadENRUDP6(record *enr.Record) (uint16, bool, error) {
-	var port enr.UDP6
-	if err := record.Load(&port); err != nil {
-		if enr.IsNotFound(err) {
-			return 0, false, nil
-		}
-		return 0, false, fmt.Errorf("invalid udp6 entry: %w", err)
-	}
-	if port == 0 {
-		return 0, false, fmt.Errorf("udp6 entry is zero")
-	}
-	return uint16(port), true, nil
-}
-
-func loadENRTCP(record *enr.Record) (uint16, bool, error) {
-	var port enr.TCP
-	if err := record.Load(&port); err != nil {
-		if enr.IsNotFound(err) {
-			return 0, false, nil
-		}
-		return 0, false, fmt.Errorf("invalid tcp entry: %w", err)
-	}
-	if port == 0 {
-		return 0, false, fmt.Errorf("tcp entry is zero")
-	}
-	return uint16(port), true, nil
-}
-
-func loadENRTCP6(record *enr.Record) (uint16, bool, error) {
-	var port enr.TCP6
-	if err := record.Load(&port); err != nil {
-		if enr.IsNotFound(err) {
-			return 0, false, nil
-		}
-		return 0, false, fmt.Errorf("invalid tcp6 entry: %w", err)
-	}
-	if port == 0 {
-		return 0, false, fmt.Errorf("tcp6 entry is zero")
-	}
-	return uint16(port), true, nil
+	return strings.Join(endpoints, "; ")
 }
 
 func (s *Suite) TestFindnodeResults(t *utesting.T) {

--- a/cmd/devp2p/internal/v5test/discv5tests.go
+++ b/cmd/devp2p/internal/v5test/discv5tests.go
@@ -296,11 +296,11 @@ func validateEndpointPairs(record *enr.Record) (string, error) {
 		return "", err
 	}
 
-	if hasUDP && !hasIP4 {
-		return "", fmt.Errorf("udp is present without ip")
+	if hasUDP && !hasIP4 && !hasIP6 {
+		return "", fmt.Errorf("udp is present without ip or ip6")
 	}
-	if hasTCP && !hasIP4 {
-		return "", fmt.Errorf("tcp is present without ip")
+	if hasTCP && !hasIP4 && !hasIP6 {
+		return "", fmt.Errorf("tcp is present without ip or ip6")
 	}
 	if hasUDP6 && !hasIP6 {
 		return "", fmt.Errorf("udp6 is present without ip6")
@@ -375,9 +375,6 @@ func requireExpectedEndpointEntries(record *enr.Record, wantIPv4, wantIPv6 strin
 		if !hasUDP {
 			return "", fmt.Errorf("missing udp entry")
 		}
-		if !hasTCP {
-			return "", fmt.Errorf("missing tcp entry")
-		}
 		if !ip4.Equal(expectedIPv4) {
 			return "", fmt.Errorf("ip entry got %s, want %s", ip4, expectedIPv4)
 		}
@@ -390,11 +387,8 @@ func requireExpectedEndpointEntries(record *enr.Record, wantIPv4, wantIPv6 strin
 		if !hasIP6 {
 			return "", fmt.Errorf("missing ip6 entry")
 		}
-		if !hasUDP6 {
-			return "", fmt.Errorf("missing udp6 entry")
-		}
-		if !hasTCP6 {
-			return "", fmt.Errorf("missing tcp6 entry")
+		if !hasUDP6 && !hasUDP {
+			return "", fmt.Errorf("missing udp6 entry or udp fallback")
 		}
 		if !ip6.Equal(expectedIPv6) {
 			return "", fmt.Errorf("ip6 entry got %s, want %s", ip6, expectedIPv6)
@@ -409,7 +403,11 @@ func requireExpectedEndpointEntries(record *enr.Record, wantIPv4, wantIPv6 strin
 		}
 	}
 	if hasIP6 {
-		endpoints = append(endpoints, fmt.Sprintf("ip6=%s udp6=%d", ip6, udp6))
+		v6UDP := udp
+		if hasUDP6 {
+			v6UDP = udp6
+		}
+		endpoints = append(endpoints, fmt.Sprintf("ip6=%s udp6=%d", ip6, v6UDP))
 		if hasTCP6 {
 			endpoints[len(endpoints)-1] += fmt.Sprintf(" tcp6=%d", tcp6)
 		}

--- a/cmd/devp2p/internal/v5test/discv5tests.go
+++ b/cmd/devp2p/internal/v5test/discv5tests.go
@@ -18,14 +18,17 @@ package v5test
 
 import (
 	"bytes"
+	"fmt"
 	"net"
 	"slices"
+	"strings"
 	"sync"
 	"time"
 
 	"github.com/ethereum/go-ethereum/internal/utesting"
 	"github.com/ethereum/go-ethereum/p2p/discover/v5wire"
 	"github.com/ethereum/go-ethereum/p2p/enode"
+	"github.com/ethereum/go-ethereum/p2p/enr"
 	"github.com/ethereum/go-ethereum/p2p/netutil"
 )
 
@@ -33,6 +36,8 @@ import (
 type Suite struct {
 	Dest             *enode.Node
 	Listen1, Listen2 string // listening addresses
+	ExpectIP         string
+	ExpectIP6        string
 }
 
 func (s *Suite) listen1(log logger) (*conn, net.PacketConn) {
@@ -248,6 +253,260 @@ func (s *Suite) TestFindnodeZeroDistance(t *utesting.T) {
 	if nodes[0].ID() != conn.remote.ID() {
 		t.Errorf("ID of response node is %v, want %v", nodes[0].ID(), conn.remote.ID())
 	}
+	summary, err := validateEndpointPairs(nodes[0].Record())
+	if err != nil {
+		t.Fatal("self record has invalid endpoint entries:", err)
+	}
+	if s.ExpectIP != "" || s.ExpectIP6 != "" {
+		summary, err = requireExpectedEndpointEntries(nodes[0].Record(), s.ExpectIP, s.ExpectIP6)
+		if err != nil {
+			t.Fatal("self record does not include expected endpoint entries:", err)
+		}
+	}
+	t.Logf("self record seq=%d endpoints: %s", nodes[0].Seq(), summary)
+}
+
+func validateEndpointPairs(record *enr.Record) (string, error) {
+	if record.Seq() == 0 {
+		return "", fmt.Errorf("ENR sequence is zero")
+	}
+
+	ip4, hasIP4, err := loadENRIPv4(record)
+	if err != nil {
+		return "", err
+	}
+	ip6, hasIP6, err := loadENRIPv6(record)
+	if err != nil {
+		return "", err
+	}
+	udp, hasUDP, err := loadENRUDP(record)
+	if err != nil {
+		return "", err
+	}
+	udp6, hasUDP6, err := loadENRUDP6(record)
+	if err != nil {
+		return "", err
+	}
+	tcp, hasTCP, err := loadENRTCP(record)
+	if err != nil {
+		return "", err
+	}
+	tcp6, hasTCP6, err := loadENRTCP6(record)
+	if err != nil {
+		return "", err
+	}
+
+	if hasUDP && !hasIP4 {
+		return "", fmt.Errorf("udp is present without ip")
+	}
+	if hasTCP && !hasIP4 {
+		return "", fmt.Errorf("tcp is present without ip")
+	}
+	if hasUDP6 && !hasIP6 {
+		return "", fmt.Errorf("udp6 is present without ip6")
+	}
+	if hasTCP6 && !hasIP6 {
+		return "", fmt.Errorf("tcp6 is present without ip6")
+	}
+	if hasIP4 && !hasUDP {
+		return "", fmt.Errorf("ip is present without udp")
+	}
+	if hasIP6 && !hasUDP6 && !hasUDP {
+		return "", fmt.Errorf("ip6 is present without udp6 or udp fallback")
+	}
+	if !((hasIP4 && hasUDP) || (hasIP6 && (hasUDP6 || hasUDP))) {
+		return "", fmt.Errorf("ENR has no usable discovery endpoint")
+	}
+
+	var endpoints []string
+	if hasIP4 {
+		endpoints = append(endpoints, fmt.Sprintf("ip=%s udp=%d", ip4, udp))
+		if hasTCP {
+			endpoints[len(endpoints)-1] += fmt.Sprintf(" tcp=%d", tcp)
+		}
+	}
+	if hasIP6 {
+		v6UDP := udp
+		if hasUDP6 {
+			v6UDP = udp6
+		}
+		endpoints = append(endpoints, fmt.Sprintf("ip6=%s udp6=%d", ip6, v6UDP))
+		if hasTCP6 {
+			endpoints[len(endpoints)-1] += fmt.Sprintf(" tcp6=%d", tcp6)
+		}
+	}
+	return strings.Join(endpoints, "; "), nil
+}
+
+func requireExpectedEndpointEntries(record *enr.Record, wantIPv4, wantIPv6 string) (string, error) {
+	ip4, hasIP4, err := loadENRIPv4(record)
+	if err != nil {
+		return "", err
+	}
+	ip6, hasIP6, err := loadENRIPv6(record)
+	if err != nil {
+		return "", err
+	}
+	udp, hasUDP, err := loadENRUDP(record)
+	if err != nil {
+		return "", err
+	}
+	udp6, hasUDP6, err := loadENRUDP6(record)
+	if err != nil {
+		return "", err
+	}
+	tcp, hasTCP, err := loadENRTCP(record)
+	if err != nil {
+		return "", err
+	}
+	tcp6, hasTCP6, err := loadENRTCP6(record)
+	if err != nil {
+		return "", err
+	}
+
+	if wantIPv4 != "" {
+		expectedIPv4 := net.ParseIP(wantIPv4).To4()
+		if expectedIPv4 == nil {
+			return "", fmt.Errorf("invalid expected IPv4 address %q", wantIPv4)
+		}
+		if !hasIP4 {
+			return "", fmt.Errorf("missing ip entry")
+		}
+		if !hasUDP {
+			return "", fmt.Errorf("missing udp entry")
+		}
+		if !hasTCP {
+			return "", fmt.Errorf("missing tcp entry")
+		}
+		if !ip4.Equal(expectedIPv4) {
+			return "", fmt.Errorf("ip entry got %s, want %s", ip4, expectedIPv4)
+		}
+	}
+	if wantIPv6 != "" {
+		expectedIPv6 := net.ParseIP(wantIPv6)
+		if expectedIPv6 == nil || expectedIPv6.To4() != nil {
+			return "", fmt.Errorf("invalid expected IPv6 address %q", wantIPv6)
+		}
+		if !hasIP6 {
+			return "", fmt.Errorf("missing ip6 entry")
+		}
+		if !hasUDP6 {
+			return "", fmt.Errorf("missing udp6 entry")
+		}
+		if !hasTCP6 {
+			return "", fmt.Errorf("missing tcp6 entry")
+		}
+		if !ip6.Equal(expectedIPv6) {
+			return "", fmt.Errorf("ip6 entry got %s, want %s", ip6, expectedIPv6)
+		}
+	}
+
+	var endpoints []string
+	if hasIP4 {
+		endpoints = append(endpoints, fmt.Sprintf("ip=%s udp=%d", ip4, udp))
+		if hasTCP {
+			endpoints[len(endpoints)-1] += fmt.Sprintf(" tcp=%d", tcp)
+		}
+	}
+	if hasIP6 {
+		endpoints = append(endpoints, fmt.Sprintf("ip6=%s udp6=%d", ip6, udp6))
+		if hasTCP6 {
+			endpoints[len(endpoints)-1] += fmt.Sprintf(" tcp6=%d", tcp6)
+		}
+	}
+	return strings.Join(endpoints, "; "), nil
+}
+
+func loadENRIPv4(record *enr.Record) (net.IP, bool, error) {
+	var ip enr.IPv4
+	if err := record.Load(&ip); err != nil {
+		if enr.IsNotFound(err) {
+			return nil, false, nil
+		}
+		return nil, false, fmt.Errorf("invalid ip entry: %w", err)
+	}
+	ip4 := net.IP(ip).To4()
+	if ip4 == nil {
+		return nil, false, fmt.Errorf("ip entry is not IPv4: %v", net.IP(ip))
+	}
+	if ip4.IsUnspecified() || ip4.IsMulticast() {
+		return nil, false, fmt.Errorf("ip entry is not usable: %v", ip4)
+	}
+	return ip4, true, nil
+}
+
+func loadENRIPv6(record *enr.Record) (net.IP, bool, error) {
+	var ip enr.IPv6
+	if err := record.Load(&ip); err != nil {
+		if enr.IsNotFound(err) {
+			return nil, false, nil
+		}
+		return nil, false, fmt.Errorf("invalid ip6 entry: %w", err)
+	}
+	ip6 := net.IP(ip)
+	if ip6.To16() == nil || ip6.To4() != nil {
+		return nil, false, fmt.Errorf("ip6 entry is not native IPv6: %v", ip6)
+	}
+	if ip6.IsUnspecified() || ip6.IsMulticast() {
+		return nil, false, fmt.Errorf("ip6 entry is not usable: %v", ip6)
+	}
+	return ip6, true, nil
+}
+
+func loadENRUDP(record *enr.Record) (uint16, bool, error) {
+	var port enr.UDP
+	if err := record.Load(&port); err != nil {
+		if enr.IsNotFound(err) {
+			return 0, false, nil
+		}
+		return 0, false, fmt.Errorf("invalid udp entry: %w", err)
+	}
+	if port == 0 {
+		return 0, false, fmt.Errorf("udp entry is zero")
+	}
+	return uint16(port), true, nil
+}
+
+func loadENRUDP6(record *enr.Record) (uint16, bool, error) {
+	var port enr.UDP6
+	if err := record.Load(&port); err != nil {
+		if enr.IsNotFound(err) {
+			return 0, false, nil
+		}
+		return 0, false, fmt.Errorf("invalid udp6 entry: %w", err)
+	}
+	if port == 0 {
+		return 0, false, fmt.Errorf("udp6 entry is zero")
+	}
+	return uint16(port), true, nil
+}
+
+func loadENRTCP(record *enr.Record) (uint16, bool, error) {
+	var port enr.TCP
+	if err := record.Load(&port); err != nil {
+		if enr.IsNotFound(err) {
+			return 0, false, nil
+		}
+		return 0, false, fmt.Errorf("invalid tcp entry: %w", err)
+	}
+	if port == 0 {
+		return 0, false, fmt.Errorf("tcp entry is zero")
+	}
+	return uint16(port), true, nil
+}
+
+func loadENRTCP6(record *enr.Record) (uint16, bool, error) {
+	var port enr.TCP6
+	if err := record.Load(&port); err != nil {
+		if enr.IsNotFound(err) {
+			return 0, false, nil
+		}
+		return 0, false, fmt.Errorf("invalid tcp6 entry: %w", err)
+	}
+	if port == 0 {
+		return 0, false, fmt.Errorf("tcp6 entry is zero")
+	}
+	return uint16(port), true, nil
 }
 
 func (s *Suite) TestFindnodeResults(t *utesting.T) {

--- a/cmd/devp2p/internal/v5test/discv5tests.go
+++ b/cmd/devp2p/internal/v5test/discv5tests.go
@@ -42,6 +42,9 @@ type Suite struct {
 	ExpectIP6        netip.Addr
 }
 
+// FindnodeZeroDistanceName is the test name that checks the remote self record.
+const FindnodeZeroDistanceName = "FindnodeZeroDistance"
+
 func (s *Suite) listen1(log logger) (*conn, net.PacketConn) {
 	c := newConn(s.Dest, log)
 	l := c.listen(s.Listen1)
@@ -61,7 +64,7 @@ func (s *Suite) AllTests() []utesting.Test {
 		{Name: "PingMultiIP", Fn: s.TestPingMultiIP},
 		{Name: "HandshakeResend", Fn: s.TestHandshakeResend},
 		{Name: "TalkRequest", Fn: s.TestTalkRequest},
-		{Name: "FindnodeZeroDistance", Fn: s.TestFindnodeZeroDistance},
+		{Name: FindnodeZeroDistanceName, Fn: s.TestFindnodeZeroDistance},
 		{Name: "FindnodeResults", Fn: s.TestFindnodeResults},
 	}
 }
@@ -365,6 +368,18 @@ func loadEntry(record *enr.Record, entry enr.Entry) (bool, error) {
 }
 
 func (entries endpointEntries) checkDanglingPorts() error {
+	if entries.hasUDP && entries.udp == 0 {
+		return fmt.Errorf("udp entry is zero")
+	}
+	if entries.hasTCP && entries.tcp == 0 {
+		return fmt.Errorf("tcp entry is zero")
+	}
+	if entries.hasUDP6 && entries.udp6 == 0 {
+		return fmt.Errorf("udp6 entry is zero")
+	}
+	if entries.hasTCP6 && entries.tcp6 == 0 {
+		return fmt.Errorf("tcp6 entry is zero")
+	}
 	if entries.hasUDP && !entries.hasIP4 && !entries.hasIP6 {
 		return fmt.Errorf("udp is present without ip or ip6")
 	}

--- a/cmd/devp2p/internal/v5test/discv5tests_test.go
+++ b/cmd/devp2p/internal/v5test/discv5tests_test.go
@@ -17,19 +17,20 @@
 package v5test
 
 import (
-	"net"
+	"net/netip"
 	"strings"
 	"testing"
 
+	"github.com/ethereum/go-ethereum/p2p/enode"
 	"github.com/ethereum/go-ethereum/p2p/enr"
 )
 
-func TestValidateEndpointPairsAllowsIPv6UDPFallback(t *testing.T) {
-	record := newTestRecord(
-		enr.IPv6(net.ParseIP("2001:db8::1").To16()),
+func TestCheckSelfRecordAllowsIPv6UDPFallback(t *testing.T) {
+	node := newTestNode(
+		enr.IPv6Addr(mustAddr("2001:db8::1")),
 		enr.UDP(30303),
 	)
-	summary, err := validateEndpointPairs(record)
+	summary, err := checkSelfRecord(node, netip.Addr{}, netip.Addr{})
 	if err != nil {
 		t.Fatalf("expected IPv6 endpoint with UDP fallback to be valid: %v", err)
 	}
@@ -38,13 +39,13 @@ func TestValidateEndpointPairsAllowsIPv6UDPFallback(t *testing.T) {
 	}
 }
 
-func TestValidateEndpointPairsAllowsRedundantUDPWithIPv6Endpoint(t *testing.T) {
-	record := newTestRecord(
-		enr.IPv6(net.ParseIP("2001:db8::1").To16()),
+func TestCheckSelfRecordAllowsRedundantUDPWithIPv6Endpoint(t *testing.T) {
+	node := newTestNode(
+		enr.IPv6Addr(mustAddr("2001:db8::1")),
 		enr.UDP(30303),
 		enr.UDP6(30304),
 	)
-	summary, err := validateEndpointPairs(record)
+	summary, err := checkSelfRecord(node, netip.Addr{}, netip.Addr{})
 	if err != nil {
 		t.Fatalf("expected IPv6 endpoint with redundant UDP to be valid: %v", err)
 	}
@@ -53,21 +54,21 @@ func TestValidateEndpointPairsAllowsRedundantUDPWithIPv6Endpoint(t *testing.T) {
 	}
 }
 
-func TestValidateEndpointPairsRejectsUDPWithoutIPAddress(t *testing.T) {
-	record := newTestRecord(enr.UDP(30303))
-	_, err := validateEndpointPairs(record)
+func TestCheckSelfRecordRejectsUDPWithoutIPAddress(t *testing.T) {
+	node := newTestNode(enr.UDP(30303))
+	_, err := checkSelfRecord(node, netip.Addr{}, netip.Addr{})
 	if err == nil || !strings.Contains(err.Error(), "udp is present without ip or ip6") {
 		t.Fatalf("expected UDP without IP address to be rejected, got %v", err)
 	}
 }
 
-func TestRequireExpectedEndpointEntriesDoesNotRequireTCP(t *testing.T) {
-	record := newTestRecord(
-		enr.IPv4(net.ParseIP("203.0.113.1").To4()),
-		enr.IPv6(net.ParseIP("2001:db8::1").To16()),
+func TestCheckSelfRecordDoesNotRequireTCP(t *testing.T) {
+	node := newTestNode(
+		enr.IPv4Addr(mustAddr("203.0.113.1")),
+		enr.IPv6Addr(mustAddr("2001:db8::1")),
 		enr.UDP(30303),
 	)
-	summary, err := requireExpectedEndpointEntries(record, "203.0.113.1", "2001:db8::1")
+	summary, err := checkSelfRecord(node, mustAddr("203.0.113.1"), mustAddr("2001:db8::1"))
 	if err != nil {
 		t.Fatalf("expected discovery endpoints without TCP entries to be valid: %v", err)
 	}
@@ -79,11 +80,23 @@ func TestRequireExpectedEndpointEntriesDoesNotRequireTCP(t *testing.T) {
 	}
 }
 
-func TestRequireExpectedEndpointEntriesNeedsIPv6DiscoveryPort(t *testing.T) {
-	record := newTestRecord(enr.IPv6(net.ParseIP("2001:db8::1").To16()))
-	_, err := requireExpectedEndpointEntries(record, "", "2001:db8::1")
+func TestCheckSelfRecordNeedsIPv6DiscoveryPort(t *testing.T) {
+	node := newTestNode(enr.IPv6Addr(mustAddr("2001:db8::1")))
+	_, err := checkSelfRecord(node, netip.Addr{}, mustAddr("2001:db8::1"))
 	if err == nil || !strings.Contains(err.Error(), "missing udp6 entry or udp fallback") {
 		t.Fatalf("expected missing IPv6 discovery port error, got %v", err)
+	}
+}
+
+func TestCheckSelfRecordAllowsZeroSequence(t *testing.T) {
+	record := newTestRecord(
+		enr.IPv4Addr(mustAddr("203.0.113.1")),
+		enr.UDP(30303),
+	)
+	record.SetSeq(0)
+	node := enode.SignNull(record, enode.ID{})
+	if _, err := checkSelfRecord(node, netip.Addr{}, netip.Addr{}); err != nil {
+		t.Fatalf("expected sequence zero to be accepted: %v", err)
 	}
 }
 
@@ -94,4 +107,16 @@ func newTestRecord(entries ...enr.Entry) *enr.Record {
 		record.Set(entry)
 	}
 	return &record
+}
+
+func newTestNode(entries ...enr.Entry) *enode.Node {
+	return enode.SignNull(newTestRecord(entries...), enode.ID{})
+}
+
+func mustAddr(raw string) netip.Addr {
+	addr, err := netip.ParseAddr(raw)
+	if err != nil {
+		panic(err)
+	}
+	return addr
 }

--- a/cmd/devp2p/internal/v5test/discv5tests_test.go
+++ b/cmd/devp2p/internal/v5test/discv5tests_test.go
@@ -62,6 +62,56 @@ func TestCheckSelfRecordRejectsUDPWithoutIPAddress(t *testing.T) {
 	}
 }
 
+func TestCheckSelfRecordRejectsZeroPortEntries(t *testing.T) {
+	tests := []struct {
+		name    string
+		entries []enr.Entry
+		wantErr string
+	}{
+		{
+			name: "udp",
+			entries: []enr.Entry{
+				enr.IPv4Addr(mustAddr("203.0.113.1")),
+				enr.UDP(0),
+			},
+			wantErr: "udp entry is zero",
+		},
+		{
+			name: "tcp",
+			entries: []enr.Entry{
+				enr.IPv4Addr(mustAddr("203.0.113.1")),
+				enr.TCP(0),
+			},
+			wantErr: "tcp entry is zero",
+		},
+		{
+			name: "udp6",
+			entries: []enr.Entry{
+				enr.IPv6Addr(mustAddr("2001:db8::1")),
+				enr.UDP6(0),
+			},
+			wantErr: "udp6 entry is zero",
+		},
+		{
+			name: "tcp6",
+			entries: []enr.Entry{
+				enr.IPv6Addr(mustAddr("2001:db8::1")),
+				enr.TCP6(0),
+			},
+			wantErr: "tcp6 entry is zero",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			node := newTestNode(tt.entries...)
+			_, err := checkSelfRecord(node, netip.Addr{}, netip.Addr{})
+			if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
+				t.Fatalf("expected %q error, got %v", tt.wantErr, err)
+			}
+		})
+	}
+}
+
 func TestCheckSelfRecordDoesNotRequireTCP(t *testing.T) {
 	node := newTestNode(
 		enr.IPv4Addr(mustAddr("203.0.113.1")),

--- a/cmd/devp2p/internal/v5test/discv5tests_test.go
+++ b/cmd/devp2p/internal/v5test/discv5tests_test.go
@@ -1,0 +1,97 @@
+// Copyright 2026 The go-ethereum Authors
+// This file is part of go-ethereum.
+//
+// go-ethereum is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// go-ethereum is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with go-ethereum. If not, see <http://www.gnu.org/licenses/>.
+
+package v5test
+
+import (
+	"net"
+	"strings"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/p2p/enr"
+)
+
+func TestValidateEndpointPairsAllowsIPv6UDPFallback(t *testing.T) {
+	record := newTestRecord(
+		enr.IPv6(net.ParseIP("2001:db8::1").To16()),
+		enr.UDP(30303),
+	)
+	summary, err := validateEndpointPairs(record)
+	if err != nil {
+		t.Fatalf("expected IPv6 endpoint with UDP fallback to be valid: %v", err)
+	}
+	if !strings.Contains(summary, "ip6=2001:db8::1 udp6=30303") {
+		t.Fatalf("unexpected endpoint summary %q", summary)
+	}
+}
+
+func TestValidateEndpointPairsAllowsRedundantUDPWithIPv6Endpoint(t *testing.T) {
+	record := newTestRecord(
+		enr.IPv6(net.ParseIP("2001:db8::1").To16()),
+		enr.UDP(30303),
+		enr.UDP6(30304),
+	)
+	summary, err := validateEndpointPairs(record)
+	if err != nil {
+		t.Fatalf("expected IPv6 endpoint with redundant UDP to be valid: %v", err)
+	}
+	if !strings.Contains(summary, "ip6=2001:db8::1 udp6=30304") {
+		t.Fatalf("unexpected endpoint summary %q", summary)
+	}
+}
+
+func TestValidateEndpointPairsRejectsUDPWithoutIPAddress(t *testing.T) {
+	record := newTestRecord(enr.UDP(30303))
+	_, err := validateEndpointPairs(record)
+	if err == nil || !strings.Contains(err.Error(), "udp is present without ip or ip6") {
+		t.Fatalf("expected UDP without IP address to be rejected, got %v", err)
+	}
+}
+
+func TestRequireExpectedEndpointEntriesDoesNotRequireTCP(t *testing.T) {
+	record := newTestRecord(
+		enr.IPv4(net.ParseIP("203.0.113.1").To4()),
+		enr.IPv6(net.ParseIP("2001:db8::1").To16()),
+		enr.UDP(30303),
+	)
+	summary, err := requireExpectedEndpointEntries(record, "203.0.113.1", "2001:db8::1")
+	if err != nil {
+		t.Fatalf("expected discovery endpoints without TCP entries to be valid: %v", err)
+	}
+	if !strings.Contains(summary, "ip=203.0.113.1 udp=30303") {
+		t.Fatalf("summary missing IPv4 endpoint: %q", summary)
+	}
+	if !strings.Contains(summary, "ip6=2001:db8::1 udp6=30303") {
+		t.Fatalf("summary missing IPv6 endpoint: %q", summary)
+	}
+}
+
+func TestRequireExpectedEndpointEntriesNeedsIPv6DiscoveryPort(t *testing.T) {
+	record := newTestRecord(enr.IPv6(net.ParseIP("2001:db8::1").To16()))
+	_, err := requireExpectedEndpointEntries(record, "", "2001:db8::1")
+	if err == nil || !strings.Contains(err.Error(), "missing udp6 entry or udp fallback") {
+		t.Fatalf("expected missing IPv6 discovery port error, got %v", err)
+	}
+}
+
+func newTestRecord(entries ...enr.Entry) *enr.Record {
+	var record enr.Record
+	record.SetSeq(1)
+	for _, entry := range entries {
+		record.Set(entry)
+	}
+	return &record
+}

--- a/cmd/devp2p/internal/v5test/framework.go
+++ b/cmd/devp2p/internal/v5test/framework.go
@@ -99,7 +99,7 @@ func (tc *conn) setEndpoint(c net.PacketConn) {
 }
 
 func (tc *conn) listen(ip string) net.PacketConn {
-	l, err := net.ListenPacket("udp", fmt.Sprintf("%v:0", ip))
+	l, err := net.ListenPacket("udp", net.JoinHostPort(ip, "0"))
 	if err != nil {
 		panic(err)
 	}

--- a/cmd/devp2p/runtest.go
+++ b/cmd/devp2p/runtest.go
@@ -77,6 +77,16 @@ var (
 		Value:    v4test.Listen2,
 		Category: flags.TestingCategory,
 	}
+	testExpectedIPFlag = &cli.StringFlag{
+		Name:     "expect-ip",
+		Usage:    "IPv4 address expected in the remote node's discv5 self record",
+		Category: flags.TestingCategory,
+	}
+	testExpectedIP6Flag = &cli.StringFlag{
+		Name:     "expect-ip6",
+		Usage:    "IPv6 address expected in the remote node's discv5 self record",
+		Category: flags.TestingCategory,
+	}
 )
 
 func runTests(ctx *cli.Context, tests []utesting.Test) error {


### PR DESCRIPTION
## Summary

- Add a discv4 protocol test that bonds a synthetic peer with distinct UDP and TCP ports, then verifies FINDNODE/NEIGHBORS preserves both endpoint ports.
- Extend the discv5 FINDNODE zero-distance test to validate the returned self ENR endpoint entries are usable and internally paired.
- Add optional `devp2p discv5 test` flags for expected IPv4 and IPv6 self-record endpoint addresses so external harnesses can validate configured dual-stack advertisements.
- Make the discv5 test listener use `net.JoinHostPort` so IPv6 listen addresses work.

## Validation

- `go test ./cmd/devp2p/...`
- `go test ./p2p/discover/... ./p2p/enode/... ./p2p/enr/...`
- `go build ./cmd/devp2p`
- `git diff --check`

## Related

- Hive integration PR: https://github.com/ethereum/hive/pull/1598