### PR TITLE
core/txpool: add transaction type filtering tests

### DIFF
--- a/core/txpool/blobpool/blobpool_test.go
+++ b/core/txpool/blobpool/blobpool_test.go
@@ -2502,3 +2502,27 @@ func TestGetRLPCache(t *testing.T) {
 		t.Fatalf("expected nil after the tx left the pool, got %d bytes", len(got))
 	}
 }
+
+func TestBlobPoolFilterType(t *testing.T) {
+	tests := []struct {
+		name string
+		kind byte
+		want bool
+	}{
+		{name: "blob", kind: types.BlobTxType, want: true},
+		{name: "legacy", kind: types.LegacyTxType, want: false},
+		{name: "access-list", kind: types.AccessListTxType, want: false},
+		{name: "dynamic-fee", kind: types.DynamicFeeTxType, want: false},
+		{name: "set-code", kind: types.SetCodeTxType, want: false},
+		{name: "unknown", kind: 0xff, want: false},
+	}
+
+	pool := new(BlobPool)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := pool.FilterType(tt.kind); got != tt.want {
+				t.Fatalf("FilterType(%#x) = %t, want %t", tt.kind, got, tt.want)
+			}
+		})
+	}
+}

--- a/core/txpool/legacypool/legacypool_test.go
+++ b/core/txpool/legacypool/legacypool_test.go
@@ -2718,3 +2718,27 @@ func BenchmarkMultiAccountBatchInsert(b *testing.B) {
 		pool.addRemotesSync([]*types.Transaction{tx})
 	}
 }
+
+func TestLegacyPoolFilterType(t *testing.T) {
+	tests := []struct {
+		name string
+		kind byte
+		want bool
+	}{
+		{name: "legacy", kind: types.LegacyTxType, want: true},
+		{name: "access-list", kind: types.AccessListTxType, want: true},
+		{name: "dynamic-fee", kind: types.DynamicFeeTxType, want: true},
+		{name: "set-code", kind: types.SetCodeTxType, want: true},
+		{name: "blob", kind: types.BlobTxType, want: false},
+		{name: "unknown", kind: 0xff, want: false},
+	}
+
+	pool := new(LegacyPool)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := pool.FilterType(tt.kind); got != tt.want {
+				t.Fatalf("FilterType(%#x) = %t, want %t", tt.kind, got, tt.want)
+			}
+		})
+	}
+}

--- a/core/txpool/txpool_test.go
+++ b/core/txpool/txpool_test.go
@@ -1,0 +1,87 @@
+// Copyright 2026 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+
+package txpool
+
+import (
+	"testing"
+
+	"github.com/ethereum/go-ethereum/core/types"
+)
+
+type filterTypeSubpool struct {
+	SubPool
+	supported map[byte]bool
+}
+
+func (p *filterTypeSubpool) FilterType(kind byte) bool {
+	return p.supported[kind]
+}
+
+func TestTxPoolFilterType(t *testing.T) {
+	tests := []struct {
+		name     string
+		subpools []SubPool
+		kind     byte
+		want     bool
+	}{
+		{
+			name: "no subpool supports type",
+			subpools: []SubPool{
+				&filterTypeSubpool{supported: map[byte]bool{types.LegacyTxType: true}},
+				&filterTypeSubpool{supported: map[byte]bool{types.BlobTxType: true}},
+			},
+			kind: types.DynamicFeeTxType,
+			want: false,
+		},
+		{
+			name: "first subpool supports type",
+			subpools: []SubPool{
+				&filterTypeSubpool{supported: map[byte]bool{types.DynamicFeeTxType: true}},
+				&filterTypeSubpool{supported: map[byte]bool{types.BlobTxType: true}},
+			},
+			kind: types.DynamicFeeTxType,
+			want: true,
+		},
+		{
+			name: "second subpool supports type",
+			subpools: []SubPool{
+				&filterTypeSubpool{supported: map[byte]bool{types.DynamicFeeTxType: true}},
+				&filterTypeSubpool{supported: map[byte]bool{types.BlobTxType: true}},
+			},
+			kind: types.BlobTxType,
+			want: true,
+		},
+		{
+			name: "unknown type",
+			subpools: []SubPool{
+				&filterTypeSubpool{supported: map[byte]bool{types.DynamicFeeTxType: true}},
+				&filterTypeSubpool{supported: map[byte]bool{types.BlobTxType: true}},
+			},
+			kind: 0xff,
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			pool := &TxPool{subpools: tt.subpools}
+			if got := pool.FilterType(tt.kind); got != tt.want {
+				t.Fatalf("FilterType(%#x) = %t, want %t", tt.kind, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Adds table-driven tests for transaction type filtering across the txpool coordinator and both concrete subpools.

The covered behavior is:

| Transaction type | TxPool | LegacyPool | BlobPool |
| --- | --- | --- | --- |
| Legacy | true | true | false |
| Access-list | true | true | false |
| Dynamic-fee | true | true | false |
| Blob | true | false | true |
| Set-code | true | true | false |
| Unknown (`0xff`) | false | false | false |

Tests were added to:

- `core/txpool/txpool_test.go`
- `core/txpool/legacypool/legacypool_test.go`
- `core/txpool/blobpool/blobpool_test.go`

No production code was changed.

Tests:
- `go test ./core/txpool/... -run 'FilterType' -count=1`
- `git diff --check`