### PR TITLE
core/vm, params: make EIP-170 activation explicit

### DIFF
--- a/core/vm/common.go
+++ b/core/vm/common.go
@@ -45,7 +45,7 @@ func CheckMaxCodeSize(rules *params.Rules, size uint64) error {
 		if size > params.MaxCodeSizeAmsterdam {
 			return fmt.Errorf("%w: code size %v limit %v", ErrMaxCodeSizeExceeded, size, params.MaxCodeSizeAmsterdam)
 		}
-	} else if rules.IsEIP158 {
+	} else if rules.IsEIP170 {
 		if size > params.MaxCodeSize {
 			return fmt.Errorf("%w: code size %v limit %v", ErrMaxCodeSizeExceeded, size, params.MaxCodeSize)
 		}

--- a/params/config.go
+++ b/params/config.go
@@ -23,6 +23,7 @@ import (
 	"math/big"
 
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/params/forks"
 )
 
@@ -944,7 +945,7 @@ func (c *ChainConfig) CheckConfigForkOrder() error {
 		{name: "daoForkBlock", block: c.DAOForkBlock, optional: true},
 		{name: "eip150Block", block: c.EIP150Block},
 		{name: "eip155Block", block: c.EIP155Block},
-		{name: "eip170Block", block: c.EIP170Block, timestamp: c.EIP170Time},
+		{name: "eip170Block", block: c.EIP170Block, timestamp: c.EIP170Time, optional: true},
 		{name: "byzantiumBlock", block: c.ByzantiumBlock},
 		{name: "constantinopleBlock", block: c.ConstantinopleBlock},
 		{name: "petersburgBlock", block: c.PetersburgBlock},
@@ -1004,6 +1005,9 @@ func (c *ChainConfig) CheckConfigForkOrder() error {
 	}
 	if c.EIP170Block != nil && c.EIP170Time != nil {
 		return fmt.Errorf("unsupported fork configuration: eip170Block %v and eip170Time %v are mutually exclusive", c.EIP170Block, *c.EIP170Time)
+	}
+	if c.EIP170Block == nil && c.EIP170Time == nil && c.EIP158Block != nil {
+		log.Warn("Chain config does not set eip170Block/eip170Time; EIP-170 activation implicitly follows eip158Block. This fallback is deprecated, please set eip170Block/eip170Time explicitly")
 	}
 
 	// Check that all forks with blobs explicitly define the blob schedule configuration.

--- a/params/config.go
+++ b/params/config.go
@@ -47,6 +47,7 @@ var (
 		EIP150Block:             big.NewInt(2_463_000),
 		EIP155Block:             big.NewInt(2_675_000),
 		EIP158Block:             big.NewInt(2_675_000),
+		EIP170Block:             big.NewInt(2_675_000),
 		ByzantiumBlock:          big.NewInt(4_370_000),
 		ConstantinopleBlock:     big.NewInt(7_280_000),
 		PetersburgBlock:         big.NewInt(7_280_000),
@@ -82,6 +83,7 @@ var (
 		EIP150Block:             big.NewInt(0),
 		EIP155Block:             big.NewInt(0),
 		EIP158Block:             big.NewInt(0),
+		EIP170Block:             big.NewInt(0),
 		ByzantiumBlock:          big.NewInt(0),
 		ConstantinopleBlock:     big.NewInt(0),
 		PetersburgBlock:         big.NewInt(0),
@@ -118,6 +120,7 @@ var (
 		EIP150Block:             big.NewInt(0),
 		EIP155Block:             big.NewInt(0),
 		EIP158Block:             big.NewInt(0),
+		EIP170Block:             big.NewInt(0),
 		ByzantiumBlock:          big.NewInt(0),
 		ConstantinopleBlock:     big.NewInt(0),
 		PetersburgBlock:         big.NewInt(0),
@@ -155,6 +158,7 @@ var (
 		EIP150Block:             big.NewInt(0),
 		EIP155Block:             big.NewInt(0),
 		EIP158Block:             big.NewInt(0),
+		EIP170Block:             big.NewInt(0),
 		ByzantiumBlock:          big.NewInt(0),
 		ConstantinopleBlock:     big.NewInt(0),
 		PetersburgBlock:         big.NewInt(0),
@@ -182,6 +186,7 @@ var (
 		EIP150Block:             big.NewInt(0),
 		EIP155Block:             big.NewInt(0),
 		EIP158Block:             big.NewInt(0),
+		EIP170Block:             big.NewInt(0),
 		ByzantiumBlock:          big.NewInt(0),
 		ConstantinopleBlock:     big.NewInt(0),
 		PetersburgBlock:         big.NewInt(0),
@@ -213,6 +218,7 @@ var (
 		EIP150Block:             big.NewInt(0),
 		EIP155Block:             big.NewInt(0),
 		EIP158Block:             big.NewInt(0),
+		EIP170Block:             big.NewInt(0),
 		ByzantiumBlock:          big.NewInt(0),
 		ConstantinopleBlock:     big.NewInt(0),
 		PetersburgBlock:         big.NewInt(0),
@@ -244,6 +250,7 @@ var (
 		EIP150Block:             big.NewInt(0),
 		EIP155Block:             big.NewInt(0),
 		EIP158Block:             big.NewInt(0),
+		EIP170Block:             big.NewInt(0),
 		ByzantiumBlock:          big.NewInt(0),
 		ConstantinopleBlock:     big.NewInt(0),
 		PetersburgBlock:         big.NewInt(0),
@@ -275,6 +282,7 @@ var (
 		EIP150Block:             big.NewInt(0),
 		EIP155Block:             big.NewInt(0),
 		EIP158Block:             big.NewInt(0),
+		EIP170Block:             big.NewInt(0),
 		ByzantiumBlock:          big.NewInt(0),
 		ConstantinopleBlock:     big.NewInt(0),
 		PetersburgBlock:         big.NewInt(0),
@@ -310,6 +318,7 @@ var (
 		EIP150Block:             nil,
 		EIP155Block:             nil,
 		EIP158Block:             nil,
+		EIP170Block:             nil,
 		ByzantiumBlock:          nil,
 		ConstantinopleBlock:     nil,
 		PetersburgBlock:         nil,
@@ -401,6 +410,12 @@ type ChainConfig struct {
 	EIP150Block *big.Int `json:"eip150Block,omitempty"` // EIP150 HF block (nil = no fork)
 	EIP155Block *big.Int `json:"eip155Block,omitempty"` // EIP155 HF block
 	EIP158Block *big.Int `json:"eip158Block,omitempty"` // EIP158 HF block
+
+	// EIP170Block and EIP170Time schedule EIP-170 (contract code size limit)
+	// by block number or timestamp. They are mutually exclusive; EIP170Time
+	// takes precedence. On Ethereum this coincides with EIP158Block.
+	EIP170Block *big.Int `json:"eip170Block,omitempty"`
+	EIP170Time  *uint64  `json:"eip170Time,omitempty"`
 
 	ByzantiumBlock      *big.Int `json:"byzantiumBlock,omitempty"`      // Byzantium switch block (nil = no fork, 0 = already on byzantium)
 	ConstantinopleBlock *big.Int `json:"constantinopleBlock,omitempty"` // Constantinople switch block (nil = no fork, 0 = already activated)
@@ -530,6 +545,12 @@ func (c *ChainConfig) String() string {
 	}
 	if c.MergeNetsplitBlock != nil {
 		result += fmt.Sprintf(", MergeNetsplitBlock: %v", c.MergeNetsplitBlock)
+	}
+	if c.EIP170Block != nil {
+		result += fmt.Sprintf(", EIP170Block: %v", c.EIP170Block)
+	}
+	if c.EIP170Time != nil {
+		result += fmt.Sprintf(", EIP170Time: %v", *c.EIP170Time)
 	}
 
 	// Add timestamp-based forks
@@ -726,6 +747,19 @@ func (c *ChainConfig) IsEIP158(num *big.Int) bool {
 	return isBlockForked(c.EIP158Block, num)
 }
 
+// IsEIP170 returns whether EIP-170 is active at the given block and time,
+// with EIP170Time taking precedence over EIP170Block.
+func (c *ChainConfig) IsEIP170(num *big.Int, time uint64) bool {
+	switch {
+	case c.EIP170Time != nil:
+		return isTimestampForked(c.EIP170Time, time)
+	case c.EIP170Block != nil:
+		return isBlockForked(c.EIP170Block, num)
+	default:
+		return c.IsEIP158(num)
+	}
+}
+
 // IsByzantium returns whether num is either equal to the Byzantium fork block or greater.
 func (c *ChainConfig) IsByzantium(num *big.Int) bool {
 	return isBlockForked(c.ByzantiumBlock, num)
@@ -910,7 +944,7 @@ func (c *ChainConfig) CheckConfigForkOrder() error {
 		{name: "daoForkBlock", block: c.DAOForkBlock, optional: true},
 		{name: "eip150Block", block: c.EIP150Block},
 		{name: "eip155Block", block: c.EIP155Block},
-		{name: "eip158Block", block: c.EIP158Block},
+		{name: "eip170Block", block: c.EIP170Block, timestamp: c.EIP170Time},
 		{name: "byzantiumBlock", block: c.ByzantiumBlock},
 		{name: "constantinopleBlock", block: c.ConstantinopleBlock},
 		{name: "petersburgBlock", block: c.PetersburgBlock},
@@ -967,6 +1001,9 @@ func (c *ChainConfig) CheckConfigForkOrder() error {
 		if !cur.optional || (cur.block != nil || cur.timestamp != nil) {
 			lastFork = cur
 		}
+	}
+	if c.EIP170Block != nil && c.EIP170Time != nil {
+		return fmt.Errorf("unsupported fork configuration: eip170Block %v and eip170Time %v are mutually exclusive", c.EIP170Block, *c.EIP170Time)
 	}
 
 	// Check that all forks with blobs explicitly define the blob schedule configuration.
@@ -1070,6 +1107,12 @@ func (c *ChainConfig) checkCompatible(newcfg *ChainConfig, headNumber *big.Int, 
 	}
 	if isForkBlockIncompatible(c.MergeNetsplitBlock, newcfg.MergeNetsplitBlock, headNumber) {
 		return newBlockCompatError("Merge netsplit fork block", c.MergeNetsplitBlock, newcfg.MergeNetsplitBlock)
+	}
+	if isForkBlockIncompatible(c.EIP170Block, newcfg.EIP170Block, headNumber) {
+		return newBlockCompatError("EIP-170 fork block", c.EIP170Block, newcfg.EIP170Block)
+	}
+	if isForkTimestampIncompatible(c.EIP170Time, newcfg.EIP170Time, headTimestamp) {
+		return newTimestampCompatError("EIP-170 fork timestamp", c.EIP170Time, newcfg.EIP170Time)
 	}
 	if isForkTimestampIncompatible(c.ShanghaiTime, newcfg.ShanghaiTime, headTimestamp) {
 		return newTimestampCompatError("Shanghai fork timestamp", c.ShanghaiTime, newcfg.ShanghaiTime)
@@ -1374,7 +1417,7 @@ func (err *ConfigCompatError) Error() string {
 // phases.
 type Rules struct {
 	IsHomestead, IsEIP150, IsEIP155, IsEIP158               bool
-	IsEIP2929, IsEIP4762                                    bool
+	IsEIP170, IsEIP2929, IsEIP4762                          bool
 	IsByzantium, IsConstantinople, IsPetersburg, IsIstanbul bool
 	IsBerlin, IsLondon                                      bool
 	IsMerge, IsShanghai, IsCancun, IsPrague, IsOsaka        bool
@@ -1391,6 +1434,7 @@ func (c *ChainConfig) Rules(num *big.Int, isMerge bool, timestamp uint64) Rules 
 		IsEIP150:         c.IsEIP150(num),
 		IsEIP155:         c.IsEIP155(num),
 		IsEIP158:         c.IsEIP158(num),
+		IsEIP170:         c.IsEIP170(num, timestamp),
 		IsByzantium:      c.IsByzantium(num),
 		IsConstantinople: c.IsConstantinople(num),
 		IsPetersburg:     c.IsPetersburg(num),


### PR DESCRIPTION
This is the first step in a list of changes that I would like to introduce in order to facilitate fork maintenance: more often than not, an EIP is activated via its fork, not the eip itself. This is a problem when forks decide not to activate some eips.

Ideally, eips could be activated one by one. I'm working on a proposal for that, but it's a major change. This one is only affecting eip 170.