### PR TITLE
crypto/blake2b: bound input of assembly call

### DIFF
--- a/crypto/blake2b/blake2b.go
+++ b/crypto/blake2b/blake2b.go
@@ -96,6 +96,12 @@ func New256(key []byte) (hash.Hash, error) { return newDigest(Size256, key) }
 // and BinaryUnmarshaler for state (de)serialization as documented by hash.Hash.
 func New(size int, key []byte) (hash.Hash, error) { return newDigest(size, key) }
 
+// maxAsmRounds bounds the work a single assembly call does. Assembly is not
+// preemptible, so an unbounded rounds argument holds every P in stop-the-world
+// for the length of the call. It must stay a multiple of 10 so that the message
+// schedule realigns at a chunk boundary.
+const maxAsmRounds = 4090
+
 // F is a compression function for BLAKE2b. It takes as an argument the state
 // vector `h`, message block vector `m`, offset counter `t`, final block indicator
 // flag `f`, and number of rounds `rounds`. The state vector provided as the first
@@ -105,7 +111,11 @@ func F(h *[8]uint64, m [16]uint64, c [2]uint64, final bool, rounds uint32) {
 	if final {
 		flag = 0xFFFFFFFFFFFFFFFF
 	}
-	f(h, &m, c[0], c[1], flag, uint64(rounds))
+	if rounds <= maxAsmRounds {
+		f(h, &m, c[0], c[1], flag, uint64(rounds))
+		return
+	}
+	fLong(h, &m, c[0], c[1], flag, uint64(rounds))
 }
 
 func newDigest(hashSize int, key []byte) (*digest, error) {

--- a/crypto/blake2b/blake2b.go
+++ b/crypto/blake2b/blake2b.go
@@ -96,11 +96,17 @@ func New256(key []byte) (hash.Hash, error) { return newDigest(Size256, key) }
 // and BinaryUnmarshaler for state (de)serialization as documented by hash.Hash.
 func New(size int, key []byte) (hash.Hash, error) { return newDigest(size, key) }
 
+// sigmaRounds is the length of the BLAKE2b message-schedule cycle: round i
+// permutes with precomputed[i%sigmaRounds]. The assembly unrolls a whole cycle
+// and loops over it, so a chunk boundary is only correct on a multiple of it.
+const sigmaRounds = 10
+
 // maxAsmRounds bounds the work a single assembly call does. Assembly is not
 // preemptible, so an unbounded rounds argument holds every P in stop-the-world
-// for the length of the call. It must stay a multiple of 10 so that the message
-// schedule realigns at a chunk boundary.
+// for the length of the call.
 const maxAsmRounds = 4090
+
+const _ uint = -(maxAsmRounds % sigmaRounds) // compile-time check: multiple of sigmaRounds
 
 // F is a compression function for BLAKE2b. It takes as an argument the state
 // vector `h`, message block vector `m`, offset counter `t`, final block indicator

--- a/crypto/blake2b/blake2bAVX2_amd64.go
+++ b/crypto/blake2b/blake2bAVX2_amd64.go
@@ -36,3 +36,36 @@ func f(h *[8]uint64, m *[16]uint64, c0, c1 uint64, flag uint64, rounds uint64) {
 		fGeneric(h, m, c0, c1, flag, rounds)
 	}
 }
+
+//go:noescape
+func fAVX2Rounds(v *[16]uint64, m *[16]uint64, rounds uint64)
+
+// fRounds must not be inlined: its prologue carries the stack-growth check that
+// is the only preemption point of the chunk loop in fLong. Inlined, the loop
+// would call NOSPLIT assembly directly and become unpreemptible again.
+//
+//go:noinline
+func fRounds(v *[16]uint64, m *[16]uint64, rounds uint64) {
+	fAVX2Rounds(v, m, rounds)
+}
+
+func fLong(h *[8]uint64, m *[16]uint64, c0, c1 uint64, flag uint64, rounds uint64) {
+	if !useAVX2 {
+		fGeneric(h, m, c0, c1, flag, rounds)
+		return
+	}
+	var v [16]uint64
+	copy(v[:8], h[:])
+	copy(v[8:], iv[:])
+	v[12] ^= c0
+	v[13] ^= c1
+	v[14] ^= flag
+	for rounds > 0 {
+		n := min(rounds, maxAsmRounds)
+		fRounds(&v, m, n)
+		rounds -= n
+	}
+	for i := range h {
+		h[i] ^= v[i] ^ v[i+8]
+	}
+}

--- a/crypto/blake2b/blake2bAVX2_amd64.s
+++ b/crypto/blake2b/blake2bAVX2_amd64.s
@@ -715,3 +715,73 @@ done:
 
 	MOVQ BP, SP
 	RET
+
+// func fAVX2Rounds(v *[16]uint64, m *[16]uint64, rounds uint64)
+//
+// Runs rounds rounds on the working vector v, which is loaded from and stored
+// back to memory rather than derived from h and folded into it. That lets the
+// caller split a long F into chunks. rounds must be a multiple of 10 except in
+// the last chunk, so that the message schedule realigns.
+TEXT ·fAVX2Rounds(SB), NOSPLIT, $0-24
+	MOVQ v+0(FP), AX
+	MOVQ m+8(FP), SI
+	MOVQ rounds+16(FP), BX
+
+	VMOVDQU ·AVX2_c40<>(SB), Y4
+	VMOVDQU ·AVX2_c48<>(SB), Y5
+
+	VMOVDQU 0(AX), Y0
+	VMOVDQU 32(AX), Y1
+	VMOVDQU 64(AX), Y2
+	VMOVDQU 96(AX), Y3
+
+rloop:
+	SUBQ $1, BX; JCS rdone
+	LOAD_MSG_AVX2_0_2_4_6_1_3_5_7_8_10_12_14_9_11_13_15()
+	ROUND_AVX2(Y12, Y13, Y14, Y15, Y10, Y4, Y5)
+
+	SUBQ $1, BX; JCS rdone
+	LOAD_MSG_AVX2_14_4_9_13_10_8_15_6_1_0_11_5_12_2_7_3()
+	ROUND_AVX2(Y12, Y13, Y14, Y15, Y10, Y4, Y5)
+
+	SUBQ $1, BX; JCS rdone
+	LOAD_MSG_AVX2_11_12_5_15_8_0_2_13_10_3_7_9_14_6_1_4()
+	ROUND_AVX2(Y12, Y13, Y14, Y15, Y10, Y4, Y5)
+
+	SUBQ $1, BX; JCS rdone
+	LOAD_MSG_AVX2_7_3_13_11_9_1_12_14_2_5_4_15_6_10_0_8()
+	ROUND_AVX2(Y12, Y13, Y14, Y15, Y10, Y4, Y5)
+
+	SUBQ $1, BX; JCS rdone
+	LOAD_MSG_AVX2_9_5_2_10_0_7_4_15_14_11_6_3_1_12_8_13()
+	ROUND_AVX2(Y12, Y13, Y14, Y15, Y10, Y4, Y5)
+
+	SUBQ $1, BX; JCS rdone
+	LOAD_MSG_AVX2_2_6_0_8_12_10_11_3_4_7_15_1_13_5_14_9()
+	ROUND_AVX2(Y12, Y13, Y14, Y15, Y10, Y4, Y5)
+
+	SUBQ $1, BX; JCS rdone
+	LOAD_MSG_AVX2_12_1_14_4_5_15_13_10_0_6_9_8_7_3_2_11()
+	ROUND_AVX2(Y12, Y13, Y14, Y15, Y10, Y4, Y5)
+
+	SUBQ $1, BX; JCS rdone
+	LOAD_MSG_AVX2_13_7_12_3_11_14_1_9_5_15_8_2_0_4_6_10()
+	ROUND_AVX2(Y12, Y13, Y14, Y15, Y10, Y4, Y5)
+
+	SUBQ $1, BX; JCS rdone
+	LOAD_MSG_AVX2_6_14_11_0_15_9_3_8_12_13_1_10_2_7_4_5()
+	ROUND_AVX2(Y12, Y13, Y14, Y15, Y10, Y4, Y5)
+
+	SUBQ $1, BX; JCS rdone
+	LOAD_MSG_AVX2_10_8_7_1_2_4_6_5_15_9_3_13_11_14_12_0()
+	ROUND_AVX2(Y12, Y13, Y14, Y15, Y10, Y4, Y5)
+
+	JMP rloop
+
+rdone:
+	VMOVDQU Y0, 0(AX)
+	VMOVDQU Y1, 32(AX)
+	VMOVDQU Y2, 64(AX)
+	VMOVDQU Y3, 96(AX)
+	VZEROUPPER
+	RET

--- a/crypto/blake2b/blake2b_f_test.go
+++ b/crypto/blake2b/blake2b_f_test.go
@@ -2,8 +2,11 @@ package blake2b
 
 import (
 	"fmt"
+	"math/rand"
 	"reflect"
+	"runtime"
 	"testing"
+	"time"
 )
 
 func TestF(t *testing.T) {
@@ -31,6 +34,93 @@ type testVector struct {
 }
 
 // https://tools.ietf.org/html/rfc7693#appendix-A
+func randomF(r *rand.Rand) (h [8]uint64, m [16]uint64, c [2]uint64, final bool) {
+	for i := range h {
+		h[i] = r.Uint64()
+	}
+	for i := range m {
+		m[i] = r.Uint64()
+	}
+	c[0], c[1] = r.Uint64(), r.Uint64()
+	return h, m, c, r.Intn(2) == 0
+}
+
+func TestFChunkedMatchesGeneric(t *testing.T) {
+	r := rand.New(rand.NewSource(1))
+	rounds := []uint32{
+		maxAsmRounds - 1, maxAsmRounds, maxAsmRounds + 1,
+		2*maxAsmRounds - 1, 2 * maxAsmRounds, 2*maxAsmRounds + 1,
+		3*maxAsmRounds + 7, 100003,
+	}
+	for _, n := range rounds {
+		for trial := range 4 {
+			h, m, c, final := randomF(r)
+			var flag uint64
+			if final {
+				flag = 0xFFFFFFFFFFFFFFFF
+			}
+			want := h
+			fGeneric(&want, &m, c[0], c[1], flag, uint64(n))
+
+			got := h
+			F(&got, m, c, final, n)
+
+			if got != want {
+				t.Fatalf("rounds=%d trial=%d: got %#x, want %#x", n, trial, got, want)
+			}
+		}
+	}
+}
+
+// gcWait reports the longest a GC had to wait while work ran in another
+// goroutine. Work the runtime cannot preempt shows up here directly.
+func gcWait(work func()) time.Duration {
+	done := make(chan struct{})
+	go func() { defer close(done); work() }()
+	var worst time.Duration
+	for {
+		select {
+		case <-done:
+			return worst
+		default:
+		}
+		start := time.Now()
+		runtime.GC()
+		worst = max(worst, time.Since(start))
+	}
+}
+
+// The rounds argument of the F precompile comes from calldata and is priced at
+// one gas per round, so a single transaction can ask for tens of millions of
+// rounds. Assembly is never preemptible, so an unchunked call blocks every
+// stop-the-world for as long as it runs.
+//
+// The budget is relative to fGeneric, which computes the same thing in Go and is
+// always preemptible: a slow or loaded runner moves both numbers together and
+// only a real regression separates them.
+func TestFLongRoundsIsPreemptible(t *testing.T) {
+	if testing.Short() || runtime.GOMAXPROCS(0) < 2 {
+		t.Skip("runs millions of rounds, and needs GOMAXPROCS >= 2 to see a stalled GC")
+	}
+	if !useAVX2 && !useAVX && !useSSE4 {
+		t.Skip("no assembly on this machine, so the round loop is already preemptible Go")
+	}
+
+	var h [8]uint64
+	var m [16]uint64
+	var c [2]uint64
+	const rounds = 8_000_000
+
+	floor := gcWait(func() { fGeneric(&h, &m, c[0], c[1], 0, rounds) })
+	got := gcWait(func() { F(&h, m, c, false, rounds) })
+
+	t.Logf("worst GC wait: F %v, pure-Go fGeneric %v", got, floor)
+	if got > 5*time.Millisecond && got > 4*floor {
+		t.Fatalf("a GC waited %v on F against %v on the pure-Go path: "+
+			"the assembly round loop is running unbounded", got, floor)
+	}
+}
+
 var testVectorsF = []testVector{
 	{
 		hIn: [8]uint64{

--- a/crypto/blake2b/blake2b_generic.go
+++ b/crypto/blake2b/blake2b_generic.go
@@ -10,9 +10,9 @@ import (
 )
 
 // the precomputed values for BLAKE2b
-// there are 10 16-byte arrays - one for each round
+// there is one 16-byte array per round of the message-schedule cycle
 // the entries are calculated from the sigma constants.
-var precomputed = [10][16]byte{
+var precomputed = [sigmaRounds][16]byte{
 	{0, 2, 4, 6, 1, 3, 5, 7, 8, 10, 12, 14, 9, 11, 13, 15},
 	{14, 4, 9, 13, 10, 8, 15, 6, 1, 0, 11, 5, 12, 2, 7, 3},
 	{11, 12, 5, 15, 8, 0, 2, 13, 10, 3, 7, 9, 14, 6, 1, 4},
@@ -52,7 +52,7 @@ func fGeneric(h *[8]uint64, m *[16]uint64, c0, c1 uint64, flag uint64, rounds ui
 	v14 ^= flag
 
 	for i := 0; i < int(rounds); i++ {
-		s := &(precomputed[i%10])
+		s := &(precomputed[i%sigmaRounds])
 
 		v0 += m[s[0]]
 		v0 += v4

--- a/crypto/blake2b/blake2b_ref.go
+++ b/crypto/blake2b/blake2b_ref.go
@@ -10,3 +10,7 @@ package blake2b
 func f(h *[8]uint64, m *[16]uint64, c0, c1 uint64, flag uint64, rounds uint64) {
 	fGeneric(h, m, c0, c1, flag, rounds)
 }
+
+func fLong(h *[8]uint64, m *[16]uint64, c0, c1 uint64, flag uint64, rounds uint64) {
+	fGeneric(h, m, c0, c1, flag, rounds)
+}


### PR DESCRIPTION
**Problem:** GC stop-the-world is slow if a large `rounds` is passed to the BLAKE2b `F` precompile.

**Root cause:** `rounds` comes straight from `calldata` as a `uint32` and is priced at one gas per round, so a single transaction can ask for tens of millions of rounds. `fAVX2`, `fAVX` and `fSSE4` run that whole loop inside `NOSPLIT` assembly:

```
TEXT ·fAVX2(SB), 4, $64-48        // 4 = NOSPLIT
	MOVQ rounds+40(FP), BX
loop:   ...
	JMP loop
```

Max GC stop-the-world stopping pause (`/sched/pauses/stopping/gc:seconds`), EPYC 4344P, `GOMAXPROCS=2`:

| rounds | main | this PR |
|---|---|---|
| 1,048,576 | 8.389 ms | 0.057 ms |
| 45,000,000 (a full block of gas) | **402.653 ms** | 0.057 ms |

Throughput is unchanged — ns/round, best of 5 runs, no collector running:

| rounds | main | this PR |
|---|---|---|
| 12 | 8.250 | 8.250 |
| 100 | 7.680 | 7.660 |
| 1000 | 7.616 | 7.606 |
| 4090 | 7.608 | 7.608 |
| 65536 | 7.587 | 7.581 |
| 1048576 | 7.587 | 7.599 |

**Fix:** `F` hands anything over 4090 rounds to `fLong`, which splits it into chunks.

References:
- Go stdlib sha256, md5: https://github.com/golang/go/issues/64417
- erigon: https://github.com/erigontech/erigon/pull/23317
