### PR TITLE
core/txpool/blobpool: delete limbo store entry before dropping indices

### DIFF
--- a/core/txpool/blobpool/limbo.go
+++ b/core/txpool/blobpool/limbo.go
@@ -251,13 +251,13 @@ func (l *limbo) getAndDrop(id uint64) (*limboBlob, error) {
 	if err = rlp.DecodeBytes(data, item); err != nil {
 		return nil, err
 	}
+	if err := l.store.Delete(id); err != nil {
+		return nil, err
+	}
 	delete(l.index, item.TxHash)
 	delete(l.groups[item.Block], id)
 	if len(l.groups[item.Block]) == 0 {
 		delete(l.groups, item.Block)
-	}
-	if err := l.store.Delete(id); err != nil {
-		return nil, err
 	}
 	return item, nil
 }


### PR DESCRIPTION
## Summary
- `getAndDrop` removed the limbo item from `index`/`groups` before `store.Delete`. If the delete failed, the function returned an error while memory no longer tracked the still-on-disk blob, so later pull/update missed it until restart.
- Delete from the store first and only drop the in-memory indices after the persistent delete succeeds.

## Test plan
- [ ] `go test ./core/txpool/blobpool/...`
- [ ] Confirm limbo pull/update still finds a blob when `store.Delete` fails, and drops both store and indices when it succeeds.