### PR TITLE
p2p/pipes: close listener when TCP dial fails

### DIFF
--- a/p2p/pipes/pipe.go
+++ b/p2p/pipes/pipe.go
@@ -36,6 +36,7 @@ func TCPPipe() (net.Conn, net.Conn, error) {
 
 	dconn, err := net.Dial("tcp", l.Addr().String())
 	if err != nil {
+		l.Close()
 		<-aerr
 		return nil, nil, err
 	}


### PR DESCRIPTION
## Summary
- `TCPPipe` waited on `Accept` after a failed `Dial` without closing the listener first, so `Accept` never returned and the helper could deadlock.
- Close the listener on dial failure to unblock `Accept` before draining the error channel.

## Test plan
- [ ] `go test ./p2p/pipes/...`
- [ ] `go test ./p2p/ -run TCPPipe`