### PR TITLE
ethclient: reject missing from in TransactionSender

### DIFF
--- a/ethclient/ethclient.go
+++ b/ethclient/ethclient.go
@@ -311,7 +311,7 @@ func (ec *Client) TransactionSender(ctx context.Context, tx *types.Transaction, 
 	// It was not found in cache, ask the server.
 	var meta struct {
 		Hash common.Hash
-		From common.Address
+		From *common.Address
 	}
 	if err = ec.c.CallContext(ctx, &meta, "eth_getTransactionByBlockHashAndIndex", block, hexutil.Uint64(index)); err != nil {
 		return common.Address{}, err
@@ -319,7 +319,10 @@ func (ec *Client) TransactionSender(ctx context.Context, tx *types.Transaction, 
 	if meta.Hash == (common.Hash{}) || meta.Hash != tx.Hash() {
 		return common.Address{}, errors.New("wrong inclusion block/index")
 	}
-	return meta.From, nil
+	if meta.From == nil {
+		return common.Address{}, errors.New("missing transaction sender")
+	}
+	return *meta.From, nil
 }
 
 // TransactionCount returns the total number of transactions in the given block.


### PR DESCRIPTION
## Summary
- `TransactionSender` unmarshaled a missing JSON `from` into the zero address, so hash checks could still pass and callers treated `0x000…` as the sender.
- Decode `from` as `*common.Address` and return an error when it is absent.

## Test plan
- [ ] `go test ./ethclient/...`
- [ ] Confirm `TransactionSender` still returns the cached or RPC sender when `from` is present, and errors when the field is omitted.