### PR TITLE
core/txpool: restore empty state fallback during snap sync

### DIFF
--- a/core/txpool/blobpool/blobpool.go
+++ b/core/txpool/blobpool/blobpool.go
@@ -653,7 +653,12 @@ func (p *BlobPool) Init(gasTip uint64, head *types.Header, reserver txpool.Reser
 	// fully synced).
 	state, err := p.chain.StateAt(head)
 	if err != nil {
-		state, err = p.chain.StateAt(p.chain.Genesis().Header())
+		empty := *head
+		empty.Root = types.EmptyRootHash
+		if p.chain.Config().IsUBT(head.Number, head.Time) {
+			empty.Root = types.EmptyBinaryHash
+		}
+		state, err = p.chain.StateAt(&empty)
 	}
 	if err != nil {
 		return err

--- a/core/txpool/blobpool/blobpool_test.go
+++ b/core/txpool/blobpool/blobpool_test.go
@@ -90,8 +90,32 @@ type testBlockChain struct {
 	blockTime *uint64
 }
 
+type statelessTestBlockChain struct {
+	*testBlockChain
+}
+
+func (bc *statelessTestBlockChain) StateAt(header *types.Header) (*state.StateDB, error) {
+	if header.Root != types.EmptyRootHash {
+		return nil, errors.New("missing trie node")
+	}
+	return state.New(types.EmptyRootHash, state.NewDatabaseForTesting())
+}
+
 func (bc *testBlockChain) Config() *params.ChainConfig {
 	return bc.config
+}
+
+func TestInitWithoutHeadOrGenesisState(t *testing.T) {
+	chain := &statelessTestBlockChain{&testBlockChain{
+		config:  params.MainnetChainConfig,
+		basefee: uint256.NewInt(params.InitialBaseFee),
+		blobfee: uint256.NewInt(params.BlobTxMinBlobGasprice),
+	}}
+	pool := New(Config{Datadir: t.TempDir()}, chain, nil)
+	if err := pool.Init(1, chain.CurrentBlock(), newReserver()); err != nil {
+		t.Fatalf("failed to initialize blobpool without chain state: %v", err)
+	}
+	pool.Close()
 }
 
 func (bc *testBlockChain) CurrentBlock() *types.Header {

--- a/core/txpool/blobpool/interface.go
+++ b/core/txpool/blobpool/interface.go
@@ -32,9 +32,6 @@ type BlockChain interface {
 	// CurrentBlock returns the current head of the chain.
 	CurrentBlock() *types.Header
 
-	// Genesis returns the genesis block of the chain.
-	Genesis() *types.Block
-
 	// CurrentFinalBlock returns the current block below which blobs should not
 	// be maintained anymore for reorg purposes.
 	CurrentFinalBlock() *types.Header

--- a/core/txpool/legacypool/legacypool.go
+++ b/core/txpool/legacypool/legacypool.go
@@ -129,9 +129,6 @@ type BlockChain interface {
 	// CurrentBlock returns the current head of the chain.
 	CurrentBlock() *types.Header
 
-	// Genesis returns the genesis block of the chain.
-	Genesis() *types.Block
-
 	// GetBlock retrieves a specific block, used during pool resets.
 	GetBlock(hash common.Hash, number uint64) *types.Block
 
@@ -322,7 +319,12 @@ func (pool *LegacyPool) Init(gasTip uint64, head *types.Header, reserver txpool.
 	// fully synced).
 	statedb, err := pool.chain.StateAt(head)
 	if err != nil {
-		statedb, err = pool.chain.StateAt(pool.chain.Genesis().Header())
+		empty := *head
+		empty.Root = types.EmptyRootHash
+		if pool.chainconfig.IsUBT(head.Number, head.Time) {
+			empty.Root = types.EmptyBinaryHash
+		}
+		statedb, err = pool.chain.StateAt(&empty)
 	}
 	if err != nil {
 		return err

--- a/core/txpool/legacypool/legacypool_test.go
+++ b/core/txpool/legacypool/legacypool_test.go
@@ -30,7 +30,10 @@ import (
 	"time"
 
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/consensus/beacon"
+	"github.com/ethereum/go-ethereum/consensus/ethash"
 	"github.com/ethereum/go-ethereum/core"
+	"github.com/ethereum/go-ethereum/core/rawdb"
 	"github.com/ethereum/go-ethereum/core/state"
 	"github.com/ethereum/go-ethereum/core/tracing"
 	"github.com/ethereum/go-ethereum/core/txpool"
@@ -69,6 +72,18 @@ type testBlockChain struct {
 	chainHeadFeed *event.Feed
 }
 
+type statelessTestBlockChain struct {
+	*testBlockChain
+	emptyRoot common.Hash
+}
+
+func (bc *statelessTestBlockChain) StateAt(header *types.Header) (*state.StateDB, error) {
+	if header.Root != bc.emptyRoot {
+		return nil, errors.New("missing trie node")
+	}
+	return state.New(types.EmptyRootHash, state.NewDatabaseForTesting())
+}
+
 func newTestBlockChain(config *params.ChainConfig, gasLimit uint64, statedb *state.StateDB, chainHeadFeed *event.Feed) *testBlockChain {
 	bc := testBlockChain{config: config, statedb: statedb, chainHeadFeed: new(event.Feed)}
 	bc.gasLimit.Store(gasLimit)
@@ -105,6 +120,48 @@ func (bc *testBlockChain) SubscribeChainHeadEvent(ch chan<- core.ChainHeadEvent)
 
 func transaction(nonce uint64, gaslimit uint64, key *ecdsa.PrivateKey) *types.Transaction {
 	return pricedTransaction(nonce, gaslimit, big.NewInt(1), key)
+}
+
+func TestInitWithoutHeadOrGenesisState(t *testing.T) {
+	for _, tc := range []struct {
+		name      string
+		ubtTime   *uint64
+		emptyRoot common.Hash
+	}{
+		{name: "mpt", emptyRoot: types.EmptyRootHash},
+		{name: "ubt", ubtTime: new(uint64), emptyRoot: types.EmptyBinaryHash},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			config := *params.TestChainConfig
+			config.UBTTime = tc.ubtTime
+			chain := &statelessTestBlockChain{
+				testBlockChain: newTestBlockChain(&config, 10000000, nil, new(event.Feed)),
+				emptyRoot:      tc.emptyRoot,
+			}
+			pool := New(testTxPoolConfig, chain)
+			if err := pool.Init(testTxPoolConfig.PriceLimit, chain.CurrentBlock(), newReserver()); err != nil {
+				t.Fatalf("failed to initialize txpool without chain state: %v", err)
+			}
+			pool.Close()
+		})
+	}
+}
+
+func TestInitDuringPathSnapSync(t *testing.T) {
+	db := rawdb.NewMemoryDatabase()
+	chain, err := core.NewBlockChain(db, &core.Genesis{Config: params.TestChainConfig}, beacon.New(ethash.NewFaker()), core.DefaultConfig().WithStateScheme(rawdb.PathScheme))
+	if err != nil {
+		t.Fatalf("failed to create blockchain: %v", err)
+	}
+	defer chain.Stop()
+	if err := chain.SnapSyncStart(); err != nil {
+		t.Fatalf("failed to start snap sync: %v", err)
+	}
+	pool := New(testTxPoolConfig, chain)
+	if err := pool.Init(testTxPoolConfig.PriceLimit, chain.CurrentBlock(), newReserver()); err != nil {
+		t.Fatalf("failed to initialize txpool during snap sync: %v", err)
+	}
+	pool.Close()
 }
 
 func pricedTransaction(nonce uint64, gaslimit uint64, gasprice *big.Int, key *ecdsa.PrivateKey) *types.Transaction {


### PR DESCRIPTION
## Overview

Yesterday I snap synced a fresh node using Geth v1.17.5 and when it had completed the state download and reached approximately 80% of the blockchain download, I was getting eepy and my PC is loud so I gracefully stopped geth (systemd sent `SIGINT`). Then the next morning, restarting it with the same datadir consistently failed during transaction-pool initialization, preventing the snap sync from resuming:

```
Disabled trie database due to state sync
State snapshot is not consistent
Loaded most recent local header          number=22,717,123
Loaded most recent local block           number=0
Loaded most recent local snap block      number=22,717,123
Loaded last snap-sync pivot marker       number=25,828,379
Genesis state is missing, wait state sync
Fatal: Failed to register the Ethereum service: missing trie node d7f8974fb5ac78d9ac099b9ad5018bedc2ce0a72dad1827a1709da30580f0544 (path ) state 0xd7f8974fb5ac78d9ac099b9ad5018bedc2ce0a72dad1827a1709da30580f0544 is not available
```

Geth encountered the same fatal error on every restart. Transaction-pool initialization failed before the downloader could resume. As a workaround, I ran `geth removedb --datadir=/data/geth --remove.state=true --remove.chain=false`, which at least preserved the downloaded chain data but deleted the state database and forced Geth to download the entire state again.

My robot gf tells me that #34700 introduced the problem, which would mean that all currently published releases from **v1.17.3 through v1.17.5** are affected.

This PR restores the transaction pools' empty-state fallback when the current head state is unavailable. It selects the correct empty root for MPT or UBT and removes the unused `Genesis` interface requirements.


## Reproduction

Geth was running as:

```console
geth \
    --mainnet \
    --datadir=/data/geth \
    --datadir.minfreedisk=102400 \
    --syncmode=snap \
    --cache=8192 \
    --authrpc.addr=127.0.0.1 \
    --authrpc.port=8551 \
    --authrpc.vhosts=localhost \
    --authrpc.jwtsecret=/data/ethereum/jwt.hex \
    --http \
    --http.addr=127.0.0.1 \
    --http.port=8545 \
    --http.api=eth,net,web3 \
    --port=30303
```

I used Prysm v7.1.8 for forkchoice updates.