### PR TITLE
crypto/bn256/google: canonicalize coordinates before testing them

### DIFF
--- a/crypto/bn256/google/canonical_test.go
+++ b/crypto/bn256/google/canonical_test.go
@@ -1,0 +1,35 @@
+// Copyright 2012 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package bn256
+
+import "testing"
+
+// TestMakeAffineZeroModP checks that a z which is a non-zero multiple of P is
+// recognised as the point at infinity. Such a z has no inverse mod P, so the
+// curve point used to hand ModInverse's nil return straight to big.Int.Mul,
+// and the twist point used to invert a zero norm and end up claiming to be the
+// affine point 0 : 0 : 1.
+func TestMakeAffineZeroModP(t *testing.T) {
+	pool := new(bnPool)
+
+	cp := newCurvePoint(pool)
+	cp.x.SetInt64(1)
+	cp.y.SetInt64(2)
+	cp.z.Set(P)
+	cp.t.SetInt64(0)
+	cp.MakeAffine(pool)
+	if !cp.IsInfinity() {
+		t.Errorf("curvePoint with z = P is (%s, %s, %s), want ∞", cp.x, cp.y, cp.z)
+	}
+
+	tp := newTwistPoint(pool)
+	tp.Set(twistGen)
+	tp.z.x.SetInt64(0)
+	tp.z.y.Set(P)
+	tp.MakeAffine(pool)
+	if !tp.IsInfinity() {
+		t.Errorf("twistPoint with z = (0, P) is %s, want ∞", tp)
+	}
+}

--- a/crypto/bn256/google/canonical_test.go
+++ b/crypto/bn256/google/canonical_test.go
@@ -120,3 +120,36 @@ func TestGFp2IsOneCanonical(t *testing.T) {
 		t.Errorf("gfP2%s.IsOne() = false, want true", one)
 	}
 }
+
+// TestGFp2InvertZero checks that inverting zero returns zero rather than
+// whatever the pool last held, matching the 0⁻¹ = 0 convention of the
+// cloudflare and gnark backends.
+func TestGFp2InvertZero(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		x, y *big.Int
+	}{
+		{"0", big.NewInt(0), big.NewInt(0)},
+		{"non-canonical 0", new(big.Int).Set(P), new(big.Int).Set(P)},
+	} {
+		pool := new(bnPool)
+		// Poison the pool so a discarded ModInverse failure would show up.
+		for i := 0; i < 8; i++ {
+			pool.Put(new(big.Int).SetInt64(0xdead0000 + int64(i)))
+		}
+		a := newGFp2(pool)
+		a.x.Set(tc.x)
+		a.y.Set(tc.y)
+
+		inv := newGFp2(pool).Invert(a, pool)
+		if !inv.IsZero() {
+			t.Errorf("Invert(%s) = %s, want (0,0)", tc.name, inv)
+		}
+
+		a.Put(pool)
+		inv.Put(pool)
+		if c := pool.Count(); c > 0 {
+			t.Errorf("Invert(%s) leaked %d pool entries", tc.name, c)
+		}
+	}
+}

--- a/crypto/bn256/google/canonical_test.go
+++ b/crypto/bn256/google/canonical_test.go
@@ -102,3 +102,21 @@ func TestNegativeIsCanonical(t *testing.T) {
 		}
 	}
 }
+
+// TestGFp2IsOneCanonical checks that IsOne only accepts the reduced one. It
+// reads y through Bits, which reports the magnitude, so -1 used to pass.
+func TestGFp2IsOneCanonical(t *testing.T) {
+	for _, e := range []*gfP2{
+		{new(big.Int), big.NewInt(-1)},
+		{new(big.Int), new(big.Int).Add(P, big.NewInt(1))},
+		{new(big.Int).Set(P), big.NewInt(1)},
+	} {
+		if e.IsOne() {
+			t.Errorf("gfP2%s.IsOne() = true, want false", e)
+		}
+	}
+	one := newGFp2(nil).SetOne()
+	if !one.IsOne() {
+		t.Errorf("gfP2%s.IsOne() = false, want true", one)
+	}
+}

--- a/crypto/bn256/google/canonical_test.go
+++ b/crypto/bn256/google/canonical_test.go
@@ -4,7 +4,15 @@
 
 package bn256
 
-import "testing"
+import (
+	"math/big"
+	"testing"
+)
+
+// reduced reports whether n is in [0, P).
+func reduced(n *big.Int) bool {
+	return n.Sign() >= 0 && n.Cmp(P) < 0
+}
 
 // TestMakeAffineZeroModP checks that a z which is a non-zero multiple of P is
 // recognised as the point at infinity. Such a z has no inverse mod P, so the
@@ -31,5 +39,66 @@ func TestMakeAffineZeroModP(t *testing.T) {
 	tp.MakeAffine(pool)
 	if !tp.IsInfinity() {
 		t.Errorf("twistPoint with z = (0, P) is %s, want ∞", tp)
+	}
+}
+
+// TestMakeAffineReduces checks that MakeAffine canonicalises the coordinates it
+// returns even when the point is already affine and so skips the inversion.
+// Add and Double leave their outputs unreduced and Negative leaves y negative,
+// so without this a caller cannot compare two points by their coordinates.
+func TestMakeAffineReduces(t *testing.T) {
+	pool := new(bnPool)
+
+	want := newCurvePoint(pool).Mul(curveGen, big.NewInt(7), pool).MakeAffine(pool)
+
+	// The same point with its coordinates shifted out of [0, P) the way the
+	// group law leaves them, once with z = 1 and once with z merely ≡ 1.
+	for _, z := range []*big.Int{big.NewInt(1), new(big.Int).Add(P, big.NewInt(1))} {
+		got := newCurvePoint(pool)
+		got.x.Add(want.x, P)
+		got.y.Sub(want.y, P)
+		got.z.Set(z)
+		got.t.SetInt64(0)
+		got.MakeAffine(pool)
+
+		if got.x.Cmp(want.x) != 0 || got.y.Cmp(want.y) != 0 {
+			t.Errorf("z = %s: MakeAffine = (%s, %s), want (%s, %s)", z, got.x, got.y, want.x, want.y)
+		}
+		if !reduced(got.x) || !reduced(got.y) || !reduced(got.z) {
+			t.Errorf("z = %s: MakeAffine left unreduced coordinates: (%s, %s, %s)", z, got.x, got.y, got.z)
+		}
+		if got.t.Cmp(big.NewInt(1)) != 0 {
+			t.Errorf("z = %s: MakeAffine left t = %s, want 1 = z²", z, got.t)
+		}
+	}
+}
+
+// TestNegativeIsCanonical checks that negating an affine point and calling
+// MakeAffine yields the reduced representation. Negative sets y to -y, and
+// MakeAffine used to return early on z = 1 without touching it.
+func TestNegativeIsCanonical(t *testing.T) {
+	pool := new(bnPool)
+
+	a := newCurvePoint(pool).Mul(curveGen, big.NewInt(7), pool).MakeAffine(pool)
+
+	neg := newCurvePoint(pool)
+	neg.Negative(a)
+	neg.MakeAffine(pool)
+	if !reduced(neg.x) || !reduced(neg.y) {
+		t.Errorf("Negative left unreduced coordinates: (%s, %s)", neg.x, neg.y)
+	}
+	if wantY := new(big.Int).Sub(P, a.y); neg.x.Cmp(a.x) != 0 || neg.y.Cmp(wantY) != 0 {
+		t.Errorf("Negative = (%s, %s), want (%s, %s)", neg.x, neg.y, a.x, wantY)
+	}
+
+	tp := newTwistPoint(pool).Mul(twistGen, big.NewInt(7), pool).MakeAffine(pool)
+	negT := newTwistPoint(pool)
+	negT.Negative(tp, pool)
+	negT.MakeAffine(pool)
+	for _, n := range []*big.Int{negT.x.x, negT.x.y, negT.y.x, negT.y.y} {
+		if !reduced(n) {
+			t.Errorf("twistPoint.Negative left unreduced coordinates: %s", negT)
+			break
+		}
 	}
 }

--- a/crypto/bn256/google/curve.go
+++ b/crypto/bn256/google/curve.go
@@ -248,6 +248,15 @@ func (c *curvePoint) Mul(a *curvePoint, scalar *big.Int, pool *bnPool) *curvePoi
 // MakeAffine converts c to affine form and returns c. If c is ∞, then it sets
 // c to 0 : 1 : 0.
 func (c *curvePoint) MakeAffine(pool *bnPool) *curvePoint {
+	// Add and Double leave their outputs unreduced, so z has to be brought
+	// into [0, P) before anything below can look at it: Bits reports the
+	// magnitude and would read -1 as 1, IsInfinity only recognises an exact
+	// zero, and ModInverse returns nil for a z that is a non-zero multiple of
+	// P, which would make the multiplication that consumes it a nil
+	// dereference.
+	if c.z.Sign() < 0 || c.z.Cmp(P) >= 0 {
+		c.z.Mod(c.z, P)
+	}
 	if words := c.z.Bits(); len(words) == 1 && words[0] == 1 {
 		return c
 	}
@@ -258,6 +267,8 @@ func (c *curvePoint) MakeAffine(pool *bnPool) *curvePoint {
 		c.t.SetInt64(0)
 		return c
 	}
+	// z is reduced and non-zero at this point and P is prime, so the two are
+	// coprime and ModInverse cannot fail.
 	zInv := pool.Get().ModInverse(c.z, P)
 	t := pool.Get().Mul(c.y, zInv)
 	t.Mod(t, P)

--- a/crypto/bn256/google/curve.go
+++ b/crypto/bn256/google/curve.go
@@ -246,7 +246,7 @@ func (c *curvePoint) Mul(a *curvePoint, scalar *big.Int, pool *bnPool) *curvePoi
 }
 
 // MakeAffine converts c to affine form and returns c. If c is ∞, then it sets
-// c to 0 : 1 : 0.
+// c to 0 : 1 : 0. On return the coordinates are reduced to [0, P).
 func (c *curvePoint) MakeAffine(pool *bnPool) *curvePoint {
 	// Add and Double leave their outputs unreduced, so z has to be brought
 	// into [0, P) before anything below can look at it: Bits reports the
@@ -258,6 +258,17 @@ func (c *curvePoint) MakeAffine(pool *bnPool) *curvePoint {
 		c.z.Mod(c.z, P)
 	}
 	if words := c.z.Bits(); len(words) == 1 && words[0] == 1 {
+		// The point is already affine and so skips the reduction below, but
+		// its x and y are no more reduced than z was. Negative in particular
+		// leaves y negative and t zero, and a caller comparing coordinates has
+		// no way to tell that apart from a different point.
+		if c.x.Sign() < 0 || c.x.Cmp(P) >= 0 {
+			c.x.Mod(c.x, P)
+		}
+		if c.y.Sign() < 0 || c.y.Cmp(P) >= 0 {
+			c.y.Mod(c.y, P)
+		}
+		c.t.SetInt64(1)
 		return c
 	}
 	if c.IsInfinity() {

--- a/crypto/bn256/google/gfp2.go
+++ b/crypto/bn256/google/gfp2.go
@@ -64,8 +64,13 @@ func (e *gfP2) IsZero() bool {
 	return e.x.Sign() == 0 && e.y.Sign() == 0
 }
 
+// IsOne reports whether e is the canonical representation of one. Values that
+// are congruent to one but not reduced, such as P+1, report false, so call
+// Minimal first where that matters.
 func (e *gfP2) IsOne() bool {
-	if e.x.Sign() != 0 {
+	// Bits reports the magnitude of y and would read -1 as 1, so reject a
+	// negative y before consulting it.
+	if e.x.Sign() != 0 || e.y.Sign() < 0 {
 		return false
 	}
 	words := e.y.Bits()

--- a/crypto/bn256/google/gfp2.go
+++ b/crypto/bn256/google/gfp2.go
@@ -207,14 +207,23 @@ func (e *gfP2) Invert(a *gfP2, pool *bnPool) *gfP2 {
 	t.Add(t, t2)
 
 	inv := pool.Get()
-	inv.ModInverse(t, P)
+	if inv.ModInverse(t, P) == nil {
+		// t is the norm x²+y² of a. P ≡ 3 mod 4, so -1 is not a square mod P
+		// and the norm vanishes only for a ≡ 0, which no caller passes.
+		// ModInverse leaves inv holding whatever the pool last put there; the
+		// multiplications below happen to wipe it, since both components of a
+		// are also ≡ 0 whenever the norm is, but say so explicitly rather than
+		// depending on that. Zero is what the cloudflare and gnark backends
+		// return for 0⁻¹, and the three must not disagree.
+		e.SetZero()
+	} else {
+		e.x.Neg(a.x)
+		e.x.Mul(e.x, inv)
+		e.x.Mod(e.x, P)
 
-	e.x.Neg(a.x)
-	e.x.Mul(e.x, inv)
-	e.x.Mod(e.x, P)
-
-	e.y.Mul(a.y, inv)
-	e.y.Mod(e.y, P)
+		e.y.Mul(a.y, inv)
+		e.y.Mod(e.y, P)
+	}
 
 	pool.Put(t)
 	pool.Put(t2)

--- a/crypto/bn256/google/twist.go
+++ b/crypto/bn256/google/twist.go
@@ -228,7 +228,7 @@ func (c *twistPoint) Mul(a *twistPoint, scalar *big.Int, pool *bnPool) *twistPoi
 }
 
 // MakeAffine converts c to affine form and returns c. If c is ∞, then it sets
-// c to 0 : 1 : 0.
+// c to 0 : 1 : 0. On return the coordinates are reduced to [0, P).
 func (c *twistPoint) MakeAffine(pool *bnPool) *twistPoint {
 	// For the reasoning here, see the same function in curve.go. The failure
 	// mode differs: a z that is a non-zero multiple of P has a zero norm, so
@@ -236,6 +236,12 @@ func (c *twistPoint) MakeAffine(pool *bnPool) *twistPoint {
 	// bogus affine point 0 : 0 : 1 rather than panicking.
 	c.z.Minimal()
 	if c.z.IsOne() {
+		// Reduce x and y for the same reason as in curve.go, and set t: Add
+		// never writes it, so a point that arrives here affine can be carrying
+		// a stale one, and the Miller loop does read t.
+		c.x.Minimal()
+		c.y.Minimal()
+		c.t.SetOne()
 		return c
 	}
 	if c.IsInfinity() {

--- a/crypto/bn256/google/twist.go
+++ b/crypto/bn256/google/twist.go
@@ -230,6 +230,11 @@ func (c *twistPoint) Mul(a *twistPoint, scalar *big.Int, pool *bnPool) *twistPoi
 // MakeAffine converts c to affine form and returns c. If c is ∞, then it sets
 // c to 0 : 1 : 0.
 func (c *twistPoint) MakeAffine(pool *bnPool) *twistPoint {
+	// For the reasoning here, see the same function in curve.go. The failure
+	// mode differs: a z that is a non-zero multiple of P has a zero norm, so
+	// Invert below returns zero and the point at infinity silently becomes the
+	// bogus affine point 0 : 0 : 1 rather than panicking.
+	c.z.Minimal()
 	if c.z.IsOne() {
 		return c
 	}
@@ -240,6 +245,8 @@ func (c *twistPoint) MakeAffine(pool *bnPool) *twistPoint {
 		c.t.SetZero()
 		return c
 	}
+	// z is reduced and non-zero at this point, so its norm is non-zero and
+	// Invert cannot fail.
 	zInv := newGFp2(pool).Invert(c.z, pool)
 	t := newGFp2(pool).Mul(c.y, zInv, pool)
 	zInv2 := newGFp2(pool).Square(zInv, pool)


### PR DESCRIPTION
**`MakeAffine` inverted an unreduced `z`.** `ModInverse` returns nil when no inverse exists. Reducing `z` first removes the case instead of detecting it: after reduction `z ∈ [1, P)` at the inversion, coprime to prime `P`. That holds for any input, including a caller who mutates the `big.Int`s `G1.CurvePoints` hands out, which a nil check would only catch after the fact.

**`MakeAffine` returned non-canonical coordinates.** The `z == 1` path returned without touching `x` and `y`, so `G1.Neg` of an affine point produced a representation `MakeAffine` would not normalize, and comparing two mathematically equal points by their coordinates was unsound. Fixing it at `MakeAffine` rather than at `Negative` covers `Add` and `Double` as well.
**`gfP2.IsOne` tested `y` through `Bits`** which reports the magnitude so `-1` read as `1`.

**`gfP2.Invert` discarded the `ModInverse` result.**