### PR TITLE
eth/filters: apply range limit after resolving latest block

### DIFF
--- a/eth/filters/filter.go
+++ b/eth/filters/filter.go
@@ -145,9 +145,6 @@ func (f *Filter) Logs(ctx context.Context) ([]*types.Log, error) {
 	if err != nil {
 		return nil, err
 	}
-	if f.rangeLimit != 0 && (end-begin) > f.rangeLimit {
-		return nil, invalidParamsErr("exceed maximum block range %d", f.rangeLimit)
-	}
 	return f.rangeLogs(ctx, begin, end)
 }
 
@@ -231,6 +228,9 @@ func (s *searchSession) updateChainView() error {
 	}
 	if lastBlock > head {
 		return errBlockRangeIntoFuture
+	}
+	if s.filter.rangeLimit != 0 && lastBlock-firstBlock > s.filter.rangeLimit {
+		return invalidParamsErr("exceed maximum block range %d", s.filter.rangeLimit)
 	}
 	s.searchRange = common.NewRange(firstBlock, lastBlock+1-firstBlock)
 


### PR DESCRIPTION
With `--rpc.rangelimit` set, `eth_getLogs` rejects any request that combines a concrete `fromBlock` with `toBlock: "latest"` (which is also the default when `toBlock` is omitted), no matter how small the actual range is.

`Filter.Logs` resolves `latest` to the `math.MaxUint64` placeholder and then runs the range limit check on it, so `end - begin` is always far above the limit. The placeholder is only replaced with the real head number later, in `updateChainView`.

This moves the check into `updateChainView`, right after the placeholder is resolved. Error message and code are unchanged, and the existing `TestRangeLimit` still passes. Checked locally that `8..latest` on a 10 block chain with limit 5 now goes through while `2..latest` is still rejected.
