### PR TITLE
core/state/snapshot: propagate dangling storage check errors

### DIFF
--- a/core/state/snapshot/utils.go
+++ b/core/state/snapshot/utils.go
@@ -32,7 +32,7 @@ import (
 // storage also has corresponding account data.
 func CheckDanglingStorage(chaindb ethdb.KeyValueStore) error {
 	if err := checkDanglingDiskStorage(chaindb); err != nil {
-		log.Error("Database check error", "err", err)
+		return err
 	}
 	return checkDanglingMemStorage(chaindb)
 }
@@ -66,7 +66,10 @@ func checkDanglingDiskStorage(chaindb ethdb.KeyValueStore) error {
 			return fmt.Errorf("dangling snapshot storage account %#x", accKey)
 		}
 	}
-	log.Info("Verified the snapshot disk storage", "time", common.PrettyDuration(time.Since(start)), "err", it.Error())
+	if err := it.Error(); err != nil {
+		return err
+	}
+	log.Info("Verified the snapshot disk storage", "time", common.PrettyDuration(time.Since(start)))
 	return nil
 }
 
@@ -78,7 +81,7 @@ func checkDanglingMemStorage(db ethdb.KeyValueStore) error {
 	err := iterateJournal(db, func(pRoot, root common.Hash, accounts map[common.Hash][]byte, storage map[common.Hash]map[common.Hash][]byte) error {
 		for accHash := range storage {
 			if _, ok := accounts[accHash]; !ok {
-				log.Error("Dangling storage - missing account", "account", fmt.Sprintf("%#x", accHash), "root", root)
+				return fmt.Errorf("dangling snapshot journal storage account %#x at root %#x", accHash, root)
 			}
 		}
 		return nil

--- a/core/state/snapshot/utils_test.go
+++ b/core/state/snapshot/utils_test.go
@@ -1,0 +1,93 @@
+// Copyright 2026 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+
+package snapshot
+
+import (
+	"bytes"
+	"errors"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/rawdb"
+	"github.com/ethereum/go-ethereum/ethdb"
+	"github.com/ethereum/go-ethereum/rlp"
+)
+
+func TestCheckDanglingStorage(t *testing.T) {
+	t.Run("disk storage", func(t *testing.T) {
+		db := rawdb.NewMemoryDatabase()
+		rawdb.WriteStorageSnapshot(db, common.HexToHash("0x01"), common.HexToHash("0x02"), []byte{0x01})
+
+		if err := CheckDanglingStorage(db); err == nil {
+			t.Fatal("dangling disk storage was not reported")
+		}
+	})
+
+	t.Run("disk iterator", func(t *testing.T) {
+		want := errors.New("test iterator error")
+		db := &iteratorErrorDatabase{
+			KeyValueStore: rawdb.NewMemoryDatabase(),
+			err:           want,
+		}
+		if err := CheckDanglingStorage(db); !errors.Is(err, want) {
+			t.Fatalf("unexpected error: got %v, want %v", err, want)
+		}
+	})
+
+	t.Run("journal storage", func(t *testing.T) {
+		db := rawdb.NewMemoryDatabase()
+		account := common.HexToHash("0x01")
+		root := common.HexToHash("0x02")
+		storage := []journalStorage{{
+			Hash: account,
+			Keys: []common.Hash{common.HexToHash("0x03")},
+			Vals: [][]byte{{0x01}},
+		}}
+		var journal bytes.Buffer
+		for _, entry := range []any{journalCurrentVersion, common.Hash{}, root, []journalAccount{}, storage} {
+			if err := rlp.Encode(&journal, entry); err != nil {
+				t.Fatal(err)
+			}
+		}
+		rawdb.WriteSnapshotJournal(db, journal.Bytes())
+
+		if err := CheckDanglingStorage(db); err == nil {
+			t.Fatal("dangling journal storage was not reported")
+		}
+	})
+}
+
+type iteratorErrorDatabase struct {
+	ethdb.KeyValueStore
+	err error
+}
+
+func (db *iteratorErrorDatabase) NewIterator(prefix, start []byte) ethdb.Iterator {
+	return &iteratorError{
+		Iterator: db.KeyValueStore.NewIterator(prefix, start),
+		err:      db.err,
+	}
+}
+
+type iteratorError struct {
+	ethdb.Iterator
+	err error
+}
+
+func (it *iteratorError) Error() error {
+	return it.err
+}


### PR DESCRIPTION
## Summary

- Propagate dangling snapshot storage check errors to the caller.
- Return disk iterator errors instead of treating them as successful exhaustion.
- Return an error when journalled storage has no corresponding account.

## Why

`CheckDanglingStorage` could report corrupted snapshot data while still returning `nil`.

Disk check errors were logged and discarded by the top-level checker. In addition, iterator errors were only included in the completion log and `checkDanglingMemStorage` logged missing accounts without returning an error. As a result, `geth snapshot verify` could report success for corrupted snapshot storage.



Tested by the following cmd:

- `go test ./core/state/snapshot`
- `go test ./cmd/geth -run '^$'`
