### PR TITLE
rpc: start connection faults after client setup

### DIFF
--- a/rpc/client_test.go
+++ b/rpc/client_test.go
@@ -348,6 +348,7 @@ func testClientCancel(transport string, t *testing.T) {
 	fl := &flakeyListener{
 		maxAcceptDelay: 1 * time.Second,
 		maxKillTimeout: 600 * time.Millisecond,
+		clientReady:    make(chan struct{}),
 	}
 
 	var client *Client
@@ -363,6 +364,7 @@ func testClientCancel(transport string, t *testing.T) {
 	default:
 		panic("unknown transport: " + transport)
 	}
+	close(fl.clientReady)
 	defer client.Close()
 
 	// The actual test starts here.
@@ -965,6 +967,7 @@ type flakeyListener struct {
 	net.Listener
 	maxKillTimeout time.Duration
 	maxAcceptDelay time.Duration
+	clientReady    chan struct{}
 }
 
 func (l *flakeyListener) Accept() (net.Conn, error) {
@@ -974,10 +977,13 @@ func (l *flakeyListener) Accept() (net.Conn, error) {
 	c, err := l.Listener.Accept()
 	if err == nil {
 		timeout := max(time.Millisecond*10, time.Duration(rand.Int63n(int64(l.maxKillTimeout))))
-		time.AfterFunc(timeout, func() {
+		go func() {
+			// The initial transport handshake must finish before fault injection begins.
+			<-l.clientReady
+			time.Sleep(timeout)
 			log.Debug(fmt.Sprintf("killing conn %v after %v", c.LocalAddr(), timeout))
 			c.Close()
-		})
+		}()
 	}
 	return c, err
 }


### PR DESCRIPTION
## Root cause

`TestClientCancelWebsocket` wraps the test server with `flakeyListener`, which starts a connection-kill timer as soon as `Accept` returns. Under race-detector load, the timer can expire while `Dial` is still completing the WebSocket handshake, causing setup to panic with `connection reset by peer` instead of exercising request cancellation.

The 10 ms minimum added in #33002 reduces the probability but does not remove the ordering race. It recurred in the inherited test in [0xPolygon/bor CI](https://github.com/0xPolygon/bor/actions/runs/33586568457/job/100111846852).

## Fix

Signal when initial client setup has completed and make connection fault timers wait for that signal before starting. Reconnected clients still receive the same randomized accept delays and connection kills because the signal remains closed after setup.

## Validation

- `go test -race ./rpc -shuffle=1788322886695128388 -count=1`
- `go test -race ./rpc -run '^TestClientCancel(Websocket|HTTP|IPC)$' -count=20 -timeout=10m`
- `make all`
- `go run ./build/ci.go test -short`
- `go run ./build/ci.go test`
- `go run ./build/ci.go lint`
- `go run ./build/ci.go check_generate`
- `go run ./build/ci.go check_baddeps`

This only changes test fault-injection timing; runtime RPC behavior is unaffected.
