### PR TITLE
accounts: remove dead code parseURL, UnmarshalJSON and Wallet

### DIFF
--- a/accounts/errors.go
+++ b/accounts/errors.go
@@ -25,10 +25,6 @@ import (
 // provides the specified account.
 var ErrUnknownAccount = errors.New("unknown account")
 
-// ErrUnknownWallet is returned for any requested operation for which no backend
-// provides the specified wallet.
-var ErrUnknownWallet = errors.New("unknown wallet")
-
 // ErrNotSupported is returned when an operation is requested from an account
 // backend that it does not support.
 var ErrNotSupported = errors.New("not supported")

--- a/accounts/manager.go
+++ b/accounts/manager.go
@@ -184,23 +184,6 @@ func (am *Manager) walletsNoLock() []Wallet {
 	return cpy
 }
 
-// Wallet retrieves the wallet associated with a particular URL.
-func (am *Manager) Wallet(url string) (Wallet, error) {
-	am.lock.RLock()
-	defer am.lock.RUnlock()
-
-	parsed, err := parseURL(url)
-	if err != nil {
-		return nil, err
-	}
-	for _, wallet := range am.walletsNoLock() {
-		if wallet.URL() == parsed {
-			return wallet, nil
-		}
-	}
-	return nil, ErrUnknownWallet
-}
-
 // Accounts returns all account addresses of all wallets within the account manager
 func (am *Manager) Accounts() []common.Address {
 	am.lock.RLock()

--- a/accounts/url.go
+++ b/accounts/url.go
@@ -18,7 +18,6 @@ package accounts
 
 import (
 	"encoding/json"
-	"errors"
 	"fmt"
 	"strings"
 )
@@ -38,18 +37,6 @@ import (
 type URL struct {
 	Scheme string // Protocol scheme to identify a capable account backend
 	Path   string // Path for the backend to identify a unique entity
-}
-
-// parseURL converts a user supplied URL into the accounts specific structure.
-func parseURL(url string) (URL, error) {
-	parts := strings.Split(url, "://")
-	if len(parts) != 2 || parts[0] == "" {
-		return URL{}, errors.New("protocol scheme missing")
-	}
-	return URL{
-		Scheme: parts[0],
-		Path:   parts[1],
-	}, nil
 }
 
 // String implements the stringer interface.
@@ -72,22 +59,6 @@ func (u URL) TerminalString() string {
 // MarshalJSON implements the json.Marshaller interface.
 func (u URL) MarshalJSON() ([]byte, error) {
 	return json.Marshal(u.String())
-}
-
-// UnmarshalJSON parses url.
-func (u *URL) UnmarshalJSON(input []byte) error {
-	var textURL string
-	err := json.Unmarshal(input, &textURL)
-	if err != nil {
-		return err
-	}
-	url, err := parseURL(textURL)
-	if err != nil {
-		return err
-	}
-	u.Scheme = url.Scheme
-	u.Path = url.Path
-	return nil
 }
 
 // Cmp compares x and y and returns:

--- a/accounts/url_test.go
+++ b/accounts/url_test.go
@@ -20,26 +20,6 @@ import (
 	"testing"
 )
 
-func TestURLParsing(t *testing.T) {
-	t.Parallel()
-	url, err := parseURL("https://ethereum.org")
-	if err != nil {
-		t.Errorf("unexpected error: %v", err)
-	}
-	if url.Scheme != "https" {
-		t.Errorf("expected: %v, got: %v", "https", url.Scheme)
-	}
-	if url.Path != "ethereum.org" {
-		t.Errorf("expected: %v, got: %v", "ethereum.org", url.Path)
-	}
-
-	for _, u := range []string{"ethereum.org", ""} {
-		if _, err = parseURL(u); err == nil {
-			t.Errorf("input %v, expected err, got: nil", u)
-		}
-	}
-}
-
 func TestURLString(t *testing.T) {
 	t.Parallel()
 	url := URL{Scheme: "https", Path: "ethereum.org"}
@@ -62,21 +42,6 @@ func TestURLMarshalJSON(t *testing.T) {
 	}
 	if string(json) != "\"https://ethereum.org\"" {
 		t.Errorf("expected: %v, got: %v", "\"https://ethereum.org\"", string(json))
-	}
-}
-
-func TestURLUnmarshalJSON(t *testing.T) {
-	t.Parallel()
-	url := &URL{}
-	err := url.UnmarshalJSON([]byte("\"https://ethereum.org\""))
-	if err != nil {
-		t.Errorf("unexpected error: %v", err)
-	}
-	if url.Scheme != "https" {
-		t.Errorf("expected: %v, got: %v", "https", url.Scheme)
-	}
-	if url.Path != "ethereum.org" {
-		t.Errorf("expected: %v, got: %v", "https", url.Path)
 	}
 }
 


### PR DESCRIPTION
While reviewing #35607 I noticed that this was all dead code.

This could potentially still be used by external clients, especially `Wallet`, but I'd be curious to know who that is.

`UnmarshalJSON`, however, makes no sense, the user should implement it themselves if they need to, because we're not really maintaining this anymore.