### PR TITLE
eth/fetcher: avoid sorting unrequested announcements

### DIFF
--- a/eth/fetcher/tx_fetcher.go
+++ b/eth/fetcher/tx_fetcher.go
@@ -136,6 +136,48 @@ type txMetadataWithSeq struct {
 	seq uint64
 }
 
+type txAnnounceEntry struct {
+	hash common.Hash
+	meta *txMetadataWithSeq
+}
+
+// txAnnounceHeap keeps the newest selected announcement at its root.
+type txAnnounceHeap []txAnnounceEntry
+
+func (h *txAnnounceHeap) push(entry txAnnounceEntry) {
+	items := append(*h, entry)
+	i := len(items) - 1
+	for i > 0 {
+		parent := (i - 1) / 2
+		if items[parent].meta.seq >= entry.meta.seq {
+			break
+		}
+		items[i] = items[parent]
+		i = parent
+	}
+	items[i] = entry
+	*h = items
+}
+
+func (h txAnnounceHeap) replaceTop(entry txAnnounceEntry) {
+	i := 0
+	for {
+		child := 2*i + 1
+		if child >= len(h) {
+			break
+		}
+		if right := child + 1; right < len(h) && h[right].meta.seq > h[child].meta.seq {
+			child = right
+		}
+		if h[child].meta.seq <= entry.meta.seq {
+			break
+		}
+		h[i] = h[child]
+		i = child
+	}
+	h[i] = entry
+}
+
 // txRequest represents an in-flight transaction retrieval request destined to
 // a specific peers.
 type txRequest struct {
@@ -1174,21 +1216,48 @@ func (f *TxFetcher) forEachPeer(peers map[string]struct{}, do func(peer string))
 // ordering to minimize the chances of transaction nonce-gaps, which result in
 // transactions being rejected by the txpool.
 func (f *TxFetcher) forEachAnnounce(announces map[common.Hash]*txMetadataWithSeq, do func(hash common.Hash, meta txMetadata) bool) {
-	type announcement struct {
-		hash common.Hash
-		meta txMetadata
-		seq  uint64
+	if len(announces) <= maxTxRetrievals {
+		type announcement struct {
+			hash common.Hash
+			meta txMetadata
+			seq  uint64
+		}
+		// Process announcements by their arrival order.
+		list := make([]announcement, 0, len(announces))
+		for hash, entry := range announces {
+			list = append(list, announcement{hash: hash, meta: entry.txMetadata, seq: entry.seq})
+		}
+		sort.Slice(list, func(i, j int) bool {
+			return list[i].seq < list[j].seq
+		})
+		for i := range list {
+			if !do(list[i].hash, list[i].meta) {
+				return
+			}
+		}
+		return
 	}
-	// Process announcements by their arrival order
-	list := make([]announcement, 0, len(announces))
+	// Retain only the oldest announcements that can fit in this request.
+	list := make(txAnnounceHeap, 0, maxTxRetrievals)
 	for hash, entry := range announces {
-		list = append(list, announcement{hash: hash, meta: entry.txMetadata, seq: entry.seq})
+		if _, ok := f.fetching[hash]; ok {
+			// Fetching entries would be skipped by the callback below.
+			continue
+		}
+		announcement := txAnnounceEntry{hash: hash, meta: entry}
+		if len(list) < maxTxRetrievals {
+			list.push(announcement)
+			continue
+		}
+		if announcement.meta.seq < list[0].meta.seq {
+			list.replaceTop(announcement)
+		}
 	}
 	sort.Slice(list, func(i, j int) bool {
-		return list[i].seq < list[j].seq
+		return list[i].meta.seq < list[j].meta.seq
 	})
 	for i := range list {
-		if !do(list[i].hash, list[i].meta) {
+		if !do(list[i].hash, list[i].meta.txMetadata) {
 			return
 		}
 	}

--- a/eth/fetcher/tx_fetcher_test.go
+++ b/eth/fetcher/tx_fetcher_test.go
@@ -2341,3 +2341,266 @@ func TestTransactionForgotten(t *testing.T) {
 		t.Errorf("wrong final underpriced cache size: got %d, want 1", size)
 	}
 }
+
+type txFetcherScheduleInput struct {
+	peers  []string
+	hashes [][]common.Hash
+	kinds  []byte
+	sizes  []uint32
+	metas  []txDeliveryMeta
+}
+
+func newTxFetcherScheduleInput(peers, announcements int, size uint32) txFetcherScheduleInput {
+	input := txFetcherScheduleInput{
+		peers:  make([]string, peers),
+		hashes: make([][]common.Hash, peers),
+		kinds:  make([]byte, announcements),
+		sizes:  make([]uint32, announcements),
+		metas:  make([]txDeliveryMeta, announcements),
+	}
+	for i := range input.kinds {
+		input.kinds[i] = types.LegacyTxType
+		input.sizes[i] = size
+		input.metas[i] = txDeliveryMeta{kind: types.LegacyTxType, size: size, sizeWithoutBlob: size}
+	}
+	for peer := range input.peers {
+		input.peers[peer] = string(rune('A' + peer))
+		input.hashes[peer] = make([]common.Hash, announcements)
+		for i := range input.hashes[peer] {
+			input.hashes[peer][i] = common.Hash{byte(peer + 1), byte(i >> 8), byte(i)}
+		}
+	}
+	return input
+}
+
+func announceTxFetcherSchedule(tb testing.TB, fetcher *TxFetcher, step <-chan struct{}, input txFetcherScheduleInput, peer int) {
+	tb.Helper()
+	if _, err := fetcher.Notify(input.peers[peer], eth.ETH70, input.kinds, input.sizes, input.hashes[peer]); err != nil {
+		tb.Fatal(err)
+	}
+	<-step
+}
+
+func startTxFetcherSchedule(tb testing.TB, input txFetcherScheduleInput, peers int) (*TxFetcher, *mclock.Simulated, chan struct{}) {
+	tb.Helper()
+
+	clock := new(mclock.Simulated)
+	step := make(chan struct{})
+	fetcher := newTestTxFetcher()
+	fetcher.clock = clock
+	fetcher.step = step
+	fetcher.rand = rand.New(rand.NewSource(0x3a29))
+	fetcher.Start()
+
+	for peer := 0; peer < peers; peer++ {
+		announceTxFetcherSchedule(tb, fetcher, step, input, peer)
+	}
+	clock.Run(txArriveTimeout)
+	<-step
+
+	return fetcher, clock, step
+}
+
+func deliverTxFetcherSchedule(fetcher *TxFetcher, step <-chan struct{}, peer string, hashes []common.Hash, metas []txDeliveryMeta) {
+	fetcher.cleanup <- &txDelivery{origin: peer, hashes: hashes, metas: metas, direct: true}
+	<-step
+}
+
+func requireTxFetcherRequest(tb testing.TB, fetcher *TxFetcher, peer string, want []common.Hash) {
+	tb.Helper()
+
+	request := fetcher.requests[peer]
+	if request == nil {
+		tb.Fatalf("peer %s has no request", peer)
+	}
+	if len(request.hashes) != len(want) {
+		tb.Fatalf("peer %s request has %d hashes, want %d", peer, len(request.hashes), len(want))
+	}
+	for i := range want {
+		if request.hashes[i] != want[i] {
+			tb.Fatalf("peer %s request hash %d is %x, want %x", peer, i, request.hashes[i], want[i])
+		}
+	}
+}
+
+func (input txFetcherScheduleInput) requestSize(offset int) int {
+	var bytes uint64
+	for i := offset; i < len(input.sizes); i++ {
+		count := i - offset + 1
+		if count >= maxTxRetrievals {
+			return count
+		}
+		bytes += uint64(input.sizes[i])
+		if bytes >= maxTxRetrievalSize {
+			return count
+		}
+	}
+	return len(input.sizes) - offset
+}
+
+func runTxFetcherSchedule(tb testing.TB, input txFetcherScheduleInput, partial bool) {
+	tb.Helper()
+
+	fetcher, _, step := startTxFetcherSchedule(tb, input, len(input.peers))
+	defer fetcher.Stop()
+
+	var (
+		delivered          = make([]int, len(input.peers))
+		partiallyDelivered = make([]bool, len(input.peers))
+		remaining          = len(input.peers) * len(input.sizes)
+	)
+	for remaining > 0 {
+		var served bool
+		for peer, name := range input.peers {
+			request := fetcher.requests[name]
+			if request == nil {
+				continue
+			}
+			if request.hashes == nil {
+				tb.Fatalf("peer %s has a dangling request", name)
+			}
+			start := delivered[peer]
+			count := input.requestSize(start)
+			requireTxFetcherRequest(tb, fetcher, name, input.hashes[peer][start:start+count])
+
+			response := count
+			if partial && !partiallyDelivered[peer] {
+				response /= 2
+				partiallyDelivered[peer] = true
+			}
+			deliverTxFetcherSchedule(fetcher, step, name, request.hashes[:response], input.metas[start:start+response])
+			delivered[peer] += response
+			remaining -= response
+			served = true
+			break
+		}
+		if !served {
+			tb.Fatal("no request available while transactions remain")
+		}
+	}
+	if len(fetcher.requests) != 0 || len(fetcher.announced) != 0 {
+		tb.Fatalf("fetcher did not drain: %d requests, %d announcements", len(fetcher.requests), len(fetcher.announced))
+	}
+}
+
+func TestTransactionFetcherLargeBacklogOrdering(t *testing.T) {
+	t.Parallel()
+
+	input := newTxFetcherScheduleInput(2, maxTxAnnounces, 1)
+	t.Run("full", func(t *testing.T) {
+		fetcher, _, step := startTxFetcherSchedule(t, input, 1)
+		defer fetcher.Stop()
+
+		peer := input.peers[0]
+		requireTxFetcherRequest(t, fetcher, peer, input.hashes[0][:maxTxRetrievals])
+		deliverTxFetcherSchedule(fetcher, step, peer, input.hashes[0][:maxTxRetrievals], input.metas[:maxTxRetrievals])
+		requireTxFetcherRequest(t, fetcher, peer, input.hashes[0][maxTxRetrievals:2*maxTxRetrievals])
+	})
+	t.Run("partial", func(t *testing.T) {
+		fetcher, _, step := startTxFetcherSchedule(t, input, 1)
+		defer fetcher.Stop()
+
+		peer := input.peers[0]
+		delivered := maxTxRetrievals / 2
+		requireTxFetcherRequest(t, fetcher, peer, input.hashes[0][:maxTxRetrievals])
+		deliverTxFetcherSchedule(fetcher, step, peer, input.hashes[0][:delivered], input.metas[:delivered])
+		requireTxFetcherRequest(t, fetcher, peer, input.hashes[0][delivered:delivered+maxTxRetrievals])
+	})
+	t.Run("alternate", func(t *testing.T) {
+		testTxFetcherLargeBacklogAlternate(t, input)
+	})
+	t.Run("timeout", func(t *testing.T) {
+		testTxFetcherLargeBacklogRescheduling(t, input, false)
+	})
+	t.Run("drop", func(t *testing.T) {
+		testTxFetcherLargeBacklogRescheduling(t, input, true)
+	})
+	t.Run("byte-limited", func(t *testing.T) {
+		input := newTxFetcherScheduleInput(1, maxTxAnnounces, maxTxRetrievalSize)
+		fetcher, _, step := startTxFetcherSchedule(t, input, 1)
+		defer fetcher.Stop()
+
+		peer := input.peers[0]
+		requireTxFetcherRequest(t, fetcher, peer, input.hashes[0][:1])
+		deliverTxFetcherSchedule(fetcher, step, peer, input.hashes[0][:1], input.metas[:1])
+		requireTxFetcherRequest(t, fetcher, peer, input.hashes[0][1:2])
+	})
+}
+
+func testTxFetcherLargeBacklogAlternate(t *testing.T, input txFetcherScheduleInput) {
+	t.Helper()
+
+	input.hashes[1] = input.hashes[0]
+	fetcher, _, step := startTxFetcherSchedule(t, input, 1)
+	defer fetcher.Stop()
+
+	first, second := input.peers[0], input.peers[1]
+	requireTxFetcherRequest(t, fetcher, first, input.hashes[0][:maxTxRetrievals])
+	announceTxFetcherSchedule(t, fetcher, step, input, 1)
+	requireTxFetcherRequest(t, fetcher, second, input.hashes[1][maxTxRetrievals:2*maxTxRetrievals])
+}
+
+func testTxFetcherLargeBacklogRescheduling(t *testing.T, input txFetcherScheduleInput, drop bool) {
+	t.Helper()
+
+	input.hashes[1] = input.hashes[0][:maxTxRetrievals]
+	fetcher, clock, step := startTxFetcherSchedule(t, input, 1)
+	defer fetcher.Stop()
+
+	first, second := input.peers[0], input.peers[1]
+	requireTxFetcherRequest(t, fetcher, first, input.hashes[0][:maxTxRetrievals])
+	announceTxFetcherSchedule(t, fetcher, step, input, 1)
+	if fetcher.requests[second] != nil {
+		t.Fatalf("peer %s requested transactions already fetching from %s", second, first)
+	}
+
+	if drop {
+		if err := fetcher.Drop(first); err != nil {
+			t.Fatal(err)
+		}
+		<-step
+	} else {
+		clock.Run(txFetchTimeout)
+		<-step
+	}
+	requireTxFetcherRequest(t, fetcher, second, input.hashes[1])
+}
+
+func BenchmarkTransactionFetcherScheduleFetches(b *testing.B) {
+	type scenario struct {
+		peers         int
+		announcements int
+		size          uint32
+		partial       bool
+	}
+	var scenarios []scenario
+	for _, peers := range []int{1, 4} {
+		for _, announcements := range []int{256, 512, 1024, 4096} {
+			scenarios = append(scenarios,
+				scenario{peers: peers, announcements: announcements, size: 1},
+				scenario{peers: peers, announcements: announcements, size: 1, partial: true},
+				scenario{peers: peers, announcements: announcements, size: maxTxRetrievalSize},
+			)
+		}
+	}
+	inputs := make([]txFetcherScheduleInput, len(scenarios))
+	for i, scenario := range scenarios {
+		inputs[i] = newTxFetcherScheduleInput(scenario.peers, scenario.announcements, scenario.size)
+	}
+
+	b.Run("all", func(b *testing.B) {
+		b.ReportAllocs()
+		for b.Loop() {
+			for i, scenario := range scenarios {
+				runTxFetcherSchedule(b, inputs[i], scenario.partial)
+			}
+		}
+	})
+	b.Run("byte-limited-guard", func(b *testing.B) {
+		input := newTxFetcherScheduleInput(4, maxTxRetrievals, maxTxRetrievalSize)
+		b.ReportAllocs()
+		for b.Loop() {
+			runTxFetcherSchedule(b, input, false)
+		}
+	})
+}


### PR DESCRIPTION
Avoid sorting every announced hash when only the next request-sized prefix is needed.

For queues above `maxTxRetrievals`, retain the oldest eligible hashes in a bounded heap and sort that prefix before the existing callback. Queues at or below the batch size keep the current full sort. The larger path still scans the backlog, but it no longer materializes or sorts every queued hash on each reschedule.

Add loop-driven ordering coverage and a scheduling benchmark for full, partial, and byte-limited responses across 256–4,096 announcements.

Tests: `go test ./eth/fetcher -count=1`; `go test -race ./eth/fetcher -run '^TestTransactionFetcher(RequestOrdering|RateLimiting|BandwidthLimiting|LargeBacklogOrdering|TimeoutRescheduling|DropRescheduling)$' -count=1`.

**Workload:** `transaction-fetch scheduling matrix to exhaustion`

| Metric | Before | After | Change |
| --- | --- | --- | --- |
| `ns/op` | 9540048587 | 3858901280 | 59.6% lower |
| `B/op` | 3037845656 | 690111664 | 77.3% lower |

Checks: 6 passed.

---

Generated by [Perfloop](https://app.perfloop.ai). Human sponsor: [Tomás Senart](https://github.com/tsenart). [Measurements and checks](https://app.perfloop.ai/t/oss/case_r68s7hnme3).