### PR TITLE
eth/downloader: rework the scheduling of body and receipt retrievals

### DIFF
--- a/eth/downloader/downloader.go
+++ b/eth/downloader/downloader.go
@@ -165,6 +165,7 @@ type Downloader struct {
 	syncStartBlock uint64    // Head snap block when Geth was started
 	syncStartTime  time.Time // Time instance when chain sync started
 	syncLogTime    time.Time // Time instance when status was last reported
+	syncLogStalls  uint64    // Fetcher rounds throttled by the result cache when status was last reported
 }
 
 // BlockChain encapsulates functions required to sync a (full or snap) blockchain.
@@ -1332,6 +1333,17 @@ func (d *Downloader) reportSnapSyncProgress(force bool) {
 	if latest.Number.Uint64() != 0 {
 		chainProgressGauge.Update(float64(block.Number.Uint64()) / float64(latest.Number.Uint64()))
 	}
-	log.Info("Syncing: chain download in progress", "synced", progress, "chain", syncedBytes, "headers", headers, "bodies", bodies, "receipts", receipts, "eta", common.PrettyDuration(eta))
+	// Report the retrieval pipeline state too: requests in flight and peers
+	// left idle tell whether the download is bound by the remote peers or by
+	// the local result cache (throttled rounds) and importer.
+	var (
+		inflight = fmt.Sprintf("%d+%d", bodyFetchMetrics.busyPeers.Snapshot().Value(), receiptFetchMetrics.busyPeers.Snapshot().Value())
+		idle     = fmt.Sprintf("%d+%d", bodyFetchMetrics.idlePeers.Snapshot().Value(), receiptFetchMetrics.idlePeers.Snapshot().Value())
+		stalls   = uint64(bodyFetchMetrics.throttled.Snapshot().Count() + receiptFetchMetrics.throttled.Snapshot().Count())
+	)
+	throttled := stalls - d.syncLogStalls
+	d.syncLogStalls = stalls
+
+	log.Info("Syncing: chain download in progress", "synced", progress, "chain", syncedBytes, "headers", headers, "bodies", bodies, "receipts", receipts, "inflight", inflight, "idle", idle, "throttled", throttled, "eta", common.PrettyDuration(eta))
 	d.syncLogTime = time.Now()
 }

--- a/eth/downloader/fetchers_concurrent.go
+++ b/eth/downloader/fetchers_concurrent.go
@@ -33,6 +33,25 @@ import (
 // to each request. Failing to do so is considered a protocol violation.
 var timeoutGracePeriod = 2 * time.Minute
 
+// slashedProbeInterval is the minimum time between two requests handed to a
+// peer whose capacity got slashed to zero by a failed delivery (empty response
+// or timeout). Every request takes the oldest pending items out of the queue
+// for a round trip; if the peer keeps coming back empty, those items bounce
+// between the failing peers while the capable ones are starved of them, and
+// the head of the result cache stalls. Probing sparingly keeps such peers out
+// of the rotation while still letting them recover.
+var slashedProbeInterval = 10 * time.Second
+
+// headStallFactor is the multiplier applied to the target round trip time to
+// obtain the threshold beyond which a request holding the head of the result
+// cache is considered lagging and is expired early, so that an idle peer can
+// retrieve the items instead.
+const headStallFactor = 2
+
+// headStallCheckInterval is the frequency at which the request holding the
+// head of the result cache is checked for lagging.
+const headStallCheckInterval = 200 * time.Millisecond
+
 // typedQueue is an interface defining the adaptor needed to translate the type
 // specific downloader/queue schedulers into the type-agnostic general concurrent
 // fetcher algorithm calls.
@@ -72,6 +91,11 @@ type typedQueue interface {
 	// it to the downloader's queue.
 	deliver(peer *peerConnection, packet *eth.Response) (int, error)
 
+	// stalled returns the peer whose request holds the head of the result cache
+	// and has been outstanding for longer than the given threshold, blocking
+	// the consumer. An empty string is returned if nothing is blocked.
+	stalled(threshold time.Duration) string
+
 	// metrics returns the collectors the concurrent fetcher reports the
 	// scheduling state of this data type into.
 	metrics() *fetchMetrics
@@ -105,12 +129,41 @@ func (d *Downloader) concurrentFetch(queue typedQueue) error {
 	}
 	defer timeout.Stop()
 
+	// untrack removes a request from the timeout heap, rescheduling the timer
+	// if the request was the next one to expire.
+	untrack := func(req *eth.Request) {
+		index, live := ordering[req]
+		if !live {
+			return
+		}
+		timeouts.Remove(index)
+		if index == 0 {
+			if !timeout.Stop() {
+				<-timeout.C
+			}
+			if timeouts.Size() > 0 {
+				_, exp := timeouts.Peek()
+				timeout.Reset(time.Until(time.Unix(0, -exp)))
+			}
+		}
+		delete(ordering, req)
+	}
+	// Periodically check whether the request holding the head of the result
+	// cache is lagging behind the rest of the peers
+	headStall := time.NewTicker(headStallCheckInterval)
+	defer headStall.Stop()
+
 	// Track the timed-out but not-yet-answered requests separately. We want to
 	// keep tracking which peers are busy (potentially overloaded), so removing
 	// all trace of a timed out request is not good. We also can't just cancel
 	// the pending request altogether as that would prevent a late response from
 	// being delivered, thus never unblocking the peer.
 	stales := make(map[string]*eth.Request)
+
+	// Track when each peer was last handed a request, to rate limit the probing
+	// of peers with a slashed capacity.
+	probes := make(map[string]time.Time)
+
 	defer func() {
 		// Abort all requests on sync cycle cancellation. The requests may still
 		// be fulfilled by the remote side, but the dispatcher will not wait to
@@ -141,16 +194,25 @@ func (d *Downloader) concurrentFetch(queue typedQueue) error {
 				idles    []*peerConnection
 				caps     []int
 				capacity int // Estimated aggregate items/s across all peers
+				slashed  int // Peers with a capacity slashed to zero by a failed delivery
 			)
 			for _, peer := range d.peers.AllPeers() {
 				pending, stale := pending[peer.id], stales[peer.id]
 
-				cap := queue.capacity(peer, time.Second)
-				capacity += cap
+				items := queue.capacity(peer, time.Second)
+				capacity += items
 
 				if pending == nil && stale == nil {
+					// A capacity of 1 is the overestimated zero left behind by a
+					// failed delivery, only probe such peers every now and again
+					if items <= 1 {
+						slashed++
+						if last, ok := probes[peer.id]; ok && time.Since(last) < slashedProbeInterval {
+							continue
+						}
+					}
 					idles = append(idles, peer)
-					caps = append(caps, cap)
+					caps = append(caps, items)
 				} else if stale != nil {
 					if waited := time.Since(stale.Sent); waited > timeoutGracePeriod {
 						// Request has been in flight longer than the grace period
@@ -204,6 +266,7 @@ func (d *Downloader) concurrentFetch(queue typedQueue) error {
 					continue
 				}
 				pending[peer.id] = req
+				probes[peer.id] = time.Now()
 				assigned++
 
 				ttl := d.peers.rates.TargetTimeout()
@@ -217,6 +280,7 @@ func (d *Downloader) concurrentFetch(queue typedQueue) error {
 			stats.idlePeers.Update(int64(len(idles) - assigned))
 			stats.busyPeers.Update(int64(len(pending)))
 			stats.stalePeers.Update(int64(len(stales)))
+			stats.slashedPeers.Update(int64(slashed))
 			stats.capacity.Update(int64(capacity))
 		}
 		// Wait for something to happen
@@ -249,25 +313,13 @@ func (d *Downloader) concurrentFetch(queue typedQueue) error {
 				queue.unreserve(peerid) // TODO(karalabe): This needs a non-expiration method
 				delete(pending, peerid)
 				req.Close()
-
-				if index, live := ordering[req]; live {
-					timeouts.Remove(index)
-					if index == 0 {
-						if !timeout.Stop() {
-							<-timeout.C
-						}
-						if timeouts.Size() > 0 {
-							_, exp := timeouts.Peek()
-							timeout.Reset(time.Until(time.Unix(0, -exp)))
-						}
-					}
-					delete(ordering, req)
-				}
+				untrack(req)
 			}
 			if req, ok := stales[peerid]; ok {
 				delete(stales, peerid)
 				req.Close()
 			}
+			delete(probes, peerid)
 
 		case <-timeout.C:
 			// Retrieve the next request which should have timed out. The check
@@ -323,24 +375,36 @@ func (d *Downloader) concurrentFetch(queue typedQueue) error {
 				d.dropPeer(peer.id)
 			}
 
+		case <-headStall.C:
+			// If the consumer is blocked on a request that has been outstanding
+			// for a lot longer than what the other peers need, expire it early
+			// and hand its items to an idle peer. The lagging peer is kept busy
+			// until it answers, but not penalized otherwise: its measured round
+			// trip already shrinks the requests it will be handed later.
+			id := queue.stalled(headStallFactor * d.peers.rates.TargetRoundTrip())
+			if id == "" {
+				continue
+			}
+			req, ok := pending[id]
+			if !ok {
+				continue
+			}
+			untrack(req)
+			delete(pending, id)
+			stales[id] = req
+
+			queue.unreserve(id)
+			queue.metrics().headExpiries.Mark(1)
+
+			if peer := d.peers.Peer(id); peer != nil {
+				peer.log.Debug("Expired request blocking the result cache head", "waited", common.PrettyDuration(time.Since(req.Sent)))
+			}
+
 		case res := <-responses:
 			// Response arrived, it may be for an existing or an already timed
 			// out request. If the former, update the timeout heap and perhaps
 			// reschedule the timeout timer.
-			index, live := ordering[res.Req]
-			if live {
-				timeouts.Remove(index)
-				if index == 0 {
-					if !timeout.Stop() {
-						<-timeout.C
-					}
-					if timeouts.Size() > 0 {
-						_, exp := timeouts.Peek()
-						timeout.Reset(time.Until(time.Unix(0, -exp)))
-					}
-				}
-				delete(ordering, res.Req)
-			}
+			untrack(res.Req)
 			// Delete the pending request (if it still exists) and mark the peer idle
 			delete(pending, res.Req.Peer)
 			delete(stales, res.Req.Peer)

--- a/eth/downloader/fetchers_concurrent.go
+++ b/eth/downloader/fetchers_concurrent.go
@@ -82,6 +82,11 @@ type typedQueue interface {
 	// reassigning to some other peer.
 	unreserve(peer string) int
 
+	// requeue is responsible for placing the current retrieval allocation of a
+	// specific peer back into the pool for some other peer to retrieve as well,
+	// without removing the allocation, so a late delivery is still accepted.
+	requeue(peer string)
+
 	// request is responsible for converting a generic fetch request into a typed
 	// one and sending it to the remote peer for fulfillment.
 	request(peer *peerConnection, req *fetchRequest, resCh chan *eth.Response) (*eth.Request, error)
@@ -377,10 +382,11 @@ func (d *Downloader) concurrentFetch(queue typedQueue) error {
 
 		case <-headStall.C:
 			// If the consumer is blocked on a request that has been outstanding
-			// for a lot longer than what the other peers need, expire it early
-			// and hand its items to an idle peer. The lagging peer is kept busy
-			// until it answers, but not penalized otherwise: its measured round
-			// trip already shrinks the requests it will be handed later.
+			// for a lot longer than what the other peers need, hand its items to
+			// an idle peer as well, keeping the original reservation: whichever
+			// reply arrives first fills the result cache, the other is dropped
+			// as stale. The lagging peer is not assigned anything else until it
+			// answers, but not penalized otherwise.
 			id := queue.stalled(headStallFactor * d.peers.rates.TargetRoundTrip())
 			if id == "" {
 				continue
@@ -393,11 +399,11 @@ func (d *Downloader) concurrentFetch(queue typedQueue) error {
 			delete(pending, id)
 			stales[id] = req
 
-			queue.unreserve(id)
+			queue.requeue(id)
 			queue.metrics().headExpiries.Mark(1)
 
 			if peer := d.peers.Peer(id); peer != nil {
-				peer.log.Debug("Expired request blocking the result cache head", "waited", common.PrettyDuration(time.Since(req.Sent)))
+				peer.log.Debug("Requeued request blocking the result cache head", "waited", common.PrettyDuration(time.Since(req.Sent)))
 			}
 
 		case res := <-responses:

--- a/eth/downloader/fetchers_concurrent_bals.go
+++ b/eth/downloader/fetchers_concurrent_bals.go
@@ -80,6 +80,10 @@ func (q *balQueue) unreserve(peer string) int {
 	return fails
 }
 
+// requeue is a no-op for access lists: they never block the consumer, so their
+// retrievals are never requeued.
+func (q *balQueue) requeue(peer string) {}
+
 // request is responsible for converting a generic fetch request into an access
 // list one and sending it to the remote peer for fulfillment.
 func (q *balQueue) request(peer *peerConnection, req *fetchRequest, resCh chan *eth.Response) (*eth.Request, error) {

--- a/eth/downloader/fetchers_concurrent_bals.go
+++ b/eth/downloader/fetchers_concurrent_bals.go
@@ -101,13 +101,6 @@ func (q *balQueue) deliver(peer *peerConnection, packet *eth.Response) (int, err
 	bals := *packet.Res.(*eth.BlockAccessListResponse)
 	hashes := packet.Meta.([]common.Hash) // {keccak256 hash per entry, zero hash if unavailable}
 
-	var size int
-	for _, bal := range bals {
-		size += len(bal)
-	}
-	balFetchMetrics.items.Update(int64(len(bals)))
-	balFetchMetrics.bytes.Mark(int64(size))
-
 	accepted, err := q.queue.DeliverBALs(peer.id, bals, hashes)
 	switch {
 	case err == nil && len(bals) == 0:
@@ -118,6 +111,12 @@ func (q *balQueue) deliver(peer *peerConnection, packet *eth.Response) (int, err
 		peer.log.Debug("Failed to deliver retrieved access lists", "err", err)
 	}
 	return accepted, err
+}
+
+// stalled is a no-op for access lists: they are a best-effort component that
+// never holds back the delivery of a block, so they cannot block the consumer.
+func (q *balQueue) stalled(threshold time.Duration) string {
+	return ""
 }
 
 // metrics returns the collectors the concurrent fetcher reports the scheduling

--- a/eth/downloader/fetchers_concurrent_bodies.go
+++ b/eth/downloader/fetchers_concurrent_bodies.go
@@ -90,18 +90,6 @@ func (q *bodyQueue) request(peer *peerConnection, req *fetchRequest, resCh chan 
 func (q *bodyQueue) deliver(peer *peerConnection, packet *eth.Response) (int, error) {
 	resp := packet.Res.(*eth.BlockBodiesResponse)
 	meta := packet.Meta.(eth.BlockBodyHashes)
-
-	var size uint64
-	for i := range *resp {
-		body := &(*resp)[i]
-		size += body.Transactions.Size() + body.Uncles.Size()
-		if body.Withdrawals != nil {
-			size += body.Withdrawals.Size()
-		}
-	}
-	bodyFetchMetrics.items.Update(int64(len(*resp)))
-	bodyFetchMetrics.bytes.Mark(int64(size))
-
 	accepted, err := q.queue.DeliverBodies(peer.id, meta, *resp)
 	switch {
 	case err == nil && len(*resp) == 0:
@@ -112,6 +100,12 @@ func (q *bodyQueue) deliver(peer *peerConnection, packet *eth.Response) (int, er
 		peer.log.Debug("Failed to deliver retrieved bodies", "err", err)
 	}
 	return accepted, err
+}
+
+// stalled returns the peer whose body request holds the head of the result
+// cache for longer than the given threshold, blocking the consumer.
+func (q *bodyQueue) stalled(threshold time.Duration) string {
+	return q.queue.StalledBodies(threshold)
 }
 
 // metrics returns the collectors the concurrent fetcher reports the scheduling

--- a/eth/downloader/fetchers_concurrent_bodies.go
+++ b/eth/downloader/fetchers_concurrent_bodies.go
@@ -71,6 +71,12 @@ func (q *bodyQueue) unreserve(peer string) int {
 	return fails
 }
 
+// requeue is responsible for placing the current body retrieval allocation of a
+// specific peer back into the pool for some other peer to retrieve as well.
+func (q *bodyQueue) requeue(peer string) {
+	q.queue.RequeueBodies(peer)
+}
+
 // request is responsible for converting a generic fetch request into a body
 // one and sending it to the remote peer for fulfillment.
 func (q *bodyQueue) request(peer *peerConnection, req *fetchRequest, resCh chan *eth.Response) (*eth.Request, error) {

--- a/eth/downloader/fetchers_concurrent_receipts.go
+++ b/eth/downloader/fetchers_concurrent_receipts.go
@@ -97,13 +97,6 @@ func (q *receiptQueue) deliver(peer *peerConnection, packet *eth.Response) (int,
 	receipts := *packet.Res.(*eth.ReceiptsRLPResponse)
 	hashes := packet.Meta.([]common.Hash) // {receipt hashes}
 
-	var size int
-	for _, receipt := range receipts {
-		size += len(receipt)
-	}
-	receiptFetchMetrics.items.Update(int64(len(receipts)))
-	receiptFetchMetrics.bytes.Mark(int64(size))
-
 	accepted, err := q.queue.DeliverReceipts(peer.id, receipts, hashes)
 	switch {
 	case err == nil && len(receipts) == 0:
@@ -114,6 +107,12 @@ func (q *receiptQueue) deliver(peer *peerConnection, packet *eth.Response) (int,
 		peer.log.Debug("Failed to deliver retrieved receipts", "err", err)
 	}
 	return accepted, err
+}
+
+// stalled returns the peer whose receipt request holds the head of the result
+// cache for longer than the given threshold, blocking the consumer.
+func (q *receiptQueue) stalled(threshold time.Duration) string {
+	return q.queue.StalledReceipts(threshold)
 }
 
 // metrics returns the collectors the concurrent fetcher reports the scheduling

--- a/eth/downloader/fetchers_concurrent_receipts.go
+++ b/eth/downloader/fetchers_concurrent_receipts.go
@@ -71,6 +71,12 @@ func (q *receiptQueue) unreserve(peer string) int {
 	return fails
 }
 
+// requeue is responsible for placing the current receipt retrieval allocation of
+// a specific peer back into the pool for some other peer to retrieve as well.
+func (q *receiptQueue) requeue(peer string) {
+	q.queue.RequeueReceipts(peer)
+}
+
 // request is responsible for converting a generic fetch request into a receipt
 // one and sending it to the remote peer for fulfillment.
 func (q *receiptQueue) request(peer *peerConnection, req *fetchRequest, resCh chan *eth.Response) (*eth.Request, error) {

--- a/eth/downloader/metrics.go
+++ b/eth/downloader/metrics.go
@@ -70,14 +70,16 @@ var (
 // fetchMetrics groups the collectors the concurrent fetcher reports into for a
 // single data type (bodies, receipts, access lists).
 type fetchMetrics struct {
-	idlePeers  *metrics.Gauge    // Peers left without a request after an assignment round
-	busyPeers  *metrics.Gauge    // Peers with a request in flight
-	stalePeers *metrics.Gauge    // Peers with a timed out but not yet answered request
-	capacity   *metrics.Gauge    // Estimated aggregate items per second across all peers
-	starved    *metrics.Meter    // Assignment rounds cut short because nothing was pending
-	throttled  *metrics.Meter    // Assignment rounds cut short by result cache throttling
-	items      metrics.Histogram // Items contained in each response
-	bytes      *metrics.Meter    // Payload bytes contained in each response
+	idlePeers    *metrics.Gauge    // Peers left without a request after an assignment round
+	busyPeers    *metrics.Gauge    // Peers with a request in flight
+	stalePeers   *metrics.Gauge    // Peers with a timed out but not yet answered request
+	slashedPeers *metrics.Gauge    // Peers with a capacity slashed to zero by a failed delivery
+	capacity     *metrics.Gauge    // Estimated aggregate items per second across all peers
+	starved      *metrics.Meter    // Assignment rounds cut short because nothing was pending
+	throttled    *metrics.Meter    // Assignment rounds cut short by result cache throttling
+	headExpiries *metrics.Meter    // Requests expired early for holding the result cache head
+	items        metrics.Histogram // Items contained in each response
+	bytes        *metrics.Meter    // Payload bytes contained in each response
 }
 
 // newFetchMetrics registers the scheduling collectors for a data type under
@@ -85,13 +87,15 @@ type fetchMetrics struct {
 func newFetchMetrics(kind string) *fetchMetrics {
 	prefix := "eth/downloader/" + kind
 	return &fetchMetrics{
-		idlePeers:  metrics.NewRegisteredGauge(prefix+"/peers/idle", nil),
-		busyPeers:  metrics.NewRegisteredGauge(prefix+"/peers/busy", nil),
-		stalePeers: metrics.NewRegisteredGauge(prefix+"/peers/stale", nil),
-		capacity:   metrics.NewRegisteredGauge(prefix+"/capacity", nil),
-		starved:    metrics.NewRegisteredMeter(prefix+"/starved", nil),
-		throttled:  metrics.NewRegisteredMeter(prefix+"/throttled", nil),
-		items:      metrics.NewRegisteredHistogram(prefix+"/items", nil, metrics.NewExpDecaySample(1028, 0.015)),
-		bytes:      metrics.NewRegisteredMeter(prefix+"/bytes", nil),
+		idlePeers:    metrics.NewRegisteredGauge(prefix+"/peers/idle", nil),
+		busyPeers:    metrics.NewRegisteredGauge(prefix+"/peers/busy", nil),
+		stalePeers:   metrics.NewRegisteredGauge(prefix+"/peers/stale", nil),
+		slashedPeers: metrics.NewRegisteredGauge(prefix+"/peers/slashed", nil),
+		capacity:     metrics.NewRegisteredGauge(prefix+"/capacity", nil),
+		starved:      metrics.NewRegisteredMeter(prefix+"/starved", nil),
+		throttled:    metrics.NewRegisteredMeter(prefix+"/throttled", nil),
+		headExpiries: metrics.NewRegisteredMeter(prefix+"/headexpire", nil),
+		items:        metrics.NewRegisteredHistogram(prefix+"/items", nil, metrics.NewExpDecaySample(1028, 0.015)),
+		bytes:        metrics.NewRegisteredMeter(prefix+"/bytes", nil),
 	}
 }

--- a/eth/downloader/peer.go
+++ b/eth/downloader/peer.go
@@ -222,10 +222,15 @@ type peerSet struct {
 }
 
 // newPeerSet creates a new peer set top track the active download sources.
+// minRoundTrip is the floor applied to the round trip estimate of the chain
+// download requests. Their replies are capped in size by the remote, making
+// them cheap to serve, so the real latency is a few hundred milliseconds.
+const minRoundTrip = 500 * time.Millisecond
+
 func newPeerSet() *peerSet {
 	return &peerSet{
 		peers: make(map[string]*peerConnection),
-		rates: msgrate.NewTrackers(log.New("proto", "eth")),
+		rates: msgrate.NewTrackers(log.New("proto", "eth"), minRoundTrip),
 	}
 }
 

--- a/eth/downloader/queue.go
+++ b/eth/downloader/queue.go
@@ -23,6 +23,7 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
+	"math"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -45,10 +46,10 @@ const (
 )
 
 var (
-	blockCacheMaxItems     = 8192              // Maximum number of blocks to cache before throttling the download
-	blockCacheInitialItems = 2048              // Initial number of blocks to start fetching, before we know the sizes of the blocks
-	blockCacheMemory       = 256 * 1024 * 1024 // Maximum amount of memory to use for block caching
-	blockCacheSizeWeight   = 0.1               // Multiplier to approximate the average block size based on past ones
+	blockCacheMaxItems     = 8192               // Maximum number of blocks to cache before throttling the download
+	blockCacheInitialItems = 2048               // Initial number of blocks to start fetching, before we know the sizes of the blocks
+	blockCacheMemory       = 1024 * 1024 * 1024 // Maximum amount of memory to use for block caching
+	blockCacheSizeWeight   = 0.1                // Multiplier to approximate the average block size based on past ones
 
 	// balCacheMemory is the memory allowance for block access lists attached
 	// to cached results, budgeted separately from blockCacheMemory: access
@@ -59,6 +60,17 @@ var (
 	// are tracked, and once over the allowance the *access list* retrieval
 	// throttles itself while block throughput stays untouched.
 	balCacheMemory = 256 * 1024 * 1024
+
+	// softResponseLimit is the target maximum size of replies remote peers
+	// send to data retrievals, mirroring the serving side limit in the eth
+	// protocol package. Items not fitting into it are silently dropped by the
+	// remote, so requests are sized to it.
+	softResponseLimit = 2 * 1024 * 1024
+
+	// requestOverfetch is the factor by which a retrieval request overshoots the
+	// number of items the average item size predicts to fit into a reply, so
+	// that a run of smaller-than-average items still fills the reply.
+	requestOverfetch = 1.5
 )
 
 var (
@@ -208,6 +220,8 @@ type queue struct {
 
 	resultCache *resultStore       // Downloaded but not yet delivered fetch results
 	resultSize  common.StorageSize // Approximate size of a block (exponential moving average)
+	bodySize    common.StorageSize // Approximate encoded size of a block body (exponential moving average)
+	receiptSize common.StorageSize // Approximate encoded size of a block's receipts (exponential moving average)
 	balBytes    atomic.Int64       // Exact encoded bytes of access lists attached to cached results
 
 	lock   *sync.RWMutex
@@ -498,6 +512,8 @@ func (q *queue) stats() []interface{} {
 		"blockTasks", q.blockTaskQueue.Size(),
 		"balTasks", q.balTaskQueue.Size(),
 		"itemSize", q.resultSize,
+		"bodySize", q.bodySize,
+		"receiptSize", q.receiptSize,
 	}
 }
 
@@ -525,6 +541,7 @@ func (q *queue) ReserveBodies(p *peerConnection, count int) (*fetchRequest, bool
 	q.lock.Lock()
 	defer q.lock.Unlock()
 
+	count = requestLimit(count, q.bodySize)
 	return q.reserveHeaders(p, count, q.blockTaskPool, q.blockTaskQueue, q.blockPendPool, bodyType)
 }
 
@@ -535,7 +552,78 @@ func (q *queue) ReserveReceipts(p *peerConnection, count int) (*fetchRequest, bo
 	q.lock.Lock()
 	defer q.lock.Unlock()
 
+	count = requestLimit(count, q.receiptSize)
 	return q.reserveHeaders(p, count, q.receiptTaskPool, q.receiptTaskQueue, q.receiptPendPool, receiptType)
+}
+
+// StalledBodies returns the peer whose body request holds the head of the
+// result cache, if the request has been outstanding for longer than the given
+// threshold. See stalledHead for details.
+func (q *queue) StalledBodies(threshold time.Duration) string {
+	q.lock.RLock()
+	defer q.lock.RUnlock()
+
+	return q.stalledHead(q.blockPendPool, bodyType, threshold)
+}
+
+// StalledReceipts returns the peer whose receipt request holds the head of the
+// result cache, if the request has been outstanding for longer than the given
+// threshold. See stalledHead for details.
+func (q *queue) StalledReceipts(threshold time.Duration) string {
+	q.lock.RLock()
+	defer q.lock.RUnlock()
+
+	return q.stalledHead(q.receiptPendPool, receiptType, threshold)
+}
+
+// stalledHead checks whether the consumer is blocked on a component of the
+// first undelivered block that is currently being retrieved, and if so, whether
+// that retrieval has been outstanding for longer than the given threshold. If
+// both hold, the peer serving the request is returned.
+//
+// Note, this method expects the queue lock to be already held.
+func (q *queue) stalledHead(pendPool map[string]*fetchRequest, kind uint, threshold time.Duration) string {
+	head, missing := q.resultCache.HeadPending(kind)
+	if !missing {
+		return ""
+	}
+	for id, request := range pendPool {
+		if len(request.Headers) == 0 {
+			continue
+		}
+		// Requested headers are sorted by number, check if the head is within
+		if request.Headers[0].Number.Uint64() > head || request.Headers[len(request.Headers)-1].Number.Uint64() < head {
+			continue
+		}
+		if time.Since(request.Time) > threshold {
+			return id
+		}
+		return ""
+	}
+	return ""
+}
+
+// requestLimit caps the number of items to request in a single retrieval to
+// what is expected to fit into a reply, given the average item size seen so
+// far. Remote peers cap their replies at softResponseLimit bytes and drop
+// the surplus, which then gets re-queued locally. That wastes nothing on the
+// wire, but every reserved item occupies a slot of the result cache until its
+// (partial) delivery, so a handful of oversized requests can exhaust the cache
+// and leave every other peer without work.
+func requestLimit(count int, size common.StorageSize) int {
+	if size == 0 {
+		return count
+	}
+	limit := int(math.Ceil(requestOverfetch * float64(softResponseLimit) / float64(size)))
+	return min(count, max(2, limit))
+}
+
+// updateSizeEstimate folds a new average item size into the running estimate.
+func updateSizeEstimate(estimate, sample common.StorageSize) common.StorageSize {
+	if estimate == 0 {
+		return sample
+	}
+	return common.StorageSize(blockCacheSizeWeight)*sample + (1-common.StorageSize(blockCacheSizeWeight))*estimate
 }
 
 // ReserveBALs reserves a set of block access list fetches for the given peer,
@@ -761,6 +849,21 @@ func (q *queue) DeliverBodies(id string, hashes eth.BlockBodyHashes, bodies []et
 	q.lock.Lock()
 	defer q.lock.Unlock()
 
+	// Track the reply size to calibrate the request sizes against the reply
+	// limit of remote peers
+	if len(bodies) > 0 {
+		var size uint64
+		for i := range bodies {
+			size += bodies[i].Transactions.Size() + bodies[i].Uncles.Size()
+			if bodies[i].Withdrawals != nil {
+				size += bodies[i].Withdrawals.Size()
+			}
+		}
+		q.bodySize = updateSizeEstimate(q.bodySize, common.StorageSize(size)/common.StorageSize(len(bodies)))
+		bodyFetchMetrics.bytes.Mark(int64(size))
+	}
+	bodyFetchMetrics.items.Update(int64(len(bodies)))
+
 	var txLists [][]*types.Transaction
 	var uncleLists [][]*types.Header
 	var withdrawalLists [][]*types.Withdrawal
@@ -827,6 +930,18 @@ func (q *queue) DeliverReceipts(id string, receiptList []rlp.RawValue, receiptLi
 	q.lock.Lock()
 	defer q.lock.Unlock()
 
+	// Track the reply size to calibrate the request sizes against the reply
+	// limit of remote peers
+	if len(receiptList) > 0 {
+		var size int
+		for _, receipts := range receiptList {
+			size += len(receipts)
+		}
+		q.receiptSize = updateSizeEstimate(q.receiptSize, common.StorageSize(size)/common.StorageSize(len(receiptList)))
+		receiptFetchMetrics.bytes.Mark(int64(size))
+	}
+	receiptFetchMetrics.items.Update(int64(len(receiptList)))
+
 	validate := func(index int, header *types.Header) error {
 		if receiptListHashes[index] != header.ReceiptHash {
 			return errInvalidReceipt
@@ -851,6 +966,13 @@ func (q *queue) DeliverReceipts(id string, receiptList []rlp.RawValue, receiptLi
 func (q *queue) DeliverBALs(id string, bals []rlp.RawValue, hashes []common.Hash) (int, error) {
 	q.lock.Lock()
 	defer q.lock.Unlock()
+
+	var size int
+	for _, bal := range bals {
+		size += len(bal)
+	}
+	balFetchMetrics.items.Update(int64(len(bals)))
+	balFetchMetrics.bytes.Mark(int64(size))
 
 	request := q.balPendPool[id]
 	if request == nil {

--- a/eth/downloader/queue.go
+++ b/eth/downloader/queue.go
@@ -783,6 +783,43 @@ func (q *queue) Revoke(peerID string) {
 	}
 }
 
+// RequeueBodies returns the bodies reserved by the given peer to the task queue
+// for another peer to retrieve as well, keeping the reservation so that a late
+// delivery is still accepted. See the requeue method for details.
+func (q *queue) RequeueBodies(peer string) {
+	q.lock.Lock()
+	defer q.lock.Unlock()
+
+	q.requeue(peer, q.blockPendPool, q.blockTaskQueue)
+}
+
+// RequeueReceipts returns the receipts reserved by the given peer to the task
+// queue for another peer to retrieve as well, keeping the reservation so that
+// a late delivery is still accepted. See the requeue method for details.
+func (q *queue) RequeueReceipts(peer string) {
+	q.lock.Lock()
+	defer q.lock.Unlock()
+
+	q.requeue(peer, q.receiptPendPool, q.receiptTaskQueue)
+}
+
+// requeue pushes the items of a pending request back into the task queue without
+// cancelling the request, so that another peer retrieves them concurrently and
+// whichever reply arrives first fills the result cache. The other reply is
+// dropped as stale on delivery, and items already delivered are skipped when
+// reserved again.
+//
+// Note, this method expects the queue lock to be already held.
+func (q *queue) requeue(peer string, pendPool map[string]*fetchRequest, taskQueue *prque.Prque[int64, *types.Header]) {
+	req := pendPool[peer]
+	if req == nil {
+		return
+	}
+	for _, header := range req.Headers {
+		taskQueue.Push(header, -int64(header.Number.Uint64()))
+	}
+}
+
 // ExpireBodies checks for in flight block body requests that exceeded a timeout
 // allowance, canceling them and returning the responsible peers for penalisation.
 func (q *queue) ExpireBodies(peer string) int {
@@ -1091,10 +1128,9 @@ func (q *queue) deliver(id string, taskPool map[common.Hash]*types.Header,
 			reconstruct(k, res)
 			accepted++
 		} else {
-			// Between here and above, some other peer filled this result,
-			// or it was indeed a no-op. This should not happen, but if it does it's
-			// not something to panic about
-			log.Error("Delivery stale", "stale", stale, "number", header.Number.Uint64(), "err", err)
+			// Some other peer filled this result in the meantime, which is the
+			// expected outcome of a requeued retrieval, or it was indeed a no-op.
+			log.Debug("Delivery stale", "stale", stale, "number", header.Number.Uint64(), "err", err)
 			foundStale = true
 		}
 		// Clean up a successful fetch

--- a/eth/downloader/resultstore.go
+++ b/eth/downloader/resultstore.go
@@ -124,6 +124,19 @@ func (r *resultStore) getFetchResult(headerNumber uint64) (item *fetchResult, in
 	return item, index, stale, throttle, nil
 }
 
+// HeadPending returns the number of the first undelivered block and whether
+// the given component is still missing for it. A missing head component is
+// what the consumer is currently waiting on.
+func (r *resultStore) HeadPending(kind uint) (uint64, bool) {
+	r.lock.RLock()
+	defer r.lock.RUnlock()
+
+	if len(r.items) == 0 || r.items[0] == nil {
+		return r.resultOffset, false
+	}
+	return r.resultOffset, r.items[0].pending.Load()&(1<<kind) != 0
+}
+
 // HasCompletedItems returns true if there are processable items available
 // this method is cheaper than countCompleted
 func (r *resultStore) HasCompletedItems() bool {

--- a/eth/protocols/snap/sync.go
+++ b/eth/protocols/snap/sync.go
@@ -525,7 +525,7 @@ func newSyncer(db ethdb.KeyValueStore, scheme string) *syncer {
 		peers:    make(map[string]SyncPeer),
 		peerJoin: new(event.Feed),
 		peerDrop: new(event.Feed),
-		rates:    msgrate.NewTrackers(log.New("proto", "snap")),
+		rates:    msgrate.NewTrackers(log.New("proto", "snap"), 0),
 		update:   make(chan struct{}, 1),
 
 		accountIdlers:  make(map[string]struct{}),

--- a/eth/protocols/snap/syncv2.go
+++ b/eth/protocols/snap/syncv2.go
@@ -438,7 +438,7 @@ func newSyncerV2(db ethdb.Database, scheme string) *syncerV2 {
 		peers:    make(map[string]SyncPeerV2),
 		peerJoin: new(event.Feed),
 		peerDrop: new(event.Feed),
-		rates:    msgrate.NewTrackers(log.New("proto", "snap")),
+		rates:    msgrate.NewTrackers(log.New("proto", "snap"), 0),
 		update:   make(chan struct{}, 1),
 
 		statelessPeers:   make(map[string]struct{}),

--- a/p2p/msgrate/msgrate.go
+++ b/p2p/msgrate/msgrate.go
@@ -226,6 +226,10 @@ type Trackers struct {
 	// run every now and again.
 	tuned time.Time
 
+	// minRoundTrip is the floor applied to the round trip estimate, and thus
+	// to the request sizing and timeouts derived from it.
+	minRoundTrip time.Duration
+
 	// The fields below can be used to override certain default values. Their
 	// purpose is to allow quicker tests. Don't use them in production.
 	OverrideTTLLimit time.Duration
@@ -235,12 +239,16 @@ type Trackers struct {
 }
 
 // NewTrackers creates an empty set of trackers to be filled with peers.
-func NewTrackers(log log.Logger) *Trackers {
+func NewTrackers(log log.Logger, minRoundTrip time.Duration) *Trackers {
+	if minRoundTrip <= 0 {
+		minRoundTrip = rttMinEstimate
+	}
 	return &Trackers{
 		trackers:         make(map[string]*Tracker),
 		roundtrip:        rttMaxEstimate,
 		confidence:       1,
 		tuned:            time.Now(),
+		minRoundTrip:     minRoundTrip,
 		OverrideTTLLimit: ttlLimit,
 		log:              log,
 	}
@@ -306,8 +314,8 @@ func (t *Trackers) medianRoundTrip() time.Duration {
 		median = time.Duration(rtts[idx])
 	}
 	// Restrict the RTT into some QoS defaults, irrelevant of true RTT
-	if median < rttMinEstimate {
-		median = rttMinEstimate
+	if median < t.minRoundTrip {
+		median = t.minRoundTrip
 	}
 	if median > rttMaxEstimate {
 		median = rttMaxEstimate


### PR DESCRIPTION
This PR reworks how body and receipt retrievals are scheduled during snap sync:

- Cap the request size by considering the 2MB reply limit
- Expire requests blocking the result cache head early and reassign their items
- Lower the downloader's round trip floor to 500ms
- Increase the result cache to 1GB

What's more, the timeout mechanism has been reworked. A timeout now only 
reassigns the request's items while keeping the request alive, instead of zeroing 
the peer's capacity and dropping it for small requests. The peer's capacity is 
decided by its reply: a late reply is measured on the items that validated.  A peer 
that never answers is dropped by the existing two minute grace period. 
