### PR TITLE
eth/protocols/eth: fix deadlock when re-requesting partial receipts

### DIFF
--- a/eth/protocols/eth/dispatcher.go
+++ b/eth/protocols/eth/dispatcher.go
@@ -277,9 +277,6 @@ loop:
 				resendOp.fail <- err
 				continue loop
 			}
-			// Restart the RTT measurement for the follow-up round, so the
-			// response time doesn't span multiple network round trips.
-			req.Sent = time.Now()
 			resendOp.fail <- nil
 
 		case cancelOp := <-p.reqCancel:

--- a/eth/protocols/eth/dispatcher.go
+++ b/eth/protocols/eth/dispatcher.go
@@ -94,6 +94,18 @@ type cancel struct {
 	fail chan error
 }
 
+// resend is a maintenance type on the dispatcher to send a follow-up packet
+// continuing a pending request under its original id. Routing it through the
+// dispatcher serializes the continuation against cancellation: the follow-up
+// is only sent if the original request is still pending.
+type resend struct {
+	id   uint64      // Request ID to continue
+	code uint64      // Message code of the follow-up packet
+	size int         // Number of items requested by the follow-up
+	data interface{} // Data content of the follow-up packet
+	fail chan error
+}
+
 // Response is a reply packet to a previously created request. It is delivered
 // on the channel assigned by the requester subsystem and contains the original
 // request embedded to allow uniquely matching it caller side.
@@ -133,6 +145,25 @@ func (p *Peer) dispatchRequest(req *Request) error {
 	select {
 	case p.reqDispatch <- reqOp:
 		return <-reqOp.fail
+	case <-p.term:
+		return errDisconnected
+	}
+}
+
+// dispatchResend schedules a follow-up packet continuing a pending request,
+// blocking until it's sent. The follow-up is silently dropped if the original
+// request has already been cancelled or fulfilled.
+func (p *Peer) dispatchResend(id uint64, code uint64, size int, data interface{}) error {
+	resendOp := &resend{
+		id:   id,
+		code: code,
+		size: size,
+		data: data,
+		fail: make(chan error),
+	}
+	select {
+	case p.reqResend <- resendOp:
+		return <-resendOp.fail
 	case <-p.term:
 		return errDisconnected
 	}
@@ -213,12 +244,36 @@ loop:
 				reqOp.fail <- err
 				continue loop
 			}
-
-			// do not overwrite if it is re-request
-			if _, ok := pending[req.id]; !ok {
-				pending[req.id] = req
-			}
+			pending[req.id] = req
 			reqOp.fail <- nil
+
+		case resendOp := <-p.reqResend:
+			// Only continue a request that is still pending: if it has been
+			// cancelled or fulfilled in the meantime, drop the follow-up
+			// silently instead of re-requesting on behalf of nobody.
+			req := pending[resendOp.id]
+			if req == nil {
+				resendOp.fail <- nil
+				continue loop
+			}
+			treq := tracker.Request{
+				ID:       req.id,
+				ReqCode:  req.code,
+				RespCode: req.want,
+				Size:     resendOp.size,
+			}
+			if err := p.tracker.Track(treq); err != nil {
+				resendOp.fail <- err
+				continue loop
+			}
+			if err := p2p.Send(p.rw, resendOp.code, resendOp.data); err != nil {
+				resendOp.fail <- err
+				continue loop
+			}
+			// Restart the RTT measurement for the follow-up round, so the
+			// response time doesn't span multiple network round trips.
+			req.Sent = time.Now()
+			resendOp.fail <- nil
 
 		case cancelOp := <-p.reqCancel:
 			// Retrieve the pending request to cancel and short circuit if it

--- a/eth/protocols/eth/dispatcher.go
+++ b/eth/protocols/eth/dispatcher.go
@@ -52,6 +52,7 @@ type Request struct {
 	want     uint64      // Message code of the response packet
 	numItems int         // Number of requested items
 	data     interface{} // Data content of the request packet
+	cleanup  func()      // Optional callback to release protocol-specific state if the request dies unfulfilled
 
 	Peer string    // Demultiplexer if cross-peer requests are batched together
 	Sent time.Time // Timestamp when the request was sent
@@ -237,10 +238,16 @@ loop:
 				Size:     req.numItems,
 			}
 			if err := p.tracker.Track(treq); err != nil {
+				if req.cleanup != nil {
+					req.cleanup()
+				}
 				reqOp.fail <- err
 				continue loop
 			}
 			if err := p2p.Send(p.rw, req.code, req.data); err != nil {
+				if req.cleanup != nil {
+					req.cleanup()
+				}
 				reqOp.fail <- err
 				continue loop
 			}
@@ -283,15 +290,12 @@ loop:
 				cancelOp.fail <- nil
 				continue
 			}
-			// Stop tracking the request
+			// Stop tracking the request and release any protocol-specific
+			// state tied to it.
 			delete(pending, cancelOp.id)
-
-			// Not sure if the request is about the receipt, but remove it anyway.
-			// TODO(rjl493456442, bosul): investigate whether we can avoid leaking peer fields here.
-			p.receiptBufferLock.Lock()
-			delete(p.receiptBuffer, cancelOp.id)
-			p.receiptBufferLock.Unlock()
-
+			if req.cleanup != nil {
+				req.cleanup()
+			}
 			cancelOp.fail <- nil
 
 		case resOp := <-p.resDispatch:

--- a/eth/protocols/eth/peer.go
+++ b/eth/protocols/eth/peer.go
@@ -468,6 +468,14 @@ func (p *Peer) RequestReceipts(hashes []common.Hash, gasUsed []uint64, timestamp
 				FirstBlockReceiptIndex: 0,
 				GetReceiptsRequest:     hashes,
 			},
+			// The buffer entry lives and dies with the request: the dispatcher
+			// releases it if the request is cancelled or fails to send, while
+			// a completed response consumes it on the delivery path.
+			cleanup: func() {
+				p.receiptBufferLock.Lock()
+				delete(p.receiptBuffer, id)
+				p.receiptBufferLock.Unlock()
+			},
 		}
 		p.receiptBufferLock.Lock()
 		p.receiptBuffer[id] = &receiptRequest{
@@ -490,12 +498,6 @@ func (p *Peer) RequestReceipts(hashes []common.Hash, gasUsed []uint64, timestamp
 		}
 	}
 	if err := p.dispatchRequest(req); err != nil {
-		// Clean the buffer entry up if the request never made it out.
-		if p.version > ETH69 {
-			p.receiptBufferLock.Lock()
-			delete(p.receiptBuffer, id)
-			p.receiptBufferLock.Unlock()
-		}
 		return nil, err
 	}
 	return req, nil

--- a/eth/protocols/eth/peer.go
+++ b/eth/protocols/eth/peer.go
@@ -496,30 +496,39 @@ func (p *Peer) RequestReceipts(hashes []common.Hash, gasUsed []uint64, timestamp
 // HandlePartialReceipts re-request partial receipts
 func (p *Peer) requestPartialReceipts(id uint64) error {
 	p.receiptBufferLock.Lock()
-	defer p.receiptBufferLock.Unlock()
 
 	// Do not re-request for the stale request
-	if _, ok := p.receiptBuffer[id]; !ok {
+	buffer, ok := p.receiptBuffer[id]
+	if !ok {
+		p.receiptBufferLock.Unlock()
 		return nil
 	}
-	lastBlock := len(p.receiptBuffer[id].list) - 1
-	lastReceipt := p.receiptBuffer[id].list[lastBlock].items.Len()
+	lastBlock := len(buffer.list) - 1
+	lastReceipt := buffer.list[lastBlock].items.Len()
 
-	hashes := p.receiptBuffer[id].request[lastBlock:]
+	hashes := buffer.request[lastBlock:]
+	p.receiptBufferLock.Unlock()
 
-	req := &Request{
-		id:   id,
-		sink: nil,
-		code: GetReceiptsMsg,
-		want: ReceiptsMsg,
-		data: &GetReceiptsPacket70{
-			RequestId:              id,
-			FirstBlockReceiptIndex: uint64(lastReceipt),
-			GetReceiptsRequest:     hashes,
-		},
-		numItems: len(hashes),
+	// The follow-up continues the original request and reuses its id, so it is
+	// sent directly instead of being dispatched: the original request is the
+	// one pending in the dispatcher and the one the completed response will be
+	// delivered to. Going through the dispatcher would also deadlock the peer,
+	// as the buffer lock would have to be held across the dispatch, which the
+	// dispatcher itself acquires when a request is cancelled.
+	treq := tracker.Request{
+		ID:       id,
+		ReqCode:  GetReceiptsMsg,
+		RespCode: ReceiptsMsg,
+		Size:     len(hashes),
 	}
-	return p.dispatchRequest(req)
+	if err := p.tracker.Track(treq); err != nil {
+		return err
+	}
+	return p2p.Send(p.rw, GetReceiptsMsg, &GetReceiptsPacket70{
+		RequestId:              id,
+		FirstBlockReceiptIndex: uint64(lastReceipt),
+		GetReceiptsRequest:     hashes,
+	})
 }
 
 // bufferReceipts validates a receipt packet and buffer the incomplete packet.

--- a/eth/protocols/eth/peer.go
+++ b/eth/protocols/eth/peer.go
@@ -76,6 +76,7 @@ type Peer struct {
 	tracker     *tracker.Tracker
 	reqDispatch chan *request  // Dispatch channel to send requests and track then until fulfillment
 	reqCancel   chan *cancel   // Dispatch channel to cancel pending requests and untrack them
+	reqResend   chan *resend   // Dispatch channel to send follow-ups for still-pending requests
 	resDispatch chan *response // Dispatch channel to fulfil pending requests and untrack them
 
 	chainConfig *params.ChainConfig // Chain configuration for fork-aware validation
@@ -102,6 +103,7 @@ func NewPeer(version uint, p *p2p.Peer, rw p2p.MsgReadWriter, txpool TxPool, blo
 		tracker:       tracker.New(cap, id, 5*time.Minute),
 		reqDispatch:   make(chan *request),
 		reqCancel:     make(chan *cancel),
+		reqResend:     make(chan *resend),
 		resDispatch:   make(chan *response),
 		txpool:        txpool,
 		blobpool:      blobpool,
@@ -488,12 +490,19 @@ func (p *Peer) RequestReceipts(hashes []common.Hash, gasUsed []uint64, timestamp
 		}
 	}
 	if err := p.dispatchRequest(req); err != nil {
+		// Clean the buffer entry up if the request never made it out.
+		if p.version > ETH69 {
+			p.receiptBufferLock.Lock()
+			delete(p.receiptBuffer, id)
+			p.receiptBufferLock.Unlock()
+		}
 		return nil, err
 	}
 	return req, nil
 }
 
-// HandlePartialReceipts re-request partial receipts
+// requestPartialReceipts re-requests the remainder of a partially delivered
+// receipt request under its original id.
 func (p *Peer) requestPartialReceipts(id uint64) error {
 	p.receiptBufferLock.Lock()
 
@@ -509,22 +518,11 @@ func (p *Peer) requestPartialReceipts(id uint64) error {
 	hashes := buffer.request[lastBlock:]
 	p.receiptBufferLock.Unlock()
 
-	// The follow-up continues the original request and reuses its id, so it is
-	// sent directly instead of being dispatched: the original request is the
-	// one pending in the dispatcher and the one the completed response will be
-	// delivered to. Going through the dispatcher would also deadlock the peer,
-	// as the buffer lock would have to be held across the dispatch, which the
-	// dispatcher itself acquires when a request is cancelled.
-	treq := tracker.Request{
-		ID:       id,
-		ReqCode:  GetReceiptsMsg,
-		RespCode: ReceiptsMsg,
-		Size:     len(hashes),
-	}
-	if err := p.tracker.Track(treq); err != nil {
-		return err
-	}
-	return p2p.Send(p.rw, GetReceiptsMsg, &GetReceiptsPacket70{
+	// The follow-up continues the original request under its original id,
+	// hand it to the dispatcher as a resend operation. The dispatcher only
+	// sends it if the original request is still pending, or silently drop
+	// the request if the original one is cancelled (with no error returned).
+	return p.dispatchResend(id, GetReceiptsMsg, len(hashes), &GetReceiptsPacket70{
 		RequestId:              id,
 		FirstBlockReceiptIndex: uint64(lastReceipt),
 		GetReceiptsRequest:     hashes,


### PR DESCRIPTION
When an eth/70 receipts response arrives with LastBlockIncomplete set, requestPartialReceipts held receiptBufferLock across dispatchRequest, which blocks until the dispatcher loop accepts the request. If the dispatcher is concurrently handling a cancellation for that peer (requester timeout or shutdown), its cancel branch acquires the same receiptBufferLock; an AB-BA deadlock. The dispatcher waits for the lock the re-request holds; the re-request waits to send on the channel whose only reader is the dispatcher. The dispatcher loop never runs again, so every request on that peer stalls permanently and the sync slot is never released. The race detector stays quiet; a lock-ordering problem, not a data race.

The fix releases the lock before sending, and sends the follow-up directly (tracker.Track + p2p.Send, the same pattern RequestPayload and RequestTxs already use) instead of going through the dispatcher. The follow-up reuses the original request ID: in the dispatcher’s pending map the original request and its sink stay in place, so the completed response is delivered to the original requester, while the tracker entry for the ID; just fulfilled by the partial response; is re-registered for the follow-up.

I didn’t add a committed test: driving the interleaving deterministically needs sleeps and reaches into peer internals, so it would be flaky in CI. Two further checks with the same harness:

Merely releasing the lock before dispatchRequest, without sending directly, trades the deadlock for an equivalent permanent stall; if the cancellation lands first the re-request registers itself in pending, and a later response then blocks forever on its nil sink (reader hung in 10 of 20 rounds; sending directly, 0 of 20). That is why the fix bypasses the dispatcher rather than only moving the unlock.
Normal flow is intact: with the original still pending, the follow-up is sent with the expected FirstBlockReceiptIndex and hash list, and the completing response reaches the original requester’s sink. (TestGetBlockPartialReceipts covers only the serving side, so this client path had no existing coverage.)
go test ./eth/protocols/eth/... ./eth/downloader/... ./eth/, with and without -race, passes. 

Happy to share the harness if it’s useful for review.