### PR TITLE
core/txpool/blobpool: count cells-first only when tx is absent

### DIFF
--- a/core/txpool/blobpool/buffer.go
+++ b/core/txpool/blobpool/buffer.go
@@ -165,8 +165,9 @@ func (b *BlobBuffer) AddCells(hash common.Hash, deliveries map[string]*PeerDeliv
 	}
 	if txe, ok := b.txs[hash]; ok {
 		b.storeCompleted(hash, txe.tx, b.cells[hash])
+	} else {
+		blobBufferCellsFirstCounter.Inc(1)
 	}
-	blobBufferCellsFirstCounter.Inc(1)
 }
 
 // storeCompleted verifies cells per-peer, sorts them, and schedules them for


### PR DESCRIPTION
## Summary
- `AddCells` incremented `blobpool/buffer/cellsfirst` even when the transaction was already buffered, so the metric counted completed pairs as well as true cells-first arrivals.
- Increment the counter only in the else branch, matching `txfirst` which counts txs that arrive before cells.

## Test plan
- [ ] `go test ./core/txpool/blobpool/...`
- [ ] Confirm `cellsfirst` increases when cells arrive before the tx, and does not increase when `AddCells` completes an already-buffered tx.