### PR TITLE
core/rawdb: close freezer if era database fails to open

### DIFF
--- a/core/rawdb/chain_freezer.go
+++ b/core/rawdb/chain_freezer.go
@@ -72,6 +72,7 @@ func newChainFreezer(datadir string, eraDir string, namespace string, readonly b
 	}
 	edb, err := eradb.New(resolveChainEraDir(datadir, eraDir))
 	if err != nil {
+		freezer.Close()
 		return nil, err
 	}
 	return &chainFreezer{


### PR DESCRIPTION
## Summary
- `newChainFreezer` left the file-based freezer open if `eradb.New` failed, leaking ancient-store file handles.
- Close the freezer on that error path before returning.

## Test plan
- [ ] `go test ./core/rawdb/ -short`