### PR TITLE
rpc: close websocket on ping write failure

### DIFF
--- a/rpc/websocket.go
+++ b/rpc/websocket.go
@@ -392,9 +392,16 @@ func (wc *websocketCodec) pingLoop() {
 		case <-pingTimer.C:
 			wc.jsonCodec.encMu.Lock()
 			wc.conn.SetWriteDeadline(time.Now().Add(wsPingWriteTimeout))
-			wc.conn.WriteMessage(websocket.PingMessage, nil)
-			wc.conn.SetReadDeadline(time.Now().Add(wsPongTimeout))
+			err := wc.conn.WriteMessage(websocket.PingMessage, nil)
+			if err == nil {
+				wc.conn.SetReadDeadline(time.Now().Add(wsPongTimeout))
+			}
 			wc.jsonCodec.encMu.Unlock()
+			if err != nil {
+				log.Trace("Failed to write websocket ping", "err", err)
+				wc.jsonCodec.close()
+				return
+			}
 			pingTimer.Reset(wsPingInterval)
 
 		case <-wc.pongReceived:


### PR DESCRIPTION
## Summary
- `pingLoop` ignored `WriteMessage` errors, so a failed idle ping still armed the pong deadline and kept pinging a dead connection.
- On ping write failure, skip the pong deadline, close the codec, and stop the loop.

## Test plan
- [ ] `go test ./rpc/...`
- [ ] Confirm idle websocket pings still work on a live connection, and a failed ping write tears the codec down instead of retrying.