### PR TITLE
eth/gasestimator: return used gas for plain transfer estimates

### DIFF
--- a/eth/gasestimator/gasestimator.go
+++ b/eth/gasestimator/gasestimator.go
@@ -117,15 +117,16 @@ func Estimate(ctx context.Context, call *core.Message, opts *Options, gasCap uin
 		log.Debug("Caller gas above allowance, capping", "requested", hi, "cap", gasCap)
 		hi = gasCap
 	}
-	// If the transaction is a plain value transfer, short circuit estimation and
-	// directly try 21000. Returning 21000 without any execution is dangerous as
-	// some tx field combos might bump the price up even for plain transfers (e.g.
-	// unused access list items). Ever so slightly wasteful, but safer overall.
+	// If the transaction is a plain value transfer, short circuit estimation by
+	// executing it once with a 21000 gas limit and returning the gas it used:
+	// exact, since a plain transfer runs no code and gets no refunds, and since
+	// EIP-2780 it can cost less than 21000. The trial execution guards against
+	// tx field combos that bump the price up (e.g. unused access list items).
 	if len(call.Data) == 0 {
 		if call.To != nil && opts.State.GetCodeSize(*call.To) == 0 {
-			failed, _, err := execute(ctx, call, opts, params.TxGas)
+			failed, result, err := execute(ctx, call, opts, params.TxGas)
 			if !failed && err == nil {
-				return params.TxGas, nil, nil
+				return result.UsedGas, nil, nil
 			}
 		}
 	}

--- a/internal/ethapi/api_test.go
+++ b/internal/ethapi/api_test.go
@@ -3954,6 +3954,67 @@ func TestCreateAccessListWithStateOverrides(t *testing.T) {
 	require.Equal(t, expected, result.Accesslist)
 }
 
+func TestEstimateGasAmsterdam(t *testing.T) {
+	t.Parallel()
+	var (
+		accounts = newAccounts(2)
+		config   = *params.MergedTestChainConfig
+		genesis  = &core.Genesis{
+			Config:     &config,
+			Difficulty: common.Big0,
+			Alloc: types.GenesisAlloc{
+				accounts[0].addr: {Balance: big.NewInt(params.Ether)},
+				accounts[1].addr: {Balance: big.NewInt(params.Ether)},
+			},
+		}
+	)
+	config.AmsterdamTime = new(uint64)
+	api := NewBlockChainAPI(newTestBackend(t, 0, genesis, beacon.New(ethash.NewFaker()), nil))
+
+	var testSuite = []struct {
+		call TransactionArgs
+		want uint64
+	}{
+		// value transfer to an existing account: EIP-2780 intrinsic gas
+		{
+			call: TransactionArgs{
+				From:  &accounts[0].addr,
+				To:    &accounts[1].addr,
+				Value: (*hexutil.Big)(big.NewInt(1000)),
+			},
+			want: 21000,
+		},
+		// zero-value call to an existing account: below the legacy 21000 floor
+		{
+			call: TransactionArgs{
+				From: &accounts[0].addr,
+				To:   &accounts[1].addr,
+			},
+			want: 15000,
+		},
+		// self transfer: base cost only
+		{
+			call: TransactionArgs{
+				From:  &accounts[0].addr,
+				To:    &accounts[0].addr,
+				Value: (*hexutil.Big)(big.NewInt(1000)),
+			},
+			want: 12000,
+		},
+	}
+	latest := rpc.LatestBlockNumber
+	for i, tc := range testSuite {
+		result, err := api.EstimateGas(context.Background(), tc.call, &rpc.BlockNumberOrHash{BlockNumber: &latest}, nil, nil)
+		if err != nil {
+			t.Errorf("test %d: want no error, have %v", i, err)
+			continue
+		}
+		if uint64(result) != tc.want {
+			t.Errorf("test %d: result mismatch, have %v, want %v", i, uint64(result), tc.want)
+		}
+	}
+}
+
 func TestEstimateGasWithMovePrecompile(t *testing.T) {
 	t.Parallel()
 	// Initialize test accounts


### PR DESCRIPTION
The plain-transfer shortcut in the gas estimator executes the call with a 21,000 gas limit and returns 21,000 on success. After Amsterdam, EIP-2780 prices these calls below 21,000: a zero-value call to an existing account costs 15,000 and a self transfer costs 12,000. The shortcut hides that and `eth_estimateGas` over-reports by up to 75%.

This change returns the used gas from the trial execution instead of the constant. A plain transfer runs no code and gets no refunds, so its used gas is the minimum gas limit that succeeds. Before Amsterdam the used gas is exactly 21,000, so behavior there does not change.

Cross-client context, measured with hive rpc-compat on the Amsterdam fixtures from ethereum/execution-apis#867: nethermind and erigon return the exact EIP-2780 minimum (15,000), besu returns 15,159, geth and reth return the 21,000 floor.

Includes a regression test at the RPC layer: 21,000 / 15,000 / 12,000 for the three transfer shapes under an Amsterdam config. The test fails without the estimator change.