### PR TITLE
eth: report gzip export finalization errors

### DIFF
--- a/eth/api_admin.go
+++ b/eth/api_admin.go
@@ -42,7 +42,7 @@ func NewAdminAPI(eth *Ethereum) *AdminAPI {
 
 // ExportChain exports the current blockchain into a local file,
 // or a range of blocks if first and last are non-nil.
-func (api *AdminAPI) ExportChain(file string, first *uint64, last *uint64) (bool, error) {
+func (api *AdminAPI) ExportChain(file string, first *uint64, last *uint64) (success bool, err error) {
 	if first == nil && last != nil {
 		return false, errors.New("last cannot be specified without first")
 	}
@@ -60,13 +60,25 @@ func (api *AdminAPI) ExportChain(file string, first *uint64, last *uint64) (bool
 	if err != nil {
 		return false, err
 	}
-	defer out.Close()
 
 	var writer io.Writer = out
+	var gzipWriter io.WriteCloser
 	if strings.HasSuffix(file, ".gz") {
-		writer = gzip.NewWriter(writer)
-		defer writer.(*gzip.Writer).Close()
+		gzipWriter = newAdminGzipWriter(out)
+		writer = gzipWriter
 	}
+	defer func() {
+		if gzipWriter != nil {
+			if closeErr := gzipWriter.Close(); err == nil && closeErr != nil {
+				success = false
+				err = fmt.Errorf("failed to finalize gzip export: %w", closeErr)
+			}
+		}
+		if closeErr := out.Close(); err == nil && closeErr != nil {
+			success = false
+			err = fmt.Errorf("failed to close export file: %w", closeErr)
+		}
+	}()
 
 	// Export the blockchain
 	if first != nil {
@@ -77,6 +89,10 @@ func (api *AdminAPI) ExportChain(file string, first *uint64, last *uint64) (bool
 		return false, err
 	}
 	return true, nil
+}
+
+var newAdminGzipWriter = func(w io.Writer) io.WriteCloser {
+	return gzip.NewWriter(w)
 }
 
 func hasAllBlocks(chain *core.BlockChain, bs []*types.Block) bool {

--- a/eth/api_admin_test.go
+++ b/eth/api_admin_test.go
@@ -1,0 +1,92 @@
+// Copyright 2026 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+
+package eth
+
+import (
+	"compress/gzip"
+	"errors"
+	"io"
+	"math/big"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/core"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/params"
+)
+
+var errLateClose = errors.New("injected late gzip close failure")
+
+type lateFailGzip struct {
+	inner  io.Writer
+	closed bool
+}
+
+func (w *lateFailGzip) Write(p []byte) (int, error) {
+	return w.inner.Write(p)
+}
+
+func (w *lateFailGzip) Close() error {
+	w.closed = true
+	return errLateClose
+}
+
+func TestAdminExportChainReportsGzipCloseFailure(t *testing.T) {
+	genesis := &core.Genesis{
+		Config: params.TestChainConfig,
+		Alloc: types.GenesisAlloc{
+			{1}: {Balance: big.NewInt(params.Ether)},
+		},
+	}
+	chain := newTestBlockChain(t, 1, genesis, nil)
+	defer chain.Stop()
+
+	var injected *lateFailGzip
+	oldFactory := newAdminGzipWriter
+	newAdminGzipWriter = func(dst io.Writer) io.WriteCloser {
+		injected = &lateFailGzip{inner: gzip.NewWriter(dst)}
+		return injected
+	}
+	defer func() { newAdminGzipWriter = oldFactory }()
+
+	path := filepath.Join(t.TempDir(), "chain.gz")
+	result, err := NewAdminAPI(&Ethereum{blockchain: chain}).ExportChain(path, nil, nil)
+	if result {
+		t.Fatal("ExportChain returned success after gzip finalization failed")
+	}
+	if !errors.Is(err, errLateClose) {
+		t.Fatalf("ExportChain error = %v, want %v", err, errLateClose)
+	}
+	if injected == nil || !injected.closed {
+		t.Fatal("fixture did not execute the failing Close")
+	}
+
+	f, err := os.Open(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer f.Close()
+	zr, err := gzip.NewReader(f)
+	if err == nil {
+		_, err = io.ReadAll(zr)
+		_ = zr.Close()
+	}
+	if err == nil {
+		t.Fatal("gzip archive unexpectedly valid")
+	}
+}


### PR DESCRIPTION
Closes #35480

## Summary

`eth.AdminAPI.ExportChain` now reports errors from gzip finalization instead of returning success for an incomplete `.gz` archive. It also propagates output-file close errors.

The implementation keeps the existing export error behavior, closes the gzip writer before the file, and uses a small writer factory so close failures are tested deterministically.

## Test coverage

Added `TestAdminExportChainReportsGzipCloseFailure`, which injects a late gzip close error and verifies that:

- `ExportChain` returns `false`.
- - The returned error wraps the gzip finalization error.
- - The gzip writer close path executes.
- - The resulting archive is rejected by the gzip reader.
## Validation

- `gofmt` passed.
- - `git diff --check` passed.
- - `go test ./eth -run '^TestAdminExportChainReportsGzipCloseFailure$' -count=1 -v` passed.
- - Commit is GPG signed and includes a DCO sign-off.
- 