### PR TITLE
eth: return canonical execution witness from debug_executionWitness

### DIFF
--- a/cmd/fetchpayload/main.go
+++ b/cmd/fetchpayload/main.go
@@ -84,14 +84,18 @@ func main() {
 	fmt.Printf("Fetched block %d (%#x)\n", block.NumberU64(), block.Hash())
 
 	// Fetch the execution witness via the debug namespace.
-	var extWitness stateless.ExtWitness
-	err = client.Client().CallContext(ctx, &extWitness, "debug_executionWitness", rpc.BlockNumber(block.NumberU64()))
+	var witnessResult executionWitnessResult
+	err = client.Client().CallContext(ctx, &witnessResult, "debug_executionWitness", rpc.BlockNumber(block.NumberU64()))
 	if err != nil {
 		fatal("failed to fetch execution witness: %v", err)
 	}
+	extWitness, err := witnessResult.toExtWitness()
+	if err != nil {
+		fatal("failed to decode witness headers: %v", err)
+	}
 
 	witness := new(stateless.Witness)
-	err = witness.FromExtWitness(&extWitness)
+	err = witness.FromExtWitness(extWitness)
 	if err != nil {
 		fatal("failed to convert witness: %v", err)
 	}
@@ -121,7 +125,7 @@ func main() {
 		case "hex":
 			data = []byte(hexutil.Encode(rlpBytes))
 		case "json":
-			data, err = marshalJSONPayload(chainID, block, &extWitness)
+			data, err = marshalJSONPayload(chainID, block, extWitness)
 			if err != nil {
 				fatal("failed to JSON-encode payload: %v", err)
 			}
@@ -153,6 +157,28 @@ func parseBlockNumber(s string) (*big.Int, error) {
 		return nil, fmt.Errorf("invalid decimal number")
 	}
 	return n, nil
+}
+
+// executionWitnessResult mirrors eth.ExecutionWitnessResult.
+type executionWitnessResult struct {
+	State   []hexutil.Bytes `json:"state"`
+	Codes   []hexutil.Bytes `json:"codes"`
+	Headers []hexutil.Bytes `json:"headers"`
+}
+
+func (r *executionWitnessResult) toExtWitness() (*stateless.ExtWitness, error) {
+	ext := &stateless.ExtWitness{
+		State: r.State,
+		Codes: r.Codes,
+	}
+	for _, enc := range r.Headers {
+		header := new(types.Header)
+		if err := rlp.DecodeBytes(enc, header); err != nil {
+			return nil, err
+		}
+		ext.Headers = append(ext.Headers, header)
+	}
+	return ext, nil
 }
 
 // jsonPayload is a JSON-friendly representation of Payload. It uses ExtWitness

--- a/eth/api_debug.go
+++ b/eth/api_debug.go
@@ -29,7 +29,6 @@ import (
 	"github.com/ethereum/go-ethereum/core"
 	"github.com/ethereum/go-ethereum/core/rawdb"
 	"github.com/ethereum/go-ethereum/core/state"
-	"github.com/ethereum/go-ethereum/core/stateless"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/internal/ethapi"
@@ -501,21 +500,35 @@ func (api *DebugAPI) GetTrieFlushInterval() (string, error) {
 	return api.eth.blockchain.GetTrieFlushInterval().String(), nil
 }
 
-func (api *DebugAPI) ExecutionWitness(bn rpc.BlockNumberOrHash) (*stateless.ExtWitness, error) {
+// ExecutionWitnessResult is the canonical execution witness format defined by
+// the execution-specs stateless validation interface: RLP-encoded headers, and
+// state/codes sorted lexicographically and deduplicated.
+type ExecutionWitnessResult struct {
+	State   []hexutil.Bytes `json:"state"`
+	Codes   []hexutil.Bytes `json:"codes"`
+	Headers []hexutil.Bytes `json:"headers"`
+}
+
+func (api *DebugAPI) ExecutionWitness(bn rpc.BlockNumberOrHash) (*ExecutionWitnessResult, error) {
+	// The pending tag does not identify an executed block, so it has no witness.
+	if number, ok := bn.Number(); ok && number == rpc.PendingBlockNumber {
+		return nil, errors.New("pending block has no witness")
+	}
 	bc := api.eth.blockchain
 	block, err := api.eth.APIBackend.BlockByNumberOrHash(context.Background(), bn)
 	if err != nil {
-		return &stateless.ExtWitness{}, fmt.Errorf("block %v not found", bn)
+		// Preserve backend errors such as history.PrunedHistoryError (code 4444).
+		return nil, err
 	}
 	// BlockByNumberOrHash returns a nil block without an error when the
 	// requested block does not exist (per the RPC spec). Guard against it
 	// to avoid a nil pointer dereference below.
 	if block == nil {
-		return &stateless.ExtWitness{}, fmt.Errorf("block %v not found", bn)
+		return nil, fmt.Errorf("block %s not found", bn.String())
 	}
 	parent := bc.GetHeader(block.ParentHash(), block.NumberU64()-1)
 	if parent == nil {
-		return &stateless.ExtWitness{}, fmt.Errorf("block %v found, but parent missing", bn)
+		return nil, fmt.Errorf("block %s found, but parent missing", bn.String())
 	}
 	config := core.ExecuteConfig{
 		WriteState:   false,
@@ -526,7 +539,25 @@ func (api *DebugAPI) ExecutionWitness(bn rpc.BlockNumberOrHash) (*stateless.ExtW
 	if err != nil {
 		return nil, err
 	}
-	return result.Witness().ToExtWitness(), nil
+	witness := result.Witness()
+	if witness == nil {
+		// ProcessBlock only builds a witness for post-Byzantium blocks.
+		return nil, fmt.Errorf("no witness available for block %s", bn.String())
+	}
+	ext := witness.ToExtWitness()
+	res := &ExecutionWitnessResult{
+		State:   ext.State,
+		Codes:   ext.Codes,
+		Headers: make([]hexutil.Bytes, 0, len(ext.Headers)),
+	}
+	for _, header := range ext.Headers {
+		enc, err := rlp.EncodeToBytes(header)
+		if err != nil {
+			return nil, err
+		}
+		res.Headers = append(res.Headers, enc)
+	}
+	return res, nil
 }
 
 // ClearTxpool clears all transactions from the transaction pool.

--- a/eth/api_debug_test.go
+++ b/eth/api_debug_test.go
@@ -19,6 +19,7 @@ package eth
 import (
 	"bytes"
 	"crypto/ecdsa"
+	"encoding/json"
 	"fmt"
 	"math/big"
 	"reflect"
@@ -29,6 +30,7 @@ import (
 
 	"github.com/davecgh/go-spew/spew"
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/consensus/beacon"
 	"github.com/ethereum/go-ethereum/consensus/ethash"
 	"github.com/ethereum/go-ethereum/core"
@@ -41,6 +43,7 @@ import (
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/params"
+	"github.com/ethereum/go-ethereum/rlp"
 	"github.com/ethereum/go-ethereum/rpc"
 	"github.com/ethereum/go-ethereum/triedb"
 	"github.com/holiman/uint256"
@@ -367,6 +370,36 @@ func TestExecutionWitnessMissingBlock(t *testing.T) {
 	missing := rpc.BlockNumberOrHashWithHash(common.HexToHash("0xdeadbeef"), false)
 	_, err := api.ExecutionWitness(missing)
 	assert.Error(t, err, "expected an error for a missing block, got nil")
+
+	pending := rpc.BlockNumberOrHashWithNumber(rpc.PendingBlockNumber)
+	_, err = api.ExecutionWitness(pending)
+	assert.Error(t, err, "expected an error for the pending tag, got nil")
+}
+
+// TestExecutionWitnessPreByzantium ensures that debug_executionWitness returns
+// an error, rather than panicking, for a pre-Byzantium block: ProcessBlock only
+// builds a witness once Byzantium is active.
+func TestExecutionWitnessPreByzantium(t *testing.T) {
+	t.Parallel()
+
+	genesis := &core.Genesis{
+		Config: &params.ChainConfig{
+			ChainID:        big.NewInt(1),
+			HomesteadBlock: big.NewInt(0),
+			EIP150Block:    big.NewInt(0),
+			EIP155Block:    big.NewInt(0),
+			EIP158Block:    big.NewInt(0),
+		},
+	}
+	blockChain := newTestBlockChain(t, 1, genesis, func(_ int, _ *core.BlockGen) {})
+	defer blockChain.Stop()
+
+	eth := &Ethereum{blockchain: blockChain}
+	eth.APIBackend = &EthAPIBackend{eth: eth}
+	api := NewDebugAPI(eth)
+
+	_, err := api.ExecutionWitness(rpc.BlockNumberOrHashWithNumber(1))
+	assert.Error(t, err, "expected an error for a pre-Byzantium block, got nil")
 }
 
 func TestDebugAPI_ClearTxpool(t *testing.T) {
@@ -434,4 +467,79 @@ func TestDebugAPI_ClearTxpool(t *testing.T) {
 	}
 
 	t.Log("Successfully cleared transaction pool")
+}
+func TestExecutionWitness(t *testing.T) {
+	t.Parallel()
+
+	accounts := newAccounts(2)
+	genesis := &core.Genesis{
+		Config: params.TestChainConfig,
+		Alloc: types.GenesisAlloc{
+			accounts[0].addr: {Balance: big.NewInt(params.Ether)},
+		},
+	}
+	signer := types.HomesteadSigner{}
+	blockChain := newTestBlockChain(t, 1, genesis, func(_ int, b *core.BlockGen) {
+		tx, _ := types.SignTx(types.NewTx(&types.LegacyTx{
+			Nonce:    0,
+			To:       &accounts[1].addr,
+			Value:    big.NewInt(1000),
+			Gas:      params.TxGas,
+			GasPrice: b.BaseFee(),
+		}), signer, accounts[0].key)
+		b.AddTx(tx)
+	})
+	defer blockChain.Stop()
+
+	eth := &Ethereum{blockchain: blockChain}
+	eth.APIBackend = &EthAPIBackend{eth: eth}
+
+	srv := rpc.NewServer()
+	if err := srv.RegisterName("debug", NewDebugAPI(eth)); err != nil {
+		t.Fatalf("failed to register debug API: %v", err)
+	}
+	client := rpc.DialInProc(srv)
+	defer client.Close()
+
+	var raw json.RawMessage
+	if err := client.Call(&raw, "debug_executionWitness", "0x1"); err != nil {
+		t.Fatalf("debug_executionWitness failed: %v", err)
+	}
+
+	var fields map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &fields); err != nil {
+		t.Fatalf("failed to unmarshal result: %v", err)
+	}
+	if _, ok := fields["keys"]; ok {
+		t.Errorf("result contains legacy keys field")
+	}
+	for _, field := range []string{"state", "codes", "headers"} {
+		if _, ok := fields[field]; !ok {
+			t.Errorf("result missing %s field", field)
+		}
+	}
+
+	var result ExecutionWitnessResult
+	if err := json.Unmarshal(raw, &result); err != nil {
+		t.Fatalf("failed to unmarshal witness: %v", err)
+	}
+	if len(result.Headers) != 1 {
+		t.Fatalf("expected 1 witness header, got %d", len(result.Headers))
+	}
+	var header types.Header
+	if err := rlp.DecodeBytes(result.Headers[0], &header); err != nil {
+		t.Fatalf("witness header is not valid RLP: %v", err)
+	}
+	if header.Hash() != blockChain.Genesis().Hash() {
+		t.Errorf("witness header hash %v does not match parent %v", header.Hash(), blockChain.Genesis().Hash())
+	}
+
+	if len(result.State) == 0 {
+		t.Error("witness state is empty")
+	}
+	for name, items := range map[string][]hexutil.Bytes{"state": result.State, "codes": result.Codes} {
+		if !slices.IsSortedFunc(items, func(a, b hexutil.Bytes) int { return bytes.Compare(a, b) }) {
+			t.Errorf("witness %s is not sorted", name)
+		}
+	}
 }


### PR DESCRIPTION
`debug_executionWitness` returns `stateless.ExtWitness` today. That shape marshals headers as JSON header objects and always emits `"keys": null`. The execution witness spec (ethereum/execution-apis#847) defines the result as the execution-specs `stateless.ExecutionWitness` format: RLP-encoded headers, and no `keys` field unless the client tracks preimages.

Changes:
- A dedicated `ExecutionWitnessResult` RPC type: `state`, `codes`, and RLP-encoded `headers`, no `keys`. Ordering is unchanged; `ToExtWitness` already sorts and deduplicates state and codes and orders headers ascending.
- Reject the `pending` tag. It does not identify an executed block, and the spec requires an error. Without a live payload the call already failed; with one it returned a witness for the pending block.
- Propagate backend errors instead of mapping every lookup failure to not-found, so `history.PrunedHistoryError` keeps its 4444 code, which the spec lists for this method.
- Guard the nil witness for pre-Byzantium blocks. `ProcessBlock` only builds a witness once Byzantium is active, and the handler dereferenced the result unconditionally, a latent crash on archive nodes.
- The not-found errors printed the raw struct (`block {0x0 <nil> false} not found`). They now use the `String` form.
- `cmd/fetchpayload` decodes the new shape.

The engine API witness encoding (`stateless.ExtWitness` over RLP) is separate and untouched.

The spec has two layers of conformance, and this PR addresses the first:

1. **Format**: the wire shape described above. With this change geth conforms fully, and the fixtures in ethereum/execution-apis#847 (generated from this branch, replayed green in hive rpc-compat) verify it.
2. **Content**: the spec requires the arrays to contain exactly what the canonical builder in execution-specs (`build_execution_witness`) produces. geth's witness collector predates that definition and collects a different item set: it records bytecode on every code read, where the canonical builder records only code the accessed account already had in the pre-state, and its state-node set falls out of geth's trie-update order rather than the canonical rules. Bringing the collector in line is a separate, larger change (reth and erigon each built a dedicated `canonical` mode for it), and the canonical definition still lives on the execution-specs zkevm project branch. This PR changes how the witness is encoded, not what geth collects.
