### PR TITLE
rpc: reset block selector when unmarshalling

### DIFF
--- a/rpc/types.go
+++ b/rpc/types.go
@@ -173,24 +173,19 @@ func (bnh *BlockNumberOrHash) UnmarshalJSON(data []byte) error {
 	}
 	switch input {
 	case "earliest":
-		bn := EarliestBlockNumber
-		bnh.BlockNumber = &bn
+		*bnh = BlockNumberOrHashWithNumber(EarliestBlockNumber)
 		return nil
 	case "latest":
-		bn := LatestBlockNumber
-		bnh.BlockNumber = &bn
+		*bnh = BlockNumberOrHashWithNumber(LatestBlockNumber)
 		return nil
 	case "pending":
-		bn := PendingBlockNumber
-		bnh.BlockNumber = &bn
+		*bnh = BlockNumberOrHashWithNumber(PendingBlockNumber)
 		return nil
 	case "finalized":
-		bn := FinalizedBlockNumber
-		bnh.BlockNumber = &bn
+		*bnh = BlockNumberOrHashWithNumber(FinalizedBlockNumber)
 		return nil
 	case "safe":
-		bn := SafeBlockNumber
-		bnh.BlockNumber = &bn
+		*bnh = BlockNumberOrHashWithNumber(SafeBlockNumber)
 		return nil
 	default:
 		if len(input) == 66 {
@@ -199,7 +194,7 @@ func (bnh *BlockNumberOrHash) UnmarshalJSON(data []byte) error {
 			if err != nil {
 				return err
 			}
-			bnh.BlockHash = &hash
+			*bnh = BlockNumberOrHashWithHash(hash, false)
 			return nil
 		} else {
 			blckNum, err := hexutil.DecodeUint64(input)
@@ -209,8 +204,7 @@ func (bnh *BlockNumberOrHash) UnmarshalJSON(data []byte) error {
 			if blckNum > math.MaxInt64 {
 				return errors.New("blocknumber too high")
 			}
-			bn := BlockNumber(blckNum)
-			bnh.BlockNumber = &bn
+			*bnh = BlockNumberOrHashWithNumber(BlockNumber(blckNum))
 			return nil
 		}
 	}

--- a/rpc/types_test.go
+++ b/rpc/types_test.go
@@ -136,6 +136,54 @@ func TestBlockNumberOrHash_UnmarshalJSON(t *testing.T) {
 	}
 }
 
+func TestBlockNumberOrHash_UnmarshalJSONReuse(t *testing.T) {
+	t.Parallel()
+
+	hash := common.HexToHash("0x1234")
+	tests := []struct {
+		name    string
+		initial BlockNumberOrHash
+		input   string
+		want    BlockNumberOrHash
+	}{
+		{
+			name:    "tag replaces hash",
+			initial: BlockNumberOrHashWithHash(hash, true),
+			input:   `"latest"`,
+			want:    BlockNumberOrHashWithNumber(LatestBlockNumber),
+		},
+		{
+			name:    "number replaces hash",
+			initial: BlockNumberOrHashWithHash(hash, true),
+			input:   `"0x1"`,
+			want:    BlockNumberOrHashWithNumber(1),
+		},
+		{
+			name:    "hash replaces number",
+			initial: BlockNumberOrHashWithNumber(LatestBlockNumber),
+			input:   `"0x0000000000000000000000000000000000000000000000000000000000001234"`,
+			want:    BlockNumberOrHashWithHash(hash, false),
+		},
+		{
+			name:    "hash replaces canonical hash",
+			initial: BlockNumberOrHashWithHash(common.HexToHash("0xabcd"), true),
+			input:   `"0x0000000000000000000000000000000000000000000000000000000000001234"`,
+			want:    BlockNumberOrHashWithHash(hash, false),
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got := test.initial
+			if err := json.Unmarshal([]byte(test.input), &got); err != nil {
+				t.Fatal("cannot unmarshal:", err)
+			}
+			if !reflect.DeepEqual(got, test.want) {
+				t.Fatalf("wrong result: have %v, want %v", got, test.want)
+			}
+		})
+	}
+}
+
 func TestBlockNumberOrHash_WithNumber_MarshalAndUnmarshal(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Description

Reset all fields of `BlockNumberOrHash` when decoding its string forms.

Previously, unmarshalling a block tag, number, or hash into a reused value only updated the selected field. This could leave a stale block number, block hash, or `requireCanonical` flag behind, producing an internally inconsistent selector.

Use the existing constructors so successful string decoding replaces the complete selector. Parsing errors continue to leave the receiver unchanged.

## Testing

Added `TestBlockNumberOrHash_UnmarshalJSONReuse` covering:

- block tags replacing canonical hashes
- block numbers replacing canonical hashes
- block hashes replacing block numbers
- raw block hashes replacing canonical hashes and resetting `requireCanonical`

Validation performed:

- `make all`
- `go run ./build/ci.go test`
- `go run ./build/ci.go lint`
- `go run ./build/ci.go check_generate`
- `go run ./build/ci.go check_baddeps`