### PR TITLE
core/filtermaps: fix panic when a reorg shortens the chain onto the rendered block

### DIFF
--- a/core/filtermaps/map_renderer.go
+++ b/core/filtermaps/map_renderer.go
@@ -739,6 +739,16 @@ func (l *logIterator) updateChainView(cv *ChainView) bool {
 	if !matchViews(cv, l.chainView, l.blockNumber) {
 		return false
 	}
+	// The delimiter flag was derived from the previous view's head number by
+	// enforceValidState and means that next() will step onto blockNumber+1.
+	// matchViews also accepts a view whose head is exactly blockNumber, so a
+	// reorg that shortens the chain down to the current block would leave the
+	// iterator expecting a block past the new head, making next() ask the view
+	// for a block number it does not have. Report a chain update instead so
+	// that the renderer restarts from a consistent snapshot.
+	if l.delimiter && l.blockNumber >= cv.HeadNumber() {
+		return false
+	}
 	l.chainView = cv
 	return true
 }

--- a/core/filtermaps/map_renderer_test.go
+++ b/core/filtermaps/map_renderer_test.go
@@ -1,0 +1,79 @@
+// Copyright 2025 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+
+package filtermaps
+
+import "testing"
+
+// TestLogIteratorUpdateChainViewShortened checks that the log iterator rejects
+// a target view update that shortens the chain down to the block the iterator
+// is currently sitting on. The iterator's delimiter flag means that the next
+// step reads block blockNumber+1, which does not exist in such a view, so
+// accepting the update would make the renderer ask the view for a block number
+// after its head.
+func TestLogIteratorUpdateChainViewShortened(t *testing.T) {
+	ts := newTestSetup(t)
+	defer ts.close()
+
+	ts.chain.addBlocks(10, 3, 2, 2, false)
+	head := ts.chain.CurrentBlock().Number.Uint64()
+
+	longView := NewChainView(ts.chain, head, ts.chain.GetCanonicalHash(head))
+	if longView == nil {
+		t.Fatal("failed to create chain view at head")
+	}
+	// shortView is the view produced by a "Shorten chain del=1" reorg; its head
+	// is exactly the block the iterator is positioned at.
+	shortView := NewChainView(ts.chain, head-1, ts.chain.GetCanonicalHash(head-1))
+	if shortView == nil {
+		t.Fatal("failed to create shortened chain view")
+	}
+	// The two views agree on the iterator's position, so matchViews alone does
+	// not catch this case; without the explicit delimiter check the update
+	// would be accepted.
+	if !matchViews(shortView, longView, head-1) {
+		t.Fatal("views unexpectedly diverge at the iterator position")
+	}
+	// Iterator sitting at the block delimiter of the last block before the
+	// long view's head, i.e. about to step onto the head block.
+	it := &logIterator{
+		params:      &ts.params,
+		chainView:   longView,
+		blockNumber: head - 1,
+		delimiter:   true,
+	}
+	if it.updateChainView(shortView) {
+		t.Fatalf("updateChainView accepted a view whose head (%d) is the iterator's block", shortView.HeadNumber())
+	}
+	if it.chainView != longView {
+		t.Fatal("chain view replaced even though the update was rejected")
+	}
+	// A view that still has a block after the iterator's position is fine.
+	if !it.updateChainView(longView) {
+		t.Fatal("updateChainView rejected a valid view update")
+	}
+	// A finished iterator does not step onto another block, so shortening the
+	// view down to its position is harmless and must still be accepted.
+	it2 := &logIterator{
+		params:      &ts.params,
+		chainView:   longView,
+		blockNumber: head - 1,
+		finished:    true,
+	}
+	if !it2.updateChainView(shortView) {
+		t.Fatal("updateChainView rejected a valid update for a finished iterator")
+	}
+}


### PR DESCRIPTION
Fixes a process-fatal `panic("invalid block number")` in the log index head renderer, seen **9 times over 5 days** on a node under sustained transaction load with frequent single-block head reorgs. The other 14 nodes on the same network, same image, same config, never hit it.

```
panic: invalid block number

filtermaps.(*ChainView).BlockHash    core/filtermaps/chain_view.go:77
filtermaps.(*ChainView).RawReceipts  core/filtermaps/chain_view.go:117
filtermaps.(*logIterator).next       core/filtermaps/map_renderer.go:773
filtermaps.(*mapRenderer).renderCurrentMap
filtermaps.(*FilterMaps).tryIndexHead core/filtermaps/indexer.go:248
```

## The bug

`logIterator.enforceValidState` derives the iterator's terminal flags from the chain view's head number: sitting on the head block means `finished`, anything else means `delimiter` — i.e. `next()` will step onto `blockNumber+1`.

`updateChainView` swaps in a new target view whenever `matchViews` agrees with the old view at the iterator's position. But `matchViews` explicitly accepts a view whose head **is** `blockNumber` (it has a dedicated branch for that equality), and it does not re-derive the flags.

So a reorg that shortens the chain to exactly the iterator's current block passes the check — block `N` is unchanged by a reorg above it — while leaving `delimiter` set. The following `next()` then asks the new view for `N+1`, one past its head, and `ChainView.BlockHash` panics.

In production, `RawReceipts` was called with exactly `head+1` in **every** occurrence, 16–25 ms after a `Shorten chain del=1` that lowered the head onto the rendered block:

```
10:38:09.102  Shorten chain  del=2 number=97,824
10:38:09.121  Extend chain   add=2 number=97,826
10:38:09.130  Shorten chain  del=1 number=97,825   <-- head lands on the rendered block
10:38:09.146  panic: invalid block number          <-- +16 ms, asked for 97,826
```

A *deeper* reorg is fine — `matchViews` returns false and the existing `errChainUpdate` path handles it. Only the exact-equality boundary escapes, which is why it needs load (longer per-block render time) to be hit at all.

## Cost of each abort

The process dies with a dirty trie, so restart logs `Head state missing, repairing` and rewinds to the last persisted state. Measured across four aborts: **2,112 / 4,749 / 5,264 / 11,357 blocks**, plus ~8 minutes of log-index re-rendering. Depth tracks time since the last state flush rather than reorg depth — two aborts rewound to the same block.

## The fix

```go
if l.delimiter && l.blockNumber >= cv.HeadNumber() {
	return false
}
```

This surfaces as `errChainUpdate`, making the renderer restart from a consistent snapshot — the path already taken for every other kind of chain update, and already tolerated by `indexerLoop` (`indexer.go:61`). Indexing semantics are unchanged; the only behavioural difference is a clean re-snapshot where the process previously died.

I deliberately did not touch `ChainView.BlockHash` — the panic there is an invariant assertion, and #34095 suggests you would rather keep those and fix the invariant. This does that.

## Testing

`TestLogIteratorUpdateChainViewShortened` covers the exact interleaving, and asserts that `matchViews` alone still accepts it — so the test pins the actual bug rather than passing incidentally. It also covers the two cases that must keep working: a view that still has a block after the iterator, and a `finished` iterator, which never steps forward and so is safe to shorten onto.

Without the fix the test fails on the `updateChainView` assertion, and calling `next()` reproduces the production stack exactly.

```
go build ./...                       ok
go test ./core/filtermaps/...        ok  17.205s
go test ./core/filtermaps/... -race  ok  163.155s
```

Background write-up: https://panda-uploads-production.devops-539.workers.dev/panda/uploads/a7974b/teardown.html
