### PR TITLE
internal/ethapi: use Amsterdam per-authorization gas in eth_createAccessList guard

### DIFF
--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -1377,8 +1377,9 @@ func AccessList(ctx context.Context, b Backend, blockNrOrHash rpc.BlockNumberOrH
 		to = crypto.CreateAddress(args.from(), uint64(*args.Nonce))
 	}
 	isPostMerge := header.Difficulty.Sign() == 0
+	rules := b.ChainConfig().Rules(header.Number, isPostMerge, header.Time)
 	// Retrieve the precompiles since they don't need to be added to the access list
-	precompiles := vm.ActivePrecompiles(b.ChainConfig().Rules(header.Number, isPostMerge, header.Time))
+	precompiles := vm.ActivePrecompiles(rules)
 
 	// addressesToExclude contains sender, receiver, precompiles and valid authorizations
 	addressesToExclude := map[common.Address]struct{}{args.from(): {}, to: {}}
@@ -1386,8 +1387,13 @@ func AccessList(ctx context.Context, b Backend, blockNrOrHash rpc.BlockNumberOrH
 		addressesToExclude[addr] = struct{}{}
 	}
 
-	// Prevent redundant operations if args contain more authorizations than EVM may handle
-	maxAuthorizations := uint64(*args.Gas) / params.CallNewAccountGas
+	// Prevent redundant operations if args contain more authorizations than EVM
+	// may handle. The per-authorization cost must match core.IntrinsicGas.
+	perAuthGas := params.CallNewAccountGas
+	if rules.IsAmsterdam {
+		perAuthGas = params.ExecutionPerAuthBaseCost
+	}
+	maxAuthorizations := uint64(*args.Gas) / perAuthGas
 	if uint64(len(args.AuthorizationList)) > maxAuthorizations {
 		return nil, 0, nil, errors.New("insufficient gas to process all authorizations")
 	}

--- a/internal/ethapi/api_test.go
+++ b/internal/ethapi/api_test.go
@@ -4488,7 +4488,7 @@ func TestCreateAccessListAuthorizationGas(t *testing.T) {
 			if tc.amsterdam {
 				// Make sure the scenario actually sits between the two
 				// per-authorization prices, otherwise the guard is not exercised.
-				require.Less(t, uint64(estimated), uint64(numAuths*params.CallNewAccountGas))
+				require.Less(t, uint64(estimated), numAuths*params.CallNewAccountGas)
 			}
 
 			// The estimate must be accepted as-is.

--- a/internal/ethapi/api_test.go
+++ b/internal/ethapi/api_test.go
@@ -4435,3 +4435,74 @@ func TestStateMethodsDefaultToLatest(t *testing.T) {
 		[]any{map[common.Address][]common.Hash{acc: {slot}}, "latest"},
 		[]any{map[common.Address][]common.Hash{acc: {slot}}})
 }
+
+// TestCreateAccessListAuthorizationGas checks that the authorization-count
+// guard in eth_createAccessList charges the same per-authorization intrinsic
+// gas as the fork in effect, so that a gas value returned by eth_estimateGas
+// is always accepted by eth_createAccessList for the same request.
+func TestCreateAccessListAuthorizationGas(t *testing.T) {
+	t.Parallel()
+
+	const numAuths = 9
+	accounts := newAccounts(numAuths + 1)
+	alloc := types.GenesisAlloc{accounts[0].addr: {Balance: big.NewInt(params.Ether)}}
+	// accounts[0] is the sender; every other account is already delegated and
+	// re-delegates, so that no account or authorization creation is charged.
+	var authList []types.SetCodeAuthorization
+	for _, acc := range accounts[1:] {
+		alloc[acc.addr] = types.Account{
+			Balance: big.NewInt(params.Ether),
+			Code:    types.AddressToDelegation(common.Address{0xbb}),
+		}
+		auth, err := types.SignSetCode(acc.key, types.SetCodeAuthorization{
+			Address: common.Address{0xaa},
+		})
+		require.NoError(t, err)
+		authList = append(authList, auth)
+	}
+	newAPI := func(amsterdam bool) *BlockChainAPI {
+		config := *params.MergedTestChainConfig
+		if amsterdam {
+			config.AmsterdamTime = new(uint64)
+		}
+		genesis := &core.Genesis{Config: &config, Difficulty: common.Big0, Alloc: alloc}
+		return NewBlockChainAPI(newTestBackend(t, 0, genesis, beacon.New(ethash.NewFaker()), nil))
+	}
+	for _, tc := range []struct {
+		name      string
+		amsterdam bool
+		perAuth   uint64
+	}{
+		{"pre-Amsterdam", false, params.CallNewAccountGas},
+		{"Amsterdam", true, params.ExecutionPerAuthBaseCost},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			api := newAPI(tc.amsterdam)
+			args := TransactionArgs{
+				From:              &accounts[0].addr,
+				To:                &accounts[0].addr,
+				AuthorizationList: authList,
+			}
+			estimated, err := api.EstimateGas(context.Background(), args, nil, nil, nil)
+			require.NoError(t, err)
+			if tc.amsterdam {
+				// Make sure the scenario actually sits between the two
+				// per-authorization prices, otherwise the guard is not exercised.
+				require.Less(t, uint64(estimated), uint64(numAuths*params.CallNewAccountGas))
+			}
+
+			// The estimate must be accepted as-is.
+			gas := estimated
+			args.Gas = &gas
+			result, err := api.CreateAccessList(context.Background(), args, nil, nil)
+			require.NoError(t, err)
+			require.Empty(t, result.Error)
+
+			// The guard must still reject a gas limit that cannot even cover
+			// the per-authorization intrinsic cost of the fork in effect.
+			gas = hexutil.Uint64(numAuths*tc.perAuth - 1)
+			_, err = api.CreateAccessList(context.Background(), args, nil, nil)
+			require.ErrorContains(t, err, "insufficient gas to process all authorizations")
+		})
+	}
+}


### PR DESCRIPTION
The authorization-count guard in `eth_createAccessList` still divides by `CallNewAccountGas` (25000). Since #35318, `core.IntrinsicGas` charges`ExecutionPerAuthBaseCost` (7816) per authorization on Amsterdam, so the guard rejects requests whose gas is between `n × 7816` and `n × 25000` -> including the value `eth_estimateGas` returns for the same request (9 re-delegations: estimate 168,831, guard requires 225,000).

This picks the per-authorization cost from the block's fork rules, same as `core.IntrinsicGas`. The added test fails on master with `insufficient gas to process all authorizations`.