### PR TITLE
docs: bump README minimum Go version to 1.25

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ archives are published at https://geth.ethereum.org/downloads/.
 
 For prerequisites and detailed build instructions please read the [Installation Instructions](https://geth.ethereum.org/docs/getting-started/installing-geth).
 
-Building `geth` requires both a Go (version 1.23 or later) and a C compiler. You can install
+Building `geth` requires both a Go (version 1.25 or later) and a C compiler. You can install
 them using your favourite package manager. Once the dependencies are installed, run
 
 ```shell


### PR DESCRIPTION
## Summary
README still says building geth needs Go 1.23 or later, but tip go.mod is go 1.25.0 and CI tests 1.25/1.26/1.27.

## Repro
1. Tip README Building the source: Go (version 1.23 or later)
2. Tip go.mod: go 1.25.0
3. Tip .github/workflows/go.yml matrix: 1.27, 1.26, 1.25

## Change
Bump the documented minimum to Go 1.25 or later.
