### PR TITLE
rpc: reject null for required arguments

### DIFF
--- a/rpc/json.go
+++ b/rpc/json.go
@@ -506,12 +506,12 @@ func parseArgumentArray(rawArgs json.RawMessage, types []reflect.Type) ([]reflec
 			return
 		}
 		argval := reflect.New(types[i])
-		if err := decodeArgument(elem, argval.Interface()); err != nil {
-			scanErr = fmt.Errorf("invalid argument %d: %v", i, err)
+		if types[i].Kind() != reflect.Pointer && isJSONNull(elem) {
+			scanErr = fmt.Errorf("missing value for required argument %d", i)
 			return
 		}
-		if argval.IsNil() && types[i].Kind() != reflect.Pointer {
-			scanErr = fmt.Errorf("missing value for required argument %d", i)
+		if err := decodeArgument(elem, argval.Interface()); err != nil {
+			scanErr = fmt.Errorf("invalid argument %d: %v", i, err)
 			return
 		}
 		args = append(args, argval.Elem())

--- a/rpc/jsonscan_test.go
+++ b/rpc/jsonscan_test.go
@@ -246,17 +246,17 @@ func TestParsePositionalArguments(t *testing.T) {
 		{"object argument", `[{"a":1}]`, []reflect.Type{tMap}, []any{map[string]int{"a": 1}}, ""},
 		{"structural bytes inside a string", `["},{"]`, []reflect.Type{tStr}, []any{`},{`}, ""},
 		{"null into a pointer", `[null]`, []reflect.Type{tPtr}, []any{(*int)(nil)}, ""},
-		{"null into a value", `[null]`, []reflect.Type{tInt}, []any{0}, ""},
 		{"missing optional argument", `[1]`, []reflect.Type{tInt, tPtr}, []any{1, (*int)(nil)}, ""},
 
 		{"too many arguments", `[1,2,3]`, []reflect.Type{tInt}, nil, "too many arguments"},
 		{"missing required argument", `[1]`, []reflect.Type{tInt, tInt}, nil, "missing value for required argument 1"},
 		{"no arguments at all", `[]`, []reflect.Type{tInt}, nil, "missing value for required argument 0"},
+		{"null into a value", `[null]`, []reflect.Type{tInt}, nil, "missing value for required argument 0"},
 		{"wrong type", `["not an int"]`, []reflect.Type{tInt}, nil, "invalid argument 0"},
 
 		// a self decoding type is handed the value directly, except for null
 		{"self decoding", `["0x1234"]`, []reflect.Type{tSelf}, []any{selfDecoding{Text: "0x1234"}}, ""},
-		{"self decoding null", `[null]`, []reflect.Type{tSelf}, nil, "invalid argument 0"},
+		{"self decoding null", `[null]`, []reflect.Type{tSelf}, nil, "missing value for required argument 0"},
 	}
 
 	for _, tc := range tests {


### PR DESCRIPTION
A JSON null passed for a required argument was silently decoded as the zero value instead of being rejected. The check meant to catch it never actually ran. This PR fixes it.