### PR TITLE
ethclient: verify withdrawal list against header root

### DIFF
--- a/ethclient/ethclient.go
+++ b/ethclient/ethclient.go
@@ -178,6 +178,13 @@ func (ec *Client) getBlock(ctx context.Context, method string, args ...interface
 	if head.TxHash != types.EmptyTxsHash && len(body.Transactions) == 0 {
 		return nil, errors.New("server returned empty transaction list but block header indicates transactions")
 	}
+	emptyWithdrawals := head.WithdrawalsHash == nil || *head.WithdrawalsHash == types.EmptyWithdrawalsHash
+	if emptyWithdrawals && len(body.Withdrawals) > 0 {
+		return nil, errors.New("server returned non-empty withdrawal list but block header indicates no withdrawals")
+	}
+	if !emptyWithdrawals && len(body.Withdrawals) == 0 {
+		return nil, errors.New("server returned empty withdrawal list but block header indicates withdrawals")
+	}
 	// Load uncles because they are not included in the block response.
 	var uncles []*types.Header
 	if len(body.UncleHashes) > 0 {


### PR DESCRIPTION
## Summary
- `getBlock` already sanity-checks uncle and transaction lists against the header roots.
- Apply the same check for withdrawals so a mismatched `withdrawalsRoot` and body list is rejected early.

## Test plan
- [x] `go build ./ethclient/...`
- [ ] `go test ./ethclient/...`