### PR TITLE
core/filtermaps: reject inverted head snapshot range

### DIFF
--- a/core/filtermaps/map_renderer.go
+++ b/core/filtermaps/map_renderer.go
@@ -237,6 +237,9 @@ func (f *FilterMaps) loadHeadSnapshot() error {
 		}
 		firstBlock = prevLastBlock + 1
 	}
+	if firstBlock > lastBlock+1 {
+		return fmt.Errorf("head snapshot range underflow: firstBlock %d lastBlock %d", firstBlock, lastBlock)
+	}
 	lvPtrs := make([]uint64, lastBlock+1-firstBlock)
 	for i := range lvPtrs {
 		lvPtrs[i], err = f.getBlockLvPointer(firstBlock + uint64(i))


### PR DESCRIPTION
## Summary
- `loadHeadSnapshot` sizes `lvPtrs` with `lastBlock+1-firstBlock`.
- If the index is inconsistent, `firstBlock` can exceed `lastBlock+1` and the uint64 subtraction wraps to a huge length, so a single `make` can OOM the process.
- Return an error for the inverted range before allocating.

## Test plan
- [ ] `go test ./core/filtermaps/...`