### PR TITLE
node: report actual closure in admin_stopWS

### DIFF
--- a/node/api.go
+++ b/node/api.go
@@ -290,11 +290,14 @@ func (api *adminAPI) StartWS(host *string, port *int, allowedOrigins *string, ap
 	return true, nil
 }
 
-// StopWS terminates all WebSocket servers.
+// StopWS terminates all WebSocket servers. It returns true if at least one
+// WebSocket endpoint was actually closed, false if none were running.
 func (api *adminAPI) StopWS() (bool, error) {
-	api.node.http.stopWS()
-	api.node.ws.stop()
-	return true, nil
+	closed := api.node.http.stopWS()
+	if api.node.ws.stop() {
+		closed = true
+	}
+	return closed, nil
 }
 
 // Peers retrieves all the information we know about each individual peer at the

--- a/node/api_test.go
+++ b/node/api_test.go
@@ -168,11 +168,26 @@ func TestStartRPC(t *testing.T) {
 			name: "ws stopped twice",
 			cfg:  Config{WSHost: "127.0.0.1"},
 			fn: func(t *testing.T, n *Node, api *adminAPI) {
-				_, err := api.StopWS()
+				stopped, err := api.StopWS()
 				assert.NoError(t, err)
+				assert.True(t, stopped, "first StopWS should report a closed endpoint")
 
-				_, err = api.StopWS()
+				stopped, err = api.StopWS()
 				assert.NoError(t, err)
+				assert.False(t, stopped, "second StopWS should report nothing closed")
+			},
+			wantReachable: false,
+			wantHandlers:  false,
+			wantRPC:       false,
+			wantWS:        false,
+		},
+		{
+			name: "ws not running, StopWS reports nothing closed",
+			cfg:  Config{},
+			fn: func(t *testing.T, n *Node, api *adminAPI) {
+				stopped, err := api.StopWS()
+				assert.NoError(t, err)
+				assert.False(t, stopped, "StopWS should report nothing closed when no endpoint is running")
 			},
 			wantReachable: false,
 			wantHandlers:  false,

--- a/node/rpcstack.go
+++ b/node/rpcstack.go
@@ -263,16 +263,19 @@ func validatePrefix(what, path string) error {
 	return nil
 }
 
-// stop shuts down the HTTP server.
-func (h *httpServer) stop() {
+// stop shuts down the HTTP server. It returns true if the server was running
+// and has been stopped, false if it was already stopped.
+func (h *httpServer) stop() bool {
 	h.mu.Lock()
 	defer h.mu.Unlock()
-	h.doStop()
+	return h.doStop()
 }
 
-func (h *httpServer) doStop() {
+// doStop shuts down the HTTP server. It returns true if the server was running
+// and has been stopped, false if it was already stopped. The caller must hold h.mu.
+func (h *httpServer) doStop() bool {
 	if h.listener == nil {
-		return // not running
+		return false // not running
 	}
 
 	// Shut down the server.
@@ -301,6 +304,7 @@ func (h *httpServer) doStop() {
 	// Clear out everything to allow re-configuring it later.
 	h.host, h.port, h.endpoint = "", 0, ""
 	h.server, h.listener = nil, nil
+	return true
 }
 
 // enableRPC turns on JSON-RPC over HTTP on the server.
@@ -366,16 +370,20 @@ func (h *httpServer) enableWS(apis []rpc.API, config wsConfig) error {
 	return nil
 }
 
-// stopWS disables JSON-RPC over WebSocket and also stops the server if it only serves WebSocket.
-func (h *httpServer) stopWS() {
+// stopWS disables JSON-RPC over WebSocket and also stops the server if it only
+// serves WebSocket. It returns true if the WebSocket handler was disabled (i.e.
+// a WebSocket endpoint was actually closed), false if WebSocket was not enabled.
+func (h *httpServer) stopWS() bool {
 	h.mu.Lock()
 	defer h.mu.Unlock()
 
-	if h.disableWS() {
-		if !h.rpcAllowed() {
-			h.doStop()
-		}
+	if !h.disableWS() {
+		return false
 	}
+	if !h.rpcAllowed() {
+		h.doStop()
+	}
+	return true
 }
 
 // disableWS disables the WebSocket handler. This is internal, the caller must hold h.mu.


### PR DESCRIPTION
Fixes point 3 of #35547.

## Problem
`admin_stopWS` returned `true` unconditionally, even with no WebSocket endpoint running. `adminAPI.StopWS` called `httpServer.stopWS()` and `httpServer.stop()` — both silently no-op when nothing is running (`doStop` early-returns when `h.listener == nil`) — then returned `true, nil` regardless. No signal in the chain could make it report anything other than success.

## Changes
Thread a "did anything actually close" bool up from existing helpers, no new state:
- `httpServer.doStop` returns `bool` — true if a running server was stopped.
- `httpServer.stop` returns the `doStop` result.
- `httpServer.stopWS` returns true if the WS handler was actually disabled (the existing `disableWS()` already returns this), false if WS wasn't enabled.
- `adminAPI.StopWS` ORs the `http`/`ws` results — true only when ≥1 endpoint closed.

The four `stop()` callers in `node.stopRPC` (node.go) discard the new return value, intentional and lint-clean (errcheck disabled in .golangci.yml).

## Behavior change
`admin_stopWS` may now return `false` when nothing was running. Intended fix; `admin_*` is not a stable RPC API and the prior behavior was flagged as a bug.

## Tests
- `TestStartRPC/ws_stopped_twice`: assert first StopWS reports a closed endpoint, second reports nothing closed.
- `TestStartRPC/ws not running, StopWS reports nothing closed` (new): StopWS on a node with no WS endpoint reports false.

## Scope
Point 3 only. Points 1 (`admin_nodeInfo`/`protocols.eth.difficulty`) and 2 (`admin_startWS` port typing) involve a code-vs-docs decision and are left for follow-up.

## Follow-ups (out of scope)
- `adminAPI.StopHTTP` (node/api.go) has the same unconditional-`true` pattern.
- Points 1 and 2 of #35547.
