### PR TITLE
core/state/snapshot, triedb/internal: return iterator error from trie root generation

### DIFF
--- a/core/state/snapshot/conversion.go
+++ b/core/state/snapshot/conversion.go
@@ -336,6 +336,12 @@ func generateTrieRoot(db ethdb.KeyValueWriter, scheme string, it Iterator, accou
 			logged, processed = time.Now(), 0
 		}
 	}
+	// The iterator may have terminated early because of a database error or
+	// the underlying snapshot layer becoming stale. Surface that instead of
+	// hashing a truncated leaf stream and reporting a bogus root.
+	if err := it.Error(); err != nil {
+		return stop(err)
+	}
 	// Commit the last part statistic.
 	if processed > 0 && stats != nil {
 		if account == (common.Hash{}) {

--- a/triedb/internal/conversion.go
+++ b/triedb/internal/conversion.go
@@ -360,6 +360,12 @@ func GenerateTrieRoot(db ethdb.KeyValueWriter, scheme string, it Iterator, accou
 			logged, processed = time.Now(), 0
 		}
 	}
+	// The iterator may have terminated early because of a database error or
+	// the underlying snapshot layer becoming stale. Surface that instead of
+	// hashing a truncated leaf stream and reporting a bogus root.
+	if err := it.Error(); err != nil {
+		return stop(err)
+	}
 	// Commit the last part statistic.
 	if processed > 0 && stats != nil {
 		if account == (common.Hash{}) {


### PR DESCRIPTION
`GenerateTrieRoot` in `triedb/internal` and `generateTrieRoot` in `core/state/snapshot` walk the snapshot iterator with `Next()` but never check `Error()` once the loop ends. The iterators only report failures there: the disk iterators surface database read errors, and the diff/fast iterators set `ErrSnapshotStale` when the layer being iterated is flattened underneath them.

Without the check an early exit looks like a complete iteration, so the truncated leaf stream is hashed and the root is returned as if generation had succeeded. The verifiers in `pathdb/verifier.go` and `snapshot.go` then report "state root hash mismatch" instead of the actual error.

The error is returned through the existing `stop` path, which already handles a non-nil error from the per-account sub-tasks, so the shutdown of the background hasher is unchanged. Same class of issue as #35603.
