### PR TITLE
core/history: copy prune point in NewPolicy

### DIFF
--- a/core/history/historymode.go
+++ b/core/history/historymode.go
@@ -133,7 +133,8 @@ func NewPolicy(mode HistoryMode, genesisHash common.Hash) (HistoryPolicy, error)
 		if point == nil {
 			return HistoryPolicy{}, fmt.Errorf("%s history pruning not available for network %s", mode, genesisHash.Hex())
 		}
-		return HistoryPolicy{Mode: mode, Target: point}, nil
+		target := *point
+		return HistoryPolicy{Mode: mode, Target: &target}, nil
 
 	default:
 		return HistoryPolicy{}, fmt.Errorf("invalid history mode: %d", mode)


### PR DESCRIPTION
## Summary
- `NewPolicy` previously returned a pointer into the package-level `staticPrunePoints` map.
- Copy the prune point so a `HistoryPolicy` cannot mutate the shared static entry.

## Test plan
- [ ] `go test ./core/history/...`
- [ ] Confirm callers that mutate `HistoryPolicy.Target` do not affect subsequent `NewPolicy` results for the same network