### PR TITLE
eth: include deleted accounts in debug_getModifiedAccounts*

### DIFF
--- a/eth/api_debug.go
+++ b/eth/api_debug.go
@@ -384,24 +384,44 @@ func (api *DebugAPI) getModifiedAccounts(startHeader, endHeader *types.Header) (
 	if err != nil {
 		return nil, err
 	}
-	oldIt, err := oldTrie.NodeIterator([]byte{})
-	if err != nil {
-		return nil, err
-	}
-	newIt, err := newTrie.NodeIterator([]byte{})
-	if err != nil {
-		return nil, err
-	}
-	diff, _ := trie.NewDifferenceIterator(oldIt, newIt)
-	iter := trie.NewIterator(diff)
-
-	var dirty []common.Address
-	for iter.Next() {
-		key := newTrie.GetKey(iter.Key)
-		if key == nil {
-			return nil, fmt.Errorf("no preimage found for hash %x", iter.Key)
+	// The difference iterator only yields leaves of its second trie, so accounts
+	// deleted between the two blocks are invisible to the old -> new direction and
+	// have to be picked up by the reverse one. Accounts modified in place show up
+	// in both, hence the deduplication.
+	var (
+		dirty []common.Address
+		seen  = make(map[common.Address]struct{})
+	)
+	collect := func(a, b *trie.StateTrie) error {
+		aIt, err := a.NodeIterator([]byte{})
+		if err != nil {
+			return err
 		}
-		dirty = append(dirty, common.BytesToAddress(key))
+		bIt, err := b.NodeIterator([]byte{})
+		if err != nil {
+			return err
+		}
+		diff, _ := trie.NewDifferenceIterator(aIt, bIt)
+		iter := trie.NewIterator(diff)
+		for iter.Next() {
+			key := b.GetKey(iter.Key)
+			if key == nil {
+				return fmt.Errorf("no preimage found for hash %x", iter.Key)
+			}
+			addr := common.BytesToAddress(key)
+			if _, ok := seen[addr]; ok {
+				continue
+			}
+			seen[addr] = struct{}{}
+			dirty = append(dirty, addr)
+		}
+		return nil
+	}
+	if err := collect(oldTrie, newTrie); err != nil {
+		return nil, err
+	}
+	if err := collect(newTrie, oldTrie); err != nil {
+		return nil, err
 	}
 	return dirty, nil
 }

--- a/eth/api_debug_test.go
+++ b/eth/api_debug_test.go
@@ -39,6 +39,7 @@ import (
 	"github.com/ethereum/go-ethereum/core/txpool/blobpool"
 	"github.com/ethereum/go-ethereum/core/txpool/legacypool"
 	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/core/vm"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/params"
 	"github.com/ethereum/go-ethereum/rpc"
@@ -337,6 +338,68 @@ func TestGetModifiedAccounts(t *testing.T) {
 			if !slices.Contains(addrs, account.addr) {
 				t.Fatalf("account %s not found in modified accounts", account.addr.Hex())
 			}
+		}
+	})
+}
+
+// TestGetModifiedAccountsDeleted checks that an account which exists in the start
+// state and is gone from the end state is reported as modified. Such an account
+// only lives in the old trie, so a one-directional difference misses it.
+func TestGetModifiedAccountsDeleted(t *testing.T) {
+	t.Parallel()
+
+	accounts := newAccounts(2)
+	victim := common.HexToAddress("0x000000000000000000000000000000000000dEaD")
+
+	// Pre-Shanghai runtime code: PUSH20 <beneficiary>; SELFDESTRUCT.
+	code := append([]byte{byte(vm.PUSH20)}, accounts[1].addr.Bytes()...)
+	code = append(code, byte(vm.SELFDESTRUCT))
+	genesis := &core.Genesis{
+		Config: params.TestChainConfig,
+		Alloc: types.GenesisAlloc{
+			accounts[0].addr: {Balance: big.NewInt(params.Ether)},
+			accounts[1].addr: {Balance: big.NewInt(params.Ether)},
+			victim:           {Balance: big.NewInt(12345), Code: code},
+		},
+	}
+	signer := types.HomesteadSigner{}
+	blockChain := newTestBlockChain(t, 1, genesis, func(_ int, b *core.BlockGen) {
+		tx, _ := types.SignTx(types.NewTx(&types.LegacyTx{
+			Nonce:    0,
+			To:       &victim,
+			Value:    big.NewInt(0),
+			Gas:      100000,
+			GasPrice: b.BaseFee(),
+		}), signer, accounts[0].key)
+		b.AddTx(tx)
+	})
+	defer blockChain.Stop()
+
+	start, end := blockChain.GetHeaderByNumber(0), blockChain.GetHeaderByNumber(1)
+	startState, err := blockChain.StateAt(start)
+	assert.NoError(t, err)
+	endState, err := blockChain.StateAt(end)
+	assert.NoError(t, err)
+	if !startState.Exist(victim) || endState.Exist(victim) {
+		t.Fatal("fixture failed to delete the account")
+	}
+	api := NewDebugAPI(&Ethereum{blockchain: blockChain})
+
+	t.Run("GetModifiedAccountsByNumber", func(t *testing.T) {
+		endNum := end.Number.Uint64()
+		addrs, err := api.GetModifiedAccountsByNumber(start.Number.Uint64(), &endNum)
+		assert.NoError(t, err)
+		if !slices.Contains(addrs, victim) {
+			t.Fatalf("deleted account %s not found in modified accounts", victim.Hex())
+		}
+	})
+
+	t.Run("GetModifiedAccountsByHash", func(t *testing.T) {
+		endHash := end.Hash()
+		addrs, err := api.GetModifiedAccountsByHash(start.Hash(), &endHash)
+		assert.NoError(t, err)
+		if !slices.Contains(addrs, victim) {
+			t.Fatalf("deleted account %s not found in modified accounts", victim.Hex())
 		}
 	})
 }


### PR DESCRIPTION
Fixes #35481. The difference iterator only yields leaves of the trie passed as its second argument, so an account that exists at the start block and is gone by the end block never shows up. Walking the reverse difference too and merging the two picks those up, with dedup for accounts that changed in place and therefore appear in both directions.

This does mean the state walk happens twice. Happy to look at a cheaper approach if that cost is a problem for this endpoint, but it already does a full trie diff so it seemed the honest fix.
