### PR TITLE
p2p/discover: try to fix TestUDPv5_lookupE2E by using SetFallbackUDP

### DIFF
--- a/p2p/discover/v5_udp_test.go
+++ b/p2p/discover/v5_udp_test.go
@@ -90,7 +90,7 @@ func startLocalhostV5(t *testing.T, cfg Config) *UDPv5 {
 	}
 	realaddr := socket.LocalAddr().(*net.UDPAddr)
 	ln.SetStaticIP(realaddr.IP)
-	ln.Set(enr.UDP(realaddr.Port))
+	ln.SetFallbackUDP(realaddr.Port)
 	udp, err := ListenV5(socket, ln, cfg)
 	if err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
The test set the local UDP port via ln.Set(enr.UDP(...)), but the "udp" ENR entry is owned by the endpoint predictor: as soon as the first node received a PONG, updateEndpoints recomputed the endpoint with no fallback port set and deleted the entry. Later nodes bootstrapping from that node's record then failed with "bad bootstrap node: missing UDP port".

Use SetFallbackUDP like startLocalhostV4 already does, so the port survives endpoint statements.

fixes CI errors like in https://github.com/ethereum/go-ethereum/actions/runs/31859911877/job/94953524792?pr=35529