### PR TITLE
rpc: reject HTTP responses with mismatched request id

### DIFF
--- a/rpc/http.go
+++ b/rpc/http.go
@@ -199,6 +199,9 @@ func (c *Client) sendHTTP(ctx context.Context, op *requestOp, msg *jsonrpcMessag
 	if err := json.NewDecoder(respBody).Decode(&resp); err != nil {
 		return err
 	}
+	if !bytes.Equal(resp.ID, msg.ID) {
+		return fmt.Errorf("response id mismatch: got %s, want %s", resp.ID, msg.ID)
+	}
 	op.resp <- batch[:]
 	return nil
 }


### PR DESCRIPTION
## Summary
- HTTP batch calls already match responses by `id` in `BatchCallContext`, but single HTTP calls accepted any decoded response body.
- Reject responses whose `id` does not match the request before handing the result back to the caller.

## Test plan
- [ ] `go test ./rpc/...`
- [ ] Confirm a single HTTP call fails when the server returns a response with a different `id`