### PR TITLE
core/rawdb: fix head truncation below a diverged tail group

### DIFF
--- a/core/rawdb/freezer.go
+++ b/core/rawdb/freezer.go
@@ -301,13 +301,40 @@ func (f *Freezer) TruncateHead(items uint64) (uint64, error) {
 	if oitems <= items {
 		return oitems, nil
 	}
+	// Tail groups are pruned independently, so their tails can differ. Cutting
+	// the head below the tail of one group is fine: that group simply retains
+	// nothing, while the groups with a lower tail keep their data. Cutting below
+	// every group's tail is not, as it discards data that no group had pruned.
+	// Reject that up front.
+	if lowest := f.lowestTail(); items < lowest {
+		return 0, fmt.Errorf("truncation below tail: head %d, lowest group tail %d", items, lowest)
+	}
 	for _, table := range f.tables {
 		if err := table.truncateHead(items); err != nil {
 			return 0, err
 		}
 	}
 	f.head.Store(items)
+
+	// A group whose tail sat above the new head has been reset down to it by the
+	// truncation above, so the cached tail has to follow.
+	for _, tail := range f.tails {
+		if tail.Load() > items {
+			tail.Store(items)
+		}
+	}
 	return oitems, nil
+}
+
+// lowestTail returns the smallest tail among the tail groups.
+func (f *Freezer) lowestTail() uint64 {
+	var lowest uint64
+	for _, tail := range f.tails {
+		if v := tail.Load(); v < lowest {
+			lowest = v
+		}
+	}
+	return lowest
 }
 
 // TruncateTail discards all data below the specified threshold across every

--- a/core/rawdb/freezer.go
+++ b/core/rawdb/freezer.go
@@ -328,10 +328,13 @@ func (f *Freezer) TruncateHead(items uint64) (uint64, error) {
 
 // lowestTail returns the smallest tail among the tail groups.
 func (f *Freezer) lowestTail() uint64 {
-	var lowest uint64
+	var (
+		lowest uint64
+		first  = true
+	)
 	for _, tail := range f.tails {
-		if v := tail.Load(); v < lowest {
-			lowest = v
+		if v := tail.Load(); first || v < lowest {
+			lowest, first = v, false
 		}
 	}
 	return lowest

--- a/core/rawdb/freezer_table.go
+++ b/core/rawdb/freezer_table.go
@@ -100,7 +100,9 @@ type freezerTable struct {
 	// should never be lower than itemOffset.
 	itemHidden atomic.Uint64
 
-	config      freezerTableConfig // table configuration (compression, prunability). Note: compression flag does not apply retroactively to existing files
+	// table configuration (compression, prunability). Note: compression flag
+	// does not apply retroactively to existing files.
+	config      freezerTableConfig
 	readonly    bool
 	maxFileSize uint32 // Max file size for data-files
 	name        string
@@ -611,18 +613,15 @@ func (t *freezerTable) truncateHead(items uint64) error {
 	if existing <= items {
 		return nil
 	}
-
 	hidden := t.itemHidden.Load()
 
+	// The new head sits below this table's tail, so nothing of it survives:
+	// everything above the new head is discarded here and everything below
+	// the tail was already pruned. Reset the table to be empty at the new
+	// head.
 	if items < hidden {
-		if existing == hidden {
-			// Empty table means that it is newly added. Its tail would be
-			// at the head, so we have to align the table down to the new head.
-			return t.resetTo(items)
-		}
-		return errors.New("truncation below tail")
+		return t.resetTo(items)
 	}
-
 	// We need to truncate, save the old size for metrics tracking
 	oldSize, err := t.sizeNolock()
 	if err != nil {

--- a/core/rawdb/freezer_test.go
+++ b/core/rawdb/freezer_test.go
@@ -564,7 +564,7 @@ func TestTruncateHeadBelowGroupTail(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer f.Close()
+	defer func() { f.Close() }()
 
 	const items = uint64(100)
 	if _, err := f.ModifyAncients(func(op ethdb.AncientWriteOp) error {

--- a/core/rawdb/freezer_test.go
+++ b/core/rawdb/freezer_test.go
@@ -544,3 +544,126 @@ func TestFreezerSuite(t *testing.T) {
 		return f
 	})
 }
+
+// TestTruncateHeadBelowGroupTail covers rolling the head back past the tail of
+// one tail group but not another. The BAL table is pruned independently of the
+// block-data tables and therefore commonly sits at a higher tail, so a deep
+// enough head truncation lands below it. The table it applies to has nothing
+// left to keep and must end up empty at the new head, with the rest of the
+// freezer truncated consistently rather than left half-applied.
+func TestTruncateHeadBelowGroupTail(t *testing.T) {
+	var (
+		dir     = t.TempDir()
+		payload = bytes.Repeat([]byte{0xab}, 32)
+		tables  = []string{
+			ChainFreezerHashTable, ChainFreezerHeaderTable,
+			ChainFreezerBodiesTable, ChainFreezerReceiptTable, ChainFreezerBALTable,
+		}
+	)
+	f, err := NewFreezer(dir, "", false, 2049, chainFreezerTableConfigs)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer f.Close()
+
+	const items = uint64(100)
+	if _, err := f.ModifyAncients(func(op ethdb.AncientWriteOp) error {
+		for i := uint64(0); i < items; i++ {
+			for _, tbl := range tables {
+				if err := op.AppendRaw(tbl, i, payload); err != nil {
+					return err
+				}
+			}
+		}
+		return nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+	// Prune the BAL group far harder than the block-data group.
+	if _, err := f.TruncateTail(ChainFreezerBlockDataGroup, 10); err != nil {
+		t.Fatalf("truncating block data tail: %v", err)
+	}
+	if _, err := f.TruncateTail(ChainFreezerBALGroup, 80); err != nil {
+		t.Fatalf("truncating BAL tail: %v", err)
+	}
+	// Cutting below every group's tail would discard data that no group had
+	// pruned, so it must be refused, and refused without touching anything.
+	if _, err := f.TruncateHead(5); err == nil {
+		t.Fatal("truncating head below every group tail succeeded, want refusal")
+	}
+	if head, _ := f.Ancients(); head != items {
+		t.Fatalf("head after refused truncation = %d, want %d", head, items)
+	}
+	for _, name := range tables {
+		if got := f.tables[name].items.Load(); got != items {
+			t.Fatalf("table %s touched by a refused truncation: items = %d, want %d", name, got, items)
+		}
+	}
+	// Roll the head back below the BAL tail, but above the block-data tail.
+	if _, err := f.TruncateHead(50); err != nil {
+		t.Fatalf("truncating head below the BAL tail: %v", err)
+	}
+	if head, _ := f.Ancients(); head != 50 {
+		t.Fatalf("head = %d, want 50", head)
+	}
+	// The BAL group follows the head down; the block-data group is untouched.
+	if tail, _ := f.Tail(ChainFreezerBALGroup); tail != 50 {
+		t.Fatalf("BAL tail = %d, want 50", tail)
+	}
+	if tail, _ := f.Tail(ChainFreezerBlockDataGroup); tail != 10 {
+		t.Fatalf("block data tail = %d, want 10", tail)
+	}
+	// Every table agrees on the head, so nothing was left half-truncated.
+	for _, name := range tables {
+		if got := f.tables[name].items.Load(); got != 50 {
+			t.Fatalf("table %s: items = %d, want 50", name, got)
+		}
+	}
+	// Block data below the new head is still readable, BAL is empty.
+	if _, err := f.Ancient(ChainFreezerBodiesTable, 49); err != nil {
+		t.Fatalf("reading body 49: %v", err)
+	}
+	if _, err := f.Ancient(ChainFreezerBALTable, 49); err == nil {
+		t.Fatal("reading BAL 49 succeeded, want out of bounds")
+	}
+	// Writing must resume cleanly across every table from the new head.
+	balPayload := []byte("post-truncate-bal")
+	if _, err := f.ModifyAncients(func(op ethdb.AncientWriteOp) error {
+		for _, tbl := range tables {
+			data := payload
+			if tbl == ChainFreezerBALTable {
+				data = balPayload
+			}
+			if err := op.AppendRaw(tbl, 50, data); err != nil {
+				return err
+			}
+		}
+		return nil
+	}); err != nil {
+		t.Fatalf("appending after truncation: %v", err)
+	}
+	got, err := f.Ancient(ChainFreezerBALTable, 50)
+	if err != nil {
+		t.Fatalf("reading BAL 50: %v", err)
+	}
+	if !bytes.Equal(got, balPayload) {
+		t.Fatalf("BAL 50 = %x, want %x", got, balPayload)
+	}
+	// The layout has to survive a reopen.
+	if err := f.Close(); err != nil {
+		t.Fatalf("closing freezer: %v", err)
+	}
+	f, err = NewFreezer(dir, "", false, 2049, chainFreezerTableConfigs)
+	if err != nil {
+		t.Fatalf("reopening freezer: %v", err)
+	}
+	if head, _ := f.Ancients(); head != 51 {
+		t.Fatalf("head after reopen = %d, want 51", head)
+	}
+	if tail, _ := f.Tail(ChainFreezerBALGroup); tail != 50 {
+		t.Fatalf("BAL tail after reopen = %d, want 50", tail)
+	}
+	if tail, _ := f.Tail(ChainFreezerBlockDataGroup); tail != 10 {
+		t.Fatalf("block data tail after reopen = %d, want 10", tail)
+	}
+}


### PR DESCRIPTION
Tail groups are pruned independently. Truncating the head below the tail of group can happen just in case the tails across the groups are not aligned.

Reset such table to empty at the new head instead, and refuse only truncations that fall below every group's tail.

Superseded #35536 