### PR TITLE
ethereum: add json tags to TransactionReceiptsQuery

### DIFF
--- a/interfaces.go
+++ b/interfaces.go
@@ -68,7 +68,7 @@ type ChainReader interface {
 // If TransactionHashes is empty, receipts for all transactions included in new blocks will be delivered.
 // Otherwise, only receipts for the specified transactions will be delivered.
 type TransactionReceiptsQuery struct {
-	TransactionHashes []common.Hash
+	TransactionHashes []common.Hash `json:"transactionHashes,omitempty"`
 }
 
 // TransactionReader provides access to past transactions and their receipts.


### PR DESCRIPTION
## Summary
- `TransactionReceiptsQuery` had no JSON tags, so subscription params serialized as the Go field name `TransactionHashes`.
- Add `json:"transactionHashes,omitempty"` so the query matches the RPC field name.

## Test plan
- [ ] `go test ./ethclient/...`
- [ ] Confirm `eth_subscribe` receipt queries encode `transactionHashes` rather than `TransactionHashes`