### PR TITLE
core: compare OffsetTime against immediate parent block

### DIFF
--- a/core/chain_makers.go
+++ b/core/chain_makers.go
@@ -298,7 +298,7 @@ func (b *BlockGen) PrevBlock(index int) *types.Block {
 // tied to chain length directly.
 func (b *BlockGen) OffsetTime(seconds int64) {
 	b.header.Time += uint64(seconds)
-	if b.header.Time <= b.cm.bottom.Header().Time {
+	if b.header.Time <= b.parent.Time() {
 		panic("block time out of range")
 	}
 	b.header.Difficulty = b.engine.CalcDifficulty(b.cm, b.header.Time, b.parent.Header())


### PR DESCRIPTION
## Summary
- `BlockGen.OffsetTime` checked the new timestamp against `cm.bottom`, which is only the genesis/parent passed to `GenerateChain`.
- Compare against the immediate `b.parent` instead so time offsets work correctly after the first generated block.

## Test plan
- [ ] `go test ./core/... -run OffsetTime`
- [ ] Run fork/difficulty tests that call `OffsetTime` on non-genesis blocks