### PR TITLE
accounts/scwallet: check deserialize error in transmitEncrypted

### DIFF
--- a/accounts/scwallet/securechannel.go
+++ b/accounts/scwallet/securechannel.go
@@ -258,7 +258,10 @@ func (s *SecureChannelSession) transmitEncrypted(cla, ins, p1, p2 byte, data []b
 	}
 
 	rapdu := &responseAPDU{}
-	rapdu.deserialize(plainData)
+	err = rapdu.deserialize(plainData)
+	if err != nil {
+		return nil, err
+	}
 
 	if rapdu.Sw1 != sw1Ok {
 		return nil, fmt.Errorf("unexpected response status Cla=%#x, Ins=%#x, Sw=%#x%x", cla, ins, rapdu.Sw1, rapdu.Sw2)


### PR DESCRIPTION
## Summary
- `transmitEncrypted` ignored the error from `responseAPDU.deserialize`, so a truncated or malformed decrypted APDU could still be treated as a valid response.
- Return the deserialize error, matching the existing check in `wallet.go`.

## Test plan
- [ ] `go test ./accounts/scwallet/...`
- [ ] Confirm encrypted APDU handling still succeeds on well-formed responses and surfaces deserialize failures.