### PR TITLE
eth, blobpool: reconcile cell fetching after custody updates

### DIFF
--- a/core/txpool/blobpool/blobpool.go
+++ b/core/txpool/blobpool/blobpool.go
@@ -118,6 +118,10 @@ const (
 
 var errLegacyTx = errors.New("legacy transaction format")
 
+// ErrBlobTxNotFound is returned when cell delivery targets a transaction that
+// is not currently tracked by the blobpool.
+var ErrBlobTxNotFound = errors.New("blob transaction not found")
+
 // blobTxMeta is the minimal subset of types.BlobTx necessary to validate and
 // schedule the blob transactions into the following blocks. Only ever add the
 // bare minimum needed fields to keep the size down (and thus number of entries
@@ -2638,7 +2642,148 @@ func (p *BlobPool) GetCustody(hash common.Hash) *types.CustodyBitmap {
 	p.lock.RLock()
 	defer p.lock.RUnlock()
 	if meta := p.lookup.txIndex[hash]; meta != nil {
-		return &meta.custody
+		custody := meta.custody
+		return &custody
 	}
 	return nil
+}
+
+// MergeCells verifies and merges additional cells into an existing pooled
+// transaction. It returns the peers whose deliveries failed verification.
+func (p *BlobPool) MergeCells(hash common.Hash, deliveries map[string]*PeerDelivery) ([]string, error) {
+	p.lock.Lock()
+	defer p.lock.Unlock()
+
+	lookupMeta := p.lookup.txIndex[hash]
+	if lookupMeta == nil {
+		return nil, fmt.Errorf("%w: %s", ErrBlobTxNotFound, hash)
+	}
+	data, err := p.store.Get(lookupMeta.id)
+	if err != nil {
+		return nil, err
+	}
+	var ptx BlobTxForPool
+	if err := rlp.DecodeBytes(data, &ptx); err != nil {
+		return nil, err
+	}
+	if ptx.CellSidecar == nil {
+		return nil, errors.New("blob transaction sidecar missing")
+	}
+	from, err := types.Sender(p.signer, ptx.Tx)
+	if err != nil {
+		return nil, err
+	}
+	var meta *blobTxMeta
+	for _, candidate := range p.index[from] {
+		if candidate.hash == hash {
+			meta = candidate
+			break
+		}
+	}
+	if meta == nil || meta.id != lookupMeta.id {
+		return nil, errors.New("blob transaction metadata missing")
+	}
+	sidecar := ptx.CellSidecar
+	var badPeers []string
+	for peer, delivery := range deliveries {
+		candidate := &types.BlobTxCellSidecar{
+			Version:     sidecar.Version,
+			Cells:       delivery.Cells,
+			Commitments: sidecar.Commitments,
+			Proofs:      sidecar.Proofs,
+			Custody:     types.NewCustodyBitmap(delivery.Indices),
+		}
+		if err := txpool.ValidateCells(candidate); err != nil {
+			badPeers = append(badPeers, peer)
+		}
+	}
+	if len(badPeers) > 0 {
+		return badPeers, nil
+	}
+
+	merged, changed, err := mergeCellDeliveries(sidecar, deliveries)
+	if err != nil || !changed {
+		return nil, err
+	}
+	ptx.CellSidecar = merged
+	blob, err := rlp.EncodeToBytes(&ptx)
+	if err != nil {
+		return nil, err
+	}
+	newID, err := p.store.Put(blob)
+	if err != nil {
+		return nil, err
+	}
+	newStorageSize := p.store.Size(newID)
+	oldID := lookupMeta.id
+	if err := p.store.Delete(oldID); err != nil {
+		if cleanupErr := p.store.Delete(newID); cleanupErr != nil {
+			log.Error("Failed to roll back merged blob transaction", "id", newID, "err", cleanupErr)
+		}
+		return nil, fmt.Errorf("failed to delete superseded blob transaction %d: %w", oldID, err)
+	}
+	oldStorageSize := meta.storageSize
+	meta.id = newID
+	meta.storageSize = newStorageSize
+	meta.size = ptx.txSize()
+	meta.sizeWithoutBlob = ptx.txSizeWithoutBlob()
+	meta.custody = &ptx.CellSidecar.Custody
+
+	lookupMeta.id = newID
+	lookupMeta.size = meta.size
+	lookupMeta.sizeWithoutBlob = meta.sizeWithoutBlob
+	lookupMeta.custody = ptx.CellSidecar.Custody
+	p.stored = p.stored - uint64(oldStorageSize) + uint64(newStorageSize)
+	p.updateStorageMetrics()
+	return nil, nil
+}
+
+func mergeCellDeliveries(sidecar *types.BlobTxCellSidecar, deliveries map[string]*PeerDelivery) (*types.BlobTxCellSidecar, bool, error) {
+	blobCount := len(sidecar.Commitments)
+	oldIndices := sidecar.Custody.Indices()
+	if len(sidecar.Cells) != blobCount*len(oldIndices) {
+		return nil, false, errors.New("invalid stored cell count")
+	}
+	mergedCustody := sidecar.Custody
+	for _, delivery := range deliveries {
+		if len(delivery.Cells) != blobCount*len(delivery.Indices) {
+			return nil, false, errors.New("invalid delivered cell count")
+		}
+		mergedCustody = mergedCustody.Union(types.NewCustodyBitmap(delivery.Indices))
+	}
+	if mergedCustody == sidecar.Custody {
+		return sidecar, false, nil
+	}
+	byBlob := make([]map[uint64]kzg4844.Cell, blobCount)
+	for blob := range blobCount {
+		byBlob[blob] = make(map[uint64]kzg4844.Cell, mergedCustody.OneCount())
+		for pos, index := range oldIndices {
+			byBlob[blob][index] = sidecar.Cells[blob*len(oldIndices)+pos]
+		}
+	}
+	for _, delivery := range deliveries {
+		for blob := range blobCount {
+			for pos, index := range delivery.Indices {
+				byBlob[blob][index] = delivery.Cells[blob*len(delivery.Indices)+pos]
+			}
+		}
+	}
+	indices := mergedCustody.Indices()
+	cells := make([]kzg4844.Cell, 0, blobCount*len(indices))
+	for blob := range blobCount {
+		for _, index := range indices {
+			cell, ok := byBlob[blob][index]
+			if !ok {
+				return nil, false, errors.New("missing merged cell")
+			}
+			cells = append(cells, cell)
+		}
+	}
+	return &types.BlobTxCellSidecar{
+		Version:     sidecar.Version,
+		Cells:       cells,
+		Commitments: sidecar.Commitments,
+		Proofs:      sidecar.Proofs,
+		Custody:     mergedCustody,
+	}, true, nil
 }

--- a/core/txpool/blobpool/blobpool_test.go
+++ b/core/txpool/blobpool/blobpool_test.go
@@ -2439,3 +2439,96 @@ func TestGetCells(t *testing.T) {
 		})
 	}
 }
+
+func TestMergeCells(t *testing.T) {
+	storage := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(storage, pendingTransactionStore), 0700); err != nil {
+		t.Fatal(err)
+	}
+	store, err := billy.Open(billy.Options{Path: filepath.Join(storage, pendingTransactionStore)}, newSlotterEIP7594(params.BlobTxMaxBlobs), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	key, _ := crypto.GenerateKey()
+	tx := makeMultiBlobTx(0, 1, 1000, 100, 2, 0, key)
+	ptx, err := newBlobTxForPool(tx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	selectCells := func(mask types.CustodyBitmap) []kzg4844.Cell {
+		var cells []kzg4844.Cell
+		for blob := range len(ptx.CellSidecar.Commitments) {
+			for _, index := range mask.Indices() {
+				cells = append(cells, ptx.CellSidecar.Cells[blob*kzg4844.CellsPerBlob+int(index)])
+			}
+		}
+		return cells
+	}
+	stored := types.NewCustodyBitmap([]uint64{0, 1, 2, 3})
+	delta := types.NewCustodyBitmap([]uint64{4, 5})
+	allCells := ptx.CellSidecar.Cells
+	ptx.CellSidecar.Cells = selectCells(stored)
+	ptx.CellSidecar.Custody = stored
+	blob, err := rlp.EncodeToBytes(ptx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.Put(blob); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	statedb, _ := state.New(types.EmptyRootHash, state.NewDatabaseForTesting())
+	statedb.AddBalance(crypto.PubkeyToAddress(key.PublicKey), uint256.NewInt(1_000_000_000), tracing.BalanceChangeUnspecified)
+	statedb.Commit(params.Rules{IsEIP158: true}, 0)
+	chain := &testBlockChain{
+		config:  params.MainnetChainConfig,
+		basefee: uint256.NewInt(params.InitialBaseFee),
+		blobfee: uint256.NewInt(params.BlobTxMinBlobGasprice),
+		statedb: statedb,
+	}
+	pool := New(Config{Datadir: storage}, chain, nil)
+	if err := pool.Init(1, chain.CurrentBlock(), newReserver()); err != nil {
+		t.Fatal(err)
+	}
+	defer pool.Close()
+
+	deltaCells := make([]kzg4844.Cell, 0, len(delta.Indices())*len(ptx.CellSidecar.Commitments))
+	for blob := range len(ptx.CellSidecar.Commitments) {
+		for _, index := range delta.Indices() {
+			deltaCells = append(deltaCells, allCells[blob*kzg4844.CellsPerBlob+int(index)])
+		}
+	}
+	badPeers, err := pool.MergeCells(tx.Hash(), map[string]*PeerDelivery{
+		"peer": {Cells: deltaCells, Indices: delta.Indices()},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(badPeers) != 0 {
+		t.Fatalf("valid delivery rejected from peers %v", badPeers)
+	}
+	wantCustody := stored.Union(delta)
+	if got := pool.GetCustody(tx.Hash()); got == nil || *got != wantCustody {
+		t.Fatalf("custody mismatch: got %v, want %v", got, wantCustody)
+	}
+	cells, _, err := pool.GetBlobCells(pool.GetBlobHashes(tx.Hash()), wantCustody)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for blob, got := range cells {
+		if len(got) != wantCustody.OneCount() {
+			t.Fatalf("blob %d returned %d cells, want %d", blob, len(got), wantCustody.OneCount())
+		}
+		for i, cell := range got {
+			if cell == nil {
+				t.Fatalf("blob %d cell %d is missing", blob, i)
+			}
+		}
+	}
+	if _, err := pool.MergeCells(common.HexToHash("0xdead"), nil); !errors.Is(err, ErrBlobTxNotFound) {
+		t.Fatalf("missing transaction error mismatch: got %v, want %v", err, ErrBlobTxNotFound)
+	}
+}

--- a/core/txpool/blobpool/cache.go
+++ b/core/txpool/blobpool/cache.go
@@ -265,7 +265,7 @@ func (c *Cache) GetCells(vhashes []common.Hash, mask types.CustodyBitmap) ([][]*
 	c.mu.Lock()
 	for vhash, idxs := range indices {
 		cached, ok := c.entries[vhash]
-		if !ok || cached.cell == nil {
+		if !ok || cached.cell == nil || mask.Difference(cached.custody).OneCount() > 0 {
 			// Entries loaded in blob mode carry no cells; fall back to
 			// the blobpool instead of serving null cells for a blob
 			// that is actually available.

--- a/eth/fetcher/blob_fetcher.go
+++ b/eth/fetcher/blob_fetcher.go
@@ -64,6 +64,7 @@ type blobTxAnnounce struct {
 	origin string              // Identifier of the peer that sent the announcement
 	txs    []common.Hash       // Hashes of transactions announced
 	cells  types.CustodyBitmap // Custody information of transactions being announced
+	pooled map[common.Hash]types.CustodyBitmap
 }
 
 type cellRequest struct {
@@ -80,8 +81,9 @@ type payloadDelivery struct {
 }
 
 type cellWithSeq struct {
-	seq   uint64
-	cells types.CustodyBitmap
+	seq       uint64
+	cells     types.CustodyBitmap
+	available types.CustodyBitmap
 }
 
 // PeerCellDelivery holds cells delivered by a single peer.
@@ -92,12 +94,13 @@ type PeerCellDelivery struct {
 
 type fetchStatus struct {
 	fetching   types.CustodyBitmap          // To avoid fetching cells which had already been fetched / currently being fetched
-	fetched    []uint64                     // Custody indices that have been fetched (per-blob, same for all blobs)
+	fetched    types.CustodyBitmap          // Custody indices that have been fetched (per-blob, same for all blobs)
 	deliveries map[string]*PeerCellDelivery // Per-peer cell deliveries
 }
 
 type BlobFetcherFunctions struct {
 	HasPayload    func(common.Hash) bool
+	GetCustody    func(common.Hash) *types.CustodyBitmap
 	AddCells      func(common.Hash, map[string]*PeerCellDelivery, types.CustodyBitmap)
 	FetchPayloads func(string, []common.Hash, types.CustodyBitmap) error
 	DropPeer      func(string)
@@ -141,6 +144,7 @@ type BlobFetcher struct {
 	fetches    map[common.Hash]*fetchStatus                   // Hash -> Bitmap, in-flight transaction cells
 	requests   map[string][]*cellRequest                      // In-flight transaction retrievals
 	alternates map[common.Hash]map[string]types.CustodyBitmap // In-flight transaction alternate origins (in case the peer is dropped)
+	sources    map[common.Hash]map[string]types.CustodyBitmap // Peer availability retained for pooled partial transactions
 
 	fn               BlobFetcherFunctions // callbacks
 	fetchProbability uint64
@@ -179,6 +183,7 @@ func NewBlobFetcher(fn BlobFetcherFunctions, custody types.CustodyBitmap, rand r
 		fetches:          make(map[common.Hash]*fetchStatus),
 		requests:         make(map[string][]*cellRequest),
 		alternates:       make(map[common.Hash]map[string]types.CustodyBitmap),
+		sources:          make(map[common.Hash]map[string]types.CustodyBitmap),
 		peerTokens:       make(map[string]*token),
 		fn:               fn,
 		fetchProbability: fetchProbability,
@@ -192,15 +197,23 @@ func NewBlobFetcher(fn BlobFetcherFunctions, custody types.CustodyBitmap, rand r
 // Notify is called when a Type 3 transaction is observed on the network. (TransactionPacket / NewPooledTransactionHashesPacket)
 func (f *BlobFetcher) Notify(peer string, txs []common.Hash, cells types.CustodyBitmap) error {
 	blobAnnounceInMeter.Mark(int64(len(txs)))
-	anns := make([]common.Hash, 0)
+	anns := make([]common.Hash, 0, len(txs))
+	pooled := make(map[common.Hash]types.CustodyBitmap)
 	for _, tx := range txs {
+		if f.fn.GetCustody != nil {
+			if custody := f.fn.GetCustody(tx); custody != nil {
+				anns = append(anns, tx)
+				pooled[tx] = *custody
+				continue
+			}
+		}
 		if f.fn.HasPayload(tx) {
 			continue
 		}
 		anns = append(anns, tx)
 	}
 
-	blobAnnounce := &blobTxAnnounce{origin: peer, txs: anns, cells: cells}
+	blobAnnounce := &blobTxAnnounce{origin: peer, txs: anns, cells: cells, pooled: pooled}
 	select {
 	case f.notify <- blobAnnounce:
 		return nil
@@ -297,6 +310,31 @@ func (f *BlobFetcher) loop() {
 				reschedule = make(map[string]struct{})
 			)
 			for _, hash := range ann.txs {
+				if stored, ok := ann.pooled[hash]; ok {
+					f.rememberSource(hash, ann.origin, ann.cells)
+					missing := f.custody.Difference(stored)
+					if missing.OneCount() == 0 {
+						continue
+					}
+					f.partial[hash] = struct{}{}
+					cells := ann.cells.Intersection(missing)
+					if cells.OneCount() == 0 {
+						continue
+					}
+					if f.fetches[hash] == nil {
+						f.fetches[hash] = &fetchStatus{
+							fetching:   stored,
+							fetched:    stored,
+							deliveries: make(map[string]*PeerCellDelivery),
+						}
+					}
+					if f.announces[ann.origin] == nil {
+						f.announces[ann.origin] = make(map[common.Hash]*cellWithSeq)
+					}
+					f.announces[ann.origin][hash] = &cellWithSeq{cells: cells, available: ann.cells, seq: nextSeq()}
+					reschedule[ann.origin] = struct{}{}
+					continue
+				}
 				if oldPeer && f.announces[ann.origin][hash] != nil {
 					// Ignore already announced information
 					// We also have to prevent reannouncement by changing cells field.
@@ -335,13 +373,15 @@ func (f *BlobFetcher) loop() {
 						f.announces[ann.origin] = make(map[common.Hash]*cellWithSeq)
 					}
 					f.announces[ann.origin][hash] = &cellWithSeq{
-						cells: types.CustodyBitmapData,
-						seq:   nextSeq(),
+						cells:     types.CustodyBitmapData,
+						available: types.CustodyBitmapData,
+						seq:       nextSeq(),
 					}
 					reschedule[ann.origin] = struct{}{}
 					continue
 				}
 				if _, ok := f.partial[hash]; ok {
+					f.rememberSource(hash, ann.origin, ann.cells)
 					// 2) Decided to send partial request of the tx
 					if f.waitlist[hash] != nil {
 						// it is already waiting for availability check
@@ -367,8 +407,9 @@ func (f *BlobFetcher) loop() {
 									f.announces[peer] = make(map[common.Hash]*cellWithSeq)
 								}
 								f.announces[peer][hash] = &cellWithSeq{
-									cells: f.custody,
-									seq:   nextSeq(),
+									cells:     f.custody,
+									available: types.CustodyBitmapAll,
+									seq:       nextSeq(),
 								}
 								delete(f.waitslots[peer], hash)
 								if len(f.waitslots[peer]) == 0 {
@@ -390,8 +431,9 @@ func (f *BlobFetcher) loop() {
 						f.announces[ann.origin] = make(map[common.Hash]*cellWithSeq)
 					}
 					f.announces[ann.origin][hash] = &cellWithSeq{
-						cells: ann.cells.Intersection(f.custody),
-						seq:   nextSeq(),
+						cells:     ann.cells.Intersection(f.custody),
+						available: ann.cells,
+						seq:       nextSeq(),
 					}
 					reschedule[ann.origin] = struct{}{}
 				}
@@ -426,8 +468,9 @@ func (f *BlobFetcher) loop() {
 							f.announces[peer] = make(map[common.Hash]*cellWithSeq)
 						}
 						f.announces[peer][hash] = &cellWithSeq{
-							cells: types.CustodyBitmapData,
-							seq:   f.txSeq,
+							cells:     types.CustodyBitmapData,
+							available: types.CustodyBitmapData,
+							seq:       f.txSeq,
 						}
 						f.txSeq++
 						delete(f.waitslots[peer], hash)
@@ -526,7 +569,7 @@ func (f *BlobFetcher) loop() {
 						Cells:   delivery.cells[i],
 						Indices: indices,
 					}
-					status.fetched = append(status.fetched, indices...)
+					status.fetched = status.fetched.Union(delivery.cellBitmap)
 				}
 
 				// Update announces of this peer
@@ -540,24 +583,10 @@ func (f *BlobFetcher) loop() {
 				}
 
 				// Check whether the all required cells are fetched
-				completed := false
-				if _, ok := f.full[hash]; ok && len(f.fetches[hash].fetched) >= kzg4844.DataPerBlob {
-					completed = true
-				} else if _, ok := f.partial[hash]; ok {
-					fetched := make([]uint64, len(f.fetches[hash].fetched))
-					copy(fetched, f.fetches[hash].fetched)
-					slices.Sort(fetched)
-
-					custodyIndices := f.custody.Indices()
-
-					completed = slices.Equal(fetched, custodyIndices)
-				}
-
-				if completed {
+				if f.completed(hash) {
 					blobFetcherFetchTime.Update(int64(time.Duration(f.clock.Now() - request.time)))
 					status := f.fetches[hash]
-					collectedCustody := types.NewCustodyBitmap(status.fetched)
-					f.fn.AddCells(hash, status.deliveries, collectedCustody)
+					f.fn.AddCells(hash, status.deliveries, status.fetched)
 
 					f.discard(hash)
 				}
@@ -634,6 +663,12 @@ func (f *BlobFetcher) loop() {
 				delete(f.announces, drop.peer)
 			}
 			delete(f.announces, drop.peer)
+			for hash, sources := range f.sources {
+				delete(sources, drop.peer)
+				if len(sources) == 0 {
+					delete(f.sources, hash)
+				}
+			}
 
 			// Clean up any active requests
 			if request, ok := f.requests[drop.peer]; ok && len(request) != 0 {
@@ -658,7 +693,11 @@ func (f *BlobFetcher) loop() {
 			}
 
 		case cells := <-f.custodyCh:
+			if cells == f.custody {
+				break
+			}
 			f.custody = cells
+			f.reconcileCustody(timeoutTimer, timeoutTrigger)
 
 		case <-f.quit:
 			return
@@ -758,7 +797,7 @@ func (f *BlobFetcher) recoverable(hash common.Hash) bool {
 	// union of already fetched cells and the cells still announced by peers
 	var covered types.CustodyBitmap
 	if status := f.fetches[hash]; status != nil {
-		covered = types.NewCustodyBitmap(status.fetched)
+		covered = status.fetched
 	}
 	for _, anns := range f.announces {
 		if cs, ok := anns[hash]; ok {
@@ -772,6 +811,113 @@ func (f *BlobFetcher) recoverable(hash common.Hash) bool {
 	// Partial case:
 	// return true if our custody can be covered
 	return f.custody.Difference(covered).OneCount() == 0
+}
+
+func (f *BlobFetcher) rememberSource(hash common.Hash, peer string, cells types.CustodyBitmap) {
+	if f.sources[hash] == nil {
+		f.sources[hash] = make(map[string]types.CustodyBitmap)
+	}
+	f.sources[hash][peer] = cells
+}
+
+func (f *BlobFetcher) completed(hash common.Hash) bool {
+	status := f.fetches[hash]
+	if status == nil {
+		return false
+	}
+	if _, ok := f.full[hash]; ok {
+		return status.fetched.OneCount() >= kzg4844.DataPerBlob
+	}
+	if _, ok := f.partial[hash]; ok {
+		return f.custody.Difference(status.fetched).OneCount() == 0
+	}
+	return false
+}
+
+func (f *BlobFetcher) reconcileCustody(timer *mclock.Timer, timeout chan struct{}) {
+	if f.fn.GetCustody != nil {
+		for hash := range f.sources {
+			if _, active := f.full[hash]; active {
+				continue
+			}
+			stored := f.fn.GetCustody(hash)
+			if stored == nil {
+				if _, active := f.partial[hash]; active {
+					continue
+				}
+				delete(f.sources, hash)
+				continue
+			}
+			if _, active := f.partial[hash]; active {
+				if f.fetches[hash] == nil {
+					f.fetches[hash] = &fetchStatus{
+						fetching:   *stored,
+						fetched:    *stored,
+						deliveries: make(map[string]*PeerCellDelivery),
+					}
+				}
+				continue
+			}
+			if f.custody.Difference(*stored).OneCount() == 0 {
+				continue
+			}
+			f.partial[hash] = struct{}{}
+			f.fetches[hash] = &fetchStatus{
+				fetching:   *stored,
+				fetched:    *stored,
+				deliveries: make(map[string]*PeerCellDelivery),
+			}
+		}
+	}
+	for peer, anns := range f.announces {
+		for hash, ann := range anns {
+			if _, ok := f.partial[hash]; !ok {
+				continue
+			}
+			ann.cells = ann.available.Intersection(f.custody)
+			if ann.cells.OneCount() == 0 {
+				delete(anns, hash)
+				delete(f.alternates[hash], peer)
+				continue
+			}
+			if f.alternates[hash] != nil {
+				f.alternates[hash][peer] = ann.cells
+			}
+		}
+		if len(anns) == 0 {
+			delete(f.announces, peer)
+		}
+	}
+	for hash := range f.partial {
+		if f.completed(hash) {
+			status := f.fetches[hash]
+			if len(status.deliveries) > 0 {
+				f.fn.AddCells(hash, status.deliveries, status.fetched)
+			}
+			f.discard(hash)
+			continue
+		}
+		if f.waitlist[hash] != nil {
+			continue
+		}
+		for peer, available := range f.sources[hash] {
+			cells := available.Intersection(f.custody)
+			if cells.OneCount() == 0 {
+				continue
+			}
+			if f.announces[peer] == nil {
+				f.announces[peer] = make(map[common.Hash]*cellWithSeq)
+			}
+			if ann := f.announces[peer][hash]; ann != nil {
+				ann.cells = cells
+				ann.available = available
+			} else {
+				f.announces[peer][hash] = &cellWithSeq{cells: cells, available: available, seq: f.txSeq}
+				f.txSeq++
+			}
+		}
+	}
+	f.scheduleFetches(timer, timeout, nil)
 }
 
 // discard removes every trace of a transaction from the fetcher: its fetch
@@ -834,7 +980,6 @@ func (f *BlobFetcher) scheduleFetches(timer *mclock.Timer, timeout chan struct{}
 				if f.fetches[hash] == nil {
 					f.fetches[hash] = &fetchStatus{
 						fetching:   unfetched,
-						fetched:    make([]uint64, 0),
 						deliveries: make(map[string]*PeerCellDelivery),
 					}
 				} else {

--- a/eth/fetcher/blob_fetcher_test.go
+++ b/eth/fetcher/blob_fetcher_test.go
@@ -102,6 +102,10 @@ type doBlobEnqueue struct {
 	custody types.CustodyBitmap
 }
 
+type doCustodyUpdate struct {
+	custody types.CustodyBitmap
+}
+
 type blobDoFunc func(*BlobFetcher)
 
 type isWaitingAvailability map[common.Hash]map[string]struct{}
@@ -824,6 +828,10 @@ func testBlobFetcher(t *testing.T, tt blobFetcherTest) {
 			}
 			<-wait
 
+		case doCustodyUpdate:
+			fetcher.UpdateCustody(step.custody)
+			<-wait
+
 		case blobDoFunc:
 			step(fetcher)
 
@@ -1007,21 +1015,11 @@ func testBlobFetcher(t *testing.T, tt blobFetcherTest) {
 
 					// Check fetched indices
 					if expected.fetched != nil {
-						if len(fetchStatus.fetched) != len(expected.fetched) {
-							t.Errorf("step %d, hash %x: fetched length mismatch, got %d, want %d", i, hash, len(fetchStatus.fetched), len(expected.fetched))
-						} else {
-							// Sort both slices before comparing
-							gotFetched := make([]uint64, len(fetchStatus.fetched))
-							copy(gotFetched, fetchStatus.fetched)
-							slices.Sort(gotFetched)
-
-							expectedFetched := make([]uint64, len(expected.fetched))
-							copy(expectedFetched, expected.fetched)
-							slices.Sort(expectedFetched)
-
-							if !slices.Equal(gotFetched, expectedFetched) {
-								t.Errorf("step %d, hash %x: fetched indices mismatch", i, hash)
-							}
+						gotFetched := fetchStatus.fetched.Indices()
+						expectedFetched := slices.Clone(expected.fetched)
+						slices.Sort(expectedFetched)
+						if !slices.Equal(gotFetched, expectedFetched) {
+							t.Errorf("step %d, hash %x: fetched indices mismatch", i, hash)
 						}
 					}
 				}
@@ -1149,4 +1147,221 @@ func TestMultiBlobDeliveryVerification(t *testing.T) {
 	if verifyErr != nil {
 		t.Fatalf("KZG cell verification failed after multi-blob delivery: %v", verifyErr)
 	}
+}
+
+func TestBlobFetcherCustodyExpansion(t *testing.T) {
+	expanded := types.NewCustodyBitmap([]uint64{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11})
+	delta := expanded.Difference(custody)
+	testBlobFetcher(t, blobFetcherTest{
+		init: func() *BlobFetcher {
+			return NewBlobFetcher(
+				BlobFetcherFunctions{
+					HasPayload:    func(common.Hash) bool { return false },
+					AddCells:      func(common.Hash, map[string]*PeerCellDelivery, types.CustodyBitmap) {},
+					FetchPayloads: func(string, []common.Hash, types.CustodyBitmap) error { return nil },
+					DropPeer:      func(string) {},
+				},
+				custody,
+				&mockRand{value: 60},
+				15,
+			)
+		},
+		steps: []interface{}{
+			doBlobNotify{peer: "A", hashes: []common.Hash{testBlobTxHashes[0]}, custody: fullCustody},
+			doBlobNotify{peer: "B", hashes: []common.Hash{testBlobTxHashes[0]}, custody: fullCustody},
+			doCustodyUpdate{custody: expanded},
+			isBlobScheduled{
+				announces: map[string][]blobAnnounce{
+					"A": {{hash: testBlobTxHashes[0], custody: expanded}},
+					"B": {{hash: testBlobTxHashes[0], custody: expanded}},
+				},
+				fetching: map[string][]blobAnnounce{
+					"A": {{hash: testBlobTxHashes[0], custody: custody}},
+					"B": {{hash: testBlobTxHashes[0], custody: delta}},
+				},
+			},
+			isFetching{hashes: map[common.Hash]fetchInfo{
+				testBlobTxHashes[0]: {fetching: &expanded, fetched: []uint64{}},
+			}},
+		},
+	})
+}
+
+func TestBlobFetcherCustodyContractionCompletesCoveredFetch(t *testing.T) {
+	contracted := types.NewCustodyBitmap([]uint64{0, 1})
+	fetched := types.NewCustodyBitmap([]uint64{0, 1, 2})
+	completed := make(chan types.CustodyBitmap, 1)
+	testBlobFetcher(t, blobFetcherTest{
+		init: func() *BlobFetcher {
+			return NewBlobFetcher(
+				BlobFetcherFunctions{
+					HasPayload: func(common.Hash) bool { return false },
+					AddCells: func(_ common.Hash, _ map[string]*PeerCellDelivery, cells types.CustodyBitmap) {
+						completed <- cells
+					},
+					FetchPayloads: func(string, []common.Hash, types.CustodyBitmap) error { return nil },
+					DropPeer:      func(string) {},
+				},
+				custody,
+				&mockRand{value: 60},
+				15,
+			)
+		},
+		steps: []interface{}{
+			blobDoFunc(func(f *BlobFetcher) {
+				f.partial[testBlobTxHashes[0]] = struct{}{}
+				f.fetches[testBlobTxHashes[0]] = &fetchStatus{
+					fetching: fetched,
+					fetched:  fetched,
+					deliveries: map[string]*PeerCellDelivery{
+						"A": {},
+					},
+				}
+			}),
+			doCustodyUpdate{custody: contracted},
+			isCompleted{testBlobTxHashes[0]},
+			blobDoFunc(func(*BlobFetcher) {
+				select {
+				case got := <-completed:
+					if got != fetched {
+						t.Fatalf("unexpected collected custody: got %v, want %v", got, fetched)
+					}
+				default:
+					t.Fatal("covered fetch was not completed after custody contraction")
+				}
+			}),
+		},
+	})
+}
+
+func TestBlobFetcherCustodyUpdateNoop(t *testing.T) {
+	testBlobFetcher(t, blobFetcherTest{
+		init: func() *BlobFetcher {
+			return NewBlobFetcher(
+				BlobFetcherFunctions{
+					HasPayload:    func(common.Hash) bool { return false },
+					AddCells:      func(common.Hash, map[string]*PeerCellDelivery, types.CustodyBitmap) {},
+					FetchPayloads: func(string, []common.Hash, types.CustodyBitmap) error { return nil },
+					DropPeer:      func(string) {},
+				},
+				custody,
+				&mockRand{value: 60},
+				15,
+			)
+		},
+		steps: []interface{}{
+			doBlobNotify{peer: "A", hashes: []common.Hash{testBlobTxHashes[0]}, custody: fullCustody},
+			doCustodyUpdate{custody: custody},
+			isWaitingAvailability{testBlobTxHashes[0]: {"A": {}}},
+		},
+	})
+}
+
+func TestBlobFetcherCustodyUpdateWhileWaiting(t *testing.T) {
+	expanded := types.NewCustodyBitmap([]uint64{0, 1, 2, 3, 4, 5, 6, 7, 8, 9})
+	testBlobFetcher(t, blobFetcherTest{
+		init: func() *BlobFetcher {
+			return NewBlobFetcher(
+				BlobFetcherFunctions{
+					HasPayload:    func(common.Hash) bool { return false },
+					AddCells:      func(common.Hash, map[string]*PeerCellDelivery, types.CustodyBitmap) {},
+					FetchPayloads: func(string, []common.Hash, types.CustodyBitmap) error { return nil },
+					DropPeer:      func(string) {},
+				},
+				custody,
+				&mockRand{value: 60},
+				15,
+			)
+		},
+		steps: []interface{}{
+			doBlobNotify{peer: "A", hashes: []common.Hash{testBlobTxHashes[0]}, custody: fullCustody},
+			doCustodyUpdate{custody: expanded},
+			isWaitingAvailability{testBlobTxHashes[0]: {"A": {}}},
+			isBlobScheduled{announces: map[string][]blobAnnounce{}, fetching: map[string][]blobAnnounce{}},
+		},
+	})
+}
+
+func TestBlobFetcherSupplementsPooledTransaction(t *testing.T) {
+	stored := types.NewCustodyBitmap([]uint64{0, 1, 2, 3})
+	required := types.NewCustodyBitmap([]uint64{0, 1, 2, 3, 4, 5})
+	delta := required.Difference(stored)
+	testBlobFetcher(t, blobFetcherTest{
+		init: func() *BlobFetcher {
+			return NewBlobFetcher(
+				BlobFetcherFunctions{
+					HasPayload: func(common.Hash) bool { return true },
+					GetCustody: func(hash common.Hash) *types.CustodyBitmap {
+						if hash == testBlobTxHashes[0] {
+							return &stored
+						}
+						return nil
+					},
+					AddCells:      func(common.Hash, map[string]*PeerCellDelivery, types.CustodyBitmap) {},
+					FetchPayloads: func(string, []common.Hash, types.CustodyBitmap) error { return nil },
+					DropPeer:      func(string) {},
+				},
+				required,
+				&mockRand{value: 60},
+				15,
+			)
+		},
+		steps: []interface{}{
+			doBlobNotify{peer: "A", hashes: []common.Hash{testBlobTxHashes[0]}, custody: fullCustody},
+			isBlobScheduled{
+				announces: map[string][]blobAnnounce{
+					"A": {{hash: testBlobTxHashes[0], custody: delta}},
+				},
+				fetching: map[string][]blobAnnounce{
+					"A": {{hash: testBlobTxHashes[0], custody: delta}},
+				},
+			},
+			isFetching{hashes: map[common.Hash]fetchInfo{
+				testBlobTxHashes[0]: {fetching: &required, fetched: stored.Indices()},
+			}},
+		},
+	})
+}
+
+func TestBlobFetcherCustodyExpansionReactivatesPooledTransaction(t *testing.T) {
+	stored := types.NewCustodyBitmap([]uint64{0, 1, 2, 3})
+	expanded := types.NewCustodyBitmap([]uint64{0, 1, 2, 3, 4, 5})
+	delta := expanded.Difference(stored)
+	testBlobFetcher(t, blobFetcherTest{
+		init: func() *BlobFetcher {
+			return NewBlobFetcher(
+				BlobFetcherFunctions{
+					HasPayload: func(common.Hash) bool { return true },
+					GetCustody: func(hash common.Hash) *types.CustodyBitmap {
+						if hash == testBlobTxHashes[0] {
+							return &stored
+						}
+						return nil
+					},
+					AddCells:      func(common.Hash, map[string]*PeerCellDelivery, types.CustodyBitmap) {},
+					FetchPayloads: func(string, []common.Hash, types.CustodyBitmap) error { return nil },
+					DropPeer:      func(string) {},
+				},
+				stored,
+				&mockRand{value: 60},
+				15,
+			)
+		},
+		steps: []interface{}{
+			doBlobNotify{peer: "A", hashes: []common.Hash{testBlobTxHashes[0]}, custody: fullCustody},
+			isBlobScheduled{announces: map[string][]blobAnnounce{}, fetching: map[string][]blobAnnounce{}},
+			doCustodyUpdate{custody: expanded},
+			isBlobScheduled{
+				announces: map[string][]blobAnnounce{
+					"A": {{hash: testBlobTxHashes[0], custody: expanded}},
+				},
+				fetching: map[string][]blobAnnounce{
+					"A": {{hash: testBlobTxHashes[0], custody: delta}},
+				},
+			},
+			isFetching{hashes: map[common.Hash]fetchInfo{
+				testBlobTxHashes[0]: {fetching: &expanded, fetched: stored.Indices()},
+			}},
+		},
+	})
 }

--- a/eth/handler.go
+++ b/eth/handler.go
@@ -107,6 +107,7 @@ type blobPool interface {
 	GetBlobHashes(hash common.Hash) []common.Hash
 	GetBlobCells(vhashes []common.Hash, mask types.CustodyBitmap) ([][]*kzg4844.Cell, [][]*kzg4844.Proof, error)
 	GetCustody(hash common.Hash) *types.CustodyBitmap
+	MergeCells(hash common.Hash, deliveries map[string]*blobpool.PeerDelivery) ([]string, error)
 	AddPooledTx(pooledTx *blobpool.BlobTxForPool) error
 	ValidateTxBasics(pooledTx *types.Transaction) error
 }
@@ -225,12 +226,24 @@ func newHandler(config *handlerConfig) (*handler, error) {
 		HasPayload: func(hash common.Hash) bool {
 			return h.blobpool.Has(hash) || blobBuffer.HasCells(hash)
 		},
+		GetCustody: h.blobpool.GetCustody,
 		AddCells: func(hash common.Hash, deliveries map[string]*fetcher.PeerCellDelivery, custody types.CustodyBitmap) {
 			converted := make(map[string]*blobpool.PeerDelivery, len(deliveries))
 			for peer, d := range deliveries {
 				converted[peer] = &blobpool.PeerDelivery{Cells: d.Cells, Indices: d.Indices}
 			}
-			blobBuffer.AddCells(hash, converted, custody)
+			badPeers, err := h.blobpool.MergeCells(hash, converted)
+			if errors.Is(err, blobpool.ErrBlobTxNotFound) {
+				blobBuffer.AddCells(hash, converted, custody)
+				return
+			}
+			if err != nil {
+				log.Error("Failed to merge blob cells", "hash", hash, "err", err)
+				return
+			}
+			for _, peer := range badPeers {
+				h.removePeer(peer)
+			}
 		},
 		DropPeer: h.removePeer,
 	}

--- a/eth/handler_test.go
+++ b/eth/handler_test.go
@@ -245,6 +245,13 @@ func (p *testTxPool) GetCustody(hash common.Hash) *types.CustodyBitmap {
 	return &mask
 }
 
+func (p *testTxPool) MergeCells(hash common.Hash, _ map[string]*blobpool.PeerDelivery) ([]string, error) {
+	if p.GetCustody(hash) == nil {
+		return nil, blobpool.ErrBlobTxNotFound
+	}
+	return nil, nil
+}
+
 // AddCells adds cells for a specific transaction hash (for testing)
 func (p *testTxPool) AddCells(hash common.Hash, cells []kzg4844.Cell, mask types.CustodyBitmap) {
 	p.lock.Lock()


### PR DESCRIPTION
## Description

`engine_forkchoiceUpdatedV4` forwards every non-nil `custodyColumns`
update to `BlobFetcher.UpdateCustody`:

```go
if custodyColumns != nil {
    api.eth.BlobFetcher().UpdateCustody(*custodyColumns)
}
```

However, the fetcher loop currently only replaces the bitmap:
```go
case cells := <-f.custodyCh:
    f.custody = cells
```

This makes new announcements observe the new custody set, but it does not reconcile queued, in-flight, or already pooled partial blob transactions whose state was created under the previous custody set.

EIP-8070 is currently in Review. Its Engine API specification requires:

- all subsequent sampling requests to adopt the new custody set;
- pending type-3 transactions to be sampled for delta columns when the custody set expands;
- an identical custody value, or null, to be treated as a blobpool-state no-op.

The specification permits, but does not require, already queued sampling requests to be patched.


Reconcile sparse blob cell fetching when the custody set changes.

Previously, `BlobFetcher.UpdateCustody` only replaced the current custody bitmap. Existing partial fetches and transactions already stored in the blobpool were not updated to fetch newly required columns. Completion also required exact equality between fetched and custody indices, so a custody contraction could leave a fetch incomplete when extra cells had already been received.

This change:

- treats identical custody updates as no-ops;
- requests only newly required columns after custody expansion;
- uses custody coverage instead of exact equality for completion;
- reconciles transactions in waitlist, announcement and active-fetch states;
- retains peer availability for later custody expansion;
- supplements partial transactions already stored in the blobpool;
- verifies and atomically persists merged cells;
- falls back to the blobpool when cached cells do not cover the requested mask.

## Tests

Added regression coverage for:

- custody expansion and delta-column requests;
- custody contraction with extra fetched cells;
- identical custody updates;
- updates during availability waiting;
- supplementing an existing pooled transaction;
- reactivating a pooled transaction after later expansion;
- verified multi-blob cell merging and persistence.