### PR TITLE
eth: return iterator errors from debug_getModifiedAccounts

### DIFF
--- a/eth/api_debug.go
+++ b/eth/api_debug.go
@@ -410,6 +410,12 @@ func (api *DebugAPI) getModifiedAccounts(startHeader, endHeader *types.Header) (
 		}
 		dirty = append(dirty, common.BytesToAddress(key))
 	}
+	// Iterator.Next returns false on both exhaustion and error, so a failure to
+	// resolve a trie node mid-traversal would otherwise be reported as a complete
+	// set of modified accounts. Surface the error instead of silently truncating.
+	if iter.Err != nil {
+		return nil, iter.Err
+	}
 	return dirty, nil
 }
 


### PR DESCRIPTION
`getModifiedAccounts` never checks `iter.Err` after the loop, so a trie node that fails to resolve mid-traversal makes `debug_getModifiedAccountsByNumber/ByHash` return a truncated account list as a complete result. Return the error instead, mirroring #35554 which fixed the same pattern for `debug_storageRangeAt`.