### PR TITLE
core/txpool/locals: check close error before replacing journal

### DIFF
--- a/core/txpool/locals/journal.go
+++ b/core/txpool/locals/journal.go
@@ -174,7 +174,9 @@ func (journal *journal) rotate(all map[common.Address]types.Transactions) error 
 		}
 		journaled += len(txs)
 	}
-	replacement.Close()
+	if err := replacement.Close(); err != nil {
+		return err
+	}
 
 	// Replace the live journal with the newly generated one
 	if err = os.Rename(journal.path+".new", journal.path); err != nil {


### PR DESCRIPTION
`rotate` writes the regenerated journal to `<path>.new` and then renames it over the live journal. The close of the temporary file is not checked, so a failed close can leave a truncated file that still gets renamed over a good journal, dropping local transactions on the next restart.

Every other write path close in this file already reports its error: in `setupWriter`, in `rotate` for the previous writer, and in `close`.

The close in the encode error branch is left as is, since an error is already being returned there.