### PR TITLE
core, eth: improve the blob fetcher

### DIFF
--- a/core/txpool/blobpool/buffer.go
+++ b/core/txpool/blobpool/buffer.go
@@ -18,6 +18,7 @@ package blobpool
 
 import (
 	"cmp"
+	"errors"
 	"fmt"
 	"slices"
 	"sync"
@@ -37,6 +38,7 @@ var (
 	blobBufferCellsFirstCounter = metrics.NewRegisteredCounter("blobpool/buffer/cellsfirst", nil)
 	blobBufferTotalTx           = metrics.NewRegisteredGauge("blobpool/buffer/txcount", nil)
 	blobBufferTotalCells        = metrics.NewRegisteredGauge("blobpool/buffer/cellcount", nil)
+	blobBufferDupCellsCounter   = metrics.NewRegisteredCounter("blobpool/buffer/dupcells", nil)
 )
 
 const (
@@ -180,8 +182,15 @@ func (b *BlobBuffer) storeCompleted(hash common.Hash, tx *types.Transaction, cel
 		return
 	}
 	blobCount := len(tx.BlobHashes())
-	sorted, custody := sortCells(cells, blobCount)
 
+	sorted, custody, err := sortCells(cells, blobCount)
+	if err != nil {
+		log.Warn("Dropping blob tx with overlapping cell deliveries", "hash", hash, "err", err)
+		blobBufferDupCellsCounter.Inc(1)
+		delete(b.cells, hash)
+		delete(b.txs, hash)
+		return
+	}
 	cellSidecar := types.BlobTxCellSidecar{
 		Version:     sidecar.Version,
 		Commitments: sidecar.Commitments,
@@ -282,7 +291,7 @@ func (b *BlobBuffer) verifyCells(entry *cellEntry, sidecar *types.BlobTxSidecar)
 // peer A: cells = [blob0_cell5, blob0_cell3, blob1_cell5, blob1_cell3]
 // peer B: cells = [blob0_cell1, blob0_cell7, blob1_cell1, blob1_cell7]
 // -> [blob0_cell1, blob0_cell3, blob0_cell5, blob0_cell7, blob1_cell1, blob1_cell3, blob1_cell5, blob1_cell7]
-func sortCells(entry *cellEntry, blobCount int) ([]kzg4844.Cell, types.CustodyBitmap) {
+func sortCells(entry *cellEntry, blobCount int) ([]kzg4844.Cell, types.CustodyBitmap, error) {
 	// indices per delivery
 	var indices []uint64
 
@@ -294,6 +303,12 @@ func sortCells(entry *cellEntry, blobCount int) ([]kzg4844.Cell, types.CustodyBi
 		for b := range blobCount {
 			blob[b] = append(blob[b], d.Cells[b*n:(b+1)*n]...)
 		}
+	}
+	// Defensive operation, rejecting the deliveries with overlapping
+	// custody index.
+	custody := types.NewCustodyBitmap(indices)
+	if custody.OneCount() != len(indices) {
+		return nil, types.CustodyBitmap{}, errors.New("duplicate cell index across deliveries")
 	}
 
 	// 2. sort
@@ -312,7 +327,5 @@ func sortCells(entry *cellEntry, blobCount int) ([]kzg4844.Cell, types.CustodyBi
 			res = append(res, blob[b][p])
 		}
 	}
-
-	custody := types.NewCustodyBitmap(indices)
-	return res, custody
+	return res, custody, nil
 }

--- a/core/txpool/blobpool/buffer_test.go
+++ b/core/txpool/blobpool/buffer_test.go
@@ -61,7 +61,10 @@ func TestSortCells(t *testing.T) {
 		},
 		custody: custody,
 	}
-	sorted, resultCustody := sortCells(entry, blobCount)
+	sorted, resultCustody, err := sortCells(entry, blobCount)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	resultIndices := resultCustody.Indices()
 	if len(resultIndices) != 4 {

--- a/eth/fetcher/blob_fetcher.go
+++ b/eth/fetcher/blob_fetcher.go
@@ -93,18 +93,32 @@ type PeerCellDelivery struct {
 
 // merge folds a subsequent delivery from the same peer in, keeping the
 // blob-major cell order.
+//
+// Both index sets must be sorted in ascending order, and must be disjoint: a
+// peer is only ever asked for cells it has not delivered yet.
 func (d *PeerCellDelivery) merge(cells []kzg4844.Cell, indices []uint64) error {
 	var (
-		n1            = len(d.Indices)
-		n2            = len(indices)
-		blobCount     = len(d.Cells) / n1
-		merged        = make([]kzg4844.Cell, 0, len(d.Cells)+len(cells))
-		mergedIndices = make([]uint64, 0, len(d.Cells)+len(cells))
+		n1 = len(d.Indices)
+		n2 = len(indices)
 	)
+	if n1 == 0 || len(d.Cells)%n1 != 0 {
+		return errors.New("corrupted cell delivery")
+	}
+	blobCount := len(d.Cells) / n1
 	if len(cells) != blobCount*n2 {
 		return errors.New("inconsistent cell count across deliveries")
 	}
-
+	// An overlapping index would be retained as a duplicate column, inflating
+	// the fetch accounting of the caller.
+	for _, index := range indices {
+		if _, found := slices.BinarySearch(d.Indices, index); found {
+			return fmt.Errorf("duplicate cell index across deliveries: %d", index)
+		}
+	}
+	var (
+		merged        = make([]kzg4844.Cell, 0, len(d.Cells)+len(cells))
+		mergedIndices = make([]uint64, 0, n1+n2)
+	)
 	for b := range blobCount {
 		i, j := 0, 0
 		for i < n1 || j < n2 {

--- a/eth/fetcher/blob_fetcher.go
+++ b/eth/fetcher/blob_fetcher.go
@@ -17,6 +17,7 @@
 package fetcher
 
 import (
+	"errors"
 	"fmt"
 	"iter"
 	"math/rand"
@@ -563,6 +564,8 @@ func (f *BlobFetcher) loop() {
 				indices := delivery.cellBitmap.Indices()
 				if len(indices) > 0 {
 					status := f.fetches[hash]
+					cells := delivery.cells[i]
+
     				if len(cells) == 0 || len(cells)%len(indices) != 0 {
         				f.fn.DropPeer(delivery.origin)
         				continue

--- a/eth/fetcher/blob_fetcher.go
+++ b/eth/fetcher/blob_fetcher.go
@@ -564,16 +564,13 @@ func (f *BlobFetcher) loop() {
 				indices := delivery.cellBitmap.Indices()
 				if len(indices) > 0 {
 					status := f.fetches[hash]
-					cells := delivery.cells[i]
-
-    				if len(cells) == 0 || len(cells)%len(indices) != 0 {
-        				f.fn.DropPeer(delivery.origin)
-        				continue
-    				}
 					// A peer may deliver again after a re-announcement; merge
 					// instead of overwriting
 					if prev, ok := status.deliveries[delivery.origin]; ok {
-						prev.merge(delivery.cells[i], indices)
+						if err := prev.merge(delivery.cells[i], indices); err != nil {
+							f.fn.DropPeer(delivery.origin)
+							continue
+						}
 					} else {
 						status.deliveries[delivery.origin] = &PeerCellDelivery{
 							Cells:   delivery.cells[i],

--- a/eth/fetcher/blob_fetcher.go
+++ b/eth/fetcher/blob_fetcher.go
@@ -543,7 +543,10 @@ func (f *BlobFetcher) loop() {
 				indices := delivery.cellBitmap.Indices()
 				if len(indices) > 0 {
 					status := f.fetches[hash]
-
+    				if len(cells) == 0 || len(cells)%len(indices) != 0 {
+        				f.fn.DropPeer(delivery.origin)
+        				continue
+    				}
 					// A peer may deliver again after a re-announcement; merge
 					// instead of overwriting
 					if prev, ok := status.deliveries[delivery.origin]; ok {

--- a/eth/fetcher/blob_fetcher.go
+++ b/eth/fetcher/blob_fetcher.go
@@ -90,6 +90,23 @@ type PeerCellDelivery struct {
 	Indices []uint64       // custody indices provided by this peer
 }
 
+// merge folds a subsequent delivery from the same peer in, keeping the
+// blob-major cell order.
+func (d *PeerCellDelivery) merge(cells []kzg4844.Cell, indices []uint64) {
+	var (
+		n1        = len(d.Indices)
+		n2        = len(indices)
+		blobCount = len(d.Cells) / n1
+		merged    = make([]kzg4844.Cell, 0, len(d.Cells)+len(cells))
+	)
+	for b := range blobCount {
+		merged = append(merged, d.Cells[b*n1:(b+1)*n1]...)
+		merged = append(merged, cells[b*n2:(b+1)*n2]...)
+	}
+	d.Cells = merged
+	d.Indices = append(d.Indices, indices...)
+}
+
 type fetchStatus struct {
 	fetching   types.CustodyBitmap          // To avoid fetching cells which had already been fetched / currently being fetched
 	fetched    []uint64                     // Custody indices that have been fetched (per-blob, same for all blobs)
@@ -192,6 +209,7 @@ func NewBlobFetcher(fn BlobFetcherFunctions, custody types.CustodyBitmap, rand r
 // Notify is called when a Type 3 transaction is observed on the network. (TransactionPacket / NewPooledTransactionHashesPacket)
 func (f *BlobFetcher) Notify(peer string, txs []common.Hash, cells types.CustodyBitmap) error {
 	blobAnnounceInMeter.Mark(int64(len(txs)))
+
 	anns := make([]common.Hash, 0)
 	for _, tx := range txs {
 		if f.fn.HasPayload(tx) {
@@ -199,8 +217,11 @@ func (f *BlobFetcher) Notify(peer string, txs []common.Hash, cells types.Custody
 		}
 		anns = append(anns, tx)
 	}
-
-	blobAnnounce := &blobTxAnnounce{origin: peer, txs: anns, cells: cells}
+	blobAnnounce := &blobTxAnnounce{
+		origin: peer,
+		txs:    anns,
+		cells:  cells,
+	}
 	select {
 	case f.notify <- blobAnnounce:
 		return nil
@@ -522,9 +543,16 @@ func (f *BlobFetcher) loop() {
 				indices := delivery.cellBitmap.Indices()
 				if len(indices) > 0 {
 					status := f.fetches[hash]
-					status.deliveries[delivery.origin] = &PeerCellDelivery{
-						Cells:   delivery.cells[i],
-						Indices: indices,
+
+					// A peer may deliver again after a re-announcement; merge
+					// instead of overwriting
+					if prev, ok := status.deliveries[delivery.origin]; ok {
+						prev.merge(delivery.cells[i], indices)
+					} else {
+						status.deliveries[delivery.origin] = &PeerCellDelivery{
+							Cells:   delivery.cells[i],
+							Indices: indices,
+						}
 					}
 					status.fetched = append(status.fetched, indices...)
 				}

--- a/eth/fetcher/blob_fetcher.go
+++ b/eth/fetcher/blob_fetcher.go
@@ -92,19 +92,39 @@ type PeerCellDelivery struct {
 
 // merge folds a subsequent delivery from the same peer in, keeping the
 // blob-major cell order.
-func (d *PeerCellDelivery) merge(cells []kzg4844.Cell, indices []uint64) {
+func (d *PeerCellDelivery) merge(cells []kzg4844.Cell, indices []uint64) error {
 	var (
-		n1        = len(d.Indices)
-		n2        = len(indices)
-		blobCount = len(d.Cells) / n1
-		merged    = make([]kzg4844.Cell, 0, len(d.Cells)+len(cells))
+		n1            = len(d.Indices)
+		n2            = len(indices)
+		blobCount     = len(d.Cells) / n1
+		merged        = make([]kzg4844.Cell, 0, len(d.Cells)+len(cells))
+		mergedIndices = make([]uint64, 0, len(d.Cells)+len(cells))
 	)
+	if len(cells) != blobCount*n2 {
+		return errors.New("inconsistent cell count across deliveries")
+	}
+
 	for b := range blobCount {
-		merged = append(merged, d.Cells[b*n1:(b+1)*n1]...)
-		merged = append(merged, cells[b*n2:(b+1)*n2]...)
+		i, j := 0, 0
+		for i < n1 || j < n2 {
+			if j == n2 || (i < n1 && d.Indices[i] < indices[j]) {
+				merged = append(merged, d.Cells[b*n1+i])
+				if b == 0 {
+					mergedIndices = append(mergedIndices, d.Indices[i])
+				}
+				i++
+			} else {
+				merged = append(merged, cells[b*n2+j])
+				if b == 0 {
+					mergedIndices = append(mergedIndices, indices[j])
+				}
+				j++
+			}
+		}
 	}
 	d.Cells = merged
-	d.Indices = append(d.Indices, indices...)
+	d.Indices = mergedIndices
+	return nil
 }
 
 type fetchStatus struct {

--- a/eth/fetcher/blob_fetcher_test.go
+++ b/eth/fetcher/blob_fetcher_test.go
@@ -1164,7 +1164,7 @@ func TestPeerCellDeliveryMerge(t *testing.T) {
 	}
 	d.merge([]kzg4844.Cell{cell(0, 2), cell(0, 5), cell(1, 2), cell(1, 5)}, []uint64{2, 5})
 
-	wantIndices := []uint64{1, 3, 2, 5}
+	wantIndices := []uint64{1, 2, 3, 5}
 	if !slices.Equal(d.Indices, wantIndices) {
 		t.Fatalf("indices mismatch: have %v, want %v", d.Indices, wantIndices)
 	}

--- a/eth/fetcher/blob_fetcher_test.go
+++ b/eth/fetcher/blob_fetcher_test.go
@@ -1150,3 +1150,31 @@ func TestMultiBlobDeliveryVerification(t *testing.T) {
 		t.Fatalf("KZG cell verification failed after multi-blob delivery: %v", verifyErr)
 	}
 }
+
+// TestPeerCellDeliveryMerge checks that merging a second delivery from the same
+// peer preserves the blob-major cell layout matching the concatenated indices.
+func TestPeerCellDeliveryMerge(t *testing.T) {
+	// Two blobs; cell contents tagged as blob*16+index for identification.
+	cell := func(blob, index int) kzg4844.Cell {
+		return kzg4844.Cell{byte(blob*16 + index)}
+	}
+	d := &PeerCellDelivery{
+		Cells:   []kzg4844.Cell{cell(0, 1), cell(0, 3), cell(1, 1), cell(1, 3)},
+		Indices: []uint64{1, 3},
+	}
+	d.merge([]kzg4844.Cell{cell(0, 2), cell(0, 5), cell(1, 2), cell(1, 5)}, []uint64{2, 5})
+
+	wantIndices := []uint64{1, 3, 2, 5}
+	if !slices.Equal(d.Indices, wantIndices) {
+		t.Fatalf("indices mismatch: have %v, want %v", d.Indices, wantIndices)
+	}
+	// Blob-major: for each blob, cells follow the merged index order.
+	n := len(wantIndices)
+	for b := range 2 {
+		for k, idx := range wantIndices {
+			if want := cell(b, int(idx)); d.Cells[b*n+k] != want {
+				t.Fatalf("blob %d pos %d: have tag %d, want tag %d", b, k, d.Cells[b*n+k][0], want[0])
+			}
+		}
+	}
+}


### PR DESCRIPTION
Add a few defensive operations to the blob fetcher, rejecting the deliveries with overlapping custody index.