### PR TITLE
triedb/pathdb: copy iterator key before release in reopenIterator

### DIFF
--- a/triedb/pathdb/context.go
+++ b/triedb/pathdb/context.go
@@ -147,7 +147,7 @@ func (ctx *generatorContext) reopenIterator(kind string) {
 		ctx.storage = internal.NewHoldableIterator(memorydb.New().NewIterator(nil, nil))
 		return
 	}
-	next := iter.Key()
+	next := common.CopyBytes(iter.Key())
 	iter.Release()
 	ctx.openIterator(kind, next[1:])
 }


### PR DESCRIPTION
## Summary
- `reopenIterator` saves the current iterator key before calling `Release()` so it can reopen at the next position.
- Pebble invalidates the slice returned by `Iterator.Key()` after release; copying the key avoids resuming from stale data.

## Test plan
- [ ] `go test ./triedb/pathdb/...`
- [ ] Run snapshot generation against a Pebble-backed database and confirm iterator reopening advances correctly