### PR TITLE
core: support initcode in GenesisAlloc

### DIFF
--- a/core/genesis.go
+++ b/core/genesis.go
@@ -22,6 +22,7 @@ import (
 	"errors"
 	"fmt"
 	"maps"
+	gomath "math"
 	"math/big"
 	"strings"
 
@@ -32,6 +33,7 @@ import (
 	"github.com/ethereum/go-ethereum/core/state"
 	"github.com/ethereum/go-ethereum/core/tracing"
 	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/core/vm"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/ethdb"
 	"github.com/ethereum/go-ethereum/log"
@@ -129,8 +131,94 @@ func ReadGenesis(db ethdb.Database) (*Genesis, error) {
 	return &genesis, nil
 }
 
+func (g *Genesis) constructorBlockContext() vm.BlockContext {
+	difficulty := g.Difficulty
+	if difficulty == nil {
+		difficulty = new(big.Int)
+	}
+	gasLimit := g.GasLimit
+	if gasLimit == 0 {
+		gasLimit = params.GenesisGasLimit
+	}
+	baseFee := g.BaseFee
+	if baseFee == nil && g.Config.IsLondon(new(big.Int).SetUint64(g.Number)) {
+		baseFee = new(big.Int).SetUint64(params.InitialBaseFee)
+	}
+	header := &types.Header{
+		Number:     new(big.Int).SetUint64(g.Number),
+		Nonce:      types.EncodeNonce(g.Nonce),
+		Time:       g.Timestamp,
+		ParentHash: g.ParentHash,
+		Extra:      g.ExtraData,
+		GasLimit:   gasLimit,
+		GasUsed:    g.GasUsed,
+		BaseFee:    baseFee,
+		Difficulty: difficulty,
+		MixDigest:  g.Mixhash,
+		Coinbase:   g.Coinbase,
+		SlotNumber: g.SlotNumber,
+	}
+	return NewEVMBlockContext(header, nil, &g.Coinbase)
+}
+
+func (g *Genesis) runConstructor(statedb *state.StateDB, blockContext vm.BlockContext, addr common.Address, initcode []byte) ([]byte, error) {
+	if initcode[0] == 0xEF {
+		return nil, errors.New("initcode starts with 0xEF")
+	}
+	statedb.SetCode(addr, initcode, tracing.CodeChangeGenesis)
+
+	evm := vm.NewEVM(blockContext, statedb, g.Config, vm.Config{})
+	code, _, err := evm.Call(addr, addr, nil, vm.NewGasBudget(gomath.MaxUint64, gomath.MaxUint64), new(uint256.Int))
+	if err != nil {
+		return nil, err
+	}
+	return code, nil
+}
+
+// applyAlloc writes the genesis allocation into the given state
+func (g *Genesis) applyAlloc(statedb *state.StateDB) error {
+	var blockContext *vm.BlockContext
+	for addr, account := range g.Alloc {
+		if account.Balance != nil {
+			statedb.AddBalance(addr, uint256.MustFromBig(account.Balance), tracing.BalanceIncreaseGenesisBalance)
+		}
+		var (
+			nonce = account.Nonce
+			code  = account.Code
+		)
+		if len(account.Constructor) > 0 {
+			if len(account.Code) > 0 {
+				return fmt.Errorf("genesis account %x specifies both code and constructor", addr)
+			}
+			if g.Config == nil {
+				return errGenesisNoConfig
+			}
+			if blockContext == nil {
+				ctx := g.constructorBlockContext()
+				blockContext = &ctx
+			}
+			ret, err := g.runConstructor(statedb, *blockContext, addr, account.Constructor)
+			if err != nil {
+				return fmt.Errorf("genesis constructor for %x failed: %w", addr, err)
+			}
+			code = ret
+			if nonce == 0 {
+				nonce = 1
+			}
+		}
+		statedb.SetCode(addr, code, tracing.CodeChangeGenesis)
+		statedb.SetNonce(addr, nonce, tracing.NonceChangeGenesis)
+		// Storage from the allocation is applied last, so it takes precedence
+		// over anything the constructor wrote.
+		for key, value := range account.Storage {
+			statedb.SetState(addr, key, value)
+		}
+	}
+	return nil
+}
+
 // hashAlloc computes the state root according to the genesis specification.
-func hashAlloc(ga *types.GenesisAlloc, isUBT bool) (common.Hash, error) {
+func hashAlloc(g *Genesis, isUBT bool) (common.Hash, error) {
 	// If a genesis-time verkle trie is requested, create a trie config
 	// with the verkle trie enabled so that the tree can be initialized
 	// as such.
@@ -154,22 +242,15 @@ func hashAlloc(ga *types.GenesisAlloc, isUBT bool) (common.Hash, error) {
 	if err != nil {
 		return common.Hash{}, err
 	}
-	for addr, account := range *ga {
-		if account.Balance != nil {
-			statedb.AddBalance(addr, uint256.MustFromBig(account.Balance), tracing.BalanceIncreaseGenesisBalance)
-		}
-		statedb.SetCode(addr, account.Code, tracing.CodeChangeGenesis)
-		statedb.SetNonce(addr, account.Nonce, tracing.NonceChangeGenesis)
-		for key, value := range account.Storage {
-			statedb.SetState(addr, key, value)
-		}
+	if err := g.applyAlloc(statedb); err != nil {
+		return common.Hash{}, err
 	}
 	return statedb.Commit(params.Rules{}, 0)
 }
 
 // flushAlloc is very similar with hash, but the main difference is all the
 // generated states will be persisted into the given database.
-func flushAlloc(ga *types.GenesisAlloc, triedb *triedb.Database, tracer *tracing.Hooks) (common.Hash, error) {
+func flushAlloc(g *Genesis, triedb *triedb.Database, tracer *tracing.Hooks) (common.Hash, error) {
 	emptyRoot := types.EmptyRootHash
 	if triedb.IsUBT() {
 		emptyRoot = types.EmptyBinaryHash
@@ -178,17 +259,8 @@ func flushAlloc(ga *types.GenesisAlloc, triedb *triedb.Database, tracer *tracing
 	if err != nil {
 		return common.Hash{}, err
 	}
-	for addr, account := range *ga {
-		if account.Balance != nil {
-			// This is not actually logged via tracer because OnGenesisBlock
-			// already captures the allocations.
-			statedb.AddBalance(addr, uint256.MustFromBig(account.Balance), tracing.BalanceIncreaseGenesisBalance)
-		}
-		statedb.SetCode(addr, account.Code, tracing.CodeChangeGenesis)
-		statedb.SetNonce(addr, account.Nonce, tracing.NonceChangeGenesis)
-		for key, value := range account.Storage {
-			statedb.SetState(addr, key, value)
-		}
+	if err := g.applyAlloc(statedb); err != nil {
+		return common.Hash{}, err
 	}
 
 	var root common.Hash
@@ -485,7 +557,7 @@ func (g *Genesis) IsUBT() bool {
 
 // ToBlock returns the genesis block according to genesis specification.
 func (g *Genesis) ToBlock() *types.Block {
-	root, err := hashAlloc(&g.Alloc, g.IsUBT())
+	root, err := hashAlloc(g, g.IsUBT())
 	if err != nil {
 		panic(err)
 	}
@@ -585,7 +657,7 @@ func (g *Genesis) Commit(db ethdb.Database, triedb *triedb.Database, tracer *tra
 		return nil, errors.New("can't start clique chain without signers")
 	}
 	// flush the data to disk and compute the state root
-	root, err := flushAlloc(&g.Alloc, triedb, tracer)
+	root, err := flushAlloc(g, triedb, tracer)
 	if err != nil {
 		return nil, err
 	}

--- a/core/genesis_test.go
+++ b/core/genesis_test.go
@@ -19,15 +19,20 @@ package core
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"math/big"
 	"reflect"
+	"strings"
 	"testing"
 
 	"github.com/davecgh/go-spew/spew"
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/consensus/ethash"
 	"github.com/ethereum/go-ethereum/core/rawdb"
+	"github.com/ethereum/go-ethereum/core/state"
 	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/ethdb"
 	"github.com/ethereum/go-ethereum/params"
 	"github.com/ethereum/go-ethereum/triedb"
@@ -228,7 +233,7 @@ func TestReadWriteGenesisAlloc(t *testing.T) {
 			{1}: {Balance: big.NewInt(1), Storage: map[common.Hash]common.Hash{{1}: {1}}},
 			{2}: {Balance: big.NewInt(2), Storage: map[common.Hash]common.Hash{{2}: {2}}},
 		}
-		hash, _ = hashAlloc(alloc, false)
+		hash, _ = hashAlloc(&Genesis{Alloc: *alloc}, false)
 	)
 	blob, _ := json.Marshal(alloc)
 	rawdb.WriteGenesisStateSpec(db, hash, blob)
@@ -334,5 +339,196 @@ func TestBinaryGenesisCommit(t *testing.T) {
 	vdb := rawdb.NewTable(db, string(rawdb.VerklePrefix))
 	if !rawdb.HasAccountTrieNode(vdb, nil) {
 		t.Fatal("could not find node")
+	}
+}
+
+var (
+	testConstructorRuntime = []byte{0xfe}
+	testConstructorInit    = []byte{
+		0x60, 0x42, 0x60, 0x01, 0x55, // SSTORE(1, 0x42)
+		0x60, 0xfe, 0x60, 0x00, 0x53, // MSTORE8(0, 0xfe)
+		0x60, 0x01, 0x60, 0x00, 0xf3, // RETURN(0, 1)
+	}
+)
+
+func TestGenesisAllocConstructor(t *testing.T) {
+	var (
+		addr  = common.HexToAddress("0xc0de")
+		db    = rawdb.NewMemoryDatabase()
+		tdb   = triedb.NewDatabase(db, triedb.HashDefaults)
+		gspec = &Genesis{
+			Config:     params.TestChainConfig,
+			Difficulty: big.NewInt(0),
+			Alloc: types.GenesisAlloc{
+				addr: {Balance: big.NewInt(1), Constructor: testConstructorInit},
+			},
+		}
+	)
+	block, err := gspec.Commit(db, tdb, nil)
+	if err != nil {
+		t.Fatalf("failed to commit genesis: %v", err)
+	}
+	if want := gspec.ToBlock().Root(); block.Root() != want {
+		t.Errorf("state root mismatch: have %x, want %x", block.Root(), want)
+	}
+	statedb, err := state.New(block.Root(), state.NewDatabase(tdb, nil))
+	if err != nil {
+		t.Fatalf("failed to open genesis state: %v", err)
+	}
+	if code := statedb.GetCode(addr); !bytes.Equal(code, testConstructorRuntime) {
+		t.Errorf("deployed code mismatch: have %#x, want %#x", code, testConstructorRuntime)
+	}
+	// Storage written by the constructor must land on the allocated account,
+	// not on some address derived from it.
+	if got, want := statedb.GetState(addr, common.Hash{31: 0x01}), (common.Hash{31: 0x42}); got != want {
+		t.Errorf("constructor storage mismatch: have %x, want %x", got, want)
+	}
+	if got := statedb.GetNonce(addr); got != 1 {
+		t.Errorf("nonce mismatch: have %d, want 1", got)
+	}
+	if got := statedb.GetBalance(addr); got.Uint64() != 1 {
+		t.Errorf("balance mismatch: have %v, want 1", got)
+	}
+	for _, stray := range []common.Address{crypto.CreateAddress(addr, 0), crypto.CreateAddress(addr, 1), {}} {
+		if statedb.Exist(stray) {
+			t.Errorf("unexpected account %x in genesis state", stray)
+		}
+	}
+}
+
+// TestGenesisAllocConstructorOverrides checks that the explicit fields of an
+// allocation take precedence over the constructor's effects.
+func TestGenesisAllocConstructorOverrides(t *testing.T) {
+	var (
+		addr  = common.HexToAddress("0xc0de")
+		db    = rawdb.NewMemoryDatabase()
+		tdb   = triedb.NewDatabase(db, triedb.HashDefaults)
+		gspec = &Genesis{
+			Config:     params.TestChainConfig,
+			Difficulty: big.NewInt(0),
+			Alloc: types.GenesisAlloc{
+				addr: {
+					Balance:     big.NewInt(1),
+					Nonce:       7,
+					Storage:     map[common.Hash]common.Hash{{31: 0x01}: {31: 0x99}},
+					Constructor: testConstructorInit,
+				},
+			},
+		}
+	)
+	block, err := gspec.Commit(db, tdb, nil)
+	if err != nil {
+		t.Fatalf("failed to commit genesis: %v", err)
+	}
+	statedb, err := state.New(block.Root(), state.NewDatabase(tdb, nil))
+	if err != nil {
+		t.Fatalf("failed to open genesis state: %v", err)
+	}
+	if got, want := statedb.GetState(addr, common.Hash{31: 0x01}), (common.Hash{31: 0x99}); got != want {
+		t.Errorf("storage mismatch: have %x, want %x", got, want)
+	}
+	if got := statedb.GetNonce(addr); got != 7 {
+		t.Errorf("nonce mismatch: have %d, want 7", got)
+	}
+	if code := statedb.GetCode(addr); !bytes.Equal(code, testConstructorRuntime) {
+		t.Errorf("deployed code mismatch: have %#x, want %#x", code, testConstructorRuntime)
+	}
+}
+
+// TestGenesisAllocConstructorFailure checks that a constructor which cannot be
+// executed surfaces an error instead of taking the process down, on both the
+// hashing and the flushing path.
+func TestGenesisAllocConstructorFailure(t *testing.T) {
+	addr := common.HexToAddress("0xc0de")
+	tests := []struct {
+		name     string
+		account  types.Account
+		noConfig bool
+		wantErr  string
+	}{
+		{
+			name:    "revert",
+			account: types.Account{Balance: big.NewInt(1), Constructor: []byte{0x60, 0x00, 0x60, 0x00, 0xfd}},
+			wantErr: "execution reverted",
+		},
+		{
+			name:    "invalid opcode",
+			account: types.Account{Balance: big.NewInt(1), Constructor: []byte{0xfe}},
+			wantErr: "invalid opcode",
+		},
+		{
+			name:    "ef prefixed initcode",
+			account: types.Account{Balance: big.NewInt(1), Constructor: []byte{0xef, 0x00}},
+			wantErr: "initcode starts with 0xEF",
+		},
+		{
+			name:    "code and constructor",
+			account: types.Account{Balance: big.NewInt(1), Code: []byte{0x00}, Constructor: testConstructorInit},
+			wantErr: "both code and constructor",
+		},
+		{
+			name:     "no chain config",
+			account:  types.Account{Balance: big.NewInt(1), Constructor: testConstructorInit},
+			noConfig: true,
+			wantErr:  errGenesisNoConfig.Error(),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gspec := &Genesis{
+				Config:     params.TestChainConfig,
+				Difficulty: big.NewInt(0),
+				Alloc:      types.GenesisAlloc{addr: tt.account},
+			}
+			if tt.noConfig {
+				gspec.Config = nil
+			}
+			err, panicked := hashAllocResult(gspec)
+			if panicked {
+				t.Errorf("hashAlloc panicked instead of returning an error: %v", err)
+			}
+			if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
+				t.Errorf("hashAlloc error = %v, want it to contain %q", err, tt.wantErr)
+			}
+			tdb := triedb.NewDatabase(rawdb.NewMemoryDatabase(), triedb.HashDefaults)
+			if _, err := flushAlloc(gspec, tdb, nil); err == nil || !strings.Contains(err.Error(), tt.wantErr) {
+				t.Errorf("flushAlloc error = %v, want it to contain %q", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+// hashAllocResult runs hashAlloc, reporting whether it aborted through a panic
+// rather than through an error.
+func hashAllocResult(g *Genesis) (err error, panicked bool) {
+	defer func() {
+		if r := recover(); r != nil {
+			err, panicked = fmt.Errorf("%v", r), true
+		}
+	}()
+	_, err = hashAlloc(g, false)
+	return err, false
+}
+
+// TestGenesisAllocConstructorJSON checks that constructors survive the JSON
+// encoding used to persist and load genesis specifications.
+func TestGenesisAllocConstructorJSON(t *testing.T) {
+	alloc := types.GenesisAlloc{
+		{1}: {Balance: big.NewInt(1), Constructor: testConstructorInit},
+		{2}: {Balance: big.NewInt(2), Code: []byte{0x00}},
+	}
+	blob, err := json.Marshal(alloc)
+	if err != nil {
+		t.Fatalf("failed to marshal alloc: %v", err)
+	}
+	if !strings.Contains(string(blob), `"constructor":"`+hexutil.Encode(testConstructorInit)+`"`) {
+		t.Fatalf("constructor missing from encoded alloc: %s", blob)
+	}
+	var reload types.GenesisAlloc
+	if err := reload.UnmarshalJSON(blob); err != nil {
+		t.Fatalf("failed to load genesis state: %v", err)
+	}
+	if !reflect.DeepEqual(reload, alloc) {
+		t.Fatalf("alloc mismatch:\n%s", spew.Sdump(reload))
 	}
 }

--- a/core/types/account.go
+++ b/core/types/account.go
@@ -38,13 +38,19 @@ type Account struct {
 	Storage map[common.Hash]common.Hash `json:"storage,omitempty"`
 	Balance *big.Int                    `json:"balance" gencodec:"required"`
 	Nonce   uint64                      `json:"nonce,omitempty"`
+
+	// Constructor is initcode executed while building the genesis state. The
+	// bytes it returns become the account code, and any storage it writes lands
+	// on this account. It is mutually exclusive with Code.
+	Constructor []byte `json:"constructor,omitempty"`
 }
 
 type accountMarshaling struct {
-	Code    hexutil.Bytes
-	Balance *math.HexOrDecimal256
-	Nonce   math.HexOrDecimal64
-	Storage map[storageJSON]storageJSON
+	Code        hexutil.Bytes
+	Balance     *math.HexOrDecimal256
+	Nonce       math.HexOrDecimal64
+	Storage     map[storageJSON]storageJSON
+	Constructor hexutil.Bytes
 }
 
 // storageJSON represents a 256 bit byte array, but allows less than 256 bits when

--- a/core/types/gen_account.go
+++ b/core/types/gen_account.go
@@ -17,10 +17,11 @@ var _ = (*accountMarshaling)(nil)
 // MarshalJSON marshals as JSON.
 func (a Account) MarshalJSON() ([]byte, error) {
 	type Account struct {
-		Code    hexutil.Bytes               `json:"code,omitempty"`
-		Storage map[storageJSON]storageJSON `json:"storage,omitempty"`
-		Balance *math.HexOrDecimal256       `json:"balance" gencodec:"required"`
-		Nonce   math.HexOrDecimal64         `json:"nonce,omitempty"`
+		Code        hexutil.Bytes               `json:"code,omitempty"`
+		Storage     map[storageJSON]storageJSON `json:"storage,omitempty"`
+		Balance     *math.HexOrDecimal256       `json:"balance" gencodec:"required"`
+		Nonce       math.HexOrDecimal64         `json:"nonce,omitempty"`
+		Constructor hexutil.Bytes               `json:"constructor,omitempty"`
 	}
 	var enc Account
 	enc.Code = a.Code
@@ -32,16 +33,18 @@ func (a Account) MarshalJSON() ([]byte, error) {
 	}
 	enc.Balance = (*math.HexOrDecimal256)(a.Balance)
 	enc.Nonce = math.HexOrDecimal64(a.Nonce)
+	enc.Constructor = a.Constructor
 	return json.Marshal(&enc)
 }
 
 // UnmarshalJSON unmarshals from JSON.
 func (a *Account) UnmarshalJSON(input []byte) error {
 	type Account struct {
-		Code    *hexutil.Bytes              `json:"code,omitempty"`
-		Storage map[storageJSON]storageJSON `json:"storage,omitempty"`
-		Balance *math.HexOrDecimal256       `json:"balance" gencodec:"required"`
-		Nonce   *math.HexOrDecimal64        `json:"nonce,omitempty"`
+		Code        *hexutil.Bytes              `json:"code,omitempty"`
+		Storage     map[storageJSON]storageJSON `json:"storage,omitempty"`
+		Balance     *math.HexOrDecimal256       `json:"balance" gencodec:"required"`
+		Nonce       *math.HexOrDecimal64        `json:"nonce,omitempty"`
+		Constructor *hexutil.Bytes              `json:"constructor,omitempty"`
 	}
 	var dec Account
 	if err := json.Unmarshal(input, &dec); err != nil {
@@ -62,6 +65,9 @@ func (a *Account) UnmarshalJSON(input []byte) error {
 	a.Balance = (*big.Int)(dec.Balance)
 	if dec.Nonce != nil {
 		a.Nonce = uint64(*dec.Nonce)
+	}
+	if dec.Constructor != nil {
+		a.Constructor = *dec.Constructor
 	}
 	return nil
 }


### PR DESCRIPTION
Some chains run a consensus that relies a lot more on deployed system contracts than Ethereum mainnet does, and unlike Ethereum these contracts are deployed at genesis time by executing an initcode (hereafter referred to as "constructor").