### PR TITLE
cmd/devp2p/internal/ethtest: fix concurrent reads in readAnyFrom

### DIFF
--- a/cmd/devp2p/internal/ethtest/suite.go
+++ b/cmd/devp2p/internal/ethtest/suite.go
@@ -1443,8 +1443,11 @@ func readAnyFrom[T any](conns ...*Conn) (*T, *Conn, error) {
 	ch := make(chan result, len(conns))
 	errCh := make(chan error, len(conns))
 
+	var wg sync.WaitGroup
 	for _, c := range conns {
+		wg.Add(1)
 		go func(c *Conn) {
+			defer wg.Done()
 			pkt, err := readUntil[T](ctx, c)
 			if err != nil {
 				if !errors.Is(err, context.Canceled) {
@@ -1455,12 +1458,20 @@ func readAnyFrom[T any](conns ...*Conn) (*T, *Conn, error) {
 			ch <- result{pkt, c}
 		}(c)
 	}
+	var (
+		r   result
+		err error
+	)
 	select {
-	case r := <-ch:
-		return r.pkt, r.c, nil
-	case err := <-errCh:
+	case r = <-ch:
+	case err = <-errCh:
+	}
+	cancel()
+	wg.Wait()
+	if err != nil {
 		return nil, nil, err
 	}
+	return r.pkt, r.c, nil
 }
 
 func (s *Suite) TestGetCells(t *utesting.T) {


### PR DESCRIPTION
readAnyFrom starts a reader goroutine for each connection and returns when one
of them receives a message. The other readers are cancelled but we don't wait them,
so they may still be reading when readAnyFrom is called again.

This can cause multiple goroutines to read from the same rlpx.Conn at once, overwriting
the read buffer and causing the flaky panic.

This PR add a logic to wait for all reader goroutines to exit before returning.