### PR TITLE
eth/filters: measure the block range limit after resolving latest

### DIFF
--- a/eth/filters/filter.go
+++ b/eth/filters/filter.go
@@ -145,9 +145,6 @@ func (f *Filter) Logs(ctx context.Context) ([]*types.Log, error) {
 	if err != nil {
 		return nil, err
 	}
-	if f.rangeLimit != 0 && (end-begin) > f.rangeLimit {
-		return nil, invalidParamsErr("exceed maximum block range %d", f.rangeLimit)
-	}
 	return f.rangeLogs(ctx, begin, end)
 }
 
@@ -199,6 +196,14 @@ func newSearchSession(ctx context.Context, filter *Filter, mb filtermaps.Matcher
 	}
 	if err := s.updateChainView(); err != nil {
 		return nil, err
+	}
+	// The range limit is checked here rather than on the requested range because
+	// the "latest" tag is carried as MaxUint64 until updateChainView resolves it
+	// against the current head. Checking it earlier would reject any range ending
+	// at the head, however short, and would underflow when the search range is
+	// specified backwards.
+	if limit := filter.rangeLimit; limit != 0 && s.searchRange.Last()-s.searchRange.First() > limit {
+		return nil, invalidParamsErr("exceed maximum block range %d", limit)
 	}
 	return s, nil
 }

--- a/eth/filters/filter_test.go
+++ b/eth/filters/filter_test.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"math/big"
 	"strings"
 	"testing"
@@ -632,22 +633,45 @@ func TestRangeLimit(t *testing.T) {
 	backend.startFilterMaps(0, false, filtermaps.DefaultParams)
 	defer backend.stopFilterMaps()
 
-	// Set rangeLimit to 5, but request a range of 9 (end - begin = 9, from 0 to 9)
-	filter := sys.NewRangeFilter(0, 9, nil, nil, 5)
-	_, err = filter.Logs(context.Background())
-	if err == nil {
-		t.Fatal("expected range limit error, got nil")
-	}
-
-	var re rpc.Error
-	if errors.As(err, &re) {
-		if re.ErrorCode() != -32602 {
-			t.Fatalf("expected error code -32602, got %d", re.ErrorCode())
-		}
-		if re.Error() != "exceed maximum block range 5" {
-			t.Fatalf("expected error message 'exceed maximum block range 5', got %q", re.Error())
-		}
-	} else {
-		t.Fatalf("expected rpc error, got %v", err)
+	latest := rpc.LatestBlockNumber.Int64()
+	for _, tc := range []struct {
+		name       string
+		begin, end int64
+		limit      uint64
+		wantErr    bool
+	}{
+		// Head is block 10 and the limit is 5 throughout.
+		{name: "explicit range over limit", begin: 0, end: 9, limit: 5, wantErr: true},
+		{name: "explicit range within limit", begin: 4, end: 9, limit: 5},
+		// The "latest" tag has to be resolved against the head before the range
+		// is measured, otherwise every query ending at the head is rejected.
+		{name: "latest end within limit", begin: 8, end: latest, limit: 5},
+		{name: "latest end over limit", begin: 0, end: latest, limit: 5, wantErr: true},
+		{name: "latest on both ends", begin: latest, end: latest, limit: 5},
+		{name: "no limit configured", begin: 0, end: latest, limit: 0},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			filter := sys.NewRangeFilter(tc.begin, tc.end, nil, nil, tc.limit)
+			_, err := filter.Logs(context.Background())
+			if !tc.wantErr {
+				if err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatal("expected range limit error, got nil")
+			}
+			var re rpc.Error
+			if !errors.As(err, &re) {
+				t.Fatalf("expected rpc error, got %v", err)
+			}
+			if re.ErrorCode() != -32602 {
+				t.Fatalf("expected error code -32602, got %d", re.ErrorCode())
+			}
+			if want := fmt.Sprintf("exceed maximum block range %d", tc.limit); re.Error() != want {
+				t.Fatalf("expected error message %q, got %q", want, re.Error())
+			}
+		})
 	}
 }


### PR DESCRIPTION
### Problem

`resolveSpecial` encodes the `latest` tag as `math.MaxUint64` so that `rangeLogs` can re-resolve it against the current head on every search iteration. The `--rpc.rangelimit` check, however, ran on that sentinel:

```go
begin, err := resolveSpecial(f.begin)
end, err := resolveSpecial(f.end)
if f.rangeLimit != 0 && (end-begin) > f.rangeLimit {
	return nil, invalidParamsErr("exceed maximum block range %d", f.rangeLimit)
}
```

So on a node started with `--rpc.rangelimit`, any `eth_getLogs` whose `toBlock` is `latest` — including the default, when `toBlock` is simply omitted — is rejected with `exceed maximum block range` regardless of how short the requested range is. With head at block 10 and `--rpc.rangelimit=5`, `{"fromBlock": "0x8"}` covers three blocks and still fails.

The same subtraction underflows when the range is given backwards through a tag, e.g. `fromBlock: "finalized"` with a numeric `toBlock` below the finalized block. `end - begin` wraps to a small number, the limit check passes, and the request then fails on the ordering check — so the range limit is reported for a range that never exceeded it, and vice versa.

This has been the behaviour since #33163 added the flag.

### Fix

Move the check into `newSearchSession`, after `updateChainView` has replaced `MaxUint64` with the actual head number and `rangeLogs` has established `firstBlock <= lastBlock`. Both operands are then concrete and ordered, so the subtraction cannot wrap and the measured range is the one that will actually be searched. The error value, its code and its message are unchanged.

### Tests

`TestRangeLimit` is rewritten as a table over one chain so the tag cases sit next to the numeric ones: explicit range over and under the limit, `latest` as the end of a short and a long range, `latest` on both ends, and no limit configured. The `latest end within limit` case fails on `master` with `exceed maximum block range 5` and passes with this change.

`go build ./...`, `gofmt`/`goimports` clean, and `go test ./eth/filters/` passes.