### PR TITLE
docs: correct miner_setGasLimit and miner_setGasPrice parameter types

### DIFF
--- a/docs/interacting-with-geth/rpc/ns-miner.md
+++ b/docs/interacting-with-geth/rpc/ns-miner.md
@@ -30,7 +30,7 @@ Sets the minimal accepted gas price when mining transactions. Any transactions t
 
 | Client  | Method invocation                                     |
 | :------ | ----------------------------------------------------- |
-| Go      | `miner.setGasPrice(number *rpc.HexNumber) bool`       |
+| Go      | `miner.SetGasPrice(gasPrice hexutil.Big) bool`        |
 | Console | `miner.setGasPrice(number)`                           |
 | RPC     | `{"method": "miner_setGasPrice", "params": [number]}` |
 
@@ -79,6 +79,6 @@ Sets the gas limit the miner will target when mining. Note: on networks where EI
 
 | Client  | Method invocation                                     |
 | :------ | ----------------------------------------------------- |
-| Go      | `miner.SetGasLimit(number *rpc.HexNumber) bool`       |
+| Go      | `miner.SetGasLimit(gasLimit hexutil.Uint64) bool`       |
 | Console | `miner.SetGasLimit(number)`                           |
 | RPC     | `{"method": "miner_setGasLimit", "params": [number]}` |


### PR DESCRIPTION
Fixes #35548

Updates the Go signature parameter types and method casing in `docs/interacting-with-geth/rpc/ns-miner.md` to reflect `eth/api_miner.go`:
- `miner_setGasPrice`: `*rpc.HexNumber` -> `hexutil.Big` (and capitalized `miner.SetGasPrice` to match Go export convention and `miner.SetGasLimit`)
- `miner_setGasLimit`: `*rpc.HexNumber` -> `hexutil.Uint64`