### PR TITLE
cmd/utils: check close error before renaming era file

### DIFF
--- a/cmd/utils/cmd.go
+++ b/cmd/utils/cmd.go
@@ -592,7 +592,9 @@ func ExportHistory(bc *core.BlockChain, dir string, first, last uint64, newBuild
 			checksums = append(checksums, common.BytesToHash(h.Sum(buf.Bytes()[:])).Hex())
 
 			// Close before rename. It's required on Windows.
-			f.Close()
+			if err := f.Close(); err != nil {
+				return err
+			}
 			final := filepath.Join(dir, filename(network, idx, id))
 			return os.Rename(tmpPath, final)
 		}(); err != nil {


### PR DESCRIPTION
In `ExportHistory`, the error from `f.Close()` is dropped right before the temporary era file is renamed to its final name. Every other I/O call in that closure returns its error (`os.Create`, `builder.Add`, `Finalize`, `Seek`, `io.Copy`, `os.Rename`), so this is the only place where a failure would not stop the export.

If the close fails, the file is now left under its temporary name and the error is returned to the caller, which is the same behaviour as the other early returns in the closure. The deferred `f.Close()` is unaffected; a second close on an already closed file is a no-op.

The explicit close itself stays where it is, since the comment above it notes it is required on Windows before the rename.
