### PR TITLE
cmd/utils: return error from writing history export checksums

### DIFF
--- a/cmd/utils/cmd.go
+++ b/cmd/utils/cmd.go
@@ -605,8 +605,7 @@ func ExportHistory(bc *core.BlockChain, dir string, first, last uint64, newBuild
 		}
 	}
 
-	_ = os.WriteFile(filepath.Join(dir, "checksums.txt"), []byte(strings.Join(checksums, "\n")), os.ModePerm)
-	return nil
+	return os.WriteFile(filepath.Join(dir, "checksums.txt"), []byte(strings.Join(checksums, "\n")), os.ModePerm)
 }
 
 // ImportPreimages imports a batch of exported hash preimages into the database.


### PR DESCRIPTION
## Summary
- `ExportHistory` ignored failures when writing `checksums.txt`, so a completed era export could still be missing or incomplete checksums without surfacing an error.
- Return the `os.WriteFile` error so callers can detect and handle checksum write failures.

## Test plan
- [ ] `go test ./cmd/utils/...`
- [ ] Confirm `ExportHistory` still writes `checksums.txt` on success and returns an error if the write fails.