### PR TITLE
internal/ethapi, core: align eth_simulateV1 blocks with the Amsterdam spec

### DIFF
--- a/core/state_transition.go
+++ b/core/state_transition.go
@@ -766,18 +766,18 @@ func (st *stateTransition) execute() (*ExecutionResult, error) {
 		effectiveTip = new(uint256.Int).Sub(msg.GasPrice, baseFee)
 	}
 	if st.evm.Config.NoBaseFee && msg.GasFeeCap.Sign() == 0 && msg.GasTipCap.Sign() == 0 {
-		// Skip fee payment when NoBaseFee is set and the fee fields
-		// are 0. This avoids a negative effectiveTip being applied to
-		// the coinbase when simulating calls.
-	} else {
-		fee := new(uint256.Int).SetUint64(gasUsed)
-		fee.Mul(fee, effectiveTip)
-		st.state.AddBalance(st.evm.Context.Coinbase, fee, tracing.BalanceIncreaseRewardTransactionFee)
+		// Zero the tip when NoBaseFee is set and the fee fields are 0. This avoids
+		// a negative effectiveTip when simulating calls, while the coinbase is
+		// still accessed like in a real block.
+		effectiveTip = new(uint256.Int)
+	}
+	fee := new(uint256.Int).SetUint64(gasUsed)
+	fee.Mul(fee, effectiveTip)
+	st.state.AddBalance(st.evm.Context.Coinbase, fee, tracing.BalanceIncreaseRewardTransactionFee)
 
-		// add the coinbase to the witness iff the fee is greater than 0
-		if rules.IsEIP4762 && fee.Sign() != 0 {
-			st.evm.AccessEvents.AddAccount(st.evm.Context.Coinbase, true, math.MaxUint64)
-		}
+	// add the coinbase to the witness iff the fee is greater than 0
+	if rules.IsEIP4762 && fee.Sign() != 0 {
+		st.evm.AccessEvents.AddAccount(st.evm.Context.Coinbase, true, math.MaxUint64)
 	}
 
 	return &ExecutionResult{

--- a/internal/ethapi/api_test.go
+++ b/internal/ethapi/api_test.go
@@ -47,6 +47,7 @@ import (
 	"github.com/ethereum/go-ethereum/core/rawdb"
 	"github.com/ethereum/go-ethereum/core/state"
 	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/core/types/bal"
 	"github.com/ethereum/go-ethereum/core/vm"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/crypto/kzg4844"
@@ -2754,6 +2755,104 @@ func TestSimulateV1WithdrawalsByFork(t *testing.T) {
 	t.Run("post-shanghai", func(t *testing.T) {
 		// MergedTestChainConfig has every fork active from genesis.
 		run(t, params.MergedTestChainConfig, nil, true)
+	})
+}
+
+// TestSimulateV1Amsterdam checks the identity of simulated blocks after
+// Amsterdam: the slot number follows the parent, the block access list
+// includes the coinbase and the EIP-7708 logs replace the traceTransfers logs.
+func TestSimulateV1Amsterdam(t *testing.T) {
+	t.Parallel()
+
+	run := func(t *testing.T, amsterdamTime uint64, blocks []simBlock) (*types.Header, []*simBlockResult) {
+		t.Helper()
+		accounts := newAccounts(2)
+		config := *params.MergedTestChainConfig
+		config.AmsterdamTime = &amsterdamTime
+		gspec := &core.Genesis{
+			Config:     &config,
+			Difficulty: common.Big0,
+			Alloc: types.GenesisAlloc{
+				accounts[0].addr: {Balance: big.NewInt(params.Ether)},
+				accounts[1].addr: {Balance: big.NewInt(params.Ether)},
+			},
+		}
+		backend := newTestBackend(t, 1, gspec, beacon.New(ethash.NewFaker()), func(i int, b *core.BlockGen) {})
+		ctx := context.Background()
+		stateDB, baseHeader, err := backend.StateAndHeaderByNumberOrHash(ctx, rpc.BlockNumberOrHashWithNumber(rpc.LatestBlockNumber))
+		require.NoError(t, err)
+		sim := &simulator{
+			b:              backend,
+			state:          stateDB,
+			base:           baseHeader,
+			chainConfig:    backend.ChainConfig(),
+			budget:         newGasBudget(0),
+			traceTransfers: true,
+		}
+		for i := range blocks {
+			blocks[i].Calls = []TransactionArgs{{
+				From:  &accounts[0].addr,
+				To:    &accounts[1].addr,
+				Value: (*hexutil.Big)(big.NewInt(1000)),
+			}}
+		}
+		results, err := sim.execute(ctx, blocks)
+		require.NoError(t, err)
+		require.Len(t, results, len(blocks))
+		return baseHeader, results
+	}
+	findAccount := func(list *bal.BlockAccessList, addr common.Address) *bal.AccountAccess {
+		for i := range *list {
+			if (*list)[i].Address == addr {
+				return &(*list)[i]
+			}
+		}
+		return nil
+	}
+	transferLogs := func(t *testing.T, res *simBlockResult, want common.Address) {
+		t.Helper()
+		require.Len(t, res.Calls, 1)
+		require.Len(t, res.Calls[0].Logs, 1, "expected exactly one transfer log")
+		require.Equal(t, want, res.Calls[0].Logs[0].Address)
+	}
+
+	t.Run("amsterdam-parent", func(t *testing.T) {
+		base, results := run(t, 0, make([]simBlock, 2))
+		require.NotNil(t, base.SlotNumber)
+		for i, res := range results {
+			header := res.Block.Header()
+			require.NotNil(t, header.SlotNumber, "block %d: slot number missing", i)
+			require.Equal(t, *base.SlotNumber+1+uint64(i), *header.SlotNumber, "block %d: slot number", i)
+			require.NotNil(t, header.BlockAccessListHash, "block %d: block access list hash missing", i)
+			transferLogs(t, res, params.SystemAddress)
+		}
+		list := results[0].Block.AccessList()
+		require.NotNil(t, list)
+		coinbase := findAccount(list, results[0].Block.Coinbase())
+		require.NotNil(t, coinbase, "coinbase missing from block access list:\n%s", list.PrettyPrint())
+		require.Empty(t, coinbase.BalanceChanges, "coinbase balance must not change with zero fees")
+		sender := findAccount(list, results[0].senders[results[0].Block.Transactions()[0].Hash()])
+		require.NotNil(t, sender)
+		require.Len(t, sender.NonceChanges, 1, "sender nonce increment must be recorded")
+	})
+
+	t.Run("fork-crossing", func(t *testing.T) {
+		// The base block is pre-Amsterdam, the second simulated block crosses the fork.
+		forkTime := hexutil.Uint64(1000)
+		blocks := make([]simBlock, 2)
+		blocks[1].BlockOverrides = &override.BlockOverrides{Time: &forkTime}
+		base, results := run(t, uint64(forkTime), blocks)
+		require.Nil(t, base.SlotNumber)
+
+		pre := results[0].Block.Header()
+		require.Nil(t, pre.SlotNumber)
+		require.Nil(t, pre.BlockAccessListHash)
+		transferLogs(t, results[0], transferAddress)
+
+		post := results[1].Block.Header()
+		require.Nil(t, post.SlotNumber, "slot number must be omitted when the parent has none")
+		require.NotNil(t, post.BlockAccessListHash)
+		transferLogs(t, results[1], params.SystemAddress)
 	})
 }
 

--- a/internal/ethapi/api_test.go
+++ b/internal/ethapi/api_test.go
@@ -47,7 +47,6 @@ import (
 	"github.com/ethereum/go-ethereum/core/rawdb"
 	"github.com/ethereum/go-ethereum/core/state"
 	"github.com/ethereum/go-ethereum/core/types"
-	"github.com/ethereum/go-ethereum/core/types/bal"
 	"github.com/ethereum/go-ethereum/core/vm"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/crypto/kzg4844"
@@ -2755,104 +2754,6 @@ func TestSimulateV1WithdrawalsByFork(t *testing.T) {
 	t.Run("post-shanghai", func(t *testing.T) {
 		// MergedTestChainConfig has every fork active from genesis.
 		run(t, params.MergedTestChainConfig, nil, true)
-	})
-}
-
-// TestSimulateV1Amsterdam checks the identity of simulated blocks after
-// Amsterdam: the slot number follows the parent, the block access list
-// includes the coinbase and the EIP-7708 logs replace the traceTransfers logs.
-func TestSimulateV1Amsterdam(t *testing.T) {
-	t.Parallel()
-
-	run := func(t *testing.T, amsterdamTime uint64, blocks []simBlock) (*types.Header, []*simBlockResult) {
-		t.Helper()
-		accounts := newAccounts(2)
-		config := *params.MergedTestChainConfig
-		config.AmsterdamTime = &amsterdamTime
-		gspec := &core.Genesis{
-			Config:     &config,
-			Difficulty: common.Big0,
-			Alloc: types.GenesisAlloc{
-				accounts[0].addr: {Balance: big.NewInt(params.Ether)},
-				accounts[1].addr: {Balance: big.NewInt(params.Ether)},
-			},
-		}
-		backend := newTestBackend(t, 1, gspec, beacon.New(ethash.NewFaker()), func(i int, b *core.BlockGen) {})
-		ctx := context.Background()
-		stateDB, baseHeader, err := backend.StateAndHeaderByNumberOrHash(ctx, rpc.BlockNumberOrHashWithNumber(rpc.LatestBlockNumber))
-		require.NoError(t, err)
-		sim := &simulator{
-			b:              backend,
-			state:          stateDB,
-			base:           baseHeader,
-			chainConfig:    backend.ChainConfig(),
-			budget:         newGasBudget(0),
-			traceTransfers: true,
-		}
-		for i := range blocks {
-			blocks[i].Calls = []TransactionArgs{{
-				From:  &accounts[0].addr,
-				To:    &accounts[1].addr,
-				Value: (*hexutil.Big)(big.NewInt(1000)),
-			}}
-		}
-		results, err := sim.execute(ctx, blocks)
-		require.NoError(t, err)
-		require.Len(t, results, len(blocks))
-		return baseHeader, results
-	}
-	findAccount := func(list *bal.BlockAccessList, addr common.Address) *bal.AccountAccess {
-		for i := range *list {
-			if (*list)[i].Address == addr {
-				return &(*list)[i]
-			}
-		}
-		return nil
-	}
-	transferLogs := func(t *testing.T, res *simBlockResult, want common.Address) {
-		t.Helper()
-		require.Len(t, res.Calls, 1)
-		require.Len(t, res.Calls[0].Logs, 1, "expected exactly one transfer log")
-		require.Equal(t, want, res.Calls[0].Logs[0].Address)
-	}
-
-	t.Run("amsterdam-parent", func(t *testing.T) {
-		base, results := run(t, 0, make([]simBlock, 2))
-		require.NotNil(t, base.SlotNumber)
-		for i, res := range results {
-			header := res.Block.Header()
-			require.NotNil(t, header.SlotNumber, "block %d: slot number missing", i)
-			require.Equal(t, *base.SlotNumber+1+uint64(i), *header.SlotNumber, "block %d: slot number", i)
-			require.NotNil(t, header.BlockAccessListHash, "block %d: block access list hash missing", i)
-			transferLogs(t, res, params.SystemAddress)
-		}
-		list := results[0].Block.AccessList()
-		require.NotNil(t, list)
-		coinbase := findAccount(list, results[0].Block.Coinbase())
-		require.NotNil(t, coinbase, "coinbase missing from block access list:\n%s", list.PrettyPrint())
-		require.Empty(t, coinbase.BalanceChanges, "coinbase balance must not change with zero fees")
-		sender := findAccount(list, results[0].senders[results[0].Block.Transactions()[0].Hash()])
-		require.NotNil(t, sender)
-		require.Len(t, sender.NonceChanges, 1, "sender nonce increment must be recorded")
-	})
-
-	t.Run("fork-crossing", func(t *testing.T) {
-		// The base block is pre-Amsterdam, the second simulated block crosses the fork.
-		forkTime := hexutil.Uint64(1000)
-		blocks := make([]simBlock, 2)
-		blocks[1].BlockOverrides = &override.BlockOverrides{Time: &forkTime}
-		base, results := run(t, uint64(forkTime), blocks)
-		require.Nil(t, base.SlotNumber)
-
-		pre := results[0].Block.Header()
-		require.Nil(t, pre.SlotNumber)
-		require.Nil(t, pre.BlockAccessListHash)
-		transferLogs(t, results[0], transferAddress)
-
-		post := results[1].Block.Header()
-		require.Nil(t, post.SlotNumber, "slot number must be omitted when the parent has none")
-		require.NotNil(t, post.BlockAccessListHash)
-		transferLogs(t, results[1], params.SystemAddress)
 	})
 }
 

--- a/internal/ethapi/simulate.go
+++ b/internal/ethapi/simulate.go
@@ -284,9 +284,6 @@ func (sim *simulator) processBlock(ctx context.Context, block *simBlock, header,
 		blockContext.BlobBaseFee = block.BlockOverrides.BlobBaseFee.ToInt()
 	}
 	precompiles := sim.activePrecompiles(header)
-	// Use the EVM rules so the synthetic transfer log is dropped only when the
-	// EIP-7708 protocol log is emitted.
-	rules := sim.chainConfig.Rules(header.Number, blockContext.Random != nil, header.Time)
 
 	// State overrides are applied prior to execution of a block
 	if err := block.StateOverrides.Apply(sim.state, precompiles); err != nil {
@@ -302,7 +299,7 @@ func (sim *simulator) processBlock(ctx context.Context, block *simBlock, header,
 		blockAccessList = bal.NewConstructionBlockAccessList()
 
 		// Block hash will be repaired after execution.
-		tracer   = newTracer(sim.traceTransfers && !rules.IsAmsterdam, blockContext.BlockNumber.Uint64(), blockContext.Time, common.Hash{}, common.Hash{}, 0)
+		tracer   = newTracer(sim.traceTransfers, blockContext.BlockNumber.Uint64(), blockContext.Time, common.Hash{}, common.Hash{}, 0)
 		vmConfig = &vm.Config{
 			NoBaseFee: !sim.validate,
 			Tracer:    tracer.Hooks(),

--- a/internal/ethapi/simulate.go
+++ b/internal/ethapi/simulate.go
@@ -284,6 +284,9 @@ func (sim *simulator) processBlock(ctx context.Context, block *simBlock, header,
 		blockContext.BlobBaseFee = block.BlockOverrides.BlobBaseFee.ToInt()
 	}
 	precompiles := sim.activePrecompiles(header)
+	// Use the EVM rules so the synthetic transfer log is dropped only when the
+	// EIP-7708 protocol log is emitted.
+	rules := sim.chainConfig.Rules(header.Number, blockContext.Random != nil, header.Time)
 
 	// State overrides are applied prior to execution of a block
 	if err := block.StateOverrides.Apply(sim.state, precompiles); err != nil {
@@ -299,7 +302,7 @@ func (sim *simulator) processBlock(ctx context.Context, block *simBlock, header,
 		blockAccessList = bal.NewConstructionBlockAccessList()
 
 		// Block hash will be repaired after execution.
-		tracer   = newTracer(sim.traceTransfers, blockContext.BlockNumber.Uint64(), blockContext.Time, common.Hash{}, common.Hash{}, 0)
+		tracer   = newTracer(sim.traceTransfers && !rules.IsAmsterdam, blockContext.BlockNumber.Uint64(), blockContext.Time, common.Hash{}, common.Hash{}, 0)
 		vmConfig = &vm.Config{
 			NoBaseFee: !sim.validate,
 			Tracer:    tracer.Hooks(),
@@ -566,6 +569,12 @@ func (sim *simulator) makeHeaders(blocks []simBlock) ([]*types.Header, error) {
 		if sim.chainConfig.IsPostMerge(number.Uint64(), timestamp) {
 			difficulty = big.NewInt(0)
 		}
+		// The slot number is unknown when the parent has none, so it is omitted then.
+		var slotNumber *uint64
+		if header.SlotNumber != nil {
+			slot := *header.SlotNumber + 1
+			slotNumber = &slot
+		}
 		header = overrides.MakeHeader(&types.Header{
 			UncleHash:        types.EmptyUncleHash,
 			ReceiptHash:      types.EmptyReceiptsHash,
@@ -575,6 +584,7 @@ func (sim *simulator) makeHeaders(blocks []simBlock) ([]*types.Header, error) {
 			GasLimit:         header.GasLimit,
 			WithdrawalsHash:  withdrawalsHash,
 			ParentBeaconRoot: parentBeaconRoot,
+			SlotNumber:       slotNumber,
 		})
 		res[bi] = header
 	}


### PR DESCRIPTION
Implements the eth_simulateV1 rules from ethereum/execution-apis#881 (issue ethereum/execution-apis#868). After Amsterdam the spec did not say what a simulated block looks like, and every client answered differently. This PR makes geth match the proposed text. Draft until the spec PR has agreement.

Two changes:

1. `internal/ethapi/simulate.go`: simulated headers carry `slotNumber` = parent slot + 1. When the parent has no slot number the field stays omitted, because no correct value exists. This also makes `SLOTNUM` return the right value in simulation.
2. `core/state_transition.go`: with `NoBaseFee` and zero fee caps, the tip is set to zero instead of skipping the coinbase credit. The coinbase is then accessed like in a real block and enters the EIP-7928 block access list with empty changes. The skip only existed to avoid a negative tip, which zeroing the tip also avoids. `eth_call`, `eth_estimateGas`, `eth_createAccessList` and the tracers share this branch. They discard the state, the zero add emits no `OnBalanceChange`, and after EIP-158 the touched empty coinbase is deleted at finalise, so their output does not change.

The `traceTransfers` change for EIP-7708 is handled in #35617.
