### PR TITLE
core/types: reuse RLP hashing helper

### DIFF
--- a/core/types/hashing.go
+++ b/core/types/hashing.go
@@ -53,28 +53,29 @@ func getPooledBuffer(size uint64) ([]byte, *bytes.Buffer, error) {
 	return b, buf, nil
 }
 
-// rlpHash encodes x and hashes the encoded bytes.
-func rlpHash(x interface{}) common.Hash {
-	return rlpHashWithPrefix(nil, x)
-}
-
 // rlpHashWithPrefix optionally writes a type prefix before encoding x.
 func rlpHashWithPrefix(prefix *byte, x interface{}) (h common.Hash) {
-	sha := hasherPool.Get().(crypto.KeccakState)
-	defer hasherPool.Put(sha)
-	sha.Reset()
-	if prefix != nil {
-		sha.Write([]byte{*prefix})
-	}
-	rlp.Encode(sha, x)
-	sha.Read(h[:])
-	return h
+    sha := hasherPool.Get().(crypto.KeccakState)
+    defer hasherPool.Put(sha)
+
+    sha.Reset()
+    if prefix != nil {
+        sha.Write([]byte{*prefix})
+    }
+    rlp.Encode(sha, x)
+    sha.Read(h[:])
+    return h
 }
 
-// prefixedRlpHash writes the prefix into the hasher before rlp-encoding x.
+// rlpHash encodes x and hashes the encoded bytes.
+func rlpHash(x interface{}) common.Hash {
+    return rlpHashWithPrefix(nil, x)
+}
+
+// prefixedRlpHash writes the prefix before RLP-encoding x.
 // It's used for typed transactions.
 func prefixedRlpHash(prefix byte, x interface{}) common.Hash {
-	return rlpHashWithPrefix(&prefix, x)
+    return rlpHashWithPrefix(&prefix, x)
 }
 
 // ListHasher defines the interface for computing the hash of a derivable list.

--- a/core/types/hashing.go
+++ b/core/types/hashing.go
@@ -54,10 +54,18 @@ func getPooledBuffer(size uint64) ([]byte, *bytes.Buffer, error) {
 }
 
 // rlpHash encodes x and hashes the encoded bytes.
-func rlpHash(x interface{}) (h common.Hash) {
+func rlpHash(x interface{}) common.Hash {
+	return rlpHashWithPrefix(nil, x)
+}
+
+// rlpHashWithPrefix optionally writes a type prefix before encoding x.
+func rlpHashWithPrefix(prefix *byte, x interface{}) (h common.Hash) {
 	sha := hasherPool.Get().(crypto.KeccakState)
 	defer hasherPool.Put(sha)
 	sha.Reset()
+	if prefix != nil {
+		sha.Write([]byte{*prefix})
+	}
 	rlp.Encode(sha, x)
 	sha.Read(h[:])
 	return h
@@ -65,14 +73,8 @@ func rlpHash(x interface{}) (h common.Hash) {
 
 // prefixedRlpHash writes the prefix into the hasher before rlp-encoding x.
 // It's used for typed transactions.
-func prefixedRlpHash(prefix byte, x interface{}) (h common.Hash) {
-	sha := hasherPool.Get().(crypto.KeccakState)
-	defer hasherPool.Put(sha)
-	sha.Reset()
-	sha.Write([]byte{prefix})
-	rlp.Encode(sha, x)
-	sha.Read(h[:])
-	return h
+func prefixedRlpHash(prefix byte, x interface{}) common.Hash {
+	return rlpHashWithPrefix(&prefix, x)
 }
 
 // ListHasher defines the interface for computing the hash of a derivable list.


### PR DESCRIPTION
Refactors the RLP hashing functions in `core/types` to share the pooled Keccak hasher setup.

`rlpHash` and `prefixedRlpHash` now call `rlpHashWithPrefix`, which handles resetting, optionally writing the transaction type prefix, encoding, hashing, and returning the hasher to the pool.

This removes duplicated code without changing hashing behavior.

Tests:
- `go test ./core/types -count=1`
- `git diff --check`