### PR TITLE
eth: add progress metrics

### DIFF
--- a/eth/downloader/downloader.go
+++ b/eth/downloader/downloader.go
@@ -1329,8 +1329,9 @@ func (d *Downloader) reportSnapSyncProgress(force bool) {
 		bodies   = fmt.Sprintf("%v@%v", log.FormatLogfmtUint64(block.Number.Uint64()), common.StorageSize(bodyBytes).TerminalString())
 		receipts = fmt.Sprintf("%v@%v", log.FormatLogfmtUint64(block.Number.Uint64()), common.StorageSize(receiptBytes).TerminalString())
 	)
-	chainProgressGauge.Update(float64(block.Number.Uint64()) / float64(latest.Number.Uint64()))
-
+	if latest.Number.Uint64() != 0 {
+		chainProgressGauge.Update(float64(block.Number.Uint64()) / float64(latest.Number.Uint64()))
+	}
 	log.Info("Syncing: chain download in progress", "synced", progress, "chain", syncedBytes, "headers", headers, "bodies", bodies, "receipts", receipts, "eta", common.PrettyDuration(eta))
 	d.syncLogTime = time.Now()
 }

--- a/eth/downloader/downloader.go
+++ b/eth/downloader/downloader.go
@@ -1329,6 +1329,8 @@ func (d *Downloader) reportSnapSyncProgress(force bool) {
 		bodies   = fmt.Sprintf("%v@%v", log.FormatLogfmtUint64(block.Number.Uint64()), common.StorageSize(bodyBytes).TerminalString())
 		receipts = fmt.Sprintf("%v@%v", log.FormatLogfmtUint64(block.Number.Uint64()), common.StorageSize(receiptBytes).TerminalString())
 	)
+	chainProgressGauge.Update(float64(block.Number.Uint64()) / float64(latest.Number.Uint64()))
+
 	log.Info("Syncing: chain download in progress", "synced", progress, "chain", syncedBytes, "headers", headers, "bodies", bodies, "receipts", receipts, "eta", common.PrettyDuration(eta))
 	d.syncLogTime = time.Now()
 }

--- a/eth/downloader/metrics.go
+++ b/eth/downloader/metrics.go
@@ -46,6 +46,9 @@ var (
 	receiptFetchMetrics = newFetchMetrics("receipts")
 	balFetchMetrics     = newFetchMetrics("bals")
 
+	// Chain download progress, reported alongside the progress log
+	chainProgressGauge = metrics.NewRegisteredGaugeFloat64("eth/downloader/chain/progress", nil)
+
 	// rttTargetGauge is the round trip time (in milliseconds) requests are
 	// currently sized for, derived from the median of the peer estimates.
 	rttTargetGauge = metrics.NewRegisteredGauge("eth/downloader/rtt/target", nil)

--- a/eth/protocols/snap/metrics.go
+++ b/eth/protocols/snap/metrics.go
@@ -27,6 +27,26 @@ var (
 	IngressRegistrationErrorMeter = metrics.NewRegisteredMeter(ingressRegistrationErrorName, nil)
 	EgressRegistrationErrorMeter  = metrics.NewRegisteredMeter(egressRegistrationErrorName, nil)
 
+	// Progress of the state download, reported alongside the progress log
+	syncProgressGauge = metrics.NewRegisteredGaugeFloat64("eth/protocols/snap/sync/progress", nil)
+	syncBytesGauge    = metrics.NewRegisteredGauge("eth/protocols/snap/sync/bytes", nil)
+	syncEstimateGauge = metrics.NewRegisteredGauge("eth/protocols/snap/sync/estimate", nil)
+	syncAccountsGauge = metrics.NewRegisteredGauge("eth/protocols/snap/sync/accounts", nil)
+	syncSlotsGauge    = metrics.NewRegisteredGauge("eth/protocols/snap/sync/slots", nil)
+	syncCodesGauge    = metrics.NewRegisteredGauge("eth/protocols/snap/sync/codes", nil)
+
+	// Progress of the state healing, reported alongside the progress log
+	healAccountsGauge = metrics.NewRegisteredGauge("eth/protocols/snap/sync/heal/trie/accounts", nil)
+	healSlotsGauge    = metrics.NewRegisteredGauge("eth/protocols/snap/sync/heal/trie/slots", nil)
+	healCodesGauge    = metrics.NewRegisteredGauge("eth/protocols/snap/sync/heal/trie/codes", nil)
+	healNodesGauge    = metrics.NewRegisteredGauge("eth/protocols/snap/sync/heal/trie/nodes", nil)
+	healPendingGauge  = metrics.NewRegisteredGauge("eth/protocols/snap/sync/heal/trie/pending", nil)
+
+	// Progress of the phases specific to snap/2
+	genProgressGauge = metrics.NewRegisteredGauge("eth/protocols/snap/sync/generation", nil)
+	balFetchedGauge  = metrics.NewRegisteredGauge("eth/protocols/snap/sync/heal/bal/fetched", nil)
+	balTotalGauge    = metrics.NewRegisteredGauge("eth/protocols/snap/sync/heal/bal/total", nil)
+
 	// accountInnerDeleteGauge is the metric to track how many dangling trie nodes
 	// covered by extension node in account trie are deleted during the sync.
 	accountInnerDeleteGauge = metrics.NewRegisteredGauge("eth/protocols/snap/sync/delete/account/inner", nil)

--- a/eth/protocols/snap/metrics.go
+++ b/eth/protocols/snap/metrics.go
@@ -44,8 +44,8 @@ var (
 
 	// Progress of the phases specific to snap/2
 	genProgressGauge = metrics.NewRegisteredGauge("eth/protocols/snap/sync/generation", nil)
-	balFetchedGauge  = metrics.NewRegisteredGauge("eth/protocols/snap/sync/heal/bal/fetched", nil)
-	balTotalGauge    = metrics.NewRegisteredGauge("eth/protocols/snap/sync/heal/bal/total", nil)
+	balFetchedGauge  = metrics.NewRegisteredGauge("eth/protocols/snap/sync/catchup/bal/fetched", nil)
+	balTotalGauge    = metrics.NewRegisteredGauge("eth/protocols/snap/sync/catchup/bal/total", nil)
 
 	// accountInnerDeleteGauge is the metric to track how many dangling trie nodes
 	// covered by extension node in account trie are deleted during the sync.

--- a/eth/protocols/snap/sync.go
+++ b/eth/protocols/snap/sync.go
@@ -3154,6 +3154,13 @@ func (s *syncer) reportSyncProgress(force bool) {
 		storage  = fmt.Sprintf("%v@%v", log.FormatLogfmtUint64(s.storageSynced), common.StorageSize(s.storageBytes.Load()).TerminalString())
 		bytecode = fmt.Sprintf("%v@%v", log.FormatLogfmtUint64(s.bytecodeSynced), common.StorageSize(s.bytecodeBytes.Load()).TerminalString())
 	)
+	syncProgressGauge.Update(float64(synced) / estBytes)
+	syncBytesGauge.Update(int64(synced))
+	syncEstimateGauge.Update(int64(estBytes))
+	syncAccountsGauge.Update(int64(s.accountSynced))
+	syncSlotsGauge.Update(int64(s.storageSynced))
+	syncCodesGauge.Update(int64(s.bytecodeSynced))
+
 	log.Info("Syncing: state download in progress", "synced", progress, "state", synced,
 		"accounts", accounts, "slots", storage, "codes", bytecode, "eta", common.PrettyDuration(estTime-elapsed))
 }
@@ -3172,9 +3179,16 @@ func (s *syncer) reportHealProgress(force bool) {
 		bytecode = fmt.Sprintf("%v@%v", log.FormatLogfmtUint64(s.bytecodeHealSynced), s.bytecodeHealBytes.TerminalString())
 		accounts = fmt.Sprintf("%v@%v", log.FormatLogfmtUint64(s.accountHealed), s.accountHealedBytes.TerminalString())
 		storage  = fmt.Sprintf("%v@%v", log.FormatLogfmtUint64(s.storageHealed), s.storageHealedBytes.TerminalString())
+		pending  = s.healer.scheduler.Pending()
 	)
+	healAccountsGauge.Update(int64(s.accountHealed))
+	healSlotsGauge.Update(int64(s.storageHealed))
+	healCodesGauge.Update(int64(s.bytecodeHealSynced))
+	healNodesGauge.Update(int64(s.trienodeHealSynced))
+	healPendingGauge.Update(int64(pending))
+
 	log.Info("Syncing: state healing in progress", "accounts", accounts, "slots", storage,
-		"codes", bytecode, "nodes", trienode, "pending", s.healer.scheduler.Pending())
+		"codes", bytecode, "nodes", trienode, "pending", pending)
 }
 
 // estimateRemainingSlots tries to determine roughly how many slots are left in

--- a/eth/protocols/snap/syncv2.go
+++ b/eth/protocols/snap/syncv2.go
@@ -678,7 +678,23 @@ func (s *syncerV2) Sync(target *types.Header, cancel chan struct{}) error {
 	if err := batch.Write(); err != nil {
 		return err
 	}
+	// Mirror the live generation progress into the metrics while it runs
+	stop := make(chan struct{})
+	go func() {
+		ticker := time.NewTicker(5 * time.Second)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ticker.C:
+				genProgressGauge.Update(int64(s.genProgress.Load()))
+			case <-stop:
+				return
+			}
+		}
+	}()
 	_, genErr := triedb.GenerateTrieWithProgress(s.db, s.scheme, root, cancel, &s.genProgress)
+	close(stop)
+	genProgressGauge.Update(int64(s.genProgress.Load()))
 	if genErr != nil {
 		return genErr
 	}
@@ -1057,6 +1073,8 @@ func (s *syncerV2) fetchAccessLists(hashes []common.Hash, headers map[common.Has
 		s.accessListSynced += uint64(len(fetched) - lastFetched)
 		lastFetched = len(fetched)
 		s.refreshProgressLocked()
+		balFetchedGauge.Update(int64(s.accessListSynced))
+		balTotalGauge.Update(int64(s.accessListTotal))
 		s.lock.Unlock()
 	}
 	// Assemble results in input order
@@ -2941,6 +2959,13 @@ func (s *syncerV2) reportSyncProgressV2(force bool) {
 		storage  = fmt.Sprintf("%v@%v", log.FormatLogfmtUint64(s.storageSynced), s.storageBytes.TerminalString())
 		bytecode = fmt.Sprintf("%v@%v", log.FormatLogfmtUint64(s.bytecodeSynced), s.bytecodeBytes.TerminalString())
 	)
+	syncProgressGauge.Update(float64(synced) / estBytes)
+	syncBytesGauge.Update(int64(synced))
+	syncEstimateGauge.Update(int64(estBytes))
+	syncAccountsGauge.Update(int64(s.accountSynced))
+	syncSlotsGauge.Update(int64(s.storageSynced))
+	syncCodesGauge.Update(int64(s.bytecodeSynced))
+
 	log.Info("Syncing: state download in progress", "synced", progress, "state", synced,
 		"accounts", accounts, "slots", storage, "codes", bytecode, "eta", common.PrettyDuration(estTime-elapsed))
 }

--- a/eth/protocols/snap/syncv2.go
+++ b/eth/protocols/snap/syncv2.go
@@ -681,7 +681,7 @@ func (s *syncerV2) Sync(target *types.Header, cancel chan struct{}) error {
 	// Mirror the live generation progress into the metrics while it runs
 	stop := make(chan struct{})
 	go func() {
-		ticker := time.NewTicker(5 * time.Second)
+		ticker := time.NewTicker(time.Second * 30)
 		defer ticker.Stop()
 		for {
 			select {


### PR DESCRIPTION
A few metrics have been added, exposing the latest progress of snap sync.