### PR TITLE
core/txpool/legacypool: preserve pending nonces during reorg

### DIFF
--- a/core/txpool/legacypool/legacypool.go
+++ b/core/txpool/legacypool/legacypool.go
@@ -1248,6 +1248,10 @@ func (pool *LegacyPool) runReorg(done chan struct{}, reset *txpoolResetRequest, 
 				delete(events, addr)
 			}
 		}
+		// Restore pending nonce overrides before promoting queued transactions.
+		for addr, list := range pool.pending {
+			pool.pendingNonces.set(addr, max(pool.pendingNonces.get(addr), list.LastElement().Nonce()+1))
+		}
 		// Reset needs promote for all addresses
 		promoteAddrs = pool.queue.addresses()
 	}

--- a/core/txpool/legacypool/legacypool_test.go
+++ b/core/txpool/legacypool/legacypool_test.go
@@ -397,6 +397,49 @@ func TestStateChangeDuringReset(t *testing.T) {
 	}
 }
 
+func TestReorgResetWithDirtyAccount(t *testing.T) {
+	t.Parallel()
+
+	pool, key := setupPool()
+	defer pool.Close()
+
+	addr := crypto.PubkeyToAddress(key.PublicKey)
+	testAddBalance(pool, addr, big.NewInt(1000000000000000))
+	testSetNonce(pool, addr, 1)
+	<-pool.requestReset(nil, nil)
+
+	// Add two executable transactions to establish a pending nonce ahead of state.
+	for _, tx := range []*types.Transaction{transaction(1, 100000, key), transaction(2, 100000, key)} {
+		if err := pool.addRemoteSync(tx); err != nil {
+			t.Fatalf("failed to add transaction %d: %v", tx.Nonce(), err)
+		}
+	}
+	// Admit the next transaction without scheduling its promotion, reproducing the
+	// state passed to runReorg when a reset and dirty-account request are coalesced.
+	tx := transaction(3, 100000, key)
+	pool.mu.Lock()
+	errs := make([]error, 1)
+	dirty := pool.addTxsLocked([]*types.Transaction{tx}, errs)
+	pool.mu.Unlock()
+	if errs[0] != nil {
+		t.Fatalf("failed to add transaction %d: %v", tx.Nonce(), errs[0])
+	}
+
+	// The new chain head includes transaction 1. Transaction 2 remains pending,
+	// so transaction 3 must be promoted by the combined reorg run.
+	testSetNonce(pool, addr, 2)
+	done := make(chan struct{})
+	pool.runReorg(done, &txpoolResetRequest{}, dirty, make(map[common.Address]*SortedMap))
+	<-done
+
+	if pending, queued := pool.Stats(); pending != 2 || queued != 0 {
+		t.Fatalf("transaction stranded after reorg: pending %d, queued %d", pending, queued)
+	}
+	if err := validatePoolInternals(pool); err != nil {
+		t.Fatalf("pool internals mismatch: %v", err)
+	}
+}
+
 func testAddBalance(pool *LegacyPool, addr common.Address, amount *big.Int) {
 	pool.mu.Lock()
 	pool.currentState.AddBalance(addr, uint256.MustFromBig(amount), tracing.BalanceChangeUnspecified)


### PR DESCRIPTION
Fixes #35649.

## Problem

When a reset and dirty-account promotion request are coalesced into one
legacy-pool reorg run, the reset recreates the pending nonce tracker from
chain state before queued transactions are promoted.

This can temporarily move the executable nonce behind transactions already
present in the pending pool, causing the next valid queued transaction to
appear gapped and remain stranded.

## Fix

Restore pending-derived nonce overrides after reset event filtering and before
queue promotion.

The restored nonce is the maximum of:

- the nonce from chain state; and
- the nonce immediately following the pending transaction list.

This preserves the executable nonce represented by pending transactions while
also ensuring it never moves behind the new chain-state nonce.

## Testing

Added a deterministic regression test for a combined reset and dirty-account
reorg batch. The test does not use sleeps, timing assumptions, or production
test hooks.

The regression test fails on the original implementation with transaction 3
remaining queued and passes with this fix.

Validation performed:

- `gofmt` and `goimports`
- `make all`
- `go test ./core/txpool/...`
- `go test -race ./core/txpool/legacypool`
- `go run ./build/ci.go test -short`
- `go run ./build/ci.go test`
- `go run ./build/ci.go lint`
- `go run ./build/ci.go check_generate`
- `go run ./build/ci.go check_baddeps`

