### PR TITLE
core/state, core/types: improve post-execution commit

### DIFF
--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -103,7 +103,6 @@ var (
 	blockValidationTimer      = metrics.NewRegisteredResettingTimer("chain/validation", nil)
 	blockCrossValidationTimer = metrics.NewRegisteredResettingTimer("chain/crossvalidation", nil)
 	blockExecutionTimer       = metrics.NewRegisteredResettingTimer("chain/execution", nil)
-	blockWriteTimer           = metrics.NewRegisteredResettingTimer("chain/write", nil)
 
 	blockReorgMeter     = metrics.NewRegisteredMeter("chain/reorg/executes", nil)
 	blockReorgAddMeter  = metrics.NewRegisteredMeter("chain/reorg/add", nil)
@@ -1649,18 +1648,25 @@ func (bc *BlockChain) writeBlockWithState(block *types.Block, receipts []*types.
 	// Note all the components of block(hash->number map, header, body, receipts)
 	// should be written atomically. BlockBatch is used for containing all components.
 	var (
-		batch = bc.db.NewBatch()
-		start = time.Now()
+		batch      = bc.db.NewBatch()
+		preimages  = statedb.Preimages()
+		blockWrite = make(chan struct{})
 	)
 	defer batch.Close()
 
-	rawdb.WriteBlock(batch, block)
-	rawdb.WriteReceipts(batch, block.Hash(), block.NumberU64(), receipts)
-	rawdb.WritePreimages(batch, statedb.Preimages())
-	if err := batch.Write(); err != nil {
-		log.Crit("Failed to write block into disk", "err", err)
-	}
-	log.Debug("Committed block data", "size", common.StorageSize(batch.ValueSize()), "elapsed", common.PrettyDuration(time.Since(start)))
+	go func() {
+		start := time.Now()
+		rawdb.WriteBlock(batch, block)
+		rawdb.WriteReceipts(batch, block.Hash(), block.NumberU64(), receipts)
+		rawdb.WritePreimages(batch, preimages)
+		if err := batch.Write(); err != nil {
+			log.Crit("Failed to write block into disk", "err", err)
+		}
+		elapsed := time.Since(start)
+		log.Debug("Committed block data", "size", common.StorageSize(batch.ValueSize()), "elapsed", common.PrettyDuration(elapsed))
+		close(blockWrite)
+	}()
+	defer func() { <-blockWrite }()
 
 	var (
 		err          error
@@ -2368,7 +2374,6 @@ func (bc *BlockChain) ProcessBlock(ctx context.Context, parentRoot common.Hash, 
 	// Write the block to the chain and get the status.
 	var status WriteStatus
 	if config.WriteState {
-		wstart := time.Now()
 		if !config.WriteHead {
 			// Don't set the head, only insert the block
 			err = bc.writeBlockWithState(block, res.Receipts, statedb)
@@ -2382,7 +2387,6 @@ func (bc *BlockChain) ProcessBlock(ctx context.Context, parentRoot common.Hash, 
 		stats.AccountCommits = statedb.AccountCommits  // Account commits are complete, we can mark them
 		stats.StorageCommits = statedb.StorageCommits  // Storage commits are complete, we can mark them
 		stats.DatabaseCommit = statedb.DatabaseCommits // Database commits are complete, we can mark them
-		stats.BlockWrite = time.Since(wstart) - max(statedb.AccountCommits, statedb.StorageCommits) /* concurrent */ - statedb.DatabaseCommits
 	}
 	elapsed := time.Since(startTime) + 1 // prevent zero division
 	stats.TotalTime = elapsed

--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -103,6 +103,7 @@ var (
 	blockValidationTimer      = metrics.NewRegisteredResettingTimer("chain/validation", nil)
 	blockCrossValidationTimer = metrics.NewRegisteredResettingTimer("chain/crossvalidation", nil)
 	blockExecutionTimer       = metrics.NewRegisteredResettingTimer("chain/execution", nil)
+	blockWriteTimer           = metrics.NewRegisteredResettingTimer("chain/write", nil)
 
 	blockReorgMeter     = metrics.NewRegisteredMeter("chain/reorg/executes", nil)
 	blockReorgAddMeter  = metrics.NewRegisteredMeter("chain/reorg/add", nil)
@@ -1664,6 +1665,7 @@ func (bc *BlockChain) writeBlockWithState(block *types.Block, receipts []*types.
 		}
 		elapsed := time.Since(start)
 		log.Debug("Committed block data", "size", common.StorageSize(batch.ValueSize()), "elapsed", common.PrettyDuration(elapsed))
+		blockWriteTimer.Update(elapsed)
 		close(blockWrite)
 	}()
 	defer func() { <-blockWrite }()

--- a/core/blockchain_stats.go
+++ b/core/blockchain_stats.go
@@ -53,7 +53,6 @@ type ExecuteStats struct {
 	Validation      time.Duration // Time spent on the block validation
 	CrossValidation time.Duration // Optional, time spent on the block cross validation
 	DatabaseCommit  time.Duration // Time spent on database commit
-	BlockWrite      time.Duration // Time spent on block write
 	TotalTime       time.Duration // The total time spent on block execution
 	MgasPerSecond   float64       // The million gas processed per second
 
@@ -87,7 +86,6 @@ func (s *ExecuteStats) reportMetrics() {
 	blockValidationTimer.Update(s.Validation)               // The time spent on block validation
 	blockCrossValidationTimer.Update(s.CrossValidation)     // The time spent on stateless cross validation
 	triedbCommitTimer.Update(s.DatabaseCommit)              // Trie database commits are complete, we can mark them
-	blockWriteTimer.Update(s.BlockWrite)                    // The time spent on block write
 	blockInsertTimer.Update(s.TotalTime)                    // The total time spent on block execution
 	chainMgaspsMeter.Update(time.Duration(s.MgasPerSecond)) // TODO(rjl493456442) generalize the ResettingTimer
 
@@ -210,7 +208,7 @@ func (s *ExecuteStats) logSlow(block *types.Block, slowBlockThreshold time.Durat
 			ExecutionMs: durationToMs(s.Execution),
 			StateReadMs: durationToMs(s.AccountReads + s.StorageReads + s.CodeReads),
 			StateHashMs: durationToMs(s.AccountHashes + s.AccountUpdates + s.StorageUpdates),
-			CommitMs:    durationToMs(max(s.AccountCommits, s.StorageCommits) + s.DatabaseCommit + s.BlockWrite),
+			CommitMs:    durationToMs(max(s.AccountCommits, s.StorageCommits) + s.DatabaseCommit),
 			TotalMs:     durationToMs(s.TotalTime),
 		},
 		Throughput: slowBlockThru{

--- a/core/state/stateupdate.go
+++ b/core/state/stateupdate.go
@@ -197,8 +197,50 @@ func encodeSlot(value common.Hash) []byte {
 	if value == (common.Hash{}) {
 		return nil
 	}
-	blob, _ := rlp.EncodeToBytes(common.TrimLeftZeroes(value[:]))
+	// The trimmed value is between 1 and 32 bytes, so its RLP is always a short
+	// string. Writing it directly saves a trip through the encoder, which this
+	// is called a few thousand times per block.
+	trimmed := common.TrimLeftZeroes(value[:])
+	if len(trimmed) == 1 && trimmed[0] < 0x80 {
+		return []byte{trimmed[0]}
+	}
+	blob := make([]byte, 1+len(trimmed))
+	blob[0] = 0x80 + byte(len(trimmed))
+	copy(blob[1:], trimmed)
 	return blob
+}
+
+// encodeAccounts encodes the given accounts into their slim RLP form, reusing a
+// single encoder across all of them.
+func encodeAccounts[K comparable](src map[K]*types.StateAccount) map[K][]byte {
+	out := make(map[K][]byte, len(src))
+	if len(src) == 0 {
+		return out
+	}
+	buf := rlp.NewEncoderBuffer(nil)
+	defer buf.Flush()
+
+	for key, account := range src {
+		if account == nil {
+			out[key] = nil
+			continue
+		}
+		out[key] = types.SlimAccountRLPInto(&buf, *account)
+	}
+	return out
+}
+
+// encodeStorages encodes the given storage slots into their trie form.
+func encodeStorages[K comparable](src map[K]map[common.Hash]common.Hash) map[K]map[common.Hash][]byte {
+	out := make(map[K]map[common.Hash][]byte, len(src))
+	for key, slots := range src {
+		subset := make(map[common.Hash][]byte, len(slots))
+		for slot, value := range slots {
+			subset[slot] = encodeSlot(value)
+		}
+		out[key] = subset
+	}
+	return out
 }
 
 // EncodeMPTState encodes all state mutations alongside their original value
@@ -207,41 +249,7 @@ func encodeSlot(value common.Hash) []byte {
 // It transforms account and storage updates into their corresponding MPT-encoded
 // key-value mappings, using the same encoding rules as the Ethereum state trie.
 func (sc *StateUpdate) EncodeMPTState() (map[common.Hash][]byte, map[common.Address][]byte, map[common.Hash]map[common.Hash][]byte, map[common.Address]map[common.Hash][]byte) {
-	var (
-		accounts      = make(map[common.Hash][]byte, len(sc.Accounts))
-		storages      = make(map[common.Hash]map[common.Hash][]byte, len(sc.Storages))
-		accountOrigin = make(map[common.Address][]byte, len(sc.AccountsOrigin))
-		storageOrigin = make(map[common.Address]map[common.Hash][]byte, len(sc.StoragesOrigin))
-	)
-	for addr, prev := range sc.AccountsOrigin {
-		if prev == nil {
-			accountOrigin[addr] = nil
-		} else {
-			accountOrigin[addr] = types.SlimAccountRLP(*prev)
-		}
-	}
-	for addrHash, data := range sc.Accounts {
-		if data == nil {
-			accounts[addrHash] = nil
-		} else {
-			accounts[addrHash] = types.SlimAccountRLP(*data)
-		}
-	}
-	for addr, slots := range sc.StoragesOrigin {
-		subset := make(map[common.Hash][]byte)
-		for key, val := range slots {
-			subset[key] = encodeSlot(val)
-		}
-		storageOrigin[addr] = subset
-	}
-	for addrHash, slots := range sc.Storages {
-		subset := make(map[common.Hash][]byte)
-		for key, val := range slots {
-			subset[key] = encodeSlot(val)
-		}
-		storages[addrHash] = subset
-	}
-	return accounts, accountOrigin, storages, storageOrigin
+	return encodeAccounts(sc.Accounts), encodeAccounts(sc.AccountsOrigin), encodeStorages(sc.Storages), encodeStorages(sc.StoragesOrigin)
 }
 
 // EncodeUBTState encodes all state mutations alongside their original value
@@ -250,41 +258,7 @@ func (sc *StateUpdate) EncodeMPTState() (map[common.Hash][]byte, map[common.Addr
 // It transforms account and storage updates into their corresponding UBT-encoded
 // key-value mappings, using the same encoding rules as the Ethereum state trie.
 func (sc *StateUpdate) EncodeUBTState() (map[common.Hash][]byte, map[common.Address][]byte, map[common.Hash]map[common.Hash][]byte, map[common.Address]map[common.Hash][]byte) {
-	var (
-		accounts      = make(map[common.Hash][]byte, len(sc.Accounts))
-		storages      = make(map[common.Hash]map[common.Hash][]byte, len(sc.Storages))
-		accountOrigin = make(map[common.Address][]byte, len(sc.AccountsOrigin))
-		storageOrigin = make(map[common.Address]map[common.Hash][]byte, len(sc.StoragesOrigin))
-	)
-	for addr, prev := range sc.AccountsOrigin {
-		if prev == nil {
-			accountOrigin[addr] = nil
-		} else {
-			accountOrigin[addr] = types.SlimAccountRLP(*prev)
-		}
-	}
-	for addrHash, data := range sc.Accounts {
-		if data == nil {
-			accounts[addrHash] = nil
-		} else {
-			accounts[addrHash] = types.SlimAccountRLP(*data)
-		}
-	}
-	for addr, slots := range sc.StoragesOrigin {
-		subset := make(map[common.Hash][]byte)
-		for key, val := range slots {
-			subset[key] = encodeSlot(val)
-		}
-		storageOrigin[addr] = subset
-	}
-	for addrHash, slots := range sc.Storages {
-		subset := make(map[common.Hash][]byte)
-		for key, val := range slots {
-			subset[key] = encodeSlot(val)
-		}
-		storages[addrHash] = subset
-	}
-	return accounts, accountOrigin, storages, storageOrigin
+	return encodeAccounts(sc.Accounts), encodeAccounts(sc.AccountsOrigin), encodeStorages(sc.Storages), encodeStorages(sc.StoragesOrigin)
 }
 
 // deriveCodeFields derives the missing fields of contract code changes

--- a/core/types/state_account.go
+++ b/core/types/state_account.go
@@ -70,21 +70,36 @@ type SlimAccount struct {
 
 // SlimAccountRLP encodes the state account in 'slim RLP' format.
 func SlimAccountRLP(account StateAccount) []byte {
-	slim := SlimAccount{
-		Nonce:   account.Nonce,
-		Balance: account.Balance,
+	buf := rlp.NewEncoderBuffer(nil)
+	defer buf.Flush()
+
+	return SlimAccountRLPInto(&buf, account)
+}
+
+// SlimAccountRLPInto encodes the state account in 'slim RLP' format into the
+// given buffer, returning the encoded bytes.
+func SlimAccountRLPInto(w *rlp.EncoderBuffer, account StateAccount) []byte {
+	w.Reset(nil)
+
+	list := w.List()
+	w.WriteUint64(account.Nonce)
+	if account.Balance != nil {
+		w.WriteUint256(account.Balance)
+	} else {
+		w.WriteUint64(0)
 	}
 	if account.Root != EmptyRootHash {
-		slim.Root = account.Root[:]
+		w.WriteBytes(account.Root[:])
+	} else {
+		w.WriteBytes(nil)
 	}
 	if !bytes.Equal(account.CodeHash, EmptyCodeHash[:]) {
-		slim.CodeHash = account.CodeHash
+		w.WriteBytes(account.CodeHash)
+	} else {
+		w.WriteBytes(nil)
 	}
-	data, err := rlp.EncodeToBytes(slim)
-	if err != nil {
-		panic(err)
-	}
-	return data
+	w.ListEnd(list)
+	return w.ToBytes()
 }
 
 // FullAccount decodes the data on the 'slim RLP' format and returns


### PR DESCRIPTION
This PR optimizes two things:

- parallelize the chain data write with the state write, the latter one is slower than the former one
- improve state update encoding with customized rlp encoder