### PR TITLE
eth/fetcher: correct the comment on announced-size peer drops

### DIFF
--- a/eth/fetcher/tx_fetcher.go
+++ b/eth/fetcher/tx_fetcher.go
@@ -794,9 +794,11 @@ func (f *TxFetcher) loop() {
 								if math.Abs(float64(size)-float64(meta.size)) > 8 {
 									log.Warn("Announced transaction size mismatch", "peer", peer, "tx", hash, "size", size, "ann", meta.size)
 
-									// Normally we should drop a peer considering this is a protocol violation.
-									// However, due to the RLP vs consensus format messyness, allow a few bytes
-									// wiggle-room where we only warn, but don't drop.
+									// Announcing a size that disagrees with the transaction served is a
+									// protocol violation, so the peer is dropped. Due to the RLP vs consensus
+									// format messyness, a few bytes of wiggle-room are tolerated: a difference
+									// of 8 bytes or less is neither warned about nor dropped for, which is why
+									// this branch is guarded above.
 									//
 									// TODO(karalabe): Get rid of this relaxation when clients are proven stable.
 									f.dropPeer(peer)
@@ -820,9 +822,11 @@ func (f *TxFetcher) loop() {
 								if math.Abs(float64(size)-float64(meta.size)) > 8 {
 									log.Warn("Announced transaction size mismatch", "peer", peer, "tx", hash, "size", size, "ann", meta.size)
 
-									// Normally we should drop a peer considering this is a protocol violation.
-									// However, due to the RLP vs consensus format messyness, allow a few bytes
-									// wiggle-room where we only warn, but don't drop.
+									// Announcing a size that disagrees with the transaction served is a
+									// protocol violation, so the peer is dropped. Due to the RLP vs consensus
+									// format messyness, a few bytes of wiggle-room are tolerated: a difference
+									// of 8 bytes or less is neither warned about nor dropped for, which is why
+									// this branch is guarded above.
 									//
 									// TODO(karalabe): Get rid of this relaxation when clients are proven stable.
 									f.dropPeer(peer)


### PR DESCRIPTION
Comment-only, no behaviour change.

`eth/fetcher/tx_fetcher.go` (twice, at the `waitlist` and `announces` branches) reads:

```go
if math.Abs(float64(size)-float64(meta.size)) > 8 {
    log.Warn("Announced transaction size mismatch", ...)

    // Normally we should drop a peer considering this is a protocol violation.
    // However, due to the RLP vs consensus format messyness, allow a few bytes
    // wiggle-room where we only warn, but don't drop.
    //
    // TODO(karalabe): Get rid of this relaxation when clients are proven stable.
    f.dropPeer(peer)
}
```

The comment says the wiggle-room means "we only warn, but don't drop", and then the next statement drops the peer. The tolerance is actually the `> 8` guard on the enclosing branch: a difference of 8 bytes or less is neither warned about nor dropped for, and anything larger is both.

I hit this while working out why several clients were being disconnected on a devnet, and read it as "geth tolerates this" for longer than I would like to admit. The `TODO` is left in place.

## Context

This came out of the same investigation as ethereum/devp2p#281, which proposes fixing the `txsize` definition in the wire spec — currently specified as the "consensus encoding", which no client actually announces. Related client fixes: NethermindEth/nethermind#13049, besu-eth/besu#11203.

Write-up: https://panda-uploads-production.devops-539.workers.dev/panda/uploads/a7974b/teardown.html
