### PR TITLE
rpc: unescape JSON object keys in fillMessage

### DIFF
--- a/rpc/json.go
+++ b/rpc/json.go
@@ -430,6 +430,13 @@ func fillMessage(input []byte, msg *jsonrpcMessage) {
 	// The raw fields point into input rather than being copied out of it, which
 	// matters because params is nearly all of a large request.
 	forEachJSONField(input, func(key, value []byte) {
+		if bytes.IndexByte(key, '\\') >= 0 {
+			var name string
+			if err := json.Unmarshal([]byte(`"`+string(key)+`"`), &name); err != nil {
+				return
+			}
+			key = []byte(name)
+		}
 		switch string(key) {
 		case "jsonrpc":
 			// The string fields go through encoding/json to unescape them.

--- a/rpc/jsonscan_test.go
+++ b/rpc/jsonscan_test.go
@@ -58,7 +58,9 @@ var messageCorpus = []string{
 	// keys in other spellings are unknown fields, only the exact names match
 	`{"METHOD":"m","ID":1}`,
 	`{"Method":"m","Id":1,"Jsonrpc":"2.0"}`,
+	// unicode escapes in keys are unescaped before matching (metho\u0064 == method)
 	"{\"metho\\u0064\":\"m\",\"i\\u0064\":7}",
+	// a double-escaped key stays literal metho\u0064 and is not the method field
 	`{"metho\\u0064":"not the method key"}`,
 	// unknown fields are ignored
 	`{"method":"m","id":1,"extra":{"a":[1,2,3]},"more":"x"}`,
@@ -127,10 +129,12 @@ func TestParseMessage(t *testing.T) {
 		{"duplicate key, last wins", `{"method":"first","method":"second","id":1}`, false, []*jsonrpcMessage{msg("", "second", "1", "", "")}},
 
 		// field names have one spelling in the spec, any other spelling is an
-		// unknown key, even where encoding/json would have matched it
+		// unknown key; unicode escapes in keys are unescaped first so they
+		// match the same way encoding/json map keys do
 		{"cased keys ignored", `{"Method":"m","ID":1,"Params":[1]}`, false, []*jsonrpcMessage{zero()}},
 		{"upper case keys ignored", `{"METHOD":"m","JSONRPC":"2.0"}`, false, []*jsonrpcMessage{zero()}},
-		{"escaped keys ignored", "{\"metho\\u0064\":\"m\",\"i\\u0064\":7}", false, []*jsonrpcMessage{zero()}},
+		{"unicode-escaped method key", "{\"metho\\u0064\":\"m\",\"i\\u0064\":7}", false, []*jsonrpcMessage{msg("", "m", "7", "", "")}},
+		{"double-escaped key is not method", `{"metho\\u0064":"not the method key"}`, false, []*jsonrpcMessage{zero()}},
 
 		// a string holding structural bytes must not end the value early
 		{
@@ -435,12 +439,6 @@ func FuzzFillMessage(f *testing.F) {
 	f.Fuzz(func(t *testing.T, input string) {
 		data := []byte(input)
 		if !json.Valid(data) {
-			return
-		}
-		if bytes.IndexByte(data, '\\') >= 0 {
-			// encoding/json unescapes map keys, so an escaped key would match
-			// in the reference but is an unknown key to fillMessage. Escape
-			// handling is pinned by the tests above.
 			return
 		}
 		var want jsonrpcMessage


### PR DESCRIPTION
## Summary
- `fillMessage` previously compared raw JSON object keys without unescaping, so unicode-escaped names like `"metho\u0064"` did not match `"method"`.
- Unescape keys that contain `\` before matching, matching `encoding/json` map-key behavior.
- Add regression coverage for unicode-escaped and double-escaped keys; let `FuzzFillMessage` also exercise escaped keys.

## Test plan
- [ ] `go test ./rpc/ -run TestParseMessage`
- [ ] Confirm `TestParseMessage/unicode-escaped_method_key` fails without the unescape change
- [ ] `go test ./rpc/ -run=FuzzFillMessage -fuzz=FuzzFillMessage -fuzztime=10s`