### PR TITLE
p2p/nat: continue gateway discovery when interface addrs fail

### DIFF
--- a/p2p/nat/natpmp.go
+++ b/p2p/nat/natpmp.go
@@ -120,7 +120,7 @@ func potentialGateways() (gws []net.IP) {
 	for _, iface := range ifaces {
 		ifaddrs, err := iface.Addrs()
 		if err != nil {
-			return gws
+			continue
 		}
 		for _, addr := range ifaddrs {
 			if x, ok := addr.(*net.IPNet); ok {


### PR DESCRIPTION
## Summary
- `potentialGateways` returned early if `iface.Addrs()` failed on any interface, skipping later interfaces that might still expose a LAN gateway.
- Continue to the next interface instead so NAT-PMP discovery can still find candidate gateways.

## Test plan
- [ ] `go test ./p2p/nat/...`
- [ ] Confirm NAT-PMP discovery still enumerates private interface subnets when one interface cannot list addresses.