### PR TITLE
eth/protocols/eth, eth/downloader: reject empty partial receipt responses

### DIFF
--- a/eth/downloader/fetchers_concurrent.go
+++ b/eth/downloader/fetchers_concurrent.go
@@ -337,7 +337,14 @@ func (d *Downloader) concurrentFetch(queue typedQueue) error {
 			// caused by a timed out request which came through in the end), set it to
 			// idle. If the delivery's stale, the peer should have already been idled.
 			if !errors.Is(err, errStaleDelivery) {
-				queue.updateCapacity(peer, accepted, res.Time)
+				items, elapsed := accepted, res.Time
+				if res.Roundtrips > 1 && items > 0 {
+					// Partial receipt response can be assembled over multiple round trips.
+					// Scale both values down to a single round trip.
+					items = max(1, items/res.Roundtrips)
+					elapsed = res.Time * time.Duration(items) / time.Duration(accepted)
+				}
+				queue.updateCapacity(peer, items, elapsed)
 			}
 			res.Done <- validityErrorOfRequest(err)
 			res.Req.Close()

--- a/eth/protocols/eth/dispatcher.go
+++ b/eth/protocols/eth/dispatcher.go
@@ -56,6 +56,8 @@ type Request struct {
 
 	Peer string    // Demultiplexer if cross-peer requests are batched together
 	Sent time.Time // Timestamp when the request was sent
+
+	roundtrips int // Number of network round trips made under this request id
 }
 
 // Close aborts an in-flight request. Although there's no way to notify the
@@ -120,6 +122,8 @@ type Response struct {
 	Meta interface{}   // Metadata generated locally on the receiver thread
 	Time time.Duration // Time it took for the request to be served
 	Done chan error    // Channel to signal message handling to the reader
+
+	Roundtrips int // Number of network round trips the exchange took
 }
 
 // response is a wrapper around a remote Response that has an error channel to
@@ -251,6 +255,7 @@ loop:
 				reqOp.fail <- err
 				continue loop
 			}
+			req.roundtrips = 1
 			pending[req.id] = req
 			reqOp.fail <- nil
 
@@ -277,6 +282,7 @@ loop:
 				resendOp.fail <- err
 				continue loop
 			}
+			req.roundtrips++
 			resendOp.fail <- nil
 
 		case cancelOp := <-p.reqCancel:
@@ -318,6 +324,7 @@ loop:
 				// with the matching request. Signal to the delivery routine that
 				// it can wait for a handler response and dispatch the data.
 				res.Time = res.recv.Sub(res.Req.Sent)
+				res.Roundtrips = res.Req.roundtrips
 				resOp.fail <- nil
 
 				// Stop tracking the request, the response dispatcher will deliver

--- a/eth/protocols/eth/handlers.go
+++ b/eth/protocols/eth/handlers.go
@@ -522,7 +522,7 @@ func handleReceipts70(backend Backend, msg Decoder, peer *Peer) error {
 		return fmt.Errorf("Receipts: %w", err)
 	}
 
-	err = peer.bufferReceipts(res.RequestId, receiptLists, res.LastBlockIncomplete, backend)
+	err = peer.bufferReceipts(res.RequestId, receiptLists, res.LastBlockIncomplete)
 	if err != nil {
 		return err
 	}

--- a/eth/protocols/eth/peer.go
+++ b/eth/protocols/eth/peer.go
@@ -533,7 +533,7 @@ func (p *Peer) requestPartialReceipts(id uint64) error {
 
 // bufferReceipts validates a receipt packet and buffer the incomplete packet.
 // If the request is completed, it appends previously collected receipts.
-func (p *Peer) bufferReceipts(requestId uint64, receiptLists []*ReceiptList, lastBlockIncomplete bool, backend Backend) error {
+func (p *Peer) bufferReceipts(requestId uint64, receiptLists []*ReceiptList, lastBlockIncomplete bool) error {
 	p.receiptBufferLock.Lock()
 	defer p.receiptBufferLock.Unlock()
 
@@ -556,6 +556,11 @@ func (p *Peer) bufferReceipts(requestId uint64, receiptLists []*ReceiptList, las
 	}
 	// Buffer the last block when the response is incomplete.
 	if lastBlockIncomplete {
+		// Prevent sending a single empty receipt.
+		if len(receiptLists) == 1 && receiptLists[0].items.Len() == 0 {
+			delete(p.receiptBuffer, requestId)
+			return errors.New("no receipt delivered in incomplete receipt response")
+		}
 		lastBlock := len(receiptLists) - 1
 		if len(buffer.list) > 0 {
 			lastBlock += len(buffer.list) - 1

--- a/eth/protocols/eth/peer_test.go
+++ b/eth/protocols/eth/peer_test.go
@@ -24,6 +24,7 @@ import (
 	"testing"
 
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/p2p"
 	"github.com/ethereum/go-ethereum/p2p/enode"
 )
@@ -62,6 +63,45 @@ func newTestPeer(name string, version uint, backend Backend) (*testPeer, <-chan 
 func (p *testPeer) close() {
 	p.Peer.Close()
 	p.app.Close()
+}
+
+// TestBufferReceiptsNoProgress checks that an incomplete receipt response
+// delivering no receipt is rejected, while an empty list at the end of a
+// multi-block response is still accepted.
+func TestBufferReceiptsNoProgress(t *testing.T) {
+	p := &Peer{receiptBuffer: make(map[uint64]*receiptRequest)}
+
+	newRequest := func(id uint64, blocks int) {
+		req := new(receiptRequest)
+		for i := 0; i < blocks; i++ {
+			req.request = append(req.request, common.Hash{byte(i + 1)})
+			req.gasUsed = append(req.gasUsed, 1_000_000)
+			req.timestamps = append(req.timestamps, 0)
+		}
+		p.receiptBuffer[id] = req
+	}
+
+	// A single empty list with the incomplete flag makes no progress.
+	newRequest(1, 1)
+	if err := p.bufferReceipts(1, []*ReceiptList{NewReceiptList(nil)}, true); err == nil {
+		t.Fatal("expected error for incomplete response without receipts")
+	}
+	if _, ok := p.receiptBuffer[1]; ok {
+		t.Fatal("buffer entry not removed after invalid response")
+	}
+
+	// An empty list preceded by other lists advances the request and is valid.
+	newRequest(2, 2)
+	lists := []*ReceiptList{
+		NewReceiptList([]*types.Receipt{{Status: 1, CumulativeGasUsed: 21000}}),
+		NewReceiptList(nil),
+	}
+	if err := p.bufferReceipts(2, lists, true); err != nil {
+		t.Fatalf("unexpected error for multi-block incomplete response: %v", err)
+	}
+	if _, ok := p.receiptBuffer[2]; !ok {
+		t.Fatal("buffer entry missing after valid incomplete response")
+	}
 }
 
 func TestPeerSet(t *testing.T) {


### PR DESCRIPTION
eth/70 can complete a receipts request over multiple round trips. Current
implementation has two issues in requester side.

1. A peer could keep a request loop alive with incomplete responses that
deliver no receipt. An incomplete response must now add at least one
receipt. A trailing empty list after other blocks is still accepted. We
already have a grace period and peer-dropping logic covering this, but an
additional guard is nice to have.

2. Response.Time is recorded across all rounds, making the peer's
roundtrip estimate incorrect. The dispatcher now counts the rounds 
made under a request id, and the downloader divides the delivered 
items and elapsed time to one round trip.