### PR TITLE
common/lru, core/vm: count entry overhead in the precompile cache budget

### DIFF
--- a/common/lru/blob_lru.go
+++ b/common/lru/blob_lru.go
@@ -107,3 +107,12 @@ func (c *SizeConstrainedCache[K, V]) Get(key K) (V, bool) {
 
 	return c.lru.Get(key)
 }
+
+// Size returns how many bytes the cache is currently holding, as measured
+// against its constraint.
+func (c *SizeConstrainedCache[K, V]) Size() uint64 {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+
+	return c.size
+}

--- a/core/vm/precompile_cache.go
+++ b/core/vm/precompile_cache.go
@@ -30,6 +30,7 @@ var (
 	precompileCacheMissMeter         = metrics.NewRegisteredMeter("chain/cache/precompile/miss", nil)
 	precompileCachePrefetchHitMeter  = metrics.NewRegisteredMeter("chain/cache/precompile/prefetch/hit", nil)
 	precompileCachePrefetchMissMeter = metrics.NewRegisteredMeter("chain/cache/precompile/prefetch/miss", nil)
+	precompileCacheBytesGauge        = metrics.NewRegisteredGauge("chain/cache/precompile/bytes", nil)
 )
 
 const (
@@ -47,7 +48,21 @@ const (
 	// run from tens of bytes to kilobytes, so a budget in entries would mean
 	// very different memory depending on the mix.
 	maxCacheablePrecompileBytes = 1024 * 1024
+
+	// perEntryOverhead approximates what an entry costs to exist, beyond the key
+	// and value bytes already counted. TestPerEntryOverhead measures it at 115
+	// to 150 bytes, moving with how full the map is, and this takes the top of
+	// that. Erring high holds fewer entries, and caps the count, since nothing
+	// measures less.
+	perEntryOverhead = 150
 )
+
+// precompileEntrySize charges an entry's key plus what it costs to exist. The
+// cache counts the value itself and calls this once per entry, on insertion and
+// again on eviction, so a fixed term here is charged and refunded per entry.
+func precompileEntrySize(key string) uint64 {
+	return uint64(len(key)) + perEntryOverhead
+}
 
 // PrecompileCache is a thread-safe cache of precompile outputs, shared between
 // the state prefetcher and block processing so the serial pass can reuse what
@@ -153,12 +168,14 @@ func (c *PrecompileCache) store(scope precompileCacheScope, key []byte, output [
 			// maxCacheablePrecompileInput against maxCacheablePrecompileOutput),
 			// so it must count towards the budget. Without it an empty output
 			// (e.g. a failed ECRECOVER) would let the cache grow without bound.
-			results = lru.NewSizeConstrainedCacheWithKeySize[string, []byte](maxCacheablePrecompileBytes, func(k string) uint64 { return uint64(len(k)) })
+			results = lru.NewSizeConstrainedCacheWithKeySize[string, []byte](maxCacheablePrecompileBytes, precompileEntrySize)
 			c.data.caches[scope] = results
 		}
 		c.data.mu.Unlock()
 	}
+	before := results.Size()
 	results.Add(string(key), common.CopyBytes(output))
+	precompileCacheBytesGauge.Inc(int64(results.Size()) - int64(before))
 }
 
 // metersFor returns the hit and miss meters of the given precompile address,

--- a/core/vm/precompile_cache_test.go
+++ b/core/vm/precompile_cache_test.go
@@ -26,10 +26,12 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	"runtime"
 	"strings"
 	"testing"
 
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/lru"
 	"github.com/ethereum/go-ethereum/params"
 )
 
@@ -474,5 +476,41 @@ func TestPrecompileCacheBoundedByKeyBytes(t *testing.T) {
 	}
 	if _, hit := cache.load(scope, firstKey); hit {
 		t.Fatal("cache is unbounded: oldest empty-output entry was never evicted")
+	}
+}
+
+// TestPerEntryOverhead re-derives the cost the budget charges per entry: fill a
+// cache with empty values, take off the key bytes, divide by the entry count.
+// Run it with -v to read the measurements. The cost moves with how full the map
+// is, so it sweeps entry counts and perEntryOverhead takes the top of what they
+// report. The bound is wide on purpose, to catch the constant being wrong by an
+// order of magnitude rather than to pin a number that moves with the Go version.
+func TestPerEntryOverhead(t *testing.T) {
+	const keyLen = 8
+
+	for _, entries := range []int{5_000, 20_000, 60_000} {
+		runtime.GC()
+		var before, after runtime.MemStats
+		runtime.ReadMemStats(&before)
+
+		// A budget nothing can reach, so every entry added is still held when
+		// the second reading is taken.
+		c := lru.NewSizeConstrainedCacheWithKeySize[string, []byte](1<<40, precompileEntrySize)
+		for i := range entries {
+			var key [keyLen]byte
+			binary.BigEndian.PutUint64(key[:], uint64(i))
+			c.Add(string(key[:]), nil)
+		}
+		runtime.GC()
+		runtime.ReadMemStats(&after)
+		runtime.KeepAlive(c)
+
+		held := int64(after.HeapAlloc) - int64(before.HeapAlloc)
+		got := (held - int64(entries)*keyLen) / int64(entries)
+		if got < perEntryOverhead/3 || got > perEntryOverhead*3 {
+			t.Errorf("%d entries: measured %d bytes each, budget charges %d", entries, got, perEntryOverhead)
+		} else {
+			t.Logf("%d entries: measured %d bytes each", entries, got)
+		}
 	}
 }


### PR DESCRIPTION
#35526 ensured that the precompile cache size was bounded by counting the key plus the value, but it didn't account for what an entry costs to exist (around 150 bytes see TestPerEntryOverhead). Filling a 1 MB cache with empty values costs 3 MB of memory at 128 byte keys, 9 MB at 32 bytes, and 68.8 MB at 3 bytes, growing as the entries get smaller. This PR ensures the cost is about 2 MB regardless of the key size by charging a 150 byte fixed cost per entry. It also adds back a gauge for the bytes held, which needs a Size accessor on
SizeConstrainedCache.