### PR TITLE
consensus/clique: return fallback difficulty when snapshot lookup fails

### DIFF
--- a/consensus/clique/clique.go
+++ b/consensus/clique/clique.go
@@ -600,7 +600,7 @@ func (c *Clique) Seal(chain consensus.ChainHeaderReader, block *types.Block, res
 func (c *Clique) CalcDifficulty(chain consensus.ChainHeaderReader, time uint64, parent *types.Header) *big.Int {
 	snap, err := c.snapshot(chain, parent.Number.Uint64(), parent.Hash(), nil)
 	if err != nil {
-		return nil
+		return new(big.Int).Set(diffNoTurn)
 	}
 	c.lock.RLock()
 	signer := c.signer


### PR DESCRIPTION
## Summary
- `CalcDifficulty` returned `nil` when snapshot lookup failed, while callers assign the result directly to header difficulty and expect a non-nil `*big.Int`.
- Return a copy of `diffNoTurn` on snapshot errors, matching the existing out-of-turn fallback.

## Test plan
- [ ] `go test ./consensus/clique/...`
- [ ] Confirm header construction still receives a non-nil difficulty if snapshot lookup fails.