### PR TITLE
node: trim bearer token in jwt handler

### DIFF
--- a/node/jwt_handler.go
+++ b/node/jwt_handler.go
@@ -48,7 +48,7 @@ func (handler *jwtHandler) ServeHTTP(out http.ResponseWriter, r *http.Request) {
 		claims   jwt.RegisteredClaims
 	)
 	if auth := r.Header.Get("Authorization"); len(auth) >= 7 && strings.EqualFold(auth[:7], "bearer ") {
-		strToken = auth[7:]
+		strToken = strings.TrimSpace(auth[7:])
 	}
 	if len(strToken) == 0 {
 		http.Error(out, "missing token", http.StatusUnauthorized)


### PR DESCRIPTION
## Summary
- JWT auth took the raw substring after \`Bearer \`, so leading or trailing whitespace in the Authorization header made an otherwise valid token fail to parse.
- Trim the token before parsing so padded Bearer values are still accepted.

## Test plan
- [ ] \`go test ./node/...\`
- [ ] Confirm a valid JWT still authenticates when the Authorization header has extra spaces around the token.