### PR TITLE
p2p/discover: don't evict the last node in the table on failed revalidation

### DIFF
--- a/p2p/discover/table.go
+++ b/p2p/discover/table.go
@@ -667,6 +667,21 @@ func (tab *Table) deleteInBucket(b *bucket, id enode.ID) *tableNode {
 	return rep
 }
 
+// bucketWouldEmptyTable reports whether b currently holds the only node(s) left in the
+// entire table, i.e. removing the sole entry of b would leave the table with no nodes
+// at all. The caller must hold tab.mutex.
+func (tab *Table) bucketWouldEmptyTable(b *bucket) bool {
+	if len(b.entries) != 1 || len(b.replacements) != 0 {
+		return false
+	}
+	for i := range tab.buckets {
+		if tab.buckets[i] != b && len(tab.buckets[i].entries) > 0 {
+			return false
+		}
+	}
+	return true
+}
+
 // bumpInBucket updates a node record if it exists in the bucket.
 // The second return value reports whether the node's endpoint (IP/port) was updated.
 func (tab *Table) bumpInBucket(b *bucket, newRecord *enode.Node, isInbound bool) (n *tableNode, endpointChanged bool) {

--- a/p2p/discover/table_reval.go
+++ b/p2p/discover/table_reval.go
@@ -159,12 +159,18 @@ func (tr *tableRevalidation) handleResponse(tab *Table, resp revalidationRespons
 
 	if !resp.didRespond {
 		n.livenessChecks /= 3
-		if n.livenessChecks <= 0 {
+		if n.livenessChecks <= 0 && !tab.bucketWouldEmptyTable(b) {
 			tab.deleteInBucket(b, n.ID())
-		} else {
-			tab.log.Debug("Node revalidation failed", "b", b.index, "id", n.ID(), "checks", n.livenessChecks, "q", n.revalList.name)
-			tr.moveToList(&tr.fast, n, now, &tab.rand)
+			return
 		}
+		// Either the node still has checks left, or removing it would leave the
+		// table completely empty. In the latter case, the node is kept and
+		// retried at the fast interval: this matters most right after startup,
+		// when the table may contain only a bootnode. If that bootnode happens
+		// to be unreachable initially, it must not be forgotten, or discovery
+		// would be stuck until the next scheduled table refresh.
+		tab.log.Debug("Node revalidation failed", "b", b.index, "id", n.ID(), "checks", n.livenessChecks, "q", n.revalList.name)
+		tr.moveToList(&tr.fast, n, now, &tab.rand)
 		return
 	}
 

--- a/p2p/discover/table_reval_test.go
+++ b/p2p/discover/table_reval_test.go
@@ -71,6 +71,95 @@ func TestRevalidation_nodeRemoved(t *testing.T) {
 	}
 }
 
+// This test checks that a node is not removed from the table by a failed revalidation
+// if doing so would leave the table completely empty. This matters most right after
+// startup, when the table may initially contain only a bootnode: if that bootnode is
+// briefly unreachable, it must stay in the table and keep being retried, or discovery
+// could get stuck until the next scheduled table refresh (up to RefreshInterval later).
+func TestRevalidation_lastNodeKept(t *testing.T) {
+	var (
+		clock     mclock.Simulated
+		transport = newPingRecorder()
+		tab, db   = newInactiveTestTable(transport, Config{Clock: &clock})
+		tr        = &tab.revalidation
+	)
+	defer db.Close()
+
+	// Add a single, unreachable node to the table.
+	node := nodeAtDistance(tab.self().ID(), 255, net.IP{77, 88, 99, 1})
+	tab.handleAddNode(addNodeOp{node: node})
+	transport.dead[node.ID()] = true
+
+	// Run several revalidation rounds. The node must survive every one of them,
+	// since it is the only node in the table.
+	for i := 0; i < 5; i++ {
+		next := tr.run(tab, clock.Now())
+		clock.Run(time.Duration(next + 1))
+		tr.run(tab, clock.Now())
+
+		var resp revalidationResponse
+		select {
+		case resp = <-tab.revalResponseCh:
+		case <-time.After(1 * time.Second):
+			t.Fatal("timed out waiting for revalidation")
+		}
+		tr.handleResponse(tab, resp)
+
+		if tab.getNode(node.ID()) == nil {
+			t.Fatalf("round %d: sole node was removed from table", i)
+		}
+		if !tr.fast.contains(node.ID()) {
+			t.Fatalf("round %d: sole node is not scheduled for another revalidation", i)
+		}
+	}
+}
+
+// This test checks that a dead node is still removed as usual when other nodes remain
+// in the table, i.e. the fix for TestRevalidation_lastNodeKept does not prevent normal
+// eviction of unreachable nodes.
+func TestRevalidation_deadNodeRemovedWhenNotAlone(t *testing.T) {
+	var (
+		clock     mclock.Simulated
+		transport = newPingRecorder()
+		tab, db   = newInactiveTestTable(transport, Config{Clock: &clock})
+		tr        = &tab.revalidation
+	)
+	defer db.Close()
+
+	// Add two nodes in different buckets: one dead, one alive.
+	deadNode := nodeAtDistance(tab.self().ID(), 255, net.IP{77, 88, 99, 1})
+	aliveNode := nodeAtDistance(tab.self().ID(), 200, net.IP{77, 88, 99, 2})
+	tab.handleAddNode(addNodeOp{node: deadNode})
+	tab.handleAddNode(addNodeOp{node: aliveNode})
+	transport.dead[deadNode.ID()] = true
+
+	// Run revalidation rounds until the dead node is pinged and removed.
+	removed := false
+	for i := 0; i < 10 && !removed; i++ {
+		next := tr.run(tab, clock.Now())
+		clock.Run(time.Duration(next + 1))
+		tr.run(tab, clock.Now())
+
+		var resp revalidationResponse
+		select {
+		case resp = <-tab.revalResponseCh:
+		case <-time.After(1 * time.Second):
+			t.Fatal("timed out waiting for revalidation")
+		}
+		tr.handleResponse(tab, resp)
+
+		if resp.n.ID() == deadNode.ID() && tab.getNode(deadNode.ID()) == nil {
+			removed = true
+		}
+	}
+	if !removed {
+		t.Fatal("dead node was never removed even though another node remains in the table")
+	}
+	if tab.getNode(aliveNode.ID()) == nil {
+		t.Fatal("alive node was unexpectedly removed")
+	}
+}
+
 // This test checks that nodes with an updated endpoint remain in the fast revalidation list.
 func TestRevalidation_endpointUpdate(t *testing.T) {
 	var (


### PR DESCRIPTION
## Summary

Fixes #20630, open since 2020 and confirmed by @fjl in the issue thread ("It looks like the part that's broken is that `newRandomLookup` doesn't retry re-inserting the bootnodes when the discovery table is empty").

- A freshly added node starts with `livenessChecks == 0`. A single failed revalidation ping divides that by 3 (still 0), and the node is deleted immediately - there is no tolerance for one failed attempt.
- If that node happens to be the *only* node in the table (the common case right after startup, when the table may contain just a bootnode), the table becomes completely empty.
- Nothing repopulates the table until the next scheduled refresh, which defaults to every 15-30 minutes (`RefreshInterval`). So if a configured bootnode is briefly unreachable at startup, the node can be stuck without any peers for a long time, even though the bootnode may come back within seconds.
- The routing table itself was substantially rewritten in 2024 (event-loop based `Table`, `tableRevalidation`), so the fix proposed for the old code in the issue thread (and in a downstream fork, celo-org/celo-blockchain#1194) no longer applies to current `master`.

## Fix

Add `Table.bucketWouldEmptyTable`, and use it in `tableRevalidation.handleResponse`: a failed revalidation check no longer deletes a node if doing so would leave the entire table with zero entries. Instead, the node is kept and requeued on the fast revalidation list, so it gets retried every few seconds until it responds. Normal eviction behavior is unchanged whenever other nodes remain in the table (the check short-circuits for any bucket with more than one entry).

## Test plan

- [x] Added `TestRevalidation_lastNodeKept`: a lone unreachable node survives repeated failed revalidations and stays queued for retry.
- [x] Added `TestRevalidation_deadNodeRemovedWhenNotAlone`: a dead node is still evicted as before once another node exists in the table, confirming normal eviction is preserved.
- [x] `go test ./p2p/...` passes.
- [x] `gofmt`/`go vet` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)