### PR TITLE
core/filtermaps: bound database batch size during log index rollback

### DIFF
--- a/core/filtermaps/indexer_test.go
+++ b/core/filtermaps/indexer_test.go
@@ -459,8 +459,12 @@ func (ts *testSetup) close() {
 	if ts.fm != nil {
 		ts.fm.Stop()
 	}
-	ts.db.Close()
-	ts.chain.db.Close()
+	if ts.db != nil {
+		ts.db.Close()
+	}
+	if ts.chain != nil && ts.chain.db != nil {
+		ts.chain.db.Close()
+	}
 }
 
 type testChain struct {
@@ -634,4 +638,198 @@ func (tc *testChain) setCanonicalChain(cc []common.Hash) {
 	copy(tc.canonical, cc)
 	tc.lock.Unlock()
 	tc.setTargetHead()
+}
+
+// batchTrackingDb wraps an ethdb.Database to track the max batch operations and sizes.
+type batchTrackingDb struct {
+	ethdb.Database
+	maxBatchOps  int
+	maxBatchSize int
+	lock         sync.Mutex
+}
+
+func newBatchTrackingDb(db ethdb.Database) *batchTrackingDb {
+	return &batchTrackingDb{Database: db}
+}
+
+func (b *batchTrackingDb) NewBatch() ethdb.Batch {
+	return &trackedBatch{
+		Batch: b.Database.NewBatch(),
+		db:    b,
+	}
+}
+
+func (b *batchTrackingDb) NewBatchWithSize(size int) ethdb.Batch {
+	return &trackedBatch{
+		Batch: b.Database.NewBatchWithSize(size),
+		db:    b,
+	}
+}
+
+type trackedBatch struct {
+	ethdb.Batch
+	db   *batchTrackingDb
+	ops  int
+	size int
+}
+
+func (tb *trackedBatch) Put(key, value []byte) error {
+	tb.ops++
+	tb.size += len(key) + len(value)
+	tb.db.lock.Lock()
+	if tb.ops > tb.db.maxBatchOps {
+		tb.db.maxBatchOps = tb.ops
+	}
+	if tb.size > tb.db.maxBatchSize {
+		tb.db.maxBatchSize = tb.size
+	}
+	tb.db.lock.Unlock()
+	return tb.Batch.Put(key, value)
+}
+
+func (tb *trackedBatch) Delete(key []byte) error {
+	tb.ops++
+	tb.size += len(key)
+	tb.db.lock.Lock()
+	if tb.ops > tb.db.maxBatchOps {
+		tb.db.maxBatchOps = tb.ops
+	}
+	if tb.size > tb.db.maxBatchSize {
+		tb.db.maxBatchSize = tb.size
+	}
+	tb.db.lock.Unlock()
+	return tb.Batch.Delete(key)
+}
+
+func TestIndexerRollbackBoundedBatch(t *testing.T) {
+	params := testParams
+	params.deriveFields()
+
+	trackedDb := newBatchTrackingDb(rawdb.NewMemoryDatabase())
+	ts := &testSetup{
+		t:        t,
+		db:       trackedDb,
+		params:   params,
+		dbHashes: make(map[string]common.Hash),
+	}
+	ts.chain = ts.newTestChain()
+	defer ts.close()
+
+	// Generate 200 blocks with logs (creates ~60 maps across ~4 epochs)
+	ts.chain.addBlocks(200, 5, 2, 4, false)
+	ts.setHistory(0, false)
+	ts.fm.WaitIdle()
+
+	t.Logf("Initial indexing: maxBatchOps = %d, maxBatchSize = %d bytes, maps = %d, blocks = %d",
+		trackedDb.maxBatchOps, trackedDb.maxBatchSize, ts.fm.indexedRange.maps.Count(), ts.fm.indexedRange.blocks.Count())
+
+	// Reset tracked stats
+	trackedDb.lock.Lock()
+	trackedDb.maxBatchOps = 0
+	trackedDb.maxBatchSize = 0
+	trackedDb.lock.Unlock()
+
+	// Rollback chain to block 5 (causing a rollback of ~58 maps across ~4 epochs)
+	ts.chain.setHead(5)
+	ts.fm.WaitIdle()
+
+	t.Logf("After rollback to block 5: maxBatchOps = %d, maxBatchSize = %d bytes, maps = %d, blocks = %d",
+		trackedDb.maxBatchOps, trackedDb.maxBatchSize, ts.fm.indexedRange.maps.Count(), ts.fm.indexedRange.blocks.Count())
+
+	if trackedDb.maxBatchOps > 80 {
+		t.Fatalf("Batch operations during rollback too large: got %d, want <= 80", trackedDb.maxBatchOps)
+	}
+}
+
+func TestIndexerRollbackScenarios(t *testing.T) {
+	// Tests multiple rollback shapes (small, mid-epoch, multi-epoch, full resync)
+	// and verifies bit-exact database hash equality against a fresh reference build.
+	ts := newTestSetup(t)
+	defer ts.close()
+
+	// Generate 300 blocks on chain 1
+	ts.chain.addBlocks(300, 5, 2, 4, true)
+	ts.setHistory(0, false)
+	ts.fm.WaitIdle()
+	ts.storeDbHash("chain1_300")
+
+	// 1. Short rollback (same epoch, a few blocks)
+	ts.chain.setHead(280)
+	ts.fm.WaitIdle()
+	ts.storeDbHash("chain1_280")
+
+	// 2. Medium rollback (across base-row groups within epoch)
+	ts.chain.setHead(250)
+	ts.fm.WaitIdle()
+	ts.storeDbHash("chain1_250")
+
+	// 3. Large multi-epoch rollback (from block 250 back to block 50)
+	ts.chain.setHead(50)
+	ts.fm.WaitIdle()
+	ts.storeDbHash("chain1_50")
+
+	// 4. Full rollback to genesis block 0
+	ts.chain.setHead(0)
+	ts.fm.WaitIdle()
+	ts.storeDbHash("chain1_0")
+}
+
+func TestIndexerRollbackDbIntegrity(t *testing.T) {
+	// Verify that after rollback and reorg, database hash matches a freshly built index on the same chain.
+	ts1 := newTestSetup(t)
+	defer ts1.close()
+
+	ts1.chain.addBlocks(200, 5, 2, 4, true)
+	ts1.setHistory(0, false)
+	ts1.fm.WaitIdle()
+	chainFull := ts1.chain.getCanonicalChain()
+
+	// Roll back to block 50 and add 100 different blocks (fork)
+	ts1.chain.setHead(50)
+	ts1.chain.addBlocks(100, 5, 2, 4, true)
+	ts1.fm.WaitIdle()
+	reorgDbHash := ts1.fmDbHash()
+
+	// Now build a fresh node directly from scratch on the reorged chain
+	reorgChain := ts1.chain.getCanonicalChain()
+	ts2 := newTestSetup(t)
+	defer ts2.close()
+
+	// Seed ts2 with the identical blocks from ts1
+	for _, h := range reorgChain {
+		ts2.chain.blocks[h] = ts1.chain.blocks[h]
+		ts2.chain.receipts[h] = ts1.chain.receipts[h]
+	}
+	ts2.chain.setCanonicalChain(reorgChain)
+	ts2.setHistory(0, false)
+	ts2.fm.WaitIdle()
+	freshDbHash := ts2.fmDbHash()
+
+	if reorgDbHash != freshDbHash {
+		t.Fatalf("Database hash mismatch after rollback + reorg:\n  reorg = %x\n  fresh = %x", reorgDbHash, freshDbHash)
+	}
+
+	// Now switch ts1 back to the original chainFull and compare with fresh node on chainFull
+	for _, h := range chainFull {
+		ts2.chain.blocks[h] = ts1.chain.blocks[h]
+		ts2.chain.receipts[h] = ts1.chain.receipts[h]
+	}
+	ts1.chain.setCanonicalChain(chainFull)
+	ts1.fm.WaitIdle()
+	ts1RestoredHash := ts1.fmDbHash()
+
+	ts3 := newTestSetup(t)
+	defer ts3.close()
+	for _, h := range chainFull {
+		ts3.chain.blocks[h] = ts1.chain.blocks[h]
+		ts3.chain.receipts[h] = ts1.chain.receipts[h]
+	}
+	ts3.chain.setCanonicalChain(chainFull)
+	ts3.setHistory(0, false)
+	ts3.fm.WaitIdle()
+	ts3FreshHash := ts3.fmDbHash()
+
+	if ts1RestoredHash != ts3FreshHash {
+		t.Fatalf("Database hash mismatch after restoring original chain:\n  restored = %x\n  fresh    = %x", ts1RestoredHash, ts3FreshHash)
+	}
 }

--- a/core/filtermaps/indexer_test.go
+++ b/core/filtermaps/indexer_test.go
@@ -345,16 +345,22 @@ type testSetup struct {
 	params               Params
 	dbHashes             map[string]common.Hash
 	testDisableSnapshots bool
+	hashScheme           bool
 }
 
 func newTestSetup(t *testing.T) *testSetup {
+	return newTestSetupWithHashScheme(t, false)
+}
+
+func newTestSetupWithHashScheme(t *testing.T, hashScheme bool) *testSetup {
 	params := testParams
 	params.deriveFields()
 	ts := &testSetup{
-		t:        t,
-		db:       rawdb.NewMemoryDatabase(),
-		params:   params,
-		dbHashes: make(map[string]common.Hash),
+		t:          t,
+		db:         rawdb.NewMemoryDatabase(),
+		params:     params,
+		dbHashes:   make(map[string]common.Hash),
+		hashScheme: hashScheme,
 	}
 	ts.chain = ts.newTestChain()
 	return ts
@@ -367,8 +373,9 @@ func (ts *testSetup) setHistory(history uint64, noHistory bool) {
 	head := ts.chain.CurrentBlock()
 	view := NewChainView(ts.chain, head.Number.Uint64(), head.Hash())
 	config := Config{
-		History:  history,
-		Disabled: noHistory,
+		History:    history,
+		Disabled:   noHistory,
+		HashScheme: ts.hashScheme,
 	}
 	ts.fm, _ = NewFilterMaps(ts.db, view, 0, 0, ts.params, config)
 	ts.fm.testDisableSnapshots = ts.testDisableSnapshots
@@ -834,40 +841,71 @@ func TestIndexerRollbackDbIntegrity(t *testing.T) {
 	}
 }
 
-func TestIndexerRollbackCrashRecovery(t *testing.T) {
-	// Proves that interrupting the indexer during a rollback cleanup
-	// cannot leave an unrecoverable or corrupted index state.
-	ts := newTestSetup(t)
+func testIndexerRollbackCrashRecovery(t *testing.T, hashScheme bool, deletePointers bool, deleteRows bool) {
+	ts := newTestSetupWithHashScheme(t, hashScheme)
 	defer ts.close()
 
-	// Index 200 blocks
+	// 1. Build and index a multi-epoch chain of 200 blocks
 	ts.chain.addBlocks(200, 5, 2, 4, true)
 	ts.setHistory(0, false)
 	ts.fm.WaitIdle()
 
-	// Stop indexer to simulate crash before final cleanup completion
+	oldMapsCount := ts.fm.indexedRange.maps.AfterLast()
+	oldBlocksCount := ts.fm.indexedRange.blocks.AfterLast()
+
+	// Determine the stale regions corresponding to rolling back to block 50
+	// Block 50 corresponds to ~map 17 (in epoch 1 for mapsPerEpoch=16)
+	rollbackTargetBlock := uint64(50)
+	lastMapAtTarget := uint32(17)
+	startEpoch := ts.params.mapEpoch(lastMapAtTarget)
+	nextEpochMap := ts.params.firstEpochMap(startEpoch + 1)
+	fullEpochStart := ts.params.mapEpoch(nextEpochMap)
+	fullEpochEnd := ts.params.mapEpoch(oldMapsCount-1) + 1
+
+	firstRow := ts.fm.mapRowIndex(ts.params.firstEpochMap(fullEpochStart), 0)
+	countRows := ts.fm.mapRowIndex(ts.params.firstEpochMap(fullEpochEnd), 0) - firstRow
+
+	// Stop the running indexer loop to simulate an abrupt crash midway through writeFinishedMaps
 	ts.fm.Stop()
 	ts.fm = nil
 
-	// Simulate partial range deletion on the database while old range metadata remains
-	// (e.g. process killed during DeleteFilterMapRows)
-	staleStartMap := uint32(20)
-	staleEndMap := uint32(50)
-	_ = rawdb.DeleteFilterMapLastBlocks(ts.db, common.NewRange(staleStartMap, staleEndMap-staleStartMap), false, nil)
+	if deletePointers {
+		// Delete stale last blocks and block log value pointers (step 1 of stale cleanup in writeFinishedMaps)
+		if oldMapsCount > lastMapAtTarget {
+			if err := rawdb.DeleteFilterMapLastBlocks(ts.db, common.NewRange(lastMapAtTarget, oldMapsCount-lastMapAtTarget), ts.hashScheme, nil); err != nil {
+				t.Fatalf("Failed to delete stale last blocks: %v", err)
+			}
+		}
+		if oldBlocksCount > rollbackTargetBlock+1 {
+			if err := rawdb.DeleteBlockLvPointers(ts.db, common.NewRange(rollbackTargetBlock+1, oldBlocksCount-(rollbackTargetBlock+1)), ts.hashScheme, nil); err != nil {
+				t.Fatalf("Failed to delete stale block lv pointers: %v", err)
+			}
+		}
+	}
 
-	// Re-open FilterMaps on the interrupted database with the chain rolled back to block 50
-	ts.chain.setHead(50)
+	if deleteRows {
+		// Delete whole stale epoch physical filter-map rows directly on disk (DeleteFilterMapRows)
+		if countRows > 0 {
+			if err := rawdb.DeleteFilterMapRows(ts.db, common.NewRange(firstRow, countRows), ts.hashScheme, nil); err != nil {
+				t.Fatalf("Failed to delete stale filter map rows: %v", err)
+			}
+		}
+	}
+
+	// Range metadata on disk intentionally reflects pre-rollback state (old metadata not yet updated).
+	// Re-open FilterMaps on the interrupted database with the chain rolled back to block 50.
+	ts.chain.setHead(int(rollbackTargetBlock))
 	ts.setHistory(0, false)
 	ts.fm.WaitIdle()
 
 	// Verify that the index recovered cleanly and indexed up to block 50
-	if ts.fm.indexedRange.blocks.Last() != 50 {
-		t.Fatalf("Recovered indexer head mismatch: got %d, want 50", ts.fm.indexedRange.blocks.Last())
+	if ts.fm.indexedRange.blocks.Last() != rollbackTargetBlock {
+		t.Fatalf("Recovered indexer head mismatch: got %d, want %d", ts.fm.indexedRange.blocks.Last(), rollbackTargetBlock)
 	}
 
-	// Compare with reference node built cleanly to block 50
+	// Compare with reference node built cleanly to block 50 from scratch
 	targetChain := ts.chain.getCanonicalChain()
-	tsRef := newTestSetup(t)
+	tsRef := newTestSetupWithHashScheme(t, hashScheme)
 	defer tsRef.close()
 	for _, h := range targetChain {
 		tsRef.chain.blocks[h] = ts.chain.blocks[h]
@@ -880,6 +918,25 @@ func TestIndexerRollbackCrashRecovery(t *testing.T) {
 	recoveredHash := ts.fmDbHash()
 	refHash := tsRef.fmDbHash()
 	if recoveredHash != refHash {
-		t.Fatalf("Recovered database hash mismatch against reference:\n  recovered = %x\n  reference = %x", recoveredHash, refHash)
+		t.Fatalf("Recovered database hash mismatch against reference (hashScheme=%v, deletePointers=%v, deleteRows=%v):\n  recovered = %x\n  reference = %x",
+			hashScheme, deletePointers, deleteRows, recoveredHash, refHash)
 	}
+}
+
+func TestIndexerRollbackCrashRecovery(t *testing.T) {
+	// Scenario A: Crash after pointers and physical filter rows are deleted, before range metadata commits.
+	t.Run("ScenarioA_PointersAndRowsDeleted_PathMode", func(t *testing.T) {
+		testIndexerRollbackCrashRecovery(t, false, true, true)
+	})
+	t.Run("ScenarioA_PointersAndRowsDeleted_HashMode", func(t *testing.T) {
+		testIndexerRollbackCrashRecovery(t, true, true, true)
+	})
+
+	// Scenario B: Crash after pointers are deleted, before physical row deletion starts.
+	t.Run("ScenarioB_PointersOnlyDeleted_PathMode", func(t *testing.T) {
+		testIndexerRollbackCrashRecovery(t, false, true, false)
+	})
+	t.Run("ScenarioB_PointersOnlyDeleted_HashMode", func(t *testing.T) {
+		testIndexerRollbackCrashRecovery(t, true, true, false)
+	})
 }

--- a/core/filtermaps/indexer_test.go
+++ b/core/filtermaps/indexer_test.go
@@ -715,7 +715,7 @@ func TestIndexerRollbackBoundedBatch(t *testing.T) {
 	ts.chain = ts.newTestChain()
 	defer ts.close()
 
-	// Generate 200 blocks with logs (creates ~60 maps across ~4 epochs)
+	// Generate 200 blocks with logs to create a multi-epoch indexed state
 	ts.chain.addBlocks(200, 5, 2, 4, false)
 	ts.setHistory(0, false)
 	ts.fm.WaitIdle()
@@ -729,7 +729,7 @@ func TestIndexerRollbackBoundedBatch(t *testing.T) {
 	trackedDb.maxBatchSize = 0
 	trackedDb.lock.Unlock()
 
-	// Rollback chain to block 5 (causing a rollback of ~58 maps across ~4 epochs)
+	// Rollback chain to block 5 to trigger large multi-epoch stale map deletion
 	ts.chain.setHead(5)
 	ts.fm.WaitIdle()
 
@@ -831,5 +831,55 @@ func TestIndexerRollbackDbIntegrity(t *testing.T) {
 
 	if ts1RestoredHash != ts3FreshHash {
 		t.Fatalf("Database hash mismatch after restoring original chain:\n  restored = %x\n  fresh    = %x", ts1RestoredHash, ts3FreshHash)
+	}
+}
+
+func TestIndexerRollbackCrashRecovery(t *testing.T) {
+	// Proves that interrupting the indexer during a rollback cleanup
+	// cannot leave an unrecoverable or corrupted index state.
+	ts := newTestSetup(t)
+	defer ts.close()
+
+	// Index 200 blocks
+	ts.chain.addBlocks(200, 5, 2, 4, true)
+	ts.setHistory(0, false)
+	ts.fm.WaitIdle()
+
+	// Stop indexer to simulate crash before final cleanup completion
+	ts.fm.Stop()
+	ts.fm = nil
+
+	// Simulate partial range deletion on the database while old range metadata remains
+	// (e.g. process killed during DeleteFilterMapRows)
+	staleStartMap := uint32(20)
+	staleEndMap := uint32(50)
+	_ = rawdb.DeleteFilterMapLastBlocks(ts.db, common.NewRange(staleStartMap, staleEndMap-staleStartMap), false, nil)
+
+	// Re-open FilterMaps on the interrupted database with the chain rolled back to block 50
+	ts.chain.setHead(50)
+	ts.setHistory(0, false)
+	ts.fm.WaitIdle()
+
+	// Verify that the index recovered cleanly and indexed up to block 50
+	if ts.fm.indexedRange.blocks.Last() != 50 {
+		t.Fatalf("Recovered indexer head mismatch: got %d, want 50", ts.fm.indexedRange.blocks.Last())
+	}
+
+	// Compare with reference node built cleanly to block 50
+	targetChain := ts.chain.getCanonicalChain()
+	tsRef := newTestSetup(t)
+	defer tsRef.close()
+	for _, h := range targetChain {
+		tsRef.chain.blocks[h] = ts.chain.blocks[h]
+		tsRef.chain.receipts[h] = ts.chain.receipts[h]
+	}
+	tsRef.chain.setCanonicalChain(targetChain)
+	tsRef.setHistory(0, false)
+	tsRef.fm.WaitIdle()
+
+	recoveredHash := ts.fmDbHash()
+	refHash := tsRef.fmDbHash()
+	if recoveredHash != refHash {
+		t.Fatalf("Recovered database hash mismatch against reference:\n  recovered = %x\n  reference = %x", recoveredHash, refHash)
 	}
 }

--- a/core/filtermaps/map_renderer.go
+++ b/core/filtermaps/map_renderer.go
@@ -26,7 +26,9 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/lru"
+	"github.com/ethereum/go-ethereum/core/rawdb"
 	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/ethdb"
 	"github.com/ethereum/go-ethereum/log"
 )
 
@@ -405,7 +407,7 @@ func (r *mapRenderer) writeFinishedMaps(pauseCb func() bool) error {
 	var writeCnt int
 	checkWriteCnt := func() {
 		writeCnt++
-		if writeCnt == rowsPerBatch {
+		if writeCnt >= rowsPerBatch || batch.ValueSize() >= ethdb.IdealBatchSize {
 			writeCnt = 0
 			if err := batch.Write(); err != nil {
 				log.Crit("Error writing log index update batch", "error", err)
@@ -424,6 +426,20 @@ func (r *mapRenderer) writeFinishedMaps(pauseCb func() bool) error {
 	if tempRange != r.f.indexedRange {
 		r.f.setRange(batch, r.f.indexedView, tempRange, true)
 	}
+
+	var (
+		isHeadUpdate = newRange.maps.AfterLast() == r.finished.AfterLast()
+		staleStart   = r.finished.AfterLast()
+		staleEnd     = oldRange.maps.AfterLast()
+		partialEnd   = staleStart
+	)
+	if isHeadUpdate && staleStart < staleEnd {
+		startEpoch := r.f.mapEpoch(staleStart)
+		if staleStart > r.f.firstEpochMap(startEpoch) {
+			partialEnd = min(r.f.firstEpochMap(startEpoch+1), staleEnd)
+		}
+	}
+
 	// add or update filter rows
 	for rowIndex := uint32(0); rowIndex < r.f.mapHeight; rowIndex++ {
 		var (
@@ -438,8 +454,9 @@ func (r *mapRenderer) writeFinishedMaps(pauseCb func() bool) error {
 			mapIndices = append(mapIndices, mapIndex)
 			rows = append(rows, row)
 		}
-		if newRange.maps.AfterLast() == r.finished.AfterLast() { // head updated; remove future entries
-			for mapIndex := r.finished.AfterLast(); mapIndex < oldRange.maps.AfterLast(); mapIndex++ {
+		// If head is updated and the boundary epoch has stale maps, clear them per-row.
+		if isHeadUpdate && staleStart < partialEnd {
+			for mapIndex := staleStart; mapIndex < partialEnd; mapIndex++ {
 				if fm, _ := r.f.filterMapCache.Get(mapIndex); fm != nil && len(fm[rowIndex]) == 0 {
 					continue
 				}
@@ -452,14 +469,34 @@ func (r *mapRenderer) writeFinishedMaps(pauseCb func() bool) error {
 		}
 		checkWriteCnt()
 	}
+
+	// Range-delete any whole stale epochs.
+	if isHeadUpdate && partialEnd < staleEnd {
+		fullEpochStart := r.f.mapEpoch(partialEnd)
+		fullEpochEnd := r.f.mapEpoch(staleEnd-1) + 1
+		firstRow := r.f.mapRowIndex(r.f.firstEpochMap(fullEpochStart), 0)
+		countRows := r.f.mapRowIndex(r.f.firstEpochMap(fullEpochEnd), 0) - firstRow
+		if err := rawdb.DeleteFilterMapRows(r.f.db, common.NewRange(firstRow, countRows), r.f.hashScheme, func(bool) bool { pauseCb(); return false }); err != nil {
+			return fmt.Errorf("failed to delete stale filter map rows in epochs [%d, %d): %v", fullEpochStart, fullEpochEnd, err)
+		}
+	}
+
 	// update filter map cache
-	if newRange.maps.AfterLast() == r.finished.AfterLast() {
+	if isHeadUpdate {
 		// head updated; cache new head maps and remove future entries
 		for mapIndex := range r.finished.Iter() {
 			r.f.filterMapCache.Add(mapIndex, r.finishedMaps[mapIndex].filterMap)
 		}
-		for mapIndex := r.finished.AfterLast(); mapIndex < oldRange.maps.AfterLast(); mapIndex++ {
-			r.f.filterMapCache.Remove(mapIndex)
+		if staleEnd-staleStart > 1000 {
+			for _, k := range r.f.filterMapCache.Keys() {
+				if k >= staleStart && k < staleEnd {
+					r.f.filterMapCache.Remove(k)
+				}
+			}
+		} else {
+			for mapIndex := staleStart; mapIndex < staleEnd; mapIndex++ {
+				r.f.filterMapCache.Remove(mapIndex)
+			}
 		}
 	} else {
 		// head not updated; do not cache maps during tail rendering because we
@@ -468,6 +505,7 @@ func (r *mapRenderer) writeFinishedMaps(pauseCb func() bool) error {
 			r.f.filterMapCache.Remove(mapIndex)
 		}
 	}
+
 	var blockNumber uint64
 	if r.finished.First() > 0 {
 		// in order to always ensure continuous block pointers, initialize
@@ -493,16 +531,43 @@ func (r *mapRenderer) writeFinishedMaps(pauseCb func() bool) error {
 			blockNumber++
 		}
 	}
-	if newRange.maps.AfterLast() == r.finished.AfterLast() { // head updated; remove future entries
-		for mapIndex := r.finished.AfterLast(); mapIndex < oldRange.maps.AfterLast(); mapIndex++ {
-			r.f.deleteLastBlockOfMap(batch, mapIndex)
-			checkWriteCnt()
+
+	if isHeadUpdate && staleStart < staleEnd {
+		// Range-delete stale last block entries and evict lastBlockCache.
+		if err := rawdb.DeleteFilterMapLastBlocks(r.f.db, common.NewRange(staleStart, staleEnd-staleStart), r.f.hashScheme, func(bool) bool { pauseCb(); return false }); err != nil {
+			return fmt.Errorf("failed to delete stale filter map last blocks [%d, %d): %v", staleStart, staleEnd, err)
 		}
-		for ; blockNumber < oldRange.blocks.AfterLast(); blockNumber++ {
-			r.f.deleteBlockLvPointer(batch, blockNumber)
-			checkWriteCnt()
+		if staleEnd-staleStart > 1000 {
+			for _, k := range r.f.lastBlockCache.Keys() {
+				if k >= staleStart && k < staleEnd {
+					r.f.lastBlockCache.Remove(k)
+				}
+			}
+		} else {
+			for mapIndex := staleStart; mapIndex < staleEnd; mapIndex++ {
+				r.f.lastBlockCache.Remove(mapIndex)
+			}
+		}
+
+		// Range-delete stale block log value pointers and evict lvPointerCache.
+		if blockNumber < oldRange.blocks.AfterLast() {
+			if err := rawdb.DeleteBlockLvPointers(r.f.db, common.NewRange(blockNumber, oldRange.blocks.AfterLast()-blockNumber), r.f.hashScheme, func(bool) bool { pauseCb(); return false }); err != nil {
+				return fmt.Errorf("failed to delete stale block lv pointers [%d, %d): %v", blockNumber, oldRange.blocks.AfterLast(), err)
+			}
+			if oldRange.blocks.AfterLast()-blockNumber > 1000 {
+				for _, k := range r.f.lvPointerCache.Keys() {
+					if k >= blockNumber && k < oldRange.blocks.AfterLast() {
+						r.f.lvPointerCache.Remove(k)
+					}
+				}
+			} else {
+				for b := blockNumber; b < oldRange.blocks.AfterLast(); b++ {
+					r.f.lvPointerCache.Remove(b)
+				}
+			}
 		}
 	}
+
 	r.finishedMaps = make(map[uint32]*renderedMap)
 	r.finished.SetFirst(r.finished.AfterLast())
 	r.f.setRange(batch, renderedView, newRange, false)

--- a/core/filtermaps/map_renderer.go
+++ b/core/filtermaps/map_renderer.go
@@ -470,42 +470,6 @@ func (r *mapRenderer) writeFinishedMaps(pauseCb func() bool) error {
 		checkWriteCnt()
 	}
 
-	// Range-delete any whole stale epochs.
-	if isHeadUpdate && partialEnd < staleEnd {
-		fullEpochStart := r.f.mapEpoch(partialEnd)
-		fullEpochEnd := r.f.mapEpoch(staleEnd-1) + 1
-		firstRow := r.f.mapRowIndex(r.f.firstEpochMap(fullEpochStart), 0)
-		countRows := r.f.mapRowIndex(r.f.firstEpochMap(fullEpochEnd), 0) - firstRow
-		if err := rawdb.DeleteFilterMapRows(r.f.db, common.NewRange(firstRow, countRows), r.f.hashScheme, func(bool) bool { pauseCb(); return false }); err != nil {
-			return fmt.Errorf("failed to delete stale filter map rows in epochs [%d, %d): %v", fullEpochStart, fullEpochEnd, err)
-		}
-	}
-
-	// update filter map cache
-	if isHeadUpdate {
-		// head updated; cache new head maps and remove future entries
-		for mapIndex := range r.finished.Iter() {
-			r.f.filterMapCache.Add(mapIndex, r.finishedMaps[mapIndex].filterMap)
-		}
-		if staleEnd-staleStart > 1000 {
-			for _, k := range r.f.filterMapCache.Keys() {
-				if k >= staleStart && k < staleEnd {
-					r.f.filterMapCache.Remove(k)
-				}
-			}
-		} else {
-			for mapIndex := staleStart; mapIndex < staleEnd; mapIndex++ {
-				r.f.filterMapCache.Remove(mapIndex)
-			}
-		}
-	} else {
-		// head not updated; do not cache maps during tail rendering because we
-		// need head maps to be available in the cache
-		for mapIndex := range r.finished.Iter() {
-			r.f.filterMapCache.Remove(mapIndex)
-		}
-	}
-
 	var blockNumber uint64
 	if r.finished.First() > 0 {
 		// in order to always ensure continuous block pointers, initialize
@@ -534,6 +498,9 @@ func (r *mapRenderer) writeFinishedMaps(pauseCb func() bool) error {
 
 	if isHeadUpdate && staleStart < staleEnd {
 		// Range-delete stale last block entries and evict lastBlockCache.
+		// Deleting lastBlock pointers first ensures that any crash before final
+		// range metadata commit will be detected as an inconsistent state and
+		// cleanly reset/rebuilt rather than leaving stale orphan keys.
 		if err := rawdb.DeleteFilterMapLastBlocks(r.f.db, common.NewRange(staleStart, staleEnd-staleStart), r.f.hashScheme, func(bool) bool { pauseCb(); return false }); err != nil {
 			return fmt.Errorf("failed to delete stale filter map last blocks [%d, %d): %v", staleStart, staleEnd, err)
 		}
@@ -565,6 +532,43 @@ func (r *mapRenderer) writeFinishedMaps(pauseCb func() bool) error {
 					r.f.lvPointerCache.Remove(b)
 				}
 			}
+		}
+
+		// Range-delete any whole stale epochs.
+		if partialEnd < staleEnd {
+			fullEpochStart := r.f.mapEpoch(partialEnd)
+			fullEpochEnd := r.f.mapEpoch(staleEnd-1) + 1
+			firstRow := r.f.mapRowIndex(r.f.firstEpochMap(fullEpochStart), 0)
+			countRows := r.f.mapRowIndex(r.f.firstEpochMap(fullEpochEnd), 0) - firstRow
+			if err := rawdb.DeleteFilterMapRows(r.f.db, common.NewRange(firstRow, countRows), r.f.hashScheme, func(bool) bool { pauseCb(); return false }); err != nil {
+				return fmt.Errorf("failed to delete stale filter map rows in epochs [%d, %d): %v", fullEpochStart, fullEpochEnd, err)
+			}
+		}
+
+		// update filter map cache
+		for mapIndex := range r.finished.Iter() {
+			r.f.filterMapCache.Add(mapIndex, r.finishedMaps[mapIndex].filterMap)
+		}
+		if staleEnd-staleStart > 1000 {
+			for _, k := range r.f.filterMapCache.Keys() {
+				if k >= staleStart && k < staleEnd {
+					r.f.filterMapCache.Remove(k)
+				}
+			}
+		} else {
+			for mapIndex := staleStart; mapIndex < staleEnd; mapIndex++ {
+				r.f.filterMapCache.Remove(mapIndex)
+			}
+		}
+	} else if !isHeadUpdate {
+		// head not updated; do not cache maps during tail rendering because we
+		// need head maps to be available in the cache
+		for mapIndex := range r.finished.Iter() {
+			r.f.filterMapCache.Remove(mapIndex)
+		}
+	} else {
+		for mapIndex := range r.finished.Iter() {
+			r.f.filterMapCache.Add(mapIndex, r.finishedMaps[mapIndex].filterMap)
 		}
 	}
 


### PR DESCRIPTION
Fixes #32153

### Problem
When the chain indexer processes a chain rollback or full chain resync, \writeFinishedMaps\ previously iterated over all stale maps beyond the new head and inserted \
il\ filter rows for every row index into a single uncommitted database batch.

Because the batch flush counter was advanced only once per row index, tens of millions of pending batch records were possible before reaching the row-based flush threshold (\1024\ rows), depending on rollback depth. This accumulated unbounded pending deletions in a single batch, causing Pebble to exceed its maximum batch size limit and panic:
\\\
panic: pebble: batch too large: >= 4.0 G
\\\

Furthermore, stale \lastBlock\ entries and \lockLvPointer\ entries iterated point deletions across stale ranges in tight loops.

### Solution
The key invariant is that **rollback distance no longer translates into one unbounded Pebble batch**:
1. **Bounded Safe Range Deletion for Whole Stale Epochs**: Whole stale epochs (\[partialEnd, staleEnd)\) are deleted via \awdb.DeleteFilterMapRows\, leveraging the contiguous keyspace layout of \mapRowIndex\ across whole epochs and utilizing the database's safe range deletion infrastructure.
2. **Boundary Partial Epoch Deletion**: Only the boundary partial epoch sharing maps with the new head (\[staleStart, partialEnd)\) is cleared row-by-row with \
il\ updates.
3. **Safe Range Deletions for Pointers**: Replaced point-delete loops for \lastBlock\ and \lockLvPointer\ with \awdb.DeleteFilterMapLastBlocks\ and \awdb.DeleteBlockLvPointers\.
4. **Batch Size Limit Guard**: Enhanced \checkWriteCnt\ to flush whenever \writeCnt >= rowsPerBatch || batch.ValueSize() >= ethdb.IdealBatchSize\.
5. **Bounded Cache Eviction**: Evicts in-memory LRU caches in bounded time based on active cache size.

### Testing
- Added deterministic unit tests reproducing the unbounded batch accumulation during rollback and proving bounded batch size (\TestIndexerRollbackBoundedBatch\).
- Added multi-epoch rollback scenario and bit-exact database hash comparison tests against fresh nodes (\TestIndexerRollbackScenarios\, \TestIndexerRollbackDbIntegrity\).
- Added crash recovery test proving that interrupting stale deletion mid-rollback cleanly recovers without index corruption (\TestIndexerRollbackCrashRecovery\).
- All existing tests in \core/filtermaps\, \core/rawdb\, and \ethdb/...\ pass.