### PR TITLE
accounts/abi: filter out unexpected logs from event stream

### DIFF
--- a/accounts/abi/abigen/source.go.tpl
+++ b/accounts/abi/abigen/source.go.tpl
@@ -459,6 +459,10 @@ var (
 						// New log arrived, parse the event and forward to the user
 						event := new({{$contract.Type}}{{.Normalized.Name}})
 						if err := _{{$contract.Type}}.contract.UnpackLog(event, "{{.Original.Name}}", log); err != nil {
+							// If the signature doesn't match, skip this log.
+							if errors.Is(err, bind.ErrEventSignatureMismatch) {
+								continue
+							}
 							return err
 						}
 						event.Raw = log

--- a/accounts/abi/bind/v2/lib.go
+++ b/accounts/abi/bind/v2/lib.go
@@ -84,6 +84,10 @@ func WatchEvents[Ev ContractEvent](c *BoundContract, opts *WatchOpts, unpack fun
 				// New log arrived, parse the event and forward to the user
 				ev, err := unpack(&log)
 				if err != nil {
+					// If the signature doesn't match, skip this log.
+					if errors.Is(err, ErrEventSignatureMismatch) {
+						continue
+					}
 					return err
 				}
 

--- a/accounts/abi/bind/v2/lib_test.go
+++ b/accounts/abi/bind/v2/lib_test.go
@@ -392,3 +392,68 @@ func TestEventUnpackEmptyTopics(t *testing.T) {
 		}
 	}
 }
+
+func TestWatchEventsIgnoreMismatch(t *testing.T) {
+	backend, err := testSetup()
+	if err != nil {
+		t.Fatalf("error setting up testing env: %v", err)
+	}
+	defer backend.Backend.Close()
+
+	deploymentParams := &bind.DeploymentParams{
+		Contracts: []*bind.MetaData{&events.CMetaData},
+	}
+	res, err := bind.LinkAndDeploy(deploymentParams, makeTestDeployer(backend))
+	if err != nil {
+		t.Fatalf("error deploying contract for testing: %v", err)
+	}
+	backend.Commit()
+
+	c := events.NewC()
+	instance := c.Instance(backend, res.Addresses[events.CMetaData.ID])
+
+	newCBasic1Ch := make(chan *events.CBasic1, 10)
+	watchOpts := &bind.WatchOpts{Context: context.Background()}
+
+	mismatchSimulated := false
+	unpackWithMismatch := func(log *types.Log) (*events.CBasic1, error) {
+		if !mismatchSimulated {
+			mismatchSimulated = true
+			return nil, bind.ErrEventSignatureMismatch
+		}
+		return c.UnpackBasic1Event(log)
+	}
+
+	sub, err := bind.WatchEvents(instance, watchOpts, unpackWithMismatch, newCBasic1Ch)
+	if err != nil {
+		t.Fatalf("WatchEvents returned error: %v", err)
+	}
+	defer sub.Unsubscribe()
+
+	packedInput := c.PackEmitMulti()
+	tx, err := bind.Transact(instance, defaultTxAuth(), packedInput)
+	if err != nil {
+		t.Fatalf("failed to send transaction: %v", err)
+	}
+	backend.Commit()
+	if _, err := bind.WaitMined(context.Background(), backend, tx.Hash()); err != nil {
+		t.Fatalf("error waiting for tx to be mined: %v", err)
+	}
+
+	timeout := time.NewTimer(5 * time.Second)
+	e1Count := 0
+
+	for {
+		select {
+		case <-newCBasic1Ch:
+			e1Count++
+			if e1Count == 1 {
+				return
+			}
+		case err := <-sub.Err():
+			t.Fatalf("subscription failed unexpectedly with error: %v", err)
+		case <-timeout.C:
+			t.Fatalf("timeout waiting for events, only got %d", e1Count)
+		}
+	}
+}


### PR DESCRIPTION
### Fixes #23938

### Rationale
When subscribing to contract events via `WatchLogs` / `WatchEvents`, external nodes (e.g. Polygon/Bor or buggy RPC proxies) may occasionally deliver logs that do not match the expected topic filter (such as `Sync` logs instead of `Swap`).

Currently, when `UnpackLog` / `unpack` returns `ErrEventSignatureMismatch`, the subscription loop terminates and exits with an error, permanently closing the subscription and causing downstream consumers to fail.

### Changes
- In `accounts/abi/abigen/source.go.tpl`: ignore `bind.ErrEventSignatureMismatch` and continue the event loop.
- In `accounts/abi/bind/v2/lib.go`: ignore `ErrEventSignatureMismatch` in `WatchEvents` and continue the event loop.
- In `accounts/abi/bind/v2/lib_test.go`: added `TestWatchEventsIgnoreMismatch` to verify that mismatched event logs are skipped without terminating the subscription.