### PR TITLE
build, tests: update test fixture

### DIFF
--- a/build/checksums.txt
+++ b/build/checksums.txt
@@ -1,9 +1,9 @@
 # This file contains sha256 checksums of optional build dependencies.
 
-# version:spec-tests tests@v20.0.0
+# version:spec-tests tests@v20.0.2
 # https://github.com/ethereum/execution-specs/releases
-# https://github.com/ethereum/execution-specs/releases/download/tests%40v20.0.0
-b183702a5b447b465873865357ced9eb342315922e52e31b714e2de115dd0bb4  fixtures.tar.gz
+# https://github.com/ethereum/execution-specs/releases/download/tests%40v20.0.2
+1280540950a4c3470a421416b6f35458a9b635827265c29e5aef1ae839ae1788  fixtures.tar.gz
 
 # version:golang 1.27.0
 # https://go.dev/dl/

--- a/tests/block_test.go
+++ b/tests/block_test.go
@@ -91,11 +91,6 @@ func TestExecutionSpecBlocktests(t *testing.T) {
 	bt.skipLoad(`.*eip7251_consolidations/contract_deployment/system_contract_deployment\.json`)
 	bt.skipLoad(`.*eip7002_el_triggerable_withdrawals/contract_deployment/system_contract_deployment\.json`)
 
-	// EIP-7610 is not implemented: a non-empty storage trie alone does not
-	// reject contract creation.
-	bt.skipLoad(`.*eip7610_create_collision/initcollision/.*`)
-	bt.skipLoad(`.*eip7610_create_collision/revert_in_create/.*`)
-
 	bt.walk(t, executionSpecBlockchainTestDir, func(t *testing.T, name string, test *BlockTest) {
 		execBlockTest(t, bt, test)
 	})

--- a/tests/state_test.go
+++ b/tests/state_test.go
@@ -97,11 +97,6 @@ func TestExecutionSpecState(t *testing.T) {
 	}
 	st := new(testMatcher)
 
-	// EIP-7610 is not implemented: a non-empty storage trie alone does not
-	// reject contract creation.
-	st.skipLoad(`.*eip7610_create_collision/initcollision/.*`)
-	st.skipLoad(`.*eip7610_create_collision/revert_in_create/.*`)
-
 	st.walk(t, executionSpecStateTestDir, func(t *testing.T, name string, test *StateTest) {
 		execStateTest(t, st, test)
 	})


### PR DESCRIPTION
https://github.com/ethereum/execution-specs/releases/tag/tests%40v20.0.2 

This PR removes the legacy EIP-7610 tests