### PR TITLE
cmd/evm/testdata/evmrun: fix flaky benchmark duration regex

### DIFF
--- a/cmd/evm/testdata/evmrun/9.out.2.txt
+++ b/cmd/evm/testdata/evmrun/9.out.2.txt
@@ -1,4 +1,4 @@
 EVM gas used:    \d+
-execution time:  \d+\.\d+.s
+execution time:  \d+(\.\d+)?.s
 allocations:     \d+
 allocated bytes: \d+


### PR DESCRIPTION
Fixes a flaky benchmark-output test. Here is an example of it failing:

https://github.com/ethereum/go-ethereum/actions/runs/32334412685/job/96322388380?pr=35440

The expected-output regex previously required a fractional component, causing the test to fail intermittently when the duration was a whole number. This change makes that component optional, accepting both `73µs` and `73.001µs`.