### PR TITLE
eth: return iterator errors from debug_storageRangeAt

### DIFF
--- a/eth/api_debug.go
+++ b/eth/api_debug.go
@@ -312,6 +312,13 @@ func storageRangeAt(statedb *state.StateDB, root common.Hash, address common.Add
 		next := common.BytesToHash(it.Key)
 		result.NextKey = &next
 	}
+	// Iterator.Next returns false on both exhaustion and error, so a failure to
+	// resolve a trie node mid-range would otherwise be reported as a complete
+	// result (a nil NextKey claims all keys were returned). Surface the error
+	// instead of silently truncating.
+	if it.Err != nil {
+		return StorageRangeResult{}, it.Err
+	}
 	return result, nil
 }
 


### PR DESCRIPTION
debug_storageRangeAt stops iterating when the iterator's Next method
returns false. Next returns false both when the range is exhausted and
when a trie node cannot be resolved, storing the failure in the
iterator's Err field. The method does not check Err after iteration, so
a trie failure can be reported as a normal result.

This also gives the response the wrong pagination meaning. When
iteration fails, the follow-up Next call used to compute NextKey returns
false and leaves NextKey nil. StorageRangeResult defines a nil NextKey
as meaning that the response includes the last key in the trie. The
caller is therefore told that the range is complete even though it was
truncated by a trie error.

Return the error already produced by the iterator. This follows the
existing handling used by other trie.NewIterator consumers, including
cmd/geth/dbcmd.go and the generators in core/state/snapshot and
triedb/pathdb.

Added a regression test that removes a storage trie node from the
database and verifies that storageRangeAt returns an error instead of a
truncated result.
