### PR TITLE
rpc: cancel handler root context before waiting on calls

### DIFF
--- a/rpc/handler.go
+++ b/rpc/handler.go
@@ -369,8 +369,8 @@ func (h *handler) handleNonBatchCall(cp *callProc, msg *jsonrpcMessage) {
 // call goroutines to shut down.
 func (h *handler) close(err error, inflightReq *requestOp) {
 	h.cancelAllRequests(err, inflightReq)
-	h.callWG.Wait()
 	h.cancelRoot()
+	h.callWG.Wait()
 	h.cancelServerSubscriptions(err)
 }
 


### PR DESCRIPTION
## Summary
- `handler.close` waited on in-flight call goroutines before cancelling `rootCtx`.
- Cancel the root context first so call goroutines can observe shutdown, then wait for them to exit.

## Test plan
- [ ] `go test ./rpc/...`
- [ ] Close an RPC connection while a long-running method is in flight and confirm it shuts down cleanly