### PR TITLE
cmd/devp2p, p2p/discover: add metrics to discovery listeners

### DIFF
--- a/cmd/devp2p/README.md
+++ b/cmd/devp2p/README.md
@@ -87,6 +87,12 @@ versions (currently discv4 and discv5) on a single UDP port. For a single-protoc
 `devp2p discv4 listen` or `devp2p discv5 listen`. Add `--rpc <addr>` to expose the
 per-protocol HTTP API (`discv4_*`, `discv5_*`).
 
+Add the global `--metrics` flag to any listen command to collect metrics. They are served
+at `/debug/metrics/prometheus` (and `/debug/metrics` as expvar JSON) on
+`--metrics.addr`:`--metrics.port`, default `127.0.0.1:6060`. The `discover/*` series
+report table size per bucket, bytes in and out, received packets per message type, and
+dropped packets per protocol version.
+
 ### Discovery Test Suites
 
 The devp2p command also contains interactive test suites for Discovery v4 and Discovery

--- a/cmd/devp2p/main.go
+++ b/cmd/devp2p/main.go
@@ -21,9 +21,11 @@ import (
 	"net/http"
 	"os"
 
+	"github.com/ethereum/go-ethereum/cmd/utils"
 	"github.com/ethereum/go-ethereum/internal/debug"
 	"github.com/ethereum/go-ethereum/internal/flags"
 	"github.com/ethereum/go-ethereum/log"
+	"github.com/ethereum/go-ethereum/metrics"
 	"github.com/ethereum/go-ethereum/p2p/enode"
 	"github.com/ethereum/go-ethereum/rpc"
 	"github.com/urfave/cli/v2"
@@ -33,9 +35,22 @@ var app = flags.NewApp("go-ethereum devp2p tool")
 
 func init() {
 	app.Flags = append(app.Flags, debug.Flags...)
+	app.Flags = append(app.Flags, utils.MetricsEnabledFlag, utils.MetricsHTTPFlag, utils.MetricsPortFlag)
 	app.Before = func(ctx *cli.Context) error {
 		flags.MigrateGlobalFlags(ctx)
-		return debug.Setup(ctx)
+		if err := debug.Setup(ctx); err != nil {
+			return err
+		}
+		cfg := metrics.DefaultConfig
+		cfg.Enabled = ctx.Bool(utils.MetricsEnabledFlag.Name)
+		if ctx.IsSet(utils.MetricsHTTPFlag.Name) {
+			cfg.HTTP = ctx.String(utils.MetricsHTTPFlag.Name)
+		}
+		if ctx.IsSet(utils.MetricsPortFlag.Name) {
+			cfg.Port = ctx.Int(utils.MetricsPortFlag.Name)
+		}
+		utils.SetupMetrics(&cfg)
+		return nil
 	}
 	app.After = func(ctx *cli.Context) error {
 		debug.Exit()

--- a/p2p/discover/metrics.go
+++ b/p2p/discover/metrics.go
@@ -37,7 +37,16 @@ var (
 	bucketsCounter      []*metrics.Counter
 	ingressTrafficMeter = metrics.NewRegisteredMeter(ingressMeterName, nil)
 	egressTrafficMeter  = metrics.NewRegisteredMeter(egressMeterName, nil)
+	v4BadPacketMeter    = metrics.NewRegisteredMeter(moduleName+"/v4/bad", nil)
+	v5BadPacketMeter    = metrics.NewRegisteredMeter(moduleName+"/v5/bad", nil)
 )
+
+// markInbound counts a received packet by its wire name, e.g. discover/ingress/PING/v4.
+func markInbound(name string) {
+	if metrics.Enabled() {
+		metrics.GetOrRegisterMeter(ingressMeterName+"/"+name, nil).Mark(1)
+	}
+}
 
 func init() {
 	for i := 0; i < nBuckets; i++ {
@@ -49,6 +58,9 @@ func init() {
 // inbound and outbound network traffic.
 type meteredUdpConn struct {
 	udpConn UDPConn
+	// skipRead is set for SharedUDPConn: its reads replay packets already
+	// counted by the primary listener's socket read.
+	skipRead bool
 }
 
 func newMeteredConn(conn UDPConn) UDPConn {
@@ -56,7 +68,8 @@ func newMeteredConn(conn UDPConn) UDPConn {
 	if !metrics.Enabled() {
 		return conn
 	}
-	return &meteredUdpConn{udpConn: conn}
+	_, shared := conn.(*SharedUDPConn)
+	return &meteredUdpConn{udpConn: conn, skipRead: shared}
 }
 
 func (c *meteredUdpConn) Close() error {
@@ -70,7 +83,9 @@ func (c *meteredUdpConn) LocalAddr() net.Addr {
 // ReadFromUDPAddrPort delegates a network read to the underlying connection, bumping the udp ingress traffic meter along the way.
 func (c *meteredUdpConn) ReadFromUDPAddrPort(b []byte) (n int, addr netip.AddrPort, err error) {
 	n, addr, err = c.udpConn.ReadFromUDPAddrPort(b)
-	ingressTrafficMeter.Mark(int64(n))
+	if !c.skipRead {
+		ingressTrafficMeter.Mark(int64(n))
+	}
 	return n, addr, err
 }
 

--- a/p2p/discover/metrics_test.go
+++ b/p2p/discover/metrics_test.go
@@ -1,0 +1,91 @@
+// Copyright 2026 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+
+package discover
+
+import (
+	"net"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/internal/testlog"
+	"github.com/ethereum/go-ethereum/log"
+	"github.com/ethereum/go-ethereum/metrics"
+	"github.com/ethereum/go-ethereum/p2p/enode"
+)
+
+// This test runs v4 and v5 on one shared socket, as a devp2p bootnode would,
+// and checks that v5 traffic forwarded through the shared connection is neither
+// counted as bad v4 traffic nor counted twice in the ingress meter.
+func TestMetricsSharedSocket(t *testing.T) {
+	metrics.Enable()
+
+	key := newkey()
+	db, _ := enode.OpenDB("")
+	defer db.Close()
+	ln := enode.NewLocalNode(db, key)
+	socket, err := net.ListenUDP("udp4", &net.UDPAddr{IP: net.IP{127, 0, 0, 1}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	realaddr := socket.LocalAddr().(*net.UDPAddr)
+	ln.SetStaticIP(realaddr.IP)
+	ln.SetFallbackUDP(realaddr.Port)
+
+	cfg := Config{PrivateKey: key, Log: testlog.Logger(t, log.LevelTrace)}
+	unhandled := make(chan ReadPacket, 100)
+	v4cfg := cfg
+	v4cfg.Unhandled = unhandled
+	v4, err := ListenV4(socket, ln, v4cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	v5, err := ListenV5(&SharedUDPConn{UDPConn: socket, Unhandled: unhandled}, ln, cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		v4.Close()
+		v5.Close()
+	}()
+	remote := startLocalhostV5(t, Config{})
+	defer remote.Close()
+
+	var (
+		v4bad   = v4BadPacketMeter.Snapshot().Count()
+		v5bad   = v5BadPacketMeter.Snapshot().Count()
+		ingress = ingressTrafficMeter.Snapshot().Count()
+		egress  = egressTrafficMeter.Snapshot().Count()
+		pings   = metrics.GetOrRegisterMeter(ingressMeterName+"/PING/v5", nil).Snapshot().Count()
+	)
+	if _, err := remote.Ping(ln.Node()); err != nil {
+		t.Fatal(err)
+	}
+	if n := v4BadPacketMeter.Snapshot().Count() - v4bad; n != 0 {
+		t.Errorf("v4 bad packet meter counted %d forwarded v5 packets", n)
+	}
+	if n := v5BadPacketMeter.Snapshot().Count() - v5bad; n != 0 {
+		t.Errorf("v5 bad packet meter counted %d packets", n)
+	}
+	if n := metrics.GetOrRegisterMeter(ingressMeterName+"/PING/v5", nil).Snapshot().Count() - pings; n != 1 {
+		t.Errorf("PING/v5 ingress meter counted %d, want 1", n)
+	}
+	// Every packet crossed localhost between two metered sockets, so bytes
+	// received can not exceed bytes sent unless the shared read counted twice.
+	in, out := ingressTrafficMeter.Snapshot().Count()-ingress, egressTrafficMeter.Snapshot().Count()-egress
+	if in > out {
+		t.Errorf("ingress %d bytes > egress %d bytes: shared socket reads counted twice", in, out)
+	}
+}

--- a/p2p/discover/v4_udp.go
+++ b/p2p/discover/v4_udp.go
@@ -556,6 +556,7 @@ func (t *UDPv4) readLoop(unhandled chan<- ReadPacket) {
 			return
 		}
 		if err := t.handlePacket(from, buf[:nbytes]); err != nil && unhandled == nil {
+			v4BadPacketMeter.Mark(1)
 			t.log.Debug("Bad discv4 packet", "addr", from, "err", err)
 		} else if err != nil && unhandled != nil {
 			p := ReadPacket{bytes.Clone(buf[:nbytes]), from}
@@ -578,6 +579,7 @@ func (t *UDPv4) handlePacket(from netip.AddrPort, buf []byte) error {
 		return err
 	}
 	packet := t.wrapPacket(rawpacket)
+	markInbound(packet.Name())
 	fromID := fromKey.ID()
 	if packet.preverify != nil {
 		err = packet.preverify(packet, from, fromID, fromKey)

--- a/p2p/discover/v5_udp.go
+++ b/p2p/discover/v5_udp.go
@@ -750,9 +750,11 @@ func (t *UDPv5) handlePacket(rawpacket []byte, fromAddr netip.AddrPort) error {
 			t.unhandled <- up
 			return nil
 		}
+		v5BadPacketMeter.Mark(1)
 		t.log.Debug("Bad discv5 packet", "id", fromID, "addr", addr, "err", err)
 		return err
 	}
+	markInbound(packet.Name())
 	if fromNode != nil {
 		// Handshake succeeded, add to table.
 		t.tab.addInboundNode(fromNode)


### PR DESCRIPTION
When running `devp2p discv4 listen`, `devp2p discv5 listen` or `devp2p discovery listen` as a bootnode, there are no metrics. The operator cannot see table size, packet rates or dropped packets.

`p2p/discover` already has metrics for bytes in and out and for table size per bucket. They never reported in devp2p because nothing called `metrics.Enable()`. This PR turns them on and adds packet counters.

## Changes

`cmd/devp2p` gets the geth flags `--metrics`, `--metrics.addr` and `--metrics.port`. The metrics server listens on `127.0.0.1:6060` by default and serves `/debug/metrics/prometheus` and `/debug/metrics`. With `--pprof` and no `--metrics.addr`, the pprof server serves the same paths. This matches geth.

`p2p/discover` counts each received packet by wire name, for example `discover/ingress/PING/v4` and `discover/ingress/FINDNODE/v5`. Two new meters, `discover/v4/bad` and `discover/v5/bad`, count packets a protocol logged as bad. The hooks sit next to the existing "Bad discv4 packet" and "Bad discv5 packet" log lines and count exactly what those log.

`newMeteredConn` now skips read metering on a `SharedUDPConn`. Before this change, a packet that v4 forwarded to v5 counted twice in `discover/ingress`, once on the socket read and once on the shared read. This also applies to geth, which uses `SharedUDPConn` in `p2p/server.go`.

## Behaviour in combined mode

v4 is the primary reader on the socket. A v4 packet that decodes but fails validation, for example an expired ping or an unsolicited pong, goes to v5 and counts in `discover/v5/bad`. This is the existing forwarding logic. The metrics only report it.

`discover/bucket/<i>/count` is one counter per bucket for the whole process. In `discovery listen` both the v4 table and the v5 table update it, so it reports the sum of both. This is pre-existing and unchanged.

## Test

`TestMetricsSharedSocket` runs v4 and v5 on one socket and pings it from a second v5 node. It checks that no forwarded packet counts as bad v4 traffic, that `PING/v5` counts once, and that bytes received do not exceed bytes sent. Without the `skipRead` change the last check fails with 1046 bytes in against 611 out.

Manual check with `devp2p --metrics discovery listen` and one `discv4 ping` from another process:

```
discover_egress 286
discover_ingress 132
discover_ingress_PING_v4 1
discover_v4_bad 0
discover_v5_bad 0
```
