### PR TITLE
core, eth: optimize chain segment insertion

### DIFF
--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -377,6 +377,7 @@ type BlockChain struct {
 
 	lastForkReadyAlert time.Time     // Last time there was a fork readiness print out
 	slowBlockThreshold time.Duration // Block execution time threshold beyond which detailed statistics will be logged
+	ancientSynced      time.Time     // Time the ancient store was last flushed during snap sync
 }
 
 // NewBlockChain returns a fully initialised block chain using information
@@ -1210,8 +1211,18 @@ func (bc *BlockChain) SnapSyncComplete(hash common.Hash, isSnapV2 bool) error {
 		bc.snaps.Rebuild(root, !isSnapV2)
 	}
 
+	// Make the synced segment durable before the chain markers point into it.
+	if err := bc.flushAncient(); err != nil {
+		return err
+	}
 	// If all checks out, manually set the head block.
-	rawdb.WriteHeadBlockHash(bc.db, hash)
+	batch := bc.db.NewBatch()
+	rawdb.WriteHeadHeaderHash(batch, hash)
+	rawdb.WriteHeadFastBlockHash(batch, hash)
+	rawdb.WriteHeadBlockHash(batch, hash)
+	if err := batch.Write(); err != nil {
+		return err
+	}
 	bc.currentBlock.Store(block.Header())
 	headBlockGauge.Update(int64(block.NumberU64()))
 
@@ -1359,6 +1370,21 @@ func (bc *BlockChain) stopWithoutSaving() {
 func (bc *BlockChain) Stop() {
 	bc.stopWithoutSaving()
 
+	// Flush the ancient store and advance the chain markers onto it, so that the
+	// segment written since the last flush is not re-downloaded after the restart.
+	// The markers only lag behind during snap sync, everything else persists them
+	// right away.
+	if err := bc.flushAncient(); err != nil {
+		log.Error("Failed to flush ancient store", "err", err)
+	} else if head := bc.currentSnapBlock.Load(); head != nil && rawdb.ReadHeadFastBlockHash(bc.db) != head.Hash() {
+		batch := bc.db.NewBatch()
+		rawdb.WriteHeadHeaderHash(batch, head.Hash())
+		rawdb.WriteHeadFastBlockHash(batch, head.Hash())
+		if err := batch.Write(); err != nil {
+			log.Error("Failed to update chain markers", "err", err)
+		}
+	}
+
 	// Ensure that the entirety of the state snapshot is journaled to disk.
 	var snapBase common.Hash
 	if bc.snaps != nil {
@@ -1442,6 +1468,29 @@ const (
 	SideStatTy
 )
 
+// ancientSyncInterval is how often the ancient store is explicitly fsync'd
+// during snap sync. Flushing fsyncs every freezer table, so it is amortized
+// across insertions instead of being run on each of them.
+//
+// The interval only matters for crash recovery: the freezer starts writing
+// data back to disk as soon as it is written (see writeback), so the flush
+// itself is cheap regardless of how much was written since the last one. The
+// head markers are only persisted on a flush though, so after an unclean
+// shutdown, everything written since the last flush is discarded by freezer
+// recovery and downloaded again. The interval bounds that to the last thirty
+// seconds worth of chain data.
+const ancientSyncInterval = 30 * time.Second
+
+// flushAncient flushes the ancient store, making everything written into it since
+// the last flush durable.
+func (bc *BlockChain) flushAncient() error {
+	if err := bc.db.SyncAncient(); err != nil {
+		return err
+	}
+	bc.ancientSynced = time.Now()
+	return nil
+}
+
 // InsertReceiptChain inserts a batch of blocks along with their receipts into
 // the database. Unlike InsertChain, this function does not verify the state root
 // in the blocks. It is used exclusively for snap sync. All the inserted blocks
@@ -1477,14 +1526,17 @@ func (bc *BlockChain) InsertReceiptChain(blockChain types.Blocks, receiptChain [
 		start = time.Now()
 		size  = int64(0)
 	)
-	// updateHead updates the head header and head snap block flags.
-	updateHead := func(header *types.Header) error {
-		batch := bc.db.NewBatch()
-		hash := header.Hash()
-		rawdb.WriteHeadHeaderHash(batch, hash)
-		rawdb.WriteHeadFastBlockHash(batch, hash)
-		if err := batch.Write(); err != nil {
-			return err
+	// updateHead updates the head header and head snap block flags. The markers are
+	// only persisted if the data they point to has already been flushed to disk.
+	updateHead := func(header *types.Header, persist bool) error {
+		if persist {
+			batch := bc.db.NewBatch()
+			hash := header.Hash()
+			rawdb.WriteHeadHeaderHash(batch, hash)
+			rawdb.WriteHeadFastBlockHash(batch, hash)
+			if err := batch.Write(); err != nil {
+				return err
+			}
 		}
 		bc.hc.currentHeader.Store(header)
 		bc.currentSnapBlock.Store(header)
@@ -1520,12 +1572,17 @@ func (bc *BlockChain) InsertReceiptChain(blockChain types.Blocks, receiptChain [
 		ancientWriteTimer.UpdateSince(start)
 		ancientBytesMeter.Mark(writeSize)
 
-		// Sync the ancient store explicitly to ensure all data has been flushed to disk.
-		start = time.Now()
-		if err := bc.db.SyncAncient(); err != nil {
-			return 0, err
+		// Flush the ancient store periodically, holding back the head markers
+		// until then; crash recovery discards whatever is past the durable tip.
+		// The very first insertion flushes right away as the timestamp is unset.
+		persist := time.Since(bc.ancientSynced) >= ancientSyncInterval
+		if persist {
+			start := time.Now()
+			if err := bc.flushAncient(); err != nil {
+				return 0, err
+			}
+			ancientSyncTimer.UpdateSince(start)
 		}
-		ancientSyncTimer.UpdateSince(start)
 		// Write hash to number mappings
 		batch := bc.db.NewBatch()
 		for _, block := range blockChain {
@@ -1535,7 +1592,7 @@ func (bc *BlockChain) InsertReceiptChain(blockChain types.Blocks, receiptChain [
 			return 0, err
 		}
 		// Update the current snap block because all block data is now present in DB.
-		if err := updateHead(blockChain[len(blockChain)-1].Header()); err != nil {
+		if err := updateHead(blockChain[len(blockChain)-1].Header(), persist); err != nil {
 			return 0, err
 		}
 		stats.processed += int32(len(blockChain))
@@ -1581,7 +1638,7 @@ func (bc *BlockChain) InsertReceiptChain(blockChain types.Blocks, receiptChain [
 				return err
 			}
 		}
-		return updateHead(blockChain[len(blockChain)-1].Header())
+		return updateHead(blockChain[len(blockChain)-1].Header(), true)
 	}
 
 	// Split the supplied blocks into two groups, according to the
@@ -1598,6 +1655,11 @@ func (bc *BlockChain) InsertReceiptChain(blockChain types.Blocks, receiptChain [
 		}
 	}
 	if index != len(blockChain) {
+		// The head markers persisted by the live path must not overtake un-synced
+		// ancient data, flush it first.
+		if err := bc.flushAncient(); err != nil {
+			return 0, err
+		}
 		if err := writeLive(blockChain[index:], receiptChain[index:]); err != nil {
 			if err == errInsertionInterrupted {
 				return 0, nil

--- a/core/rawdb/database.go
+++ b/core/rawdb/database.go
@@ -138,8 +138,9 @@ func (db *nofreezedb) TruncateTail(group string, items uint64) (uint64, error) {
 }
 
 // SyncAncient returns an error as we don't have a backing chain freezer.
+// SyncAncient is a no-op without an ancient store, there is nothing to flush.
 func (db *nofreezedb) SyncAncient() error {
-	return errNotSupported
+	return nil
 }
 
 func (db *nofreezedb) ReadAncients(fn func(reader ethdb.AncientReaderOp) error) (err error) {

--- a/core/rawdb/freezer_batch.go
+++ b/core/rawdb/freezer_batch.go
@@ -30,6 +30,13 @@ const (
 	// for a single freezer table batch.
 	freezerBatchBufferLimit = 2 * 1024 * 1024
 
+	// freezerWritebackThreshold is the amount of data written to a table since
+	// the last writeback was initiated, beyond which the kernel is asked to
+	// start writing it out. Smaller amounts are left for the next commit to
+	// pick up, or for the eventual fsync: initiating the writeback of a few
+	// KB is not worth the separate IO nor the rewrite of the partial last page.
+	freezerWritebackThreshold = 1024 * 1024
+
 	// freezerTableFlushThreshold defines the threshold for triggering a freezer
 	// table sync operation. If the number of accumulated uncommitted items exceeds
 	// this value, a sync will be scheduled.
@@ -104,11 +111,15 @@ type freezerTableBatch struct {
 	indexBuffer []byte
 	curItem     uint64 // expected index of next append
 	totalBytes  int64  // counts written bytes since reset
+
+	// writebackFrom is the offset in the head file from which the written data
+	// has not been handed to the kernel for writeback yet, -1 if none.
+	writebackFrom int64
 }
 
 // newBatch creates a new batch for the freezer table.
 func (t *freezerTable) newBatch() *freezerTableBatch {
-	batch := &freezerTableBatch{t: t}
+	batch := &freezerTableBatch{t: t, writebackFrom: -1}
 	if !t.config.noSnappy {
 		batch.sb = new(snappyBuffer)
 	}
@@ -122,6 +133,7 @@ func (batch *freezerTableBatch) reset() {
 	batch.indexBuffer = batch.indexBuffer[:0]
 	batch.curItem = batch.t.items.Load()
 	batch.totalBytes = 0
+	batch.writebackFrom = -1
 }
 
 // Append rlp-encodes and adds data at the end of the freezer table. The item number is a
@@ -172,6 +184,7 @@ func (batch *freezerTableBatch) appendItem(data []byte) error {
 			return err
 		}
 		itemOffset = 0
+		batch.writebackFrom = -1 // The tail of the old file is left to the fsync
 	}
 
 	// Put data to buffer.
@@ -204,6 +217,16 @@ func (batch *freezerTableBatch) commit() error {
 	}
 	dataSize := int64(len(batch.dataBuffer))
 	batch.dataBuffer = batch.dataBuffer[:0]
+
+	// Start writing the data out to disk as it accumulates, so that the
+	// periodic sync of the table finds little left to flush
+	if batch.writebackFrom < 0 {
+		batch.writebackFrom = batch.t.headBytes
+	}
+	if end := batch.t.headBytes + dataSize; end-batch.writebackFrom >= freezerWritebackThreshold {
+		writeback(batch.t.head, batch.writebackFrom, end-batch.writebackFrom)
+		batch.writebackFrom = -1
+	}
 
 	_, err = batch.t.index.Write(batch.indexBuffer)
 	if err != nil {

--- a/core/rawdb/freezer_writeback_linux.go
+++ b/core/rawdb/freezer_writeback_linux.go
@@ -1,0 +1,42 @@
+// Copyright 2026 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+
+//go:build linux
+
+package rawdb
+
+import (
+	"os"
+
+	"golang.org/x/sys/unix"
+)
+
+// writeback asks the kernel to start writing the given range of the file out
+// to disk, without waiting for it to complete.
+//
+// Left alone, the kernel keeps freshly written data dirty in the page cache
+// until it ages out or the dirty set grows past the background threshold, both
+// of which are far beyond what a freezer flush interval accumulates. The next
+// fsync then has to write everything out at once, blocking the writer for as
+// long as that takes. Kicking off writeback as the data is written keeps the
+// dirty set down to the last few buffers and turns the fsync into a cheap
+// journal commit plus device flush, at a steady disk load instead of bursts.
+//
+// This is a hint only: errors are ignored, the data is still made durable by
+// the eventual fsync.
+func writeback(file *os.File, offset, size int64) {
+	unix.SyncFileRange(int(file.Fd()), offset, size, unix.SYNC_FILE_RANGE_WRITE)
+}

--- a/core/rawdb/freezer_writeback_other.go
+++ b/core/rawdb/freezer_writeback_other.go
@@ -1,0 +1,26 @@
+// Copyright 2026 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+
+//go:build !linux
+
+package rawdb
+
+import "os"
+
+// writeback is a no-op on platforms without a way to initiate writeback of a
+// file range without waiting for it; the data is written out by the eventual
+// fsync instead.
+func writeback(file *os.File, offset, size int64) {}

--- a/eth/downloader/downloader.go
+++ b/eth/downloader/downloader.go
@@ -47,7 +47,7 @@ var (
 	MaxBALFetch     = 128 // Number of block access lists to allow fetching per request
 
 	maxQueuedHeaders           = 32 * 1024                        // [eth/62] Maximum number of headers to queue for import (DOS protection)
-	maxHeadersProcess          = 2048                             // Number of header download results to import at once into the chain
+	maxHeadersProcess          = 20480                            // Number of header download results to import at once into the chain
 	maxResultsProcess          = 2048                             // Number of content download results to import at once into the chain
 	fullMaxForkAncestry uint64 = params.FullImmutabilityThreshold // Maximum chain reorganisation (locally redeclared so tests can reduce it)
 


### PR DESCRIPTION
Previously, snap sync triggered an ancient-store sync after every chain-segment insertion. This added unnecessary overhead because fsync is expensive, and syncing the ancient store flushes multiple files at once.

This PR delays the ancient-store sync until the accumulated written data reaches the threshold. Until the ancient store is explicitly synced, the corresponding chain markers in the key-value store are also left unpersisted. This prevents gaps in chain segments after an unclean shutdown.