### PR TITLE
triedb/pathdb: use pathdb prefix for storage clean metric

### DIFF
--- a/triedb/pathdb/metrics.go
+++ b/triedb/pathdb/metrics.go
@@ -114,5 +114,5 @@ var (
 	storageTrieReadCounter = metrics.NewRegisteredCounter("pathdb/generation/duration/storage/trieread", nil)
 	storageSnapReadCounter = metrics.NewRegisteredCounter("pathdb/generation/duration/storage/snapread", nil)
 	storageWriteCounter    = metrics.NewRegisteredCounter("pathdb/generation/duration/storage/write", nil)
-	storageCleanCounter    = metrics.NewRegisteredCounter("state/snapshot/generation/duration/storage/clean", nil)
+	storageCleanCounter    = metrics.NewRegisteredCounter("pathdb/generation/duration/storage/clean", nil)
 )


### PR DESCRIPTION
## Summary
- `storageCleanCounter` still used the legacy `state/snapshot/generation/...` metric name.
- Rename it to `pathdb/generation/duration/storage/clean` to match the other pathdb generation counters.

## Test plan
- [ ] `go test ./triedb/pathdb/...`
- [ ] Confirm metrics dashboards use the new `pathdb/generation/duration/storage/clean` name