### PR TITLE
accounts: parse account URLs with strings.Cut

### DIFF
--- a/accounts/url.go
+++ b/accounts/url.go
@@ -42,13 +42,13 @@ type URL struct {
 
 // parseURL converts a user supplied URL into the accounts specific structure.
 func parseURL(url string) (URL, error) {
-	parts := strings.Split(url, "://")
-	if len(parts) != 2 || parts[0] == "" {
+	scheme, path, ok := strings.Cut(url, "://")
+	if !ok || scheme == "" {
 		return URL{}, errors.New("protocol scheme missing")
 	}
 	return URL{
-		Scheme: parts[0],
-		Path:   parts[1],
+		Scheme: scheme,
+		Path:   path,
 	}, nil
 }
 

--- a/accounts/url_test.go
+++ b/accounts/url_test.go
@@ -33,6 +33,17 @@ func TestURLParsing(t *testing.T) {
 		t.Errorf("expected: %v, got: %v", "ethereum.org", url.Path)
 	}
 
+	url, err = parseURL("extapi://http://localhost:8545")
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	if url.Scheme != "extapi" {
+		t.Errorf("expected: %v, got: %v", "extapi", url.Scheme)
+	}
+	if url.Path != "http://localhost:8545" {
+		t.Errorf("expected: %v, got: %v", "http://localhost:8545", url.Path)
+	}
+
 	for _, u := range []string{"ethereum.org", ""} {
 		if _, err = parseURL(u); err == nil {
 			t.Errorf("input %v, expected err, got: nil", u)


### PR DESCRIPTION
## Summary
- `parseURL` used `strings.Split`, which breaks when the path contains another `://` (e.g. external signer endpoints like `extapi://http://localhost:8545`).
- Split only on the first `://` with `strings.Cut` so the scheme stays `extapi` and the path keeps the full endpoint URL.

## Test plan
- [x] `go test ./accounts/ -run TestURLParsing`
- [ ] Look up an external signer wallet via `Manager.Wallet("extapi://http://...")`